### PR TITLE
feat(guardian): audio route tagging + on-device TTS (#424 Tasks 2-3, #425 Task 4)

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -248,6 +248,9 @@ extension FlutterError: Error {}
               }
           }
       }
+
+      // Report new route to backend so consolidator knows current echo risk
+      GuardianModeManager.shared.reportPlaybackEvent()
   }
 
   @objc private func handleApplicationDidBecomeActive(notification: Notification) {

--- a/app/ios/Runner/GuardianMode/GuardianModeManager.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModeManager.swift
@@ -231,6 +231,45 @@ class GuardianModeManager: NSObject {
         NSLog("GuardianMode: Health OK (depth: \(depth), rate: \(rate), injections: \(stats))")
     }
 
+    // MARK: - Playback Route Reporting
+
+    /// Fire-and-forget POST to backend recording the current audio output route.
+    /// Called on each audio injection and on route changes so backend knows echo risk.
+    func reportPlaybackEvent(durationMs: Int = 0) {
+        let session = AVAudioSession.sharedInstance()
+        guard let port = session.currentRoute.outputs.first else { return }
+
+        let portType = port.portType.rawValue
+        let portName = port.portName
+        let deviceUID = port.uid
+
+        let uid = UserDefaults.standard.string(forKey: "flutter.uid")
+                   ?? UserDefaults.standard.string(forKey: "uid")
+                   ?? "unknown"
+        guard uid != "unknown" else { return }
+
+        let backendURL = GuardianModePollingService.shared.backendURL
+        guard let url = URL(string: "\(backendURL)/v1/ella/guardian/playback-event") else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 3.0
+
+        let body: [String: Any] = [
+            "uid": uid,
+            "port_type": portType,
+            "port_name": portName,
+            "device_uid": deviceUID,
+            "duration_ms": durationMs
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: body) else { return }
+        request.httpBody = data
+
+        URLSession.shared.dataTask(with: request) { _, _, _ in }.resume()
+        NSLog("PLAYBACK_EVENT port=\(portType) device=\(portName.isEmpty ? "unknown" : portName) uid=\(uid)")
+    }
+
     // MARK: - Audio Injection with Pre-download + Retry
 
     /// Inject remote audio with pre-download and retry logic
@@ -242,6 +281,9 @@ class GuardianModeManager: NSObject {
             self.totalInjections += 1
             let seq = self.injectionSequence
             let filename = audioURL.lastPathComponent
+
+            // Report current output route to backend for echo risk tracking
+            self.reportPlaybackEvent()
 
             NSLog("INJECT_START #\(seq) (\(filename)) id=\(eventId) ts=\(Date().timeIntervalSince1970)")
 

--- a/app/ios/Runner/GuardianMode/GuardianModePollingService.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModePollingService.swift
@@ -1,7 +1,11 @@
 import Foundation
+import AVFoundation
 
 class GuardianModePollingService {
     static let shared = GuardianModePollingService()
+
+    // Strong reference — AVSpeechSynthesizer must outlive the speak call
+    private let speechSynthesizer = AVSpeechSynthesizer()
 
     private init() {}
 
@@ -136,6 +140,17 @@ class GuardianModePollingService {
         return nil
     }
 
+    // MARK: - On-Device TTS
+
+    private func speakText(_ text: String) {
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+        utterance.rate = 0.5
+        utterance.pitchMultiplier = 1.0
+        speechSynthesizer.speak(utterance)
+        NSLog("TTS_SPEAK: \(text.prefix(80))")
+    }
+
     // MARK: - Private Methods
 
     private func createPollTimer() {
@@ -169,11 +184,15 @@ class GuardianModePollingService {
                         message: result.message ?? "",
                         metadata: result.metadata?.dict ?? [:]
                     )
-                } else if let urlString = result.url,
+                } else if let urlString = result.url, !urlString.isEmpty,
                           let audioURL = URL(string: urlString) {
                     NSLog("POLL_RECEIVED(\(eventId)) ts=\(Date().timeIntervalSince1970)")
                     // Inject via GuardianModeManager (handles pre-download + retry)
                     GuardianModeManager.shared.injectRemoteAudio(audioURL: audioURL, eventId: eventId)
+                } else if let message = result.message, !message.isEmpty {
+                    // Text-only (consolidated) — use on-device TTS
+                    NSLog("POLL_TTS(\(eventId)) message=\(message.prefix(50))")
+                    speakText(message)
                 }
             }
         } catch {


### PR DESCRIPTION
## Summary

- **#424 Task 2** — `GuardianModeManager.reportPlaybackEvent()`: detects current `AVAudioSession` output port and POSTs `{port_type, port_name, device_uid, duration_ms}` to `/v1/ella/guardian/playback-event` (fire-and-forget). Called at the start of every `injectRemoteAudio()`.
- **#424 Task 3** — `AppDelegate.handleAudioSessionRouteChange`: calls `reportPlaybackEvent()` after each route change so backend echo risk stays fresh when user plugs/unplugs headphones mid-session.
- **#425 Task 4** — `GuardianModePollingService.executePoll()`: handles `url == ""` (text-only consolidated items) by speaking via `AVSpeechSynthesizer` (on-device TTS). Synthesizer held as an instance variable to avoid deallocation during speech.

## Test plan
- [ ] Build succeeds ✅
- [ ] Guardian audio injection → `PLAYBACK_EVENT port=Speaker` log appears on device
- [ ] Plug in headphones → route change fires → new `PLAYBACK_EVENT port=Headphones` log
- [ ] Backend `/playback-event` endpoint (from #424 Task 1) returns `{"echo_risk": "none"}` for headphones, `"high"` for Speaker
- [ ] Enqueue 3+ items → consolidator triggers → iOS speaks consolidated message via TTS (no audio URL)
- [ ] Normal audio items (url non-empty) still play via `GuardianModeManager` unchanged

Refs: ellaaicare/ella-ai#424, ellaaicare/ella-ai#425

🤖 Generated with [Claude Code](https://claude.com/claude-code)