### PR TITLE
fix(guardian): gate checks IS NULL instead of == OFF (#544)

### DIFF
--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -445,6 +445,28 @@ async def enqueue(
 
     item_id = req.id or f"guardian_{uuid.uuid4().hex[:12]}"
 
+    # --- guardian_mode gate: reject inserts when guardian is OFF (NULL) ---
+    if req.priority != "debug":
+        _pool = await _get_pool()
+        mode_row = await _pool.fetchrow(
+            "SELECT guardian_mode FROM users WHERE LOWER(omi_uid) = LOWER($1)",
+            uid,
+        )
+        guardian_mode = mode_row["guardian_mode"] if mode_row else None
+        if guardian_mode is None:
+            # NULL = guardian is off (iOS sends override:null → DB stores NULL via CHECK constraint)
+            _elapsed = int((time.time() - _start) * 1000)
+            print(
+                f"[FLOW:GUARDIAN-ENQUEUE] uid={uid} REJECTED guardian_mode=NULL latency={_elapsed}ms",
+                flush=True,
+            )
+            return {
+                "ok": False,
+                "rejected": True,
+                "reason": "guardian_mode is OFF (NULL)",
+                "suggestion": "Route critical alerts to iMessage instead",
+            }
+
     # Serialize metadata to JSON string for the JSONB column
     metadata_str = json.dumps(req.metadata) if req.metadata else "{}"
 


### PR DESCRIPTION
## Summary

- Adds guardian_mode gate to `enqueue()` in `ella/routers/guardian.py`
- Gate rejects enqueue when `guardian_mode IS NULL` (guardian is off)
- Fixes the bug from #541 where `== "OFF"` never matched — the DB stores NULL when guardian is off, not the string "OFF"
- Debug-priority requests bypass the gate

## Root Cause (from #542)

When iOS turns guardian OFF, it sends `{override: null, features: []}`.
The dashboard route computes `legacyMode = 'OFF'` and tries to write it,
but the `guardian_mode` CHECK constraint blocks `'OFF'`. The write fails
with a 500 error and the DB value stays NULL (or becomes NULL for new users).

The `#541` gate checked `(mode_row["guardian_mode"] or "").upper() == "OFF"` —
this never matched NULL, so enqueue was never blocked.

## Fix

```python
guardian_mode = mode_row["guardian_mode"] if mode_row else None
if guardian_mode is None:
    # NULL = guardian is off (iOS sends override:null → DB stores NULL via CHECK constraint)
    return {"ok": False, "rejected": True, "reason": "guardian_mode is OFF (NULL)", ...}
```

## Dashboard route.ts finding (Fix 2)

The route does NOT write empty string `""`. It writes the string `'OFF'`
which violates the DB CHECK constraint → 500 error → DB value stays NULL.
No change needed to route.ts per issue instructions.

## Verification

Greg's account has `guardian_mode = CUSTOM` — gate will NOT block his requests.
Users with `guardian_mode IS NULL` will have enqueue rejected correctly.

Closes #544. See also #542.