### PR TITLE
OMI: expose internal assessment on conversation payloads

### DIFF
--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -23,6 +23,7 @@ NOTE: Caregiver CRUD endpoints moved to n8n (ella-ai-care repo). iOS calls n8n w
 import hashlib
 import hmac
 import io
+import json
 import logging
 import os
 import secrets
@@ -31,6 +32,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
+import asyncpg
 import httpx
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
@@ -51,6 +53,7 @@ from utils.other.storage import storage_client
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/ella", tags=["ella"])
+_resolve_pool: Optional[asyncpg.Pool] = None
 
 # GCS bucket for Ella TTS audio files (defaults to project's Firebase Storage bucket)
 ELLA_AUDIO_BUCKET = os.getenv("ELLA_AUDIO_BUCKET", "omi-dev-ca005.firebasestorage.app")
@@ -58,6 +61,8 @@ ELLA_AUDIO_BUCKET = os.getenv("ELLA_AUDIO_BUCKET", "omi-dev-ca005.firebasestorag
 # OpenAI TTS configuration
 OPENAI_TTS_MODEL = os.getenv("ELLA_TTS_MODEL", "tts-1")
 OPENAI_TTS_VOICE = os.getenv("ELLA_TTS_VOICE", "nova")
+PROVISION_API_KEY = os.getenv("ELLA_PROVISION_API_KEY", os.getenv("ELLA_PROVISION_API_TOKEN", ""))
+PROVISION_API_URL = os.getenv("ELLA_PROVISION_URL", "http://100.76.138.56:8200")
 
 
 # ============================================================================
@@ -180,6 +185,80 @@ def _update_correction_audit(
     )
 
 
+async def _get_resolve_pool() -> asyncpg.Pool:
+    global _resolve_pool
+    if _resolve_pool is None:
+        _resolve_pool = await asyncpg.create_pool(
+            host="127.0.0.1",
+            port=5433,
+            user="postgres",
+            password=os.getenv("ELLA_POSTGRES_PASSWORD", "postgres"),
+            database="ella_ai",
+            min_size=1,
+            max_size=4,
+        )
+    return _resolve_pool
+
+
+async def _resolve_agent_id_for_uid(uid: str) -> Optional[str]:
+    pool = await _get_resolve_pool()
+    row = await pool.fetchrow(
+        """
+        SELECT ac.agents
+        FROM users u
+        LEFT JOIN agent_clusters ac ON ac.user_id = u.id
+        WHERE u.omi_uid = $1
+        """,
+        uid,
+    )
+    if not row or not row["agents"]:
+        return None
+
+    agents = row["agents"]
+    if isinstance(agents, str):
+        try:
+            agents = json.loads(agents)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(agents, dict):
+        return None
+    return agents.get("userAgentId")
+
+
+async def _fetch_internal_assessment(uid: str, conversation_id: str) -> Optional[dict]:
+    """Best-effort fetch of Observer sidecar internal_assessment.
+
+    This keeps the app-facing conversation payload aligned with the OpenClaw sidecar
+    without making the summary PATCH path depend on Mac Mini reachability.
+    """
+    try:
+        agent_id = await _resolve_agent_id_for_uid(uid)
+        if not agent_id:
+            return None
+
+        headers = {}
+        if PROVISION_API_KEY:
+            headers["Authorization"] = f"Bearer {PROVISION_API_KEY}"
+
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(
+                f"{PROVISION_API_URL}/workspace/{agent_id}/metadata/conversations/{conversation_id}",
+                headers=headers,
+            )
+
+        if resp.status_code >= 400:
+            return None
+
+        data = resp.json()
+        assessment = data.get("internal_assessment")
+        return assessment if isinstance(assessment, dict) else None
+    except Exception as e:
+        logger.warning(
+            "Failed to fetch internal_assessment from Provision API",
+            extra={"uid": uid, "conversation_id": conversation_id},
+        )
+        logger.warning(str(e))
+        return None
 @router.patch("/conversation/{conversation_id}/summary")
 async def update_conversation_summary(
     conversation_id: str,
@@ -256,6 +335,9 @@ async def update_conversation_summary(
     )
     update_data["summary_versions"] = version_update["summary_versions"]
     update_data["active_summary_version_id"] = version_update["active_summary_version_id"]
+    internal_assessment = await _fetch_internal_assessment(uid, conversation_id)
+    if internal_assessment:
+        update_data["internal_assessment"] = internal_assessment
     if update.correction_id:
         existing_state = conversation.get("correction_state") or {}
         update_data["correction_state"] = {

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -231,6 +231,14 @@ class CorrectionState(BaseModel):
     error: Optional[str] = Field(default=None, description="Last correction processing error if any")
 
 
+class InternalAssessment(BaseModel):
+    media_likelihood: Optional[float] = Field(default=None, description="Likelihood the audio was primarily media")
+    speaker_confidence: Optional[str] = Field(default=None, description="Confidence in speaker attribution")
+    risk_level: Optional[str] = Field(default=None, description="Internal risk classification")
+    caregiver_relevance: Optional[str] = Field(default=None, description="How relevant this is to caregiver workflows")
+    escalation_recommendation: Optional[str] = Field(default=None, description="Recommended escalation action")
+    reason_codes: List[str] = Field(default_factory=list, description="Machine-readable internal assessment reasons")
+    notes: Optional[str] = Field(default=None, description="Short internal notes for debug/operator use")
 class Geolocation(BaseModel):
     google_place_id: Optional[str] = None
     latitude: float
@@ -327,6 +335,7 @@ class Conversation(BaseModel):
     summary_versions: List[SummaryVersion] = []
     active_summary_version_id: Optional[str] = None
     correction_state: Optional[CorrectionState] = None
+    internal_assessment: Optional[InternalAssessment] = None
     transcript_segments: List[TranscriptSegment] = []
     transcript_segments_compressed: Optional[bool] = False
     geolocation: Optional[Geolocation] = None

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -12,6 +12,9 @@ sys.modules.setdefault("database.conversations", MagicMock())
 sys.modules.setdefault("database.memories", MagicMock())
 sys.modules.setdefault("database.users", MagicMock())
 sys.modules.setdefault("httpx", MagicMock())
+sys.modules.setdefault("asyncpg", MagicMock())
+sys.modules.setdefault("firebase_admin", MagicMock())
+sys.modules.setdefault("utils.other.endpoints", MagicMock())
 sys.modules.setdefault("utils.notifications", MagicMock())
 sys.modules.setdefault("utils.other.storage", MagicMock())
 sys.modules.pop("ella.config", None)
@@ -270,3 +273,62 @@ def test_update_conversation_summary_records_version_and_marks_correction_applie
     assert audit_updates[0]["status"] == "applied"
     assert audit_updates[0]["applied_summary_version_id"] == "corr-v2"
     assert result["active_summary_version_id"] == "corr-v2"
+
+
+def test_update_conversation_summary_persists_internal_assessment_when_available(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: {
+            "structured": {
+                "title": "Original title",
+                "overview": "[Ella] Original overview with enough detail to preserve.",
+                "emoji": "🧠",
+                "category": callbacks.CategoryEnum.health,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "build_summary_version_update",
+        lambda conversation, **kwargs: {
+            "summary_versions": [{"id": "obs-v2", "title": kwargs["next_structured"]["title"]}],
+            "active_summary_version_id": "obs-v2",
+            "new_summary_version_id": "obs-v2",
+        },
+    )
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "update_conversation",
+        lambda uid, conversation_id, update_data: captured.setdefault("update_data", update_data),
+    )
+    async def fake_fetch_internal_assessment(uid, conversation_id):
+        return {
+            "media_likelihood": 0.92,
+            "speaker_confidence": "low",
+            "risk_level": "none",
+            "caregiver_relevance": "low",
+            "escalation_recommendation": "none",
+            "reason_codes": ["likely_media_or_background_audio"],
+            "notes": "Likely ambient media.",
+        }
+
+    monkeypatch.setattr(callbacks, "_fetch_internal_assessment", fake_fetch_internal_assessment)
+
+    asyncio.run(
+        callbacks.update_conversation_summary(
+            "conv-123",
+            callbacks.ConversationSummaryUpdate(
+                title="Observer title",
+                overview="[Ella] Observer overview with enough detail to safely replace the summary.",
+                summary_source="observer",
+                summary_kind="observer_enriched",
+            ),
+            uid="user-123",
+        )
+    )
+
+    assert captured["update_data"]["internal_assessment"]["media_likelihood"] == 0.92
+    assert captured["update_data"]["internal_assessment"]["reason_codes"] == ["likely_media_or_background_audio"]


### PR DESCRIPTION
## Summary
- add `internal_assessment` as a typed sibling field on conversation records
- persist that field during Ella summary write-back by pulling the matching OpenClaw sidecar assessment
- keep the sidecar fetch best-effort so visible summaries do not depend on Mac Mini reachability
- add unit coverage for the new conversation payload field

## Testing
- `python3 -m py_compile backend/models/conversation.py backend/ella/routers/callbacks.py`
- `/Users/ellaai/dev/omi/backend/.venv/bin/python -m pytest backend/tests/unit/test_ella_callbacks_summary_update.py`

Closes #114