### PR TITLE
fix: require auth for Ella policy view

### DIFF
--- a/backend/ella/routers/escalations.py
+++ b/backend/ella/routers/escalations.py
@@ -11,8 +11,10 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 import asyncpg
+from firebase_admin.auth import InvalidIdTokenError
 from fastapi import APIRouter, Header, HTTPException
 from pydantic import BaseModel, Field
+from utils.other import endpoints as auth_endpoints
 
 from ella.services.escalation_policy import (
     CaregiverPolicyContext,
@@ -64,6 +66,40 @@ def _verify_key(x_guardian_key: Optional[str], x_escalation_key: Optional[str], 
     provided = x_escalation_key or x_guardian_key or key
     if provided != ESCALATION_WEBHOOK_KEY:
         raise HTTPException(status_code=403, detail="Invalid escalation key")
+
+
+def _resolve_policy_view_uid(
+    uid: Optional[str],
+    authorization: Optional[str],
+    x_guardian_key: Optional[str],
+    x_escalation_key: Optional[str],
+    key: Optional[str],
+) -> str:
+    """Resolve the policy-view UID for either app auth or internal callers."""
+    provided_key = x_escalation_key or x_guardian_key or key
+    if provided_key == ESCALATION_WEBHOOK_KEY:
+        if not uid:
+            raise HTTPException(status_code=400, detail="uid is required for internal policy lookup")
+        return uid
+
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Authorization header not found")
+
+    parts = str(authorization).split(" ")
+    if len(parts) != 2 or parts[0].lower() != "bearer" or not parts[1]:
+        raise HTTPException(status_code=401, detail="Invalid authorization token")
+
+    try:
+        authenticated_uid = auth_endpoints.verify_token(parts[1])
+    except InvalidIdTokenError:
+        raise HTTPException(status_code=401, detail="Invalid authorization token")
+    except Exception as e:
+        print(f"Error verifying Firebase ID token: {type(e).__name__}: {e}", flush=True)
+        raise HTTPException(status_code=401, detail="Invalid authorization token")
+
+    if uid and uid != authenticated_uid:
+        raise HTTPException(status_code=403, detail="Authenticated user cannot read another user's escalation policy")
+    return authenticated_uid
 
 
 async def _load_context(uid: str) -> tuple[UserPolicyContext, list[CaregiverPolicyContext]]:
@@ -165,9 +201,16 @@ async def evaluate_escalation(
 
 
 @router.get("/policy")
-async def get_escalation_policy(uid: str):
+async def get_escalation_policy(
+    uid: Optional[str] = None,
+    authorization: Optional[str] = Header(None, alias="Authorization"),
+    x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
+    x_escalation_key: Optional[str] = Header(None, alias="X-Escalation-Key"),
+    key: Optional[str] = Header(None, alias="X-Key"),
+):
     """Return the read-only effective policy view for user/caregiver UI."""
-    user, caregivers = await _load_context(uid)
+    resolved_uid = _resolve_policy_view_uid(uid, authorization, x_guardian_key, x_escalation_key, key)
+    user, caregivers = await _load_context(resolved_uid)
     policy = build_plain_language_policy_view(user, caregivers)
     return {
         "ok": True,

--- a/backend/tests/unit/test_ella_escalations_router_auth.py
+++ b/backend/tests/unit/test_ella_escalations_router_auth.py
@@ -1,0 +1,80 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+_ROUTER_PATH = Path(__file__).resolve().parents[2] / "ella" / "routers" / "escalations.py"
+_SPEC = importlib.util.spec_from_file_location("ella_escalations_under_test", _ROUTER_PATH)
+escalations = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+_SPEC.loader.exec_module(escalations)
+
+
+def test_policy_view_uid_allows_internal_key_with_explicit_uid():
+    assert (
+        escalations._resolve_policy_view_uid(
+            "uid-1",
+            authorization=None,
+            x_guardian_key=escalations.ESCALATION_WEBHOOK_KEY,
+            x_escalation_key=None,
+            key=None,
+        )
+        == "uid-1"
+    )
+
+
+def test_policy_view_uid_requires_uid_for_internal_key():
+    with pytest.raises(HTTPException) as exc:
+        escalations._resolve_policy_view_uid(
+            None,
+            authorization=None,
+            x_guardian_key=escalations.ESCALATION_WEBHOOK_KEY,
+            x_escalation_key=None,
+            key=None,
+        )
+
+    assert exc.value.status_code == 400
+
+
+def test_policy_view_uid_uses_authenticated_uid_when_uid_omitted(monkeypatch):
+    monkeypatch.setattr(escalations.auth_endpoints, "verify_token", lambda token: "uid-1")
+
+    assert (
+        escalations._resolve_policy_view_uid(
+            None,
+            authorization="Bearer token-1",
+            x_guardian_key=None,
+            x_escalation_key=None,
+            key=None,
+        )
+        == "uid-1"
+    )
+
+
+def test_policy_view_uid_rejects_cross_user_read(monkeypatch):
+    monkeypatch.setattr(escalations.auth_endpoints, "verify_token", lambda token: "uid-1")
+
+    with pytest.raises(HTTPException) as exc:
+        escalations._resolve_policy_view_uid(
+            "uid-2",
+            authorization="Bearer token-1",
+            x_guardian_key=None,
+            x_escalation_key=None,
+            key=None,
+        )
+
+    assert exc.value.status_code == 403
+
+
+def test_policy_view_uid_requires_authorization_without_internal_key():
+    with pytest.raises(HTTPException) as exc:
+        escalations._resolve_policy_view_uid(
+            "uid-1",
+            authorization=None,
+            x_guardian_key=None,
+            x_escalation_key=None,
+            key=None,
+        )
+
+    assert exc.value.status_code == 401


### PR DESCRIPTION
## Summary
- Require Firebase Bearer auth for GET /v1/ella/escalations/policy by default
- Preserve internal service access via X-Guardian-Key / X-Escalation-Key with explicit uid
- Reject cross-user reads when an authenticated user supplies another uid
- Add focused unit coverage for policy-view UID resolution

## Verification
- /tmp/omi-policy-view-venv/bin/python -m pytest backend/tests/unit/test_ella_escalation_policy.py backend/tests/unit/test_ella_escalations_router_auth.py
- /tmp/omi-policy-view-venv/bin/python -m black --check backend/ella/routers/escalations.py backend/tests/unit/test_ella_escalations_router_auth.py

Refs ellaaicare/ella-ai#629