### PR TITLE
[codex] Add OpenClaw direct voice session provider

### DIFF
--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -22,6 +22,7 @@ import logging
 import time
 from datetime import datetime, timedelta
 from typing import List, Optional
+from urllib.parse import urlencode
 
 import asyncpg
 import httpx
@@ -104,6 +105,14 @@ V2V_PROVIDERS = {
         "default_mode": "gemini-live",
         "endpoint_env": "ELLA_VOICE_ENDPOINT",  # Same proxy, different mode
         "key_check": lambda: bool(GEMINI_API_KEY),
+    },
+    "openclaw-direct": {
+        "name": "OpenClaw Direct (V2V)",
+        "description": "Stable OMI websocket contract backed by STT -> OpenClaw -> TTS",
+        "default_mode": "openclaw-direct-v1",
+        "endpoint_env": "ELLA_VOICE_ENDPOINT",
+        "key_check": lambda: bool(ELLA_SESSION_SECRET),
+        "include_token_in_endpoint": True,
     },
 }
 
@@ -246,6 +255,15 @@ def create_session_token(
     return jwt.encode(payload, ELLA_SESSION_SECRET, algorithm="HS256")
 
 
+def build_voice_endpoint(endpoint: str, voice_mode: str, token: Optional[str] = None) -> str:
+    """Build a websocket endpoint without disturbing existing provider response shapes."""
+    params = {"mode": voice_mode}
+    if token:
+        params["token"] = token
+    separator = "&" if "?" in endpoint else "?"
+    return f"{endpoint}{separator}{urlencode(params)}"
+
+
 # ============================================================================
 # Endpoints
 # ============================================================================
@@ -307,6 +325,16 @@ async def get_voice_providers():
             "requires_session": True,
             "session_endpoint": "/v1/voice/session",
         },
+        {
+            "id": "openclaw-direct",
+            "name": "OpenClaw Direct (V2V)",
+            "type": "v2v",
+            "description": "Stable OMI websocket contract backed by OpenClaw",
+            "available": V2V_PROVIDERS["openclaw-direct"]["key_check"](),
+            "requires_session": True,
+            "session_endpoint": "/v1/voice/session",
+            "default_mode": V2V_PROVIDERS["openclaw-direct"]["default_mode"],
+        },
     ]
     return {"providers": providers}
 
