### PR TITLE
fix: support guardian json audio uploads

### DIFF
--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -12,6 +12,8 @@ Queue: ella-postgres guardian_queue table.
 Audio files: /var/www/ella-ai-care.com/audio/{uid}/*.mp3
 """
 
+import base64
+import binascii
 import json
 import os
 import time
@@ -403,6 +405,14 @@ class EnqueueRequest(BaseModel):
     message: Optional[str] = None
     trigger: Optional[str] = None
     metadata: Optional[dict] = None
+
+
+class UploadJsonRequest(BaseModel):
+    """JSON body for trusted n8n audio uploads."""
+
+    uid: str
+    audio_base64: str
+    filename: Optional[str] = None
 
 
 def _trace_id_from_metadata(metadata: Optional[dict], fallback: str) -> str:
@@ -900,6 +910,26 @@ async def enqueue(
 # ---------------------------------------------------------------------------
 
 
+def _store_audio_content(uid: str, content: bytes, filename: Optional[str] = None) -> dict:
+    user_dir = os.path.join(AUDIO_BASE_DIR, uid)
+    os.makedirs(user_dir, exist_ok=True)
+
+    ts = int(time.time())
+    fname = filename or f"{ts}-{uuid.uuid4().hex[:12]}.mp3"
+    filepath = os.path.join(user_dir, fname)
+
+    with open(filepath, "wb") as f:
+        f.write(content)
+
+    public_url = f"{AUDIO_PUBLIC_URL}/{uid}/{fname}"
+    return {
+        "url": public_url,
+        "path": filepath,
+        "size_bytes": len(content),
+        "filename": fname,
+    }
+
+
 @router.post("/upload")
 async def upload_audio(
     file: UploadFile = File(...),
@@ -912,33 +942,44 @@ async def upload_audio(
     _start = time.time()
     _verify_key(x_guardian_key, key)
 
-    # Create user directory
-    user_dir = os.path.join(AUDIO_BASE_DIR, uid)
-    os.makedirs(user_dir, exist_ok=True)
-
-    # Generate filename
-    ts = int(time.time())
-    fname = filename or f"{ts}-{uuid.uuid4().hex[:12]}.mp3"
-    filepath = os.path.join(user_dir, fname)
-
-    # Write file
     content = await file.read()
-    with open(filepath, "wb") as f:
-        f.write(content)
-
-    public_url = f"{AUDIO_PUBLIC_URL}/{uid}/{fname}"
+    result = _store_audio_content(uid, content, filename)
 
     _elapsed = int((time.time() - _start) * 1000)
     print(
-        f"[FLOW:GUARDIAN-UPLOAD] uid={uid} file={fname} size={len(content)}B latency={_elapsed}ms url={public_url}",
+        f"[FLOW:GUARDIAN-UPLOAD] uid={uid} file={result['filename']} size={result['size_bytes']}B "
+        f"latency={_elapsed}ms url={result['url']}",
         flush=True,
     )
 
-    return {
-        "url": public_url,
-        "path": filepath,
-        "size_bytes": len(content),
-    }
+    return {k: v for k, v in result.items() if k != "filename"}
+
+
+@router.post("/upload-json")
+async def upload_audio_json(
+    req: UploadJsonRequest,
+    x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
+    key: Optional[str] = Header(None, alias="X-Key"),
+):
+    """Upload a base64-encoded audio file and return its public URL."""
+    _start = time.time()
+    _verify_key(x_guardian_key, key)
+
+    try:
+        content = base64.b64decode(req.audio_base64, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="Invalid base64 audio") from exc
+
+    result = _store_audio_content(req.uid, content, req.filename)
+
+    _elapsed = int((time.time() - _start) * 1000)
+    print(
+        f"[FLOW:GUARDIAN-UPLOAD-JSON] uid={req.uid} file={result['filename']} size={result['size_bytes']}B "
+        f"latency={_elapsed}ms url={result['url']}",
+        flush=True,
+    )
+
+    return {k: v for k, v in result.items() if k != "filename"}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -436,12 +436,15 @@ async def _stream_handler(
         audio_ring_buffer = AudioRingBuffer(RING_BUFFER_DURATION, sample_rate)
 
     # Conversation timeout (to process the conversation after x seconds of silence)
-    # Max: 4h, min 2m
+    # Binary audio sessions keep the legacy 2m minimum. Custom STT sessions can
+    # finalize faster because the app has already provided transcript segments.
     conversation_creation_timeout = conversation_timeout
     if conversation_creation_timeout == -1:
         conversation_creation_timeout = 4 * 60 * 60
-    if conversation_creation_timeout < 120:
-        conversation_creation_timeout = 120
+    min_conversation_timeout = 10 if use_custom_stt else 120
+    if conversation_creation_timeout < min_conversation_timeout:
+        conversation_creation_timeout = min_conversation_timeout
+    inactivity_timeout_seconds = max(inactivity_timeout_seconds, conversation_creation_timeout + 30)
 
     # Stream transcript
     # Callback for when pusher finishes processing a conversation


### PR DESCRIPTION
## Summary
- Add /v1/ella/guardian/upload-json for trusted n8n base64 audio uploads
- Share the existing guardian audio file storage path with multipart uploads
- Preserve Guardian key enforcement and upload trace logging

## Tests
- python3 -m py_compile backend/ella/routers/guardian.py