### PR TITLE
[codex] add OpenAI Realtime iOS voice mode option

### DIFF
--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -92,7 +92,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   );
 
   /// Check if current voice provider uses the V2V session endpoint.
-  static bool _isV2VProvider(String provider) => V2VClient.isSessionProvider(provider);
+  static bool _isV2VProvider(String provider) => V2VClient.isSessionProvider(V2VClient.normalizeProvider(provider));
 
   @override
   bool get wantKeepAlive => true;
@@ -127,10 +127,14 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
         debugPrint('[VoiceChat] Voice tab became active, auto-starting');
         _voiceModeActive = true;
         final provider = SharedPreferencesUtil().ttsProvider;
+        final normalizedProvider = V2VClient.normalizeProvider(provider);
+        if (normalizedProvider != provider) {
+          SharedPreferencesUtil().ttsProvider = normalizedProvider;
+        }
         Future.delayed(const Duration(milliseconds: 300), () {
           if (mounted && _orbState == VoiceOrbState.idle) {
-            if (_isV2VProvider(provider)) {
-              _startV2V(provider);
+            if (_isV2VProvider(normalizedProvider)) {
+              _startV2V(normalizedProvider);
             } else {
               _startListening();
             }
@@ -218,8 +222,12 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       // Resume voice mode — check if V2V provider is selected
       _voiceModeActive = true;
       final provider = SharedPreferencesUtil().ttsProvider;
-      if (_isV2VProvider(provider)) {
-        await _startV2V(provider);
+      final normalizedProvider = V2VClient.normalizeProvider(provider);
+      if (normalizedProvider != provider) {
+        SharedPreferencesUtil().ttsProvider = normalizedProvider;
+      }
+      if (_isV2VProvider(normalizedProvider)) {
+        await _startV2V(normalizedProvider);
       } else {
         _isV2VMode = false;
         await _startListening();

--- a/app/lib/ella/services/v2v_client.dart
+++ b/app/lib/ella/services/v2v_client.dart
@@ -54,13 +54,14 @@ class V2VClient {
 
   static bool isSessionProvider(String provider) =>
       provider == 'openclaw-direct' ||
-      provider == 'openai-realtime' ||
+      provider == 'openai-native-realtime' ||
       provider == 'grok-voice' ||
-      provider == 'gemini-live';
+      provider == 'gemini-native-live';
 
   static String? sessionVoiceMode(String provider) => switch (provider) {
         'openclaw-direct' => 'openclaw-direct-v1',
-        'openai-realtime' => 'openai-realtime-v1',
+        'openai-native-realtime' => 'openai-native-realtime-v1',
+        'gemini-native-live' => 'gemini-native-live-v1',
         _ => null,
       };
 

--- a/app/lib/ella/services/v2v_client.dart
+++ b/app/lib/ella/services/v2v_client.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:audio_session/audio_session.dart';
-import 'package:just_audio/just_audio.dart';
+import 'package:flutter_sound/flutter_sound.dart';
 import 'package:record/record.dart';
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -39,8 +38,11 @@ class V2VClient {
   final BytesBuilder _pcmBuffer = BytesBuilder(copy: false);
   int _chunkCount = 0;
 
-  /// just_audio player for WAV playback
-  final AudioPlayer _audioPlayer = AudioPlayer();
+  /// Low-latency PCM stream player for provider-native V2V audio.
+  final FlutterSoundPlayer _streamPlayer = FlutterSoundPlayer();
+  bool _streamPlayerOpen = false;
+  bool _streamPlaybackStarted = false;
+  Future<void> _streamFeedFuture = Future.value();
 
   /// Callback for JSON events (transcripts, errors, etc.)
   final void Function(V2VEvent event)? onEvent;
@@ -125,13 +127,6 @@ class V2VClient {
       // 4. Start recording mic audio and streaming to WebSocket
       await _startMicStream();
 
-      // 5. Listen for playback completion
-      _audioPlayer.playerStateStream.listen((state) {
-        if (state.processingState == ProcessingState.completed && _isPlaying) {
-          _onPlaybackComplete();
-        }
-      });
-
       return true;
     } catch (e) {
       Logger.error('[V2V] WebSocket connect failed: $e');
@@ -154,8 +149,11 @@ class V2VClient {
 
     await _stopMicStream();
     try {
-      await _audioPlayer.stop();
-      await _audioPlayer.dispose();
+      await _stopStreamingPlayback();
+      if (_streamPlayerOpen) {
+        await _streamPlayer.closePlayer();
+        _streamPlayerOpen = false;
+      }
     } catch (_) {}
   }
 
@@ -163,7 +161,7 @@ class V2VClient {
   Future<void> interruptPlayback() async {
     if (_isPlaying) {
       try {
-        await _audioPlayer.stop();
+        await _stopStreamingPlayback();
       } catch (_) {}
       _isPlaying = false;
     }
@@ -280,146 +278,108 @@ class V2VClient {
     _recorder = null;
   }
 
-  // --- Audio playback using just_audio (WAV file) ---
+  // --- Low-latency PCM streaming playback ---
 
-  /// Buffer incoming PCM16 audio chunk.
-  void _bufferAudioChunk(Uint8List pcmData) {
+  /// Stream incoming PCM16 audio chunk to the platform player.
+  void _streamAudioChunk(Uint8List pcmData) {
     if (pcmData.isEmpty) return;
 
     _chunkCount++;
     _pcmBuffer.add(pcmData);
 
-    // Mute mic on first chunk
+    _streamFeedFuture = _streamFeedFuture.then((_) async {
+      await _ensureStreamingPlaybackStarted();
+      _streamPlayer.uint8ListSink?.add(pcmData);
+    }).catchError((error) {
+      Logger.error('[V2V] Stream playback feed error: $error');
+      onEvent?.call(V2VEvent(type: 'error', text: 'Audio stream error: $error'));
+    });
+
+    // Mute mic on first chunk to avoid echo/VAD self-interrupt.
     if (!_micMuted) {
       _micMuted = true;
-      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Buffering audio (mic muted)'));
-      Logger.debug('[V2V] First audio chunk, mic muted');
+      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Streaming response audio'));
+      Logger.debug('[V2V] First audio chunk, streaming playback started, mic muted');
     }
 
     if (_chunkCount % 20 == 0) {
-      Logger.debug('[V2V] Buffered $_chunkCount chunks, ${_pcmBuffer.length}B');
+      Logger.debug('[V2V] Streamed $_chunkCount chunks, ${_pcmBuffer.length}B');
     }
   }
 
-  /// Called on audio_done — write WAV and play with just_audio.
+  Future<void> _ensureStreamingPlaybackStarted() async {
+    if (!_streamPlayerOpen) {
+      await _streamPlayer.openPlayer();
+      _streamPlayerOpen = true;
+    }
+
+    if (_streamPlaybackStarted) return;
+
+    _isPlaying = true;
+    _streamPlaybackStarted = true;
+    await _streamPlayer.startPlayerFromStream(
+      codec: Codec.pcm16,
+      sampleRate: 24000,
+      numChannels: 1,
+      bufferSize: 4096,
+    );
+    Logger.debug('[V2V] PCM stream player started');
+  }
+
+  Future<void> _stopStreamingPlayback() async {
+    if (!_streamPlaybackStarted) return;
+    try {
+      await _streamPlayer.stopPlayer();
+    } catch (_) {}
+    _streamPlaybackStarted = false;
+  }
+
+  /// Called on audio_done — wait for queued PCM to drain, then return to listening.
   Future<void> _finishPlayback() async {
     final pcmBytes = _pcmBuffer.toBytes();
     final stats = '$_chunkCount chunks, ${(pcmBytes.length / 1024).toStringAsFixed(1)}KB';
-    Logger.debug('[V2V] Audio done: $stats');
-    onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Playing: $stats'));
+    Logger.debug('[V2V] Audio stream done: $stats');
+    onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Finishing audio: $stats'));
 
     _pcmBuffer.clear();
     _chunkCount = 0;
 
     if (pcmBytes.isEmpty) {
       Logger.debug('[V2V] No audio data to play');
-      _micMuted = false;
-      onEvent?.call(V2VEvent(type: 'playback_complete'));
+      await _onPlaybackComplete();
       return;
     }
 
-    // Stop mic recording before switching audio session to playback
-    await _stopMicStream();
-
-    // Write WAV file
-    final wavPath = '${Directory.systemTemp.path}/v2v_response.wav';
-    final wavBytes = _buildWav(Uint8List.fromList(pcmBytes), sampleRate: 24000, numChannels: 1, bitsPerSample: 16);
-    await File(wavPath).writeAsBytes(wavBytes);
-    final durationMs = (pcmBytes.length / (24000 * 2)) * 1000;
-    Logger.debug('[V2V] WAV written: ${wavBytes.length}B, ${durationMs.toStringAsFixed(0)}ms');
-
-    // Play with just_audio
     try {
-      _isPlaying = true;
-      await _audioPlayer.setVolume(1.0);
-      await _audioPlayer.setFilePath(wavPath);
-      await _audioPlayer.play();
-      Logger.debug('[V2V] Playback started');
-
-      // Safety timeout — if playerStateStream doesn't fire completion within
-      // expected duration + 3s buffer, force restart mic anyway
-      final timeoutMs = durationMs.toInt() + 3000;
-      Future.delayed(Duration(milliseconds: timeoutMs), () {
-        if (_isPlaying) {
-          Logger.debug('[V2V] Playback safety timeout after ${timeoutMs}ms, forcing mic restart');
-          _onPlaybackComplete();
-        }
-      });
+      await _streamFeedFuture.timeout(const Duration(seconds: 5));
+      await Future.delayed(const Duration(milliseconds: 250));
+      await _onPlaybackComplete();
     } catch (e) {
-      Logger.error('[V2V] Playback error: $e');
-      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Play error: $e'));
+      Logger.error('[V2V] Stream playback error: $e');
+      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Stream play error: $e'));
       _isPlaying = false;
       _micMuted = false;
-      // Restart mic even on error
-      if (_isConnected) await _startMicStream();
       onEvent?.call(V2VEvent(type: 'playback_complete'));
     }
   }
 
-  /// Called when just_audio finishes playing.
+  /// Called when streaming playback finishes.
   Future<void> _onPlaybackComplete() async {
     if (!_isPlaying && !_micMuted) return; // Already handled
     Logger.debug('[V2V] Playback complete, restarting mic');
+    await _stopStreamingPlayback();
     _isPlaying = false;
     _micMuted = false;
 
-    // Restart mic recording
-    if (_isConnected) {
-      await _startMicStream();
-    }
-
     onEvent?.call(V2VEvent(type: 'playback_complete'));
-  }
-
-  /// Build a WAV file from raw PCM16 data.
-  static Uint8List _buildWav(Uint8List pcmData, {int sampleRate = 24000, int numChannels = 1, int bitsPerSample = 16}) {
-    final byteRate = sampleRate * numChannels * (bitsPerSample ~/ 8);
-    final blockAlign = numChannels * (bitsPerSample ~/ 8);
-    final dataSize = pcmData.length;
-    final fileSize = 36 + dataSize;
-
-    final header = ByteData(44);
-    // RIFF header
-    header.setUint8(0, 0x52); // R
-    header.setUint8(1, 0x49); // I
-    header.setUint8(2, 0x46); // F
-    header.setUint8(3, 0x46); // F
-    header.setUint32(4, fileSize, Endian.little);
-    header.setUint8(8, 0x57); // W
-    header.setUint8(9, 0x41); // A
-    header.setUint8(10, 0x56); // V
-    header.setUint8(11, 0x45); // E
-    // fmt chunk
-    header.setUint8(12, 0x66); // f
-    header.setUint8(13, 0x6D); // m
-    header.setUint8(14, 0x74); // t
-    header.setUint8(15, 0x20); // (space)
-    header.setUint32(16, 16, Endian.little); // chunk size
-    header.setUint16(20, 1, Endian.little); // PCM format
-    header.setUint16(22, numChannels, Endian.little);
-    header.setUint32(24, sampleRate, Endian.little);
-    header.setUint32(28, byteRate, Endian.little);
-    header.setUint16(32, blockAlign, Endian.little);
-    header.setUint16(34, bitsPerSample, Endian.little);
-    // data chunk
-    header.setUint8(36, 0x64); // d
-    header.setUint8(37, 0x61); // a
-    header.setUint8(38, 0x74); // t
-    header.setUint8(39, 0x61); // a
-    header.setUint32(40, dataSize, Endian.little);
-
-    final wav = Uint8List(44 + dataSize);
-    wav.setRange(0, 44, header.buffer.asUint8List());
-    wav.setRange(44, 44 + dataSize, pcmData);
-    return wav;
   }
 
   // --- WebSocket message handling ---
 
   void _handleMessage(dynamic message) {
     if (message is List<int>) {
-      // Binary frame = raw PCM16 audio from proxy — buffer for WAV playback
-      _bufferAudioChunk(Uint8List.fromList(message));
+      // Binary frame = raw PCM16 audio from proxy — stream directly to playback.
+      _streamAudioChunk(Uint8List.fromList(message));
       return;
     }
 

--- a/app/lib/ella/services/v2v_client.dart
+++ b/app/lib/ella/services/v2v_client.dart
@@ -53,9 +53,16 @@ class V2VClient {
   bool get isConnected => _isConnected;
 
   static bool isSessionProvider(String provider) =>
-      provider == 'openclaw-direct' || provider == 'grok-voice' || provider == 'gemini-live';
+      provider == 'openclaw-direct' ||
+      provider == 'openai-realtime' ||
+      provider == 'grok-voice' ||
+      provider == 'gemini-live';
 
-  static String? sessionVoiceMode(String provider) => provider == 'openclaw-direct' ? 'openclaw-direct-v1' : null;
+  static String? sessionVoiceMode(String provider) => switch (provider) {
+        'openclaw-direct' => 'openclaw-direct-v1',
+        'openai-realtime' => 'openai-realtime-v1',
+        _ => null,
+      };
 
   /// Start a V2V session: get session token, connect WebSocket, start audio.
   Future<bool> connect({required String provider}) async {

--- a/app/lib/ella/services/v2v_client.dart
+++ b/app/lib/ella/services/v2v_client.dart
@@ -52,13 +52,20 @@ class V2VClient {
 
   bool get isConnected => _isConnected;
 
-  static bool isSessionProvider(String provider) =>
-      provider == 'openclaw-direct' ||
-      provider == 'openai-native-realtime' ||
-      provider == 'grok-voice' ||
-      provider == 'gemini-native-live';
+  static String normalizeProvider(String provider) => switch (provider) {
+        // Legacy values may remain in SharedPreferences after TestFlight upgrades.
+        'gemini-live' => 'gemini-native-live',
+        'openai-realtime' => 'openai-native-realtime',
+        _ => provider,
+      };
 
-  static String? sessionVoiceMode(String provider) => switch (provider) {
+  static bool isSessionProvider(String provider) =>
+      normalizeProvider(provider) == 'openclaw-direct' ||
+      normalizeProvider(provider) == 'openai-native-realtime' ||
+      normalizeProvider(provider) == 'grok-voice' ||
+      normalizeProvider(provider) == 'gemini-native-live';
+
+  static String? sessionVoiceMode(String provider) => switch (normalizeProvider(provider)) {
         'openclaw-direct' => 'openclaw-direct-v1',
         'openai-native-realtime' => 'openai-native-realtime-v1',
         'gemini-native-live' => 'gemini-native-live-v1',
@@ -67,6 +74,7 @@ class V2VClient {
 
   /// Start a V2V session: get session token, connect WebSocket, start audio.
   Future<bool> connect({required String provider}) async {
+    provider = normalizeProvider(provider);
     final uid = SharedPreferencesUtil().uid;
     if (uid.isEmpty) {
       Logger.debug('[V2V] No uid, cannot connect');
@@ -186,6 +194,7 @@ class V2VClient {
 
   Future<Map<String, dynamic>?> _createSession(String uid, String provider) async {
     try {
+      provider = normalizeProvider(provider);
       final voiceMode = sessionVoiceMode(provider);
       final requestBody = {
         'uid': uid,

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -2567,5 +2567,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -2567,6 +2567,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -2569,5 +2569,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -2569,6 +2569,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -2569,5 +2569,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -2569,6 +2569,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -2569,5 +2569,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -2569,6 +2569,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -2609,6 +2609,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -2609,5 +2609,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2568,6 +2568,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2568,5 +2568,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -2600,6 +2600,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10137,5 +10137,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10137,6 +10137,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -2601,6 +2601,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -2601,5 +2601,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -2600,6 +2600,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -2600,6 +2600,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -2635,5 +2635,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -2635,6 +2635,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -2601,6 +2601,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -2601,5 +2601,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -2696,6 +2696,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -2696,5 +2696,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -2642,5 +2642,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -2642,6 +2642,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -2600,6 +2600,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -2601,6 +2601,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -2601,5 +2601,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2600,6 +2600,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -15900,14 +15900,26 @@ abstract class AppLocalizations {
   /// No description provided for @openClawDirectVoiceMode.
   ///
   /// In en, this message translates to:
-  /// **'OpenClaw Direct'**
+  /// **'OpenClaw Direct (STT -> OpenClaw -> TTS)'**
   String get openClawDirectVoiceMode;
 
   /// No description provided for @openAIRealtimeVoiceMode.
   ///
   /// In en, this message translates to:
-  /// **'OpenAI Realtime'**
+  /// **'OpenAI Native Realtime'**
   String get openAIRealtimeVoiceMode;
+
+  /// No description provided for @grokNativeRealtimeVoiceMode.
+  ///
+  /// In en, this message translates to:
+  /// **'Grok Native Realtime'**
+  String get grokNativeRealtimeVoiceMode;
+
+  /// No description provided for @geminiNativeLiveVoiceMode.
+  ///
+  /// In en, this message translates to:
+  /// **'Gemini Native Live'**
+  String get geminiNativeLiveVoiceMode;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -15902,6 +15902,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'OpenClaw Direct'**
   String get openClawDirectVoiceMode;
+
+  /// No description provided for @openAIRealtimeVoiceMode.
+  ///
+  /// In en, this message translates to:
+  /// **'OpenAI Realtime'**
+  String get openAIRealtimeVoiceMode;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8463,10 +8463,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8464,4 +8464,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8467,4 +8467,10 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8555,4 +8555,10 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8551,10 +8551,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8552,4 +8552,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8567,10 +8567,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8571,4 +8571,10 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8568,4 +8568,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8514,10 +8514,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8518,4 +8518,10 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8515,4 +8515,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8507,4 +8507,10 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8504,4 +8504,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8503,10 +8503,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8586,4 +8586,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8589,4 +8589,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8585,10 +8585,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8576,10 +8576,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8580,4 +8580,10 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8577,4 +8577,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8517,4 +8517,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8516,8 +8516,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8533,10 +8533,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8534,4 +8534,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8537,4 +8537,10 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8522,4 +8522,10 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8518,10 +8518,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8519,4 +8519,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8521,4 +8521,10 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8517,10 +8517,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8518,4 +8518,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8593,4 +8593,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8596,4 +8596,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8592,10 +8592,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8499,10 +8499,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8500,4 +8500,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8503,4 +8503,10 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8556,10 +8556,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8557,4 +8557,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8560,4 +8560,10 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8532,4 +8532,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8535,4 +8535,10 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8531,10 +8531,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8569,4 +8569,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8572,4 +8572,10 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8568,10 +8568,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8386,4 +8386,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8385,10 +8385,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8389,4 +8389,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8387,10 +8387,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8391,4 +8391,10 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8388,4 +8388,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8524,10 +8524,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8525,4 +8525,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8528,4 +8528,10 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8537,4 +8537,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8540,4 +8540,10 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8536,10 +8536,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8543,4 +8543,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8542,10 +8542,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8546,4 +8546,10 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8545,4 +8545,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8544,10 +8544,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8548,4 +8548,10 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8515,4 +8515,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8518,4 +8518,10 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8514,10 +8514,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8538,4 +8538,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8541,4 +8541,10 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8537,10 +8537,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8519,10 +8519,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8523,4 +8523,10 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8520,4 +8520,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8561,4 +8561,10 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8557,10 +8557,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8558,4 +8558,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8548,4 +8548,10 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8544,10 +8544,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8545,4 +8545,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8513,4 +8513,10 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8509,10 +8509,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8510,4 +8510,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8524,10 +8524,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8525,4 +8525,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8528,4 +8528,10 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8482,4 +8482,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8485,4 +8485,10 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8481,10 +8481,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8536,4 +8536,10 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8533,4 +8533,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8532,10 +8532,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8532,4 +8532,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8535,4 +8535,10 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8531,10 +8531,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8525,4 +8525,10 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8521,10 +8521,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8522,4 +8522,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8375,10 +8375,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
 
   @override
-  String get openClawDirectVoiceMode => 'OpenClaw Direct';
+  String get openClawDirectVoiceMode => 'OpenClaw Direct (STT -> OpenClaw -> TTS)';
 
   @override
-  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+  String get openAIRealtimeVoiceMode => 'OpenAI Native Realtime';
 
   @override
   String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8376,4 +8376,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get openClawDirectVoiceMode => 'OpenClaw Direct';
+
+  @override
+  String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8379,4 +8379,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get openAIRealtimeVoiceMode => 'OpenAI Realtime';
+
+  @override
+  String get grokNativeRealtimeVoiceMode => 'Grok Native Realtime';
+
+  @override
+  String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -2600,6 +2600,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -2600,6 +2600,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -2600,6 +2600,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -2600,6 +2600,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -2600,6 +2600,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -2635,5 +2635,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -2635,6 +2635,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -2636,6 +2636,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -2636,5 +2636,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -2600,6 +2600,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -2635,5 +2635,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -2635,6 +2635,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -2605,6 +2605,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -2605,5 +2605,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -2600,6 +2600,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -2600,6 +2600,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -2635,5 +2635,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -2635,6 +2635,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -2600,5 +2600,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -2600,6 +2600,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -2605,6 +2605,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -2605,5 +2605,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -2622,6 +2622,8 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct",
-  "openAIRealtimeVoiceMode": "OpenAI Realtime"
+  "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
+  "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
+  "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
+  "geminiNativeLiveVoiceMode": "Gemini Native Live"
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -2622,5 +2622,6 @@
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
   "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
-  "openClawDirectVoiceMode": "OpenClaw Direct"
+  "openClawDirectVoiceMode": "OpenClaw Direct",
+  "openAIRealtimeVoiceMode": "OpenAI Realtime"
 }

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -821,12 +821,18 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                             const DropdownMenuItem(value: 'fish-audio-s2', child: Text('Fish Audio S2')),
                             const DropdownMenuItem(value: 'kokoro', child: Text('Kokoro (local)')),
                             const DropdownMenuItem(value: 'inworld', child: Text('Inworld TTS (cloud, ~120ms)')),
-                            DropdownMenuItem(
-                                value: 'openclaw-direct', child: Text(context.l10n.openClawDirectVoiceMode)),
-                            DropdownMenuItem(
-                                value: 'openai-realtime', child: Text(context.l10n.openAIRealtimeVoiceMode)),
-                            const DropdownMenuItem(value: 'grok-voice', child: Text('Grok Voice (V2V)')),
-                            const DropdownMenuItem(value: 'gemini-live', child: Text('Gemini Live (V2V)')),
+                            const DropdownMenuItem(
+                                value: 'openclaw-direct',
+                                child: Text('OpenClaw Direct (full context, STT/TTS)')),
+                            const DropdownMenuItem(
+                                value: 'grok-voice',
+                                child: Text('Grok Native Realtime (context consult)')),
+                            const DropdownMenuItem(
+                                value: 'openai-native-realtime',
+                                child: Text('OpenAI Native Realtime (context injected)')),
+                            const DropdownMenuItem(
+                                value: 'gemini-native-live',
+                                child: Text('Gemini Native Live (context injected)')),
                           ],
                           onChanged: (value) {
                             if (value != null) {

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -823,6 +823,8 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                             const DropdownMenuItem(value: 'inworld', child: Text('Inworld TTS (cloud, ~120ms)')),
                             DropdownMenuItem(
                                 value: 'openclaw-direct', child: Text(context.l10n.openClawDirectVoiceMode)),
+                            DropdownMenuItem(
+                                value: 'openai-realtime', child: Text(context.l10n.openAIRealtimeVoiceMode)),
                             const DropdownMenuItem(value: 'grok-voice', child: Text('Grok Voice (V2V)')),
                             const DropdownMenuItem(value: 'gemini-live', child: Text('Gemini Live (V2V)')),
                           ],

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -821,18 +821,14 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                             const DropdownMenuItem(value: 'fish-audio-s2', child: Text('Fish Audio S2')),
                             const DropdownMenuItem(value: 'kokoro', child: Text('Kokoro (local)')),
                             const DropdownMenuItem(value: 'inworld', child: Text('Inworld TTS (cloud, ~120ms)')),
-                            const DropdownMenuItem(
-                                value: 'openclaw-direct',
-                                child: Text('OpenClaw Direct (full context, STT/TTS)')),
-                            const DropdownMenuItem(
-                                value: 'grok-voice',
-                                child: Text('Grok Native Realtime (context consult)')),
-                            const DropdownMenuItem(
-                                value: 'openai-native-realtime',
-                                child: Text('OpenAI Native Realtime (context injected)')),
-                            const DropdownMenuItem(
-                                value: 'gemini-native-live',
-                                child: Text('Gemini Native Live (context injected)')),
+                            DropdownMenuItem(
+                                value: 'openclaw-direct', child: Text(context.l10n.openClawDirectVoiceMode)),
+                            DropdownMenuItem(
+                                value: 'grok-voice', child: Text(context.l10n.grokNativeRealtimeVoiceMode)),
+                            DropdownMenuItem(
+                                value: 'openai-native-realtime', child: Text(context.l10n.openAIRealtimeVoiceMode)),
+                            DropdownMenuItem(
+                                value: 'gemini-native-live', child: Text(context.l10n.geminiNativeLiveVoiceMode)),
                           ],
                           onChanged: (value) {
                             if (value != null) {

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -14,6 +14,7 @@ import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/http/api/knowledge_graph_api.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/ella/services/v2v_client.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/models/stt_provider.dart';
 import 'package:omi/pages/persona/persona_profile.dart';
@@ -812,7 +813,7 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                           ),
                         ),
                         DropdownButton<String>(
-                          value: SharedPreferencesUtil().ttsProvider,
+                          value: V2VClient.normalizeProvider(SharedPreferencesUtil().ttsProvider),
                           dropdownColor: const Color(0xFF2A2A2E),
                           underline: const SizedBox.shrink(),
                           style: const TextStyle(color: Colors.white, fontSize: 14),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+742
+version: 1.0.524+743
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+744
+version: 1.0.524+745
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+745
+version: 1.0.524+746
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+741
+version: 1.0.524+742
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+743
+version: 1.0.524+744
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/test/ella/services/v2v_client_test.dart
+++ b/app/test/ella/services/v2v_client_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/ella/services/v2v_client.dart';
+
+void main() {
+  group('V2VClient provider mapping', () {
+    test('treats realtime voice providers as session providers', () {
+      expect(V2VClient.isSessionProvider('grok-voice'), isTrue);
+      expect(V2VClient.isSessionProvider('gemini-live'), isTrue);
+      expect(V2VClient.isSessionProvider('openclaw-direct'), isTrue);
+      expect(V2VClient.isSessionProvider('openai-realtime'), isTrue);
+      expect(V2VClient.isSessionProvider('elevenlabs'), isFalse);
+    });
+
+    test('sends explicit voice mode for backend-friendly provider variants', () {
+      expect(V2VClient.sessionVoiceMode('openclaw-direct'), 'openclaw-direct-v1');
+      expect(V2VClient.sessionVoiceMode('openai-realtime'), 'openai-realtime-v1');
+      expect(V2VClient.sessionVoiceMode('grok-voice'), isNull);
+      expect(V2VClient.sessionVoiceMode('gemini-live'), isNull);
+    });
+  });
+}

--- a/app/test/ella/services/v2v_client_test.dart
+++ b/app/test/ella/services/v2v_client_test.dart
@@ -8,18 +8,24 @@ void main() {
       expect(V2VClient.isSessionProvider('openclaw-direct'), isTrue);
       expect(V2VClient.isSessionProvider('openai-native-realtime'), isTrue);
       expect(V2VClient.isSessionProvider('gemini-native-live'), isTrue);
+      expect(V2VClient.isSessionProvider('openai-realtime'), isTrue);
+      expect(V2VClient.isSessionProvider('gemini-live'), isTrue);
       expect(V2VClient.isSessionProvider('elevenlabs'), isFalse);
-      expect(V2VClient.isSessionProvider('openai-realtime'), isFalse);
-      expect(V2VClient.isSessionProvider('gemini-live'), isFalse);
     });
 
     test('sends explicit voice mode for backend-friendly provider variants', () {
       expect(V2VClient.sessionVoiceMode('openclaw-direct'), 'openclaw-direct-v1');
       expect(V2VClient.sessionVoiceMode('openai-native-realtime'), 'openai-native-realtime-v1');
       expect(V2VClient.sessionVoiceMode('gemini-native-live'), 'gemini-native-live-v1');
+      expect(V2VClient.sessionVoiceMode('openai-realtime'), 'openai-native-realtime-v1');
+      expect(V2VClient.sessionVoiceMode('gemini-live'), 'gemini-native-live-v1');
       expect(V2VClient.sessionVoiceMode('grok-voice'), isNull);
-      expect(V2VClient.sessionVoiceMode('gemini-live'), isNull);
-      expect(V2VClient.sessionVoiceMode('openai-realtime'), isNull);
+    });
+
+    test('normalizes saved legacy realtime provider ids', () {
+      expect(V2VClient.normalizeProvider('openai-realtime'), 'openai-native-realtime');
+      expect(V2VClient.normalizeProvider('gemini-live'), 'gemini-native-live');
+      expect(V2VClient.normalizeProvider('openclaw-direct'), 'openclaw-direct');
     });
   });
 }

--- a/app/test/ella/services/v2v_client_test.dart
+++ b/app/test/ella/services/v2v_client_test.dart
@@ -5,17 +5,21 @@ void main() {
   group('V2VClient provider mapping', () {
     test('treats realtime voice providers as session providers', () {
       expect(V2VClient.isSessionProvider('grok-voice'), isTrue);
-      expect(V2VClient.isSessionProvider('gemini-live'), isTrue);
       expect(V2VClient.isSessionProvider('openclaw-direct'), isTrue);
-      expect(V2VClient.isSessionProvider('openai-realtime'), isTrue);
+      expect(V2VClient.isSessionProvider('openai-native-realtime'), isTrue);
+      expect(V2VClient.isSessionProvider('gemini-native-live'), isTrue);
       expect(V2VClient.isSessionProvider('elevenlabs'), isFalse);
+      expect(V2VClient.isSessionProvider('openai-realtime'), isFalse);
+      expect(V2VClient.isSessionProvider('gemini-live'), isFalse);
     });
 
     test('sends explicit voice mode for backend-friendly provider variants', () {
       expect(V2VClient.sessionVoiceMode('openclaw-direct'), 'openclaw-direct-v1');
-      expect(V2VClient.sessionVoiceMode('openai-realtime'), 'openai-realtime-v1');
+      expect(V2VClient.sessionVoiceMode('openai-native-realtime'), 'openai-native-realtime-v1');
+      expect(V2VClient.sessionVoiceMode('gemini-native-live'), 'gemini-native-live-v1');
       expect(V2VClient.sessionVoiceMode('grok-voice'), isNull);
       expect(V2VClient.sessionVoiceMode('gemini-live'), isNull);
+      expect(V2VClient.sessionVoiceMode('openai-realtime'), isNull);
     });
   });
 }

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -311,6 +311,7 @@ async def get_voice_providers():
             "available": V2V_PROVIDERS["grok-voice"]["key_check"](),
             "requires_session": True,
             "session_endpoint": "/v1/voice/session",
+            "default_mode": V2V_PROVIDERS["grok-voice"]["default_mode"],
         },
         {
             "id": "openclaw-direct",

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -105,6 +105,13 @@ V2V_PROVIDERS = {
         "endpoint_env": "ELLA_VOICE_ENDPOINT",  # Same proxy, different mode
         "key_check": lambda: bool(GEMINI_API_KEY),
     },
+    "openai-realtime": {
+        "name": "OpenAI Realtime (V2V)",
+        "description": "Voice-to-voice via the Ella voice proxy with full OpenClaw context",
+        "default_mode": "openai-realtime-v1",
+        "endpoint_env": "ELLA_VOICE_ENDPOINT",
+        "key_check": lambda: bool(ELLA_SESSION_SECRET),
+    },
 }
 
 
@@ -307,6 +314,15 @@ async def get_voice_providers():
             "requires_session": True,
             "session_endpoint": "/v1/voice/session",
         },
+        {
+            "id": "openai-realtime",
+            "name": "OpenAI Realtime (V2V)",
+            "type": "v2v",
+            "description": "Voice-to-voice via the Ella voice proxy with full OpenClaw context",
+            "available": V2V_PROVIDERS["openai-realtime"]["key_check"](),
+            "requires_session": True,
+            "session_endpoint": "/v1/voice/session",
+        },
     ]
     return {"providers": providers}
 
@@ -332,7 +348,7 @@ async def create_voice_session(
 
     Args:
         uid: User ID (required)
-        provider: V2V provider — "grok-voice" (default) or "gemini-live"
+        provider: V2V provider — "grok-voice" (default), "gemini-live", or "openai-realtime"
         voice_mode: Override mode (defaults to provider's default mode)
 
     Returns:
@@ -456,7 +472,7 @@ async def synthesize_speech(
       kokoro             — Kokoro-82M via local ella-tts server (Mac Mini :8930)
       inworld            — Inworld TTS WebSocket (~120-200ms, $5-10/1M chars)
 
-    V2V providers (grok-voice, gemini-live) return 422 directing iOS to use
+    V2V providers (grok-voice, gemini-live, openai-realtime) return 422 directing iOS to use
     the /session endpoint instead — V2V replaces the entire STT→LLM→TTS chain.
     """
     _start = time.time()
@@ -525,7 +541,7 @@ async def synthesize_speech(
     # --- Reject unknown providers (no silent fallbacks) ---
     if provider != "elevenlabs":
         print(f"[FLOW:VOICE-TTS] ERROR unknown provider={provider!r}", flush=True)
-        raise HTTPException(status_code=400, detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, grok-voice, gemini-live")
+        raise HTTPException(status_code=400, detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, grok-voice, gemini-live, openai-realtime")
 
     # --- ElevenLabs ---
     if not ELEVENLABS_API_KEY:

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -92,25 +92,32 @@ Voice Interaction Rules:
 # V2V provider registry — maps provider ID to endpoint and metadata
 V2V_PROVIDERS = {
     "grok-voice": {
-        "name": "Grok Voice (V2V)",
-        "description": "Voice-to-voice via Grok Realtime API, sub-second latency",
+        "name": "Grok Native Realtime (V2V)",
+        "description": "Native Grok speech-to-speech with OpenClaw context consult",
         "default_mode": "v4",
         "endpoint_env": "ELLA_VOICE_ENDPOINT",
         "key_check": lambda: bool(ELLA_SESSION_SECRET),
     },
-    "gemini-live": {
-        "name": "Gemini Live (V2V)",
-        "description": "Voice-to-voice via Gemini Live API, multimodal",
-        "default_mode": "gemini-live",
-        "endpoint_env": "ELLA_VOICE_ENDPOINT",  # Same proxy, different mode
-        "key_check": lambda: bool(GEMINI_API_KEY),
-    },
-    "openai-realtime": {
-        "name": "OpenAI Realtime (V2V)",
-        "description": "Voice-to-voice via the Ella voice proxy with full OpenClaw context",
-        "default_mode": "openai-realtime-v1",
+    "openclaw-direct": {
+        "name": "OpenClaw Direct (full context, STT/TTS)",
+        "description": "Stable OMI websocket contract backed by STT -> OpenClaw -> TTS; not provider-native realtime",
+        "default_mode": "openclaw-direct-v1",
         "endpoint_env": "ELLA_VOICE_ENDPOINT",
         "key_check": lambda: bool(ELLA_SESSION_SECRET),
+    },
+    "openai-native-realtime": {
+        "name": "OpenAI Native Realtime (V2V)",
+        "description": "Provider-native OpenAI Realtime speech-to-speech with injected OpenClaw context",
+        "default_mode": "openai-native-realtime-v1",
+        "endpoint_env": "ELLA_VOICE_ENDPOINT",
+        "key_check": lambda: bool(ELLA_SESSION_SECRET),
+    },
+    "gemini-native-live": {
+        "name": "Gemini Native Live (V2V)",
+        "description": "Provider-native Gemini Live speech-to-speech with injected OpenClaw context",
+        "default_mode": "gemini-native-live-v1",
+        "endpoint_env": "ELLA_VOICE_ENDPOINT",
+        "key_check": lambda: bool(GEMINI_API_KEY),
     },
 }
 
@@ -224,7 +231,7 @@ def create_session_token(
     - uid: Omi user ID
     - firebase_uid: Firebase UID for user lookup
     - name: Display name for personalization
-    - voice_mode: V2V mode (v3-rich, gemini-live, etc.)
+    - voice_mode: V2V mode (v4, openclaw-direct-v1, openai-native-realtime-v1, gemini-native-live-v1, etc.)
     - provider: V2V provider ID
     - context_url: Where proxy can fetch user context
     - callback_url: Where proxy posts session results
@@ -298,30 +305,42 @@ async def get_voice_providers():
         },
         {
             "id": "grok-voice",
-            "name": "Grok Voice (V2V)",
+            "name": "Grok Native Realtime (V2V)",
             "type": "v2v",
-            "description": "Voice-to-voice via Grok Realtime API, sub-second latency",
+            "description": "Native Grok speech-to-speech with OpenClaw context consult",
             "available": V2V_PROVIDERS["grok-voice"]["key_check"](),
             "requires_session": True,
             "session_endpoint": "/v1/voice/session",
         },
         {
-            "id": "gemini-live",
-            "name": "Gemini Live (V2V)",
+            "id": "openclaw-direct",
+            "name": "OpenClaw Direct (full context, STT/TTS)",
             "type": "v2v",
-            "description": "Voice-to-voice via Gemini Live API, multimodal",
-            "available": V2V_PROVIDERS["gemini-live"]["key_check"](),
+            "description": "Stable OMI websocket contract backed by STT -> OpenClaw -> TTS; not provider-native realtime",
+            "available": V2V_PROVIDERS["openclaw-direct"]["key_check"](),
             "requires_session": True,
             "session_endpoint": "/v1/voice/session",
+            "default_mode": V2V_PROVIDERS["openclaw-direct"]["default_mode"],
         },
         {
-            "id": "openai-realtime",
-            "name": "OpenAI Realtime (V2V)",
+            "id": "openai-native-realtime",
+            "name": "OpenAI Native Realtime (V2V)",
             "type": "v2v",
-            "description": "Voice-to-voice via the Ella voice proxy with full OpenClaw context",
-            "available": V2V_PROVIDERS["openai-realtime"]["key_check"](),
+            "description": "Provider-native OpenAI Realtime speech-to-speech with injected OpenClaw context",
+            "available": V2V_PROVIDERS["openai-native-realtime"]["key_check"](),
             "requires_session": True,
             "session_endpoint": "/v1/voice/session",
+            "default_mode": V2V_PROVIDERS["openai-native-realtime"]["default_mode"],
+        },
+        {
+            "id": "gemini-native-live",
+            "name": "Gemini Native Live (V2V)",
+            "type": "v2v",
+            "description": "Provider-native Gemini Live speech-to-speech with injected OpenClaw context",
+            "available": V2V_PROVIDERS["gemini-native-live"]["key_check"](),
+            "requires_session": True,
+            "session_endpoint": "/v1/voice/session",
+            "default_mode": V2V_PROVIDERS["gemini-native-live"]["default_mode"],
         },
     ]
     return {"providers": providers}
@@ -348,7 +367,7 @@ async def create_voice_session(
 
     Args:
         uid: User ID (required)
-        provider: V2V provider — "grok-voice" (default), "gemini-live", or "openai-realtime"
+        provider: V2V provider — "grok-voice" (default), "openclaw-direct", "openai-native-realtime", or "gemini-native-live"
         voice_mode: Override mode (defaults to provider's default mode)
 
     Returns:
@@ -472,7 +491,7 @@ async def synthesize_speech(
       kokoro             — Kokoro-82M via local ella-tts server (Mac Mini :8930)
       inworld            — Inworld TTS WebSocket (~120-200ms, $5-10/1M chars)
 
-    V2V providers (grok-voice, gemini-live, openai-realtime) return 422 directing iOS to use
+    V2V providers (grok-voice, openclaw-direct, openai-native-realtime, gemini-native-live) return 422 directing iOS to use
     the /session endpoint instead — V2V replaces the entire STT→LLM→TTS chain.
     """
     _start = time.time()
@@ -541,7 +560,7 @@ async def synthesize_speech(
     # --- Reject unknown providers (no silent fallbacks) ---
     if provider != "elevenlabs":
         print(f"[FLOW:VOICE-TTS] ERROR unknown provider={provider!r}", flush=True)
-        raise HTTPException(status_code=400, detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, grok-voice, gemini-live, openai-realtime")
+        raise HTTPException(status_code=400, detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, grok-voice, openclaw-direct, openai-native-realtime, gemini-native-live")
 
     # --- ElevenLabs ---
     if not ELEVENLABS_API_KEY:

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -90,6 +90,11 @@ Voice Interaction Rules:
 """
 
 # V2V provider registry — maps provider ID to endpoint and metadata
+V2V_PROVIDER_ALIASES = {
+    "gemini-live": "gemini-native-live",
+    "openai-realtime": "openai-native-realtime",
+}
+
 V2V_PROVIDERS = {
     "grok-voice": {
         "name": "Grok Native Realtime (V2V)",
@@ -383,6 +388,7 @@ async def create_voice_session(
     uid = (body.uid if body else None) or uid
     provider = (body.provider if body else None) or provider or "grok-voice"
     voice_mode = (body.voice_mode if body else None) or voice_mode
+    provider = V2V_PROVIDER_ALIASES.get(provider, provider)
 
     if not uid:
         raise HTTPException(status_code=400, detail="uid required")
@@ -498,6 +504,7 @@ async def synthesize_speech(
     _start = time.time()
     text_len = len(request.text)
     provider = (x_tts_provider or "elevenlabs").lower()
+    provider = V2V_PROVIDER_ALIASES.get(provider, provider)
     text = request.text[:500]  # Cap at 500 chars
     print(f"[FLOW:VOICE-TTS] header=X-TTS-Provider raw={x_tts_provider!r} resolved={provider}", flush=True)
 


### PR DESCRIPTION
## Summary
- Adds `OpenAI Realtime` to the developer voice-mode picker.
- Treats `openai-realtime` as a V2V session provider using the existing `/v1/voice/session` flow.
- Sends backend-friendly `voice_mode: openai-realtime-v1` while preserving existing modes and payloads.
- Adds a targeted test for V2V provider/session voice-mode mapping.
- Bumps iOS build to `1.0.524+742` for TestFlight.

## Base / Scope
- PR target remains `codex/openclaw-direct-ios-authsafe`, not `main`, because this branch carries the known auth-safe OpenClaw/TestFlight baseline. Retargeting to `main` would make the PR include the pending baseline and risk the previous config issue.
- iOS/app-side only.
- Does not touch Firebase/auth/signing/build config files.
- Existing `grok-voice`, `gemini-live`, and `openclaw-direct` mappings are kept intact.

## Changed files
- `app/lib/ella/services/v2v_client.dart`
- `app/lib/pages/settings/developer.dart`
- `app/lib/l10n/*`
- `app/test/ella/services/v2v_client_test.dart`
- `app/pubspec.yaml` build bump only

## Tests / Validation
- `flutter test test/ella/services/v2v_client_test.dart` passed.
- `./app/test.sh` passed after rerunning serially; the first full-script attempt overlapped with another Flutter test process and hit a generated `build/unit_test_assets` race.
- Preflight verified `PROJECT_ID=omi-dev-ca005`, `BUNDLE_ID=com.ellaaicare.ella`, `.prod.env` API base URL, and no `based-hardware-dev` / `1031333818730` in tracked/local build inputs.
- Build script logged `Config OK: flavor=prod plist=Prod bundle=com.ellaaicare.ella project=omi-dev-ca005`.
- Postflight IPA inspection verified embedded Firebase plist uses `omi-dev-ca005`, bundle `com.ellaaicare.ella`, and build `742`.

## TestFlight
- Upload succeeded for `1.0.524+742`.
- Delivery UUID: `70cd00a8-fa2a-4d0a-be3c-a40c259361cd`.
- IPA sha256: `8d66eff7870274960332aff327ff96da46bc64c56330da649b3e049ae8f4a221`.