### PR TITLE
[codex] Add debug-only iOS internal assessment rendering

### DIFF
--- a/app/lib/backend/schema/conversation.dart
+++ b/app/lib/backend/schema/conversation.dart
@@ -189,6 +189,7 @@ class ServerConversation {
   final String? language; // applies to friend/omi only
 
   final ConversationExternalData? externalIntegration;
+  final Object? internalAssessment;
 
   ConversationStatus status;
   bool discarded;
@@ -217,6 +218,7 @@ class ServerConversation {
     this.source,
     this.language,
     this.externalIntegration,
+    this.internalAssessment,
     this.status = ConversationStatus.completed,
     this.isLocked = false,
     this.starred = false,
@@ -248,6 +250,7 @@ class ServerConversation {
       deleted: json['deleted'] ?? false,
       externalIntegration:
           json['external_data'] != null ? ConversationExternalData.fromJson(json['external_data']) : null,
+      internalAssessment: json['internal_assessment'],
       status: json['status'] != null
           ? ConversationStatus.values.asNameMap()[json['status']] ?? ConversationStatus.completed
           : ConversationStatus.completed,
@@ -274,6 +277,7 @@ class ServerConversation {
       'source': source?.toString(),
       'language': language,
       'external_data': externalIntegration?.toJson(),
+      'internal_assessment': internalAssessment,
       'status': status.toString().split('.').last,
       'is_locked': isLocked,
       'starred': starred,
@@ -283,6 +287,29 @@ class ServerConversation {
 
   int unassignedSegmentsLength() {
     return transcriptSegments.where((element) => (element.personId == null && !element.isUser)).length;
+  }
+
+  bool get hasInternalAssessment {
+    final payload = internalAssessment;
+    if (payload == null) return false;
+    if (payload is String) return payload.trim().isNotEmpty;
+    if (payload is List) return payload.isNotEmpty;
+    if (payload is Map) return payload.isNotEmpty;
+    return true;
+  }
+
+  String? get internalAssessmentDebugText {
+    final payload = internalAssessment;
+    if (payload == null) return null;
+    if (payload is String) {
+      final trimmed = payload.trim();
+      return trimmed.isEmpty ? null : trimmed;
+    }
+    try {
+      return const JsonEncoder.withIndent('  ').convert(payload);
+    } catch (_) {
+      return payload.toString();
+    }
   }
 
   int speakerWithMostUnassignedSegments() {

--- a/app/lib/pages/conversation_detail/page.dart
+++ b/app/lib/pages/conversation_detail/page.dart
@@ -35,6 +35,7 @@ import 'package:omi/widgets/extensions/string.dart';
 import 'conversation_detail_provider.dart';
 import 'test_prompts.dart';
 import 'widgets/audio_download_progress_sheet.dart';
+import 'widgets/internal_assessment_debug_sheet.dart';
 import 'widgets/name_speaker_sheet.dart';
 import 'widgets/share_to_contacts_sheet.dart';
 import 'package:omi/ella/ella_theme.dart';
@@ -1324,6 +1325,24 @@ class _SummaryTabState extends State<SummaryTab> with AutomaticKeepAliveClientMi
   @override
   bool get wantKeepAlive => true;
 
+  void _maybeShowInternalAssessment(BuildContext context) {
+    final conversation = context.read<ConversationDetailProvider>().conversation;
+    if (!DebugInternalAssessmentSheet.isSupported(
+      conversation,
+      isDebugMode: kDebugMode,
+      isIOS: PlatformService.isIOS,
+    )) {
+      return;
+    }
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (_) => DebugInternalAssessmentSheet(conversation: conversation),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     super.build(context);
@@ -1343,6 +1362,7 @@ class _SummaryTabState extends State<SummaryTab> with AutomaticKeepAliveClientMi
               widget.onTapWhenSearchEmpty!();
             }
           },
+          onLongPress: () => _maybeShowInternalAssessment(context),
           child: Selector<ConversationDetailProvider, Tuple3<bool, bool, Function(int)>>(
             selector: (context, provider) =>
                 Tuple3(provider.conversation.discarded, provider.showRatingUI, provider.setConversationRating),

--- a/app/lib/pages/conversation_detail/widgets/internal_assessment_debug_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/internal_assessment_debug_sheet.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/utils/platform/platform_service.dart';
+import 'package:omi/ella/ella_theme.dart';
+
+bool shouldShowInternalAssessmentDebugUi({
+  required bool isDebugMode,
+  required bool isIOS,
+  required ServerConversation conversation,
+}) {
+  return isDebugMode && isIOS && conversation.hasInternalAssessment;
+}
+
+class DebugInternalAssessmentSheet extends StatelessWidget {
+  final ServerConversation conversation;
+
+  const DebugInternalAssessmentSheet({super.key, required this.conversation});
+
+  @visibleForTesting
+  static bool isSupported(ServerConversation conversation, {bool isDebugMode = kDebugMode, bool isIOS = false}) {
+    return shouldShowInternalAssessmentDebugUi(
+      isDebugMode: isDebugMode,
+      isIOS: isIOS,
+      conversation: conversation,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final payload = conversation.internalAssessmentDebugText;
+
+    return SafeArea(
+      child: Container(
+        decoration: const BoxDecoration(
+          color: EllaColors.bgPrimary,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+        ),
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    context.l10n.developer,
+                    style: const TextStyle(
+                      color: EllaColors.textPrimary,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  onPressed: payload == null
+                      ? null
+                      : () {
+                          Clipboard.setData(ClipboardData(text: payload));
+                          ScaffoldMessenger.of(
+                            context,
+                          ).showSnackBar(SnackBar(content: Text(context.l10n.summaryCopiedToClipboard)));
+                        },
+                  icon: const Icon(Icons.copy_rounded, color: EllaColors.textPrimary),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: 360),
+              child: Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: EllaColors.bgSecondary,
+                  borderRadius: BorderRadius.circular(18),
+                  border: Border.all(color: EllaColors.bgTertiary),
+                ),
+                child: SingleChildScrollView(
+                  child: SelectableText(
+                    payload ?? context.l10n.noSummaryForConversation,
+                    style: TextStyle(
+                      color: EllaColors.textPrimary,
+                      fontSize: 13,
+                      height: 1.4,
+                      fontFamily: PlatformService.isIOS ? 'Menlo' : null,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/backend/schema/conversation_test.dart
+++ b/app/test/backend/schema/conversation_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/conversation.dart';
+
+void main() {
+  group('ServerConversation internal assessment', () {
+    test('parses and serializes sibling internal_assessment payload', () {
+      final conversation = ServerConversation.fromJson({
+        'id': 'conv-1',
+        'created_at': '2026-04-23T12:00:00Z',
+        'structured': {
+          'title': 'Debug conversation',
+          'overview': 'Overview',
+          'emoji': '',
+          'category': 'other',
+          'action_items': [],
+          'events': [],
+        },
+        'transcript_segments': [],
+        'apps_results': [],
+        'audio_files': [],
+        'internal_assessment': {
+          'score': 0.93,
+          'reasons': ['low_confidence_title'],
+        },
+      });
+
+      expect(conversation.hasInternalAssessment, isTrue);
+      expect(conversation.internalAssessmentDebugText, contains('"score": 0.93'));
+      expect(conversation.toJson()['internal_assessment'], {
+        'score': 0.93,
+        'reasons': ['low_confidence_title'],
+      });
+    });
+  });
+}

--- a/app/test/pages/conversation_detail/debug_internal_assessment_sheet_test.dart
+++ b/app/test/pages/conversation_detail/debug_internal_assessment_sheet_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/conversation_detail/widgets/internal_assessment_debug_sheet.dart';
+
+void main() {
+  ServerConversation buildConversation({Object? internalAssessment}) {
+    return ServerConversation(
+      id: 'conv-debug',
+      createdAt: DateTime.parse('2026-04-23T12:00:00Z').toLocal(),
+      structured: Structured('Title', 'Overview'),
+      internalAssessment: internalAssessment,
+    );
+  }
+
+  group('DebugInternalAssessmentSheet', () {
+    testWidgets('renders formatted internal assessment payload', (tester) async {
+      final conversation = buildConversation(
+        internalAssessment: {
+          'score': 0.42,
+          'notes': ['needs_review'],
+        },
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: DebugInternalAssessmentSheet(conversation: conversation)),
+        ),
+      );
+
+      expect(find.text('Developer'), findsOneWidget);
+      expect(find.textContaining('"score": 0.42'), findsOneWidget);
+      expect(find.textContaining('"needs_review"'), findsOneWidget);
+    });
+
+    test('isSupported only enables the debug UI for iOS debug builds', () {
+      final conversation = buildConversation(internalAssessment: {'score': 1});
+
+      expect(DebugInternalAssessmentSheet.isSupported(conversation, isDebugMode: true, isIOS: true), isTrue);
+      expect(DebugInternalAssessmentSheet.isSupported(conversation, isDebugMode: false, isIOS: true), isFalse);
+      expect(DebugInternalAssessmentSheet.isSupported(conversation, isDebugMode: true, isIOS: false), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What changed
- parse and serialize the `internal_assessment` sibling field on `ServerConversation`
- add a hidden debug-only iOS long-press reveal on the summary surface that opens a copyable internal assessment sheet
- add targeted tests for schema handling and the debug sheet gating/rendering

## Why
OMI PR #117 adds the backend payload. The iOS app needs debug-only rendering support for this field without changing the default conversation UX.

## Impact
- no default conversation UI changes for production users
- debug builds on iOS can inspect the raw `internal_assessment` payload when present

## Validation
- `./test.sh`
- `flutter test test/backend/schema/conversation_test.dart test/pages/conversation_detail/debug_internal_assessment_sheet_test.dart`

## Related
- Closes #115