### PR TITLE
feat(ella): add iOS conversation correction endpoint

### DIFF
--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -293,6 +293,15 @@ def _register_routers(app) -> None:
     except ImportError as e:
         print(f"  ⚠️ Ella debug metadata not available: {e}", flush=True)
 
+    # App-facing conversation correction endpoint (iOS Correct Summary)
+    try:
+        from ella.routers.corrections import router as corrections_router
+
+        app.include_router(corrections_router, tags=["Conversation Corrections"])
+        print("  🌐 /v1/conversations/*/corrections - Summary correction loop", flush=True)
+    except ImportError as e:
+        print(f"  ⚠️ Ella corrections not available: {e}", flush=True)
+
     # Escalation policy resolver (classifier output -> deterministic delivery plan)
     try:
         from ella.routers.escalations import router as escalations_router

--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -298,7 +298,7 @@ def _register_routers(app) -> None:
         from ella.routers.corrections import router as corrections_router
 
         app.include_router(corrections_router, tags=["Conversation Corrections"])
-        print("  🌐 /v1/conversations/*/corrections - Summary correction loop", flush=True)
+        print("  🌐 /v1/ella/conversations/*/corrections - Summary correction loop", flush=True)
     except ImportError as e:
         print(f"  ⚠️ Ella corrections not available: {e}", flush=True)
 

--- a/backend/ella/routers/__init__.py
+++ b/backend/ella/routers/__init__.py
@@ -7,17 +7,20 @@ Routers:
 - voice: Voice session management (token issuance)
 - guardian: Guardian Mode audio delivery queue for iOS
 - resolve: User identity to OpenClaw agent resolution
