### PR TITLE
[codex] Speak cyborg scanner debug events

### DIFF
--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -73,6 +73,8 @@ _ECHO_RISK = {
     "USBAudio": "low",
 }
 
+SCANNER_DEBUG_TRIGGERS = {"scanner-l3-escalation", "scanner-l3-clear"}
+
 
 async def _get_pool() -> asyncpg.Pool:
     """Get or create the asyncpg connection pool."""
@@ -98,6 +100,47 @@ def _verify_key(
     provided = x_guardian_key or key
     if provided != GUARDIAN_WEBHOOK_KEY:
         raise HTTPException(status_code=403, detail="Invalid guardian key")
+
+
+def _is_cyborg_mode(guardian_mode: Optional[str]) -> bool:
+    return (guardian_mode or "").upper() == "CYBORG"
+
+
+def _cyborg_message_from_debug_event(req: "EnqueueRequest") -> str:
+    metadata = req.metadata or {}
+    summary = metadata.get("summary") if isinstance(metadata, dict) else None
+    category = metadata.get("category") if isinstance(metadata, dict) else None
+
+    if req.trigger == "scanner-l3-escalation":
+        if summary:
+            return f"I noticed: {summary}"
+        if category and category != "none":
+            return f"I noticed something in the {category} category."
+        return req.message or "I noticed something that may need your attention."
+
+    if req.trigger == "scanner-l3-clear":
+        if summary and summary != "none":
+            return f"I heard that. {summary}"
+        return "I heard that. No action needed."
+
+    return req.message or "I heard that."
+
+
+def _promote_cyborg_debug_event(req: "EnqueueRequest", guardian_mode: Optional[str]) -> bool:
+    """Convert scanner debug events into user-facing TTS canaries in CYBORG mode."""
+    if req.priority != "debug" or req.trigger not in SCANNER_DEBUG_TRIGGERS or not _is_cyborg_mode(guardian_mode):
+        return False
+
+    metadata = dict(req.metadata or {})
+    metadata["original_priority"] = req.priority
+    metadata["original_trigger"] = req.trigger
+    metadata["cyborg_promoted"] = True
+
+    req.message = _cyborg_message_from_debug_event(req)
+    req.priority = "normal"
+    req.trigger = f"cyborg-{req.trigger}"
+    req.metadata = metadata
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -445,14 +488,16 @@ async def enqueue(
 
     item_id = req.id or f"guardian_{uuid.uuid4().hex[:12]}"
 
+    pool = await _get_pool()
+    mode_row = await pool.fetchrow(
+        "SELECT guardian_mode FROM users WHERE LOWER(omi_uid) = LOWER($1)",
+        uid,
+    )
+    guardian_mode = mode_row["guardian_mode"] if mode_row else None
+    cyborg_promoted = _promote_cyborg_debug_event(req, guardian_mode)
+
     # --- guardian_mode gate: reject inserts when guardian is OFF (NULL) ---
     if req.priority != "debug":
-        _pool = await _get_pool()
-        mode_row = await _pool.fetchrow(
-            "SELECT guardian_mode FROM users WHERE LOWER(omi_uid) = LOWER($1)",
-            uid,
-        )
-        guardian_mode = mode_row["guardian_mode"] if mode_row else None
         if guardian_mode is None:
             # NULL = guardian is off (iOS sends override:null → DB stores NULL via CHECK constraint)
             _elapsed = int((time.time() - _start) * 1000)
@@ -470,7 +515,6 @@ async def enqueue(
     # Serialize metadata to JSON string for the JSONB column
     metadata_str = json.dumps(req.metadata) if req.metadata else "{}"
 
-    pool = await _get_pool()
     await pool.execute(
         """
         INSERT INTO guardian_queue (id, uid, url, priority, message, trigger_type, metadata)
@@ -493,7 +537,11 @@ async def enqueue(
     )
 
     _elapsed = int((time.time() - _start) * 1000)
-    print(f"[FLOW:GUARDIAN-ENQUEUE] uid={uid} id={item_id} priority={req.priority} trigger={req.trigger} queued={count} latency={_elapsed}ms", flush=True)
+    print(
+        f"[FLOW:GUARDIAN-ENQUEUE] uid={uid} id={item_id} priority={req.priority} "
+        f"trigger={req.trigger} queued={count} cyborg_promoted={cyborg_promoted} latency={_elapsed}ms",
+        flush=True,
+    )
 
     return {"ok": True, "id": item_id, "queued": count}
 

--- a/backend/tests/unit/test_guardian_cyborg_debug.py
+++ b/backend/tests/unit/test_guardian_cyborg_debug.py
@@ -1,0 +1,80 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+sys.modules.setdefault("asyncpg", MagicMock())
+sys.modules.setdefault("httpx", MagicMock())
+
+_backend_path = Path(__file__).resolve().parents[2]
+if str(_backend_path) not in sys.path:
+    sys.path.insert(0, str(_backend_path))
+
+resolve_module = types.ModuleType("ella.routers.resolve")
+resolve_module.resolve_user_routing = MagicMock()
+sys.modules.setdefault("ella.routers.resolve", resolve_module)
+
+_guardian_path = _backend_path / "ella" / "routers" / "guardian.py"
+_guardian_spec = importlib.util.spec_from_file_location("ella_guardian_test_module", _guardian_path)
+guardian = importlib.util.module_from_spec(_guardian_spec)
+assert _guardian_spec is not None and _guardian_spec.loader is not None
+_guardian_spec.loader.exec_module(guardian)
+
+
+def test_promotes_scanner_escalation_debug_event_in_cyborg_mode():
+    req = guardian.EnqueueRequest(
+        uid="uid-123",
+        url="",
+        priority="debug",
+        trigger="scanner-l3-escalation",
+        message="Scanner escalated: question -> agent",
+        metadata={"summary": "A direct question was detected.", "category": "question"},
+    )
+
+    promoted = guardian._promote_cyborg_debug_event(req, "CYBORG")
+
+    assert promoted is True
+    assert req.priority == "normal"
+    assert req.trigger == "cyborg-scanner-l3-escalation"
+    assert req.message == "I noticed: A direct question was detected."
+    assert req.metadata["original_priority"] == "debug"
+    assert req.metadata["original_trigger"] == "scanner-l3-escalation"
+    assert req.metadata["cyborg_promoted"] is True
+
+
+def test_promotes_scanner_clear_debug_event_in_cyborg_mode():
+    req = guardian.EnqueueRequest(
+        uid="uid-123",
+        url="",
+        priority="debug",
+        trigger="scanner-l3-clear",
+        message="Scanner: clear - none",
+        metadata={"summary": "none", "category": "none"},
+    )
+
+    promoted = guardian._promote_cyborg_debug_event(req, "CYBORG")
+
+    assert promoted is True
+    assert req.priority == "normal"
+    assert req.trigger == "cyborg-scanner-l3-clear"
+    assert req.message == "I heard that. No action needed."
+
+
+def test_keeps_scanner_debug_event_silent_outside_cyborg_mode():
+    req = guardian.EnqueueRequest(
+        uid="uid-123",
+        url="",
+        priority="debug",
+        trigger="scanner-l3-escalation",
+        message="Scanner escalated: question -> agent",
+        metadata={"summary": "A direct question was detected.", "category": "question"},
+    )
+
+    promoted = guardian._promote_cyborg_debug_event(req, "ACTIVE_SUPPORT")
+
+    assert promoted is False
+    assert req.priority == "debug"
+    assert req.trigger == "scanner-l3-escalation"
+    assert req.message == "Scanner escalated: question -> agent"


### PR DESCRIPTION
## Summary

Fixes the cyborg-mode guardian test path confirmed in ellaaicare/ella-ai#592.

In normal guardian modes, scanner `priority=debug` events remain debug-only and route to `DebugEventBuffer`. In `guardian_mode=CYBORG`, scanner debug events are promoted to user-facing `priority=normal` text-only guardian queue items, which uses the already-verified iOS on-device TTS fallback.

This preserves debug telemetry via metadata fields:
- `original_priority`
- `original_trigger`
- `cyborg_promoted=true`

## Validation

- `/Users/ellaai/.venvs/codex-py314/bin/python -m pytest backend/tests/unit/test_guardian_cyborg_debug.py -q` -> `3 passed`
- `python3 -m py_compile backend/ella/routers/guardian.py`
- `git diff --check -- backend/ella/routers/guardian.py backend/tests/unit/test_guardian_cyborg_debug.py`

## Live evidence

Before this patch, the user confirmed they heard a manually enqueued canary with `priority=normal`, `url=""`, and a non-empty `message`. The same device was silently consuming scanner-generated `priority=debug`, `url_len=0` events, which established that the remaining bug was priority/contract, not iOS polling or TTS.
