### PR TITLE
Fix Ella onboarding websocket readiness

### DIFF
--- a/backend/ella/routers/auto_provision.py
+++ b/backend/ella/routers/auto_provision.py
@@ -13,6 +13,7 @@ Two-phase flow:
 import json
 import logging
 import os
+from datetime import datetime, timezone
 from typing import Optional
 
 import asyncpg
@@ -95,6 +96,54 @@ async def get_agent_cluster(uid: str) -> Optional[dict]:
     except Exception as e:
         logger.error(f"Error checking agent cluster for uid={uid}: {e}")
         return None
+
+
+async def ensure_firestore_user_document(uid: str) -> bool:
+    """Create the minimal upstream OMI Firestore user doc for a known Ella user.
+
+    The websocket transcription path still gates on database/users.py, which
+    checks Firestore users/{uid}. Ella onboarding provisions Postgres and
+    OpenClaw first, so a newly onboarded user can be valid for Ella but rejected
+    by /v4/listen until this compatibility document exists.
+    """
+    try:
+        pool = await _get_pool()
+        row = await pool.fetchrow(
+            """
+            SELECT name, email, timezone
+            FROM users
+            WHERE omi_uid = $1
+            """,
+            uid,
+        )
+        if not row:
+            return False
+
+        from database._client import db
+
+        user_ref = db.collection("users").document(uid)
+        if user_ref.get().exists:
+            return True
+
+        now = datetime.now(timezone.utc)
+        user_ref.set(
+            {
+                "uid": uid,
+                "name": row["name"] or "User",
+                "email": row["email"],
+                "time_zone": row["timezone"] or "America/Los_Angeles",
+                "created_at": now,
+                "updated_at": now,
+                "private_cloud_sync_enabled": True,
+                "store_recording_permission": True,
+            },
+            merge=True,
+        )
+        logger.info(f"Created Firestore OMI user document for uid={uid}")
+        return True
+    except Exception as e:
+        logger.error(f"Error ensuring Firestore user document for uid={uid}: {e}", exc_info=True)
+        return False
 
 
 async def auto_provision_user(uid: str, name: str = "User") -> dict:

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -2119,7 +2119,12 @@ async def listen_handler(
 
     # Ella sidecar: auto-provision check
     try:
-        from ella.routers.auto_provision import get_agent_cluster, auto_provision_user
+        from ella.routers.auto_provision import (
+            auto_provision_user,
+            ensure_firestore_user_document,
+            get_agent_cluster,
+        )
+        await ensure_firestore_user_document(uid)
         cluster = await get_agent_cluster(uid)
         if not cluster:
             logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- create the minimal upstream Firestore users/{uid} document for valid Ella Postgres users before /v4/listen validation
- keep the bootstrap limited to known Ella users so unknown UIDs still fail the existing gate

## Tests
- python3 -m py_compile backend/ella/routers/auto_provision.py backend/routers/transcribe.py
- uv run --with pytest python -m pytest tests/unit/test_ella_escalation_policy.py