### PR TITLE
feat: add Ella escalation policy resolver

### DIFF
--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -293,6 +293,15 @@ def _register_routers(app) -> None:
     except ImportError as e:
         print(f"  ⚠️ Ella debug metadata not available: {e}", flush=True)
 
+    # Escalation policy resolver (classifier output -> deterministic delivery plan)
+    try:
+        from ella.routers.escalations import router as escalations_router
+
+        app.include_router(escalations_router, tags=["Ella Escalations"])
+        print("  🌐 /v1/ella/escalations/* - Escalation policy", flush=True)
+    except ImportError as e:
+        print(f"  ⚠️ Ella escalation policy not available: {e}", flush=True)
+
     # Voice session management (token issuance for Ella Voice)
     if ELLA_VOICE_V2_ENABLED:
         try:
@@ -302,7 +311,6 @@ def _register_routers(app) -> None:
             print("  🌐 /v1/voice/* - Voice session endpoints", flush=True)
         except ImportError as e:
             print(f"  ⚠️ Voice endpoints not available: {e}", flush=True)
-
 
     # Guardian Mode (audio queue for iOS)
     if ELLA_GUARDIAN_ENABLED:

--- a/backend/ella/routers/escalations.py
+++ b/backend/ella/routers/escalations.py
@@ -1,0 +1,160 @@
+"""Ella escalation policy API.
+
+This endpoint evaluates classified safety/care events and returns a delivery
+plan. It intentionally does not send messages itself; n8n/OpenClaw execute the
+returned plan and report delivery status to trace tables.
+"""
+
+import json
+import os
+from typing import Any, Optional
+
+import asyncpg
+from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel, Field
+
+from ella.services.escalation_policy import (
+    CaregiverPolicyContext,
+    EscalationEvent,
+    UserPolicyContext,
+    evaluate_escalation_policy,
+)
+
+router = APIRouter(prefix="/v1/ella/escalations", tags=["Ella Escalations"])
+
+ESCALATION_WEBHOOK_KEY = os.getenv(
+    "ELLA_ESCALATION_WEBHOOK_KEY",
+    os.getenv("GUARDIAN_WEBHOOK_KEY", "4f13699d8462adf71e35d2098e6a791f"),
+)
+
+_pool: Optional[asyncpg.Pool] = None
+
+
+class EscalationEvaluateRequest(BaseModel):
+    uid: str
+    trace_id: Optional[str] = None
+    source: str = "unknown"
+    event_type: str = "unknown"
+    severity: str = "low"
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    ambiguity: float = Field(default=0.0, ge=0.0, le=1.0)
+    summary: str = ""
+    evidence: dict[str, Any] = Field(default_factory=dict)
+    requested_channels: list[str] = Field(default_factory=list)
+
+
+async def _get_pool() -> asyncpg.Pool:
+    global _pool
+    if _pool is None:
+        _pool = await asyncpg.create_pool(
+            host="127.0.0.1",
+            port=5433,
+            user="postgres",
+            password=os.getenv("ELLA_POSTGRES_PASSWORD", "postgres"),
+            database="ella_ai",
+            min_size=1,
+            max_size=5,
+        )
+    return _pool
+
+
+def _verify_key(x_guardian_key: Optional[str], x_escalation_key: Optional[str], key: Optional[str]) -> None:
+    provided = x_escalation_key or x_guardian_key or key
+    if provided != ESCALATION_WEBHOOK_KEY:
+        raise HTTPException(status_code=403, detail="Invalid escalation key")
+
+
+async def _load_context(uid: str) -> tuple[UserPolicyContext, list[CaregiverPolicyContext]]:
+    pool = await _get_pool()
+    user_row = await pool.fetchrow(
+        """
+        SELECT id, omi_uid, guardian_mode, email, identities
+        FROM users
+        WHERE LOWER(omi_uid) = LOWER($1)
+        """,
+        uid,
+    )
+    if not user_row:
+        raise HTTPException(status_code=404, detail={"error": "user_not_found", "uid": uid})
+
+    identities = user_row["identities"] or {}
+    if isinstance(identities, str):
+        identities = json.loads(identities)
+    user = UserPolicyContext(
+        uid=user_row["omi_uid"],
+        user_id=str(user_row["id"]),
+        guardian_mode=user_row["guardian_mode"],
+        user_email=user_row["email"],
+        user_phone=identities.get("phone") if isinstance(identities, dict) else None,
+    )
+
+    caregiver_rows = await pool.fetch(
+        """
+        SELECT id, status::text AS status, is_emergency_contact, email, phone, permissions
+        FROM caregivers
+        WHERE user_id = $1
+          AND status::text = 'ACTIVE'
+        ORDER BY is_emergency_contact DESC, created_at ASC
+        """,
+        user_row["id"],
+    )
+    caregivers: list[CaregiverPolicyContext] = []
+    for row in caregiver_rows:
+        permissions = row["permissions"] or {}
+        if isinstance(permissions, str):
+            permissions = json.loads(permissions)
+        caregivers.append(
+            CaregiverPolicyContext(
+                caregiver_id=str(row["id"]),
+                status=row["status"],
+                is_emergency_contact=bool(row["is_emergency_contact"]),
+                email=row["email"],
+                phone=row["phone"],
+                permissions=permissions if isinstance(permissions, dict) else {},
+            )
+        )
+    return user, caregivers
+
+
+async def _log_decision(uid: str, decision: dict[str, Any]) -> None:
+    try:
+        pool = await _get_pool()
+        await pool.execute(
+            """
+            INSERT INTO guardian_pipeline_events (trace_id, uid, stage, status, metadata)
+            VALUES ($1, $2, 'escalation_policy_decided', 'success', $3::jsonb)
+            """,
+            decision["trace_id"],
+            uid,
+            json.dumps(decision),
+        )
+    except Exception:
+        # Trace writes should not block the policy response.
+        return
+
+
+@router.post("/evaluate")
+async def evaluate_escalation(
+    req: EscalationEvaluateRequest,
+    x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
+    x_escalation_key: Optional[str] = Header(None, alias="X-Escalation-Key"),
+    key: Optional[str] = Header(None, alias="X-Key"),
+):
+    """Evaluate a classified event and return a deterministic delivery plan."""
+    _verify_key(x_guardian_key, x_escalation_key, key)
+    user, caregivers = await _load_context(req.uid)
+    event = EscalationEvent(
+        uid=req.uid,
+        trace_id=req.trace_id or req.uid,
+        source=req.source,
+        event_type=req.event_type,
+        severity=req.severity,
+        confidence=req.confidence,
+        ambiguity=req.ambiguity,
+        summary=req.summary,
+        evidence=req.evidence,
+        requested_channels=tuple(req.requested_channels),
+    )
+    decision = evaluate_escalation_policy(event, user, caregivers).to_dict()
+    await _log_decision(req.uid, decision)
+    return {"ok": True, **decision}