@@ -332,7 +360,7 @@ async def create_voice_session(
 
     Args:
         uid: User ID (required)
-        provider: V2V provider — "grok-voice" (default) or "gemini-live"
+        provider: V2V provider — "grok-voice" (default), "gemini-live", or "openclaw-direct"
         voice_mode: Override mode (defaults to provider's default mode)
 
     Returns:
@@ -377,9 +405,7 @@ async def create_voice_session(
     user_display_name = None
     try:
         pool = await _get_pool()
-        row = await pool.fetchrow(
-            "SELECT name FROM users WHERE omi_uid = $1", uid
-        )
+        row = await pool.fetchrow("SELECT name FROM users WHERE omi_uid = $1", uid)
         if row:
             user_display_name = row["name"]
     except Exception as e:
@@ -394,9 +420,14 @@ async def create_voice_session(
             provider=provider,
         )
 
-        # Build endpoint URL with mode query param
+        # Build endpoint URL with mode query param. Existing providers keep token separate
+        # for backwards compatibility; openclaw-direct returns a ready-to-connect URL.
         endpoint = os.getenv(provider_info["endpoint_env"], ELLA_VOICE_ENDPOINT)
-        endpoint_with_mode = f"{endpoint}?mode={resolved_mode}"
+        endpoint_with_mode = build_voice_endpoint(
+            endpoint,
+            resolved_mode,
+            token if provider_info.get("include_token_in_endpoint") else None,
+        )
 
         _elapsed = int((time.time() - _start) * 1000)
         print(
@@ -490,7 +521,10 @@ async def synthesize_speech(
                 )
             _elapsed = int((time.time() - _start) * 1000)
             if response.status_code != 200:
-                print(f"[FLOW:VOICE-TTS] ERROR provider={provider} status={response.status_code} latency={_elapsed}ms", flush=True)
+                print(
+                    f"[FLOW:VOICE-TTS] ERROR provider={provider} status={response.status_code} latency={_elapsed}ms",
+                    flush=True,
+                )
                 raise HTTPException(status_code=502, detail=f"ella-tts error: {response.status_code}")
             audio_size = len(response.content)
             print(f"[FLOW:VOICE-TTS] OK provider={provider} audio_bytes={audio_size} latency={_elapsed}ms", flush=True)
@@ -525,7 +559,10 @@ async def synthesize_speech(
     # --- Reject unknown providers (no silent fallbacks) ---
     if provider != "elevenlabs":
         print(f"[FLOW:VOICE-TTS] ERROR unknown provider={provider!r}", flush=True)
-        raise HTTPException(status_code=400, detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, grok-voice, gemini-live")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, grok-voice, gemini-live, openclaw-direct",
+        )
 
     # --- ElevenLabs ---
     if not ELEVENLABS_API_KEY:
@@ -554,11 +591,17 @@ async def synthesize_speech(
         _elapsed = int((time.time() - _start) * 1000)
 
         if response.status_code != 200:
-            print(f"[FLOW:VOICE-TTS] ERROR provider=elevenlabs status={response.status_code} latency={_elapsed}ms body={response.text[:200]}", flush=True)
+            print(
+                f"[FLOW:VOICE-TTS] ERROR provider=elevenlabs status={response.status_code} latency={_elapsed}ms body={response.text[:200]}",
+                flush=True,
+            )
             raise HTTPException(status_code=502, detail=f"ElevenLabs error: {response.status_code}")
 
         audio_size = len(response.content)
-        print(f"[FLOW:VOICE-TTS] OK provider=elevenlabs voice={request.voice_id} audio_bytes={audio_size} latency={_elapsed}ms", flush=True)
+        print(
+            f"[FLOW:VOICE-TTS] OK provider=elevenlabs voice={request.voice_id} audio_bytes={audio_size} latency={_elapsed}ms",
+            flush=True,
+        )
 
         return Response(content=response.content, media_type="audio/mpeg")
 
@@ -602,8 +645,6 @@ async def voice_health():
 # ============================================================================
 
 
-
-
 async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
     """Fetch recent OMI conversation summaries from Firestore for voice context.
     Returns formatted string of recent conversations (title + overview)."""
@@ -611,17 +652,20 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
         # Direct Firestore query — simpler than get_conversations() to avoid
         # composite index requirements (discarded + created_at needs index)
         from google.cloud import firestore
+
         db = firestore.Client()
         convos_ref = (
-            db.collection("users").document(uid).collection("conversations")
+            db.collection("users")
+            .document(uid)
+            .collection("conversations")
             .order_by("created_at", direction=firestore.Query.DESCENDING)
             .limit(limit)
         )
         convos = [doc.to_dict() for doc in convos_ref.stream()]
-        
+
         if not convos:
             return ""
-        
+
         parts = []
         for c in convos:
             structured = c.get("structured", {})
@@ -629,7 +673,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
             overview = structured.get("overview", "")
             emoji = structured.get("emoji", "")
             created = c.get("created_at")
-            
+
             # Format timestamp
             ts = ""
             if created:
@@ -637,7 +681,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
                     ts = created.strftime("%b %d %I:%M %p")
                 else:
                     ts = str(created)[:16]
-            
+
             entry = f"- {emoji} {title}"
             if overview:
                 # Truncate long overviews
@@ -646,7 +690,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
             if ts:
                 entry += f" ({ts})"
             parts.append(entry)
-        
+
         return "\n".join(parts)
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Conversation fetch failed: {e}")
@@ -658,18 +702,18 @@ async def _fetch_memory_context(gateway_url: str, gateway_token: str, user_name:
     Returns formatted string of relevant memory snippets."""
     if not gateway_token:
         return ""
-    
+
     headers = {
         "Authorization": f"Bearer {gateway_token}",
         "Content-Type": "application/json",
     }
-    
+
     results_all = []
     queries = [
         f"{user_name} recent activity today schedule important",
         f"recent conversations events updates news",
     ]
-    
+
     try:
         async with httpx.AsyncClient(timeout=8.0) as client:
             for query in queries:
@@ -683,6 +727,7 @@ async def _fetch_memory_context(gateway_url: str, gateway_token: str, user_name:
                         data = resp.json()
                         if data.get("ok"):
                             import json as json_mod
+
                             results_text = data["result"]["content"][0]["text"]
                             results = json_mod.loads(results_text).get("results", [])
                             for r in results[:3]:
@@ -696,10 +741,10 @@ async def _fetch_memory_context(gateway_url: str, gateway_token: str, user_name:
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Memory context fetch failed: {e}")
         return ""
-    
+
     if not results_all:
         return ""
-    
+
     # Sort by score, deduplicate, take top 5
     results_all.sort(key=lambda x: x[1], reverse=True)
     seen = set()
@@ -711,8 +756,9 @@ async def _fetch_memory_context(gateway_url: str, gateway_token: str, user_name:
             unique.append(snippet)
         if len(unique) >= 5:
             break
-    
+
     return "\n---\n".join(unique)
+
 
 def _extract_caregiver_section(user_profile: str) -> str:
     """Extract caregiver-relevant notes from USER.md content."""
@@ -791,18 +837,11 @@ async def get_voice_context(request: Request):
                 )
                 if resp.status_code == 200:
                     file_list = resp.json().get("files", [])
-                    files = {
-                        f.get("name", f.get("filename", "")): f.get("content", "")
-                        for f in file_list
-                    }
-                    logger.info(
-                        f"[FLOW:VOICE-CONTEXT] Loaded {len(files)} workspace files "
-                        f"for agent={agent_id}"
-                    )
+                    files = {f.get("name", f.get("filename", "")): f.get("content", "") for f in file_list}
+                    logger.info(f"[FLOW:VOICE-CONTEXT] Loaded {len(files)} workspace files " f"for agent={agent_id}")
                 else:
                     logger.warning(
-                        f"[FLOW:VOICE-CONTEXT] Provision API returned "
-                        f"{resp.status_code} for agent={agent_id}"
+                        f"[FLOW:VOICE-CONTEXT] Provision API returned " f"{resp.status_code} for agent={agent_id}"
                     )
         except Exception as e:
             logger.warning(f"[FLOW:VOICE-CONTEXT] Provision API error: {e}")
@@ -827,6 +866,7 @@ async def get_voice_context(request: Request):
     memory_context = ""
     try:
         import asyncio as _aio
+
         # Run both fetches concurrently
         conv_task = _aio.create_task(_fetch_recent_conversations(uid, limit=5))
         mem_task = _aio.create_task(_fetch_memory_context(gateway_url, gateway_token, row["name"] or "user"))
@@ -862,7 +902,7 @@ async def get_voice_context(request: Request):
         except Exception as _ve:
             logger.warning(f"[FLOW:VOICE-CONTEXT] Voice daily log read error: {_ve}")
     memory = files.get("MEMORY.md", "")[:500]
-    
+
     # Additional workspace files for richer context
     tools_md = files.get("TOOLS.md", "")[:500]  # Agent capabilities awareness
     shared_reports = ""
@@ -910,44 +950,45 @@ async def search_omi_conversations(request: Request):
     """
     Search OMI conversations for a user. Called by Grok voice proxy during live calls
     when the user asks to look up specific past conversations.
-    
+
     Body:
         uid (str): Firebase UID of the user
         query (str): Search terms (matched against title and overview)
         limit (int, optional): Max results (default: 5, max: 10)
-    
+
     Returns list of matching conversations with title, overview, and timestamp.
     """
     body = await request.json()
     uid = body.get("uid", "")
     query = body.get("query", "")
     limit = min(body.get("limit", 5), 10)
-    
+
     if not uid:
         raise HTTPException(status_code=400, detail="uid required")
     if not query:
         raise HTTPException(status_code=400, detail="query required")
-    
+
     logger.info(f"[FLOW:VOICE-SEARCH] uid={uid} query=\"{query}\" limit={limit}")
-    
+
     try:
         from google.cloud import firestore
+
         db = firestore.Client()
-        
+
         from datetime import datetime, timedelta
         import re as re_mod
-        
+
         # Parse date hints from query for date-range filtering
         now = datetime.utcnow()
         date_filter_start = None
         date_filter_end = None
         keyword_terms = []
-        
+
         query_lower = query.lower().strip()
-        
+
         # Date patterns: "march 8", "march 8th", "3/8", "yesterday", "last week", "today"
         date_parsed = False
-        
+
         if "yesterday" in query_lower:
             d = now - timedelta(days=1)
             date_filter_start = d.replace(hour=0, minute=0, second=0)
@@ -972,15 +1013,34 @@ async def search_omi_conversations(request: Request):
         else:
             # Try "month day" pattern: "march 8", "march 8th", "mar 8"
             month_names = {
-                "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
-                "apr": 4, "april": 4, "may": 5, "jun": 6, "june": 6, "jul": 7, "july": 7,
-                "aug": 8, "august": 8, "sep": 9, "september": 9, "oct": 10, "october": 10,
-                "nov": 11, "november": 11, "dec": 12, "december": 12,
+                "jan": 1,
+                "january": 1,
+                "feb": 2,
+                "february": 2,
+                "mar": 3,
+                "march": 3,
+                "apr": 4,
+                "april": 4,
+                "may": 5,
+                "jun": 6,
+                "june": 6,
+                "jul": 7,
+                "july": 7,
+                "aug": 8,
+                "august": 8,
+                "sep": 9,
+                "september": 9,
+                "oct": 10,
+                "october": 10,
+                "nov": 11,
+                "november": 11,
+                "dec": 12,
+                "december": 12,
             }
             date_match = re_mod.search(
                 r"(january|february|march|april|may|june|july|august|september|october|november|december|"
                 r"jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)\s+(\d{1,2})(?:st|nd|rd|th)?",
-                query_lower
+                query_lower,
             )
             if date_match:
                 month_str = date_match.group(1)
@@ -997,21 +1057,23 @@ async def search_omi_conversations(request: Request):
                         date_filter_end = target.replace(hour=23, minute=59, second=59)
                         date_parsed = True
                         # Remove date part from query for keyword matching
-                        remaining = query_lower[:date_match.start()] + query_lower[date_match.end():]
+                        remaining = query_lower[: date_match.start()] + query_lower[date_match.end() :]
                         keyword_terms = [t for t in remaining.split() if t]
                     except ValueError:
                         pass
-        
+
         if not date_parsed:
             keyword_terms = query_lower.split()
-        
+
         logger.info(f"[FLOW:VOICE-SEARCH] date_filter={date_filter_start}->{date_filter_end}, keywords={keyword_terms}")
-        
+
         # Fetch conversations — use date filter if we have one, otherwise get last 100
         if date_filter_start and date_filter_end:
             # Firestore query with date range
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .where("created_at", ">=", date_filter_start)
                 .where("created_at", "<=", date_filter_end)
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
@@ -1019,29 +1081,31 @@ async def search_omi_conversations(request: Request):
             )
         else:
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
                 .limit(100)
             )
         convos = [doc.to_dict() for doc in convos_ref.stream()]
-        
+
         # Client-side keyword match (skip if only date search with no keywords)
         matches = []
-        
+
         for c in convos:
             structured = c.get("structured", {})
             title = (structured.get("title", "") or "").lower()
             overview = (structured.get("overview", "") or "").lower()
             category = (structured.get("category", "") or "").lower()
-            
+
             # Include formatted date in searchable text
             created = c.get("created_at")
             date_str = ""
             if created and hasattr(created, "strftime"):
                 date_str = created.strftime("%B %d %Y %b %A").lower()  # "march 18 2026 mar monday"
-            
+
             searchable = f"{title} {overview} {category} {date_str}"
-            
+
             if keyword_terms:
                 # Score: how many keyword terms match
                 score = sum(1 for term in keyword_terms if term in searchable)
@@ -1050,11 +1114,11 @@ async def search_omi_conversations(request: Request):
             else:
                 # Date-only search — return all conversations from that date
                 matches.append((1, c))
-        
+
         # Sort by score (desc), then by recency
         matches.sort(key=lambda x: x[0], reverse=True)
         matches = matches[:limit]
-        
+
         results = []
         for score, c in matches:
             structured = c.get("structured", {})
@@ -1065,19 +1129,21 @@ async def search_omi_conversations(request: Request):
                     ts = created.strftime("%Y-%m-%d %I:%M %p")
                 else:
                     ts = str(created)[:16]
-            
-            results.append({
-                "title": structured.get("title", "Untitled"),
-                "overview": structured.get("overview", ""),
-                "emoji": structured.get("emoji", ""),
-                "category": structured.get("category", ""),
-                "timestamp": ts,
-                "score": score,
-            })
-        
+
+            results.append(
+                {
+                    "title": structured.get("title", "Untitled"),
+                    "overview": structured.get("overview", ""),
+                    "emoji": structured.get("emoji", ""),
+                    "category": structured.get("category", ""),
+                    "timestamp": ts,
+                    "score": score,
+                }
+            )
+
         logger.info(f"[FLOW:VOICE-SEARCH] Found {len(results)} matches for \"{query}\"")
         return {"results": results, "total_searched": len(convos), "query": query}
-    
+
     except Exception as e:
         logger.error(f"[FLOW:VOICE-SEARCH] Error: {e}")
         return {"results": [], "error": str(e), "query": query}
@@ -1092,19 +1158,33 @@ async def search_omi_conversations(request: Request):
 # Privacy policy: maps agent_role -> source -> access level
 # True = full access, False = no access, "own" = own data only, "full" = full
 SEARCH_POLICY = {
-    "user":      {"workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": "own"},
-    "caregiver": {"workspace": True, "omi_full": False, "omi_meta": True, "memories": False, "voice": False, "scanner": "full"},
-    "scanner":   {"workspace": False, "omi_full": False, "omi_meta": False, "memories": False, "voice": False, "scanner": False},
-    "voice":     {"workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": False},
+    "user": {"workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": "own"},
+    "caregiver": {
+        "workspace": True,
+        "omi_full": False,
+        "omi_meta": True,
+        "memories": False,
+        "voice": False,
+        "scanner": "full",
+    },
+    "scanner": {
+        "workspace": False,
+        "omi_full": False,
+        "omi_meta": False,
+        "memories": False,
+        "voice": False,
+        "scanner": False,
+    },
+    "voice": {"workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": False},
 }
 
 # Which source keys map to which request-level source names
 _SOURCE_TO_POLICY_KEYS = {
     "workspace": ["workspace"],
-    "omi":       ["omi_full", "omi_meta"],
-    "memories":  ["memories"],
-    "voice":     ["voice"],
-    "scanner":   ["scanner"],
+    "omi": ["omi_full", "omi_meta"],
+    "memories": ["memories"],
+    "voice": ["voice"],
+    "scanner": ["scanner"],
 }
 
 
@@ -1174,21 +1254,21 @@ async def _search_workspace(uid: str, agent_id: str, query: str, limit: int) -> 
             if resp.status_code == 200:
                 data = resp.json()
                 for item in data.get("results", [])[:limit]:
-                    results.append({
-                        "source": "workspace",
-                        "title": item.get("file", ""),
-                        "content": (item.get("snippet", "") or item.get("content", ""))[:500],
-                        "timestamp": "",
-                        "score": item.get("score", 1),
-                        "metadata": {"file": item.get("file", "")},
-                    })
+                    results.append(
+                        {
+                            "source": "workspace",
+                            "title": item.get("file", ""),
+                            "content": (item.get("snippet", "") or item.get("content", ""))[:500],
+                            "timestamp": "",
+                            "score": item.get("score", 1),
+                            "metadata": {"file": item.get("file", "")},
+                        }
+                    )
                 return results
 
             # 404 = no search endpoint; fall back to reading key files
             if resp.status_code != 404:
-                logger.warning(
-                    f"[FLOW:UNIFIED-SEARCH] Provision search returned {resp.status_code}"
-                )
+                logger.warning(f"[FLOW:UNIFIED-SEARCH] Provision search returned {resp.status_code}")
                 return results
 
             # Fallback: read files list and grep
@@ -1220,14 +1300,16 @@ async def _search_workspace(uid: str, agent_id: str, query: str, limit: int) -> 
                     if not snippet:
                         snippet = content[:200]
 
-                    results.append({
-                        "source": "workspace",
-                        "title": fname,
-                        "content": snippet,
-                        "timestamp": "",
-                        "score": score,
-                        "metadata": {"file": fname},
-                    })
+                    results.append(
+                        {
+                            "source": "workspace",
+                            "title": fname,
+                            "content": snippet,
+                            "timestamp": "",
+                            "score": score,
+                            "metadata": {"file": fname},
+                        }
+                    )
 
             # Sort by score desc, limit
             results.sort(key=lambda x: x["score"], reverse=True)
@@ -1281,10 +1363,29 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             keyword_terms = [t for t in query_lower.replace("last month", "").split() if t]
         else:
             month_names = {
-                "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
-                "apr": 4, "april": 4, "may": 5, "jun": 6, "june": 6, "jul": 7, "july": 7,
-                "aug": 8, "august": 8, "sep": 9, "september": 9, "oct": 10, "october": 10,
-                "nov": 11, "november": 11, "dec": 12, "december": 12,
+                "jan": 1,
+                "january": 1,
+                "feb": 2,
+                "february": 2,
+                "mar": 3,
+                "march": 3,
+                "apr": 4,
+                "april": 4,
+                "may": 5,
+                "jun": 6,
+                "june": 6,
+                "jul": 7,
+                "july": 7,
+                "aug": 8,
+                "august": 8,
+                "sep": 9,
+                "september": 9,
+                "oct": 10,
+                "october": 10,
+                "nov": 11,
+                "november": 11,
+                "dec": 12,
+                "december": 12,
             }
             date_match = _re.search(
                 r"(january|february|march|april|may|june|july|august|september|october|"
@@ -1316,7 +1417,9 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
         # --- Firestore query ---
         if date_filter_start and date_filter_end:
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .where("created_at", ">=", date_filter_start)
                 .where("created_at", "<=", date_filter_end)
                 .order_by("created_at", direction=_fs.Query.DESCENDING)
@@ -1324,7 +1427,9 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             )
         else:
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .order_by("created_at", direction=_fs.Query.DESCENDING)
                 .limit(100)
             )
@@ -1370,17 +1475,19 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
                 # Caregiver: truncate overview to first 100 chars, no raw content
                 overview_text = overview_text[:100] + ("..." if len(overview_text) > 100 else "")
 
-            results.append({
-                "source": "omi",
-                "title": structured.get("title", "Untitled"),
-                "content": overview_text,
-                "timestamp": ts,
-                "score": score,
-                "metadata": {
-                    "emoji": structured.get("emoji", ""),
-                    "category": structured.get("category", ""),
-                },
-            })
+            results.append(
+                {
+                    "source": "omi",
+                    "title": structured.get("title", "Untitled"),
+                    "content": overview_text,
+                    "timestamp": ts,
+                    "score": score,
+                    "metadata": {
+                        "emoji": structured.get("emoji", ""),
+                        "category": structured.get("category", ""),
+                    },
+                }
+            )
 
         return results
 
@@ -1401,7 +1508,9 @@ async def _search_memories(uid: str, query: str, limit: int) -> list:
 
         # Fetch recent memories sorted by scoring (same pattern as database/memories.py)
         memories_ref = (
-            db.collection("users").document(uid).collection("memories")
+            db.collection("users")
+            .document(uid)
+            .collection("memories")
             .order_by("scoring", direction=_fs.Query.DESCENDING)
             .order_by("created_at", direction=_fs.Query.DESCENDING)
             .limit(100)
@@ -1436,17 +1545,19 @@ async def _search_memories(uid: str, query: str, limit: int) -> list:
                     ts = str(created)[:16]
 
             display_content = mem.get("structured_memory", "") or mem.get("content", "")
-            results.append({
-                "source": "memories",
-                "title": (mem.get("category", "") or "Memory").title(),
-                "content": (display_content or "")[:500],
-                "timestamp": ts,
-                "score": score,
-                "metadata": {
-                    "category": mem.get("category", ""),
-                    "id": mem.get("id", ""),
-                },
-            })
+            results.append(
+                {
+                    "source": "memories",
+                    "title": (mem.get("category", "") or "Memory").title(),
+                    "content": (display_content or "")[:500],
+                    "timestamp": ts,
+                    "score": score,
+                    "metadata": {
+                        "category": mem.get("category", ""),
+                        "id": mem.get("id", ""),
+                    },
+                }
+            )
 
         return results
 
@@ -1514,14 +1625,16 @@ async def _search_voice_logs(uid: str, agent_id: str, query: str, limit: int) ->
                     if not snippet:
                         snippet = content[:200]
 
-                    results.append({
-                        "source": "voice",
-                        "title": fname,
-                        "content": snippet,
-                        "timestamp": fname.replace("voice/", "").replace(".md", ""),
-                        "score": score,
-                        "metadata": {"file": fname},
-                    })
+                    results.append(
+                        {
+                            "source": "voice",
+                            "title": fname,
+                            "content": snippet,
+                            "timestamp": fname.replace("voice/", "").replace(".md", ""),
+                            "score": score,
+                            "metadata": {"file": fname},
+                        }
+                    )
 
             results.sort(key=lambda x: x["score"], reverse=True)
             return results[:limit]
@@ -1591,19 +1704,24 @@ async def _search_scanner_logs(uid: str, query: str, limit: int, access_level: s
                     ts = row["created_at"].strftime("%Y-%m-%d %I:%M %p")
 
                 display_content = result_data.get("summary", row["transcript_preview"] or "")
-                matches.append((score, {
-                    "source": "scanner",
-                    "title": f"[{(row['urgency'] or 'info').upper()}] {row['category'] or 'alert'}",
-                    "content": (display_content or "")[:500],
-                    "timestamp": ts,
-                    "score": score,
-                    "metadata": {
-                        "category": row["category"] or "",
-                        "urgency": row["urgency"] or "",
-                        "escalated": row["escalated"],
-                        "id": str(row["id"]),
-                    },
-                }))
+                matches.append(
+                    (
+                        score,
+                        {
+                            "source": "scanner",
+                            "title": f"[{(row['urgency'] or 'info').upper()}] {row['category'] or 'alert'}",
+                            "content": (display_content or "")[:500],
+                            "timestamp": ts,
+                            "score": score,
+                            "metadata": {
+                                "category": row["category"] or "",
+                                "urgency": row["urgency"] or "",
+                                "escalated": row["escalated"],
+                                "id": str(row["id"]),
+                            },
+                        },
+                    )
+                )
 
         matches.sort(key=lambda x: x[0], reverse=True)
         return [m[1] for m in matches[:limit]]
@@ -1645,7 +1763,9 @@ async def unified_search(request: Request):
     if not query:
         raise HTTPException(status_code=400, detail="query required")
     if agent_role not in SEARCH_POLICY:
-        raise HTTPException(status_code=400, detail=f"Invalid agent_role: {agent_role}. Must be one of: {list(SEARCH_POLICY.keys())}")
+        raise HTTPException(
+            status_code=400, detail=f"Invalid agent_role: {agent_role}. Must be one of: {list(SEARCH_POLICY.keys())}"
+        )
 
     # Validate agent-uid association
     if not _validate_agent_uid(agent_id, uid):

--- a/backend/tests/unit/test_ella_voice_openclaw_direct.py
+++ b/backend/tests/unit/test_ella_voice_openclaw_direct.py
@@ -1,0 +1,105 @@
+import asyncio
+import importlib.util
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+from urllib.parse import parse_qs, urlparse
+
+import jwt
+
+sys.modules.setdefault("asyncpg", MagicMock())
+
+_backend_path = Path(__file__).resolve().parents[2]
+if str(_backend_path) not in sys.path:
+    sys.path.insert(0, str(_backend_path))
+
+
+def load_voice_module():
+    os.environ["ELLA_SESSION_SECRET"] = "test-secret"
+    os.environ["ELLA_VOICE_ENDPOINT"] = "wss://voice.ella-ai-care.com/ws"
+    module_path = _backend_path / "ella" / "routers" / "voice.py"
+    spec = importlib.util.spec_from_file_location("ella_voice_test_module", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_openclaw_direct_provider_is_registered():
+    voice = load_voice_module()
+
+    provider = voice.V2V_PROVIDERS["openclaw-direct"]
+
+    assert provider["default_mode"] == "openclaw-direct-v1"
+    assert provider["endpoint_env"] == "ELLA_VOICE_ENDPOINT"
+    assert provider["key_check"]() is True
+
+
+def test_openclaw_direct_session_token_claims():
+    voice = load_voice_module()
+
+    token = voice.create_session_token(
+        uid="omi-user-1",
+        firebase_uid="firebase-1",
+        display_name="Margaret",
+        provider="openclaw-direct",
+        voice_mode="openclaw-direct-v1",
+    )
+    payload = jwt.decode(token, "test-secret", algorithms=["HS256"])
+
+    assert payload["uid"] == "omi-user-1"
+    assert payload["firebase_uid"] == "firebase-1"
+    assert payload["name"] == "Margaret"
+    assert payload["provider"] == "openclaw-direct"
+    assert payload["voice_mode"] == "openclaw-direct-v1"
+    assert payload["iss"] == "omi-backend"
+    assert payload["context_url"].endswith("/v1/users/omi-user-1/context")
+    assert payload["callback_url"].endswith("/v1/ella/voice-session")
+    assert datetime.fromtimestamp(payload["exp"], tz=timezone.utc) > datetime.now(timezone.utc)
+
+
+def test_openclaw_direct_endpoint_includes_mode_and_token():
+    voice = load_voice_module()
+
+    endpoint = voice.build_voice_endpoint(
+        "wss://voice.ella-ai-care.com/ws",
+        "openclaw-direct-v1",
+        "jwt-token",
+    )
+    parsed = urlparse(endpoint)
+    query = parse_qs(parsed.query)
+
+    assert parsed.scheme == "wss"
+    assert parsed.netloc == "voice.ella-ai-care.com"
+    assert query["mode"] == ["openclaw-direct-v1"]
+    assert query["token"] == ["jwt-token"]
+
+
+def test_create_openclaw_direct_voice_session(monkeypatch):
+    voice = load_voice_module()
+
+    class FakePool:
+        async def fetchrow(self, query, uid):
+            return {"name": "Margaret"}
+
+    async def fake_get_pool():
+        return FakePool()
+
+    monkeypatch.setattr(voice, "_get_pool", fake_get_pool)
+
+    response = asyncio.run(
+        voice.create_voice_session(
+            body=voice.VoiceSessionRequest(
+                uid="omi-user-1",
+                provider="openclaw-direct",
+            )
+        )
+    )
+
+    assert response.provider == "openclaw-direct"
+    assert response.voice_mode == "openclaw-direct-v1"
+    assert response.audio_format["sample_rate"] == 24000
+    assert "mode=openclaw-direct-v1" in response.voice_endpoint
+    assert "token=" in response.voice_endpoint


### PR DESCRIPTION
## Summary

Companion backend change for ellaaicare/ella-ai#773 and ellaaicare/omi#119.

- Registers `provider=openclaw-direct` on `POST /v1/voice/session` with default `voice_mode=openclaw-direct-v1`.
- Keeps existing `grok-voice` and `gemini-live` response behavior intact.
- Adds required JWT claims for the proxy: `provider`, `voice_mode`, `context_url`, `callback_url`, `uid`, `firebase_uid`, `name`, `exp`, and `iss=omi-backend`.
- Returns a ready-to-connect websocket endpoint for OpenClaw Direct: `wss://voice.ella-ai-care.com/ws?mode=openclaw-direct-v1&token=<jwt>` while still returning `session_token` separately.
- Adds unit coverage for provider registration, token claims, endpoint construction, and session response.

## Validation

- `uvx --with pytest --with fastapi --with httpx --with websockets --with PyJWT --with pydantic pytest backend/tests/unit/test_ella_voice_openclaw_direct.py`
- `python3 -m py_compile backend/ella/routers/voice.py backend/tests/unit/test_ella_voice_openclaw_direct.py`

## Deployment Notes

Requires the companion voice proxy PR in `ellaaicare/ella-ai` before iOS can complete a live `openclaw-direct-v1` websocket turn. The OMI working tree has unrelated untracked iOS signing artifacts; this PR stages only `backend/ella/routers/voice.py` and the new unit test.