+- corrections: Authenticated iOS summary correction submission
 
 These add endpoints that don't exist in vanilla OMI:
 - /v1/ella/* - Callback endpoints for Letta agents
 - /v1/ella/chat/* - Grok streaming chat
 - /v1/ella/guardian/* - Guardian Mode audio queue
 - /v1/ella/resolve - User-to-agent resolution
+- /v1/conversations/{id}/corrections - iOS Correct Summary
 - /v1/voice/* - Voice session management
 """
 
 from .callbacks import router as callbacks_router
 from .chat import router as chat_router
+from .corrections import router as corrections_router
 from .guardian import router as guardian_router
 from .resolve import router as resolve_router
 from .voice import router as voice_router
@@ -25,6 +28,7 @@ from .voice import router as voice_router
 __all__ = [
     "callbacks_router",
     "chat_router",
+    "corrections_router",
     "guardian_router",
     "resolve_router",
     "voice_router",

--- a/backend/ella/routers/__init__.py
+++ b/backend/ella/routers/__init__.py
@@ -14,7 +14,7 @@ These add endpoints that don't exist in vanilla OMI:
 - /v1/ella/chat/* - Grok streaming chat
 - /v1/ella/guardian/* - Guardian Mode audio queue
 - /v1/ella/resolve - User-to-agent resolution
-- /v1/conversations/{id}/corrections - iOS Correct Summary
+- /v1/ella/conversations/{id}/corrections - iOS Correct Summary
 - /v1/voice/* - Voice session management
 """
 

--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -6,7 +6,6 @@ of the upstream OMI conversation router so future upstream syncs do not have to
 carry this custom app contract as a core patch.
 """
 
-import json
 import logging
 import uuid
 from datetime import datetime, timezone
@@ -19,7 +18,6 @@ from pydantic import BaseModel, Field, field_validator
 import database.conversations as conversations_db
 from database._client import db
 from ella.config import ELLA_CONFIG
-from ella.routers.resolve import resolve_user_routing
 from utils.other import endpoints as auth
 
 logger = logging.getLogger(__name__)
@@ -140,49 +138,7 @@ def _append_correction_event(
     ref.set({"events": events, "updated_at": event.get("at") or _now_iso()}, merge=True)
 
 
-def _correction_markdown(
-    *,
-    uid: str,
-    conversation_id: str,
-    correction_id: str,
-    request: ConversationCorrectionRequest,
-    structured: dict[str, Any],
-    transcript: str,
-    submitted_at: str,
-) -> str:
-    context_json = json.dumps(request.summary_context.model_dump(), indent=2, sort_keys=True)
-    structured_json = json.dumps(structured, indent=2, sort_keys=True)
-    return f"""# Conversation Summary Correction
-
-- correction_id: {correction_id}
-- uid: {uid}
-- conversation_id: {conversation_id}
-- source: {request.source}
-- submitted_at: {submitted_at}
-
-## Correction Text
-
-{request.correction_text}
-
-## iOS Summary Context
-
-```json
-{context_json}
-```
-
-## Current Backend Summary
-
-```json
-{structured_json}
-```
-
-## Full Transcript
-
-{transcript or "(No transcript text was available from OMI.)"}
-"""
-
-
-async def _enqueue_correction(
+async def _submit_correction_to_n8n(
     *,
     uid: str,
     conversation_id: str,
@@ -193,94 +149,38 @@ async def _enqueue_correction(
     transcript: str,
     segment_count: int,
 ) -> dict[str, Any]:
-    routing_info = await resolve_user_routing(uid)
-    routing = (routing_info or {}).get("routing") or {}
-    agent_id = routing.get("agentId")
-    provision_url = (routing.get("provisionUrl") or "").rstrip("/")
-    provision_token = routing.get("provisionToken") or ""
-
-    if not agent_id or not provision_url:
-        raise RuntimeError("OpenClaw routing is missing agentId or provisionUrl")
-
-    correction_file = f"corrections/{correction_id}.md"
-    submitted_at = _now_iso()
-    markdown = _correction_markdown(
-        uid=uid,
-        conversation_id=conversation_id,
-        correction_id=correction_id,
-        request=request,
-        structured=structured,
-        transcript=transcript,
-        submitted_at=submitted_at,
-    )
-    headers = {}
-    if provision_token:
-        headers = {"Authorization": f"Bearer {provision_token}", "x-api-key": provision_token}
-
+    webhook_url = f"{ELLA_CONFIG.n8n_base_url.rstrip('/')}/webhook/conversation-correction"
+    payload = {
+        "uid": uid,
+        "conversation_id": conversation_id,
+        "correction_id": correction_id,
+        "trace_id": trace_id,
+        "correction_text": request.correction_text,
+        "text": request.correction_text,
+        "correction_type": _correction_category(request.correction_text, request.summary_context),
+        "source": request.source,
+        "summary_context": request.summary_context.model_dump(),
+        "current_summary": structured,
+        "transcript": transcript,
+        "segments_count": segment_count,
+    }
     async with httpx.AsyncClient(timeout=20.0) as client:
-        write_resp = await client.put(
-            f"{provision_url}/workspace/{agent_id}/write",
-            headers=headers,
-            json={"filepath": correction_file, "content": markdown},
-        )
-        write_resp.raise_for_status()
-
-        observe_resp = await client.post(
-            f"{provision_url}/workspace/{agent_id}/observe",
-            headers=headers,
-            json={
-                "trigger": "correction_submitted",
-                "turn_count": 0,
-                "conversation_id": conversation_id,
-                "uid": uid,
-                "omi_uid": uid,
-                "title": structured.get("title") or "",
-                "emoji": structured.get("emoji") or "",
-                "category": structured.get("category") or "other",
-                "segments_count": segment_count,
-                "correction_id": correction_id,
-                "correction_text": request.correction_text,
-                "correction_source": request.source,
-                "correction_file": correction_file,
-                "summary_context": request.summary_context.model_dump(),
-                "trace_id": trace_id,
-            },
-        )
-        observe_resp.raise_for_status()
-
-        n8n_status = "accepted"
-        try:
-            n8n_resp = await client.post(
-                f"{ELLA_CONFIG.n8n_base_url.rstrip('/')}/webhook/reprocess-queue",
-                json={
-                    "uid": uid,
-                    "conversations": [
-                        {
-                            "conversation_id": conversation_id,
-                            "reason": f"iOS summary correction {correction_id}",
-                            "correction_id": correction_id,
-                        }
-                    ],
-                },
-            )
-            n8n_resp.raise_for_status()
-        except Exception as exc:
-            logger.warning(
-                "Correction queued in OpenClaw but n8n reprocess-queue webhook failed",
-                extra={"uid": uid, "conversation_id": conversation_id, "correction_id": correction_id},
-            )
-            n8n_status = f"failed: {exc}"
+        response = await client.post(webhook_url, json=payload)
+        response.raise_for_status()
+    try:
+        response_body = response.json()
+    except Exception:
+        response_body = {}
 
     return {
-        "agent_id": agent_id,
-        "correction_file": correction_file,
-        "provision_observe": "accepted",
-        "n8n_reprocess_queue": n8n_status,
+        "n8n_webhook": "conversation-correction",
+        "n8n_status_code": response.status_code,
+        "n8n_response": response_body,
     }
 
 
 @router.post(
-    "/v1/conversations/{conversation_id}/corrections",
+    "/v1/ella/conversations/{conversation_id}/corrections",
     response_model=ConversationCorrectionResponse,
     status_code=status.HTTP_202_ACCEPTED,
 )
@@ -321,7 +221,7 @@ async def submit_conversation_correction(
     _persist_correction_audit(uid, conversation_id, correction_id, audit_payload)
 
     try:
-        queue_result = await _enqueue_correction(
+        queue_result = await _submit_correction_to_n8n(
             uid=uid,
             conversation_id=conversation_id,
             correction_id=correction_id,
@@ -333,7 +233,7 @@ async def submit_conversation_correction(
         )
     except Exception as exc:
         logger.exception(
-            "Failed to enqueue conversation correction",
+            "Failed to submit conversation correction to n8n",
             extra={"uid": uid, "conversation_id": conversation_id, "correction_id": correction_id},
         )
         _persist_correction_audit(

--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -1,0 +1,383 @@
+"""
+Ella conversation correction endpoints.
+
+This router is intentionally registered through the Ella extension hook instead
+of the upstream OMI conversation router so future upstream syncs do not have to
+carry this custom app contract as a core patch.
+"""
+
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field, field_validator
+
+import database.conversations as conversations_db
+from database._client import db
+from ella.config import ELLA_CONFIG
+from ella.routers.resolve import resolve_user_routing
+from utils.other import endpoints as auth
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["conversation-corrections"])
+
+
+class SummaryContext(BaseModel):
+    title: Optional[str] = None
+    overview: Optional[str] = None
+    app_summary: Optional[str] = None
+
+
+class ConversationCorrectionRequest(BaseModel):
+    correction_text: str = Field(..., min_length=1, max_length=4000)
+    source: str = Field(default="ios", min_length=1, max_length=64)
+    summary_context: SummaryContext = Field(default_factory=SummaryContext)
+
+    @field_validator("correction_text")
+    @classmethod
+    def _strip_correction_text(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("correction_text cannot be blank")
+        return stripped
+
+
+class ConversationCorrectionResponse(BaseModel):
+    correction_id: str
+    conversation_id: str
+    trace_id: str
+    status: str
+    queued: bool
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _structured_summary(conversation: dict[str, Any]) -> dict[str, Any]:
+    structured = conversation.get("structured") or {}
+    return {
+        "title": structured.get("title") or conversation.get("title") or "",
+        "overview": structured.get("overview") or conversation.get("overview") or "",
+        "emoji": structured.get("emoji") or conversation.get("emoji") or "",
+        "category": str(structured.get("category") or conversation.get("category") or "other"),
+    }
+
+
+def _segment_text(segment: dict[str, Any]) -> str:
+    text = segment.get("text") or ""
+    speaker = segment.get("speaker") or segment.get("speaker_name")
+    if not speaker:
+        speaker = "User" if segment.get("is_user") else "Speaker"
+    return f"{speaker}: {text}".strip()
+
+
+def _format_transcript(conversation: dict[str, Any]) -> str:
+    segments = conversation.get("transcript_segments") or []
+    lines = [_segment_text(segment) for segment in segments if (segment.get("text") or "").strip()]
+    return "\n\n".join(lines)
+
+
+def _correction_category(text: str, summary_context: SummaryContext) -> str:
+    haystack = " ".join(
+        [
+            text,
+            summary_context.title or "",
+            summary_context.overview or "",
+            summary_context.app_summary or "",
+        ]
+    ).lower()
+    if any(word in haystack for word in ("name", "person", "speaker", "identity", "attribution")):
+        return "identity"
+    if any(word in haystack for word in ("tv", "podcast", "video", "movie", "background", "media")):
+        return "media"
+    if any(word in haystack for word in ("title", "headline")):
+        return "title"
+    if any(word in haystack for word in ("topic", "about", "missed", "forgot")):
+        return "topic"
+    return "other"
+
+
+def _audit_ref(uid: str, conversation_id: str, correction_id: str):
+    return (
+        db.collection("users")
+        .document(uid)
+        .collection("conversations")
+        .document(conversation_id)
+        .collection("corrections")
+        .document(correction_id)
+    )
+
+
+def _persist_correction_audit(
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+    payload: dict[str, Any],
+) -> None:
+    _audit_ref(uid, conversation_id, correction_id).set(payload, merge=True)
+
+
+def _append_correction_event(
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+    event: dict[str, Any],
+) -> None:
+    ref = _audit_ref(uid, conversation_id, correction_id)
+    try:
+        snapshot = ref.get()
+        existing = snapshot.to_dict() if getattr(snapshot, "exists", False) else {}
+    except Exception:
+        existing = {}
+    events = list((existing or {}).get("events") or [])
+    events.append(event)
+    ref.set({"events": events, "updated_at": event.get("at") or _now_iso()}, merge=True)
+
+
+def _correction_markdown(
+    *,
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+    request: ConversationCorrectionRequest,
+    structured: dict[str, Any],
+    transcript: str,
+    submitted_at: str,
+) -> str:
+    context_json = json.dumps(request.summary_context.model_dump(), indent=2, sort_keys=True)
+    structured_json = json.dumps(structured, indent=2, sort_keys=True)
+    return f"""# Conversation Summary Correction
+
+- correction_id: {correction_id}
+- uid: {uid}
+- conversation_id: {conversation_id}
+- source: {request.source}
+- submitted_at: {submitted_at}
+
+## Correction Text
+
+{request.correction_text}
+
+## iOS Summary Context
+
+```json
+{context_json}
+```
+
+## Current Backend Summary
+
+```json
+{structured_json}
+```
+
+## Full Transcript
+
+{transcript or "(No transcript text was available from OMI.)"}
+"""
+
+
+async def _enqueue_correction(
+    *,
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+    trace_id: str,
+    request: ConversationCorrectionRequest,
+    structured: dict[str, Any],
+    transcript: str,
+    segment_count: int,
+) -> dict[str, Any]:
+    routing_info = await resolve_user_routing(uid)
+    routing = (routing_info or {}).get("routing") or {}
+    agent_id = routing.get("agentId")
+    provision_url = (routing.get("provisionUrl") or "").rstrip("/")
+    provision_token = routing.get("provisionToken") or ""
+
+    if not agent_id or not provision_url:
+        raise RuntimeError("OpenClaw routing is missing agentId or provisionUrl")
+
+    correction_file = f"corrections/{correction_id}.md"
+    submitted_at = _now_iso()
+    markdown = _correction_markdown(
+        uid=uid,
+        conversation_id=conversation_id,
+        correction_id=correction_id,
+        request=request,
+        structured=structured,
+        transcript=transcript,
+        submitted_at=submitted_at,
+    )
+    headers = {}
+    if provision_token:
+        headers = {"Authorization": f"Bearer {provision_token}", "x-api-key": provision_token}
+
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        write_resp = await client.put(
+            f"{provision_url}/workspace/{agent_id}/write",
+            headers=headers,
+            json={"filepath": correction_file, "content": markdown},
+        )
+        write_resp.raise_for_status()
+
+        observe_resp = await client.post(
+            f"{provision_url}/workspace/{agent_id}/observe",
+            headers=headers,
+            json={
+                "trigger": "correction_submitted",
+                "turn_count": 0,
+                "conversation_id": conversation_id,
+                "uid": uid,
+                "omi_uid": uid,
+                "title": structured.get("title") or "",
+                "emoji": structured.get("emoji") or "",
+                "category": structured.get("category") or "other",
+                "segments_count": segment_count,
+                "correction_id": correction_id,
+                "correction_text": request.correction_text,
+                "correction_source": request.source,
+                "correction_file": correction_file,
+                "summary_context": request.summary_context.model_dump(),
+                "trace_id": trace_id,
+            },
+        )
+        observe_resp.raise_for_status()
+
+        n8n_status = "accepted"
+        try:
+            n8n_resp = await client.post(
+                f"{ELLA_CONFIG.n8n_base_url.rstrip('/')}/webhook/reprocess-queue",
+                json={
+                    "uid": uid,
+                    "conversations": [
+                        {
+                            "conversation_id": conversation_id,
+                            "reason": f"iOS summary correction {correction_id}",
+                            "correction_id": correction_id,
+                        }
+                    ],
+                },
+            )
+            n8n_resp.raise_for_status()
+        except Exception as exc:
+            logger.warning(
+                "Correction queued in OpenClaw but n8n reprocess-queue webhook failed",
+                extra={"uid": uid, "conversation_id": conversation_id, "correction_id": correction_id},
+            )
+            n8n_status = f"failed: {exc}"
+
+    return {
+        "agent_id": agent_id,
+        "correction_file": correction_file,
+        "provision_observe": "accepted",
+        "n8n_reprocess_queue": n8n_status,
+    }
+
+
+@router.post(
+    "/v1/conversations/{conversation_id}/corrections",
+    response_model=ConversationCorrectionResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def submit_conversation_correction(
+    conversation_id: str,
+    request: ConversationCorrectionRequest,
+    uid: str = Depends(auth.get_current_user_uid),
+) -> ConversationCorrectionResponse:
+    conversation = conversations_db.get_conversation(uid, conversation_id)
+    if conversation is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    if conversation.get("is_locked", False):
+        raise HTTPException(status_code=402, detail="Conversation locked")
+
+    correction_id = str(uuid.uuid4())
+    trace_id = f"correction:{conversation_id}:{correction_id}"
+    submitted_at = _now_iso()
+    structured = _structured_summary(conversation)
+    transcript = _format_transcript(conversation)
+    segment_count = len(conversation.get("transcript_segments") or [])
+
+    audit_payload = {
+        "correction_id": correction_id,
+        "trace_id": trace_id,
+        "uid": uid,
+        "conversation_id": conversation_id,
+        "status": "submitted",
+        "source": request.source,
+        "correction_text": request.correction_text,
+        "category": _correction_category(request.correction_text, request.summary_context),
+        "summary_context": request.summary_context.model_dump(),
+        "current_summary": structured,
+        "segment_count": segment_count,
+        "created_at": submitted_at,
+        "updated_at": submitted_at,
+        "events": [{"stage": "submitted", "status": "ok", "at": submitted_at, "trace_id": trace_id}],
+    }
+    _persist_correction_audit(uid, conversation_id, correction_id, audit_payload)
+
+    try:
+        queue_result = await _enqueue_correction(
+            uid=uid,
+            conversation_id=conversation_id,
+            correction_id=correction_id,
+            trace_id=trace_id,
+            request=request,
+            structured=structured,
+            transcript=transcript,
+            segment_count=segment_count,
+        )
+    except Exception as exc:
+        logger.exception(
+            "Failed to enqueue conversation correction",
+            extra={"uid": uid, "conversation_id": conversation_id, "correction_id": correction_id},
+        )
+        _persist_correction_audit(
+            uid,
+            conversation_id,
+            correction_id,
+            {
+                "status": "queue_failed",
+                "updated_at": _now_iso(),
+                "queue_error": str(exc),
+            },
+        )
+        _append_correction_event(
+            uid,
+            conversation_id,
+            correction_id,
+            {"stage": "queue_failed", "status": "error", "at": _now_iso(), "trace_id": trace_id, "error": str(exc)},
+        )
+        return ConversationCorrectionResponse(
+            correction_id=correction_id,
+            conversation_id=conversation_id,
+            trace_id=trace_id,
+            status="queue_failed",
+            queued=False,
+        )
+
+    queued_at = _now_iso()
+    _persist_correction_audit(
+        uid,
+        conversation_id,
+        correction_id,
+        {"status": "queued", "updated_at": queued_at, "queue_result": queue_result},
+    )
+    _append_correction_event(
+        uid,
+        conversation_id,
+        correction_id,
+        {"stage": "queued", "status": "ok", "at": queued_at, "trace_id": trace_id, "queue_result": queue_result},
+    )
+
+    return ConversationCorrectionResponse(
+        correction_id=correction_id,
+        conversation_id=conversation_id,
+        trace_id=trace_id,
+        status="queued",
+        queued=True,
+    )

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -1,0 +1,180 @@
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+sys.modules.setdefault("database._client", MagicMock(db=MagicMock()))
+sys.modules.setdefault("database.conversations", MagicMock())
+sys.modules.setdefault("httpx", MagicMock())
+sys.modules.setdefault("utils.other.endpoints", MagicMock())
+sys.modules.setdefault("ella.config", MagicMock(ELLA_CONFIG=SimpleNamespace(n8n_base_url="https://n8n.test")))
+sys.modules.setdefault("ella.routers.resolve", MagicMock())
+
+_backend_path = Path(__file__).resolve().parents[2]
+if str(_backend_path) not in sys.path:
+    sys.path.insert(0, str(_backend_path))
+
+_corrections_path = _backend_path / "ella" / "routers" / "corrections.py"
+_corrections_spec = importlib.util.spec_from_file_location("ella_corrections_test_module", _corrections_path)
+corrections = importlib.util.module_from_spec(_corrections_spec)
+assert _corrections_spec is not None and _corrections_spec.loader is not None
+_corrections_spec.loader.exec_module(corrections)
+
+
+def _conversation():
+    return {
+        "transcript_segments": [
+            {"is_user": True, "text": "The podcast said memory can be tricky."},
+            {"speaker": "Plato", "text": "That was the TV, not me."},
+        ],
+        "structured": {
+            "title": "Memory concern",
+            "overview": "[Ella] Plato discussed memory issues.",
+            "emoji": "🧠",
+            "category": "health",
+        },
+    }
+
+
+def test_submit_correction_accepts_ios_payload_and_queues(monkeypatch):
+    audits = []
+    events = []
+    enqueued = {}
+
+    monkeypatch.setattr(corrections.conversations_db, "get_conversation", lambda uid, conversation_id: _conversation())
+    monkeypatch.setattr(
+        corrections,
+        "_persist_correction_audit",
+        lambda uid, conversation_id, correction_id, payload: audits.append(
+            {
+                "uid": uid,
+                "conversation_id": conversation_id,
+                "correction_id": correction_id,
+                "payload": payload,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        corrections,
+        "_append_correction_event",
+        lambda uid, conversation_id, correction_id, event: events.append(event),
+    )
+
+    async def fake_enqueue(**kwargs):
+        enqueued.update(kwargs)
+        return {"agent_id": "ella-user-test", "correction_file": "corrections/corr.md"}
+
+    monkeypatch.setattr(corrections, "_enqueue_correction", fake_enqueue)
+
+    result = asyncio.run(
+        corrections.submit_conversation_correction(
+            "conv-123",
+            corrections.ConversationCorrectionRequest(
+                correction_text="This was background TV audio, not a real memory concern.",
+                source="ios",
+                summary_context={
+                    "title": "Memory concern",
+                    "overview": "[Ella] Plato discussed memory issues.",
+                    "app_summary": "The app summary was too clinical.",
+                },
+            ),
+            uid="user-123",
+        )
+    )
+
+    assert result.status == "queued"
+    assert result.queued is True
+    assert result.conversation_id == "conv-123"
+    assert result.correction_id
+    assert result.trace_id.startswith("correction:conv-123:")
+    assert audits[0]["uid"] == "user-123"
+    assert audits[0]["payload"]["status"] == "submitted"
+    assert audits[0]["payload"]["category"] == "media"
+    assert audits[0]["payload"]["correction_text"] == "This was background TV audio, not a real memory concern."
+    assert enqueued["uid"] == "user-123"
+    assert enqueued["conversation_id"] == "conv-123"
+    assert "The podcast said memory can be tricky." in enqueued["transcript"]
+    assert enqueued["request"].summary_context.app_summary == "The app summary was too clinical."
+    assert events[-1]["stage"] == "queued"
+
+
+def test_submit_correction_uses_authenticated_uid_for_ownership(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: calls.append((uid, conversation_id)) or None,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(
+            corrections.submit_conversation_correction(
+                "conv-123",
+                corrections.ConversationCorrectionRequest(correction_text="Wrong person."),
+                uid="authenticated-user",
+            )
+        )
+
+    assert excinfo.value.status_code == 404
+    assert calls == [("authenticated-user", "conv-123")]
+
+
+def test_submit_correction_rejects_locked_conversation(monkeypatch):
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: {"is_locked": True},
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(
+            corrections.submit_conversation_correction(
+                "conv-locked",
+                corrections.ConversationCorrectionRequest(correction_text="Please fix this."),
+                uid="user-123",
+            )
+        )
+
+    assert excinfo.value.status_code == 402
+
+
+def test_submit_correction_persists_failure_trace_and_still_returns_202(monkeypatch):
+    audits = []
+    events = []
+
+    monkeypatch.setattr(corrections.conversations_db, "get_conversation", lambda uid, conversation_id: _conversation())
+    monkeypatch.setattr(
+        corrections,
+        "_persist_correction_audit",
+        lambda uid, conversation_id, correction_id, payload: audits.append(payload),
+    )
+    monkeypatch.setattr(
+        corrections,
+        "_append_correction_event",
+        lambda uid, conversation_id, correction_id, event: events.append(event),
+    )
+
+    async def failing_enqueue(**kwargs):
+        raise RuntimeError("provision offline")
+
+    monkeypatch.setattr(corrections, "_enqueue_correction", failing_enqueue)
+
+    result = asyncio.run(
+        corrections.submit_conversation_correction(
+            "conv-123",
+            corrections.ConversationCorrectionRequest(correction_text="Please correct the summary."),
+            uid="user-123",
+        )
+    )
+
+    assert result.status == "queue_failed"
+    assert result.queued is False
+    assert audits[-1]["status"] == "queue_failed"
+    assert audits[-1]["queue_error"] == "provision offline"
+    assert events[-1]["stage"] == "queue_failed"
+    assert events[-1]["status"] == "error"

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -13,7 +13,6 @@ sys.modules.setdefault("database.conversations", MagicMock())
 sys.modules.setdefault("httpx", MagicMock())
 sys.modules.setdefault("utils.other.endpoints", MagicMock())
 sys.modules.setdefault("ella.config", MagicMock(ELLA_CONFIG=SimpleNamespace(n8n_base_url="https://n8n.test")))
-sys.modules.setdefault("ella.routers.resolve", MagicMock())
 
 _backend_path = Path(__file__).resolve().parents[2]
 if str(_backend_path) not in sys.path:
@@ -44,7 +43,7 @@ def _conversation():
 def test_submit_correction_accepts_ios_payload_and_queues(monkeypatch):
     audits = []
     events = []
-    enqueued = {}
+    submitted = {}
 
     monkeypatch.setattr(corrections.conversations_db, "get_conversation", lambda uid, conversation_id: _conversation())
     monkeypatch.setattr(
@@ -65,11 +64,11 @@ def test_submit_correction_accepts_ios_payload_and_queues(monkeypatch):
         lambda uid, conversation_id, correction_id, event: events.append(event),
     )
 
-    async def fake_enqueue(**kwargs):
-        enqueued.update(kwargs)
-        return {"agent_id": "ella-user-test", "correction_file": "corrections/corr.md"}
+    async def fake_submit_to_n8n(**kwargs):
+        submitted.update(kwargs)
+        return {"n8n_webhook": "conversation-correction", "n8n_status_code": 200}
 
-    monkeypatch.setattr(corrections, "_enqueue_correction", fake_enqueue)
+    monkeypatch.setattr(corrections, "_submit_correction_to_n8n", fake_submit_to_n8n)
 
     result = asyncio.run(
         corrections.submit_conversation_correction(
@@ -96,10 +95,10 @@ def test_submit_correction_accepts_ios_payload_and_queues(monkeypatch):
     assert audits[0]["payload"]["status"] == "submitted"
     assert audits[0]["payload"]["category"] == "media"
     assert audits[0]["payload"]["correction_text"] == "This was background TV audio, not a real memory concern."
-    assert enqueued["uid"] == "user-123"
-    assert enqueued["conversation_id"] == "conv-123"
-    assert "The podcast said memory can be tricky." in enqueued["transcript"]
-    assert enqueued["request"].summary_context.app_summary == "The app summary was too clinical."
+    assert submitted["uid"] == "user-123"
+    assert submitted["conversation_id"] == "conv-123"
+    assert "The podcast said memory can be tricky." in submitted["transcript"]
+    assert submitted["request"].summary_context.app_summary == "The app summary was too clinical."
     assert events[-1]["stage"] == "queued"
 
 
@@ -143,7 +142,7 @@ def test_submit_correction_rejects_locked_conversation(monkeypatch):
     assert excinfo.value.status_code == 402
 
 
-def test_submit_correction_persists_failure_trace_and_still_returns_202(monkeypatch):
+def test_submit_correction_persists_n8n_failure_trace_and_still_returns_202(monkeypatch):
     audits = []
     events = []
 
@@ -159,10 +158,10 @@ def test_submit_correction_persists_failure_trace_and_still_returns_202(monkeypa
         lambda uid, conversation_id, correction_id, event: events.append(event),
     )
 
-    async def failing_enqueue(**kwargs):
-        raise RuntimeError("provision offline")
+    async def failing_submit_to_n8n(**kwargs):
+        raise RuntimeError("n8n offline")
 
-    monkeypatch.setattr(corrections, "_enqueue_correction", failing_enqueue)
+    monkeypatch.setattr(corrections, "_submit_correction_to_n8n", failing_submit_to_n8n)
 
     result = asyncio.run(
         corrections.submit_conversation_correction(
@@ -175,6 +174,87 @@ def test_submit_correction_persists_failure_trace_and_still_returns_202(monkeypa
     assert result.status == "queue_failed"
     assert result.queued is False
     assert audits[-1]["status"] == "queue_failed"
-    assert audits[-1]["queue_error"] == "provision offline"
+    assert audits[-1]["queue_error"] == "n8n offline"
     assert events[-1]["stage"] == "queue_failed"
     assert events[-1]["status"] == "error"
+
+
+def test_router_uses_custom_ella_namespace_only():
+    paths = {route.path for route in corrections.router.routes}
+
+    assert "/v1/ella/conversations/{conversation_id}/corrections" in paths
+    assert "/v1/conversations/{conversation_id}/corrections" not in paths
+
+
+def test_submit_to_n8n_posts_single_structured_workflow_payload(monkeypatch):
+    calls = []
+
+    class FakeResponse:
+        status_code = 200
+        content = b'{"status":"processing"}'
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"status": "processing"}
+
+    class FakeAsyncClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, json):
+            calls.append({"url": url, "json": json, "timeout": self.timeout})
+            return FakeResponse()
+
+    monkeypatch.setattr(corrections.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = asyncio.run(
+        corrections._submit_correction_to_n8n(
+            uid="user-123",
+            conversation_id="conv-123",
+            correction_id="corr-123",
+            trace_id="correction:conv-123:corr-123",
+            request=corrections.ConversationCorrectionRequest(
+                correction_text="This was background TV audio.",
+                source="ios",
+                summary_context={"title": "Memory concern"},
+            ),
+            structured={"title": "Memory concern", "overview": "[Ella] old", "emoji": "", "category": "health"},
+            transcript="Speaker: transcript",
+            segment_count=1,
+        )
+    )
+
+    assert result["n8n_webhook"] == "conversation-correction"
+    assert calls == [
+        {
+            "url": "https://n8n.test/webhook/conversation-correction",
+            "json": {
+                "uid": "user-123",
+                "conversation_id": "conv-123",
+                "correction_id": "corr-123",
+                "trace_id": "correction:conv-123:corr-123",
+                "correction_text": "This was background TV audio.",
+                "text": "This was background TV audio.",
+                "correction_type": "media",
+                "source": "ios",
+                "summary_context": {"title": "Memory concern", "overview": None, "app_summary": None},
+                "current_summary": {
+                    "title": "Memory concern",
+                    "overview": "[Ella] old",
+                    "emoji": "",
+                    "category": "health",
+                },
+                "transcript": "Speaker: transcript",
+                "segments_count": 1,
+            },
+            "timeout": 20.0,
+        }
+    ]


### PR DESCRIPTION
## Summary
- Move Correct Summary submission to custom Ella route: POST /v1/ella/conversations/{conversation_id}/corrections
- Keep OMI as thin authenticated boundary: Firebase UID ownership check, Firestore correction audit/events, and one n8n webhook submission
- Remove direct OpenClaw routing from OMI; no resolve_user_routing, /workspace/{agent_id}/write, /observe, or reprocess-queue calls from this endpoint
- Send structured correction payload to n8n /webhook/conversation-correction with full transcript, current summary, correction_id, and trace_id

## Tests
- /home/letta/.local/bin/pytest backend/tests/unit/test_ella_conversation_corrections.py backend/tests/unit/test_ella_callbacks_summary_update.py -q
- python3.12 -m py_compile backend/ella/routers/corrections.py backend/tests/unit/test_ella_conversation_corrections.py

Refs ellaaicare/ella-ai#640. n8n/OpenClaw workflow PR: ellaaicare/ella-ai#641