### PR TITLE
fix(ios): use x-openclaw-session-key header, drop user field in Pattern C (#543)

### DIFF
--- a/app/lib/ella/services/ella_chat_service.dart
+++ b/app/lib/ella/services/ella_chat_service.dart
@@ -266,6 +266,7 @@ Stream<ServerMessageChunk> sendEllaChatStream(String text) async* {
       headers: {
         'Authorization': 'Bearer ${endpoint.token}',
         'x-openclaw-scopes': 'operator.write',
+        if (endpoint.sessionKey.isNotEmpty) 'x-openclaw-session-key': endpoint.sessionKey,
         ..._ellaDebugHeaders(routeSource: 'pattern-c'),
       },
       body: jsonEncode({
@@ -274,7 +275,6 @@ Stream<ServerMessageChunk> sendEllaChatStream(String text) async* {
           {'role': 'user', 'content': text},
         ],
         'stream': true,
-        'user': endpoint.sessionKey,
       }),
     )) {
       if (line.trim().isEmpty || line.startsWith(':')) continue;

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.522+717
+version: 1.0.522+718
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- Adds `x-openclaw-session-key: {sessionKey}` header to Pattern C direct OpenClaw calls
- Removes `user: {sessionKey}` from the request body
- Mirrors the server-side `chat.py` fix (removing `user` field there) — same root cause, same fix

## Root cause
The OpenAI-compatible `user` field in the request body causes OpenClaw to create an `openai:{value}` session bucket. When `sessionKey` from resolve is used as the `user` field, it creates `openai:direct:ella:omi-...` — a different bucket than the canonical `direct:ella:omi-...` session used by n8n and identityLinks. When `user` was a random UUID (prior to resolve), it created `openai:UUID` — one new isolated session per app launch.

The correct approach (per OpenClaw docs) is `x-openclaw-session-key` header, not the `user` body field.

## Behaviour after fix
- Pattern C calls route to the same `direct:ella:omi-...` session as n8n enrichment
- No new `openai:` session buckets created
- iMessage ↔ iOS chat history now unified (both map to same session via identityLinks)

Closes: ellaaicare/ella-ai#543

🤖 Generated with [Claude Code](https://claude.com/claude-code)