### PR TITLE
feat(ella): Alert Channels UI + Guardian semantics (#656)

### DIFF
--- a/app/lib/ella/models/escalation_policy.dart
+++ b/app/lib/ella/models/escalation_policy.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+
+import 'package:omi/ella/ella_theme.dart';
+
+/// Channel status entry from the escalation policy.
+class ChannelStatus {
+  final String channel;
+  final bool enabled;
+  final String reason;
+
+  const ChannelStatus({
+    required this.channel,
+    required this.enabled,
+    required this.reason,
+  });
+
+  factory ChannelStatus.fromJson(Map<String, dynamic> json) {
+    return ChannelStatus(
+      channel: json['channel'] as String? ?? '',
+      enabled: json['enabled'] as bool? ?? false,
+      reason: json['reason'] as String? ?? '',
+    );
+  }
+
+  /// Human-readable channel name.
+  String get displayName {
+    switch (channel) {
+      case 'guardian_audio':
+        return 'Guardian Audio';
+      case 'imessage':
+        return 'iMessage';
+      case 'email':
+        return 'Email';
+      default:
+        return channel.replaceAll('_', ' ').split(' ').map((w) => w[0].toUpperCase() + w.substring(1)).join(' ');
+    }
+  }
+
+  IconData get icon {
+    switch (channel) {
+      case 'guardian_audio':
+        return Icons.volume_up;
+      case 'imessage':
+        return Icons.message;
+      case 'email':
+        return Icons.email;
+      default:
+        return Icons.notifications;
+    }
+  }
+}
+
+/// Emergency contact section from the escalation policy.
+class EmergencyContactPolicy {
+  final bool configured;
+  final String? caregiverId;
+  final String? displayName;
+  final String? status;
+  final String text;
+
+  const EmergencyContactPolicy({
+    required this.configured,
+    this.caregiverId,
+    this.displayName,
+    this.status,
+    required this.text,
+  });
+
+  factory EmergencyContactPolicy.fromJson(Map<String, dynamic> json) {
+    return EmergencyContactPolicy(
+      configured: json['configured'] as bool? ?? false,
+      caregiverId: json['caregiver_id'] as String?,
+      displayName: json['display_name'] as String?,
+      status: json['status'] as String?,
+      text: json['text'] as String? ?? '',
+    );
+  }
+}
+
+/// Caregiver permissions from the escalation policy.
+class CaregiverPermissions {
+  final bool emergencyAlerts;
+  final bool dailySummary;
+  final bool weeklySummary;
+
+  const CaregiverPermissions({
+    required this.emergencyAlerts,
+    required this.dailySummary,
+    required this.weeklySummary,
+  });
+
+  factory CaregiverPermissions.fromJson(Map<String, dynamic> json) {
+    return CaregiverPermissions(
+      emergencyAlerts: json['emergency_alerts'] as bool? ?? json['urgent_alerts'] as bool? ?? false,
+      dailySummary: json['daily_summary'] as bool? ?? false,
+      weeklySummary: json['weekly_summary'] as bool? ?? false,
+    );
+  }
+}
+
+/// Per-caregiver policy view from the escalation policy.
+class CaregiverPolicyView {
+  final String caregiverId;
+  final String displayName;
+  final String? relationship;
+  final String status;
+  final bool isEmergencyContact;
+  final List<ChannelStatus> channels;
+  final CaregiverPermissions permissions;
+  final String plainLanguage;
+
+  const CaregiverPolicyView({
+    required this.caregiverId,
+    required this.displayName,
+    this.relationship,
+    required this.status,
+    required this.isEmergencyContact,
+    required this.channels,
+    required this.permissions,
+    required this.plainLanguage,
+  });
+
+  factory CaregiverPolicyView.fromJson(Map<String, dynamic> json) {
+    return CaregiverPolicyView(
+      caregiverId: json['caregiver_id'] as String? ?? '',
+      displayName: json['display_name'] as String? ?? 'Caregiver',
+      relationship: json['relationship'] as String?,
+      status: json['status'] as String? ?? 'UNKNOWN',
+      isEmergencyContact: json['is_emergency_contact'] as bool? ?? false,
+      channels: (json['channels'] as List<dynamic>? ?? [])
+          .map((c) => ChannelStatus.fromJson(c as Map<String, dynamic>))
+          .toList(),
+      permissions: CaregiverPermissions.fromJson(json['permissions'] as Map<String, dynamic>? ?? {}),
+      plainLanguage: json['plain_language'] as String? ?? '',
+    );
+  }
+}
+
+/// Single severity/decision rule from the escalation policy.
+class EscalationRule {
+  final String severity;
+  final String decision;
+  final String title;
+  final String text;
+
+  const EscalationRule({
+    required this.severity,
+    required this.decision,
+    required this.title,
+    required this.text,
+  });
+
+  factory EscalationRule.fromJson(Map<String, dynamic> json) {
+    return EscalationRule(
+      severity: json['severity'] as String? ?? 'low',
+      decision: json['decision'] as String? ?? 'log_only',
+      title: json['title'] as String? ?? '',
+      text: json['text'] as String? ?? '',
+    );
+  }
+
+  /// Severity color for UI display.
+  Color get severityColor {
+    switch (severity) {
+      case 'critical':
+        return EllaColors.error;
+      case 'high':
+        return const Color(0xFFF59E0B); // amber
+      case 'medium':
+        return EllaColors.primary;
+      default:
+        return EllaColors.textTertiary;
+    }
+  }
+
+  /// Human-readable decision name.
+  String get decisionLabel {
+    switch (decision) {
+      case 'notify_now':
+        return 'Notify Immediately';
+      case 'ask_user_first':
+        return 'Ask You First';
+      case 'queue_for_report':
+        return 'Include in Report';
+      case 'log_only':
+        return 'Log Only';
+      default:
+        return decision.replaceAll('_', ' ').split(' ').map((w) => w[0].toUpperCase() + w.substring(1)).join(' ');
+    }
+  }
+}
+
+/// Display helper section from the escalation policy.
+class EscalationPolicyDisplay {
+  final String title;
+  final String subtitle;
+  final String emergencyContact;
+  final List<String> rules;
+
+  const EscalationPolicyDisplay({
+    required this.title,
+    required this.subtitle,
+    required this.emergencyContact,
+    required this.rules,
+  });
+
+  factory EscalationPolicyDisplay.fromJson(Map<String, dynamic> json) {
+    return EscalationPolicyDisplay(
+      title: json['title'] as String? ?? 'How Ella handles alerts',
+      subtitle: json['subtitle'] as String? ?? '',
+      emergencyContact: json['emergency_contact'] as String? ?? '',
+      rules: (json['rules'] as List<dynamic>? ?? []).map((r) => r as String).toList(),
+    );
+  }
+}
+
+/// Top-level escalation policy model.
+class EscalationPolicy {
+  final String policyVersion;
+  final String uid;
+  final List<ChannelStatus> userChannels;
+  final String? guardianMode;
+  final EmergencyContactPolicy emergencyContact;
+  final List<CaregiverPolicyView> caregivers;
+  final List<EscalationRule> rules;
+  final List<String> privacyNotes;
+  final EscalationPolicyDisplay display;
+  final String generatedAt;
+
+  const EscalationPolicy({
+    required this.policyVersion,
+    required this.uid,
+    required this.userChannels,
+    this.guardianMode,
+    required this.emergencyContact,
+    required this.caregivers,
+    required this.rules,
+    required this.privacyNotes,
+    required this.display,
+    required this.generatedAt,
+  });
+
+  factory EscalationPolicy.fromJson(Map<String, dynamic> json) {
+    final user = json['user'] as Map<String, dynamic>? ?? {};
+    return EscalationPolicy(
+      policyVersion: json['policy_version'] as String? ?? 'unknown',
+      uid: json['uid'] as String? ?? '',
+      userChannels: (user['channels'] as List<dynamic>? ?? [])
+          .map((c) => ChannelStatus.fromJson(c as Map<String, dynamic>))
+          .toList(),
+      guardianMode: user['guardian_mode'] as String?,
+      emergencyContact: EmergencyContactPolicy.fromJson(json['emergency_contact'] as Map<String, dynamic>? ?? {}),
+      caregivers: (json['caregivers'] as List<dynamic>? ?? [])
+          .map((c) => CaregiverPolicyView.fromJson(c as Map<String, dynamic>))
+          .toList(),
+      rules: (json['rules'] as List<dynamic>? ?? [])
+          .map((r) => EscalationRule.fromJson(r as Map<String, dynamic>))
+          .toList(),
+      privacyNotes: (json['privacy_notes'] as List<dynamic>? ?? []).map((n) => n as String).toList(),
+      display: EscalationPolicyDisplay.fromJson(json['display'] as Map<String, dynamic>? ?? {}),
+      generatedAt: json['generated_at'] as String? ?? '',
+    );
+  }
+}

--- a/app/lib/ella/pages/alert_channels_page.dart
+++ b/app/lib/ella/pages/alert_channels_page.dart
@@ -1,0 +1,556 @@
+import 'package:flutter/material.dart';
+
+import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/ella/models/escalation_policy.dart';
+import 'package:omi/ella/pages/ella_emergency_contact_page.dart';
+import 'package:omi/ella/services/escalation_policy_api.dart' as policy_api;
+import 'package:omi/utils/l10n_extensions.dart';
+
+class AlertChannelsPage extends StatefulWidget {
+  const AlertChannelsPage({super.key});
+
+  @override
+  State<AlertChannelsPage> createState() => _AlertChannelsPageState();
+}
+
+class _AlertChannelsPageState extends State<AlertChannelsPage> {
+  bool _loading = true;
+  EscalationPolicy? _policy;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPolicy();
+  }
+
+  Future<void> _loadPolicy() async {
+    setState(() => _loading = true);
+    final policy = await policy_api.getEscalationPolicy();
+    if (mounted) {
+      setState(() {
+        _policy = policy;
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: EllaColors.bgPrimary,
+      appBar: AppBar(
+        backgroundColor: EllaColors.bgPrimary,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: EllaColors.textPrimary),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        title: Text(
+          context.l10n.ellaAlertChannels,
+          style: const TextStyle(
+            fontSize: 22,
+            fontWeight: FontWeight.w700,
+            color: EllaColors.textPrimary,
+          ),
+        ),
+        centerTitle: false,
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator(color: EllaColors.primary))
+          : _policy == null
+              ? _buildUnavailable()
+              : RefreshIndicator(
+                  color: EllaColors.primary,
+                  onRefresh: _loadPolicy,
+                  child: _buildPolicyContent(),
+                ),
+    );
+  }
+
+  Widget _buildUnavailable() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.cloud_off, size: 48, color: EllaColors.textTertiary),
+            const SizedBox(height: 16),
+            Text(
+              context.l10n.ellaAlertChannelsUnavailable,
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600, color: EllaColors.textPrimary),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              context.l10n.ellaAlertChannelsPullRetry,
+              style: const TextStyle(fontSize: 14, color: EllaColors.textTertiary),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            TextButton(
+              onPressed: _loadPolicy,
+              child: Text(context.l10n.ellaAlertChannelsRetry,
+                  style: const TextStyle(fontSize: 16, color: EllaColors.primary)),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPolicyContent() {
+    final p = _policy!;
+    return ListView(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      children: [
+        // Intro subtitle
+        if (p.display.subtitle.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(left: 4, bottom: 16),
+            child: Text(
+              p.display.subtitle,
+              style: const TextStyle(fontSize: 14, color: EllaColors.textTertiary),
+            ),
+          ),
+
+        // YOUR CHANNELS
+        _SectionHeader(label: context.l10n.ellaAlertChannelsYourChannels),
+        ...p.userChannels.map((c) => _ChannelStatusRow(channel: c)),
+        if (p.userChannels.isEmpty)
+          Padding(
+            padding: const EdgeInsets.only(left: 4, top: 4, bottom: 8),
+            child: Text(context.l10n.ellaAlertChannelsNoChannels,
+                style: const TextStyle(fontSize: 14, color: EllaColors.textTertiary)),
+          ),
+
+        const SizedBox(height: 20),
+
+        // EMERGENCY CONTACT
+        _SectionHeader(label: context.l10n.ellaAlertChannelsEmergencyContact),
+        _EmergencyContactCard(contact: p.emergencyContact),
+
+        const SizedBox(height: 20),
+
+        // CAREGIVER NOTIFICATIONS
+        if (p.caregivers.isNotEmpty) ...[
+          _SectionHeader(label: context.l10n.ellaAlertChannelsCaregiverNotifications),
+          ...p.caregivers.map((c) => _CaregiverPolicyRow(caregiver: c)),
+          const SizedBox(height: 20),
+        ],
+
+        // ALERT RULES
+        _SectionHeader(label: context.l10n.ellaAlertChannelsAlertRules),
+        ...p.rules.map((r) => _RuleCard(rule: r)),
+
+        const SizedBox(height: 20),
+
+        // PRIVACY NOTES
+        if (p.privacyNotes.isNotEmpty) ...[
+          _SectionHeader(label: context.l10n.ellaAlertChannelsPrivacyNotes),
+          ...p.privacyNotes.map((note) => Padding(
+                padding: const EdgeInsets.only(left: 4, bottom: 8),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('•  ', style: TextStyle(fontSize: 14, color: EllaColors.textTertiary)),
+                    Expanded(
+                      child: Text(note, style: const TextStyle(fontSize: 14, color: EllaColors.textSecondary)),
+                    ),
+                  ],
+                ),
+              )),
+          const SizedBox(height: 20),
+        ],
+
+        // Footer
+        Center(
+          child: Text(
+            'Policy ${p.policyVersion}  •  ${p.generatedAt.substring(0, p.generatedAt.length > 19 ? 19 : p.generatedAt.length)}',
+            style: const TextStyle(fontSize: 11, color: EllaColors.textTertiary),
+          ),
+        ),
+        const SizedBox(height: 32),
+      ],
+    );
+  }
+}
+
+// ── Private widgets ────────────────────────────────────────────────────────
+
+class _SectionHeader extends StatelessWidget {
+  final String label;
+  const _SectionHeader({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 4, bottom: 8),
+      child: Text(
+        label,
+        style: const TextStyle(
+          fontSize: 13,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.8,
+          color: EllaColors.textTertiary,
+        ),
+      ),
+    );
+  }
+}
+
+class _ChannelStatusRow extends StatelessWidget {
+  final ChannelStatus channel;
+  const _ChannelStatusRow({required this.channel});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: EllaColors.bgSecondary,
+          borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+        ),
+        child: Row(
+          children: [
+            Icon(channel.icon, size: 20, color: EllaColors.primary),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    channel.displayName,
+                    style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500, color: EllaColors.textPrimary),
+                  ),
+                  if (channel.reason.isNotEmpty)
+                    Text(
+                      channel.reason,
+                      style: const TextStyle(fontSize: 13, color: EllaColors.textTertiary),
+                    ),
+                ],
+              ),
+            ),
+            // Read-only badge
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              decoration: BoxDecoration(
+                color: channel.enabled
+                    ? EllaColors.primary.withValues(alpha: 0.1)
+                    : EllaColors.textTertiary.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                channel.enabled ? context.l10n.ellaAlertChannelsEnabled : context.l10n.ellaAlertChannelsDisabled,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: channel.enabled ? EllaColors.primary : EllaColors.textTertiary,
+                ),
+              ),
+            ),
+            const SizedBox(width: 6),
+            const Icon(Icons.lock_outline, size: 14, color: EllaColors.textTertiary),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmergencyContactCard extends StatelessWidget {
+  final EmergencyContactPolicy contact;
+  const _EmergencyContactCard({required this.contact});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: EllaColors.bgSecondary,
+        borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+      ),
+      child: contact.configured
+          ? Row(
+              children: [
+                Container(
+                  width: 36,
+                  height: 36,
+                  decoration: BoxDecoration(
+                    color: EllaColors.error.withValues(alpha: 0.1),
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(Icons.emergency, size: 18, color: EllaColors.error),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        contact.displayName ?? 'Emergency Contact',
+                        style:
+                            const TextStyle(fontSize: 16, fontWeight: FontWeight.w500, color: EllaColors.textPrimary),
+                      ),
+                      if (contact.text.isNotEmpty)
+                        Text(
+                          contact.text,
+                          style: const TextStyle(fontSize: 13, color: EllaColors.textTertiary),
+                        ),
+                    ],
+                  ),
+                ),
+                _StatusDot(status: contact.status ?? 'ACTIVE'),
+              ],
+            )
+          : InkWell(
+              onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const EllaEmergencyContactPage())),
+              borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Row(
+                  children: [
+                    const Icon(Icons.add_circle_outline, size: 20, color: EllaColors.primary),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            context.l10n.ellaAlertChannelsNotConfigured,
+                            style: const TextStyle(
+                                fontSize: 16, fontWeight: FontWeight.w500, color: EllaColors.textPrimary),
+                          ),
+                          Text(
+                            context.l10n.ellaAlertChannelsSetUpContact,
+                            style: const TextStyle(fontSize: 13, color: EllaColors.primary),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const Icon(Icons.chevron_right, size: 20, color: EllaColors.textTertiary),
+                  ],
+                ),
+              ),
+            ),
+    );
+  }
+}
+
+class _StatusDot extends StatelessWidget {
+  final String status;
+  const _StatusDot({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final isActive = status == 'ACTIVE';
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 8,
+          height: 8,
+          decoration: BoxDecoration(
+            color: isActive ? EllaColors.primary : EllaColors.textTertiary,
+            shape: BoxShape.circle,
+          ),
+        ),
+        const SizedBox(width: 4),
+        Text(
+          status,
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w600,
+            color: isActive ? EllaColors.primary : EllaColors.textTertiary,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CaregiverPolicyRow extends StatelessWidget {
+  final CaregiverPolicyView caregiver;
+  const _CaregiverPolicyRow({required this.caregiver});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: EllaColors.bgSecondary,
+          borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    caregiver.displayName,
+                    style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500, color: EllaColors.textPrimary),
+                  ),
+                ),
+                if (caregiver.isEmergencyContact)
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                    decoration: BoxDecoration(
+                      color: EllaColors.error.withValues(alpha: 0.1),
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: const Text(
+                      'Emergency',
+                      style: TextStyle(fontSize: 10, fontWeight: FontWeight.w600, color: EllaColors.error),
+                    ),
+                  ),
+                const SizedBox(width: 8),
+                _StatusDot(status: caregiver.status),
+              ],
+            ),
+            if (caregiver.relationship != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 2),
+                child: Text(
+                  caregiver.relationship!,
+                  style: const TextStyle(fontSize: 13, color: EllaColors.textTertiary),
+                ),
+              ),
+            const SizedBox(height: 8),
+            // Channel chips
+            Wrap(
+              spacing: 6,
+              runSpacing: 4,
+              children: caregiver.channels
+                  .map((c) => Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                        decoration: BoxDecoration(
+                          color: c.enabled
+                              ? EllaColors.primary.withValues(alpha: 0.1)
+                              : EllaColors.textTertiary.withValues(alpha: 0.1),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Text(
+                          c.displayName,
+                          style: TextStyle(
+                            fontSize: 11,
+                            fontWeight: FontWeight.w500,
+                            color: c.enabled ? EllaColors.primary : EllaColors.textTertiary,
+                          ),
+                        ),
+                      ))
+                  .toList(),
+            ),
+            const SizedBox(height: 8),
+            // Permissions
+            Row(
+              children: [
+                _PermissionChip(label: 'Alerts', enabled: caregiver.permissions.emergencyAlerts),
+                const SizedBox(width: 8),
+                _PermissionChip(label: 'Daily', enabled: caregiver.permissions.dailySummary),
+                const SizedBox(width: 8),
+                _PermissionChip(label: 'Weekly', enabled: caregiver.permissions.weeklySummary),
+              ],
+            ),
+            if (caregiver.plainLanguage.isNotEmpty) ...[
+              const SizedBox(height: 6),
+              Text(
+                caregiver.plainLanguage,
+                style: const TextStyle(fontSize: 13, color: EllaColors.textTertiary),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PermissionChip extends StatelessWidget {
+  final String label;
+  final bool enabled;
+  const _PermissionChip({required this.label, required this.enabled});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(
+          enabled ? Icons.check_circle : Icons.cancel,
+          size: 14,
+          color: enabled ? EllaColors.primary : EllaColors.textTertiary,
+        ),
+        const SizedBox(width: 3),
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: 12,
+            color: enabled ? EllaColors.textPrimary : EllaColors.textTertiary,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _RuleCard extends StatelessWidget {
+  final EscalationRule rule;
+  const _RuleCard({required this.rule});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Container(
+        decoration: BoxDecoration(
+          color: EllaColors.bgSecondary,
+          borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Severity color bar
+            Container(
+              width: 4,
+              height: 60,
+              decoration: BoxDecoration(
+                color: rule.severityColor,
+                borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(EllaSizes.radiusMedium),
+                  bottomLeft: Radius.circular(EllaSizes.radiusMedium),
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 4),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      rule.title,
+                      style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600, color: EllaColors.textPrimary),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      rule.text.isNotEmpty ? rule.text : rule.decisionLabel,
+                      style: const TextStyle(fontSize: 13, color: EllaColors.textTertiary),
+                      maxLines: 3,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/ella/pages/ella_settings_page.dart
+++ b/app/lib/ella/pages/ella_settings_page.dart
@@ -11,6 +11,7 @@ import 'package:omi/ella/ella_theme.dart';
 import 'package:omi/ella/models/caregiver.dart';
 import 'package:omi/ella/pages/conversation_lifecycle_settings_page.dart';
 import 'package:omi/ella/pages/ella_care_team_page.dart';
+import 'package:omi/ella/pages/alert_channels_page.dart';
 import 'package:omi/ella/pages/ella_emergency_contact_page.dart';
 import 'package:omi/ella/pages/ella_profile_page.dart';
 import 'package:omi/ella/models/guardian_mode.dart';
@@ -246,6 +247,15 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
                   MaterialPageRoute(builder: (context) => const EllaEmergencyContactPage()),
                 );
                 _loadData();
+              },
+            ),
+            const SizedBox(height: 8),
+            EllaSettingsRow(
+              icon: Icons.notifications_active,
+              title: context.l10n.ellaAlertChannels,
+              subtitle: context.l10n.ellaAlertChannelsSubtitle,
+              onTap: () {
+                Navigator.push(context, MaterialPageRoute(builder: (context) => const AlertChannelsPage()));
               },
             ),
 

--- a/app/lib/ella/pages/guardian_mode_page.dart
+++ b/app/lib/ella/pages/guardian_mode_page.dart
@@ -75,14 +75,13 @@ class _GuardianModePageState extends State<GuardianModePage> {
   }
 
   GuardianModeState get _pendingState => GuardianModeState(
-    override: _selectedOverride,
-    features: _selectedOverride != null ? [] : _selectedFeatures.toList(),
-  );
+        override: _selectedOverride,
+        features: _selectedOverride != null ? [] : _selectedFeatures.toList(),
+      );
 
   bool get _hasChanges {
     final pending = _pendingState;
-    return pending.override != _currentState.override ||
-        !_sameFeatures(pending.features, _currentState.features);
+    return pending.override != _currentState.override || !_sameFeatures(pending.features, _currentState.features);
   }
 
   bool _sameFeatures(List<String> a, List<String> b) {
@@ -188,9 +187,7 @@ class _GuardianModePageState extends State<GuardianModePage> {
         name: _fallbackLabel(key),
         description: '',
         detailsBullets: const [],
-        color: GuardianModeKey.fromString(key).isOverride
-            ? const Color(0xFFEC4899)
-            : const Color(0xFF14B8A6),
+        color: GuardianModeKey.fromString(key).isOverride ? const Color(0xFFEC4899) : const Color(0xFF14B8A6),
       ),
     );
   }
@@ -283,7 +280,7 @@ class _GuardianModePageState extends State<GuardianModePage> {
                       const Padding(
                         padding: EdgeInsets.only(left: 4, bottom: 10),
                         child: Text(
-                          'Replaces the care system entirely.',
+                          'Controls how Ella detects and processes conversations. Does not change who receives alerts.',
                           style: TextStyle(
                             fontSize: 13,
                             color: EllaColors.textTertiary,
@@ -359,7 +356,7 @@ class _GuardianModePageState extends State<GuardianModePage> {
                       const Padding(
                         padding: EdgeInsets.only(left: 4, bottom: 10),
                         child: Text(
-                          'Combine multiple features simultaneously.',
+                          'Choose which care features are active. Critical alerts to your emergency contact remain active even when Guardian is off.',
                           style: TextStyle(
                             fontSize: 13,
                             color: EllaColors.textTertiary,
@@ -392,9 +389,7 @@ class _GuardianModePageState extends State<GuardianModePage> {
 
                       // ── Turn Guardian Off ──────────────────────────────────
                       _TurnOffButton(
-                        isOff:
-                            _selectedOverride == null &&
-                            _selectedFeatures.isEmpty,
+                        isOff: _selectedOverride == null && _selectedFeatures.isEmpty,
                         onTap: () {
                           setState(() {
                             _selectedOverride = null;
@@ -465,9 +460,7 @@ class _OverrideRow extends StatelessWidget {
           duration: const Duration(milliseconds: 180),
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
           decoration: BoxDecoration(
-            color: isSelected
-                ? preset.color.withValues(alpha: 0.08)
-                : EllaColors.bgSecondary,
+            color: isSelected ? preset.color.withValues(alpha: 0.08) : EllaColors.bgSecondary,
             borderRadius: BorderRadius.circular(EllaSizes.radiusLarge),
             border: Border.all(
               color: isSelected ? preset.color : Colors.transparent,
@@ -488,9 +481,7 @@ class _OverrideRow extends StatelessWidget {
                     width: 2,
                   ),
                 ),
-                child: isSelected
-                    ? const Icon(Icons.check, size: 12, color: Colors.white)
-                    : null,
+                child: isSelected ? const Icon(Icons.check, size: 12, color: Colors.white) : null,
               ),
               const SizedBox(width: 14),
               Expanded(
@@ -502,9 +493,7 @@ class _OverrideRow extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
-                        color: isSelected
-                            ? preset.color
-                            : EllaColors.textPrimary,
+                        color: isSelected ? preset.color : EllaColors.textPrimary,
                       ),
                     ),
                     if (preset.description.isNotEmpty)
@@ -558,9 +547,7 @@ class _FeatureRow extends StatelessWidget {
           duration: const Duration(milliseconds: 180),
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
           decoration: BoxDecoration(
-            color: isChecked && !dimmed
-                ? preset.color.withValues(alpha: 0.08)
-                : EllaColors.bgSecondary,
+            color: isChecked && !dimmed ? preset.color.withValues(alpha: 0.08) : EllaColors.bgSecondary,
             borderRadius: BorderRadius.circular(EllaSizes.radiusLarge),
             border: Border.all(
               color: isChecked && !dimmed ? effectiveColor : Colors.transparent,
@@ -576,19 +563,13 @@ class _FeatureRow extends StatelessWidget {
                 height: 20,
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(5),
-                  color: isChecked && !dimmed
-                      ? effectiveColor
-                      : Colors.transparent,
+                  color: isChecked && !dimmed ? effectiveColor : Colors.transparent,
                   border: Border.all(
-                    color: isChecked && !dimmed
-                        ? effectiveColor
-                        : EllaColors.bgTertiary,
+                    color: isChecked && !dimmed ? effectiveColor : EllaColors.bgTertiary,
                     width: 2,
                   ),
                 ),
-                child: isChecked && !dimmed
-                    ? const Icon(Icons.check, size: 12, color: Colors.white)
-                    : null,
+                child: isChecked && !dimmed ? const Icon(Icons.check, size: 12, color: Colors.white) : null,
               ),
               const SizedBox(width: 14),
               Expanded(
@@ -600,9 +581,7 @@ class _FeatureRow extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
-                        color: isChecked && !dimmed
-                            ? effectiveColor
-                            : textColor,
+                        color: isChecked && !dimmed ? effectiveColor : textColor,
                       ),
                     ),
                     if (preset.description.isNotEmpty)
@@ -612,9 +591,7 @@ class _FeatureRow extends StatelessWidget {
                           preset.description,
                           style: TextStyle(
                             fontSize: 13,
-                            color: dimmed
-                                ? EllaColors.textTertiary.withValues(alpha: 0.5)
-                                : EllaColors.textTertiary,
+                            color: dimmed ? EllaColors.textTertiary.withValues(alpha: 0.5) : EllaColors.textTertiary,
                           ),
                         ),
                       ),
@@ -653,13 +630,26 @@ class _TurnOffButton extends StatelessWidget {
           ),
           padding: const EdgeInsets.symmetric(vertical: 14),
         ),
-        child: Text(
-          isOff ? 'Guardian Off' : 'Turn Guardian Off',
-          style: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.w500,
-            color: isOff ? EllaColors.bgTertiary : const Color(0xFF9CA3AF),
-          ),
+        child: Column(
+          children: [
+            Text(
+              isOff ? 'Guardian Off' : 'Turn Guardian Off',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w500,
+                color: isOff ? EllaColors.bgTertiary : const Color(0xFF9CA3AF),
+              ),
+            ),
+            const SizedBox(height: 2),
+            Text(
+              'Disables audio and non-critical check-ins. Emergency alerts stay active.',
+              style: TextStyle(
+                fontSize: 12,
+                color: isOff ? EllaColors.bgTertiary : const Color(0xFF9CA3AF).withValues(alpha: 0.7),
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
         ),
       ),
     );

--- a/app/lib/ella/services/escalation_policy_api.dart
+++ b/app/lib/ella/services/escalation_policy_api.dart
@@ -1,0 +1,33 @@
+import 'dart:convert';
+
+import 'package:omi/backend/http/shared.dart';
+import 'package:omi/ella/models/escalation_policy.dart';
+import 'package:omi/env/env.dart';
+import 'package:omi/utils/logger.dart';
+
+/// GET /v1/ella/escalations/policy
+///
+/// Returns the read-only effective escalation policy for the current user.
+/// Uses [makeApiCall] which auto-injects the Firebase Bearer token.
+Future<EscalationPolicy?> getEscalationPolicy() async {
+  final response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/ella/escalations/policy',
+    method: 'GET',
+    headers: {},
+    body: '',
+  );
+
+  if (response == null || response.statusCode != 200) {
+    final code = response?.statusCode ?? 0;
+    Logger.debug('EscalationPolicy API failed: $code');
+    return null;
+  }
+
+  try {
+    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    return EscalationPolicy.fromJson(json);
+  } catch (e) {
+    Logger.debug('EscalationPolicy parse error: $e');
+    return null;
+  }
+}

--- a/app/lib/ella/widgets/guardian_mode_button.dart
+++ b/app/lib/ella/widgets/guardian_mode_button.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 
 import 'package:omi/ella/ella_theme.dart';
 import 'package:omi/ella/services/guardian_mode_service.dart';
+import 'package:omi/utils/l10n_extensions.dart';
 
 class GuardianModeButton extends StatefulWidget {
   const GuardianModeButton({super.key});
@@ -106,7 +107,7 @@ class _GuardianModeButtonState extends State<GuardianModeButton> with SingleTick
   String _getStatusText() {
     switch (_guardianService.currentState) {
       case GuardianModeState.idle:
-        return 'Guardian Mode OFF';
+        return 'Guardian OFF';
       case GuardianModeState.active:
         return 'Guardian Mode ON';
       case GuardianModeState.error:
@@ -122,37 +123,40 @@ class _GuardianModeButtonState extends State<GuardianModeButton> with SingleTick
       mainAxisSize: MainAxisSize.min,
       children: [
         // Button
-        GestureDetector(
-          onTap: _onTap,
-          child: AnimatedBuilder(
-            animation: _pulseController,
-            builder: (context, child) {
-              final pulseValue = isActive ? _pulseController.value : 0.0;
-              final glowRadius = 20.0 + (pulseValue * 10.0);
+        Tooltip(
+          message: isActive ? context.l10n.ellaGuardianOnTooltip : context.l10n.ellaGuardianOffTooltip,
+          child: GestureDetector(
+            onTap: _onTap,
+            child: AnimatedBuilder(
+              animation: _pulseController,
+              builder: (context, child) {
+                final pulseValue = isActive ? _pulseController.value : 0.0;
+                final glowRadius = 20.0 + (pulseValue * 10.0);
 
-              return Container(
-                width: 80,
-                height: 80,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: _getButtonColor(),
-                  boxShadow: isActive
-                      ? [
-                          BoxShadow(
-                            color: EllaColors.primary.withOpacity(0.6),
-                            blurRadius: glowRadius,
-                            spreadRadius: glowRadius / 4,
-                          ),
-                        ]
-                      : null,
-                ),
-                child: Icon(
-                  _getIcon(),
-                  color: Colors.white,
-                  size: 40,
-                ),
-              );
-            },
+                return Container(
+                  width: 80,
+                  height: 80,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: _getButtonColor(),
+                    boxShadow: isActive
+                        ? [
+                            BoxShadow(
+                              color: EllaColors.primary.withValues(alpha: 0.6),
+                              blurRadius: glowRadius,
+                              spreadRadius: glowRadius / 4,
+                            ),
+                          ]
+                        : null,
+                  ),
+                  child: Icon(
+                    _getIcon(),
+                    color: Colors.white,
+                    size: 40,
+                  ),
+                );
+              },
+            ),
           ),
         ),
         const SizedBox(height: 12),

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -2549,5 +2549,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -2551,5 +2551,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -2551,5 +2551,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -2551,5 +2551,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -2591,5 +2591,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2550,5 +2550,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -2582,5 +2582,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10119,5 +10119,22 @@
   "ellaProfileName": "Name",
   "ellaProfileNotSet": "Not set",
   "ellaProfileSave": "Save",
-  "ellaProfileSaved": "Profile saved"
+  "ellaProfileSaved": "Profile saved",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -2583,5 +2583,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -2582,5 +2582,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -2582,5 +2582,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -2617,5 +2617,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -2583,5 +2583,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -2678,5 +2678,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -2624,5 +2624,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -2582,5 +2582,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -2583,5 +2583,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2582,5 +2582,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -15794,6 +15794,108 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Profile saved'**
   String get ellaProfileSaved;
+
+  /// No description provided for @ellaAlertChannels.
+  ///
+  /// In en, this message translates to:
+  /// **'Alert Channels'**
+  String get ellaAlertChannels;
+
+  /// No description provided for @ellaAlertChannelsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'How Ella handles alerts and notifications'**
+  String get ellaAlertChannelsSubtitle;
+
+  /// No description provided for @ellaAlertChannelsUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to load alert policy'**
+  String get ellaAlertChannelsUnavailable;
+
+  /// No description provided for @ellaAlertChannelsPullRetry.
+  ///
+  /// In en, this message translates to:
+  /// **'Pull down to retry'**
+  String get ellaAlertChannelsPullRetry;
+
+  /// No description provided for @ellaAlertChannelsRetry.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry'**
+  String get ellaAlertChannelsRetry;
+
+  /// No description provided for @ellaAlertChannelsYourChannels.
+  ///
+  /// In en, this message translates to:
+  /// **'YOUR CHANNELS'**
+  String get ellaAlertChannelsYourChannels;
+
+  /// No description provided for @ellaAlertChannelsNoChannels.
+  ///
+  /// In en, this message translates to:
+  /// **'No channels configured'**
+  String get ellaAlertChannelsNoChannels;
+
+  /// No description provided for @ellaAlertChannelsEmergencyContact.
+  ///
+  /// In en, this message translates to:
+  /// **'EMERGENCY CONTACT'**
+  String get ellaAlertChannelsEmergencyContact;
+
+  /// No description provided for @ellaAlertChannelsNotConfigured.
+  ///
+  /// In en, this message translates to:
+  /// **'No emergency contact selected'**
+  String get ellaAlertChannelsNotConfigured;
+
+  /// No description provided for @ellaAlertChannelsSetUpContact.
+  ///
+  /// In en, this message translates to:
+  /// **'Set up an emergency contact'**
+  String get ellaAlertChannelsSetUpContact;
+
+  /// No description provided for @ellaAlertChannelsCaregiverNotifications.
+  ///
+  /// In en, this message translates to:
+  /// **'CAREGIVER NOTIFICATIONS'**
+  String get ellaAlertChannelsCaregiverNotifications;
+
+  /// No description provided for @ellaAlertChannelsAlertRules.
+  ///
+  /// In en, this message translates to:
+  /// **'ALERT RULES'**
+  String get ellaAlertChannelsAlertRules;
+
+  /// No description provided for @ellaAlertChannelsPrivacyNotes.
+  ///
+  /// In en, this message translates to:
+  /// **'PRIVACY NOTES'**
+  String get ellaAlertChannelsPrivacyNotes;
+
+  /// No description provided for @ellaAlertChannelsEnabled.
+  ///
+  /// In en, this message translates to:
+  /// **'Enabled'**
+  String get ellaAlertChannelsEnabled;
+
+  /// No description provided for @ellaAlertChannelsDisabled.
+  ///
+  /// In en, this message translates to:
+  /// **'Disabled'**
+  String get ellaAlertChannelsDisabled;
+
+  /// No description provided for @ellaGuardianOffTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.'**
+  String get ellaGuardianOffTooltip;
+
+  /// No description provided for @ellaGuardianOnTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Guardian ON: Audio monitoring and care features active.'**
+  String get ellaGuardianOnTooltip;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8409,4 +8409,56 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8497,4 +8497,56 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8513,4 +8513,56 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8460,4 +8460,56 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8449,4 +8449,56 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8531,4 +8531,56 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8522,4 +8522,56 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8462,4 +8462,56 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8479,4 +8479,56 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8464,4 +8464,56 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8463,4 +8463,56 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8538,4 +8538,56 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8445,4 +8445,56 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8502,4 +8502,56 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8477,4 +8477,56 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8514,4 +8514,56 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8331,4 +8331,56 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8333,4 +8333,56 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8470,4 +8470,56 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8482,4 +8482,56 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8488,4 +8488,56 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8490,4 +8490,56 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8460,4 +8460,56 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8483,4 +8483,56 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8465,4 +8465,56 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8503,4 +8503,56 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8490,4 +8490,56 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8455,4 +8455,56 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8470,4 +8470,56 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8427,4 +8427,56 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8478,4 +8478,56 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8477,4 +8477,56 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8467,4 +8467,56 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8321,4 +8321,56 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get ellaProfileSaved => 'Profile saved';
+
+  @override
+  String get ellaAlertChannels => 'Alert Channels';
+
+  @override
+  String get ellaAlertChannelsSubtitle => 'How Ella handles alerts and notifications';
+
+  @override
+  String get ellaAlertChannelsUnavailable => 'Unable to load alert policy';
+
+  @override
+  String get ellaAlertChannelsPullRetry => 'Pull down to retry';
+
+  @override
+  String get ellaAlertChannelsRetry => 'Retry';
+
+  @override
+  String get ellaAlertChannelsYourChannels => 'YOUR CHANNELS';
+
+  @override
+  String get ellaAlertChannelsNoChannels => 'No channels configured';
+
+  @override
+  String get ellaAlertChannelsEmergencyContact => 'EMERGENCY CONTACT';
+
+  @override
+  String get ellaAlertChannelsNotConfigured => 'No emergency contact selected';
+
+  @override
+  String get ellaAlertChannelsSetUpContact => 'Set up an emergency contact';
+
+  @override
+  String get ellaAlertChannelsCaregiverNotifications => 'CAREGIVER NOTIFICATIONS';
+
+  @override
+  String get ellaAlertChannelsAlertRules => 'ALERT RULES';
+
+  @override
+  String get ellaAlertChannelsPrivacyNotes => 'PRIVACY NOTES';
+
+  @override
+  String get ellaAlertChannelsEnabled => 'Enabled';
+
+  @override
+  String get ellaAlertChannelsDisabled => 'Disabled';
+
+  @override
+  String get ellaGuardianOffTooltip =>
+      'Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.';
+
+  @override
+  String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -2582,5 +2582,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -2582,5 +2582,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -2582,5 +2582,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -2582,5 +2582,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -2582,5 +2582,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -2617,5 +2617,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -2618,5 +2618,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -2582,5 +2582,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -2617,5 +2617,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -2587,5 +2587,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -2582,5 +2582,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -2582,5 +2582,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -2617,5 +2617,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -2582,5 +2582,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -2587,5 +2587,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -2604,5 +2604,22 @@
   "coworker": "Coworker",
   "linkedIn": "LinkedIn",
   "appStore": "App Store",
-  "googleSearch": "Google Search"
+  "googleSearch": "Google Search",
+  "ellaAlertChannels": "Alert Channels",
+  "ellaAlertChannelsSubtitle": "How Ella handles alerts and notifications",
+  "ellaAlertChannelsUnavailable": "Unable to load alert policy",
+  "ellaAlertChannelsPullRetry": "Pull down to retry",
+  "ellaAlertChannelsRetry": "Retry",
+  "ellaAlertChannelsYourChannels": "YOUR CHANNELS",
+  "ellaAlertChannelsNoChannels": "No channels configured",
+  "ellaAlertChannelsEmergencyContact": "EMERGENCY CONTACT",
+  "ellaAlertChannelsNotConfigured": "No emergency contact selected",
+  "ellaAlertChannelsSetUpContact": "Set up an emergency contact",
+  "ellaAlertChannelsCaregiverNotifications": "CAREGIVER NOTIFICATIONS",
+  "ellaAlertChannelsAlertRules": "ALERT RULES",
+  "ellaAlertChannelsPrivacyNotes": "PRIVACY NOTES",
+  "ellaAlertChannelsEnabled": "Enabled",
+  "ellaAlertChannelsDisabled": "Disabled",
+  "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
 }


### PR DESCRIPTION
## Summary
- **Alert Channels page**: Read-only view of the effective escalation policy fetched from `GET /v1/ella/escalations/policy`. Sections: YOUR CHANNELS, EMERGENCY CONTACT (with CTA to set up contact if unconfigured), CAREGIVER NOTIFICATIONS, ALERT RULES (severity-colored), PRIVACY NOTES.
- **Guardian Mode copy**: Detection modes now explain they control *how* Ella processes conversations, not *who* receives alerts. Turn-off button adds subtitle: "Disables audio and non-critical check-ins. Emergency alerts stay active."
- **Guardian button**: "Guardian Mode OFF" → "Guardian OFF", wrapped in `Tooltip` with l10n-able semantic explanations.
- **Defensive parsing**: Every `fromJson` factory uses `?? default` for required fields, `?? {}` for nested objects, `?? []` for lists. Unknown v2 fields are silently ignored; missing v1 fields fall back to safe defaults. No crash on partial/evolving API responses.

## Changed files
- `lib/ella/models/escalation_policy.dart` — NEW: typed models
- `lib/ella/services/escalation_policy_api.dart` — NEW: API client
- `lib/ella/pages/alert_channels_page.dart` — NEW: read-only policy UI
- `lib/ella/pages/ella_settings_page.dart` — Alert Channels row in CARE TEAM
- `lib/ella/pages/guardian_mode_page.dart` — Updated copy
- `lib/ella/widgets/guardian_mode_button.dart` — Shortened text + Tooltip
- 33 ARB files — 17 new l10n keys each

## Test plan
- [x] `flutter analyze` — 0 errors in changed files (info-only warnings pre-exist)
- [x] `flutter gen-l10n` — generated successfully
- [x] `test.sh` — 21/21 tests pass
- [ ] Manual: Alert Channels page loads and displays policy from backend
- [ ] Manual: Guardian OFF tooltip shows correct text
- [ ] Manual: Emergency contact CTA navigates to EllaEmergencyContactPage
- [ ] Manual: Pull-to-refresh reloads policy
- [ ] Manual: Error state shows retry button when API unreachable

Closes #656