### PR TITLE
feat(ella): expose conversation length setting

### DIFF
--- a/app/lib/backend/http/api/users.dart
+++ b/app/lib/backend/http/api/users.dart
@@ -142,7 +142,7 @@ Future<bool> deletePermissionAndRecordings() async {
   return response.statusCode == 200;
 }
 
-/**/
+//
 
 Future<bool> setPrivateCloudSyncEnabled(bool value) async {
   var response = await makeApiCall(
@@ -298,12 +298,7 @@ Future<bool> setMessageResponseRating(String messageId, int value, {String? reas
     url += '&reason=$reason';
   }
 
-  var response = await makeApiCall(
-    url: url,
-    headers: {},
-    method: 'POST',
-    body: '',
-  );
+  var response = await makeApiCall(url: url, headers: {}, method: 'POST', body: '');
   if (response == null) return false;
   Logger.debug('setMessageResponseRating response: ${response.body}');
   return response.statusCode == 200;
@@ -329,12 +324,7 @@ Future<bool> getHasConversationSummaryRating(String conversationId) async {
 
 // User language preference API calls
 Future<String?> getUserPrimaryLanguage() async {
-  var response = await makeApiCall(
-    url: '${Env.apiBaseUrl}v1/users/language',
-    headers: {},
-    method: 'GET',
-    body: '',
-  );
+  var response = await makeApiCall(url: '${Env.apiBaseUrl}v1/users/language', headers: {}, method: 'GET', body: '');
   if (response == null) return null;
   Logger.debug('getUserPrimaryLanguage response: ${response.body}');
 
@@ -434,10 +424,7 @@ Future<Map<String, dynamic>?> getTranscriptionPreferences() async {
   return null;
 }
 
-Future<bool> setTranscriptionPreferences({
-  bool? singleLanguageMode,
-  List<String>? vocabulary,
-}) async {
+Future<bool> setTranscriptionPreferences({bool? singleLanguageMode, List<String>? vocabulary}) async {
   Map<String, dynamic> body = {};
   if (singleLanguageMode != null) {
     body['single_language_mode'] = singleLanguageMode;
@@ -454,6 +441,58 @@ Future<bool> setTranscriptionPreferences({
   );
   if (response == null) return false;
   Logger.debug('setTranscriptionPreferences response: ${response.body}');
+  return response.statusCode == 200;
+}
+
+class ConversationLifecyclePreferences {
+  final bool? conversationMaxDurationEnabled;
+  final int? conversationMaxDurationSeconds;
+
+  const ConversationLifecyclePreferences({
+    required this.conversationMaxDurationEnabled,
+    required this.conversationMaxDurationSeconds,
+  });
+
+  factory ConversationLifecyclePreferences.fromJson(Map<String, dynamic> json) {
+    return ConversationLifecyclePreferences(
+      conversationMaxDurationEnabled: json['conversation_max_duration_enabled'] as bool?,
+      conversationMaxDurationSeconds: json['conversation_max_duration_seconds'] as int?,
+    );
+  }
+}
+
+Future<ConversationLifecyclePreferences?> getConversationLifecyclePreferences() async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/users/conversation-lifecycle-preferences',
+    headers: {},
+    method: 'GET',
+    body: '',
+  );
+  if (response == null) return null;
+  Logger.debug('getConversationLifecyclePreferences response: ${response.body}');
+  if (response.statusCode == 200) {
+    return ConversationLifecyclePreferences.fromJson(jsonDecode(response.body));
+  }
+  return null;
+}
+
+Future<bool> setConversationLifecyclePreferences({
+  bool? conversationMaxDurationEnabled,
+  int? conversationMaxDurationSeconds,
+}) async {
+  final body = {
+    'conversation_max_duration_enabled': conversationMaxDurationEnabled,
+    'conversation_max_duration_seconds': conversationMaxDurationSeconds,
+  };
+
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/users/conversation-lifecycle-preferences',
+    headers: {},
+    method: 'PATCH',
+    body: jsonEncode(body),
+  );
+  if (response == null) return false;
+  Logger.debug('setConversationLifecyclePreferences response: ${response.body}');
   return response.statusCode == 200;
 }
 
@@ -595,12 +634,7 @@ Future<String?> generateDailySummary({String? date}) async {
 // Onboarding State
 
 Future<Map<String, dynamic>?> getUserOnboardingState() async {
-  var response = await makeApiCall(
-    url: '${Env.apiBaseUrl}v1/users/onboarding',
-    headers: {},
-    method: 'GET',
-    body: '',
-  );
+  var response = await makeApiCall(url: '${Env.apiBaseUrl}v1/users/onboarding', headers: {}, method: 'GET', body: '');
   if (response == null) return null;
   Logger.debug('getUserOnboardingState response: ${response.body}');
   if (response.statusCode == 200) {
@@ -694,12 +728,7 @@ Future<EllaProvisionResult> provisionEllaUser({
         .post(
           Uri.parse('$_ellaDashboardBase/api/onboarding'),
           headers: {'Content-Type': 'application/json'},
-          body: jsonEncode({
-            'firebaseUid': firebaseUid,
-            'email': email,
-            'name': name,
-            'timezone': timezone,
-          }),
+          body: jsonEncode({'firebaseUid': firebaseUid, 'email': email, 'name': name, 'timezone': timezone}),
         )
         .timeout(const Duration(seconds: 60));
 
@@ -735,7 +764,8 @@ Future<EllaProvisionResult> provisionEllaUser({
       final provisioned = data['provisioned'] as bool? ?? true;
       final isPreProvisioned = !provisioned && agents != null;
       Logger.debug(
-          'Ella provisioning success: userId=$userId provisioned=$provisioned preProvisioned=$isPreProvisioned');
+        'Ella provisioning success: userId=$userId provisioned=$provisioned preProvisioned=$isPreProvisioned',
+      );
       return EllaProvisionResult(isPreProvisioned: isPreProvisioned);
     } else {
       Logger.debug('Ella provisioning failed: ${response.statusCode} ${response.body}');

--- a/app/lib/ella/pages/conversation_lifecycle_settings_page.dart
+++ b/app/lib/ella/pages/conversation_lifecycle_settings_page.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+
+import 'package:provider/provider.dart';
+
+import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/providers/user_provider.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+
+class ConversationLifecycleSettingsPage extends StatelessWidget {
+  const ConversationLifecycleSettingsPage({super.key});
+
+  static const List<int> _durationOptions = [30 * 60, 45 * 60, 60 * 60, 90 * 60];
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<UserProvider>();
+
+    return Scaffold(
+      backgroundColor: EllaColors.bgPrimary,
+      appBar: AppBar(
+        backgroundColor: EllaColors.bgPrimary,
+        elevation: 0,
+        title: Text(
+          context.l10n.ellaMaxConversationLengthTitle,
+          style: const TextStyle(fontSize: 22, fontWeight: FontWeight.w700, color: EllaColors.textPrimary),
+        ),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(
+            context.l10n.ellaMaxConversationLengthDescription,
+            style: const TextStyle(fontSize: 16, height: 1.4, color: EllaColors.textSecondary),
+          ),
+          const SizedBox(height: 20),
+          _ConversationLifecycleOption(
+            title: context.l10n.ellaMaxConversationLengthBackendDefault,
+            subtitle: context.l10n.ellaMaxConversationLengthBackendDefaultDesc,
+            selected:
+                provider.conversationMaxDurationEnabled == null && provider.conversationMaxDurationSeconds == null,
+            saving: provider.isUpdatingConversationLifecyclePreferences,
+            onTap: () => _save(context, provider, enabled: null, seconds: null),
+          ),
+          const SizedBox(height: 8),
+          ..._durationOptions.map((seconds) {
+            final minutes = seconds ~/ 60;
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: _ConversationLifecycleOption(
+                title: context.l10n.minLabel(minutes),
+                subtitle: context.l10n.ellaMaxConversationLengthMinutesDesc(minutes),
+                selected:
+                    provider.conversationMaxDurationEnabled == true &&
+                    provider.conversationMaxDurationSeconds == seconds,
+                saving: provider.isUpdatingConversationLifecyclePreferences,
+                onTap: () => _save(context, provider, enabled: true, seconds: seconds),
+              ),
+            );
+          }),
+          _ConversationLifecycleOption(
+            title: context.l10n.ellaMaxConversationLengthDisabled,
+            subtitle: context.l10n.ellaMaxConversationLengthDisabledDesc,
+            selected: provider.conversationMaxDurationEnabled == false,
+            saving: provider.isUpdatingConversationLifecyclePreferences,
+            onTap: () => _save(context, provider, enabled: false, seconds: null),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _save(
+    BuildContext context,
+    UserProvider provider, {
+    required bool? enabled,
+    required int? seconds,
+  }) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final success = await provider.updateConversationMaxDuration(enabled: enabled, seconds: seconds);
+    if (!context.mounted) return;
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          success ? context.l10n.ellaMaxConversationLengthSaved : context.l10n.ellaMaxConversationLengthSaveFailed,
+        ),
+      ),
+    );
+  }
+}
+
+class _ConversationLifecycleOption extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final bool selected;
+  final bool saving;
+  final VoidCallback onTap;
+
+  const _ConversationLifecycleOption({
+    required this.title,
+    required this.subtitle,
+    required this.selected,
+    required this.saving,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      selected: selected,
+      child: InkWell(
+        onTap: saving ? null : onTap,
+        borderRadius: BorderRadius.circular(EllaSizes.radiusLarge),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 160),
+          padding: const EdgeInsets.all(18),
+          decoration: BoxDecoration(
+            color: EllaColors.bgSecondary,
+            borderRadius: BorderRadius.circular(EllaSizes.radiusLarge),
+            border: Border.all(color: selected ? EllaColors.primary : EllaColors.bgTertiary, width: selected ? 2 : 1),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600, color: EllaColors.textPrimary),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(subtitle, style: const TextStyle(fontSize: 15, height: 1.35, color: EllaColors.textSecondary)),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              if (saving && selected)
+                const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2, color: EllaColors.primary),
+                )
+              else if (selected)
+                const Icon(Icons.check_circle, color: EllaColors.primary, size: 24)
+              else
+                const Icon(Icons.radio_button_unchecked, color: EllaColors.textTertiary, size: 24),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/ella/pages/ella_settings_page.dart
+++ b/app/lib/ella/pages/ella_settings_page.dart
@@ -9,6 +9,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/core/app_shell.dart';
 import 'package:omi/ella/ella_theme.dart';
 import 'package:omi/ella/models/caregiver.dart';
+import 'package:omi/ella/pages/conversation_lifecycle_settings_page.dart';
 import 'package:omi/ella/pages/ella_care_team_page.dart';
 import 'package:omi/ella/pages/ella_emergency_contact_page.dart';
 import 'package:omi/ella/pages/ella_profile_page.dart';
@@ -21,6 +22,7 @@ import 'package:omi/ella/widgets/ella_settings_row.dart';
 import 'package:omi/pages/capture/connect.dart';
 import 'package:omi/pages/settings/settings_drawer.dart';
 import 'package:omi/providers/device_provider.dart';
+import 'package:omi/providers/user_provider.dart';
 import 'package:omi/utils/auth_utils.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
@@ -100,6 +102,14 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
     return context.l10n.ellaFamilyCaregiversSubtitle(_caregivers.length);
   }
 
+  String _conversationMaxDurationSubtitle(UserProvider userProvider) {
+    final enabled = userProvider.conversationMaxDurationEnabled;
+    final seconds = userProvider.conversationMaxDurationSeconds;
+    if (enabled == false) return context.l10n.ellaMaxConversationLengthDisabled;
+    if (enabled == true && seconds != null) return context.l10n.minLabel(seconds ~/ 60);
+    return context.l10n.ellaMaxConversationLengthBackendDefault;
+  }
+
   Future<void> _signOut() async {
     showDialog(
       context: context,
@@ -124,14 +134,15 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
               Navigator.of(ctx).pop();
               await signOutAndClearUserData(context);
               if (mounted) {
-                Navigator.of(context).pushAndRemoveUntil(
-                  MaterialPageRoute(builder: (context) => const AppShell()),
-                  (route) => false,
-                );
+                Navigator.of(
+                  context,
+                ).pushAndRemoveUntil(MaterialPageRoute(builder: (context) => const AppShell()), (route) => false);
               }
             },
-            child:
-                Text(context.l10n.ellaSettingsSignOut, style: const TextStyle(fontSize: 18, color: EllaColors.error)),
+            child: Text(
+              context.l10n.ellaSettingsSignOut,
+              style: const TextStyle(fontSize: 18, color: EllaColors.error),
+            ),
           ),
         ],
       ),
@@ -144,6 +155,7 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
         ? SharedPreferencesUtil().givenName
         : SharedPreferencesUtil().fullName;
     final deviceName = context.watch<DeviceProvider>().connectedDevice?.name ?? 'Not connected';
+    final userProvider = context.watch<UserProvider>();
 
     return Scaffold(
       backgroundColor: EllaColors.bgPrimary,
@@ -170,10 +182,7 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
               title: context.l10n.ellaSettingsProfile,
               subtitle: _profileSubtitle(userName),
               onTap: () async {
-                await Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => const EllaProfilePage()),
-                );
+                await Navigator.push(context, MaterialPageRoute(builder: (context) => const EllaProfilePage()));
                 setState(() {}); // refresh after profile edits
               },
             ),
@@ -189,7 +198,7 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
               onTap: () async {
                 final updated = await Navigator.push<GuardianModeState>(
                   context,
-                  MaterialPageRoute(builder: (context) => GuardianModePage(showDemo: true)),
+                  MaterialPageRoute(builder: (context) => const GuardianModePage(showDemo: true)),
                 );
                 if (updated != null && mounted) {
                   _loadData(); // refresh mode display
@@ -207,10 +216,7 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
                 onTap: () {
                   Clipboard.setData(ClipboardData(text: SharedPreferencesUtil().ellaKey));
                   ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Ella Key copied to clipboard'),
-                      duration: Duration(seconds: 2),
-                    ),
+                    const SnackBar(content: Text('Ella Key copied to clipboard'), duration: Duration(seconds: 2)),
                   );
                 },
               ),
@@ -223,10 +229,7 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
               title: context.l10n.ellaFamilyCaregivers,
               subtitle: _caregiverCountSubtitle(),
               onTap: () async {
-                await Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => const EllaCareTeamPage()),
-                );
+                await Navigator.push(context, MaterialPageRoute(builder: (context) => const EllaCareTeamPage()));
                 _loadData();
               },
             ),
