### PR TITLE
feat: Guardian Mode backend — audio delivery queue for iOS

### DIFF
--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -32,6 +32,7 @@ ELLA_SCANNER_ENABLED = os.getenv("ELLA_SCANNER_ENABLED", "true").lower() == "tru
 ELLA_NOTIFICATIONS_ENABLED = os.getenv("ELLA_NOTIFICATIONS_ENABLED", "true").lower() == "true"
 ELLA_VOICE_V2_ENABLED = os.getenv("ELLA_VOICE_V2_ENABLED", "true").lower() == "true"
 ELLA_TESTING_ENABLED = os.getenv("ELLA_TESTING_ENABLED", "false").lower() == "true"
+ELLA_GUARDIAN_ENABLED = os.getenv("ELLA_GUARDIAN_ENABLED", "true").lower() == "true"
 
 # n8n Configuration
 ELLA_N8N_BASE_URL = os.getenv("ELLA_N8N_BASE_URL", "https://n8n.ella-ai-care.com")
@@ -145,6 +146,7 @@ def register_ella_extensions(app) -> None:
     print(f"   • n8n Scanner:    {'✅ ON' if ELLA_SCANNER_ENABLED else '❌ OFF'}", flush=True)
     print(f"   • Notifications:  {'✅ ON' if ELLA_NOTIFICATIONS_ENABLED else '❌ OFF'}", flush=True)
     print(f"   • Voice V2:       {'✅ ON' if ELLA_VOICE_V2_ENABLED else '❌ OFF'}", flush=True)
+    print(f"   • Guardian Mode: {'✅ ON' if ELLA_GUARDIAN_ENABLED else '❌ OFF'}", flush=True)
     print(f"   • Testing:        {'✅ ON' if ELLA_TESTING_ENABLED else '❌ OFF'}", flush=True)
     print(f"   • Chat Debug:     Level {_dl} ({_dl_label})", flush=True)
     print("", flush=True)
@@ -274,6 +276,17 @@ def _register_routers(app) -> None:
         except ImportError as e:
             print(f"  ⚠️ Voice endpoints not available: {e}", flush=True)
 
+
+    # Guardian Mode (audio queue for iOS)
+    if ELLA_GUARDIAN_ENABLED:
+        try:
+            from ella.routers.guardian import router as guardian_router
+
+            app.include_router(guardian_router, tags=["Guardian Mode"])
+            print("  🌐 /v1/ella/guardian/* - Guardian Mode endpoints", flush=True)
+        except ImportError as e:
+            print(f"  ⚠️ Guardian Mode not available: {e}", flush=True)
+
     # Testing endpoints (dev only)
     if ELLA_TESTING_ENABLED:
         try:
