### PR TITLE
Harden Ella correction n8n response handling

### DIFF
--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -138,6 +138,15 @@ def _append_correction_event(
     ref.set({"events": events, "updated_at": event.get("at") or _now_iso()}, merge=True)
 
 
+def _n8n_correction_response_is_accepted(response_body: Any) -> bool:
+    if not isinstance(response_body, dict):
+        return False
+    if response_body.get("queued") is True or response_body.get("success") is True:
+        return True
+    status_value = str(response_body.get("status") or "").lower()
+    return status_value in {"accepted", "ok", "processing", "queued", "success"}
+
+
 async def _submit_correction_to_n8n(
     *,
     uid: str,
@@ -166,11 +175,12 @@ async def _submit_correction_to_n8n(
     }
     async with httpx.AsyncClient(timeout=20.0) as client:
         response = await client.post(webhook_url, json=payload)
-        response.raise_for_status()
     try:
         response_body = response.json()
     except Exception:
         response_body = {}
+    if response.status_code >= 400 and not _n8n_correction_response_is_accepted(response_body):
+        response.raise_for_status()
 
     return {
         "n8n_webhook": "conversation-correction",

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -258,3 +258,53 @@ def test_submit_to_n8n_posts_single_structured_workflow_payload(monkeypatch):
             "timeout": 20.0,
         }
     ]
+
+
+def test_submit_to_n8n_accepts_async_success_body_even_with_bad_http_status(monkeypatch):
+    class FakeResponse:
+        status_code = 500
+        content = b'{"status":"processing","queued":true}'
+
+        def raise_for_status(self):
+            raise AssertionError("raise_for_status should not run for accepted n8n async responses")
+
+        def json(self):
+            return {"status": "processing", "queued": True, "trace_id": "trace-123"}
+
+    class FakeAsyncClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, json):
+            return FakeResponse()
+
+    monkeypatch.setattr(corrections.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = asyncio.run(
+        corrections._submit_correction_to_n8n(
+            uid="user-123",
+            conversation_id="conv-123",
+            correction_id="corr-123",
+            trace_id="trace-123",
+            request=corrections.ConversationCorrectionRequest(
+                correction_text="This was background TV audio.",
+                source="ios",
+                summary_context={"title": "Memory concern"},
+            ),
+            structured={"title": "Memory concern"},
+            transcript="Speaker: transcript",
+            segment_count=1,
+        )
+    )
+
+    assert result == {
+        "n8n_webhook": "conversation-correction",
+        "n8n_status_code": 500,
+        "n8n_response": {"status": "processing", "queued": True, "trace_id": "trace-123"},
+    }


### PR DESCRIPTION
## Summary
- Parse the n8n correction webhook response body before raising on HTTP errors.
- Accept explicit async success states such as queued/processing/success even if n8n miscodes the HTTP status.
- Keep raising real non-success HTTP failures.
- Add a regression test for the successful queued body with HTTP 500 case observed in smoke testing.

## Test
- /Users/ellaai/.venvs/codex-py314/bin/python -m pytest -q backend/tests/unit/test_ella_conversation_corrections.py

## Notes
This is a guardrail only. The n8n workflow should still be fixed to return HTTP 202 on queued success instead of successful HTTP 500.