### PR TITLE
feat: add Ella escalation policy view

### DIFF
--- a/backend/ella/routers/escalations.py
+++ b/backend/ella/routers/escalations.py
@@ -7,6 +7,7 @@ returned plan and report delivery status to trace tables.
 
 import json
 import os
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 import asyncpg
@@ -17,6 +18,7 @@ from ella.services.escalation_policy import (
     CaregiverPolicyContext,
     EscalationEvent,
     UserPolicyContext,
+    build_plain_language_policy_view,
     evaluate_escalation_policy,
 )
 
@@ -90,7 +92,7 @@ async def _load_context(uid: str) -> tuple[UserPolicyContext, list[CaregiverPoli
 
     caregiver_rows = await pool.fetch(
         """
-        SELECT id, status::text AS status, is_emergency_contact, email, phone, permissions
+        SELECT id, status::text AS status, is_emergency_contact, name, relationship, email, phone, permissions
         FROM caregivers
         WHERE user_id = $1
           AND status::text = 'ACTIVE'
@@ -108,6 +110,8 @@ async def _load_context(uid: str) -> tuple[UserPolicyContext, list[CaregiverPoli
                 caregiver_id=str(row["id"]),
                 status=row["status"],
                 is_emergency_contact=bool(row["is_emergency_contact"]),
+                name=row["name"],
+                relationship=row["relationship"],
                 email=row["email"],
                 phone=row["phone"],
                 permissions=permissions if isinstance(permissions, dict) else {},
@@ -158,3 +162,15 @@ async def evaluate_escalation(
     decision = evaluate_escalation_policy(event, user, caregivers).to_dict()
     await _log_decision(req.uid, decision)
     return {"ok": True, **decision}
+
+
+@router.get("/policy")
+async def get_escalation_policy(uid: str):
+    """Return the read-only effective policy view for user/caregiver UI."""
+    user, caregivers = await _load_context(uid)
+    policy = build_plain_language_policy_view(user, caregivers)
+    return {
+        "ok": True,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        **policy,
+    }

--- a/backend/ella/services/escalation_policy.py
+++ b/backend/ella/services/escalation_policy.py
@@ -54,6 +54,8 @@ class CaregiverPolicyContext:
     caregiver_id: str
     status: str
     is_emergency_contact: bool
+    name: Optional[str] = None
+    relationship: Optional[str] = None
     email: Optional[str] = None
     phone: Optional[str] = None
     permissions: dict[str, Any] = field(default_factory=dict)
@@ -251,3 +253,162 @@ def evaluate_escalation_policy(
         reason="low_severity_event",
         trace_id=trace_id,
     )
+
+
+def build_plain_language_policy_view(
+    user: UserPolicyContext,
+    caregivers: list[CaregiverPolicyContext],
+) -> dict[str, Any]:
+    """Return the read-only effective escalation policy for UI display."""
+    emergency_caregivers = _emergency_caregivers(caregivers)
+    emergency_caregiver = emergency_caregivers[0] if emergency_caregivers else None
+    guardian_audio_enabled = _guardian_audio_enabled(user.guardian_mode)
+
+    def channel_status(channel: str, enabled: bool, reason: str) -> dict[str, Any]:
+        return {
+            "channel": channel,
+            "enabled": enabled,
+            "reason": reason,
+        }
+
+    caregiver_views: list[dict[str, Any]] = []
+    for caregiver in caregivers:
+        permissions = caregiver.permissions or {}
+        emergency_alerts = _permission_enabled(
+            permissions,
+            ("receive_emergency_alerts", "emergency_alerts", "urgent_alerts"),
+            default=True,
+        )
+        daily_summary = _permission_enabled(
+            permissions,
+            ("receive_daily_summary", "daily_summary", "daily_summary_email"),
+            default=False,
+        )
+        weekly_summary = _permission_enabled(
+            permissions,
+            ("receive_weekly_summary", "weekly_summary"),
+            default=False,
+        )
+        caregiver_views.append(
+            {
+                "caregiver_id": caregiver.caregiver_id,
+                "display_name": caregiver.name or "Caregiver",
+                "relationship": caregiver.relationship,
+                "status": caregiver.status,
+                "is_emergency_contact": caregiver.is_emergency_contact,
+                "channels": [
+                    channel_status(
+                        CHANNEL_IMESSAGE,
+                        bool(caregiver.phone),
+                        "Phone number on file" if caregiver.phone else "No phone number on file",
+                    ),
+                    channel_status(
+                        CHANNEL_EMAIL,
+                        bool(caregiver.email),
+                        "Email on file" if caregiver.email else "No email on file",
+                    ),
+                ],
+                "permissions": {
+                    "emergency_alerts": emergency_alerts,
+                    "daily_summary": daily_summary,
+                    "weekly_summary": weekly_summary,
+                },
+                "plain_language": (
+                    "This caregiver can receive urgent safety alerts."
+                    if caregiver.is_emergency_contact and emergency_alerts
+                    else "This caregiver will not receive immediate emergency alerts unless you enable it."
+                ),
+            }
+        )
+
+    emergency_contact_text = (
+        f"{emergency_caregiver.name or 'Your emergency caregiver'} is selected as the emergency contact."
+        if emergency_caregiver
+        else "No active emergency caregiver is selected."
+    )
+
+    critical_targets = ["you"]
+    if emergency_caregiver:
+        critical_targets.append("your selected emergency caregiver")
+
+    rules = [
+        {
+            "severity": SEVERITY_CRITICAL,
+            "decision": DECISION_NOTIFY_NOW if emergency_caregiver or guardian_audio_enabled else DECISION_LOG_ONLY,
+            "title": "Critical safety concerns",
+            "text": (
+                "Critical safety concerns notify "
+                + " and ".join(critical_targets)
+                + " immediately when those channels are available."
+            ),
+        },
+        {
+            "severity": SEVERITY_HIGH,
+            "decision": DECISION_ASK_USER_FIRST,
+            "title": "High concern events",
+            "text": "High concern events try to ask you first before notifying a caregiver.",
+        },
+        {
+            "severity": SEVERITY_MEDIUM,
+            "decision": DECISION_QUEUE_FOR_REPORT,
+            "title": "Medium or ambiguous events",
+            "text": "Medium or ambiguous events are saved for review or a recap unless they repeat or get worse.",
+        },
+        {
+            "severity": SEVERITY_LOW,
+            "decision": DECISION_LOG_ONLY,
+            "title": "Low concern events",
+            "text": "Low concern events are logged only and do not notify caregivers immediately.",
+        },
+    ]
+
+    display_rules = [rule["text"] for rule in rules]
+    display_rules.append(
+        "Caregiver reports are privacy-filtered and should include trends or concerns, not raw private chats."
+    )
+
+    return {
+        "policy_version": "ella.escalation_policy.v1",
+        "source": "omi_backend",
+        "uid": user.uid,
+        "user": {
+            "guardian_mode": user.guardian_mode,
+            "channels": [
+                channel_status(
+                    CHANNEL_GUARDIAN_AUDIO,
+                    guardian_audio_enabled,
+                    "Guardian audio mode is active" if guardian_audio_enabled else "Guardian audio mode is off",
+                ),
+                channel_status(
+                    CHANNEL_IMESSAGE,
+                    bool(user.user_phone),
+                    "Phone number on file" if user.user_phone else "No phone number on file",
+                ),
+                channel_status(
+                    CHANNEL_EMAIL,
+                    bool(user.user_email),
+                    "Email on file" if user.user_email else "No email on file",
+                ),
+            ],
+        },
+        "emergency_contact": {
+            "configured": emergency_caregiver is not None,
+            "caregiver_id": emergency_caregiver.caregiver_id if emergency_caregiver else None,
+            "display_name": emergency_caregiver.name if emergency_caregiver else None,
+            "status": emergency_caregiver.status if emergency_caregiver else None,
+            "text": emergency_contact_text,
+        },
+        "caregivers": caregiver_views,
+        "rules": rules,
+        "privacy_notes": [
+            "Emergency alerts can contact the selected emergency caregiver when policy allows it.",
+            "Caregiver reports should include trends, concerns, and escalations, not raw private chats.",
+            "The backend owns these rules so app displays do not drift from delivery behavior.",
+        ],
+        "display": {
+            "title": "How Ella handles alerts",
+            "subtitle": "These rules are resolved by the server from your current caregiver and channel settings.",
+            "emergency_contact": emergency_contact_text,
+            "rules": display_rules,
+        },
+    }

--- a/backend/tests/unit/test_ella_escalation_policy.py
+++ b/backend/tests/unit/test_ella_escalation_policy.py
@@ -9,6 +9,7 @@ from ella.services.escalation_policy import (
     CaregiverPolicyContext,
     EscalationEvent,
     UserPolicyContext,
+    build_plain_language_policy_view,
     evaluate_escalation_policy,
 )
 
@@ -45,6 +46,8 @@ def _caregiver(**overrides):
         "caregiver_id": "caregiver-1",
         "status": "ACTIVE",
         "is_emergency_contact": True,
+        "name": "Emily",
+        "relationship": "daughter",
         "email": "caregiver@example.test",
         "phone": "+15550000002",
         "permissions": {},
@@ -124,3 +127,58 @@ def test_low_event_logs_only():
 
     assert decision.decision == DECISION_LOG_ONLY
     assert decision.delivery_plan == ()
+
+
+def test_plain_language_policy_view_summarizes_effective_channels_and_rules():
+    policy = build_plain_language_policy_view(
+        _user(guardian_mode="cyborg"),
+        [_caregiver(permissions={"receive_emergency_alerts": True, "receive_daily_summary": True})],
+    )
+
+    assert policy["policy_version"] == "ella.escalation_policy.v1"
+    assert policy["source"] == "omi_backend"
+    assert policy["emergency_contact"] == {
+        "configured": True,
+        "caregiver_id": "caregiver-1",
+        "display_name": "Emily",
+        "status": "ACTIVE",
+        "text": "Emily is selected as the emergency contact.",
+    }
+    assert policy["user"]["channels"][0] == {
+        "channel": CHANNEL_GUARDIAN_AUDIO,
+        "enabled": True,
+        "reason": "Guardian audio mode is active",
+    }
+    assert policy["caregivers"][0]["display_name"] == "Emily"
+    assert policy["caregivers"][0]["permissions"]["emergency_alerts"] is True
+    assert policy["caregivers"][0]["permissions"]["daily_summary"] is True
+    assert policy["rules"][0]["severity"] == "critical"
+    assert "notify you and your selected emergency caregiver" in policy["rules"][0]["text"]
+    assert "not raw private chats" in policy["display"]["rules"][-1]
+
+
+def test_plain_language_policy_view_handles_missing_emergency_contact():
+    policy = build_plain_language_policy_view(
+        _user(guardian_mode=None, user_email=None, user_phone=None),
+        [_caregiver(is_emergency_contact=False, email=None, phone=None)],
+    )
+
+    assert policy["emergency_contact"]["configured"] is False
+    assert policy["emergency_contact"]["text"] == "No active emergency caregiver is selected."
+    assert policy["user"]["channels"] == [
+        {
+            "channel": CHANNEL_GUARDIAN_AUDIO,
+            "enabled": False,
+            "reason": "Guardian audio mode is off",
+        },
+        {
+            "channel": CHANNEL_IMESSAGE,
+            "enabled": False,
+            "reason": "No phone number on file",
+        },
+        {
+            "channel": CHANNEL_EMAIL,
+            "enabled": False,
+            "reason": "No email on file",
+        },
+    ]


### PR DESCRIPTION
## Summary
- Add read-only GET /v1/ella/escalations/policy?uid=... for iOS plain-language escalation rules UI
- Reuse the existing escalation policy context and expose user/caregiver channel availability, emergency contact state, rule text, and privacy notes
- Extend caregiver policy context with display name/relationship and add focused unit coverage

## Verification
- /tmp/omi-policy-view-venv/bin/python -m pytest backend/tests/unit/test_ella_escalation_policy.py
- /tmp/omi-policy-view-venv/bin/python -m black --check backend/ella/services/escalation_policy.py backend/ella/routers/escalations.py backend/tests/unit/test_ella_escalation_policy.py

Refs ellaaicare/ella-ai#629