@@ -246,6 +249,20 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
               },
             ),
 
+            // CAPTURE section
+            _buildSectionHeader(context.l10n.ellaCaptureSection),
+            EllaSettingsRow(
+              icon: Icons.schedule,
+              title: context.l10n.ellaMaxConversationLengthTitle,
+              subtitle: _conversationMaxDurationSubtitle(userProvider),
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => const ConversationLifecycleSettingsPage()),
+                );
+              },
+            ),
+
             // DEVICE section
             _buildSectionHeader(context.l10n.ellaDeviceSection),
             EllaSettingsRow(
@@ -253,10 +270,7 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
               title: context.l10n.ellaSettingsDevice,
               subtitle: deviceName,
               onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => const ConnectDevicePage()),
-                );
+                Navigator.push(context, MaterialPageRoute(builder: (context) => const ConnectDevicePage()));
               },
             ),
 
@@ -273,10 +287,7 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
               icon: Icons.timeline,
               title: 'Debug Event Log',
               subtitle: 'Real-time scanner decisions and escalations',
-              onTap: () => Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => const DebugEventLogPage()),
-              ),
+              onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const DebugEventLogPage())),
             ),
             const SizedBox(height: 8),
 
@@ -307,10 +318,7 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
             const SizedBox(height: 24),
             if (_appVersion.isNotEmpty)
               Center(
-                child: Text(
-                  _appVersion,
-                  style: const TextStyle(fontSize: 14, color: EllaColors.textDisabled),
-                ),
+                child: Text(_appVersion, style: const TextStyle(fontSize: 14, color: EllaColors.textDisabled)),
               ),
             const SizedBox(height: 32),
           ],

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10025,8 +10025,26 @@
   "ellaSave": "Save",
   "ellaCancel": "Cancel",
   "ellaCareTeamSection": "CARE TEAM",
