### PR TITLE
OMI: expose internal assessment on conversation payloads

### DIFF
--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -83,7 +83,29 @@ Future<ServerConversation?> reProcessConversationServer(String conversationId, {
   return null;
 }
 
-Future<bool> submitConversationCorrection({
+class CorrectionSubmitResult {
+  final bool success;
+  final String? correctionId;
+  final String? traceId;
+  final String? error;
+
+  CorrectionSubmitResult({
+    required this.success,
+    this.correctionId,
+    this.traceId,
+    this.error,
+  });
+
+  factory CorrectionSubmitResult.fromJson(Map<String, dynamic> json) {
+    return CorrectionSubmitResult(
+      success: true,
+      correctionId: json['correction_id'] as String?,
+      traceId: json['trace_id'] as String?,
+    );
+  }
+}
+
+Future<CorrectionSubmitResult> submitConversationCorrection({
   required String conversationId,
   required String correctionText,
   String? summaryTitle,
@@ -104,9 +126,20 @@ Future<bool> submitConversationCorrection({
       },
     }),
   );
-  if (response == null) return false;
+  if (response == null) {
+    Logger.debug('submitConversationCorrection: response was null');
+    return CorrectionSubmitResult(success: false, error: 'Network error');
+  }
   Logger.debug('submitConversationCorrection: ${response.statusCode} ${response.body}');
-  return response.statusCode == 200 || response.statusCode == 201 || response.statusCode == 202;
+  if (response.statusCode == 200 || response.statusCode == 201 || response.statusCode == 202) {
+    try {
+      final body = jsonDecode(response.body) as Map<String, dynamic>;
+      return CorrectionSubmitResult.fromJson(body);
+    } catch (_) {
+      return CorrectionSubmitResult(success: true);
+    }
+  }
+  return CorrectionSubmitResult(success: false, error: 'HTTP ${response.statusCode}');
 }
 
 Future<bool> deleteConversationServer(String conversationId) async {

--- a/app/lib/backend/schema/conversation.dart
+++ b/app/lib/backend/schema/conversation.dart
@@ -171,6 +171,38 @@ class AudioFile {
       };
 }
 
+class CorrectionState {
+  final String? correctionId;
+  final bool pending;
+  final String? status;
+  final String? source;
+  final DateTime? submittedAt;
+  final DateTime? updatedAt;
+  final String? error;
+
+  CorrectionState({
+    this.correctionId,
+    this.pending = false,
+    this.status,
+    this.source,
+    this.submittedAt,
+    this.updatedAt,
+    this.error,
+  });
+
+  factory CorrectionState.fromJson(Map<String, dynamic> json) {
+    return CorrectionState(
+      correctionId: json['correction_id'] as String?,
+      pending: json['pending'] as bool? ?? false,
+      status: json['status'] as String?,
+      source: json['source'] as String?,
+      submittedAt: json['submitted_at'] != null ? DateTime.parse(json['submitted_at']).toLocal() : null,
+      updatedAt: json['updated_at'] != null ? DateTime.parse(json['updated_at']).toLocal() : null,
+      error: json['error'] as String?,
+    );
+  }
+}
+
 class ServerConversation {
   final String id;
   final DateTime createdAt;
@@ -200,6 +232,9 @@ class ServerConversation {
   // local label
   bool isNew = false;
 
+  // Correction state from summary correction pipeline
+  CorrectionState? correctionState;
+
   ServerConversation({
     required this.id,
     required this.createdAt,
@@ -221,6 +256,7 @@ class ServerConversation {
     this.isLocked = false,
     this.starred = false,
     this.folderId,
+    this.correctionState,
   });
 
   factory ServerConversation.fromJson(Map<String, dynamic> json) {
@@ -254,6 +290,9 @@ class ServerConversation {
       isLocked: json['is_locked'] ?? false,
       starred: json['starred'] ?? false,
       folderId: json['folder_id'],
+      correctionState: json['correction_state'] != null
+          ? CorrectionState.fromJson(json['correction_state'])
+          : null,
     );
   }
 
@@ -278,6 +317,17 @@ class ServerConversation {
       'is_locked': isLocked,
       'starred': starred,
       'folder_id': folderId,
+      'correction_state': correctionState != null
+          ? {
+              'correction_id': correctionState!.correctionId,
+              'pending': correctionState!.pending,
+              'status': correctionState!.status,
+              'source': correctionState!.source,
+              'submitted_at': correctionState!.submittedAt?.toUtc().toIso8601String(),
+              'updated_at': correctionState!.updatedAt?.toUtc().toIso8601String(),
+              'error': correctionState!.error,
+            }
+          : null,
     };
   }
 

--- a/app/lib/pages/conversation_detail/widgets.dart
+++ b/app/lib/pages/conversation_detail/widgets.dart
@@ -775,7 +775,7 @@ class _CorrectSummarySheetState extends State<_CorrectSummarySheet> {
     final messenger = ScaffoldMessenger.of(context);
     final navigator = Navigator.of(context);
 
-    final ok = await submitConversationCorrection(
+    final result = await submitConversationCorrection(
       conversationId: widget.conversation.id,
       correctionText: correctionText,
       summaryTitle: widget.conversation.structured.title,
@@ -786,16 +786,25 @@ class _CorrectSummarySheetState extends State<_CorrectSummarySheet> {
     if (!mounted) return;
     setState(() => _isSubmitting = false);
 
-    if (ok) {
+    if (result.success) {
       HapticFeedback.mediumImpact();
+      final traceInfo = result.traceId != null ? '\nTrace: ${result.traceId}' : '';
       messenger.showSnackBar(
-        const SnackBar(content: Text('Correction submitted. Ella will recheck this summary.')),
+        SnackBar(
+          content: Text(
+            'Queued for review. Ella will update this summary shortly.$traceInfo',
+          ),
+          backgroundColor: const Color(0xFF2D7A3A),
+        ),
       );
       navigator.pop();
     } else {
       HapticFeedback.lightImpact();
       messenger.showSnackBar(
-        const SnackBar(content: Text('Could not submit correction yet. Please try again later.')),
+        SnackBar(
+          content: Text('Could not submit correction: ${result.error ?? "Unknown error"}'),
+          backgroundColor: const Color(0xFFB33A3A),
+        ),
       );
     }
   }

--- a/app/lib/pages/conversation_detail/widgets.dart
+++ b/app/lib/pages/conversation_detail/widgets.dart
@@ -760,6 +760,10 @@ class _CorrectSummarySheet extends StatefulWidget {
 class _CorrectSummarySheetState extends State<_CorrectSummarySheet> {
   final TextEditingController _controller = TextEditingController();
   bool _isSubmitting = false;
+  bool _isPolling = false;
+  int _pollCount = 0;
+  static const int _maxPolls = 10;
+  static const Duration _pollInterval = Duration(seconds: 3);
 
   @override
   void dispose() {
@@ -784,26 +788,80 @@ class _CorrectSummarySheetState extends State<_CorrectSummarySheet> {
     );
 
     if (!mounted) return;
-    setState(() => _isSubmitting = false);
 
-    if (result.success) {
-      HapticFeedback.mediumImpact();
-      final traceInfo = result.traceId != null ? '\nTrace: ${result.traceId}' : '';
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(
-            'Queued for review. Ella will update this summary shortly.$traceInfo',
-          ),
-          backgroundColor: const Color(0xFF2D7A3A),
-        ),
-      );
-      navigator.pop();
-    } else {
+    if (!result.success) {
+      setState(() => _isSubmitting = false);
       HapticFeedback.lightImpact();
       messenger.showSnackBar(
         SnackBar(
           content: Text('Could not submit correction: ${result.error ?? "Unknown error"}'),
           backgroundColor: const Color(0xFFB33A3A),
+        ),
+      );
+      return;
+    }
+
+    // Start polling for correction completion
+    setState(() {
+      _isSubmitting = false;
+      _isPolling = true;
+      _pollCount = 0;
+    });
+
+    HapticFeedback.mediumImpact();
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          'Queued for review. Checking for updated summary...',
+          style: const TextStyle(color: Colors.white),
+        ),
+        backgroundColor: const Color(0xFF2D7A3A),
+        duration: const Duration(seconds: 4),
+      ),
+    );
+
+    await _pollForCorrection();
+    if (!mounted) return;
+    navigator.pop();
+  }
+
+  Future<void> _pollForCorrection() async {
+    while (_pollCount < _maxPolls) {
+      await Future.delayed(_pollInterval);
+      if (!mounted || !_isPolling) return;
+
+      _pollCount++;
+      try {
+        final updated = await getConversationById(widget.conversation.id);
+        if (!mounted || !_isPolling) return;
+
+        if (updated?.correctionState == null || !updated!.correctionState!.pending) {
+          // Correction processed — refresh the conversation detail
+          if (mounted) {
+            final provider = Provider.of<ConversationDetailProvider>(context, listen: false);
+            provider.refreshConversation();
+          }
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Summary updated!'),
+                backgroundColor: Color(0xFF2D7A3A),
+              ),
+            );
+          }
+          return;
+        }
+      } catch (_) {
+        // Continue polling on error
+      }
+    }
+
+    // Max polls reached — give up but don't show error
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Correction submitted. Refresh to see updated summary.'),
+          backgroundColor: Color(0xFF2D7A3A),
         ),
       );
     }
@@ -886,7 +944,7 @@ class _CorrectSummarySheetState extends State<_CorrectSummarySheet> {
               SizedBox(
                 width: double.infinity,
                 child: FilledButton(
-                  onPressed: _isSubmitting ? null : _submit,
+                  onPressed: (_isSubmitting || _isPolling) ? null : _submit,
                   style: FilledButton.styleFrom(
                     backgroundColor: EllaColors.primary,
                     foregroundColor: Colors.white,
@@ -894,7 +952,7 @@ class _CorrectSummarySheetState extends State<_CorrectSummarySheet> {
                     padding: const EdgeInsets.symmetric(vertical: 14),
                     shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
                   ),
-                  child: _isSubmitting
+                  child: _isSubmitting || _isPolling
                       ? const SizedBox(
                           width: 18,
                           height: 18,

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -36,6 +36,109 @@ def _ensure_timezone_aware(dt: datetime) -> datetime:
     return dt
 
 
+def _category_value(value: Any) -> str:
+    if value is None:
+        return 'other'
+    raw = getattr(value, 'value', value)
+    return str(raw or 'other')
+
+
+def _has_summary_content(structured: Optional[Dict[str, Any]]) -> bool:
+    structured = structured or {}
+    return any(
+        str(structured.get(field) or '').strip()
+        for field in ('title', 'overview', 'emoji', 'category')
+    )
+
+
+def _build_summary_version_payload(
+    *,
+    structured: Dict[str, Any],
+    created_at: datetime,
+    source: str,
+    kind: str,
+    is_active: bool,
+    correction_id: Optional[str] = None,
+    based_on_version_id: Optional[str] = None,
+    version_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    return {
+        'id': version_id or str(uuid.uuid4()),
+        'created_at': _ensure_timezone_aware(created_at),
+        'source': source,
+        'kind': kind,
+        'title': structured.get('title') or '',
+        'overview': structured.get('overview') or '',
+        'emoji': structured.get('emoji') or '🧠',
+        'category': _category_value(structured.get('category')),
+        'correction_id': correction_id,
+        'based_on_version_id': based_on_version_id,
+        'is_active': is_active,
+    }
+
+
+def bootstrap_summary_versioning_update(conversation_data: Dict[str, Any]) -> Dict[str, Any]:
+    if not conversation_data or conversation_data.get('summary_versions'):
+        return {}
+
+    structured = conversation_data.get('structured') or {}
+    if not _has_summary_content(structured):
+        return {}
+
+    created_at = conversation_data.get('created_at') or datetime.now(timezone.utc)
+    version = _build_summary_version_payload(
+        structured=structured,
+        created_at=_ensure_timezone_aware(created_at),
+        source='legacy',
+        kind='legacy_current',
+        is_active=True,
+    )
+    return {
+        'summary_versions': [version],
+        'active_summary_version_id': version['id'],
+    }
+
+
+def build_summary_version_update(
+    conversation_data: Dict[str, Any],
+    *,
+    next_structured: Dict[str, Any],
+    source: str = 'observer',
+    kind: str = 'observer_enriched',
+    correction_id: Optional[str] = None,
+    based_on_version_id: Optional[str] = None,
+    activate: bool = True,
+) -> Dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    bootstrap_update = bootstrap_summary_versioning_update(conversation_data)
+    versions = copy.deepcopy(conversation_data.get('summary_versions') or bootstrap_update.get('summary_versions') or [])
+    active_summary_version_id = (
+        conversation_data.get('active_summary_version_id') or bootstrap_update.get('active_summary_version_id')
+    )
+
+    if activate:
+        for version in versions:
+            version['is_active'] = False
+
+    base_version_id = based_on_version_id or active_summary_version_id
+    new_version = _build_summary_version_payload(
+        structured=next_structured,
+        created_at=now,
+        source=source,
+        kind=kind,
+        correction_id=correction_id,
+        based_on_version_id=base_version_id,
+        is_active=activate,
+    )
+    versions.append(new_version)
+
+    return {
+        'summary_versions': versions,
+        'active_summary_version_id': new_version['id'] if activate else active_summary_version_id,
+        'new_summary_version_id': new_version['id'],
+    }
+
+
 # *********************************
 # ******* ENCRYPTION HELPERS ******
 # *********************************

--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -161,6 +161,7 @@ class ConversationSummaryUpdate(BaseModel):
     correction_id: Optional[str] = None
     based_on_version_id: Optional[str] = None
     set_active: bool = True
+    trace_id: Optional[str] = None
 
 
 def _update_correction_audit(
@@ -178,6 +179,40 @@ def _update_correction_audit(
         .document(correction_id)
         .set(payload, merge=True)
     )
+
+
+def _active_summary_version(conversation: dict) -> Optional[dict]:
+    active_id = conversation.get("active_summary_version_id")
+    versions = conversation.get("summary_versions") or []
+    if active_id:
+        for version in versions:
+            if version.get("id") == active_id:
+                return version
+    for version in versions:
+        if version.get("is_active"):
+            return version
+    return None
+
+
+def _enrichment_candidate_reason(conversation: dict) -> Optional[str]:
+    enrichment_state = conversation.get("enrichment_state") or {}
+    status = enrichment_state.get("status")
+    if status == "writeback_applied":
+        return None
+    if status == "failed":
+        return "enrichment_failed"
+    if enrichment_state.get("pending"):
+        return "enrichment_pending"
+
+    active_version = _active_summary_version(conversation)
+    if not active_version:
+        return "missing_active_summary_version"
+
+    source = str(active_version.get("source") or "")
+    kind = str(active_version.get("kind") or "")
+    if source == "observer" and kind in {"observer_enriched", "corrected_enriched"}:
+        return None
+    return "active_summary_not_enriched"
 
 
 @router.patch("/conversation/{conversation_id}/summary")
@@ -254,8 +289,18 @@ async def update_conversation_summary(
         based_on_version_id=update.based_on_version_id,
         activate=update.set_active,
     )
+    state_updated_at = datetime.now(timezone.utc)
     update_data["summary_versions"] = version_update["summary_versions"]
     update_data["active_summary_version_id"] = version_update["active_summary_version_id"]
+    update_data["enrichment_state"] = {
+        "status": "writeback_applied",
+        "pending": False,
+        "source": update.summary_source,
+        "kind": update.summary_kind,
+        "trace_id": update.trace_id,
+        "updated_at": state_updated_at,
+        "error": None,
+    }
     if update.correction_id:
         existing_state = conversation.get("correction_state") or {}
         update_data["correction_state"] = {
@@ -264,7 +309,7 @@ async def update_conversation_summary(
             "pending": False,
             "source": existing_state.get("source"),
             "submitted_at": existing_state.get("submitted_at"),
-            "updated_at": datetime.now(timezone.utc),
+            "updated_at": state_updated_at,
             "active_summary_version_id": version_update["active_summary_version_id"],
         }
 
@@ -302,6 +347,66 @@ async def update_conversation_summary(
         "updated_fields": list(update_data.keys()),
         "active_summary_version_id": version_update["active_summary_version_id"],
         "sanitizer_warnings": sanitized_update.warnings,
+    }
+
+
+@router.get("/conversations/enrichment/reconcile-candidates")
+async def list_enrichment_reconcile_candidates(
+    uid: Optional[str] = None,
+    lookback_minutes: int = 180,
+    limit: int = 25,
+):
+    """
+    Internal helper for n8n reconciliation.
+    Returns recent completed conversations whose active summary is not yet
+    marked as observer-enriched in OMI.
+    """
+    if not uid:
+        raise HTTPException(status_code=400, detail="uid query parameter required")
+    if lookback_minutes <= 0:
+        raise HTTPException(status_code=400, detail="lookback_minutes must be positive")
+    if limit <= 0 or limit > 200:
+        raise HTTPException(status_code=400, detail="limit must be between 1 and 200")
+
+    start_date = datetime.now(timezone.utc) - timedelta(minutes=lookback_minutes)
+    get_recent = getattr(conversations_db, "get_conversations_without_photos", conversations_db.get_conversations)
+    conversations = get_recent(
+        uid,
+        limit=limit,
+        offset=0,
+        include_discarded=False,
+        statuses=["completed"],
+        start_date=start_date,
+    )
+
+    candidates = []
+    for conversation in conversations:
+        reason = _enrichment_candidate_reason(conversation)
+        if not reason:
+            continue
+
+        active_version = _active_summary_version(conversation) or {}
+        structured = conversation.get("structured") or {}
+        candidates.append(
+            {
+                "conversation_id": conversation.get("id"),
+                "created_at": conversation.get("created_at"),
+                "title": structured.get("title") or conversation.get("title") or "",
+                "reason": reason,
+                "active_summary_version_id": conversation.get("active_summary_version_id"),
+                "active_summary_source": active_version.get("source"),
+                "active_summary_kind": active_version.get("kind"),
+                "enrichment_state": conversation.get("enrichment_state"),
+            }
+        )
+
+    return {
+        "uid": uid,
+        "lookback_minutes": lookback_minutes,
+        "limit": limit,
+        "total_scanned": len(conversations),
+        "candidate_count": len(candidates),
+        "candidates": candidates,
     }
 
 

--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -155,6 +155,11 @@ class ConversationSummaryUpdate(BaseModel):
     overview: Optional[str] = None
     emoji: Optional[str] = None
     category: Optional[str] = None
+    summary_source: str = "observer"
+    summary_kind: str = "observer_enriched"
+    correction_id: Optional[str] = None
+    based_on_version_id: Optional[str] = None
+    set_active: bool = True
 
 
 @router.patch("/conversation/{conversation_id}/summary")
@@ -170,6 +175,10 @@ async def update_conversation_summary(
     """
     if not uid:
         raise HTTPException(status_code=400, detail="uid query parameter required")
+
+    conversation = conversations_db.get_conversation(uid, conversation_id)
+    if conversation is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
 
     try:
         sanitized_update = sanitize_summary_update(
@@ -208,6 +217,36 @@ async def update_conversation_summary(
     if not update_data:
         raise HTTPException(status_code=400, detail="No fields to update")
 
+    structured = dict((conversation.get("structured") or {}))
+    if sanitized_update.title is not None:
+        structured["title"] = sanitized_update.title
+    if sanitized_update.overview is not None:
+        structured["overview"] = sanitized_update.overview
+    if sanitized_update.emoji is not None:
+        structured["emoji"] = sanitized_update.emoji
+    if sanitized_update.category is not None:
+        structured["category"] = sanitized_update.category
+
+    version_update = conversations_db.build_summary_version_update(
+        conversation,
+        next_structured=structured,
+        source=update.summary_source,
+        kind=update.summary_kind,
+        correction_id=update.correction_id,
+        based_on_version_id=update.based_on_version_id,
+        activate=update.set_active,
+    )
+    update_data["summary_versions"] = version_update["summary_versions"]
+    update_data["active_summary_version_id"] = version_update["active_summary_version_id"]
+    if update.correction_id:
+        update_data["correction_state"] = {
+            "correction_id": update.correction_id,
+            "status": "applied",
+            "pending": False,
+            "updated_at": datetime.now(timezone.utc),
+            "active_summary_version_id": version_update["active_summary_version_id"],
+        }
+
     try:
         conversations_db.update_conversation(uid, conversation_id, update_data)
     except Exception as e:
@@ -218,6 +257,7 @@ async def update_conversation_summary(
         "status": "ok",
         "conversation_id": conversation_id,
         "updated_fields": list(update_data.keys()),
+        "active_summary_version_id": version_update["active_summary_version_id"],
         "sanitizer_warnings": sanitized_update.warnings,
     }
 

--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -38,6 +38,7 @@ from pydantic import BaseModel, Field
 import database.conversations as conversations_db
 import database.memories as memories_db
 import database.users as users_db
+from database._client import db
 from models.conversation import CategoryEnum
 
 
@@ -162,6 +163,23 @@ class ConversationSummaryUpdate(BaseModel):
     set_active: bool = True
 
 
+def _update_correction_audit(
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+    payload: dict,
+) -> None:
+    (
+        db.collection("users")
+        .document(uid)
+        .collection("conversations")
+        .document(conversation_id)
+        .collection("corrections")
+        .document(correction_id)
+        .set(payload, merge=True)
+    )
+
+
 @router.patch("/conversation/{conversation_id}/summary")
 async def update_conversation_summary(
     conversation_id: str,
@@ -239,10 +257,13 @@ async def update_conversation_summary(
     update_data["summary_versions"] = version_update["summary_versions"]
     update_data["active_summary_version_id"] = version_update["active_summary_version_id"]
     if update.correction_id:
+        existing_state = conversation.get("correction_state") or {}
         update_data["correction_state"] = {
             "correction_id": update.correction_id,
             "status": "applied",
             "pending": False,
+            "source": existing_state.get("source"),
+            "submitted_at": existing_state.get("submitted_at"),
             "updated_at": datetime.now(timezone.utc),
             "active_summary_version_id": version_update["active_summary_version_id"],
         }
@@ -252,6 +273,28 @@ async def update_conversation_summary(
     except Exception as e:
         logging.error(f"Failed to update conversation summary: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+    if update.correction_id:
+        try:
+            _update_correction_audit(
+                uid,
+                conversation_id,
+                update.correction_id,
+                {
+                    "status": "applied",
+                    "updated_at": datetime.now(timezone.utc).isoformat(),
+                    "applied_at": datetime.now(timezone.utc).isoformat(),
+                    "applied_summary_version_id": version_update["active_summary_version_id"],
+                    "summary_version_kind": update.summary_kind,
+                    "summary_version_source": update.summary_source,
+                },
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to update correction audit after summary apply",
+                extra={"uid": uid, "conversation_id": conversation_id, "correction_id": update.correction_id},
+            )
+            logger.warning(str(e))
 
     return {
         "status": "ok",

--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -23,6 +23,7 @@ NOTE: Caregiver CRUD endpoints moved to n8n (ella-ai-care repo). iOS calls n8n w
 import hashlib
 import hmac
 import io
+import json
 import logging
 import os
 import secrets
@@ -31,6 +32,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
+import asyncpg
 import httpx
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
@@ -51,6 +53,7 @@ from utils.other.storage import storage_client
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/ella", tags=["ella"])
+_resolve_pool: Optional[asyncpg.Pool] = None
 
 # GCS bucket for Ella TTS audio files (defaults to project's Firebase Storage bucket)
 ELLA_AUDIO_BUCKET = os.getenv("ELLA_AUDIO_BUCKET", "omi-dev-ca005.firebasestorage.app")
@@ -58,6 +61,8 @@ ELLA_AUDIO_BUCKET = os.getenv("ELLA_AUDIO_BUCKET", "omi-dev-ca005.firebasestorag
 # OpenAI TTS configuration
 OPENAI_TTS_MODEL = os.getenv("ELLA_TTS_MODEL", "tts-1")
 OPENAI_TTS_VOICE = os.getenv("ELLA_TTS_VOICE", "nova")
+PROVISION_API_KEY = os.getenv("ELLA_PROVISION_API_KEY", os.getenv("ELLA_PROVISION_API_TOKEN", ""))
+PROVISION_API_URL = os.getenv("ELLA_PROVISION_URL", "http://100.76.138.56:8200")
 
 
 # ============================================================================
@@ -215,6 +220,82 @@ def _enrichment_candidate_reason(conversation: dict) -> Optional[str]:
     return "active_summary_not_enriched"
 
 
+async def _get_resolve_pool() -> asyncpg.Pool:
+    global _resolve_pool
+    if _resolve_pool is None:
+        _resolve_pool = await asyncpg.create_pool(
+            host="127.0.0.1",
+            port=5433,
+            user="postgres",
+            password=os.getenv("ELLA_POSTGRES_PASSWORD", "postgres"),
+            database="ella_ai",
+            min_size=1,
+            max_size=4,
+        )
+    return _resolve_pool
+
+
+async def _resolve_agent_id_for_uid(uid: str) -> Optional[str]:
+    pool = await _get_resolve_pool()
+    row = await pool.fetchrow(
+        """
+        SELECT ac.agents
+        FROM users u
+        LEFT JOIN agent_clusters ac ON ac.user_id = u.id
+        WHERE u.omi_uid = $1
+        """,
+        uid,
+    )
+    if not row or not row["agents"]:
+        return None
+
+    agents = row["agents"]
+    if isinstance(agents, str):
+        try:
+            agents = json.loads(agents)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(agents, dict):
+        return None
+    return agents.get("userAgentId")
+
+
+async def _fetch_internal_assessment(uid: str, conversation_id: str) -> Optional[dict]:
+    """Best-effort fetch of Observer sidecar internal_assessment.
+
+    This keeps the app-facing conversation payload aligned with the OpenClaw sidecar
+    without making the summary PATCH path depend on Mac Mini reachability.
+    """
+    try:
+        agent_id = await _resolve_agent_id_for_uid(uid)
+        if not agent_id:
+            return None
+
+        headers = {}
+        if PROVISION_API_KEY:
+            headers["Authorization"] = f"Bearer {PROVISION_API_KEY}"
+
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(
+                f"{PROVISION_API_URL}/workspace/{agent_id}/metadata/conversations/{conversation_id}",
+                headers=headers,
+            )
+
+        if resp.status_code >= 400:
+            return None
+
+        data = resp.json()
+        assessment = data.get("internal_assessment")
+        return assessment if isinstance(assessment, dict) else None
+    except Exception as e:
+        logger.warning(
+            "Failed to fetch internal_assessment from Provision API",
+            extra={"uid": uid, "conversation_id": conversation_id},
+        )
+        logger.warning(str(e))
+        return None
+
+
 @router.patch("/conversation/{conversation_id}/summary")
 async def update_conversation_summary(
     conversation_id: str,
@@ -301,6 +382,9 @@ async def update_conversation_summary(
         "updated_at": state_updated_at,
         "error": None,
     }
+    internal_assessment = await _fetch_internal_assessment(uid, conversation_id)
+    if internal_assessment:
+        update_data["internal_assessment"] = internal_assessment
     if update.correction_id:
         existing_state = conversation.get("correction_state") or {}
         update_data["correction_state"] = {

--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -127,6 +127,10 @@ def _persist_correction_audit(
     _audit_ref(uid, conversation_id, correction_id).set(payload, merge=True)
 
 
+def _update_conversation_correction_state(uid: str, conversation_id: str, update_data: dict[str, Any]) -> None:
+    conversations_db.update_conversation(uid, conversation_id, update_data)
+
+
 def _append_correction_event(
     uid: str,
     conversation_id: str,
@@ -212,6 +216,29 @@ async def _submit_conversation_correction(
     structured = _structured_summary(conversation)
     transcript = _format_transcript(conversation)
     segment_count = len(conversation.get("transcript_segments") or [])
+    bootstrap_update = {}
+    bootstrap_builder = getattr(conversations_db, "bootstrap_summary_versioning_update", None)
+    if callable(bootstrap_builder):
+        bootstrap_update = bootstrap_builder(conversation)
+
+    submitted_state = {
+        "correction_id": correction_id,
+        "status": "submitted",
+        "pending": True,
+        "source": request.source,
+        "submitted_at": submitted_at,
+        "updated_at": submitted_at,
+        "active_summary_version_id": bootstrap_update.get("active_summary_version_id")
+        or conversation.get("active_summary_version_id"),
+    }
+    _update_conversation_correction_state(
+        uid,
+        conversation_id,
+        {
+            **bootstrap_update,
+            "correction_state": submitted_state,
+        },
+    )
 
     audit_payload = {
         "correction_id": correction_id,
@@ -247,13 +274,14 @@ async def _submit_conversation_correction(
             "Failed to submit conversation correction to n8n",
             extra={"uid": uid, "conversation_id": conversation_id, "correction_id": correction_id},
         )
+        failed_at = _now_iso()
         _persist_correction_audit(
             uid,
             conversation_id,
             correction_id,
             {
                 "status": "queue_failed",
-                "updated_at": _now_iso(),
+                "updated_at": failed_at,
                 "queue_error": str(exc),
             },
         )
@@ -261,7 +289,23 @@ async def _submit_conversation_correction(
             uid,
             conversation_id,
             correction_id,
-            {"stage": "queue_failed", "status": "error", "at": _now_iso(), "trace_id": trace_id, "error": str(exc)},
+            {"stage": "queue_failed", "status": "error", "at": failed_at, "trace_id": trace_id, "error": str(exc)},
+        )
+        _update_conversation_correction_state(
+            uid,
+            conversation_id,
+            {
+                "correction_state": {
+                    "correction_id": correction_id,
+                    "status": "queue_failed",
+                    "pending": False,
+                    "source": request.source,
+                    "submitted_at": submitted_at,
+                    "updated_at": failed_at,
+                    "active_summary_version_id": submitted_state.get("active_summary_version_id"),
+                    "error": str(exc),
+                }
+            },
         )
         return ConversationCorrectionResponse(
             correction_id=correction_id,
@@ -272,6 +316,15 @@ async def _submit_conversation_correction(
         )
 
     queued_at = _now_iso()
+    queued_state = {
+        "correction_id": correction_id,
+        "status": "queued",
+        "pending": True,
+        "source": request.source,
+        "submitted_at": submitted_at,
+        "updated_at": queued_at,
+        "active_summary_version_id": submitted_state.get("active_summary_version_id"),
+    }
     _persist_correction_audit(
         uid,
         conversation_id,
@@ -284,6 +337,7 @@ async def _submit_conversation_correction(
         correction_id,
         {"stage": "queued", "status": "ok", "at": queued_at, "trace_id": trace_id, "queue_result": queue_result},
     )
+    _update_conversation_correction_state(uid, conversation_id, {"correction_state": queued_state})
 
     return ConversationCorrectionResponse(
         correction_id=correction_id,

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -241,6 +241,16 @@ class EnrichmentState(BaseModel):
     error: Optional[str] = Field(default=None, description="Last enrichment processing error if any")
 
 
+class InternalAssessment(BaseModel):
+    media_likelihood: Optional[float] = Field(default=None, description="Likelihood the audio was primarily media")
+    speaker_confidence: Optional[str] = Field(default=None, description="Confidence in speaker attribution")
+    risk_level: Optional[str] = Field(default=None, description="Internal risk classification")
+    caregiver_relevance: Optional[str] = Field(default=None, description="How relevant this is to caregiver workflows")
+    escalation_recommendation: Optional[str] = Field(default=None, description="Recommended escalation action")
+    reason_codes: List[str] = Field(default_factory=list, description="Machine-readable internal assessment reasons")
+    notes: Optional[str] = Field(default=None, description="Short internal notes for debug/operator use")
+
+
 class Geolocation(BaseModel):
     google_place_id: Optional[str] = None
     latitude: float
@@ -338,6 +348,7 @@ class Conversation(BaseModel):
     active_summary_version_id: Optional[str] = None
     correction_state: Optional[CorrectionState] = None
     enrichment_state: Optional[EnrichmentState] = None
+    internal_assessment: Optional[InternalAssessment] = None
     transcript_segments: List[TranscriptSegment] = []
     transcript_segments_compressed: Optional[bool] = False
     geolocation: Optional[Geolocation] = None

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -204,6 +204,33 @@ class Structured(BaseModel):
         return result.strip()
 
 
+class SummaryVersion(BaseModel):
+    id: str = Field(description="Unique identifier for this summary version")
+    created_at: datetime = Field(description="When this summary version was created")
+    source: str = Field(default="observer", description="Producer of this summary version")
+    kind: str = Field(default="observer_enriched", description="Semantic type of this summary version")
+    title: str = Field(default="", description="Summary title for this version")
+    overview: str = Field(default="", description="Summary overview for this version")
+    emoji: str = Field(default="🧠", description="Summary emoji for this version")
+    category: CategoryEnum = Field(default=CategoryEnum.other, description="Summary category for this version")
+    correction_id: Optional[str] = Field(default=None, description="Correction event that produced this version")
+    based_on_version_id: Optional[str] = Field(default=None, description="Parent summary version identifier")
+    is_active: bool = Field(default=False, description="Whether this version is currently active")
+
+
+class CorrectionState(BaseModel):
+    correction_id: Optional[str] = Field(default=None, description="Latest correction event identifier")
+    status: Optional[str] = Field(default=None, description="Correction lifecycle status")
+    pending: bool = Field(default=False, description="Whether a correction is still pending")
+    source: Optional[str] = Field(default=None, description="Where the correction came from")
+    submitted_at: Optional[datetime] = Field(default=None, description="When the correction was first submitted")
+    updated_at: Optional[datetime] = Field(default=None, description="When the correction state last changed")
+    active_summary_version_id: Optional[str] = Field(
+        default=None, description="Currently active summary version while this state applies"
+    )
+    error: Optional[str] = Field(default=None, description="Last correction processing error if any")
+
+
 class Geolocation(BaseModel):
     google_place_id: Optional[str] = None
     latitude: float
@@ -297,6 +324,9 @@ class Conversation(BaseModel):
     language: Optional[str] = None  # applies only to Friend # TODO: once released migrate db to default 'en'
 
     structured: Structured
+    summary_versions: List[SummaryVersion] = []
+    active_summary_version_id: Optional[str] = None
+    correction_state: Optional[CorrectionState] = None
     transcript_segments: List[TranscriptSegment] = []
     transcript_segments_compressed: Optional[bool] = False
     geolocation: Optional[Geolocation] = None

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -231,6 +231,16 @@ class CorrectionState(BaseModel):
     error: Optional[str] = Field(default=None, description="Last correction processing error if any")
 
 
+class EnrichmentState(BaseModel):
+    status: Optional[str] = Field(default=None, description="Normal enrichment lifecycle status")
+    pending: bool = Field(default=False, description="Whether enrichment is still pending")
+    source: Optional[str] = Field(default=None, description="Producer of the active enriched summary")
+    kind: Optional[str] = Field(default=None, description="Semantic type of the active enriched summary")
+    trace_id: Optional[str] = Field(default=None, description="Trace identifier for the last enrichment attempt")
+    updated_at: Optional[datetime] = Field(default=None, description="When enrichment state last changed")
+    error: Optional[str] = Field(default=None, description="Last enrichment processing error if any")
+
+
 class Geolocation(BaseModel):
     google_place_id: Optional[str] = None
     latitude: float
@@ -327,6 +337,7 @@ class Conversation(BaseModel):
     summary_versions: List[SummaryVersion] = []
     active_summary_version_id: Optional[str] = None
     correction_state: Optional[CorrectionState] = None
+    enrichment_state: Optional[EnrichmentState] = None
     transcript_segments: List[TranscriptSegment] = []
     transcript_segments_compressed: Optional[bool] = False
     geolocation: Optional[Geolocation] = None

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -204,6 +204,7 @@ def test_get_conversation_data_404s_when_missing(monkeypatch):
 
 def test_update_conversation_summary_records_version_and_marks_correction_applied(monkeypatch):
     captured = {}
+    audit_updates = []
 
     monkeypatch.setattr(
         callbacks.conversations_db,
@@ -214,7 +215,12 @@ def test_update_conversation_summary_records_version_and_marks_correction_applie
                 "overview": "[Ella] Original overview with enough detail to preserve.",
                 "emoji": "🧠",
                 "category": callbacks.CategoryEnum.health,
-            }
+            },
+            "correction_state": {
+                "correction_id": "corr-123",
+                "source": "ios",
+                "submitted_at": "2026-04-22T17:00:00+00:00",
+            },
         },
     )
     monkeypatch.setattr(
@@ -233,6 +239,11 @@ def test_update_conversation_summary_records_version_and_marks_correction_applie
         callbacks.conversations_db,
         "update_conversation",
         lambda uid, conversation_id, update_data: captured.setdefault("update_data", update_data),
+    )
+    monkeypatch.setattr(
+        callbacks,
+        "_update_correction_audit",
+        lambda uid, conversation_id, correction_id, payload: audit_updates.append(payload),
     )
 
     result = asyncio.run(
@@ -254,4 +265,8 @@ def test_update_conversation_summary_records_version_and_marks_correction_applie
     assert captured["update_data"]["correction_state"]["status"] == "applied"
     assert captured["update_data"]["correction_state"]["pending"] is False
     assert captured["update_data"]["correction_state"]["correction_id"] == "corr-123"
+    assert captured["update_data"]["correction_state"]["source"] == "ios"
+    assert captured["update_data"]["correction_state"]["submitted_at"] == "2026-04-22T17:00:00+00:00"
+    assert audit_updates[0]["status"] == "applied"
+    assert audit_updates[0]["applied_summary_version_id"] == "corr-v2"
     assert result["active_summary_version_id"] == "corr-v2"

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -12,6 +12,9 @@ sys.modules.setdefault("database.conversations", MagicMock())
 sys.modules.setdefault("database.memories", MagicMock())
 sys.modules.setdefault("database.users", MagicMock())
 sys.modules.setdefault("httpx", MagicMock())
+sys.modules.setdefault("asyncpg", MagicMock())
+sys.modules.setdefault("firebase_admin", MagicMock())
+sys.modules.setdefault("utils.other.endpoints", MagicMock())
 sys.modules.setdefault("utils.notifications", MagicMock())
 sys.modules.setdefault("utils.other.storage", MagicMock())
 sys.modules.pop("ella.config", None)
@@ -324,6 +327,65 @@ def test_update_conversation_summary_records_enrichment_state(monkeypatch):
     assert enrichment_state["trace_id"] == "trace-123"
     assert enrichment_state["error"] is None
     assert result["active_summary_version_id"] == "obs-v2"
+
+
+def test_update_conversation_summary_persists_internal_assessment_when_available(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: {
+            "structured": {
+                "title": "Original title",
+                "overview": "[Ella] Original overview with enough detail to preserve.",
+                "emoji": "🧠",
+                "category": callbacks.CategoryEnum.health,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "build_summary_version_update",
+        lambda conversation, **kwargs: {
+            "summary_versions": [{"id": "obs-v2", "title": kwargs["next_structured"]["title"]}],
+            "active_summary_version_id": "obs-v2",
+            "new_summary_version_id": "obs-v2",
+        },
+    )
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "update_conversation",
+        lambda uid, conversation_id, update_data: captured.setdefault("update_data", update_data),
+    )
+    async def fake_fetch_internal_assessment(uid, conversation_id):
+        return {
+            "media_likelihood": 0.92,
+            "speaker_confidence": "low",
+            "risk_level": "none",
+            "caregiver_relevance": "low",
+            "escalation_recommendation": "none",
+            "reason_codes": ["likely_media_or_background_audio"],
+            "notes": "Likely ambient media.",
+        }
+
+    monkeypatch.setattr(callbacks, "_fetch_internal_assessment", fake_fetch_internal_assessment)
+
+    asyncio.run(
+        callbacks.update_conversation_summary(
+            "conv-123",
+            callbacks.ConversationSummaryUpdate(
+                title="Observer title",
+                overview="[Ella] Observer overview with enough detail to safely replace the summary.",
+                summary_source="observer",
+                summary_kind="observer_enriched",
+            ),
+            uid="user-123",
+        )
+    )
+
+    assert captured["update_data"]["internal_assessment"]["media_likelihood"] == 0.92
+    assert captured["update_data"]["internal_assessment"]["reason_codes"] == ["likely_media_or_background_audio"]
 
 
 def test_list_enrichment_reconcile_candidates_filters_to_unenriched_recent_conversations(monkeypatch):

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -270,3 +270,107 @@ def test_update_conversation_summary_records_version_and_marks_correction_applie
     assert audit_updates[0]["status"] == "applied"
     assert audit_updates[0]["applied_summary_version_id"] == "corr-v2"
     assert result["active_summary_version_id"] == "corr-v2"
+
+
+def test_update_conversation_summary_records_enrichment_state(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: {
+            "structured": {
+                "title": "Original title",
+                "overview": "[Ella] Original overview with enough detail to preserve.",
+                "emoji": "🧠",
+                "category": callbacks.CategoryEnum.health,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "build_summary_version_update",
+        lambda conversation, **kwargs: {
+            "summary_versions": [{"id": "obs-v2", "title": kwargs["next_structured"]["title"]}],
+            "active_summary_version_id": "obs-v2",
+            "new_summary_version_id": "obs-v2",
+        },
+    )
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "update_conversation",
+        lambda uid, conversation_id, update_data: captured.setdefault("update_data", update_data),
+    )
+
+    result = asyncio.run(
+        callbacks.update_conversation_summary(
+            "conv-123",
+            callbacks.ConversationSummaryUpdate(
+                title="Observer title",
+                overview="[Ella] Observer overview with enough detail to safely replace the summary.",
+                summary_source="observer",
+                summary_kind="observer_enriched",
+                trace_id="trace-123",
+            ),
+            uid="user-123",
+        )
+    )
+
+    enrichment_state = captured["update_data"]["enrichment_state"]
+    assert enrichment_state["status"] == "writeback_applied"
+    assert enrichment_state["pending"] is False
+    assert enrichment_state["source"] == "observer"
+    assert enrichment_state["kind"] == "observer_enriched"
+    assert enrichment_state["trace_id"] == "trace-123"
+    assert enrichment_state["error"] is None
+    assert result["active_summary_version_id"] == "obs-v2"
+
+
+def test_list_enrichment_reconcile_candidates_filters_to_unenriched_recent_conversations(monkeypatch):
+    fixture = [
+        {
+            "id": "conv-enriched",
+            "created_at": "2026-04-23T18:00:00Z",
+            "structured": {"title": "Enriched"},
+            "active_summary_version_id": "v1",
+            "summary_versions": [
+                {"id": "v1", "source": "observer", "kind": "observer_enriched", "is_active": True}
+            ],
+            "enrichment_state": {"status": "writeback_applied"},
+        },
+        {
+            "id": "conv-missing",
+            "created_at": "2026-04-23T18:05:00Z",
+            "structured": {"title": "Missing enrich"},
+            "active_summary_version_id": "v2",
+            "summary_versions": [{"id": "v2", "source": "legacy", "kind": "legacy_current", "is_active": True}],
+        },
+        {
+            "id": "conv-failed",
+            "created_at": "2026-04-23T18:10:00Z",
+            "structured": {"title": "Failed enrich"},
+            "active_summary_version_id": "v3",
+            "summary_versions": [
+                {"id": "v3", "source": "observer", "kind": "observer_enriched", "is_active": True}
+            ],
+            "enrichment_state": {"status": "failed", "error": "timeout"},
+        },
+    ]
+
+    monkeypatch.setattr(callbacks.conversations_db, "get_conversations_without_photos", lambda uid, **kwargs: fixture)
+    monkeypatch.setattr(callbacks.conversations_db, "get_conversations", lambda uid, **kwargs: fixture)
+
+    result = asyncio.run(
+        callbacks.list_enrichment_reconcile_candidates(
+            uid="user-123",
+            lookback_minutes=180,
+            limit=25,
+        )
+    )
+
+    assert result["uid"] == "user-123"
+    assert result["total_scanned"] == 3
+    assert result["candidate_count"] == 2
+    assert [candidate["conversation_id"] for candidate in result["candidates"]] == ["conv-missing", "conv-failed"]
+    assert result["candidates"][0]["reason"] == "active_summary_not_enriched"
+    assert result["candidates"][1]["reason"] == "enrichment_failed"

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -200,3 +200,58 @@ def test_get_conversation_data_404s_when_missing(monkeypatch):
 
     assert excinfo.value.status_code == 404
     assert "Conversation not found" in excinfo.value.detail
+
+
+def test_update_conversation_summary_records_version_and_marks_correction_applied(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: {
+            "structured": {
+                "title": "Original title",
+                "overview": "[Ella] Original overview with enough detail to preserve.",
+                "emoji": "🧠",
+                "category": callbacks.CategoryEnum.health,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "build_summary_version_update",
+        lambda conversation, **kwargs: {
+            "summary_versions": [
+                {"id": "legacy-v1", "title": "Original title"},
+                {"id": "corr-v2", "title": kwargs["next_structured"]["title"]},
+            ],
+            "active_summary_version_id": "corr-v2",
+            "new_summary_version_id": "corr-v2",
+        },
+    )
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "update_conversation",
+        lambda uid, conversation_id, update_data: captured.setdefault("update_data", update_data),
+    )
+
+    result = asyncio.run(
+        callbacks.update_conversation_summary(
+            "conv-123",
+            callbacks.ConversationSummaryUpdate(
+                title="Corrected title",
+                overview="[Ella] Corrected overview with enough detail to safely replace the summary.",
+                correction_id="corr-123",
+                summary_kind="corrected_enriched",
+                summary_source="observer",
+            ),
+            uid="user-123",
+        )
+    )
+
+    assert captured["update_data"]["summary_versions"][1]["id"] == "corr-v2"
+    assert captured["update_data"]["active_summary_version_id"] == "corr-v2"
+    assert captured["update_data"]["correction_state"]["status"] == "applied"
+    assert captured["update_data"]["correction_state"]["pending"] is False
+    assert captured["update_data"]["correction_state"]["correction_id"] == "corr-123"
+    assert result["active_summary_version_id"] == "corr-v2"

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -45,8 +45,19 @@ def test_submit_correction_accepts_ios_payload_and_queues(monkeypatch):
     audits = []
     events = []
     submitted = {}
+    conversation_updates = []
 
     monkeypatch.setattr(corrections.conversations_db, "get_conversation", lambda uid, conversation_id: _conversation())
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "bootstrap_summary_versioning_update",
+        lambda conversation: {"summary_versions": [{"id": "legacy-v1"}], "active_summary_version_id": "legacy-v1"},
+    )
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "update_conversation",
+        lambda uid, conversation_id, update_data: conversation_updates.append(update_data),
+    )
     monkeypatch.setattr(
         corrections,
         "_persist_correction_audit",
@@ -101,6 +112,10 @@ def test_submit_correction_accepts_ios_payload_and_queues(monkeypatch):
     assert "The podcast said memory can be tricky." in submitted["transcript"]
     assert submitted["request"].summary_context.app_summary == "The app summary was too clinical."
     assert events[-1]["stage"] == "queued"
+    assert conversation_updates[0]["correction_state"]["status"] == "submitted"
+    assert conversation_updates[0]["active_summary_version_id"] == "legacy-v1"
+    assert conversation_updates[-1]["correction_state"]["status"] == "queued"
+    assert conversation_updates[-1]["correction_state"]["active_summary_version_id"] == "legacy-v1"
 
 
 def test_submit_correction_uses_authenticated_uid_for_ownership(monkeypatch):
@@ -146,8 +161,15 @@ def test_submit_correction_rejects_locked_conversation(monkeypatch):
 def test_submit_correction_persists_n8n_failure_trace_and_still_returns_202(monkeypatch):
     audits = []
     events = []
+    conversation_updates = []
 
     monkeypatch.setattr(corrections.conversations_db, "get_conversation", lambda uid, conversation_id: _conversation())
+    monkeypatch.setattr(corrections.conversations_db, "bootstrap_summary_versioning_update", lambda conversation: {})
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "update_conversation",
+        lambda uid, conversation_id, update_data: conversation_updates.append(update_data),
+    )
     monkeypatch.setattr(
         corrections,
         "_persist_correction_audit",
@@ -178,6 +200,9 @@ def test_submit_correction_persists_n8n_failure_trace_and_still_returns_202(monk
     assert audits[-1]["queue_error"] == "n8n offline"
     assert events[-1]["stage"] == "queue_failed"
     assert events[-1]["status"] == "error"
+    assert conversation_updates[0]["correction_state"]["status"] == "submitted"
+    assert conversation_updates[-1]["correction_state"]["status"] == "queue_failed"
+    assert conversation_updates[-1]["correction_state"]["pending"] is False
 
 
 def test_router_uses_custom_ella_namespace_only():


### PR DESCRIPTION
Superseded by PR #117, which contains the clean minimal backend-only change for internal assessment payload exposure.