@@ -298,6 +311,7 @@ __all__ = [
     'ELLA_NOTIFICATIONS_ENABLED',
     'ELLA_VOICE_V2_ENABLED',
     'ELLA_TESTING_ENABLED',
+    'ELLA_GUARDIAN_ENABLED',
     'ELLA_N8N_BASE_URL',
     'GROK_V2V_PROXY_URL',
     # Adapter registry

--- a/backend/ella/routers/__init__.py
+++ b/backend/ella/routers/__init__.py
@@ -5,19 +5,23 @@ Routers:
 - callbacks: Receives callbacks from Ella n8n/Letta agents
 - chat: Streaming chat via Grok (xAI)
 - voice: Voice session management (token issuance)
+- guardian: Guardian Mode audio delivery queue for iOS
 
 These add endpoints that don't exist in vanilla OMI:
 - /v1/ella/* - Callback endpoints for Letta agents
 - /v1/ella/chat/* - Grok streaming chat
+- /v1/ella/guardian/* - Guardian Mode audio queue
 - /v1/voice/* - Voice session management
 """
 
 from .callbacks import router as callbacks_router
 from .chat import router as chat_router
+from .guardian import router as guardian_router
 from .voice import router as voice_router
 
 __all__ = [
-    'callbacks_router',
-    'chat_router',
-    'voice_router',
+    "callbacks_router",
+    "chat_router",
+    "guardian_router",
+    "voice_router",
 ]

--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -1,0 +1,261 @@
+"""
+Guardian Mode Router - Audio delivery queue for iOS Guardian Mode.
+
+Endpoints:
+- GET  /v1/ella/guardian/next-audio?uid={uid}  - iOS polls, pops from queue
+- POST /v1/ella/guardian/enqueue               - n8n enqueues after TTS
+- POST /v1/ella/guardian/upload                - n8n uploads MP3 binary
+- GET  /v1/ella/guardian/queue?uid={uid}       - debug/dashboard view
+
+Queue: ella-postgres guardian_queue table.
+Audio files: /var/www/ella-ai-care.com/audio/{uid}/*.mp3
+"""
+
+import os
+import time
+import uuid
+from typing import Optional
+
+import asyncpg
+from fastapi import APIRouter, File, Form, Header, HTTPException, UploadFile
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/v1/ella/guardian", tags=["Guardian Mode"])
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+AUDIO_BASE_DIR = "/var/www/ella-ai-care.com/audio"
+AUDIO_PUBLIC_URL = "https://ella-ai-care.com/audio"
+GUARDIAN_WEBHOOK_KEY = os.getenv(
+    "GUARDIAN_WEBHOOK_KEY", "4f13699d8462adf71e35d2098e6a791f"
+)
+
+# Database connection pool (lazy-initialized)
+_pool: Optional[asyncpg.Pool] = None
+
+
+async def _get_pool() -> asyncpg.Pool:
+    """Get or create the asyncpg connection pool."""
+    global _pool
+    if _pool is None:
+        _pool = await asyncpg.create_pool(
+            host="127.0.0.1",
+            port=5433,
+            user="postgres",
+            password=os.getenv("ELLA_POSTGRES_PASSWORD", "postgres"),
+            database="ella_ai",
+            min_size=2,
+            max_size=10,
+        )
+    return _pool
+
+
+def _verify_key(
+    x_guardian_key: Optional[str] = None,
+    key: Optional[str] = None,
+) -> None:
+    """Verify webhook authentication key."""
+    provided = x_guardian_key or key
+    if provided != GUARDIAN_WEBHOOK_KEY:
+        raise HTTPException(status_code=403, detail="Invalid guardian key")
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class EnqueueRequest(BaseModel):
+    """JSON body for enqueue endpoint."""
+    uid: Optional[str] = None
+    userID: Optional[str] = None  # alias accepted from n8n
+    url: str
+    id: Optional[str] = None
+    priority: str = "normal"
+    message: Optional[str] = None
+    trigger: Optional[str] = None
+    metadata: Optional[dict] = None
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/ella/guardian/next-audio?uid={uid}
+# iOS polls this. Returns and consumes next queued audio clip.
+# ---------------------------------------------------------------------------
+
+
+@router.get("/next-audio")
+async def next_audio(uid: str):
+    """Pop next audio clip from queue for the given user."""
+    if not uid or uid == "unknown":
+        return {"url": None}
+
+    pool = await _get_pool()
+
+    # Atomic pop: SELECT ... FOR UPDATE SKIP LOCKED + UPDATE in one query
+    row = await pool.fetchrow(
+        """
+        UPDATE guardian_queue
+        SET consumed_at = NOW()
+        WHERE id = (
+            SELECT id FROM guardian_queue
+            WHERE uid = $1 AND consumed_at IS NULL
+            ORDER BY
+                CASE priority
+                    WHEN urgent THEN 0
+                    WHEN normal THEN 1
+                    WHEN scheduled THEN 2
+                END,
+                created_at ASC
+            LIMIT 1
+            FOR UPDATE SKIP LOCKED
+        )
+        RETURNING id, url, priority, message, created_at
+        """,
+        uid,
+    )
+
+    if row is None:
+        return {"url": None}
+
+    return {
+        "url": row["url"],
+        "id": row["id"],
+        "priority": row["priority"],
+        "message": row["message"],
+        "created_at": row["created_at"].isoformat() if row["created_at"] else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/ella/guardian/enqueue
+# n8n calls this after TTS generation + audio upload.
+# Accepts JSON body (EnqueueRequest).
+# ---------------------------------------------------------------------------
+
+
+@router.post("/enqueue")
+async def enqueue(
+    req: EnqueueRequest,
+    x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
+    key: Optional[str] = Header(None, alias="X-Key"),
+):
+    """Enqueue an audio clip for a user."""
+    _verify_key(x_guardian_key, key)
+
+    uid = req.uid or req.userID
+    if not uid:
+        raise HTTPException(status_code=400, detail="uid (or userID) is required")
+
+    item_id = req.id or f"guardian_{uuid.uuid4().hex[:12]}"
+
+    # Serialize metadata to JSON string for the JSONB column
+    import json as _json
+    metadata_str = _json.dumps(req.metadata) if req.metadata else "{}"
+
+    pool = await _get_pool()
+    await pool.execute(
+        """
+        INSERT INTO guardian_queue (id, uid, url, priority, message, trigger_type, metadata)
+        VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+        ON CONFLICT (id) DO NOTHING
+        """,
+        item_id,
+        uid,
+        req.url,
+        req.priority,
+        req.message,
+        req.trigger,
+        metadata_str,
+    )
+
+    # Count pending items for this user
+    count = await pool.fetchval(
+        "SELECT COUNT(*) FROM guardian_queue WHERE uid = $1 AND consumed_at IS NULL",
+        uid,
+    )
+
+    return {"ok": True, "id": item_id, "queued": count}
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/ella/guardian/upload
+# n8n uploads TTS audio binary (multipart form).
+# ---------------------------------------------------------------------------
+
+
+@router.post("/upload")
+async def upload_audio(
+    file: UploadFile = File(...),
+    uid: str = Form(...),
+    filename: Optional[str] = Form(None),
+    x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
+    key: Optional[str] = Header(None, alias="X-Key"),
+):
+    """Upload an audio file and return its public URL."""
+    _verify_key(x_guardian_key, key)
+
+    # Create user directory
+    user_dir = os.path.join(AUDIO_BASE_DIR, uid)
+    os.makedirs(user_dir, exist_ok=True)
+
+    # Generate filename
+    ts = int(time.time())
+    fname = filename or f"{ts}-{uuid.uuid4().hex[:12]}.mp3"
+    filepath = os.path.join(user_dir, fname)
+
+    # Write file
+    content = await file.read()
+    with open(filepath, "wb") as f:
+        f.write(content)
+
+    public_url = f"{AUDIO_PUBLIC_URL}/{uid}/{fname}"
+
+    return {
+        "url": public_url,
+        "path": filepath,
+        "size_bytes": len(content),
+    }
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/ella/guardian/queue?uid={uid}
+# Debug / dashboard endpoint. Returns full queue without consuming.
+# ---------------------------------------------------------------------------
+
+
+@router.get("/queue")
+async def view_queue(uid: str):
+    """View pending queue items for a user (non-consuming read)."""
+    pool = await _get_pool()
+
+    rows = await pool.fetch(
+        """
+        SELECT id, url, priority, message, trigger_type, created_at
+        FROM guardian_queue
+        WHERE uid = $1 AND consumed_at IS NULL
+        ORDER BY
+            CASE priority
+                WHEN urgent THEN 0
+                WHEN normal THEN 1
+                WHEN scheduled THEN 2
+            END,
+            created_at ASC
+        """,
+        uid,
+    )
+
+    items = [
+        {
+            "id": r["id"],
+            "url": r["url"],
+            "priority": r["priority"],
+            "message": r["message"],
+            "trigger_type": r["trigger_type"],
+            "created_at": r["created_at"].isoformat() if r["created_at"] else None,
+        }
+        for r in rows
+    ]
+
+    return {"uid": uid, "count": len(items), "items": items}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -254,3 +254,4 @@ pycountry==24.6.1
 google-cloud-translate==3.20.2
 langdetect==1.0.9
 lc3py==1.1.3
+asyncpg==0.31.0


### PR DESCRIPTION
## Summary

- Add `guardian.py` router with 4 endpoints for Guardian Mode audio delivery
- Add `guardian_queue` postgres table for audio clip queue management
- Add Caddy `/audio/*` static file route for serving MP3 files
- Add audio cleanup cron (7-day TTL)
- Install asyncpg for async postgres access

## Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/v1/ella/guardian/next-audio?uid={uid}` | iOS polls, atomic pop with priority ordering |
| POST | `/v1/ella/guardian/enqueue` | n8n enqueues audio after TTS |
| POST | `/v1/ella/guardian/upload` | Upload MP3 binary, returns public URL |
| GET | `/v1/ella/guardian/queue?uid={uid}` | Debug/dashboard view |

## Test plan

- [x] Database connection and table existence verified
- [x] Empty queue returns `{"url": null}` 
- [x] Enqueue inserts correctly
- [x] Atomic pop works with priority ordering (urgent > normal > scheduled)
- [x] Queue empty after pop
- [x] 7/7 database-level tests passed
- [ ] Full endpoint integration test after deploy

## Related

- Parent: ellaaicare/ella-ai#102 (Guardian Mode PRD)
- Tracking: ellaaicare/ella-ai#113 (Phase 1A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)