### PR TITLE
[codex] Add Ella conversation data route for reprocessing

### DIFF
--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -17,6 +17,7 @@ Endpoints:
 - POST   /v1/ella/chat/stream                           - Stream chat response from Grok (xAI)
 NOTE: Caregiver CRUD endpoints moved to n8n (ella-ai-care repo). iOS calls n8n webhooks directly.
 - GET    /v1/ella/health                               - Health check
+- GET    /v1/ella/conversation/{id}/data               - Fetch conversation data with transcript (internal)
 """
 
 import hashlib
@@ -207,6 +208,78 @@ async def update_conversation_summary(
 
 
 # ============================================================================
+# Conversation Data Fetch (for reprocessing pipeline)
+# ============================================================================
+
+
+def _conversation_field(conversation, key: str, default=None):
+    if isinstance(conversation, dict):
+        return conversation.get(key, default)
+    return getattr(conversation, key, default)
+
+
+def _structured_field(structured, key: str):
+    if isinstance(structured, dict):
+        return structured.get(key)
+    return getattr(structured, key, None)
+
+
+@router.get("/conversation/{conversation_id}/data")
+async def get_conversation_data(
+    conversation_id: str,
+    uid: Optional[str] = None,
+):
+    """
+    Fetch conversation data used by the reprocessing pipeline when re-firing the
+    conversation-ready webhook. Internal endpoint; requires uid as query param.
+    """
+    if not uid:
+        raise HTTPException(status_code=400, detail="uid query parameter required")
+
+    try:
+        conversation = conversations_db.get_conversation(uid, conversation_id)
+    except Exception as e:
+        logging.error(f"Failed to fetch conversation {conversation_id}: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+    if conversation is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    segments = _conversation_field(conversation, "transcript_segments", []) or []
+    transcript_parts = []
+    for segment in segments:
+        if isinstance(segment, dict):
+            speaker = "User" if segment.get("is_user") else (segment.get("speaker") or "Other")
+            text = segment.get("text", "")
+        else:
+            speaker = "User" if getattr(segment, "is_user", False) else (getattr(segment, "speaker", None) or "Other")
+            text = getattr(segment, "text", "")
+        transcript_parts.append(f"{speaker}: {text}")
+
+    structured_src = _conversation_field(conversation, "structured", {}) or {}
+    structured = {}
+    if structured_src:
+        structured = {
+            "title": _structured_field(structured_src, "title"),
+            "overview": _structured_field(structured_src, "overview"),
+            "emoji": _structured_field(structured_src, "emoji"),
+            "category": _structured_field(structured_src, "category"),
+        }
+        if structured.get("category") and hasattr(structured["category"], "value"):
+            structured["category"] = structured["category"].value
+
+    return {
+        "conversation_id": conversation_id,
+        "uid": uid,
+        "transcript": "\n\n".join(transcript_parts),
+        "segment_count": len(segments),
+        "structured": structured,
+        "started_at": str(_conversation_field(conversation, "started_at", "")),
+        "finished_at": str(_conversation_field(conversation, "finished_at", "")),
+    }
+
+
+# ============================================================================
 # Endpoints
 # ============================================================================
 
@@ -227,6 +300,7 @@ async def ella_health():
             "/v1/ella/generate-dashboard-token",
             "# Caregiver CRUD: n8n.ella-ai-care.com/webhook/caregiver-*",
             "/v1/ella/chat/stream",
+            "/v1/ella/conversation/{id}/data",
             "/v1/ella/health",
         ],
     }

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -11,6 +11,7 @@ sys.modules.setdefault("database._client", MagicMock())
 sys.modules.setdefault("database.conversations", MagicMock())
 sys.modules.setdefault("database.memories", MagicMock())
 sys.modules.setdefault("database.users", MagicMock())
+sys.modules.setdefault("httpx", MagicMock())
 sys.modules.setdefault("utils.notifications", MagicMock())
 sys.modules.setdefault("utils.other.storage", MagicMock())
 sys.modules.setdefault("ella.config", MagicMock())
@@ -69,3 +70,55 @@ def test_update_conversation_summary_rejects_invalid_category():
 
     assert excinfo.value.status_code == 400
     assert "Invalid category" in excinfo.value.detail
+
+
+def test_get_conversation_data_returns_transcript_payload(monkeypatch):
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: {
+            "transcript_segments": [
+                {"is_user": True, "text": "Can you reprocess this?"},
+                {"speaker": "Other", "text": "Yes, with the full transcript."},
+            ],
+            "structured": {
+                "title": "Original title",
+                "overview": "Original overview",
+                "emoji": "🧠",
+                "category": callbacks.CategoryEnum.technology,
+            },
+            "started_at": "2026-04-10T10:00:00Z",
+            "finished_at": "2026-04-10T10:05:00Z",
+        },
+    )
+
+    result = asyncio.run(callbacks.get_conversation_data("conv-123", uid="user-123"))
+
+    assert result["conversation_id"] == "conv-123"
+    assert result["uid"] == "user-123"
+    assert result["segment_count"] == 2
+    assert result["transcript"] == "User: Can you reprocess this?\n\nOther: Yes, with the full transcript."
+    assert result["structured"]["title"] == "Original title"
+    assert result["structured"]["overview"] == "Original overview"
+    assert result["structured"]["emoji"] == "🧠"
+    assert result["structured"]["category"] == "technology"
+    assert result["started_at"] == "2026-04-10T10:00:00Z"
+    assert result["finished_at"] == "2026-04-10T10:05:00Z"
+
+
+def test_get_conversation_data_requires_uid():
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(callbacks.get_conversation_data("conv-123"))
+
+    assert excinfo.value.status_code == 400
+    assert "uid query parameter required" in excinfo.value.detail
+
+
+def test_get_conversation_data_404s_when_missing(monkeypatch):
+    monkeypatch.setattr(callbacks.conversations_db, "get_conversation", lambda uid, conversation_id: None)
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(callbacks.get_conversation_data("missing-conv", uid="user-123"))
+
+    assert excinfo.value.status_code == 404
+    assert "Conversation not found" in excinfo.value.detail


### PR DESCRIPTION
## Summary

Adds the OMI backend route needed by the Ella reprocessing pipeline to fetch transcript-bearing conversation data before re-firing the n8n `conversation-ready` webhook.

Changes:
- Added `GET /v1/ella/conversation/{conversation_id}/data`, requiring `uid` as a query parameter.
- Returns transcript text, segment count, structured summary fields, and start/finish timestamps.
- Added focused unit tests for happy path, missing UID, and missing conversation behavior.

Supports ellaaicare/ella-ai#579 and companion ella-ai PR #591.

## Validation

- `/Users/ellaai/.venvs/codex-py314/bin/python -m pytest backend/tests/unit/test_ella_callbacks_summary_update.py -q` -> `5 passed`
- `python3 -m py_compile backend/ella/routers/callbacks.py`
- `git diff --check -- backend/ella/routers/callbacks.py backend/tests/unit/test_ella_callbacks_summary_update.py`
