### PR TITLE
fix(ios): caregiver invite resend/status UX (#626)

### DIFF
--- a/app/lib/ella/models/caregiver.dart
+++ b/app/lib/ella/models/caregiver.dart
@@ -7,6 +7,7 @@ class Caregiver {
   final String status; // normalized lowercase: "active" or "invited"
   final DateTime? joinedAt;
   final DateTime? invitedAt;
+  final DateTime? inviteExpiresAt;
   final bool receiveDailySummary;
 
   Caregiver({
@@ -18,6 +19,7 @@ class Caregiver {
     required this.status,
     this.joinedAt,
     this.invitedAt,
+    this.inviteExpiresAt,
     this.receiveDailySummary = true,
   });
 
@@ -32,6 +34,7 @@ class Caregiver {
             ? DateTime.parse(json['joined_at'])
             : (json['accepted_at'] != null ? DateTime.parse(json['accepted_at']) : null),
         invitedAt = json['invited_at'] != null ? DateTime.parse(json['invited_at']) : null,
+        inviteExpiresAt = json['invite_expires_at'] != null ? DateTime.parse(json['invite_expires_at']) : null,
         receiveDailySummary = (json['permissions'] as Map<String, dynamic>?)?['receive_daily_summary'] as bool? ?? true;
 
   String get initial => name.isNotEmpty ? name[0].toUpperCase() : '?';
@@ -59,6 +62,7 @@ class Caregiver {
 
   bool get isActive => status.toLowerCase() == 'active';
   bool get isInvited => status.toLowerCase() == 'invited';
+  bool get isExpired => isInvited && inviteExpiresAt != null && inviteExpiresAt!.isBefore(DateTime.now());
 }
 
 class InviteResponse {

--- a/app/lib/ella/pages/ella_care_team_page.dart
+++ b/app/lib/ella/pages/ella_care_team_page.dart
@@ -16,7 +16,7 @@ class EllaCareTeamPage extends StatefulWidget {
   State<EllaCareTeamPage> createState() => _EllaCareTeamPageState();
 }
 
-class _EllaCareTeamPageState extends State<EllaCareTeamPage> {
+class _EllaCareTeamPageState extends State<EllaCareTeamPage> with WidgetsBindingObserver {
   List<Caregiver> _caregivers = [];
   bool _loading = true;
   static const int _maxCaregivers = 5;
@@ -24,7 +24,21 @@ class _EllaCareTeamPageState extends State<EllaCareTeamPage> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _loadCaregivers();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _loadCaregivers();
+    }
   }
 
   Future<void> _loadCaregivers() async {

--- a/app/lib/ella/pages/ella_caregiver_detail_page.dart
+++ b/app/lib/ella/pages/ella_caregiver_detail_page.dart
@@ -86,7 +86,7 @@ class _EllaCaregiverDetailPageState extends State<EllaCaregiverDetailPage> {
   }
 
   Future<void> _resendInvite() async {
-    if (_resending || _caregiver.phone == null) return;
+    if (_resending) return;
     setState(() => _resending = true);
     try {
       await caregiver_api.resendInvite(
@@ -97,6 +97,7 @@ class _EllaCaregiverDetailPageState extends State<EllaCaregiverDetailPage> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(context.l10n.ellaResendSuccess(_caregiver.name))),
         );
+        await _refreshFromBackend();
       }
     } catch (_) {
       if (mounted) {
@@ -158,11 +159,21 @@ class _EllaCaregiverDetailPageState extends State<EllaCaregiverDetailPage> {
   @override
   Widget build(BuildContext context) {
     final cg = _caregiver;
-    final statusColor = cg.isActive ? EllaColors.success : EllaColors.warning;
-    final statusLabel = cg.isActive ? context.l10n.ellaCaregiverStatusActive : context.l10n.ellaCaregiverStatusInvited;
+    final statusColor = cg.isActive
+        ? EllaColors.success
+        : cg.isExpired
+            ? EllaColors.error
+            : EllaColors.warning;
+    final statusLabel = cg.isActive
+        ? context.l10n.ellaCaregiverStatusActive
+        : cg.isExpired
+            ? context.l10n.ellaCaregiverStatusExpired
+            : context.l10n.ellaCaregiverStatusInvited;
     final dateLabel = cg.isActive
         ? context.l10n.ellaJoinedDate(_formatDate(cg.joinedAt))
-        : context.l10n.ellaInvitedDate(_formatDate(cg.invitedAt));
+        : cg.isExpired
+            ? context.l10n.ellaInviteExpiredDate(_formatDate(cg.inviteExpiresAt))
+            : context.l10n.ellaInvitedDate(_formatDate(cg.invitedAt));
 
     return Scaffold(
       backgroundColor: EllaColors.bgPrimary,
@@ -239,7 +250,7 @@ class _EllaCaregiverDetailPageState extends State<EllaCaregiverDetailPage> {
                 const SizedBox(height: 4),
                 Text(dateLabel,
                     style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w400, color: EllaColors.textTertiary)),
-                if (cg.isInvited) ...[
+                if (cg.isInvited || cg.isExpired) ...[
                   const SizedBox(height: 12),
                   Semantics(
                     button: true,

--- a/app/lib/ella/widgets/ella_caregiver_row.dart
+++ b/app/lib/ella/widgets/ella_caregiver_row.dart
@@ -14,10 +14,18 @@ class EllaCaregiverRow extends StatelessWidget {
     this.onTap,
   });
 
-  Color get _statusColor => caregiver.isActive ? EllaColors.success : EllaColors.warning;
+  Color get _statusColor => caregiver.isActive
+      ? EllaColors.success
+      : caregiver.isExpired
+          ? EllaColors.error
+          : EllaColors.warning;
 
   String _statusLabel(BuildContext context) {
-    return caregiver.isActive ? context.l10n.ellaCaregiverStatusActive : context.l10n.ellaCaregiverStatusInvited;
+    return caregiver.isActive
+        ? context.l10n.ellaCaregiverStatusActive
+        : caregiver.isExpired
+            ? context.l10n.ellaCaregiverStatusExpired
+            : context.l10n.ellaCaregiverStatusInvited;
   }
 
   @override

--- a/app/lib/ella/widgets/ella_caregiver_row.dart
+++ b/app/lib/ella/widgets/ella_caregiver_row.dart
@@ -52,7 +52,7 @@ class EllaCaregiverRow extends StatelessWidget {
                 height: 48,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  color: EllaColors.primary.withOpacity(0.15),
+                  color: EllaColors.primary.withValues(alpha: 0.15),
                 ),
                 child: Center(
                   child: Text(

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -9925,6 +9925,15 @@
   "ellaCareTeamFullDialog": "Your care team is full (5 people). Remove someone to add a new member.",
   "ellaCaregiverStatusActive": "Active — receives alerts",
   "ellaCaregiverStatusInvited": "Invited — waiting to join",
+  "ellaCaregiverStatusExpired": "Invite expired",
+  "ellaInviteExpiredDate": "Invite expired {date}",
+  "@ellaInviteExpiredDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "ellaFamilyCaregivers": "Family & Caregivers",
   "ellaFamilyCaregiversSubtitle": "{count, plural, =1{1 person} other{{count} people}}",
   "@ellaFamilyCaregiversSubtitle": {

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -15255,6 +15255,18 @@ abstract class AppLocalizations {
   /// **'Invited — waiting to join'**
   String get ellaCaregiverStatusInvited;
 
+  /// No description provided for @ellaCaregiverStatusExpired.
+  ///
+  /// In en, this message translates to:
+  /// **'Invite expired'**
+  String get ellaCaregiverStatusExpired;
+
+  /// No description provided for @ellaInviteExpiredDate.
+  ///
+  /// In en, this message translates to:
+  /// **'Invite expired {date}'**
+  String ellaInviteExpiredDate(String date);
+
   /// No description provided for @ellaFamilyCaregivers.
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8112,6 +8112,14 @@ class AppLocalizationsAr extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8200,6 +8200,14 @@ class AppLocalizationsBg extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8216,6 +8216,14 @@ class AppLocalizationsCa extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8163,6 +8163,14 @@ class AppLocalizationsCs extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8152,6 +8152,14 @@ class AppLocalizationsDa extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8234,6 +8234,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8225,6 +8225,14 @@ class AppLocalizationsEl extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8165,6 +8165,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8182,6 +8182,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8167,6 +8167,14 @@ class AppLocalizationsEt extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8166,6 +8166,14 @@ class AppLocalizationsFi extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8241,6 +8241,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8148,6 +8148,14 @@ class AppLocalizationsHi extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8205,6 +8205,14 @@ class AppLocalizationsHu extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8180,6 +8180,14 @@ class AppLocalizationsId extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8217,6 +8217,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8034,6 +8034,14 @@ class AppLocalizationsJa extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8036,6 +8036,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8173,6 +8173,14 @@ class AppLocalizationsLt extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8185,6 +8185,14 @@ class AppLocalizationsLv extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8191,6 +8191,14 @@ class AppLocalizationsMs extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8193,6 +8193,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8163,6 +8163,14 @@ class AppLocalizationsNo extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8186,6 +8186,14 @@ class AppLocalizationsPl extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8168,6 +8168,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8206,6 +8206,14 @@ class AppLocalizationsRo extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8193,6 +8193,14 @@ class AppLocalizationsRu extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8158,6 +8158,14 @@ class AppLocalizationsSk extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8173,6 +8173,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8130,6 +8130,14 @@ class AppLocalizationsTh extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8181,6 +8181,14 @@ class AppLocalizationsTr extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8180,6 +8180,14 @@ class AppLocalizationsUk extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8170,6 +8170,14 @@ class AppLocalizationsVi extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8024,6 +8024,14 @@ class AppLocalizationsZh extends AppLocalizations {
   String get ellaCaregiverStatusInvited => 'Invited — waiting to join';
 
   @override
+  String get ellaCaregiverStatusExpired => 'Invite expired';
+
+  @override
+  String ellaInviteExpiredDate(String date) {
+    return 'Invite expired $date';
+  }
+
+  @override
   String get ellaFamilyCaregivers => 'Family & Caregivers';
 
   @override

--- a/app/test/ella/models/caregiver_test.dart
+++ b/app/test/ella/models/caregiver_test.dart
@@ -30,5 +30,58 @@ void main() {
       expect(caregiver.status, 'invited');
       expect(caregiver.receiveDailySummary, isFalse);
     });
+
+    test('isExpired is true when invited and invite_expires_at is in the past', () {
+      final caregiver = Caregiver.fromJson({
+        'id': 'cg-exp',
+        'name': 'Bob',
+        'relationship': 'son',
+        'status': 'INVITED',
+        'invite_expires_at': '2020-01-01T00:00:00.000Z',
+      });
+
+      expect(caregiver.isInvited, isTrue);
+      expect(caregiver.isExpired, isTrue);
+      expect(caregiver.isActive, isFalse);
+    });
+
+    test('isExpired is false when invited and invite_expires_at is in the future', () {
+      final future = DateTime.now().add(const Duration(days: 7)).toIso8601String();
+      final caregiver = Caregiver.fromJson({
+        'id': 'cg-pending',
+        'name': 'Alice',
+        'relationship': 'daughter',
+        'status': 'INVITED',
+        'invite_expires_at': future,
+      });
+
+      expect(caregiver.isInvited, isTrue);
+      expect(caregiver.isExpired, isFalse);
+    });
+
+    test('isExpired is false when no invite_expires_at', () {
+      final caregiver = Caregiver.fromJson({
+        'id': 'cg-no-exp',
+        'name': 'Carol',
+        'relationship': 'spouse',
+        'status': 'INVITED',
+      });
+
+      expect(caregiver.isInvited, isTrue);
+      expect(caregiver.isExpired, isFalse);
+    });
+
+    test('isExpired is false for active caregiver even with past expiry', () {
+      final caregiver = Caregiver.fromJson({
+        'id': 'cg-active',
+        'name': 'Dave',
+        'relationship': 'friend',
+        'status': 'ACTIVE',
+        'invite_expires_at': '2020-01-01T00:00:00.000Z',
+      });
+
+      expect(caregiver.isActive, isTrue);
+      expect(caregiver.isExpired, isFalse);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Fixes ella-ai#626 — caregiver invite resend/status UX improvements for the iOS app.

**Problem**: The resend invite button was blocked for caregivers without a phone number (email-only invites silently failed). There was no visual distinction between pending and expired invites, and no refresh on app resume.

**Changes**:
- **Remove phone-null guard on `_resendInvite()`** — email-only caregivers can now resend invites via the n8n webhook
- **Add `inviteExpiresAt` to Caregiver model** — parsed from `invite_expires_at` field already returned by the n8n caregiver-list API
- **Add `isExpired` getter** — `isInvited && inviteExpiresAt != null && inviteExpiresAt.isBefore(now)`
- **Three-state status UI** — Active (green), Invited (yellow), Expired (red) in both the caregiver row widget and detail page
- **"Resend Invite" shown for expired caregivers** — previously only shown for `isInvited` (expired invites stayed as `INVITED` in the backend enum)
- **Refresh detail from backend after successful resend** — calls `_refreshFromBackend()` so the new expiry date appears immediately
- **Refresh caregiver list on app resume** — added `WidgetsBindingObserver` so dashboard-accepted caregivers appear Active without reinstall
- **Add l10n strings**: `ellaCaregiverStatusExpired`, `ellaInviteExpiredDate`

## Test output

```
00:00 +6: All tests passed!

  ✅ normalizes backend enum status casing
  ✅ reads daily summary permission from backend permissions
  ✅ isExpired is true when invited and invite_expires_at is in the past
  ✅ isExpired is false when invited and invite_expires_at is in the future
  ✅ isExpired is false when no invite_expires_at
  ✅ isExpired is false for active caregiver even with past expiry
```

`dart analyze` — clean (no errors or warnings from changed files).

## Test plan

- [ ] Invite a caregiver with email only (no phone) → tap "Resend Invite" on detail page → confirm invite sends
- [ ] Wait for invite to expire (or set `invite_expires_at` to past in DB) → confirm red "Invite expired" status appears in list and detail
- [ ] Tap "Resend Invite" on expired caregiver → confirm new invite sends and expiry refreshes
- [ ] Accept a caregiver invite from the dashboard → return to iOS app → confirm caregiver shows "Active" without manual refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)