### PR TITLE
Expose guarded OpenClaw native voice provider

### DIFF
--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -58,6 +58,11 @@ PROVISION_API_URL = os.getenv("ELLA_PROVISION_API_URL", "http://100.76.138.56:82
 PROVISION_API_TOKEN = os.getenv("ELLA_PROVISION_API_TOKEN", "")
 DEFAULT_GATEWAY_URL = os.getenv("OPENCLAW_URL", "http://100.76.138.56:19001")
 OPENCLAW_GATEWAY_TOKEN = os.getenv("OPENCLAW_GATEWAY_TOKEN", "")
+OPENCLAW_NATIVE_VOICE_ENABLED = os.getenv("OPENCLAW_NATIVE_VOICE_ENABLED", "").lower() in (
+    "1",
+    "true",
+    "yes",
+)
 
 # Database connection pool (lazy-initialized, shared pattern with other Ella routers)
 _pool: Optional[asyncpg.Pool] = None
@@ -113,6 +118,15 @@ V2V_PROVIDERS = {
         "endpoint_env": "ELLA_VOICE_ENDPOINT",
         "key_check": lambda: bool(ELLA_SESSION_SECRET),
         "include_token_in_endpoint": True,
+    },
+    "openclaw-native": {
+        "name": "OpenClaw Native (blocked)",
+        "description": "Investigated native voice-call path; blocked because current runtime is telephony/Twilio Media Streams only",
+        "default_mode": "openclaw-native-v1",
+        "endpoint_env": "ELLA_VOICE_ENDPOINT",
+        "key_check": lambda: bool(ELLA_SESSION_SECRET) and OPENCLAW_NATIVE_VOICE_ENABLED,
+        "include_token_in_endpoint": True,
+        "blocked_reason": "OpenClaw voice-call exposes /voice/webhook plus Twilio Media Streams JSON/G.711 mu-law, not an OMI PCM websocket.",
     },
 }
 
@@ -335,6 +349,17 @@ async def get_voice_providers():
             "session_endpoint": "/v1/voice/session",
             "default_mode": V2V_PROVIDERS["openclaw-direct"]["default_mode"],
         },
+        {
+            "id": "openclaw-native",
+            "name": "OpenClaw Native (blocked)",
+            "type": "v2v",
+            "description": V2V_PROVIDERS["openclaw-native"]["description"],
+            "available": V2V_PROVIDERS["openclaw-native"]["key_check"](),
+            "requires_session": True,
+            "session_endpoint": "/v1/voice/session",
+            "default_mode": V2V_PROVIDERS["openclaw-native"]["default_mode"],
+            "blocked_reason": V2V_PROVIDERS["openclaw-native"]["blocked_reason"],
+        },
     ]
     return {"providers": providers}
 