--- a/backend/ella/services/escalation_policy.py
+++ b/backend/ella/services/escalation_policy.py
@@ -1,0 +1,253 @@
+"""Deterministic caregiver escalation policy for Ella.
+
+The scanner/main agent/Observer should classify events; this module decides
+whether and how the system is allowed to notify users and caregivers.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+Severity = str
+Decision = str
+
+SEVERITY_CRITICAL = "critical"
+SEVERITY_HIGH = "high"
+SEVERITY_MEDIUM = "medium"
+SEVERITY_LOW = "low"
+
+DECISION_NOTIFY_NOW = "notify_now"
+DECISION_ASK_USER_FIRST = "ask_user_first"
+DECISION_QUEUE_FOR_REPORT = "queue_for_report"
+DECISION_LOG_ONLY = "log_only"
+DECISION_SUPPRESS = "suppress"
+
+CHANNEL_GUARDIAN_AUDIO = "guardian_audio"
+CHANNEL_IMESSAGE = "imessage"
+CHANNEL_EMAIL = "email"
+
+
+@dataclass(frozen=True)
+class EscalationEvent:
+    uid: str
+    trace_id: str
+    source: str
+    event_type: str
+    severity: Severity
+    confidence: float
+    ambiguity: float
+    summary: str
+    requested_channels: tuple[str, ...] = ()
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class UserPolicyContext:
+    uid: str
+    user_id: Optional[str] = None
+    guardian_mode: Optional[str] = None
+    user_email: Optional[str] = None
+    user_phone: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class CaregiverPolicyContext:
+    caregiver_id: str
+    status: str
+    is_emergency_contact: bool
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    permissions: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class DeliveryStep:
+    target: str
+    channel: str
+    priority: str
+    caregiver_id: Optional[str] = None
+    fallback: Optional[str] = None
+    reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "target": self.target,
+            "channel": self.channel,
+            "priority": self.priority,
+            "reason": self.reason,
+        }
+        if self.caregiver_id:
+            data["caregiver_id"] = self.caregiver_id
+        if self.fallback:
+            data["fallback"] = self.fallback
+        return data
+
+
+@dataclass(frozen=True)
+class EscalationPolicyDecision:
+    decision: Decision
+    reason: str
+    trace_id: str
+    requires_ack: bool = False
+    delivery_plan: tuple[DeliveryStep, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decision": self.decision,
+            "reason": self.reason,
+            "trace_id": self.trace_id,
+            "requires_ack": self.requires_ack,
+            "delivery_plan": [step.to_dict() for step in self.delivery_plan],
+        }
+
+
+def _normalize_severity(value: str) -> Severity:
+    normalized = (value or "").strip().lower()
+    if normalized in {SEVERITY_CRITICAL, SEVERITY_HIGH, SEVERITY_MEDIUM, SEVERITY_LOW}:
+        return normalized
+    return SEVERITY_LOW
+
+
+def _guardian_audio_enabled(guardian_mode: Optional[str]) -> bool:
+    if guardian_mode is None:
+        return False
+    normalized = str(guardian_mode).strip().lower()
+    return normalized not in {"", "off", "none", "disabled", "null"}
+
+
+def _permission_enabled(permissions: dict[str, Any], keys: tuple[str, ...], default: bool = False) -> bool:
+    for key in keys:
+        if key in permissions:
+            return bool(permissions.get(key))
+    return default
+
+
+def _emergency_caregivers(caregivers: list[CaregiverPolicyContext]) -> list[CaregiverPolicyContext]:
+    return [
+        caregiver for caregiver in caregivers if caregiver.status.upper() == "ACTIVE" and caregiver.is_emergency_contact
+    ]
+
+
+def _critical_delivery_plan(
+    user: UserPolicyContext,
+    caregivers: list[CaregiverPolicyContext],
+) -> tuple[DeliveryStep, ...]:
+    steps: list[DeliveryStep] = []
+
+    if _guardian_audio_enabled(user.guardian_mode):
+        steps.append(
+            DeliveryStep(
+                target="user",
+                channel=CHANNEL_GUARDIAN_AUDIO,
+                priority="urgent",
+                reason="guardian_mode_active",
+            )
+        )
+
+    for caregiver in _emergency_caregivers(caregivers):
+        urgent_allowed = _permission_enabled(
+            caregiver.permissions,
+            ("receive_emergency_alerts", "emergency_alerts", "urgent_alerts"),
+            default=True,
+        )
+        if not urgent_allowed:
+            continue
+        if caregiver.phone:
+            steps.append(
+                DeliveryStep(
+                    target="emergency_caregiver",
+                    caregiver_id=caregiver.caregiver_id,
+                    channel=CHANNEL_IMESSAGE,
+                    fallback=CHANNEL_EMAIL if caregiver.email else None,
+                    priority="urgent",
+                    reason="selected_emergency_contact",
+                )
+            )
+        elif caregiver.email:
+            steps.append(
+                DeliveryStep(
+                    target="emergency_caregiver",
+                    caregiver_id=caregiver.caregiver_id,
+                    channel=CHANNEL_EMAIL,
+                    priority="urgent",
+                    reason="selected_emergency_contact_no_phone",
+                )
+            )
+
+    return tuple(steps)
+
+
+def evaluate_escalation_policy(
+    event: EscalationEvent,
+    user: UserPolicyContext,
+    caregivers: list[CaregiverPolicyContext],
+) -> EscalationPolicyDecision:
+    """Return a deterministic delivery decision for a classified event."""
+    severity = _normalize_severity(event.severity)
+    trace_id = event.trace_id or event.uid
+    ambiguous = event.ambiguity >= 0.7 or event.confidence < 0.5
+
+    if severity == SEVERITY_CRITICAL:
+        plan = _critical_delivery_plan(user, caregivers)
+        if plan:
+            return EscalationPolicyDecision(
+                decision=DECISION_NOTIFY_NOW,
+                reason="critical_event",
+                trace_id=trace_id,
+                requires_ack=True,
+                delivery_plan=plan,
+            )
+        return EscalationPolicyDecision(
+            decision=DECISION_LOG_ONLY,
+            reason="critical_event_no_reachable_targets",
+            trace_id=trace_id,
+            requires_ack=True,
+        )
+
+    if ambiguous:
+        return EscalationPolicyDecision(
+            decision=DECISION_QUEUE_FOR_REPORT,
+            reason="ambiguous_or_low_confidence",
+            trace_id=trace_id,
+        )
+
+    if severity == SEVERITY_HIGH:
+        plan: list[DeliveryStep] = []
+        if _guardian_audio_enabled(user.guardian_mode):
+            plan.append(
+                DeliveryStep(
+                    target="user",
+                    channel=CHANNEL_GUARDIAN_AUDIO,
+                    priority="high",
+                    reason="ask_user_before_caregiver_escalation",
+                )
+            )
+        elif user.phone:
+            plan.append(
+                DeliveryStep(
+                    target="user",
+                    channel=CHANNEL_IMESSAGE,
+                    fallback=CHANNEL_EMAIL if user.user_email else None,
+                    priority="high",
+                    reason="guardian_audio_unavailable",
+                )
+            )
+        return EscalationPolicyDecision(
+            decision=DECISION_ASK_USER_FIRST if plan else DECISION_QUEUE_FOR_REPORT,
+            reason="high_event_user_first",
+            trace_id=trace_id,
+            requires_ack=bool(plan),
+            delivery_plan=tuple(plan),
+        )
+
+    if severity == SEVERITY_MEDIUM or event.event_type == "routine_report":
+        return EscalationPolicyDecision(
+            decision=DECISION_QUEUE_FOR_REPORT,
+            reason="reportable_nonurgent_event",
+            trace_id=trace_id,
+        )
+
+    return EscalationPolicyDecision(
+        decision=DECISION_LOG_ONLY,
+        reason="low_severity_event",
+        trace_id=trace_id,
+    )

--- a/backend/tests/unit/test_ella_escalation_policy.py
+++ b/backend/tests/unit/test_ella_escalation_policy.py
@@ -1,0 +1,126 @@
+from ella.services.escalation_policy import (
+    CHANNEL_EMAIL,
+    CHANNEL_GUARDIAN_AUDIO,
+    CHANNEL_IMESSAGE,
+    DECISION_ASK_USER_FIRST,
+    DECISION_LOG_ONLY,
+    DECISION_NOTIFY_NOW,
+    DECISION_QUEUE_FOR_REPORT,
+    CaregiverPolicyContext,
+    EscalationEvent,
+    UserPolicyContext,
+    evaluate_escalation_policy,
+)
+
+
+def _event(**overrides):
+    data = {
+        "uid": "uid-1",
+        "trace_id": "trace-1",
+        "source": "scanner",
+        "event_type": "safety",
+        "severity": "low",
+        "confidence": 0.9,
+        "ambiguity": 0.0,
+        "summary": "test",
+    }
+    data.update(overrides)
+    return EscalationEvent(**data)
+
+
+def _user(**overrides):
+    data = {
+        "uid": "uid-1",
+        "user_id": "user-1",
+        "guardian_mode": "cyborg",
+        "user_email": "user@example.test",
+        "user_phone": "+15550000001",
+    }
+    data.update(overrides)
+    return UserPolicyContext(**data)
+
+
+def _caregiver(**overrides):
+    data = {
+        "caregiver_id": "caregiver-1",
+        "status": "ACTIVE",
+        "is_emergency_contact": True,
+        "email": "caregiver@example.test",
+        "phone": "+15550000002",
+        "permissions": {},
+    }
+    data.update(overrides)
+    return CaregiverPolicyContext(**data)
+
+
+def test_critical_event_notifies_user_audio_and_emergency_caregiver_imessage():
+    decision = evaluate_escalation_policy(
+        _event(severity="critical"),
+        _user(guardian_mode="maximum_awareness"),
+        [_caregiver()],
+    )
+
+    assert decision.decision == DECISION_NOTIFY_NOW
+    assert decision.requires_ack is True
+    assert [step.channel for step in decision.delivery_plan] == [CHANNEL_GUARDIAN_AUDIO, CHANNEL_IMESSAGE]
+    assert decision.delivery_plan[1].fallback == CHANNEL_EMAIL
+
+
+def test_critical_event_respects_disabled_caregiver_emergency_alert_permission():
+    decision = evaluate_escalation_policy(
+        _event(severity="critical"),
+        _user(guardian_mode="alert"),
+        [_caregiver(permissions={"receive_emergency_alerts": False})],
+    )
+
+    assert decision.decision == DECISION_NOTIFY_NOW
+    assert len(decision.delivery_plan) == 1
+    assert decision.delivery_plan[0].target == "user"
+
+
+def test_critical_event_uses_email_when_caregiver_has_no_phone():
+    decision = evaluate_escalation_policy(
+        _event(severity="critical"),
+        _user(guardian_mode=None),
+        [_caregiver(phone=None)],
+    )
+
+    assert decision.decision == DECISION_NOTIFY_NOW
+    assert len(decision.delivery_plan) == 1
+    assert decision.delivery_plan[0].target == "emergency_caregiver"
+    assert decision.delivery_plan[0].channel == CHANNEL_EMAIL
+
+
+def test_high_event_asks_user_first_without_contacting_caregiver():
+    decision = evaluate_escalation_policy(
+        _event(severity="high"),
+        _user(guardian_mode="cyborg"),
+        [_caregiver()],
+    )
+
+    assert decision.decision == DECISION_ASK_USER_FIRST
+    assert decision.requires_ack is True
+    assert len(decision.delivery_plan) == 1
+    assert decision.delivery_plan[0].target == "user"
+
+
+def test_ambiguous_medium_event_queues_for_report():
+    decision = evaluate_escalation_policy(
+        _event(severity="medium", confidence=0.4, ambiguity=0.8),
+        _user(),
+        [_caregiver()],
+    )
+
+    assert decision.decision == DECISION_QUEUE_FOR_REPORT
+    assert decision.delivery_plan == ()
+
+
+def test_low_event_logs_only():
+    decision = evaluate_escalation_policy(
+        _event(severity="low"),
+        _user(),
+        [_caregiver()],
+    )
+
+    assert decision.decision == DECISION_LOG_ONLY
+    assert decision.delivery_plan == ()


### PR DESCRIPTION
## Summary
- Adds a pure Ella escalation policy resolver for classifier output -> deterministic delivery plan.
- Adds `POST /v1/ella/escalations/evaluate` to load user/caregiver context from Postgres, evaluate policy, and write a trace event.
- Registers the escalation router under Ella extensions.
- Adds focused unit tests for critical, high, ambiguous/medium, and low event behavior.

Related Ella issue: ellaaicare/ella-ai#627

## Verification
- `/Users/ellaai/.cache/ella-omi-pytest-venv/bin/python -m pytest backend/tests/unit/test_ella_escalation_policy.py`
- `/Users/ellaai/.cache/ella-omi-pytest-venv/bin/python -m black --check backend/ella/services/escalation_policy.py backend/ella/routers/escalations.py backend/tests/unit/test_ella_escalation_policy.py backend/ella/__init__.py`

## Notes
This is intentionally backend-only. n8n should consume the returned `delivery_plan` and execute iMessage/email/audio delivery with callbacks; iOS/dashboard should own consent and settings UI.
