### PR TITLE
feat(ella): add summary correction composer

### DIFF
--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -83,6 +83,32 @@ Future<ServerConversation?> reProcessConversationServer(String conversationId, {
   return null;
 }
 
+Future<bool> submitConversationCorrection({
+  required String conversationId,
+  required String correctionText,
+  String? summaryTitle,
+  String? summaryOverview,
+  String? appSummary,
+}) async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/conversations/$conversationId/corrections',
+    headers: {},
+    method: 'POST',
+    body: jsonEncode({
+      'correction_text': correctionText,
+      'source': 'ios',
+      'summary_context': {
+        if (summaryTitle != null) 'title': summaryTitle,
+        if (summaryOverview != null) 'overview': summaryOverview,
+        if (appSummary != null) 'app_summary': appSummary,
+      },
+    }),
+  );
+  if (response == null) return false;
+  Logger.debug('submitConversationCorrection: ${response.statusCode} ${response.body}');
+  return response.statusCode == 200 || response.statusCode == 201 || response.statusCode == 202;
+}
+
 Future<bool> deleteConversationServer(String conversationId) async {
   var response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/conversations/$conversationId',

--- a/app/lib/pages/conversation_detail/widgets.dart
+++ b/app/lib/pages/conversation_detail/widgets.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -19,7 +17,6 @@ import 'package:omi/backend/schema/folder.dart';
 import 'package:omi/backend/schema/geolocation.dart';
 import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/utils/l10n_extensions.dart';
-import 'package:omi/gen/assets.gen.dart';
 import 'package:omi/pages/apps/app_detail/app_detail.dart';
 import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
 import 'package:omi/pages/conversation_detail/test_prompts.dart';
@@ -679,7 +676,227 @@ class AppResultDetailWidget extends StatelessWidget {
                 ),
               ),
             ),
+          if (content.isNotEmpty) ...[
+            const SizedBox(height: 18),
+            _CorrectSummaryButton(
+              conversation: conversation,
+              appSummary: content,
+            ),
+          ],
         ],
+      ),
+    );
+  }
+}
+
+class _CorrectSummaryButton extends StatelessWidget {
+  final ServerConversation conversation;
+  final String appSummary;
+
+  const _CorrectSummaryButton({
+    required this.conversation,
+    required this.appSummary,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(18),
+        onTap: () {
+          HapticFeedback.lightImpact();
+          showModalBottomSheet(
+            context: context,
+            isScrollControlled: true,
+            backgroundColor: Colors.transparent,
+            builder: (context) => _CorrectSummarySheet(
+              conversation: conversation,
+              appSummary: appSummary,
+            ),
+          );
+        },
+        child: Ink(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          decoration: BoxDecoration(
+            color: EllaColors.bgSecondary,
+            borderRadius: BorderRadius.circular(18),
+            border: Border.all(color: EllaColors.bgTertiary),
+          ),
+          child: const Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              FaIcon(FontAwesomeIcons.penToSquare, size: 15, color: EllaColors.primary),
+              SizedBox(width: 8),
+              Text(
+                'Correct Summary',
+                style: TextStyle(
+                  color: EllaColors.textPrimary,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CorrectSummarySheet extends StatefulWidget {
+  final ServerConversation conversation;
+  final String appSummary;
+
+  const _CorrectSummarySheet({
+    required this.conversation,
+    required this.appSummary,
+  });
+
+  @override
+  State<_CorrectSummarySheet> createState() => _CorrectSummarySheetState();
+}
+
+class _CorrectSummarySheetState extends State<_CorrectSummarySheet> {
+  final TextEditingController _controller = TextEditingController();
+  bool _isSubmitting = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    final correctionText = _controller.text.trim();
+    if (correctionText.isEmpty || _isSubmitting) return;
+
+    setState(() => _isSubmitting = true);
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+
+    final ok = await submitConversationCorrection(
+      conversationId: widget.conversation.id,
+      correctionText: correctionText,
+      summaryTitle: widget.conversation.structured.title,
+      summaryOverview: widget.conversation.structured.overview,
+      appSummary: widget.appSummary,
+    );
+
+    if (!mounted) return;
+    setState(() => _isSubmitting = false);
+
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Correction submitted. Ella will recheck this summary.')),
+      );
+      navigator.pop();
+    } else {
+      HapticFeedback.lightImpact();
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Could not submit correction yet. Please try again later.')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+
+    return Padding(
+      padding: EdgeInsets.only(bottom: bottomInset),
+      child: Container(
+        decoration: const BoxDecoration(
+          color: EllaColors.bgPrimary,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+        ),
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+        child: SafeArea(
+          top: false,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Container(
+                  width: 44,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: EllaColors.bgTertiary,
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 20),
+              const Text(
+                'Correct Summary',
+                style: TextStyle(
+                  color: EllaColors.textPrimary,
+                  fontSize: 22,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 8),
+              const Text(
+                'Tell Ella what was wrong in your own words. The conversation ID and current summary are attached in the background.',
+                style: TextStyle(
+                  color: EllaColors.textSecondary,
+                  fontSize: 15,
+                  height: 1.35,
+                ),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _controller,
+                autofocus: true,
+                minLines: 4,
+                maxLines: 8,
+                textInputAction: TextInputAction.newline,
+                style: const TextStyle(color: EllaColors.textPrimary, fontSize: 16),
+                decoration: InputDecoration(
+                  hintText: 'Example: This was Greg and his son watching NASA news, not a group meeting.',
+                  hintStyle: const TextStyle(color: EllaColors.textTertiary),
+                  filled: true,
+                  fillColor: EllaColors.bgSecondary,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(18),
+                    borderSide: const BorderSide(color: EllaColors.bgTertiary),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(18),
+                    borderSide: const BorderSide(color: EllaColors.bgTertiary),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(18),
+                    borderSide: const BorderSide(color: EllaColors.primary, width: 1.5),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: _isSubmitting ? null : _submit,
+                  style: FilledButton.styleFrom(
+                    backgroundColor: EllaColors.primary,
+                    foregroundColor: Colors.white,
+                    disabledBackgroundColor: EllaColors.bgTertiary,
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                  ),
+                  child: _isSubmitting
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                        )
+                      : const Text('Submit Correction'),
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
Implements the iOS slice of ellaaicare/ella-ai#582.

Changes:
- Adds a lightweight `Correct Summary` affordance under conversation summaries.
- Opens a natural-language correction sheet instead of a structured form.
- Sends hidden context through the API client: conversation_id, correction_text, source=ios, current title, structured overview, and rendered app summary.
- Targets backend contract: POST /v1/conversations/{conversation_id}/corrections.

Important integration note:
- This PR does not implement backend storage/reprocessing. The endpoint must be implemented by the backend/n8n owner before #582 can be closed end-to-end.

Validation:
- dart format lib/backend/http/api/conversations.dart lib/pages/conversation_detail/widgets.dart
- git diff --check -- app/lib/backend/http/api/conversations.dart app/lib/pages/conversation_detail/widgets.dart
- flutter analyze --no-fatal-infos --no-fatal-warnings lib/backend/http/api/conversations.dart lib/pages/conversation_detail/widgets.dart (exits 0; existing lint infos remain in touched files)
- ./test.sh