### PR TITLE
[codex] Align iOS guardian mode contracts

### DIFF
--- a/app/lib/ella/models/guardian_mode.dart
+++ b/app/lib/ella/models/guardian_mode.dart
@@ -7,6 +7,7 @@ enum GuardianModeKey {
   maximumAwareness,
   custom,
   cyborg,
+  chatbot,
   off,
   demo,
   memorySupport;
@@ -23,6 +24,8 @@ enum GuardianModeKey {
         return GuardianModeKey.custom;
       case 'CYBORG':
         return GuardianModeKey.cyborg;
+      case 'CHATBOT':
+        return GuardianModeKey.chatbot;
       case 'OFF':
         return GuardianModeKey.off;
       case 'DEMO':
@@ -46,6 +49,8 @@ enum GuardianModeKey {
         return 'CUSTOM';
       case GuardianModeKey.cyborg:
         return 'CYBORG';
+      case GuardianModeKey.chatbot:
+        return 'CHATBOT';
       case GuardianModeKey.off:
         return 'OFF';
       case GuardianModeKey.demo:
@@ -57,7 +62,10 @@ enum GuardianModeKey {
 
   /// Returns true if this key is an "Intelligence Mode" override (exclusive,
   /// replaces care system entirely).
-  bool get isOverride => this == GuardianModeKey.cyborg || this == GuardianModeKey.demo;
+  bool get isOverride =>
+      this == GuardianModeKey.cyborg ||
+      this == GuardianModeKey.chatbot ||
+      this == GuardianModeKey.demo;
 
   /// Returns true if this key is a composable "Care Feature" checkbox.
   bool get isCareFeature =>
@@ -107,7 +115,7 @@ class GuardianPreset {
 /// Two-tier guardian mode state: an optional exclusive override (Intelligence
 /// Mode) and a set of composable care features.
 class GuardianModeState {
-  /// Nullable — 'CYBORG' | 'DEMO' | null
+  /// Nullable — 'CYBORG' | 'CHATBOT' | 'DEMO' | null
   final String? override;
 
   /// List of active care feature keys e.g. ['ACTIVE_SUPPORT', 'MEMORY_SUPPORT']
@@ -123,11 +131,14 @@ class GuardianModeState {
       final rawFeatures = json['features'];
       return GuardianModeState(
         override: json['override'] as String?,
-        features: rawFeatures is List ? List<String>.from(rawFeatures) : const [],
+        features: rawFeatures is List
+            ? List<String>.from(rawFeatures)
+            : const [],
       );
     }
     // Legacy schema: {mode: 'ACTIVE_SUPPORT'}
-    final modeStr = json['mode'] as String? ?? json['currentMode'] as String? ?? '';
+    final modeStr =
+        json['mode'] as String? ?? json['currentMode'] as String? ?? '';
     final key = GuardianModeKey.fromString(modeStr);
     if (key.isOverride) {
       return GuardianModeState(override: key.toApiString());
@@ -138,10 +149,7 @@ class GuardianModeState {
     return GuardianModeState(features: [key.toApiString()]);
   }
 
-  Map<String, dynamic> toJson() => {
-        'override': override,
-        'features': features,
-      };
+  Map<String, dynamic> toJson() => {'override': override, 'features': features};
 }
 
 class GuardianModeInfo {
@@ -206,6 +214,8 @@ class GuardianModeInfo {
         return 'Custom';
       case GuardianModeKey.cyborg:
         return 'Cyborg';
+      case GuardianModeKey.chatbot:
+        return 'Chatbot';
       case GuardianModeKey.off:
         return 'Off';
       case GuardianModeKey.demo:
@@ -227,6 +237,8 @@ class GuardianModeInfo {
         return const Color(0xFF8B5CF6);
       case GuardianModeKey.cyborg:
         return const Color(0xFFEC4899);
+      case GuardianModeKey.chatbot:
+        return const Color(0xFFF97316);
       case GuardianModeKey.off:
         return const Color(0xFF6B7280);
       case GuardianModeKey.demo:

--- a/app/lib/ella/pages/guardian_mode_page.dart
+++ b/app/lib/ella/pages/guardian_mode_page.dart
@@ -19,7 +19,9 @@ class _GuardianModePageState extends State<GuardianModePage> {
   List<GuardianPreset> _allPresets = [];
 
   // Current saved state (from server).
-  GuardianModeState _currentState = const GuardianModeState(features: ['ACTIVE_SUPPORT']);
+  GuardianModeState _currentState = const GuardianModeState(
+    features: ['ACTIVE_SUPPORT'],
+  );
 
   // Pending selection state (user has made changes but not saved).
   String? _selectedOverride; // 'CYBORG' | 'DEMO' | null
@@ -73,9 +75,9 @@ class _GuardianModePageState extends State<GuardianModePage> {
   }
 
   GuardianModeState get _pendingState => GuardianModeState(
-        override: _selectedOverride,
-        features: _selectedOverride != null ? [] : _selectedFeatures.toList(),
-      );
+    override: _selectedOverride,
+    features: _selectedOverride != null ? [] : _selectedFeatures.toList(),
+  );
 
   bool get _hasChanges {
     final pending = _pendingState;
@@ -153,7 +155,10 @@ class _GuardianModePageState extends State<GuardianModePage> {
                 onPressed: () => Navigator.of(ctx).pop(false),
                 child: const Text(
                   'Cancel',
-                  style: TextStyle(fontSize: 16, color: EllaColors.textTertiary),
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: EllaColors.textTertiary,
+                  ),
                 ),
               ),
               TextButton(
@@ -194,6 +199,8 @@ class _GuardianModePageState extends State<GuardianModePage> {
     switch (key) {
       case 'CYBORG':
         return 'Cyborg';
+      case 'CHATBOT':
+        return 'Chatbot';
       case 'DEMO':
         return 'Demo';
       case 'EMERGENCY_ONLY':
@@ -212,7 +219,7 @@ class _GuardianModePageState extends State<GuardianModePage> {
   // ── Intelligence mode rows (exclusive radio) ──────────────────────────────
 
   List<String> get _overrideModes {
-    final modes = ['CYBORG'];
+    final modes = ['CYBORG', 'CHATBOT'];
     if (widget.showDemo) modes.add('DEMO');
     return modes;
   }
@@ -248,18 +255,26 @@ class _GuardianModePageState extends State<GuardianModePage> {
         centerTitle: false,
       ),
       body: _loading
-          ? const Center(child: CircularProgressIndicator(color: EllaColors.primary))
+          ? const Center(
+              child: CircularProgressIndicator(color: EllaColors.primary),
+            )
           : Column(
               children: [
                 Expanded(
                   child: ListView(
-                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 8,
+                    ),
                     children: [
                       const Padding(
                         padding: EdgeInsets.only(left: 4, bottom: 16),
                         child: Text(
                           'Choose how closely Ella monitors and supports your loved one.',
-                          style: TextStyle(fontSize: 16, color: EllaColors.textTertiary),
+                          style: TextStyle(
+                            fontSize: 16,
+                            color: EllaColors.textTertiary,
+                          ),
                         ),
                       ),
 
@@ -269,7 +284,10 @@ class _GuardianModePageState extends State<GuardianModePage> {
                         padding: EdgeInsets.only(left: 4, bottom: 10),
                         child: Text(
                           'Replaces the care system entirely.',
-                          style: TextStyle(fontSize: 13, color: EllaColors.textTertiary),
+                          style: TextStyle(
+                            fontSize: 13,
+                            color: EllaColors.textTertiary,
+                          ),
                         ),
                       ),
                       ..._overrideModes.map((key) {
@@ -297,24 +315,38 @@ class _GuardianModePageState extends State<GuardianModePage> {
                           onTap: () => Navigator.push(
                             context,
                             MaterialPageRoute(
-                                builder: (_) => const EllaDemoScenariosPage()),
+                              builder: (_) => const EllaDemoScenariosPage(),
+                            ),
                           ),
-                          borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+                          borderRadius: BorderRadius.circular(
+                            EllaSizes.radiusMedium,
+                          ),
                           child: Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 10),
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 4,
+                              vertical: 10,
+                            ),
                             child: Row(
                               children: [
-                                const Icon(Icons.list_alt,
-                                    color: EllaColors.primary, size: 20),
+                                const Icon(
+                                  Icons.list_alt,
+                                  color: EllaColors.primary,
+                                  size: 20,
+                                ),
                                 const SizedBox(width: 10),
                                 const Text(
                                   'View Demo Scenarios',
                                   style: TextStyle(
-                                      fontSize: 16, color: EllaColors.primary),
+                                    fontSize: 16,
+                                    color: EllaColors.primary,
+                                  ),
                                 ),
                                 const Spacer(),
-                                const Icon(Icons.chevron_right,
-                                    color: EllaColors.textTertiary, size: 20),
+                                const Icon(
+                                  Icons.chevron_right,
+                                  color: EllaColors.textTertiary,
+                                  size: 20,
+                                ),
                               ],
                             ),
                           ),
@@ -328,7 +360,10 @@ class _GuardianModePageState extends State<GuardianModePage> {
                         padding: EdgeInsets.only(left: 4, bottom: 10),
                         child: Text(
                           'Combine multiple features simultaneously.',
-                          style: TextStyle(fontSize: 13, color: EllaColors.textTertiary),
+                          style: TextStyle(
+                            fontSize: 13,
+                            color: EllaColors.textTertiary,
+                          ),
                         ),
                       ),
                       ..._careFeatureKeys.map((key) {
@@ -357,7 +392,9 @@ class _GuardianModePageState extends State<GuardianModePage> {
 
                       // ── Turn Guardian Off ──────────────────────────────────
                       _TurnOffButton(
-                        isOff: _selectedOverride == null && _selectedFeatures.isEmpty,
+                        isOff:
+                            _selectedOverride == null &&
+                            _selectedFeatures.isEmpty,
                         onTap: () {
                           setState(() {
                             _selectedOverride = null;
@@ -428,7 +465,9 @@ class _OverrideRow extends StatelessWidget {
           duration: const Duration(milliseconds: 180),
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
           decoration: BoxDecoration(
-            color: isSelected ? preset.color.withValues(alpha: 0.08) : EllaColors.bgSecondary,
+            color: isSelected
+                ? preset.color.withValues(alpha: 0.08)
+                : EllaColors.bgSecondary,
             borderRadius: BorderRadius.circular(EllaSizes.radiusLarge),
             border: Border.all(
               color: isSelected ? preset.color : Colors.transparent,
@@ -463,7 +502,9 @@ class _OverrideRow extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
-                        color: isSelected ? preset.color : EllaColors.textPrimary,
+                        color: isSelected
+                            ? preset.color
+                            : EllaColors.textPrimary,
                       ),
                     ),
                     if (preset.description.isNotEmpty)
@@ -535,9 +576,13 @@ class _FeatureRow extends StatelessWidget {
                 height: 20,
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(5),
-                  color: isChecked && !dimmed ? effectiveColor : Colors.transparent,
+                  color: isChecked && !dimmed
+                      ? effectiveColor
+                      : Colors.transparent,
                   border: Border.all(
-                    color: isChecked && !dimmed ? effectiveColor : EllaColors.bgTertiary,
+                    color: isChecked && !dimmed
+                        ? effectiveColor
+                        : EllaColors.bgTertiary,
                     width: 2,
                   ),
                 ),
@@ -555,7 +600,9 @@ class _FeatureRow extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
-                        color: isChecked && !dimmed ? effectiveColor : textColor,
+                        color: isChecked && !dimmed
+                            ? effectiveColor
+                            : textColor,
                       ),
                     ),
                     if (preset.description.isNotEmpty)

--- a/app/lib/ella/services/guardian_mode_api.dart
+++ b/app/lib/ella/services/guardian_mode_api.dart
@@ -25,10 +25,12 @@ Future<GuardianModeInfo?> getGuardianMode() async {
   final uid = _userId;
   if (uid.isEmpty) return null;
   try {
-    final response = await http.get(
-      Uri.parse('$_dashboardBase/api/users/$uid/guardian-mode'),
-      headers: {'Content-Type': 'application/json'},
-    ).timeout(const Duration(seconds: 10));
+    final response = await http
+        .get(
+          Uri.parse('$_dashboardBase/api/users/$uid/guardian-mode'),
+          headers: {'Content-Type': 'application/json'},
+        )
+        .timeout(const Duration(seconds: 10));
 
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body) as Map<String, dynamic>;
@@ -47,16 +49,18 @@ Future<GuardianModeInfo?> getGuardianMode() async {
 /// PUT /api/users/{userId}/guardian-mode
 ///
 /// Sends the new two-tier body:
-///   { "override": "CYBORG" | "DEMO" | null, "features": [...] }
+///   { "override": "CYBORG" | "CHATBOT" | "DEMO" | null, "features": [...] }
 Future<bool> setGuardianModeTwoTier(GuardianModeState state) async {
   final uid = _userId;
   if (uid.isEmpty) return false;
   try {
-    final response = await http.put(
-      Uri.parse('$_dashboardBase/api/users/$uid/guardian-mode'),
-      headers: {'Content-Type': 'application/json'},
-      body: jsonEncode(state.toJson()),
-    ).timeout(const Duration(seconds: 10));
+    final response = await http
+        .put(
+          Uri.parse('$_dashboardBase/api/users/$uid/guardian-mode'),
+          headers: {'Content-Type': 'application/json'},
+          body: jsonEncode(state.toJson()),
+        )
+        .timeout(const Duration(seconds: 10));
 
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body) as Map<String, dynamic>;
@@ -75,11 +79,13 @@ Future<bool> setGuardianMode(GuardianModeKey mode) async {
   final uid = _userId;
   if (uid.isEmpty) return false;
   try {
-    final response = await http.put(
-      Uri.parse('$_dashboardBase/api/users/$uid/guardian-mode'),
-      headers: {'Content-Type': 'application/json'},
-      body: jsonEncode({'mode': mode.toApiString()}),
-    ).timeout(const Duration(seconds: 10));
+    final response = await http
+        .put(
+          Uri.parse('$_dashboardBase/api/users/$uid/guardian-mode'),
+          headers: {'Content-Type': 'application/json'},
+          body: jsonEncode({'mode': mode.toApiString()}),
+        )
+        .timeout(const Duration(seconds: 10));
 
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body) as Map<String, dynamic>;
@@ -97,16 +103,20 @@ Future<bool> setGuardianMode(GuardianModeKey mode) async {
 Future<List<GuardianPreset>> getGuardianPresets() async {
   if (_cachedPresets != null) return _cachedPresets!;
   try {
-    final response = await http.get(
-      Uri.parse('$_dashboardBase/api/guardian/presets'),
-      headers: {'Content-Type': 'application/json'},
-    ).timeout(const Duration(seconds: 10));
+    final response = await http
+        .get(
+          Uri.parse('$_dashboardBase/api/guardian/presets'),
+          headers: {'Content-Type': 'application/json'},
+        )
+        .timeout(const Duration(seconds: 10));
 
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body) as Map<String, dynamic>;
       if (data['success'] == true) {
         final list = data['presets'] as List;
-        _cachedPresets = list.map((p) => GuardianPreset.fromJson(p as Map<String, dynamic>)).toList();
+        _cachedPresets = list
+            .map((p) => GuardianPreset.fromJson(p as Map<String, dynamic>))
+            .toList();
         return _cachedPresets!;
       }
     }
@@ -119,46 +129,80 @@ Future<List<GuardianPreset>> getGuardianPresets() async {
 
 /// Hard-coded fallback so the UI works even if the presets endpoint is down.
 List<GuardianPreset> _fallbackPresets() => [
-      GuardianPreset(
-        presetKey: 'EMERGENCY_ONLY',
-        name: 'Emergency Alerts',
-        description: 'Critical alerts only — fall detection, medical emergencies, fire/smoke.',
-        detailsBullets: ['Medical emergencies', 'Fall detection', 'Fire/smoke'],
-        color: const Color(0xFFF59E0B),
-      ),
-      GuardianPreset(
-        presetKey: 'ACTIVE_SUPPORT',
-        name: 'Active Support',
-        description: 'Emergency alerts + recall assistance + schedule reminders + pattern monitoring.',
-        detailsBullets: ['Medical emergencies', 'Wake words (always active)', 'Recall assistance'],
-        color: const Color(0xFF14B8A6),
-      ),
-      GuardianPreset(
-        presetKey: 'MAXIMUM_AWARENESS',
-        name: 'Maximum Awareness',
-        description: 'Maximum monitoring — all conversations and activities.',
-        detailsBullets: ['All emergency alerts', 'All conversations monitored', 'Full pattern tracking'],
-        color: const Color(0xFF6366F1),
-      ),
-      GuardianPreset(
-        presetKey: 'MEMORY_SUPPORT',
-        name: 'Memory Support',
-        description: 'Proactive memory cues and gentle recall assistance for cognitive support.',
-        detailsBullets: ['Memory cues', 'Daily routine reminders', 'Cognitive pattern monitoring'],
-        color: const Color(0xFF10B981),
-      ),
-      GuardianPreset(
-        presetKey: 'CYBORG',
-        name: 'Cyborg',
-        description: 'Continuous real-time audio response — every utterance gets an Ella reply in your ear.',
-        detailsBullets: ['All utterances processed', 'Real-time audio responses', 'Continuous conversation context'],
-        color: const Color(0xFFEC4899),
-      ),
-      GuardianPreset(
-        presetKey: 'DEMO',
-        name: 'Demo',
-        description: 'Demonstration mode with scripted responses for showcasing Ella.',
-        detailsBullets: ['Scripted demo responses', 'Showcase mode'],
-        color: const Color(0xFF3B82F6),
-      ),
-    ];
+  GuardianPreset(
+    presetKey: 'EMERGENCY_ONLY',
+    name: 'Emergency Alerts',
+    description:
+        'Critical alerts only — fall detection, medical emergencies, fire/smoke.',
+    detailsBullets: ['Medical emergencies', 'Fall detection', 'Fire/smoke'],
+    color: const Color(0xFFF59E0B),
+  ),
+  GuardianPreset(
+    presetKey: 'ACTIVE_SUPPORT',
+    name: 'Active Support',
+    description:
+        'Emergency alerts + recall assistance + schedule reminders + pattern monitoring.',
+    detailsBullets: [
+      'Medical emergencies',
+      'Wake words (always active)',
+      'Recall assistance',
+    ],
+    color: const Color(0xFF14B8A6),
+  ),
+  GuardianPreset(
+    presetKey: 'MAXIMUM_AWARENESS',
+    name: 'Maximum Awareness',
+    description:
+        'High-sensitivity care monitoring for risk, vulnerability, health, cognitive, emotional, and social support signals.',
+    detailsBullets: [
+      'Broad care monitoring',
+      'Lower alert thresholds',
+      'Helpful during outings or recovery',
+    ],
+    color: const Color(0xFF6366F1),
+  ),
+  GuardianPreset(
+    presetKey: 'MEMORY_SUPPORT',
+    name: 'Memory Support',
+    description:
+        'Proactive memory cues and gentle recall assistance for cognitive support.',
+    detailsBullets: [
+      'Memory cues',
+      'Daily routine reminders',
+      'Cognitive pattern monitoring',
+    ],
+    color: const Color(0xFF10B981),
+  ),
+  GuardianPreset(
+    presetKey: 'CYBORG',
+    name: 'Cyborg',
+    description:
+        'Experimental ambient intelligence — Ella listens broadly and speaks only when she can add useful context, coaching, memory, or insight.',
+    detailsBullets: [
+      'Ambient world enhancement',
+      'Useful companion asides',
+      'Experimental brain-enhancer mode',
+    ],
+    color: const Color(0xFFEC4899),
+  ),
+  GuardianPreset(
+    presetKey: 'CHATBOT',
+    name: 'Chatbot',
+    description:
+        'Full two-way voice conversation with Ella, focused on primary-speaker user utterances.',
+    detailsBullets: [
+      'Conversational replies',
+      'Suppresses media/background audio',
+      'Best for direct voice chat',
+    ],
+    color: const Color(0xFFF97316),
+  ),
+  GuardianPreset(
+    presetKey: 'DEMO',
+    name: 'Demo',
+    description:
+        'Demonstration mode with scripted responses for showcasing Ella.',
+    detailsBullets: ['Scripted demo responses', 'Showcase mode'],
+    color: const Color(0xFF3B82F6),
+  ),
+];


### PR DESCRIPTION
## Summary
- Adds CHATBOT as an iOS guardian override mode.
- Updates fallback guardian preset copy for CYBORG and Maximum Awareness to match the corrected mode contracts.
- Shows Chatbot alongside Cyborg in the iOS Intelligence Mode list.

## Why
The app fallback state and mode picker were behind the intended product model. CYBORG should be described as ambient intelligence / brain enhancement, Maximum Awareness should be care-monitoring focused, and Chatbot should be available as a distinct direct-conversation mode.

## Validation
- Ran `dart format` on the changed Dart files.
- Ran `git diff --check` on the changed Dart files.
- OMI pre-commit hooks passed during commit.
