### PR TITLE
[codex] add OpenClaw Direct iOS voice mode on release baseline

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -677,7 +677,7 @@ class SharedPreferencesUtil {
   String get pendingEmergency => getString('pendingEmergency');
   set pendingEmergency(String value) => saveString('pendingEmergency', value);
 
-  // TTS Provider (dev setting) — elevenlabs | fish-audio-s2 | kokoro
+  // Voice provider (dev setting) — TTS providers plus V2V session providers.
   String get ttsProvider => getString('devTtsProvider', defaultValue: 'elevenlabs');
   set ttsProvider(String value) => saveString('devTtsProvider', value);
 

--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -91,8 +91,8 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     unicode: true,
   );
 
-  /// Check if current TTS provider is a V2V provider.
-  static bool _isV2VProvider(String provider) => provider == 'grok-voice' || provider == 'gemini-live';
+  /// Check if current voice provider uses the V2V session endpoint.
+  static bool _isV2VProvider(String provider) => V2VClient.isSessionProvider(provider);
 
   @override
   bool get wantKeepAlive => true;

--- a/app/lib/ella/services/v2v_client.dart
+++ b/app/lib/ella/services/v2v_client.dart
@@ -52,6 +52,11 @@ class V2VClient {
 
   bool get isConnected => _isConnected;
 
+  static bool isSessionProvider(String provider) =>
+      provider == 'openclaw-direct' || provider == 'grok-voice' || provider == 'gemini-live';
+
+  static String? sessionVoiceMode(String provider) => provider == 'openclaw-direct' ? 'openclaw-direct-v1' : null;
+
   /// Start a V2V session: get session token, connect WebSocket, start audio.
   Future<bool> connect({required String provider}) async {
     final uid = SharedPreferencesUtil().uid;
@@ -76,7 +81,7 @@ class V2VClient {
 
     // 3. Connect WebSocket
     final wsUrl = '$endpoint&token=$token';
-    Logger.debug('[V2V] Connecting to WebSocket...');
+    Logger.debug('[V2V] Connecting to WebSocket for provider=$provider...');
 
     try {
       _channel = IOWebSocketChannel.connect(
@@ -173,10 +178,17 @@ class V2VClient {
 
   Future<Map<String, dynamic>?> _createSession(String uid, String provider) async {
     try {
+      final voiceMode = sessionVoiceMode(provider);
+      final requestBody = {
+        'uid': uid,
+        'provider': provider,
+        if (voiceMode != null) 'voice_mode': voiceMode,
+      };
+
       final response = await makeApiCall(
         url: '${Env.apiBaseUrl}v1/voice/session',
         headers: {'Content-Type': 'application/json'},
-        body: jsonEncode({'uid': uid, 'provider': provider}),
+        body: jsonEncode(requestBody),
         method: 'POST',
         timeout: const Duration(seconds: 10),
       );
@@ -187,7 +199,7 @@ class V2VClient {
       }
 
       final data = jsonDecode(response.body) as Map<String, dynamic>;
-      Logger.debug('[V2V] Session created: provider=$provider');
+      Logger.debug('[V2V] Session created: provider=$provider voice_mode=${voiceMode ?? "default"}');
       return data;
     } catch (e) {
       Logger.error('[V2V] Session create error: $e');

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -2566,5 +2566,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -2568,5 +2568,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -2568,5 +2568,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -2568,5 +2568,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -2608,5 +2608,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2567,5 +2567,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -2599,5 +2599,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10136,5 +10136,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -2599,5 +2599,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -2599,5 +2599,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -2634,5 +2634,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -2695,5 +2695,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -2641,5 +2641,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -2599,5 +2599,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2599,5 +2599,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -15896,6 +15896,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Guardian ON: Audio monitoring and care features active.'**
   String get ellaGuardianOnTooltip;
+
+  /// No description provided for @openClawDirectVoiceMode.
+  ///
+  /// In en, this message translates to:
+  /// **'OpenClaw Direct'**
+  String get openClawDirectVoiceMode;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8461,4 +8461,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8549,4 +8549,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8565,4 +8565,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8512,4 +8512,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8501,4 +8501,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8583,4 +8583,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8574,4 +8574,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8514,4 +8514,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8531,4 +8531,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8516,4 +8516,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8515,4 +8515,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8590,4 +8590,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8497,4 +8497,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8554,4 +8554,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8529,4 +8529,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8566,4 +8566,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8383,4 +8383,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8385,4 +8385,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8522,4 +8522,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8534,4 +8534,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8540,4 +8540,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8542,4 +8542,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8512,4 +8512,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8535,4 +8535,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8517,4 +8517,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8555,4 +8555,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8542,4 +8542,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8507,4 +8507,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8522,4 +8522,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8479,4 +8479,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8530,4 +8530,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8529,4 +8529,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8519,4 +8519,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8373,4 +8373,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get openClawDirectVoiceMode => 'OpenClaw Direct';
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -2599,5 +2599,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -2599,5 +2599,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -2599,5 +2599,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -2599,5 +2599,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -2599,5 +2599,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -2634,5 +2634,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -2635,5 +2635,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -2599,5 +2599,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -2634,5 +2634,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -2604,5 +2604,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -2599,5 +2599,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -2599,5 +2599,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -2634,5 +2634,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -2599,5 +2599,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -2604,5 +2604,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -2621,5 +2621,6 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "openClawDirectVoiceMode": "OpenClaw Direct"
 }

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -816,13 +816,15 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                           dropdownColor: const Color(0xFF2A2A2E),
                           underline: const SizedBox.shrink(),
                           style: const TextStyle(color: Colors.white, fontSize: 14),
-                          items: const [
-                            DropdownMenuItem(value: 'elevenlabs', child: Text('ElevenLabs')),
-                            DropdownMenuItem(value: 'fish-audio-s2', child: Text('Fish Audio S2')),
-                            DropdownMenuItem(value: 'kokoro', child: Text('Kokoro (local)')),
-                            DropdownMenuItem(value: 'inworld', child: Text('Inworld TTS (cloud, ~120ms)')),
-                            DropdownMenuItem(value: 'grok-voice', child: Text('Grok Voice (V2V)')),
-                            DropdownMenuItem(value: 'gemini-live', child: Text('Gemini Live (V2V)')),
+                          items: [
+                            const DropdownMenuItem(value: 'elevenlabs', child: Text('ElevenLabs')),
+                            const DropdownMenuItem(value: 'fish-audio-s2', child: Text('Fish Audio S2')),
+                            const DropdownMenuItem(value: 'kokoro', child: Text('Kokoro (local)')),
+                            const DropdownMenuItem(value: 'inworld', child: Text('Inworld TTS (cloud, ~120ms)')),
+                            DropdownMenuItem(
+                                value: 'openclaw-direct', child: Text(context.l10n.openClawDirectVoiceMode)),
+                            const DropdownMenuItem(value: 'grok-voice', child: Text('Grok Voice (V2V)')),
+                            const DropdownMenuItem(value: 'gemini-live', child: Text('Gemini Live (V2V)')),
                           ],
                           onChanged: (value) {
                             if (value != null) {

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+734
+version: 1.0.524+735
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary

Implements the iOS-only portion of `ellaaicare/omi#119` on top of the release source-of-truth branch `release/ios-latest`.

- Adds `OpenClaw Direct` to the existing developer voice engine picker without removing or changing existing modes.
- Treats `openclaw-direct` as a V2V session provider in the existing voice runtime.
- Reuses the existing binary PCM WebSocket V2V transport instead of introducing WebRTC or raw OpenClaw RPC in Flutter.
- Sends the backend-owned session contract for this provider only:

```json
{
  "uid": "<firebase uid>",
  "provider": "openclaw-direct",
  "voice_mode": "openclaw-direct-v1"
}
```

Also bumps the release baseline from `1.0.524+734` to `1.0.524+735` for TestFlight.

Backend/proxy handling for `provider=openclaw-direct` and `mode=openclaw-direct-v1` remains delegated to `ella-ai#773`.

## Validation

- `./app/test.sh`
- `flutter test test/utils/app_localizations_helper_test.dart`
- `SKIP_PULL=1 ./build-and-upload.sh` from `app/ios`

## TestFlight

Uploaded successfully from the release-baseline branch.

- Version/build: `1.0.524+735`
- Delivery UUID: `c92b21c1-d3d9-4ee9-89a6-3beb8b448791`
- IPA: `/Users/ellaai/worktrees/omi-ios-agent/app/build/ios/EllaCare.ipa`
- IPA sha256: `d02598bd796aef105d6998202ce1327a9b8e013485c1530939592929ba2fa184`