+  "ellaCaptureSection": "CAPTURE",
   "ellaDeviceSection": "DEVICE",
   "ellaAboutSection": "ABOUT",
+  "ellaMaxConversationLengthTitle": "Maximum Conversation Length",
+  "ellaMaxConversationLengthConfig": "Split long captures on the backend",
+  "ellaMaxConversationLengthDescription": "Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.",
+  "ellaMaxConversationLengthBackendDefault": "Backend default",
+  "ellaMaxConversationLengthBackendDefaultDesc": "Use Ella's current default: 30 minutes.",
+  "ellaMaxConversationLengthDisabled": "Disabled",
+  "ellaMaxConversationLengthDisabledDesc": "Do not split conversations just because a recording is long.",
+  "ellaMaxConversationLengthMinutesDesc": "Split after {minutes} minutes of continuous recording.",
+  "@ellaMaxConversationLengthMinutesDesc": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "ellaMaxConversationLengthSaved": "Conversation length setting saved.",
+  "ellaMaxConversationLengthSaveFailed": "Couldn't save conversation length setting.",
   "ellaJoinedDate": "Joined {date}",
   "@ellaJoinedDate": {
     "placeholders": {

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -15555,6 +15555,12 @@ abstract class AppLocalizations {
   /// **'CARE TEAM'**
   String get ellaCareTeamSection;
 
+  /// No description provided for @ellaCaptureSection.
+  ///
+  /// In en, this message translates to:
+  /// **'CAPTURE'**
+  String get ellaCaptureSection;
+
   /// No description provided for @ellaDeviceSection.
   ///
   /// In en, this message translates to:
@@ -15566,6 +15572,66 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'ABOUT'**
   String get ellaAboutSection;
+
+  /// No description provided for @ellaMaxConversationLengthTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Maximum Conversation Length'**
+  String get ellaMaxConversationLengthTitle;
+
+  /// No description provided for @ellaMaxConversationLengthConfig.
+  ///
+  /// In en, this message translates to:
+  /// **'Split long captures on the backend'**
+  String get ellaMaxConversationLengthConfig;
+
+  /// No description provided for @ellaMaxConversationLengthDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.'**
+  String get ellaMaxConversationLengthDescription;
+
+  /// No description provided for @ellaMaxConversationLengthBackendDefault.
+  ///
+  /// In en, this message translates to:
+  /// **'Backend default'**
+  String get ellaMaxConversationLengthBackendDefault;
+
+  /// No description provided for @ellaMaxConversationLengthBackendDefaultDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Use Ella\'s current default: 30 minutes.'**
+  String get ellaMaxConversationLengthBackendDefaultDesc;
+
+  /// No description provided for @ellaMaxConversationLengthDisabled.
+  ///
+  /// In en, this message translates to:
+  /// **'Disabled'**
+  String get ellaMaxConversationLengthDisabled;
+
+  /// No description provided for @ellaMaxConversationLengthDisabledDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Do not split conversations just because a recording is long.'**
+  String get ellaMaxConversationLengthDisabledDesc;
+
+  /// No description provided for @ellaMaxConversationLengthMinutesDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Split after {minutes} minutes of continuous recording.'**
+  String ellaMaxConversationLengthMinutesDesc(int minutes);
+
+  /// No description provided for @ellaMaxConversationLengthSaved.
+  ///
+  /// In en, this message translates to:
+  /// **'Conversation length setting saved.'**
+  String get ellaMaxConversationLengthSaved;
+
+  /// No description provided for @ellaMaxConversationLengthSaveFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t save conversation length setting.'**
+  String get ellaMaxConversationLengthSaveFailed;
 
   /// No description provided for @ellaJoinedDate.
   ///

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8282,10 +8282,46 @@ class AppLocalizationsAr extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8370,10 +8370,46 @@ class AppLocalizationsBg extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8386,10 +8386,46 @@ class AppLocalizationsCa extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8333,10 +8333,46 @@ class AppLocalizationsCs extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8322,10 +8322,46 @@ class AppLocalizationsDa extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8404,10 +8404,46 @@ class AppLocalizationsDe extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8395,10 +8395,46 @@ class AppLocalizationsEl extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8335,10 +8335,46 @@ class AppLocalizationsEn extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8352,10 +8352,46 @@ class AppLocalizationsEs extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8337,10 +8337,46 @@ class AppLocalizationsEt extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8336,10 +8336,46 @@ class AppLocalizationsFi extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8411,10 +8411,46 @@ class AppLocalizationsFr extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8318,10 +8318,46 @@ class AppLocalizationsHi extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8375,10 +8375,46 @@ class AppLocalizationsHu extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8350,10 +8350,46 @@ class AppLocalizationsId extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8387,10 +8387,46 @@ class AppLocalizationsIt extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8204,10 +8204,46 @@ class AppLocalizationsJa extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8206,10 +8206,46 @@ class AppLocalizationsKo extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8343,10 +8343,46 @@ class AppLocalizationsLt extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8355,10 +8355,46 @@ class AppLocalizationsLv extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8361,10 +8361,46 @@ class AppLocalizationsMs extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8363,10 +8363,46 @@ class AppLocalizationsNl extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8333,10 +8333,46 @@ class AppLocalizationsNo extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8356,10 +8356,46 @@ class AppLocalizationsPl extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8338,10 +8338,46 @@ class AppLocalizationsPt extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8376,10 +8376,46 @@ class AppLocalizationsRo extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8363,10 +8363,46 @@ class AppLocalizationsRu extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8328,10 +8328,46 @@ class AppLocalizationsSk extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8343,10 +8343,46 @@ class AppLocalizationsSv extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8300,10 +8300,46 @@ class AppLocalizationsTh extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8351,10 +8351,46 @@ class AppLocalizationsTr extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8350,10 +8350,46 @@ class AppLocalizationsUk extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8340,10 +8340,46 @@ class AppLocalizationsVi extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8194,10 +8194,46 @@ class AppLocalizationsZh extends AppLocalizations {
   String get ellaCareTeamSection => 'CARE TEAM';
 
   @override
+  String get ellaCaptureSection => 'CAPTURE';
+
+  @override
   String get ellaDeviceSection => 'DEVICE';
 
   @override
   String get ellaAboutSection => 'ABOUT';
+
+  @override
+  String get ellaMaxConversationLengthTitle => 'Maximum Conversation Length';
+
+  @override
+  String get ellaMaxConversationLengthConfig => 'Split long captures on the backend';
+
+  @override
+  String get ellaMaxConversationLengthDescription =>
+      'Ella can automatically split very long continuous recordings into smaller conversations so summaries stay specific and useful. This is handled by the backend while recording continues.';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefault => 'Backend default';
+
+  @override
+  String get ellaMaxConversationLengthBackendDefaultDesc => 'Use Ella\'s current default: 30 minutes.';
+
+  @override
+  String get ellaMaxConversationLengthDisabled => 'Disabled';
+
+  @override
+  String get ellaMaxConversationLengthDisabledDesc => 'Do not split conversations just because a recording is long.';
+
+  @override
+  String ellaMaxConversationLengthMinutesDesc(int minutes) {
+    return 'Split after $minutes minutes of continuous recording.';
+  }
+
+  @override
+  String get ellaMaxConversationLengthSaved => 'Conversation length setting saved.';
+
+  @override
+  String get ellaMaxConversationLengthSaveFailed => 'Couldn\'t save conversation length setting.';
 
   @override
   String ellaJoinedDate(String date) {

--- a/app/lib/providers/user_provider.dart
+++ b/app/lib/providers/user_provider.dart
@@ -1,10 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:awesome_notifications/awesome_notifications.dart';
-import 'package:geolocator/geolocator.dart';
-
 import 'package:omi/backend/http/api/privacy.dart';
-import 'package:omi/backend/http/api/users.dart' as users_api;
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/geolocation.dart';
@@ -39,15 +36,23 @@ class UserProvider with ChangeNotifier {
   bool _singleLanguageMode = false;
   List<String> _transcriptionVocabulary = [];
 
+  // Conversation lifecycle preferences. Null means use the backend default.
+  bool? _conversationMaxDurationEnabled;
+  int? _conversationMaxDurationSeconds;
+
   // Loading states for transcription settings
   bool _isUpdatingSingleLanguageMode = false;
   bool _isUpdatingVocabulary = false;
+  bool _isUpdatingConversationLifecyclePreferences = false;
 
   // Transcription preferences getters
   bool get singleLanguageMode => _singleLanguageMode;
   List<String> get transcriptionVocabulary => _transcriptionVocabulary;
+  bool? get conversationMaxDurationEnabled => _conversationMaxDurationEnabled;
+  int? get conversationMaxDurationSeconds => _conversationMaxDurationSeconds;
   bool get isUpdatingSingleLanguageMode => _isUpdatingSingleLanguageMode;
   bool get isUpdatingVocabulary => _isUpdatingVocabulary;
+  bool get isUpdatingConversationLifecyclePreferences => _isUpdatingConversationLifecyclePreferences;
 
   String get dataProtectionLevel => _dataProtectionLevel;
   bool get isLoading => _isLoading;
@@ -121,6 +126,9 @@ class UserProvider with ChangeNotifier {
       // Load transcription preferences (will sync with API and update cache)
       await _loadTranscriptionPreferences();
 
+      // Load server-owned conversation splitting preferences.
+      await _loadConversationLifecyclePreferences();
+
       final migrationStatus = userProfile['migration_status'];
       if (migrationStatus != null && migrationStatus['status'] == 'in_progress') {
         final targetLevel = migrationStatus['target_level'];
@@ -184,6 +192,19 @@ class UserProvider with ChangeNotifier {
     }
   }
 
+  Future<void> _loadConversationLifecyclePreferences() async {
+    try {
+      final prefs = await getConversationLifecyclePreferences();
+      if (prefs != null) {
+        _conversationMaxDurationEnabled = prefs.conversationMaxDurationEnabled;
+        _conversationMaxDurationSeconds = prefs.conversationMaxDurationSeconds;
+        notifyListeners();
+      }
+    } catch (e) {
+      Logger.error('Failed to load conversation lifecycle preferences: $e');
+    }
+  }
+
   Future<void> optInForTrainingData() async {
     try {
       final success = await setTrainingDataOptIn();
@@ -238,6 +259,31 @@ class UserProvider with ChangeNotifier {
       return false;
     } finally {
       _isUpdatingVocabulary = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> updateConversationMaxDuration({required bool? enabled, required int? seconds}) async {
+    if (_isUpdatingConversationLifecyclePreferences) return false;
+
+    _isUpdatingConversationLifecyclePreferences = true;
+    notifyListeners();
+
+    try {
+      final success = await setConversationLifecyclePreferences(
+        conversationMaxDurationEnabled: enabled,
+        conversationMaxDurationSeconds: seconds,
+      );
+      if (success) {
+        _conversationMaxDurationEnabled = enabled;
+        _conversationMaxDurationSeconds = seconds;
+      }
+      return success;
+    } catch (e, stackTrace) {
+      Logger.error('Failed to update conversation lifecycle preferences: $e\n$stackTrace');
+      return false;
+    } finally {
+      _isUpdatingConversationLifecyclePreferences = false;
       notifyListeners();
     }
   }


### PR DESCRIPTION
Implements ellaaicare/ella-ai#610.

Changes:
- Adds a typed app API wrapper for GET/PATCH /v1/users/conversation-lifecycle-preferences.
- Loads and saves conversation max-duration preferences through UserProvider, preserving null as backend default.
- Adds an Ella Settings > Capture > Maximum Conversation Length page with backend default, 30/45/60/90 minute, and disabled options.
- Regenerates app localization accessors for the new Ella settings strings.

Validation:
- flutter analyze lib/backend/http/api/users.dart lib/providers/user_provider.dart lib/ella/pages/ella_settings_page.dart lib/ella/pages/conversation_lifecycle_settings_page.dart
- ./test.sh
- git diff --check