@@ -360,7 +385,7 @@ async def create_voice_session(
 
     Args:
         uid: User ID (required)
-        provider: V2V provider — "grok-voice" (default), "gemini-live", or "openclaw-direct"
+        provider: V2V provider — "grok-voice" (default), "gemini-live", "openclaw-direct", or "openclaw-native"
         voice_mode: Override mode (defaults to provider's default mode)
 
     Returns:
@@ -421,7 +446,7 @@ async def create_voice_session(
         )
 
         # Build endpoint URL with mode query param. Existing providers keep token separate
-        # for backwards compatibility; openclaw-direct returns a ready-to-connect URL.
+        # for backwards compatibility; OpenClaw proxy-backed modes return a ready-to-connect URL.
         endpoint = os.getenv(provider_info["endpoint_env"], ELLA_VOICE_ENDPOINT)
         endpoint_with_mode = build_voice_endpoint(
             endpoint,
@@ -561,7 +586,7 @@ async def synthesize_speech(
         print(f"[FLOW:VOICE-TTS] ERROR unknown provider={provider!r}", flush=True)
         raise HTTPException(
             status_code=400,
-            detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, grok-voice, gemini-live, openclaw-direct",
+            detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, grok-voice, gemini-live, openclaw-direct, openclaw-native",
         )
 
     # --- ElevenLabs ---

--- a/backend/tests/unit/test_ella_voice_openclaw_direct.py
+++ b/backend/tests/unit/test_ella_voice_openclaw_direct.py
@@ -16,9 +16,13 @@ if str(_backend_path) not in sys.path:
     sys.path.insert(0, str(_backend_path))
 
 
-def load_voice_module():
+def load_voice_module(openclaw_native_enabled: bool = False):
     os.environ["ELLA_SESSION_SECRET"] = "test-secret"
     os.environ["ELLA_VOICE_ENDPOINT"] = "wss://voice.ella-ai-care.com/ws"
+    if openclaw_native_enabled:
+        os.environ["OPENCLAW_NATIVE_VOICE_ENABLED"] = "true"
+    else:
+        os.environ.pop("OPENCLAW_NATIVE_VOICE_ENABLED", None)
     module_path = _backend_path / "ella" / "routers" / "voice.py"
     spec = importlib.util.spec_from_file_location("ella_voice_test_module", module_path)
     module = importlib.util.module_from_spec(spec)
@@ -103,3 +107,44 @@ def test_create_openclaw_direct_voice_session(monkeypatch):
     assert response.audio_format["sample_rate"] == 24000
     assert "mode=openclaw-direct-v1" in response.voice_endpoint
     assert "token=" in response.voice_endpoint
+
+
+def test_openclaw_native_provider_is_registered_but_blocked_by_default():
+    voice = load_voice_module()
+
+    provider = voice.V2V_PROVIDERS["openclaw-native"]
+
+    assert provider["default_mode"] == "openclaw-native-v1"
+    assert provider["endpoint_env"] == "ELLA_VOICE_ENDPOINT"
+    assert provider["key_check"]() is False
+    assert "Twilio Media Streams" in provider["blocked_reason"]
+
+
+def test_openclaw_native_session_uses_proxy_contract_when_enabled(monkeypatch):
+    voice = load_voice_module(openclaw_native_enabled=True)
+
+    class FakePool:
+        async def fetchrow(self, query, uid):
+            return None
+
+    async def fake_get_pool():
+        return FakePool()
+
+    monkeypatch.setattr(voice, "_get_pool", fake_get_pool)
+
+    response = asyncio.run(
+        voice.create_voice_session(
+            body=voice.VoiceSessionRequest(
+                uid="omi-user-1",
+                provider="openclaw-native",
+            )
+        )
+    )
+
+    parsed = urlparse(response.voice_endpoint)
+    query = parse_qs(parsed.query)
+    assert response.provider == "openclaw-native"
+    assert response.voice_mode == "openclaw-native-v1"
+    assert response.audio_format["sample_rate"] == 24000
+    assert query["mode"] == ["openclaw-native-v1"]
+    assert query["token"]


### PR DESCRIPTION
## Summary
- Adds `openclaw-native` to `/v1/voice/providers` and `/v1/voice/session` as a guarded provider using mode `openclaw-native-v1`.
- Provider is unavailable by default unless `OPENCLAW_NATIVE_VOICE_ENABLED=true`; this prevents iOS/TestFlight from selecting a runtime path that is not mobile-compatible yet.
- Preserves the existing `openclaw-direct` provider and ready-to-connect proxy URL behavior.

## Protocol contract
- OMI-facing contract, when explicitly enabled: `wss://voice.ella-ai-care.com/ws?mode=openclaw-native-v1&token=<jwt>` with PCM16 little-endian, 24 kHz, mono frames.
- Backend/proxy currently blocks the mode because installed OpenClaw `voice-call` exposes telephony/Twilio Media Streams, not an OMI PCM websocket.

## Tests
- `/Users/ellaai/.local/bin/uvx --with pytest --with fastapi --with httpx --with websockets --with PyJWT --with pydantic pytest backend/tests/unit/test_ella_voice_openclaw_direct.py`

Depends on #123 for the existing OpenClaw Direct OMI provider.