### PR TITLE
[codex] Fix Guardian Bluetooth audio routing

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -42,11 +42,9 @@ extension FlutterError: Error {}
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
 
-    // Configure audio session for background recording
+    // Configure audio session for background recording and Guardian playback.
     do {
-        let audioSession = AVAudioSession.sharedInstance()
-        try audioSession.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker, .allowBluetooth, .mixWithOthers])
-        try audioSession.setActive(true, options: [])
+        try AppDelegate.configureGuardianAudioSession(reason: "app_launch")
         print("AppDelegate: Audio session configured for background recording")
 
         // Observe audio session interruptions
@@ -54,14 +52,14 @@ extension FlutterError: Error {}
             self,
             selector: #selector(handleAudioSessionInterruption),
             name: AVAudioSession.interruptionNotification,
-            object: audioSession
+            object: AVAudioSession.sharedInstance()
         )
 
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleAudioSessionRouteChange),
             name: AVAudioSession.routeChangeNotification,
-            object: audioSession
+            object: AVAudioSession.sharedInstance()
         )
 
         // Reactivate audio session when app becomes active
@@ -203,6 +201,82 @@ extension FlutterError: Error {}
 
   // MARK: - Audio Session Handlers
 
+  static func configureGuardianAudioSession(reason: String) throws {
+      let audioSession = AVAudioSession.sharedInstance()
+      let options: AVAudioSession.CategoryOptions = [
+          .allowBluetooth,
+          .allowBluetoothA2DP,
+          .allowAirPlay,
+          .mixWithOthers
+      ]
+
+      try audioSession.setCategory(.playAndRecord, mode: .default, options: options)
+      try audioSession.setActive(true, options: [])
+      try applyGuardianOutputRoutePolicy(audioSession: audioSession, reason: reason)
+      logGuardianAudioRoute(audioSession: audioSession, reason: reason)
+  }
+
+  static func refreshGuardianOutputRoute(reason: String) {
+      let audioSession = AVAudioSession.sharedInstance()
+      do {
+          try applyGuardianOutputRoutePolicy(audioSession: audioSession, reason: reason)
+          logGuardianAudioRoute(audioSession: audioSession, reason: reason)
+      } catch {
+          print("AppDelegate: Failed to refresh Guardian audio route (\(reason)): \(error.localizedDescription)")
+      }
+  }
+
+  private static func applyGuardianOutputRoutePolicy(audioSession: AVAudioSession, reason: String) throws {
+      if hasExternalOutput(audioSession.currentRoute.outputs) {
+          try audioSession.overrideOutputAudioPort(.none)
+          print("AppDelegate: Guardian audio route keeps external output (\(reason))")
+          return
+      }
+
+      // Clear stale speaker overrides first so a newly connected Bluetooth route can become active.
+      try audioSession.overrideOutputAudioPort(.none)
+
+      if hasExternalOutput(audioSession.currentRoute.outputs) {
+          print("AppDelegate: Guardian audio route switched to external output (\(reason))")
+          return
+      }
+
+      if shouldForceSpeakerFallback(outputs: audioSession.currentRoute.outputs) {
+          try audioSession.overrideOutputAudioPort(.speaker)
+          print("AppDelegate: Guardian audio route using speaker fallback (\(reason))")
+      }
+  }
+
+  private static func hasExternalOutput(_ outputs: [AVAudioSessionPortDescription]) -> Bool {
+      return outputs.contains { output in
+          switch output.portType {
+          case .airPlay, .bluetoothA2DP, .bluetoothHFP, .bluetoothLE, .carAudio, .headphones, .usbAudio:
+              return true
+          default:
+              return false
+          }
+      }
+  }
+
+  private static func shouldForceSpeakerFallback(outputs: [AVAudioSessionPortDescription]) -> Bool {
+      guard !hasExternalOutput(outputs) else { return false }
+      return outputs.isEmpty || outputs.contains { $0.portType == .builtInReceiver }
+  }
+
+  private static func logGuardianAudioRoute(audioSession: AVAudioSession, reason: String) {
+      let outputs = audioSession.currentRoute.outputs
+          .map { "\($0.portType.rawValue):\($0.portName)" }
+          .joined(separator: ", ")
+      let inputs = audioSession.currentRoute.inputs
+          .map { "\($0.portType.rawValue):\($0.portName)" }
+          .joined(separator: ", ")
+      let availableInputs = audioSession.availableInputs?
+          .map { "\($0.portType.rawValue):\($0.portName)" }
+          .joined(separator: ", ") ?? "none"
+
+      print("AppDelegate: Guardian audio route [\(reason)] category=\(audioSession.category.rawValue) options=\(audioSession.categoryOptions.rawValue) outputs=[\(outputs)] inputs=[\(inputs)] availableInputs=[\(availableInputs)]")
+  }
+
   @objc private func handleAudioSessionInterruption(notification: Notification) {
       guard let userInfo = notification.userInfo,
             let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
@@ -215,9 +289,8 @@ extension FlutterError: Error {}
           print("AppDelegate: Audio session interrupted")
       case .ended:
           print("AppDelegate: Audio session interruption ended")
-          // Reactivate audio session
           do {
-              try AVAudioSession.sharedInstance().setActive(true)
+              try AppDelegate.configureGuardianAudioSession(reason: "interruption_ended")
               print("AppDelegate: Audio session reactivated after interruption")
           } catch {
               print("AppDelegate: Failed to reactivate audio session: \(error)")
@@ -235,19 +308,7 @@ extension FlutterError: Error {}
       }
 
       print("AppDelegate: Audio route changed - reason: \(reason.rawValue)")
-
-      // When headphones or Bluetooth are removed, iOS defaults .playAndRecord back to the
-      // earpiece. Override to the loudspeaker so guardian audio stays audible.
-      if reason == .oldDeviceUnavailable {
-          DispatchQueue.main.async {
-              do {
-                  try AVAudioSession.sharedInstance().overrideOutputAudioPort(.speaker)
-                  print("AppDelegate: Forced output to loudspeaker after device removal")
-              } catch {
-                  print("AppDelegate: Failed to override output port: \(error)")
-              }
-          }
-      }
+      AppDelegate.refreshGuardianOutputRoute(reason: "route_change_\(reason.rawValue)")
 
       // Report route changes only while an exact Guardian playback span is active.
       GuardianModeManager.shared.reportActivePlaybackRouteChange()
@@ -258,7 +319,7 @@ extension FlutterError: Error {}
       do {
           let audioSession = AVAudioSession.sharedInstance()
           if !audioSession.isOtherAudioPlaying {
-              try audioSession.setActive(true)
+              try AppDelegate.configureGuardianAudioSession(reason: "app_became_active")
               print("AppDelegate: Audio session reactivated on app becoming active")
           }
       } catch {

--- a/app/ios/Runner/GuardianMode/GuardianModeManager.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModeManager.swift
@@ -334,7 +334,7 @@ class GuardianModeManager: NSObject {
 
     // MARK: - Audio Injection with Pre-download + Retry
 
-    /// Inject remote audio with pre-download and retry logic
+    /// Inject remote audio with pre-download and retry logic.
     func injectRemoteAudio(
         audioURL: URL,
         eventId: String,
@@ -364,114 +364,148 @@ class GuardianModeManager: NSObject {
             NSLog("INJECT_START #\(seq) (\(filename)) id=\(eventId) trace=\(resolvedTraceId) ts=\(Date().timeIntervalSince1970)")
             AppDelegate.refreshGuardianOutputRoute(reason: "guardian_remote_audio")
 
-            // Inject remote audio directly (no download - progressive streaming)
-            Task {
-                await self.injectRemoteAudioDirect(
-                    remoteURL: audioURL,
-                    context: playbackContext,
-                    seq: seq,
-                    filename: filename,
-                    attempt: 1
-                )
-            }
+            self.downloadAndInjectAudio(
+                remoteURL: audioURL,
+                context: playbackContext,
+                seq: seq,
+                filename: filename,
+                attempt: 1
+            )
         }
     }
 
-    /// Inject remote audio directly into the player queue (progressive streaming)
-    /// KEY: Inserts FIRST (triggers loading), THEN waits for .readyToPlay
-    private func injectRemoteAudioDirect(
+    private func downloadAndInjectAudio(
         remoteURL: URL,
         context: PlaybackContext,
         seq: Int,
         filename: String,
         attempt: Int
-    ) async {
-        // Must be called on self.queue
-        guard let player = self.audioPlayer, self.isActive else {
+    ) {
+        guard self.isActive else {
             NSLog("INJECT_FAILED #\(seq) (\(filename)) reason=not_active")
-            reportGuardianPlaybackFailure(
-                context: context,
-                error: "not_active"
-            )
-            await MainActor.run { self.failedInjections += 1 }
+            reportGuardianPlaybackFailure(context: context, error: "not_active")
+            self.failedInjections += 1
             return
         }
 
-        let audioItem = AVPlayerItem(url: remoteURL)
+        let downloadStart = Date()
+        let request = URLRequest(url: remoteURL, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: 10.0)
+        let task = URLSession.shared.downloadTask(with: request) { [weak self] tempURL, response, error in
+            guard let self = self else { return }
 
-        // Insert into queue FIRST - this triggers AVPlayer to start loading!
-        player.insert(audioItem, after: nil)
-
-        // Wait for item to become ready (production logging - minimal)
-        let startTime = Date()
-        let timeout: TimeInterval = 10.0
-        var iteration = 0
-
-        while audioItem.status == .unknown {
-            iteration += 1
-
-            // Check for error
-            if let error = audioItem.error {
-                NSLog("❌ ITEM_ERROR #\(seq) (\(filename)) - \(error.localizedDescription)")
-                reportGuardianPlaybackFailure(
-                    context: context,
-                    error: error.localizedDescription
-                )
-                await MainActor.run { self.failedInjections += 1 }
+            if let error = error {
+                self.queue.async {
+                    NSLog("DOWNLOAD_FAILED #\(seq) (\(filename)) attempt=\(attempt) error=\(error.localizedDescription)")
+                    if attempt < 3 {
+                        self.retryDownloadAndInject(
+                            remoteURL: remoteURL,
+                            context: context,
+                            seq: seq,
+                            filename: filename,
+                            attempt: attempt + 1
+                        )
+                    } else {
+                        self.reportGuardianPlaybackFailure(context: context, error: "download_failed:\(error.localizedDescription)")
+                        self.failedInjections += 1
+                    }
+                }
                 return
             }
 
-            // Check timeout
-            if Date().timeIntervalSince(startTime) > timeout {
-                NSLog("❌ TIMEOUT #\(seq) (\(filename)) after 10s - status: \(audioItem.status.rawValue)")
-                reportGuardianPlaybackFailure(
-                    context: context,
-                    error: "ready_timeout"
-                )
-                await MainActor.run { self.failedInjections += 1 }
+            guard let tempURL = tempURL else {
+                self.queue.async {
+                    NSLog("DOWNLOAD_FAILED #\(seq) (\(filename)) reason=no_temp_file")
+                    self.reportGuardianPlaybackFailure(context: context, error: "download_failed:no_temp_file")
+                    self.failedInjections += 1
+                }
                 return
             }
 
-            // Only log if taking unusually long (> 5 seconds)
-            if iteration == 100 {
-                NSLog("⚠️ Slow load #\(seq) (\(filename)) - still waiting after 5s")
+            let httpStatus = (response as? HTTPURLResponse)?.statusCode ?? 200
+            guard (200..<300).contains(httpStatus) else {
+                self.queue.async {
+                    NSLog("DOWNLOAD_FAILED #\(seq) (\(filename)) http_status=\(httpStatus)")
+                    self.reportGuardianPlaybackFailure(context: context, error: "download_failed:http_\(httpStatus)")
+                    self.failedInjections += 1
+                }
+                return
             }
 
-            // Wait 50ms before checking again
-            try? await Task.sleep(nanoseconds: 50_000_000)
-        }
+            let fileSize = (try? FileManager.default.attributesOfItem(atPath: tempURL.path)[.size] as? NSNumber)?.intValue ?? 0
+            guard fileSize > 0 else {
+                self.queue.async {
+                    NSLog("DOWNLOAD_FAILED #\(seq) (\(filename)) reason=empty_file")
+                    self.reportGuardianPlaybackFailure(context: context, error: "download_failed:empty_file")
+                    self.failedInjections += 1
+                }
+                return
+            }
 
-        // Check if buffering succeeded
-        if audioItem.status == .failed {
-            let errorMsg = audioItem.error?.localizedDescription ?? "unknown"
-            NSLog("ITEM_FAILED #\(seq) (\(filename)) error=\(errorMsg)")
-            reportGuardianPlaybackFailure(
-                context: context,
-                error: errorMsg
-            )
-            await MainActor.run { self.failedInjections += 1 }
+            do {
+                let localURL = self.cacheDir.appendingPathComponent(self.cacheFilename(for: context.queueItemId, remoteURL: remoteURL))
+                if FileManager.default.fileExists(atPath: localURL.path) {
+                    try FileManager.default.removeItem(at: localURL)
+                }
+                try FileManager.default.moveItem(at: tempURL, to: localURL)
+
+                self.queue.async {
+                    let latencyMs = Int(Date().timeIntervalSince(downloadStart) * 1000)
+                    NSLog("DOWNLOAD_COMPLETE #\(seq) (\(filename)) bytes=\(fileSize) latency_ms=\(latencyMs)")
+                    self.injectLocalAudio(
+                        localURL: localURL,
+                        context: context,
+                        seq: seq,
+                        filename: filename,
+                        downloadLatencyMs: latencyMs
+                    )
+                }
+            } catch {
+                self.queue.async {
+                    NSLog("DOWNLOAD_FAILED #\(seq) (\(filename)) reason=cache_move_error error=\(error.localizedDescription)")
+                    self.reportGuardianPlaybackFailure(context: context, error: "download_failed:cache_move_error:\(error.localizedDescription)")
+                    self.failedInjections += 1
+                }
+            }
+        }
+        task.resume()
+    }
+
+    private func retryDownloadAndInject(
+        remoteURL: URL,
+        context: PlaybackContext,
+        seq: Int,
+        filename: String,
+        attempt: Int
+    ) {
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + Double(attempt) * 0.5) { [weak self] in
+            self?.queue.async {
+                self?.downloadAndInjectAudio(
+                    remoteURL: remoteURL,
+                    context: context,
+                    seq: seq,
+                    filename: filename,
+                    attempt: attempt
+                )
+            }
+        }
+    }
+
+    private func injectLocalAudio(
+        localURL: URL,
+        context: PlaybackContext,
+        seq: Int,
+        filename: String,
+        downloadLatencyMs: Int
+    ) {
+        guard let player = self.audioPlayer, self.isActive else {
+            NSLog("INJECT_FAILED #\(seq) (\(filename)) reason=not_active_after_download")
+            reportGuardianPlaybackFailure(context: context, error: "not_active_after_download")
+            failedInjections += 1
             return
         }
 
-        guard audioItem.status == .readyToPlay else {
-            NSLog("INJECT_FAILED #\(seq) (\(filename)) reason=unexpected_status_\(audioItem.status.rawValue)")
-            reportGuardianPlaybackFailure(
-                context: context,
-                error: "unexpected_status_\(audioItem.status.rawValue)"
-            )
-            await MainActor.run { self.failedInjections += 1 }
-            return
-        }
-
-        let readyTime = Date().timeIntervalSince(startTime)
-
-        // Only log unusual load times (production logging - minimal)
-        if readyTime > 5.0 {
-            NSLog("⚠️ Slow load #\(seq) (\(filename)) - took \(String(format: "%.2f", readyTime))s")
-        } else if readyTime < 0.5 {
-            NSLog("⚡ Fast load #\(seq) (\(filename)) - took \(String(format: "%.2f", readyTime))s")
-        }
-        // Normal loads (0.5-5s) are silent - tracked by successfulInjections counter
+        let audioItem = AVPlayerItem(url: localURL)
+        let itemQueuedAt = Date()
 
         player.publisher(for: \.currentItem)
             .sink { [weak self, weak audioItem] currentItem in
@@ -479,7 +513,8 @@ class GuardianModeManager: NSObject {
                 self.reportGuardianPlaybackStartedIfNeeded(
                     item: audioItem,
                     context: context,
-                    readyLatencyMs: Int(readyTime * 1000)
+                    readyLatencyMs: Int(Date().timeIntervalSince(itemQueuedAt) * 1000),
+                    downloadLatencyMs: downloadLatencyMs
                 )
             }
             .store(in: &cancellables)
@@ -507,8 +542,49 @@ class GuardianModeManager: NSObject {
             }
             .store(in: &cancellables)
 
+        audioItem.publisher(for: \.status)
+            .sink { [weak self, weak audioItem] status in
+                guard let self = self, let audioItem = audioItem else { return }
+                if status == .readyToPlay {
+                    NSLog("ITEM_READY #\(seq) (\(filename)) queued_latency_ms=\(Int(Date().timeIntervalSince(itemQueuedAt) * 1000))")
+                    if player.currentItem === audioItem {
+                        self.reportGuardianPlaybackStartedIfNeeded(
+                            item: audioItem,
+                            context: context,
+                            readyLatencyMs: Int(Date().timeIntervalSince(itemQueuedAt) * 1000),
+                            downloadLatencyMs: downloadLatencyMs
+                        )
+                    }
+                } else if status == .failed {
+                    let error = audioItem.error?.localizedDescription ?? "item_failed"
+                    NSLog("ITEM_FAILED #\(seq) (\(filename)) error=\(error)")
+                    self.reportGuardianPlaybackFailure(context: context, error: error, item: audioItem)
+                    self.queue.async { self.failedInjections += 1 }
+                }
+            }
+            .store(in: &cancellables)
+
+        let afterItem = player.currentItem
+        if player.canInsert(audioItem, after: afterItem) {
+            player.insert(audioItem, after: afterItem)
+            NSLog("INJECT_OK #\(seq) (\(filename)) position=after_current depth=\(player.items().count) ts=\(Date().timeIntervalSince1970)")
+        } else if player.canInsert(audioItem, after: nil) {
+            player.insert(audioItem, after: nil)
+            NSLog("INJECT_OK #\(seq) (\(filename)) position=end depth=\(player.items().count) ts=\(Date().timeIntervalSince1970)")
+        } else {
+            NSLog("INJECT_FAILED #\(seq) (\(filename)) reason=cannot_insert")
+            reportGuardianPlaybackFailure(context: context, error: "cannot_insert", item: audioItem)
+            failedInjections += 1
+            return
+        }
+
         if player.currentItem === audioItem {
-            reportGuardianPlaybackStartedIfNeeded(item: audioItem, context: context, readyLatencyMs: Int(readyTime * 1000))
+            reportGuardianPlaybackStartedIfNeeded(
+                item: audioItem,
+                context: context,
+                readyLatencyMs: Int(Date().timeIntervalSince(itemQueuedAt) * 1000),
+                downloadLatencyMs: downloadLatencyMs
+            )
         }
 
         // Ensure player is actually playing
@@ -520,12 +596,17 @@ class GuardianModeManager: NSObject {
     private func reportGuardianPlaybackStartedIfNeeded(
         item: AVPlayerItem,
         context: PlaybackContext,
-        readyLatencyMs: Int
+        readyLatencyMs: Int,
+        downloadLatencyMs: Int
     ) {
         queue.async { [weak self] in
             guard let self = self else { return }
             let itemId = ObjectIdentifier(item)
             guard !self.playbackStartedItems.contains(itemId) else { return }
+            guard item.status == .readyToPlay else {
+                NSLog("PLAYBACK_START_DEFERRED item=\(context.queueItemId) status=\(item.status.rawValue)")
+                return
+            }
 
             self.playbackStartedItems.insert(itemId)
             self.playbackStartedAt[itemId] = Date()
@@ -533,6 +614,7 @@ class GuardianModeManager: NSObject {
 
             var eventMetadata = context.metadata
             eventMetadata["ready_latency_ms"] = readyLatencyMs
+            eventMetadata["download_latency_ms"] = downloadLatencyMs
             self.reportPlaybackEvent(
                 eventType: "started",
                 queueItemId: context.queueItemId,
@@ -594,6 +676,15 @@ class GuardianModeManager: NSObject {
                 }
             }
         }
+    }
+
+    private func cacheFilename(for queueItemId: String, remoteURL: URL) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        let safeId = String(queueItemId.map { character in
+            character.unicodeScalars.allSatisfy { allowed.contains($0) } ? character : "_"
+        })
+        let ext = remoteURL.pathExtension.isEmpty ? "mp3" : remoteURL.pathExtension
+        return "\(safeId).\(ext)"
     }
 
     // MARK: - Cache Cleanup

--- a/app/ios/Runner/GuardianMode/GuardianModeManager.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModeManager.swift
@@ -62,9 +62,9 @@ class GuardianModeManager: NSObject {
                 return
             }
 
-            // Activate audio session (configured in AppDelegate, activated here before playback)
+            // Re-apply route policy before playback so stale speaker overrides do not persist.
             let audioSession = AVAudioSession.sharedInstance()
-            try audioSession.setActive(true)
+            try AppDelegate.configureGuardianAudioSession(reason: "guardian_start")
 
             // Detailed audio session diagnostics
             NSLog("🔊 SESSION_STATE_DETAILED:")
@@ -362,6 +362,7 @@ class GuardianModeManager: NSObject {
             )
 
             NSLog("INJECT_START #\(seq) (\(filename)) id=\(eventId) trace=\(resolvedTraceId) ts=\(Date().timeIntervalSince1970)")
+            AppDelegate.refreshGuardianOutputRoute(reason: "guardian_remote_audio")
 
             // Inject remote audio directly (no download - progressive streaming)
             Task {

--- a/app/ios/Runner/GuardianMode/GuardianModePollingService.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModePollingService.swift
@@ -173,6 +173,7 @@ class GuardianModePollingService: NSObject, AVSpeechSynthesizerDelegate {
             startedAt: Date()
         )
 
+        AppDelegate.refreshGuardianOutputRoute(reason: "guardian_tts")
         let utterance = AVSpeechUtterance(string: text)
         utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
         utterance.rate = 0.5

--- a/app/lib/ella/services/guardian_mode_api.dart
+++ b/app/lib/ella/services/guardian_mode_api.dart
@@ -12,8 +12,12 @@ const String _dashboardBase = 'https://ella-ai-care.com';
 List<GuardianPreset>? _cachedPresets;
 
 String get _userId {
-  final ellaId = SharedPreferencesUtil().ellaUserId;
-  return ellaId.isNotEmpty ? ellaId : SharedPreferencesUtil().uid;
+  // The dashboard route now accepts the OMI/Firebase UID. Prefer that stable
+  // identity so stale cached Ella UUIDs cannot read or update a different row.
+  final uid = SharedPreferencesUtil().uid;
+  if (uid.isNotEmpty) return uid;
+
+  return SharedPreferencesUtil().ellaUserId;
 }
 
 /// GET /api/users/{userId}/guardian-mode
@@ -25,12 +29,10 @@ Future<GuardianModeInfo?> getGuardianMode() async {
   final uid = _userId;
   if (uid.isEmpty) return null;
   try {
-    final response = await http
-        .get(
-          Uri.parse('$_dashboardBase/api/users/$uid/guardian-mode'),
-          headers: {'Content-Type': 'application/json'},
-        )
-        .timeout(const Duration(seconds: 10));
+    final response = await http.get(
+      Uri.parse('$_dashboardBase/api/users/$uid/guardian-mode'),
+      headers: {'Content-Type': 'application/json'},
+    ).timeout(const Duration(seconds: 10));
 
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body) as Map<String, dynamic>;
@@ -103,20 +105,16 @@ Future<bool> setGuardianMode(GuardianModeKey mode) async {
 Future<List<GuardianPreset>> getGuardianPresets() async {
   if (_cachedPresets != null) return _cachedPresets!;
   try {
-    final response = await http
-        .get(
-          Uri.parse('$_dashboardBase/api/guardian/presets'),
-          headers: {'Content-Type': 'application/json'},
-        )
-        .timeout(const Duration(seconds: 10));
+    final response = await http.get(
+      Uri.parse('$_dashboardBase/api/guardian/presets'),
+      headers: {'Content-Type': 'application/json'},
+    ).timeout(const Duration(seconds: 10));
 
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body) as Map<String, dynamic>;
       if (data['success'] == true) {
         final list = data['presets'] as List;
-        _cachedPresets = list
-            .map((p) => GuardianPreset.fromJson(p as Map<String, dynamic>))
-            .toList();
+        _cachedPresets = list.map((p) => GuardianPreset.fromJson(p as Map<String, dynamic>)).toList();
         return _cachedPresets!;
       }
     }
@@ -129,80 +127,75 @@ Future<List<GuardianPreset>> getGuardianPresets() async {
 
 /// Hard-coded fallback so the UI works even if the presets endpoint is down.
 List<GuardianPreset> _fallbackPresets() => [
-  GuardianPreset(
-    presetKey: 'EMERGENCY_ONLY',
-    name: 'Emergency Alerts',
-    description:
-        'Critical alerts only — fall detection, medical emergencies, fire/smoke.',
-    detailsBullets: ['Medical emergencies', 'Fall detection', 'Fire/smoke'],
-    color: const Color(0xFFF59E0B),
-  ),
-  GuardianPreset(
-    presetKey: 'ACTIVE_SUPPORT',
-    name: 'Active Support',
-    description:
-        'Emergency alerts + recall assistance + schedule reminders + pattern monitoring.',
-    detailsBullets: [
-      'Medical emergencies',
-      'Wake words (always active)',
-      'Recall assistance',
-    ],
-    color: const Color(0xFF14B8A6),
-  ),
-  GuardianPreset(
-    presetKey: 'MAXIMUM_AWARENESS',
-    name: 'Maximum Awareness',
-    description:
-        'High-sensitivity care monitoring for risk, vulnerability, health, cognitive, emotional, and social support signals.',
-    detailsBullets: [
-      'Broad care monitoring',
-      'Lower alert thresholds',
-      'Helpful during outings or recovery',
-    ],
-    color: const Color(0xFF6366F1),
-  ),
-  GuardianPreset(
-    presetKey: 'MEMORY_SUPPORT',
-    name: 'Memory Support',
-    description:
-        'Proactive memory cues and gentle recall assistance for cognitive support.',
-    detailsBullets: [
-      'Memory cues',
-      'Daily routine reminders',
-      'Cognitive pattern monitoring',
-    ],
-    color: const Color(0xFF10B981),
-  ),
-  GuardianPreset(
-    presetKey: 'CYBORG',
-    name: 'Cyborg',
-    description:
-        'Experimental ambient intelligence — Ella listens broadly and speaks only when she can add useful context, coaching, memory, or insight.',
-    detailsBullets: [
-      'Ambient world enhancement',
-      'Useful companion asides',
-      'Experimental brain-enhancer mode',
-    ],
-    color: const Color(0xFFEC4899),
-  ),
-  GuardianPreset(
-    presetKey: 'CHATBOT',
-    name: 'Chatbot',
-    description:
-        'Full two-way voice conversation with Ella, focused on primary-speaker user utterances.',
-    detailsBullets: [
-      'Conversational replies',
-      'Suppresses media/background audio',
-      'Best for direct voice chat',
-    ],
-    color: const Color(0xFFF97316),
-  ),
-  GuardianPreset(
-    presetKey: 'DEMO',
-    name: 'Demo',
-    description:
-        'Demonstration mode with scripted responses for showcasing Ella.',
-    detailsBullets: ['Scripted demo responses', 'Showcase mode'],
-    color: const Color(0xFF3B82F6),
-  ),
-];
+      GuardianPreset(
+        presetKey: 'EMERGENCY_ONLY',
+        name: 'Emergency Alerts',
+        description: 'Critical alerts only — fall detection, medical emergencies, fire/smoke.',
+        detailsBullets: ['Medical emergencies', 'Fall detection', 'Fire/smoke'],
+        color: const Color(0xFFF59E0B),
+      ),
+      GuardianPreset(
+        presetKey: 'ACTIVE_SUPPORT',
+        name: 'Active Support',
+        description: 'Emergency alerts + recall assistance + schedule reminders + pattern monitoring.',
+        detailsBullets: [
+          'Medical emergencies',
+          'Wake words (always active)',
+          'Recall assistance',
+        ],
+        color: const Color(0xFF14B8A6),
+      ),
+      GuardianPreset(
+        presetKey: 'MAXIMUM_AWARENESS',
+        name: 'Maximum Awareness',
+        description:
+            'High-sensitivity care monitoring for risk, vulnerability, health, cognitive, emotional, and social support signals.',
+        detailsBullets: [
+          'Broad care monitoring',
+          'Lower alert thresholds',
+          'Helpful during outings or recovery',
+        ],
+        color: const Color(0xFF6366F1),
+      ),
+      GuardianPreset(
+        presetKey: 'MEMORY_SUPPORT',
+        name: 'Memory Support',
+        description: 'Proactive memory cues and gentle recall assistance for cognitive support.',
+        detailsBullets: [
+          'Memory cues',
+          'Daily routine reminders',
+          'Cognitive pattern monitoring',
+        ],
+        color: const Color(0xFF10B981),
+      ),
+      GuardianPreset(
+        presetKey: 'CYBORG',
+        name: 'Cyborg',
+        description:
+            'Experimental ambient intelligence — Ella listens broadly and speaks only when she can add useful context, coaching, memory, or insight.',
+        detailsBullets: [
+          'Ambient world enhancement',
+          'Useful companion asides',
+          'Experimental brain-enhancer mode',
+        ],
+        color: const Color(0xFFEC4899),
+      ),
+      GuardianPreset(
+        presetKey: 'CHATBOT',
+        name: 'Chatbot',
+        description: 'Full two-way voice conversation with Ella, focused on primary-speaker user utterances.',
+        detailsBullets: [
+          'Conversational replies',
+          'Suppresses media/background audio',
+          'Best for direct voice chat',
+        ],
+        color: const Color(0xFFF97316),
+      ),
+      GuardianPreset(
+        presetKey: 'DEMO',
+        name: 'Demo',
+        description: 'Demonstration mode with scripted responses for showcasing Ella.',
+        detailsBullets: ['Scripted demo responses', 'Showcase mode'],
+        color: const Color(0xFF3B82F6),
+      ),
+    ];

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.522+747
+version: 1.0.522+748
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.522+748
+version: 1.0.524+749
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+749
+version: 1.0.524+757
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.522+727
+version: 1.0.522+734
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.522+734
+version: 1.0.522+747
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary

Fixes the iOS Guardian playback route policy diagnosed in ellaaicare/ella-ai#785.

This branch is intentionally stacked on `codex/guardian-playback-events` / PR #127 so a TestFlight build keeps the #753 playback identity and loop-suppression telemetry while adding the #785 route-selection fix.

## Changes

- Replaces the app-wide `.playAndRecord` + `.defaultToSpeaker` session setup with a Guardian route policy that keeps recording support but enables `.allowBluetooth`, `.allowBluetoothA2DP`, `.allowAirPlay`, and `.mixWithOthers`.
- Clears stale speaker overrides before Guardian playback and route refreshes, so connected Bluetooth/headset routes can remain selected.
- Uses speaker fallback only when no external output route is active and iOS would otherwise fall back to receiver/earpiece.
- Re-applies the policy at app launch, interruption recovery, app active, Guardian start, remote Guardian audio injection, on-device Guardian TTS, and route-change handling.
- Bumps iOS build to `1.0.522+734` to avoid uploading behind the current TestFlight build.

## Validation

- `./test.sh`
- `flutter build ios --flavor prod --release --no-codesign`
- `git diff --check`

Hardware Bluetooth/headset, speaker fallback, and route-transition validation still requires an installed TestFlight/device build.