### PR TITLE
fix: process custom stt transcript-only streams

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -1858,6 +1858,9 @@ async def _stream_handler(
                                 suggested_segments = json_data.get('segments', [])
                                 stt_provider = json_data.get('stt_provider')
                                 if suggested_segments:
+                                    if first_audio_byte_timestamp is None:
+                                        first_audio_byte_timestamp = last_activity_time
+                                        last_usage_record_timestamp = first_audio_byte_timestamp
                                     # Attach stt_provider to each segment
                                     if stt_provider:
                                         for seg in suggested_segments:

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -14,7 +14,7 @@ sys.modules.setdefault("database.users", MagicMock())
 sys.modules.setdefault("httpx", MagicMock())
 sys.modules.setdefault("utils.notifications", MagicMock())
 sys.modules.setdefault("utils.other.storage", MagicMock())
-sys.modules.setdefault("ella.config", MagicMock())
+sys.modules.pop("ella.config", None)
 sys.modules.setdefault("database.ella_contacts", MagicMock())
 
 _backend_path = Path(__file__).resolve().parents[2]

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -12,7 +12,7 @@ sys.modules.setdefault("database._client", MagicMock(db=MagicMock()))
 sys.modules.setdefault("database.conversations", MagicMock())
 sys.modules.setdefault("httpx", MagicMock())
 sys.modules.setdefault("utils.other.endpoints", MagicMock())
-sys.modules.setdefault("ella.config", MagicMock(ELLA_CONFIG=SimpleNamespace(n8n_base_url="https://n8n.test")))
+sys.modules.pop("ella.config", None)
 
 _backend_path = Path(__file__).resolve().parents[2]
 if str(_backend_path) not in sys.path:
@@ -23,6 +23,7 @@ _corrections_spec = importlib.util.spec_from_file_location("ella_corrections_tes
 corrections = importlib.util.module_from_spec(_corrections_spec)
 assert _corrections_spec is not None and _corrections_spec.loader is not None
 _corrections_spec.loader.exec_module(corrections)
+corrections.ELLA_CONFIG = SimpleNamespace(n8n_base_url="https://n8n.test")
 
 
 def _conversation():

--- a/backend/tests/unit/test_users_add_sample_transaction.py
+++ b/backend/tests/unit/test_users_add_sample_transaction.py
@@ -10,6 +10,7 @@ os.environ.setdefault(
 
 # Mock the database client to avoid needing GCP credentials
 sys.modules["database._client"] = MagicMock()
+sys.modules.pop("database.users", None)
 sys.modules["stripe"] = MagicMock()
 
 


### PR DESCRIPTION
## Summary
- initialize the listen stream timestamp when custom STT sends suggested transcript segments without binary audio
- fix unit test isolation so the full OMI unit suite can run in one process without MagicMock module leakage

## Tests
- uv run --with pytest --with fastapi==0.112.0 --with python-multipart python -m pytest tests/unit

Refs ellaaicare/ella-ai#669