### PR TITLE
Add versioned summary state for corrections

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -36,6 +36,109 @@ def _ensure_timezone_aware(dt: datetime) -> datetime:
     return dt
 
 
+def _category_value(value: Any) -> str:
+    if value is None:
+        return 'other'
+    raw = getattr(value, 'value', value)
+    return str(raw or 'other')
+
+
+def _has_summary_content(structured: Optional[Dict[str, Any]]) -> bool:
+    structured = structured or {}
+    return any(
+        str(structured.get(field) or '').strip()
+        for field in ('title', 'overview', 'emoji', 'category')
+    )
+
+
+def _build_summary_version_payload(
+    *,
+    structured: Dict[str, Any],
+    created_at: datetime,
+    source: str,
+    kind: str,
+    is_active: bool,
+    correction_id: Optional[str] = None,
+    based_on_version_id: Optional[str] = None,
+    version_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    return {
+        'id': version_id or str(uuid.uuid4()),
+        'created_at': _ensure_timezone_aware(created_at),
+        'source': source,
+        'kind': kind,
+        'title': structured.get('title') or '',
+        'overview': structured.get('overview') or '',
+        'emoji': structured.get('emoji') or '🧠',
+        'category': _category_value(structured.get('category')),
+        'correction_id': correction_id,
+        'based_on_version_id': based_on_version_id,
+        'is_active': is_active,
+    }
+
+
+def bootstrap_summary_versioning_update(conversation_data: Dict[str, Any]) -> Dict[str, Any]:
+    if not conversation_data or conversation_data.get('summary_versions'):
+        return {}
+
+    structured = conversation_data.get('structured') or {}
+    if not _has_summary_content(structured):
+        return {}
+
+    created_at = conversation_data.get('created_at') or datetime.now(timezone.utc)
+    version = _build_summary_version_payload(
+        structured=structured,
+        created_at=_ensure_timezone_aware(created_at),
+        source='legacy',
+        kind='legacy_current',
+        is_active=True,
+    )
+    return {
+        'summary_versions': [version],
+        'active_summary_version_id': version['id'],
+    }
+
+
+def build_summary_version_update(
+    conversation_data: Dict[str, Any],
+    *,
+    next_structured: Dict[str, Any],
+    source: str = 'observer',
+    kind: str = 'observer_enriched',
+    correction_id: Optional[str] = None,
+    based_on_version_id: Optional[str] = None,
+    activate: bool = True,
+) -> Dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    bootstrap_update = bootstrap_summary_versioning_update(conversation_data)
+    versions = copy.deepcopy(conversation_data.get('summary_versions') or bootstrap_update.get('summary_versions') or [])
+    active_summary_version_id = (
+        conversation_data.get('active_summary_version_id') or bootstrap_update.get('active_summary_version_id')
+    )
+
+    if activate:
+        for version in versions:
+            version['is_active'] = False
+
+    base_version_id = based_on_version_id or active_summary_version_id
+    new_version = _build_summary_version_payload(
+        structured=next_structured,
+        created_at=now,
+        source=source,
+        kind=kind,
+        correction_id=correction_id,
+        based_on_version_id=base_version_id,
+        is_active=activate,
+    )
+    versions.append(new_version)
+
+    return {
+        'summary_versions': versions,
+        'active_summary_version_id': new_version['id'] if activate else active_summary_version_id,
+        'new_summary_version_id': new_version['id'],
+    }
+
+
 # *********************************
 # ******* ENCRYPTION HELPERS ******
 # *********************************

--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -155,6 +155,11 @@ class ConversationSummaryUpdate(BaseModel):
     overview: Optional[str] = None
     emoji: Optional[str] = None
     category: Optional[str] = None
+    summary_source: str = "observer"
+    summary_kind: str = "observer_enriched"
+    correction_id: Optional[str] = None
+    based_on_version_id: Optional[str] = None
+    set_active: bool = True
 
 
 @router.patch("/conversation/{conversation_id}/summary")
@@ -170,6 +175,10 @@ async def update_conversation_summary(
     """
     if not uid:
         raise HTTPException(status_code=400, detail="uid query parameter required")
+
+    conversation = conversations_db.get_conversation(uid, conversation_id)
+    if conversation is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
 
     try:
         sanitized_update = sanitize_summary_update(
@@ -208,6 +217,36 @@ async def update_conversation_summary(
     if not update_data:
         raise HTTPException(status_code=400, detail="No fields to update")
 
+    structured = dict((conversation.get("structured") or {}))
+    if sanitized_update.title is not None:
+        structured["title"] = sanitized_update.title
+    if sanitized_update.overview is not None:
+        structured["overview"] = sanitized_update.overview
+    if sanitized_update.emoji is not None:
+        structured["emoji"] = sanitized_update.emoji
+    if sanitized_update.category is not None:
+        structured["category"] = sanitized_update.category
+
+    version_update = conversations_db.build_summary_version_update(
+        conversation,
+        next_structured=structured,
+        source=update.summary_source,
+        kind=update.summary_kind,
+        correction_id=update.correction_id,
+        based_on_version_id=update.based_on_version_id,
+        activate=update.set_active,
+    )
+    update_data["summary_versions"] = version_update["summary_versions"]
+    update_data["active_summary_version_id"] = version_update["active_summary_version_id"]
+    if update.correction_id:
+        update_data["correction_state"] = {
+            "correction_id": update.correction_id,
+            "status": "applied",
+            "pending": False,
+            "updated_at": datetime.now(timezone.utc),
+            "active_summary_version_id": version_update["active_summary_version_id"],
+        }
+
     try:
         conversations_db.update_conversation(uid, conversation_id, update_data)
     except Exception as e:
@@ -218,6 +257,7 @@ async def update_conversation_summary(
         "status": "ok",
         "conversation_id": conversation_id,
         "updated_fields": list(update_data.keys()),
+        "active_summary_version_id": version_update["active_summary_version_id"],
         "sanitizer_warnings": sanitized_update.warnings,
     }
 

--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -38,6 +38,7 @@ from pydantic import BaseModel, Field
 import database.conversations as conversations_db
 import database.memories as memories_db
 import database.users as users_db
+from database._client import db
 from models.conversation import CategoryEnum
 
 
@@ -162,6 +163,23 @@ class ConversationSummaryUpdate(BaseModel):
     set_active: bool = True
 
 
+def _update_correction_audit(
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+    payload: dict,
+) -> None:
+    (
+        db.collection("users")
+        .document(uid)
+        .collection("conversations")
+        .document(conversation_id)
+        .collection("corrections")
+        .document(correction_id)
+        .set(payload, merge=True)
+    )
+
+
 @router.patch("/conversation/{conversation_id}/summary")
 async def update_conversation_summary(
     conversation_id: str,
@@ -239,10 +257,13 @@ async def update_conversation_summary(
     update_data["summary_versions"] = version_update["summary_versions"]
     update_data["active_summary_version_id"] = version_update["active_summary_version_id"]
     if update.correction_id:
+        existing_state = conversation.get("correction_state") or {}
         update_data["correction_state"] = {
             "correction_id": update.correction_id,
             "status": "applied",
             "pending": False,
+            "source": existing_state.get("source"),
+            "submitted_at": existing_state.get("submitted_at"),
             "updated_at": datetime.now(timezone.utc),
             "active_summary_version_id": version_update["active_summary_version_id"],
         }
@@ -252,6 +273,28 @@ async def update_conversation_summary(
     except Exception as e:
         logging.error(f"Failed to update conversation summary: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+    if update.correction_id:
+        try:
+            _update_correction_audit(
+                uid,
+                conversation_id,
+                update.correction_id,
+                {
+                    "status": "applied",
+                    "updated_at": datetime.now(timezone.utc).isoformat(),
+                    "applied_at": datetime.now(timezone.utc).isoformat(),
+                    "applied_summary_version_id": version_update["active_summary_version_id"],
+                    "summary_version_kind": update.summary_kind,
+                    "summary_version_source": update.summary_source,
+                },
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to update correction audit after summary apply",
+                extra={"uid": uid, "conversation_id": conversation_id, "correction_id": update.correction_id},
+            )
+            logger.warning(str(e))
 
     return {
         "status": "ok",

--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -127,6 +127,10 @@ def _persist_correction_audit(
     _audit_ref(uid, conversation_id, correction_id).set(payload, merge=True)
 
 
+def _update_conversation_correction_state(uid: str, conversation_id: str, update_data: dict[str, Any]) -> None:
+    conversations_db.update_conversation(uid, conversation_id, update_data)
+
+
 def _append_correction_event(
     uid: str,
     conversation_id: str,
@@ -212,6 +216,29 @@ async def _submit_conversation_correction(
     structured = _structured_summary(conversation)
     transcript = _format_transcript(conversation)
     segment_count = len(conversation.get("transcript_segments") or [])
+    bootstrap_update = {}
+    bootstrap_builder = getattr(conversations_db, "bootstrap_summary_versioning_update", None)
+    if callable(bootstrap_builder):
+        bootstrap_update = bootstrap_builder(conversation)
+
+    submitted_state = {
+        "correction_id": correction_id,
+        "status": "submitted",
+        "pending": True,
+        "source": request.source,
+        "submitted_at": submitted_at,
+        "updated_at": submitted_at,
+        "active_summary_version_id": bootstrap_update.get("active_summary_version_id")
+        or conversation.get("active_summary_version_id"),
+    }
+    _update_conversation_correction_state(
+        uid,
+        conversation_id,
+        {
+            **bootstrap_update,
+            "correction_state": submitted_state,
+        },
+    )
 
     audit_payload = {
         "correction_id": correction_id,
@@ -247,13 +274,14 @@ async def _submit_conversation_correction(
             "Failed to submit conversation correction to n8n",
             extra={"uid": uid, "conversation_id": conversation_id, "correction_id": correction_id},
         )
+        failed_at = _now_iso()
         _persist_correction_audit(
             uid,
             conversation_id,
             correction_id,
             {
                 "status": "queue_failed",
-                "updated_at": _now_iso(),
+                "updated_at": failed_at,
                 "queue_error": str(exc),
             },
         )
@@ -261,7 +289,23 @@ async def _submit_conversation_correction(
             uid,
             conversation_id,
             correction_id,
-            {"stage": "queue_failed", "status": "error", "at": _now_iso(), "trace_id": trace_id, "error": str(exc)},
+            {"stage": "queue_failed", "status": "error", "at": failed_at, "trace_id": trace_id, "error": str(exc)},
+        )
+        _update_conversation_correction_state(
+            uid,
+            conversation_id,
+            {
+                "correction_state": {
+                    "correction_id": correction_id,
+                    "status": "queue_failed",
+                    "pending": False,
+                    "source": request.source,
+                    "submitted_at": submitted_at,
+                    "updated_at": failed_at,
+                    "active_summary_version_id": submitted_state.get("active_summary_version_id"),
+                    "error": str(exc),
+                }
+            },
         )
         return ConversationCorrectionResponse(
             correction_id=correction_id,
@@ -272,6 +316,15 @@ async def _submit_conversation_correction(
         )
 
     queued_at = _now_iso()
+    queued_state = {
+        "correction_id": correction_id,
+        "status": "queued",
+        "pending": True,
+        "source": request.source,
+        "submitted_at": submitted_at,
+        "updated_at": queued_at,
+        "active_summary_version_id": submitted_state.get("active_summary_version_id"),
+    }
     _persist_correction_audit(
         uid,
         conversation_id,
@@ -284,6 +337,7 @@ async def _submit_conversation_correction(
         correction_id,
         {"stage": "queued", "status": "ok", "at": queued_at, "trace_id": trace_id, "queue_result": queue_result},
     )
+    _update_conversation_correction_state(uid, conversation_id, {"correction_state": queued_state})
 
     return ConversationCorrectionResponse(
         correction_id=correction_id,

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -204,6 +204,33 @@ class Structured(BaseModel):
         return result.strip()
 
 
+class SummaryVersion(BaseModel):
+    id: str = Field(description="Unique identifier for this summary version")
+    created_at: datetime = Field(description="When this summary version was created")
+    source: str = Field(default="observer", description="Producer of this summary version")
+    kind: str = Field(default="observer_enriched", description="Semantic type of this summary version")
+    title: str = Field(default="", description="Summary title for this version")
+    overview: str = Field(default="", description="Summary overview for this version")
+    emoji: str = Field(default="🧠", description="Summary emoji for this version")
+    category: CategoryEnum = Field(default=CategoryEnum.other, description="Summary category for this version")
+    correction_id: Optional[str] = Field(default=None, description="Correction event that produced this version")
+    based_on_version_id: Optional[str] = Field(default=None, description="Parent summary version identifier")
+    is_active: bool = Field(default=False, description="Whether this version is currently active")
+
+
+class CorrectionState(BaseModel):
+    correction_id: Optional[str] = Field(default=None, description="Latest correction event identifier")
+    status: Optional[str] = Field(default=None, description="Correction lifecycle status")
+    pending: bool = Field(default=False, description="Whether a correction is still pending")
+    source: Optional[str] = Field(default=None, description="Where the correction came from")
+    submitted_at: Optional[datetime] = Field(default=None, description="When the correction was first submitted")
+    updated_at: Optional[datetime] = Field(default=None, description="When the correction state last changed")
+    active_summary_version_id: Optional[str] = Field(
+        default=None, description="Currently active summary version while this state applies"
+    )
+    error: Optional[str] = Field(default=None, description="Last correction processing error if any")
+
+
 class Geolocation(BaseModel):
     google_place_id: Optional[str] = None
     latitude: float
@@ -297,6 +324,9 @@ class Conversation(BaseModel):
     language: Optional[str] = None  # applies only to Friend # TODO: once released migrate db to default 'en'
 
     structured: Structured
+    summary_versions: List[SummaryVersion] = []
+    active_summary_version_id: Optional[str] = None
+    correction_state: Optional[CorrectionState] = None
     transcript_segments: List[TranscriptSegment] = []
     transcript_segments_compressed: Optional[bool] = False
     geolocation: Optional[Geolocation] = None

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -204,6 +204,7 @@ def test_get_conversation_data_404s_when_missing(monkeypatch):
 
 def test_update_conversation_summary_records_version_and_marks_correction_applied(monkeypatch):
     captured = {}
+    audit_updates = []
 
     monkeypatch.setattr(
         callbacks.conversations_db,
@@ -214,7 +215,12 @@ def test_update_conversation_summary_records_version_and_marks_correction_applie
                 "overview": "[Ella] Original overview with enough detail to preserve.",
                 "emoji": "🧠",
                 "category": callbacks.CategoryEnum.health,
-            }
+            },
+            "correction_state": {
+                "correction_id": "corr-123",
+                "source": "ios",
+                "submitted_at": "2026-04-22T17:00:00+00:00",
+            },
         },
     )
     monkeypatch.setattr(
@@ -233,6 +239,11 @@ def test_update_conversation_summary_records_version_and_marks_correction_applie
         callbacks.conversations_db,
         "update_conversation",
         lambda uid, conversation_id, update_data: captured.setdefault("update_data", update_data),
+    )
+    monkeypatch.setattr(
+        callbacks,
+        "_update_correction_audit",
+        lambda uid, conversation_id, correction_id, payload: audit_updates.append(payload),
     )
 
     result = asyncio.run(
@@ -254,4 +265,8 @@ def test_update_conversation_summary_records_version_and_marks_correction_applie
     assert captured["update_data"]["correction_state"]["status"] == "applied"
     assert captured["update_data"]["correction_state"]["pending"] is False
     assert captured["update_data"]["correction_state"]["correction_id"] == "corr-123"
+    assert captured["update_data"]["correction_state"]["source"] == "ios"
+    assert captured["update_data"]["correction_state"]["submitted_at"] == "2026-04-22T17:00:00+00:00"
+    assert audit_updates[0]["status"] == "applied"
+    assert audit_updates[0]["applied_summary_version_id"] == "corr-v2"
     assert result["active_summary_version_id"] == "corr-v2"

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -200,3 +200,58 @@ def test_get_conversation_data_404s_when_missing(monkeypatch):
 
     assert excinfo.value.status_code == 404
     assert "Conversation not found" in excinfo.value.detail
+
+
+def test_update_conversation_summary_records_version_and_marks_correction_applied(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: {
+            "structured": {
+                "title": "Original title",
+                "overview": "[Ella] Original overview with enough detail to preserve.",
+                "emoji": "🧠",
+                "category": callbacks.CategoryEnum.health,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "build_summary_version_update",
+        lambda conversation, **kwargs: {
+            "summary_versions": [
+                {"id": "legacy-v1", "title": "Original title"},
+                {"id": "corr-v2", "title": kwargs["next_structured"]["title"]},
+            ],
+            "active_summary_version_id": "corr-v2",
+            "new_summary_version_id": "corr-v2",
+        },
+    )
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "update_conversation",
+        lambda uid, conversation_id, update_data: captured.setdefault("update_data", update_data),
+    )
+
+    result = asyncio.run(
+        callbacks.update_conversation_summary(
+            "conv-123",
+            callbacks.ConversationSummaryUpdate(
+                title="Corrected title",
+                overview="[Ella] Corrected overview with enough detail to safely replace the summary.",
+                correction_id="corr-123",
+                summary_kind="corrected_enriched",
+                summary_source="observer",
+            ),
+            uid="user-123",
+        )
+    )
+
+    assert captured["update_data"]["summary_versions"][1]["id"] == "corr-v2"
+    assert captured["update_data"]["active_summary_version_id"] == "corr-v2"
+    assert captured["update_data"]["correction_state"]["status"] == "applied"
+    assert captured["update_data"]["correction_state"]["pending"] is False
+    assert captured["update_data"]["correction_state"]["correction_id"] == "corr-123"
+    assert result["active_summary_version_id"] == "corr-v2"

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -45,8 +45,19 @@ def test_submit_correction_accepts_ios_payload_and_queues(monkeypatch):
     audits = []
     events = []
     submitted = {}
+    conversation_updates = []
 
     monkeypatch.setattr(corrections.conversations_db, "get_conversation", lambda uid, conversation_id: _conversation())
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "bootstrap_summary_versioning_update",
+        lambda conversation: {"summary_versions": [{"id": "legacy-v1"}], "active_summary_version_id": "legacy-v1"},
+    )
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "update_conversation",
+        lambda uid, conversation_id, update_data: conversation_updates.append(update_data),
+    )
     monkeypatch.setattr(
         corrections,
         "_persist_correction_audit",
@@ -101,6 +112,10 @@ def test_submit_correction_accepts_ios_payload_and_queues(monkeypatch):
     assert "The podcast said memory can be tricky." in submitted["transcript"]
     assert submitted["request"].summary_context.app_summary == "The app summary was too clinical."
     assert events[-1]["stage"] == "queued"
+    assert conversation_updates[0]["correction_state"]["status"] == "submitted"
+    assert conversation_updates[0]["active_summary_version_id"] == "legacy-v1"
+    assert conversation_updates[-1]["correction_state"]["status"] == "queued"
+    assert conversation_updates[-1]["correction_state"]["active_summary_version_id"] == "legacy-v1"
 
 
 def test_submit_correction_uses_authenticated_uid_for_ownership(monkeypatch):
@@ -146,8 +161,15 @@ def test_submit_correction_rejects_locked_conversation(monkeypatch):
 def test_submit_correction_persists_n8n_failure_trace_and_still_returns_202(monkeypatch):
     audits = []
     events = []
+    conversation_updates = []
 
     monkeypatch.setattr(corrections.conversations_db, "get_conversation", lambda uid, conversation_id: _conversation())
+    monkeypatch.setattr(corrections.conversations_db, "bootstrap_summary_versioning_update", lambda conversation: {})
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "update_conversation",
+        lambda uid, conversation_id, update_data: conversation_updates.append(update_data),
+    )
     monkeypatch.setattr(
         corrections,
         "_persist_correction_audit",
@@ -178,6 +200,9 @@ def test_submit_correction_persists_n8n_failure_trace_and_still_returns_202(monk
     assert audits[-1]["queue_error"] == "n8n offline"
     assert events[-1]["stage"] == "queue_failed"
     assert events[-1]["status"] == "error"
+    assert conversation_updates[0]["correction_state"]["status"] == "submitted"
+    assert conversation_updates[-1]["correction_state"]["status"] == "queue_failed"
+    assert conversation_updates[-1]["correction_state"]["pending"] is False
 
 
 def test_router_uses_custom_ella_namespace_only():


### PR DESCRIPTION
## Summary
- add additive summary version and correction state fields to conversation records
- bootstrap and append summary versions from the existing Ella summary callback without changing the active structured contract
- mark conversation-level correction state during submission/queueing and cover the new behavior with unit tests

## Testing
- python3 -m py_compile backend/models/conversation.py backend/database/conversations.py backend/ella/routers/corrections.py backend/ella/routers/callbacks.py
- .venv/bin/python -m pytest tests/unit/test_ella_conversation_corrections.py tests/unit/test_ella_callbacks_summary_update.py