### PR TITLE
Backend rebase: fresh upstream + Ella sidecar

### DIFF
--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -12,6 +12,7 @@ This implements the hybrid auth approach:
 """
 
 import os
+import time
 import logging
 from datetime import datetime, timedelta
 from typing import Optional
@@ -174,20 +175,53 @@ class TtsRequest(BaseModel):
 
 
 ELEVENLABS_API_KEY = os.getenv("ELEVENLABS_API_KEY", "")
+TTS_PROVIDER = os.getenv("TTS_PROVIDER", "elevenlabs")  # elevenlabs or local
+LOCAL_TTS_URL = os.getenv("LOCAL_TTS_URL", "http://100.76.138.56:8930")  # Mac Mini Kokoro
+LOCAL_TTS_FALLBACK = os.getenv("LOCAL_TTS_FALLBACK", "elevenlabs")
 
 
 @router.post("/tts")
 async def synthesize_speech(request: TtsRequest):
     """
-    Synthesize speech from text via ElevenLabs.
+    Synthesize speech from text.
 
-    Proxies TTS requests so the API key stays server-side.
-    Returns audio/mpeg bytes directly.
+    Routes to local Kokoro (Mac Mini) or ElevenLabs based on TTS_PROVIDER env.
+    Returns audio bytes directly.
     """
+    text = request.text[:500]  # Cap at 500 chars for v1
+    provider = TTS_PROVIDER.lower()
+
+    # Local TTS (Kokoro on Mac Mini via Tailscale)
+    if provider == "local":
+        try:
+            t0 = time.time()
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.post(
+                    f"{LOCAL_TTS_URL}/v1/audio/speech",
+                    json={
+                        "input": text,
+                        "voice": "nova",
+                        "response_format": "pcm",
+                    },
+                )
+            elapsed = (time.time() - t0) * 1000
+            if response.status_code == 200:
+                logger.info(f"[Voice TTS] Local Kokoro: {len(response.content)} bytes, {elapsed:.0f}ms")
+                return Response(content=response.content, media_type="audio/L16;rate=24000")
+            else:
+                logger.warning(f"[Voice TTS] Local Kokoro returned {response.status_code}, falling back to {LOCAL_TTS_FALLBACK}")
+        except (httpx.ConnectError, httpx.TimeoutException) as e:
+            logger.warning(f"[Voice TTS] Local Kokoro unreachable: {e}, falling back to {LOCAL_TTS_FALLBACK}")
+        except Exception as e:
+            logger.error(f"[Voice TTS] Local Kokoro error: {e}, falling back to {LOCAL_TTS_FALLBACK}")
+
+        # Fallback - only continue to ElevenLabs if fallback is configured
+        if LOCAL_TTS_FALLBACK != "elevenlabs":
+            raise HTTPException(status_code=503, detail="Local TTS unreachable and no fallback configured")
+
+    # ElevenLabs (default or fallback)
     if not ELEVENLABS_API_KEY:
         raise HTTPException(status_code=500, detail="ELEVENLABS_API_KEY not configured")
-
-    text = request.text[:500]  # Cap at 500 chars for v1
 
     try:
         async with httpx.AsyncClient() as client:
@@ -229,5 +263,7 @@ async def voice_health():
         "service": "ella-voice",
         "voice_endpoint": ELLA_VOICE_ENDPOINT,
         "session_secret_configured": bool(ELLA_SESSION_SECRET),
-        "tts_configured": bool(ELEVENLABS_API_KEY),
+        "tts_provider": TTS_PROVIDER,
+        "tts_configured": bool(ELEVENLABS_API_KEY) if TTS_PROVIDER == "elevenlabs" else bool(LOCAL_TTS_URL),
+        "local_tts_url": LOCAL_TTS_URL if TTS_PROVIDER == "local" else None,
     }


### PR DESCRIPTION
## Summary

- Rebases backend onto **current upstream** (`BasedHardware/omi` main) with Ella sidecar extensions cleanly applied on top
- Gives us all upstream backend improvements (3,073 commits worth) while preserving all Ella functionality
- Clean 2-commit history: sidecar copy + router fixes

## Changes

**Ella sidecar (copied from `feature/ella-v2-fresh`):**
- `backend/ella/` — 27 files (routers, adapters, hooks, config, docs)
- `backend/utils/ella/` — 6 files (summary, memory, scanner, chat adapters)

**Upstream files patched (minimal, safe changes):**
- `backend/main.py` — 8 lines appended (Ella mount with try/except)
- `backend/routers/transcribe.py` — Ella context + scanner integration (wrapped in try/except)
- `backend/utils/llm/conversation_processing.py` — Ella summary adapter hook (falls back to upstream LLM on failure)
- `backend/utils/conversations/process_conversation.py` — Pass uid/conversation_id to summary function
- `backend/utils/llm/clients.py` — Ella context functions (ContextVar-based, thread-safe)

## Safety

- All Ella integrations wrapped in `try/except ImportError` — if Ella code is removed, upstream runs clean
- Adapter pattern: Ella hooks run first, fall back to upstream on any failure
- No upstream behavior changed when `ELLA_ENABLED=false`

## Testing

- [ ] `uvicorn main:app` starts without errors
- [ ] Upstream API endpoints respond
- [ ] Ella endpoints respond (`/v1/ella/*`)
- [ ] MCP endpoint works
- [ ] Summary adapter triggers on conversation completion

## Related

- Tracking issue: ellaaicare/ella-ai#107
- Strategy discussion: ellaaicare/ella-ai#106

🤖 Generated with [Claude Code](https://claude.com/claude-code)