### PR TITLE
Show Observer debug metadata in Ella app

### DIFF
--- a/app/lib/ella/pages/debug_event_log_page.dart
+++ b/app/lib/ella/pages/debug_event_log_page.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:omi/ella/services/debug_event_buffer.dart';
+import 'package:omi/ella/services/debug_metadata_api.dart';
 
 class DebugEventLogPage extends StatefulWidget {
   const DebugEventLogPage({super.key});
@@ -12,12 +13,16 @@ class DebugEventLogPage extends StatefulWidget {
 
 class _DebugEventLogPageState extends State<DebugEventLogPage> {
   final _buffer = DebugEventBuffer.instance;
+  List<DebugMetadataItem> _metadataItems = [];
+  DebugMetadataItem? _selectedMetadata;
+  bool _loadingMetadata = false;
 
   @override
   void initState() {
     super.initState();
     _buffer.addListener(_onUpdate);
     _buffer.refresh();
+    _refreshMetadata();
   }
 
   @override
@@ -28,58 +33,158 @@ class _DebugEventLogPageState extends State<DebugEventLogPage> {
 
   void _onUpdate() => setState(() {});
 
+  Future<void> _refreshAll() async {
+    await Future.wait([_buffer.refresh(), _refreshMetadata()]);
+  }
+
+  Future<void> _refreshMetadata() async {
+    setState(() => _loadingMetadata = true);
+    final items = await fetchRecentDebugMetadata();
+    if (!mounted) return;
+    setState(() {
+      _metadataItems = items;
+      _selectedMetadata = items.isNotEmpty ? items.first : null;
+      _loadingMetadata = false;
+    });
+  }
+
+  Future<void> _loadMetadataForEvent(DebugEvent event) async {
+    final conversationId = event.metadata['conversation_id'] as String? ?? '';
+    if (conversationId.isEmpty) return;
+
+    setState(() => _loadingMetadata = true);
+    final item = await fetchDebugMetadata(conversationId);
+    if (!mounted) return;
+    setState(() {
+      if (item != null) {
+        _selectedMetadata = item;
+        final withoutDuplicate = _metadataItems.where((m) => m.conversationId != item.conversationId).toList();
+        _metadataItems = [item, ...withoutDuplicate];
+      }
+      _loadingMetadata = false;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final events = _buffer.events;
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Debug Event Log'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.refresh),
-            onPressed: _buffer.refresh,
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Debug Event Log'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Live Events'),
+              Tab(text: 'Metadata'),
+            ],
           ),
-          IconButton(
-            icon: const Icon(Icons.delete_outline),
-            onPressed: () async {
-              await _buffer.clear();
-            },
-          ),
-        ],
-      ),
-      body: events.isEmpty
-          ? const Center(
-              child: Text(
-                'No debug events yet.\nWaiting for scanner activity...',
-                textAlign: TextAlign.center,
-              ),
-            )
-          : ListView.builder(
-              itemCount: events.length,
-              itemBuilder: (context, i) {
-                final e = events[i];
-                return ExpansionTile(
-                  leading: Text(
-                    _emoji(e.triggerType),
-                    style: const TextStyle(fontSize: 20),
-                  ),
-                  title: Text(e.message, style: const TextStyle(fontSize: 13)),
-                  subtitle: Text(
-                    '${e.triggerType}  ·  ${_formatTime(e.receivedAt)}',
-                    style: TextStyle(fontSize: 11, color: Colors.grey[600]),
-                  ),
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                      child: SelectableText(
-                        const JsonEncoder.withIndent('  ').convert(e.metadata),
-                        style: const TextStyle(fontFamily: 'monospace', fontSize: 11),
-                      ),
-                    ),
-                  ],
-                );
+          actions: [
+            IconButton(icon: const Icon(Icons.refresh), onPressed: _refreshAll),
+            IconButton(
+              icon: const Icon(Icons.delete_outline),
+              onPressed: () async {
+                await _buffer.clear();
               },
             ),
+          ],
+        ),
+        body: TabBarView(children: [_buildEventsTab(events), _buildMetadataTab()]),
+      ),
+    );
+  }
+
+  Widget _buildEventsTab(List<DebugEvent> events) {
+    if (events.isEmpty) {
+      return const Center(
+        child: Text(
+          'No live debug events yet.\nCheck Metadata for persisted Observer sidecars.',
+          textAlign: TextAlign.center,
+        ),
+      );
+    }
+
+    return ListView.builder(
+      itemCount: events.length,
+      itemBuilder: (context, i) {
+        final e = events[i];
+        final conversationId = e.metadata['conversation_id'] as String? ?? '';
+        return ExpansionTile(
+          leading: Text(_emoji(e.triggerType), style: const TextStyle(fontSize: 20)),
+          title: Text(e.message, style: const TextStyle(fontSize: 13)),
+          subtitle: Text(
+            '${e.triggerType}  ·  ${_formatTime(e.receivedAt)}',
+            style: TextStyle(fontSize: 11, color: Colors.grey[600]),
+          ),
+          children: [
+            if (conversationId.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton.icon(
+                    onPressed: _loadingMetadata ? null : () => _loadMetadataForEvent(e),
+                    icon: const Icon(Icons.data_object, size: 16),
+                    label: Text('Load sidecar metadata for $conversationId'),
+                  ),
+                ),
+              ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: SelectableText(
+                const JsonEncoder.withIndent('  ').convert(e.metadata),
+                style: const TextStyle(fontFamily: 'monospace', fontSize: 11),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildMetadataTab() {
+    if (_loadingMetadata && _metadataItems.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_metadataItems.isEmpty) {
+      return const Center(child: Text('No Observer sidecar metadata found yet.', textAlign: TextAlign.center));
+    }
+
+    return Column(
+      children: [
+        Expanded(
+          flex: 2,
+          child: ListView.builder(
+            itemCount: _metadataItems.length,
+            itemBuilder: (context, i) {
+              final item = _metadataItems[i];
+              final selected = item.conversationId == _selectedMetadata?.conversationId;
+              return ListTile(
+                selected: selected,
+                dense: true,
+                leading: const Icon(Icons.data_object, size: 20),
+                title: Text(item.conversationId, style: const TextStyle(fontSize: 13)),
+                subtitle: Text(
+                  '${item.path}  ·  ${item.lastModified != null ? _formatTime(item.lastModified!) : 'unknown'}',
+                  style: TextStyle(fontSize: 11, color: Colors.grey[600]),
+                ),
+                onTap: () => setState(() => _selectedMetadata = item),
+              );
+            },
+          ),
+        ),
+        const Divider(height: 1),
+        Expanded(
+          flex: 3,
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: SelectableText(
+              const JsonEncoder.withIndent('  ').convert(_selectedMetadata?.metadata ?? {}),
+              style: const TextStyle(fontFamily: 'monospace', fontSize: 11),
+            ),
+          ),
+        ),
+      ],
     );
   }
 

--- a/app/lib/ella/services/debug_metadata_api.dart
+++ b/app/lib/ella/services/debug_metadata_api.dart
@@ -1,0 +1,71 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:omi/backend/http/shared.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/env/env.dart';
+
+class DebugMetadataItem {
+  final String conversationId;
+  final DateTime? lastModified;
+  final String path;
+  final int size;
+  final Map<String, dynamic> metadata;
+
+  const DebugMetadataItem({
+    required this.conversationId,
+    required this.lastModified,
+    required this.path,
+    required this.size,
+    required this.metadata,
+  });
+
+  factory DebugMetadataItem.fromMap(Map<String, dynamic> map) {
+    return DebugMetadataItem(
+      conversationId: map['conversation_id'] as String? ?? '',
+      lastModified: DateTime.tryParse(map['lastModified'] as String? ?? ''),
+      path: map['path'] as String? ?? '',
+      size: map['size'] as int? ?? 0,
+      metadata: (map['metadata'] as Map?)?.cast<String, dynamic>() ?? {},
+    );
+  }
+}
+
+String get _uid => SharedPreferencesUtil().uid;
+
+Future<List<DebugMetadataItem>> fetchRecentDebugMetadata({int limit = 50}) async {
+  if (_uid.isEmpty || Env.apiBaseUrl == null) return [];
+  try {
+    final uid = Uri.encodeQueryComponent(_uid);
+    final url = '${Env.apiBaseUrl}v1/ella/debug/conversations/metadata?uid=$uid&limit=$limit';
+    final response = await makeApiCall(url: url, headers: {}, body: '', method: 'GET');
+    if (response == null || response.statusCode != 200) return [];
+
+    final decoded = jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>;
+    final items = decoded['items'] as List? ?? [];
+    return items
+        .cast<Map>()
+        .map((item) => DebugMetadataItem.fromMap(item.cast<String, dynamic>()))
+        .where((item) => item.conversationId.isNotEmpty)
+        .toList();
+  } catch (e) {
+    debugPrint('fetchRecentDebugMetadata error: $e');
+    return [];
+  }
+}
+
+Future<DebugMetadataItem?> fetchDebugMetadata(String conversationId) async {
+  if (_uid.isEmpty || conversationId.isEmpty || Env.apiBaseUrl == null) return null;
+  try {
+    final uid = Uri.encodeQueryComponent(_uid);
+    final encodedConversationId = Uri.encodeComponent(conversationId);
+    final url = '${Env.apiBaseUrl}v1/ella/debug/conversations/$encodedConversationId/metadata?uid=$uid';
+    final response = await makeApiCall(url: url, headers: {}, body: '', method: 'GET');
+    if (response == null || response.statusCode != 200) return null;
+
+    return DebugMetadataItem.fromMap(jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>);
+  } catch (e) {
+    debugPrint('fetchDebugMetadata error: $e');
+    return null;
+  }
+}

--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -284,6 +284,15 @@ def _register_routers(app) -> None:
     except ImportError as e:
         print(f"  ⚠️ Ella trace not available: {e}", flush=True)
 
+    # Debug metadata proxy (Observer sidecars)
+    try:
+        from ella.routers.debug_metadata import router as debug_metadata_router
+
+        app.include_router(debug_metadata_router, tags=["Ella Debug"])
+        print("  🌐 /v1/ella/debug/conversations/* - Observer metadata", flush=True)
+    except ImportError as e:
+        print(f"  ⚠️ Ella debug metadata not available: {e}", flush=True)
+
     # Voice session management (token issuance for Ella Voice)
     if ELLA_VOICE_V2_ENABLED:
         try:

--- a/backend/ella/routers/debug_metadata.py
+++ b/backend/ella/routers/debug_metadata.py
@@ -1,0 +1,94 @@
+"""
+Ella debug metadata proxy.
+
+Developer-only endpoints for viewing OpenClaw Observer sidecars without leaking
+internal scanner/routing metadata into user-facing summaries or reports.
+"""
+
+import os
+from typing import Optional
+
+import httpx
+from fastapi import APIRouter, HTTPException, Query, Response
+
+from ella.routers.resolve import PROVISION_API_KEY, PROVISION_API_URL, resolve_user_routing
+
+router = APIRouter(prefix="/v1/ella/debug", tags=["ella-debug"])
+
+DEBUG_METADATA_ENABLED = os.getenv("ELLA_DEBUG_METADATA_ENABLED", "true").lower() == "true"
+
+
+def _debug_response_headers(response: Response) -> None:
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["X-Ella-Visibility"] = "internal"
+
+
+async def _agent_id_for_uid(uid: str) -> str:
+    if not DEBUG_METADATA_ENABLED:
+        raise HTTPException(status_code=404, detail="Debug metadata is disabled")
+    if not uid:
+        raise HTTPException(status_code=400, detail="uid query parameter required")
+
+    resolved = await resolve_user_routing(uid)
+    routing = resolved.get("routing") if resolved else None
+    agent_id = routing.get("agentId") if routing else None
+    if not agent_id:
+        raise HTTPException(status_code=404, detail="No OpenClaw agent found for uid")
+    return agent_id
+
+
+async def _fetch_provision_metadata(path: str, params: Optional[dict] = None) -> dict:
+    headers = {}
+    if PROVISION_API_KEY:
+        headers["Authorization"] = f"Bearer {PROVISION_API_KEY}"
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(f"{PROVISION_API_URL}{path}", params=params or {}, headers=headers)
+    except httpx.RequestError as e:
+        raise HTTPException(status_code=502, detail=f"Provision API unavailable: {e}")
+
+    if resp.status_code == 404:
+        raise HTTPException(status_code=404, detail="Observer metadata not found")
+    if resp.status_code in {401, 403}:
+        raise HTTPException(status_code=502, detail="Provision API rejected debug metadata request")
+    if resp.status_code >= 400:
+        raise HTTPException(status_code=502, detail=f"Provision API error: {resp.status_code}")
+
+    try:
+        return resp.json()
+    except ValueError:
+        raise HTTPException(status_code=502, detail="Provision API returned invalid JSON")
+
+
+@router.get("/conversations/metadata")
+async def list_conversation_metadata(
+    response: Response,
+    uid: str = Query(..., description="Firebase/OMI user UID"),
+    limit: int = Query(50, ge=1, le=200),
+):
+    """List recent Observer sidecar metadata for a user's OpenClaw agent."""
+    _debug_response_headers(response)
+    agent_id = await _agent_id_for_uid(uid)
+    data = await _fetch_provision_metadata(
+        f"/workspace/{agent_id}/metadata/conversations",
+        params={"limit": limit},
+    )
+    data["uid"] = uid
+    data["agent_id"] = agent_id
+    return data
+
+
+@router.get("/conversations/{conversation_id}/metadata")
+async def read_conversation_metadata(
+    conversation_id: str,
+    response: Response,
+    uid: str = Query(..., description="Firebase/OMI user UID"),
+):
+    """Read one Observer sidecar metadata document for a user's conversation."""
+    _debug_response_headers(response)
+    agent_id = await _agent_id_for_uid(uid)
+    data = await _fetch_provision_metadata(f"/workspace/{agent_id}/metadata/conversations/{conversation_id}")
+    data["uid"] = uid
+    data["agent_id"] = agent_id
+    return data

--- a/backend/tests/unit/test_ella_debug_metadata.py
+++ b/backend/tests/unit/test_ella_debug_metadata.py
@@ -1,0 +1,65 @@
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException, Response
+
+sys.modules.setdefault("asyncpg", MagicMock())
+sys.modules.setdefault("database._client", MagicMock())
+
+ella_module = types.ModuleType("ella")
+routers_module = types.ModuleType("ella.routers")
+resolve_module = types.ModuleType("ella.routers.resolve")
+resolve_module.PROVISION_API_KEY = ""
+resolve_module.PROVISION_API_URL = "http://provision.test"
+resolve_module.resolve_user_routing = MagicMock()
+sys.modules["ella"] = ella_module
+sys.modules["ella.routers"] = routers_module
+sys.modules["ella.routers.resolve"] = resolve_module
+
+_backend_path = Path(__file__).resolve().parents[2]
+if str(_backend_path) not in sys.path:
+    sys.path.insert(0, str(_backend_path))
+
+_module_path = Path(__file__).resolve().parents[2] / "ella" / "routers" / "debug_metadata.py"
+_spec = importlib.util.spec_from_file_location("ella_debug_metadata_test_module", _module_path)
+debug_metadata = importlib.util.module_from_spec(_spec)
+assert _spec is not None and _spec.loader is not None
+_spec.loader.exec_module(debug_metadata)
+
+
+def test_list_conversation_metadata_proxies_by_resolved_agent(monkeypatch):
+    async def fake_resolve_user_routing(uid):
+        return {"routing": {"agentId": "ella-omi-test"}}
+
+    async def fake_fetch(path, params=None):
+        return {"count": 1, "items": [{"conversation_id": "conv-123"}], "path": path, "params": params}
+
+    monkeypatch.setattr(debug_metadata, "resolve_user_routing", fake_resolve_user_routing)
+    monkeypatch.setattr(debug_metadata, "_fetch_provision_metadata", fake_fetch)
+
+    response = Response()
+    result = asyncio.run(debug_metadata.list_conversation_metadata(response, uid="user-123", limit=25))
+
+    assert result["uid"] == "user-123"
+    assert result["agent_id"] == "ella-omi-test"
+    assert result["path"] == "/workspace/ella-omi-test/metadata/conversations"
+    assert result["params"] == {"limit": 25}
+    assert response.headers["Cache-Control"] == "no-store"
+    assert response.headers["X-Ella-Visibility"] == "internal"
+
+
+def test_read_conversation_metadata_requires_resolved_agent(monkeypatch):
+    async def fake_resolve_user_routing(uid):
+        return {"routing": {}}
+
+    monkeypatch.setattr(debug_metadata, "resolve_user_routing", fake_resolve_user_routing)
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(debug_metadata.read_conversation_metadata("conv-123", Response(), uid="user-123"))
+
+    assert excinfo.value.status_code == 404


### PR DESCRIPTION
Implements ellaaicare/ella-ai#606 for the OMI backend/iOS app.\n\nAdds a debug metadata proxy endpoint and a Metadata tab in the iOS Debug Event Log.