### PR TITLE
[codex] sanitize Ella summary writebacks

### DIFF
--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -43,6 +43,7 @@ from models.conversation import CategoryEnum
 
 from database.ella_contacts import create_contact, delete_contact, get_contact, get_contacts, update_contact
 from ella.config import ELLA_CONFIG
+from ella.services.summary_sanitizer import SummarySanitizationError, sanitize_summary_update
 from utils.notifications import send_notification
 from utils.other.storage import storage_client
 
@@ -170,20 +171,33 @@ async def update_conversation_summary(
     if not uid:
         raise HTTPException(status_code=400, detail="uid query parameter required")
 
+    try:
+        sanitized_update = sanitize_summary_update(
+            title=update.title,
+            overview=update.overview,
+            emoji=update.emoji,
+            category=update.category,
+        )
+    except SummarySanitizationError as e:
+        raise HTTPException(
+            status_code=422,
+            detail={"message": "Unsafe conversation summary", "violations": e.violations},
+        )
+
     # Build Firestore dot-notation update dict
     update_data = {}
-    if update.title is not None:
-        update_data["structured.title"] = update.title
-    if update.overview is not None:
-        update_data["structured.overview"] = update.overview
-    if update.emoji is not None:
-        update_data["structured.emoji"] = update.emoji
-    if update.category is not None:
+    if sanitized_update.title is not None:
+        update_data["structured.title"] = sanitized_update.title
+    if sanitized_update.overview is not None:
+        update_data["structured.overview"] = sanitized_update.overview
+    if sanitized_update.emoji is not None:
+        update_data["structured.emoji"] = sanitized_update.emoji
+    if sanitized_update.category is not None:
         try:
-            CategoryEnum(update.category)
+            CategoryEnum(sanitized_update.category)
         except ValueError:
-            raise HTTPException(status_code=400, detail=f"Invalid category: '{update.category}'")
-        update_data["structured.category"] = update.category
+            raise HTTPException(status_code=400, detail=f"Invalid category: '{sanitized_update.category}'")
+        update_data["structured.category"] = sanitized_update.category
 
     # Keep this internal callback in parity with the MCP tool path so the app
     # will surface the refreshed structured overview instead of stale app output.
@@ -204,6 +218,7 @@ async def update_conversation_summary(
         "status": "ok",
         "conversation_id": conversation_id,
         "updated_fields": list(update_data.keys()),
+        "sanitizer_warnings": sanitized_update.warnings,
     }
 
 

--- a/backend/ella/services/summary_sanitizer.py
+++ b/backend/ella/services/summary_sanitizer.py
@@ -1,0 +1,127 @@
+"""Guards for Ella conversation summary write-back."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+ELLA_PREFIX = "[Ella] "
+MIN_OVERVIEW_CHARS = 40
+
+_RAW_SCANNER_COUNT_RE = re.compile(
+    r"\b(?:scanner\s+)?(?:picked\s+up|reported|flagged|found|detected)?\s*\d+\s+"
+    r"(?:escalations?|events?|detections?|flags?|segments?)\b",
+    re.IGNORECASE,
+)
+_RAW_SCANNER_CATEGORY_RE = re.compile(
+    r"\b(?:categories?|category\s+hits?|signals?)\s*[:=]\s*[a-z][a-z\s,/+-]*(?:,\s*[a-z][a-z\s/+-]*){2,}",
+    re.IGNORECASE,
+)
+_INTERNAL_JARGON_RE = re.compile(
+    r"\b(?:qmd|write-?back|routing|model[_ -]?runner|tool\s+(?:call|error|trace)|"
+    r"metadata/conversations|scanner[_ -]?logs?|observer[_ -]?logs?|openclaw\s+workspace|mcp|n8n)\b",
+    re.IGNORECASE,
+)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+class SummarySanitizationError(ValueError):
+    """Raised when a candidate summary is not safe to write to user-facing fields."""
+
+    def __init__(self, violations: list[str]):
+        self.violations = violations
+        super().__init__("; ".join(violations))
+
+
+@dataclass(frozen=True)
+class SanitizedSummary:
+    title: Optional[str] = None
+    overview: Optional[str] = None
+    emoji: Optional[str] = None
+    category: Optional[str] = None
+    warnings: list[str] = field(default_factory=list)
+
+
+def sanitize_summary_update(
+    *,
+    title: Optional[str] = None,
+    overview: Optional[str] = None,
+    emoji: Optional[str] = None,
+    category: Optional[str] = None,
+) -> SanitizedSummary:
+    """Validate and normalize fields before writing an Ella summary to Firestore."""
+    warnings: list[str] = []
+    cleaned_overview = None
+
+    if overview is not None:
+        cleaned_overview = _sanitize_overview(overview, warnings)
+
+    return SanitizedSummary(
+        title=_clean_optional_text(title),
+        overview=cleaned_overview,
+        emoji=_clean_optional_text(emoji),
+        category=_clean_optional_text(category),
+        warnings=warnings,
+    )
+
+
+def _sanitize_overview(overview: str, warnings: list[str]) -> str:
+    candidate = _normalize_text(overview)
+    violations: list[str] = []
+
+    if not candidate:
+        violations.append("overview is empty")
+    elif len(candidate) < MIN_OVERVIEW_CHARS:
+        violations.append("overview is too short to replace an existing summary")
+
+    if candidate and not candidate.startswith(ELLA_PREFIX):
+        candidate = f"{ELLA_PREFIX}{candidate}"
+        warnings.append("overview_missing_ella_prefix")
+
+    candidate = _remove_raw_scanner_audit_sentences(candidate, warnings)
+
+    if _RAW_SCANNER_COUNT_RE.search(candidate):
+        violations.append("overview contains raw scanner counts")
+    if _RAW_SCANNER_CATEGORY_RE.search(candidate):
+        violations.append("overview contains raw scanner category lists")
+    if _INTERNAL_JARGON_RE.search(candidate):
+        violations.append("overview contains internal debug or routing jargon")
+    if candidate and not candidate.startswith(ELLA_PREFIX):
+        violations.append("overview must start with [Ella] prefix")
+    if len(candidate) < MIN_OVERVIEW_CHARS:
+        violations.append("overview is too short after sanitization")
+
+    if violations:
+        raise SummarySanitizationError(sorted(set(violations)))
+
+    return candidate
+
+
+def _remove_raw_scanner_audit_sentences(candidate: str, warnings: list[str]) -> str:
+    sentences = re.split(r"(?<=[.!?])\s+", candidate)
+    kept: list[str] = []
+    removed = False
+
+    for sentence in sentences:
+        if _RAW_SCANNER_COUNT_RE.search(sentence) or _RAW_SCANNER_CATEGORY_RE.search(sentence):
+            removed = True
+            continue
+        kept.append(sentence)
+
+    if not removed:
+        return candidate
+
+    warnings.append("removed_raw_scanner_audit")
+    return _normalize_text(" ".join(kept))
+
+
+def _clean_optional_text(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    return _normalize_text(value)
+
+
+def _normalize_text(value: str) -> str:
+    return _WHITESPACE_RE.sub(" ", value).strip()

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel
 import database.memories as memories_db
 import database.conversations as conversations_db
 import database.mcp_api_key as mcp_api_key_db
+from ella.services.summary_sanitizer import SummarySanitizationError, sanitize_summary_update
 from models.memories import MemoryDB, Memory, MemoryCategory
 from models.conversation import CategoryEnum
 from utils.llm.memories import identify_category_for_memory
@@ -310,21 +311,31 @@ def execute_tool(user_id: str, tool_name: str, arguments: dict) -> dict:
         if not conversation:
             raise ToolExecutionError("Conversation not found", code=-32001)
 
+        try:
+            sanitized_update = sanitize_summary_update(
+                title=arguments.get("title") if "title" in arguments else None,
+                overview=arguments.get("overview") if "overview" in arguments else None,
+                emoji=arguments.get("emoji") if "emoji" in arguments else None,
+                category=arguments.get("category") if "category" in arguments else None,
+            )
+        except SummarySanitizationError as e:
+            raise ToolExecutionError(f"Unsafe conversation summary: {', '.join(e.violations)}", code=-32602)
+
         # Build update dict with dot-notation for Firestore nested fields
         update_data = {}
         if "title" in arguments:
-            update_data["structured.title"] = arguments["title"]
+            update_data["structured.title"] = sanitized_update.title
         if "overview" in arguments:
-            update_data["structured.overview"] = arguments["overview"]
+            update_data["structured.overview"] = sanitized_update.overview
         if "emoji" in arguments:
-            update_data["structured.emoji"] = arguments["emoji"]
+            update_data["structured.emoji"] = sanitized_update.emoji
         if "category" in arguments:
             # Validate category
             try:
-                CategoryEnum(arguments["category"])
+                CategoryEnum(sanitized_update.category)
             except ValueError:
-                raise ToolExecutionError(f"Invalid category: '{arguments['category']}'", code=-32602)
-            update_data["structured.category"] = arguments["category"]
+                raise ToolExecutionError(f"Invalid category: '{sanitized_update.category}'", code=-32602)
+            update_data["structured.category"] = sanitized_update.category
 
         if not update_data:
             raise ToolExecutionError("At least one field (title, overview, emoji, category) must be provided")
@@ -340,7 +351,11 @@ def execute_tool(user_id: str, tool_name: str, arguments: dict) -> dict:
 
         conversations_db.update_conversation(user_id, conversation_id, update_data)
 
-        return {"success": True, "updated_fields": list(update_data.keys())}
+        return {
+            "success": True,
+            "updated_fields": list(update_data.keys()),
+            "sanitizer_warnings": sanitized_update.warnings,
+        }
 
     else:
         raise ToolExecutionError(f"Unknown tool: {tool_name}", code=-32601)

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -17,6 +17,10 @@ sys.modules.setdefault("utils.other.storage", MagicMock())
 sys.modules.setdefault("ella.config", MagicMock())
 sys.modules.setdefault("database.ella_contacts", MagicMock())
 
+_backend_path = Path(__file__).resolve().parents[2]
+if str(_backend_path) not in sys.path:
+    sys.path.insert(0, str(_backend_path))
+
 _callbacks_path = Path(__file__).resolve().parents[2] / "ella" / "routers" / "callbacks.py"
 _callbacks_spec = importlib.util.spec_from_file_location("ella_callbacks_test_module", _callbacks_path)
 callbacks = importlib.util.module_from_spec(_callbacks_spec)
@@ -39,7 +43,7 @@ def test_update_conversation_summary_clears_stale_app_results(monkeypatch):
             "conv-123",
             callbacks.ConversationSummaryUpdate(
                 title="Updated title",
-                overview="[Ella] Updated overview",
+                overview="[Ella] Updated overview with enough context to safely replace the prior summary.",
                 emoji="🧠",
                 category="personal",
             ),
@@ -51,11 +55,85 @@ def test_update_conversation_summary_clears_stale_app_results(monkeypatch):
     assert captured["uid"] == "user-123"
     assert captured["conversation_id"] == "conv-123"
     assert captured["update_data"]["structured.title"] == "Updated title"
-    assert captured["update_data"]["structured.overview"] == "[Ella] Updated overview"
+    assert (
+        captured["update_data"]["structured.overview"]
+        == "[Ella] Updated overview with enough context to safely replace the prior summary."
+    )
     assert captured["update_data"]["structured.emoji"] == "🧠"
     assert captured["update_data"]["structured.category"] == "personal"
     assert captured["update_data"]["apps_results"] == []
     assert captured["update_data"]["plugins_results"] == []
+    assert result["sanitizer_warnings"] == []
+
+
+def test_update_conversation_summary_adds_missing_ella_prefix(monkeypatch):
+    captured = {}
+
+    def fake_update_conversation(uid, conversation_id, update_data):
+        captured["update_data"] = update_data
+
+    monkeypatch.setattr(callbacks.conversations_db, "update_conversation", fake_update_conversation)
+
+    result = asyncio.run(
+        callbacks.update_conversation_summary(
+            "conv-123",
+            callbacks.ConversationSummaryUpdate(
+                overview="Updated overview with enough useful context to safely replace the prior summary.",
+            ),
+            uid="user-123",
+        )
+    )
+
+    assert captured["update_data"]["structured.overview"].startswith("[Ella] ")
+    assert result["sanitizer_warnings"] == ["overview_missing_ella_prefix"]
+
+
+def test_update_conversation_summary_removes_raw_scanner_audit_sentence(monkeypatch):
+    captured = {}
+
+    def fake_update_conversation(uid, conversation_id, update_data):
+        captured["update_data"] = update_data
+
+    monkeypatch.setattr(callbacks.conversations_db, "update_conversation", fake_update_conversation)
+
+    result = asyncio.run(
+        callbacks.update_conversation_summary(
+            "conv-123",
+            callbacks.ConversationSummaryUpdate(
+                overview=(
+                    "[Ella] The conversation centered on testing Omi device reliability, privacy, and caregiver "
+                    "alert behavior while nearby media played in the background. "
+                    "Scanner picked up 416 escalations across cognitive, emotional, health, and media categories."
+                ),
+            ),
+            uid="user-123",
+        )
+    )
+
+    assert "416 escalations" not in captured["update_data"]["structured.overview"]
+    assert result["sanitizer_warnings"] == ["removed_raw_scanner_audit"]
+
+
+def test_update_conversation_summary_rejects_internal_debug_jargon(monkeypatch):
+    monkeypatch.setattr(callbacks.conversations_db, "update_conversation", MagicMock())
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(
+            callbacks.update_conversation_summary(
+                "conv-123",
+                callbacks.ConversationSummaryUpdate(
+                    overview=(
+                        "[Ella] The transcript mostly covered device testing and family conversation. "
+                        "The n8n write-back routing selected a model_runner retry."
+                    ),
+                ),
+                uid="user-123",
+            )
+        )
+
+    assert excinfo.value.status_code == 422
+    assert any("internal debug or routing jargon" in violation for violation in excinfo.value.detail["violations"])
+    callbacks.conversations_db.update_conversation.assert_not_called()
 
 
 def test_update_conversation_summary_rejects_invalid_category():

--- a/backend/tests/unit/test_mcp_summary_sanitizer.py
+++ b/backend/tests/unit/test_mcp_summary_sanitizer.py
@@ -1,0 +1,88 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_backend_path = Path(__file__).resolve().parents[2]
+if str(_backend_path) not in sys.path:
+    sys.path.insert(0, str(_backend_path))
+
+sys.modules.setdefault("database._client", MagicMock())
+sys.modules.setdefault("database.memories", MagicMock())
+sys.modules.setdefault("database.conversations", MagicMock())
+sys.modules.setdefault("database.mcp_api_key", MagicMock())
+
+_llm_memories = types.ModuleType("utils.llm.memories")
+_llm_memories.identify_category_for_memory = MagicMock()
+sys.modules.setdefault("utils.llm.memories", _llm_memories)
+
+_mcp_path = _backend_path / "routers" / "mcp_sse.py"
+_mcp_spec = importlib.util.spec_from_file_location("mcp_sse_test_module", _mcp_path)
+mcp_sse = importlib.util.module_from_spec(_mcp_spec)
+assert _mcp_spec is not None and _mcp_spec.loader is not None
+_mcp_spec.loader.exec_module(mcp_sse)
+
+
+def test_update_conversation_summary_mcp_sanitizes_before_write(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        mcp_sse.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: {"id": conversation_id},
+    )
+
+    def fake_update_conversation(uid, conversation_id, update_data):
+        captured["uid"] = uid
+        captured["conversation_id"] = conversation_id
+        captured["update_data"] = update_data
+
+    monkeypatch.setattr(mcp_sse.conversations_db, "update_conversation", fake_update_conversation)
+
+    result = mcp_sse.execute_tool(
+        "user-123",
+        "update_conversation_summary",
+        {
+            "conversation_id": "conv-123",
+            "overview": "Useful ambient summary with enough detail to safely replace the prior text.",
+            "category": "technology",
+        },
+    )
+
+    assert result["success"] is True
+    assert result["sanitizer_warnings"] == ["overview_missing_ella_prefix"]
+    assert captured["uid"] == "user-123"
+    assert captured["conversation_id"] == "conv-123"
+    assert captured["update_data"]["structured.overview"].startswith("[Ella] ")
+    assert captured["update_data"]["structured.category"] == "technology"
+    assert captured["update_data"]["apps_results"] == []
+    assert captured["update_data"]["plugins_results"] == []
+
+
+def test_update_conversation_summary_mcp_rejects_debug_jargon(monkeypatch):
+    monkeypatch.setattr(
+        mcp_sse.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: {"id": conversation_id},
+    )
+    monkeypatch.setattr(mcp_sse.conversations_db, "update_conversation", MagicMock())
+
+    with pytest.raises(mcp_sse.ToolExecutionError) as excinfo:
+        mcp_sse.execute_tool(
+            "user-123",
+            "update_conversation_summary",
+            {
+                "conversation_id": "conv-123",
+                "overview": (
+                    "[Ella] The transcript mostly covered device testing and family conversation. "
+                    "The qmd routing trace selected a write-back retry."
+                ),
+            },
+        )
+
+    assert excinfo.value.code == -32602
+    assert "Unsafe conversation summary" in excinfo.value.message
+    mcp_sse.conversations_db.update_conversation.assert_not_called()


### PR DESCRIPTION
## Summary
- Add a shared Ella summary write-back sanitizer for user-facing structured summaries.
- Apply it to both the n8n callback route and the MCP `update_conversation_summary` tool route.
- Auto-repair safe issues like a missing `[Ella] ` prefix or an obvious raw scanner-audit sentence, while rejecting internal debug/routing/model/tool leakage before it can overwrite Firestore.

## Why
The live canary for ellaaicare/ella-ai#604 showed one reprocessed summary leaking scanner metadata into the user-facing overview. This adds a backend guardrail at the final write-back boundary so future Observer/model regressions fail closed instead of degrading the iOS summary.

## Validation
- `python3 -m py_compile backend/ella/services/summary_sanitizer.py backend/ella/routers/callbacks.py backend/routers/mcp_sse.py backend/tests/unit/test_ella_callbacks_summary_update.py backend/tests/unit/test_mcp_summary_sanitizer.py`
- `/tmp/omi-pytest-venv/bin/python -m pytest backend/tests/unit/test_ella_callbacks_summary_update.py backend/tests/unit/test_mcp_summary_sanitizer.py -q`

Refs ellaaicare/ella-ai#604
