### PR TITLE
fix(ios): normalize caregiver status refresh

### DIFF
--- a/app/lib/ella/models/caregiver.dart
+++ b/app/lib/ella/models/caregiver.dart
@@ -4,7 +4,7 @@ class Caregiver {
   final String? phone;
   final String? email;
   final String relationship;
-  final String status; // "active" or "invited"
+  final String status; // normalized lowercase: "active" or "invited"
   final DateTime? joinedAt;
   final DateTime? invitedAt;
   final bool receiveDailySummary;
@@ -27,8 +27,10 @@ class Caregiver {
         phone = json['phone'],
         email = json['email'],
         relationship = json['relationship'] ?? '',
-        status = json['status'] ?? 'invited',
-        joinedAt = json['joined_at'] != null ? DateTime.parse(json['joined_at']) : null,
+        status = (json['status'] ?? 'invited').toString().toLowerCase(),
+        joinedAt = json['joined_at'] != null
+            ? DateTime.parse(json['joined_at'])
+            : (json['accepted_at'] != null ? DateTime.parse(json['accepted_at']) : null),
         invitedAt = json['invited_at'] != null ? DateTime.parse(json['invited_at']) : null,
         receiveDailySummary = (json['permissions'] as Map<String, dynamic>?)?['receive_daily_summary'] as bool? ?? true;
 
@@ -55,8 +57,8 @@ class Caregiver {
     }
   }
 
-  bool get isActive => status == 'active';
-  bool get isInvited => status == 'invited';
+  bool get isActive => status.toLowerCase() == 'active';
+  bool get isInvited => status.toLowerCase() == 'invited';
 }
 
 class InviteResponse {

--- a/app/lib/ella/pages/ella_caregiver_detail_page.dart
+++ b/app/lib/ella/pages/ella_caregiver_detail_page.dart
@@ -9,7 +9,6 @@ import 'package:omi/ella/models/caregiver.dart';
 import 'package:omi/ella/services/caregiver_api.dart' as caregiver_api;
 import 'package:omi/ella/widgets/ella_permission_toggle.dart';
 import 'package:omi/utils/l10n_extensions.dart';
-import 'package:omi/utils/logger.dart';
 
 class EllaCaregiverDetailPage extends StatefulWidget {
   final Caregiver caregiver;
@@ -21,6 +20,7 @@ class EllaCaregiverDetailPage extends StatefulWidget {
 }
 
 class _EllaCaregiverDetailPageState extends State<EllaCaregiverDetailPage> {
+  late Caregiver _caregiver;
   late bool _dailySummary;
   late bool _isEmergencyContact;
   bool _resending = false;
@@ -29,23 +29,10 @@ class _EllaCaregiverDetailPageState extends State<EllaCaregiverDetailPage> {
   @override
   void initState() {
     super.initState();
-    _dailySummary = widget.caregiver.receiveDailySummary;
+    _caregiver = widget.caregiver;
+    _dailySummary = _caregiver.receiveDailySummary;
     _isEmergencyContact = false;
-    _loadEmergencyContact();
-  }
-
-  Future<void> _loadEmergencyContact() async {
-    try {
-      final emergencyId = await caregiver_api.getEmergencyContactId();
-      if (mounted) {
-        setState(() {
-          _isEmergencyContact = emergencyId == widget.caregiver.id;
-          _loadingEmergency = false;
-        });
-      }
-    } catch (_) {
-      if (mounted) setState(() => _loadingEmergency = false);
-    }
+    _refreshFromBackend();
   }
 
   Future<void> _refreshFromBackend() async {
@@ -53,17 +40,19 @@ class _EllaCaregiverDetailPageState extends State<EllaCaregiverDetailPage> {
       final caregivers = await caregiver_api.getCaregivers();
       final emergencyId = await caregiver_api.getEmergencyContactId();
       final updated = caregivers.firstWhere(
-        (c) => c.id == widget.caregiver.id,
-        orElse: () => widget.caregiver,
+        (c) => c.id == _caregiver.id,
+        orElse: () => _caregiver,
       );
       if (mounted) {
         setState(() {
           _dailySummary = updated.receiveDailySummary;
-          _isEmergencyContact = emergencyId == widget.caregiver.id;
+          _caregiver = updated;
+          _isEmergencyContact = emergencyId == updated.id;
+          _loadingEmergency = false;
         });
       }
     } catch (_) {
-      // Keep existing state on failure
+      if (mounted) setState(() => _loadingEmergency = false);
     }
   }
 
@@ -75,7 +64,7 @@ class _EllaCaregiverDetailPageState extends State<EllaCaregiverDetailPage> {
   Future<void> _toggleDailySummary(bool value) async {
     setState(() => _dailySummary = value);
     try {
-      await caregiver_api.updateCaregiverPermissions(widget.caregiver.id, dailySummary: value);
+      await caregiver_api.updateCaregiverPermissions(_caregiver.id, dailySummary: value);
     } catch (_) {
       if (mounted) setState(() => _dailySummary = !value);
     }
@@ -86,7 +75,7 @@ class _EllaCaregiverDetailPageState extends State<EllaCaregiverDetailPage> {
     setState(() => _isEmergencyContact = value);
     try {
       if (value) {
-        await caregiver_api.setEmergencyContact(widget.caregiver.id);
+        await caregiver_api.setEmergencyContact(_caregiver.id);
       } else {
         // Clear emergency contact by setting to empty — backend clears the field
         await caregiver_api.clearEmergencyContact();
@@ -97,16 +86,16 @@ class _EllaCaregiverDetailPageState extends State<EllaCaregiverDetailPage> {
   }
 
   Future<void> _resendInvite() async {
-    if (_resending || widget.caregiver.phone == null) return;
+    if (_resending || _caregiver.phone == null) return;
     setState(() => _resending = true);
     try {
       await caregiver_api.resendInvite(
         uid: SharedPreferencesUtil().uid,
-        caregiverId: widget.caregiver.id,
+        caregiverId: _caregiver.id,
       );
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(context.l10n.ellaResendSuccess(widget.caregiver.name))),
+          SnackBar(content: Text(context.l10n.ellaResendSuccess(_caregiver.name))),
         );
       }
     } catch (_) {
@@ -126,11 +115,11 @@ class _EllaCaregiverDetailPageState extends State<EllaCaregiverDetailPage> {
         backgroundColor: EllaColors.bgSecondary,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(EllaSizes.radiusLarge)),
         title: Text(
-          context.l10n.ellaRemoveConfirmTitle(widget.caregiver.name),
+          context.l10n.ellaRemoveConfirmTitle(_caregiver.name),
           style: const TextStyle(fontSize: 22, fontWeight: FontWeight.w700, color: EllaColors.textPrimary),
         ),
         content: Text(
-          context.l10n.ellaRemoveConfirmDescription(widget.caregiver.name),
+          context.l10n.ellaRemoveConfirmDescription(_caregiver.name),
           style: const TextStyle(fontSize: 18, color: EllaColors.textSecondary, height: 1.5),
         ),
         actions: [
@@ -150,10 +139,10 @@ class _EllaCaregiverDetailPageState extends State<EllaCaregiverDetailPage> {
     if (confirmed != true || !mounted) return;
 
     try {
-      await caregiver_api.removeCaregiver(widget.caregiver.id);
+      await caregiver_api.removeCaregiver(_caregiver.id);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(context.l10n.ellaRemoveSuccess(widget.caregiver.name))),
+          SnackBar(content: Text(context.l10n.ellaRemoveSuccess(_caregiver.name))),
         );
         Navigator.of(context).pop();
       }
@@ -168,7 +157,7 @@ class _EllaCaregiverDetailPageState extends State<EllaCaregiverDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    final cg = widget.caregiver;
+    final cg = _caregiver;
     final statusColor = cg.isActive ? EllaColors.success : EllaColors.warning;
     final statusLabel = cg.isActive ? context.l10n.ellaCaregiverStatusActive : context.l10n.ellaCaregiverStatusInvited;
     final dateLabel = cg.isActive
@@ -202,7 +191,7 @@ class _EllaCaregiverDetailPageState extends State<EllaCaregiverDetailPage> {
               height: 72,
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
-                color: EllaColors.primary.withOpacity(0.15),
+                color: EllaColors.primary.withValues(alpha: 0.15),
               ),
               child: Center(
                 child: Text(

--- a/app/lib/ella/services/caregiver_api.dart
+++ b/app/lib/ella/services/caregiver_api.dart
@@ -87,6 +87,7 @@ Future<void> updateCaregiverPermissions(String caregiverId, {required bool daily
       'uid': _uid,
       'caregiver_id': caregiverId,
       'receive_daily_summary': dailySummary,
+      'daily_summary_email': dailySummary,
     }),
   );
   if (response.statusCode != 200) {

--- a/app/test/ella/models/caregiver_test.dart
+++ b/app/test/ella/models/caregiver_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/ella/models/caregiver.dart';
+
+void main() {
+  group('Caregiver', () {
+    test('normalizes backend enum status casing', () {
+      final caregiver = Caregiver.fromJson({
+        'id': 'caregiver-1',
+        'name': 'Emily',
+        'relationship': 'friend',
+        'status': 'ACTIVE',
+        'accepted_at': '2026-04-12T18:12:03.120Z',
+      });
+
+      expect(caregiver.status, 'active');
+      expect(caregiver.isActive, isTrue);
+      expect(caregiver.isInvited, isFalse);
+      expect(caregiver.joinedAt, DateTime.parse('2026-04-12T18:12:03.120Z'));
+    });
+
+    test('reads daily summary permission from backend permissions', () {
+      final caregiver = Caregiver.fromJson({
+        'id': 'caregiver-1',
+        'name': 'Emily',
+        'relationship': 'friend',
+        'status': 'INVITED',
+        'permissions': {'receive_daily_summary': false},
+      });
+
+      expect(caregiver.status, 'invited');
+      expect(caregiver.receiveDailySummary, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Normalize caregiver status casing from the live backend so `ACTIVE` renders as Active instead of falling through to Invited.
- Use the refreshed caregiver record on the detail page after opening, including accepted date fallback for joined date display.
- Send `daily_summary_email` with caregiver permission updates to keep the n8n permissions contract aligned.
- Add focused model tests for status normalization and daily summary parsing.

## Root Cause
The live caregiver list webhook returns enum-style statuses like `ACTIVE`, while the iOS model only treated lowercase `active` as active. The detail page also fetched backend data but continued rendering the original `widget.caregiver` instance.

## Validation
- `dart analyze app/lib/ella/models/caregiver.dart app/lib/ella/pages/ella_caregiver_detail_page.dart app/lib/ella/services/caregiver_api.dart app/test/ella/models/caregiver_test.dart`
- `flutter test test/ella/models/caregiver_test.dart`
- Live n8n `caregiver-set-emergency` smoke: empty `caregiver_id` cleared emergency contact and restoring the caregiver ID set it back.
