### PR TITLE
[codex] Write iOS chat and voice turns to canonical ledger

### DIFF
--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -12,12 +12,12 @@ import 'package:speech_to_text/speech_to_text.dart';
 
 import 'package:uuid/uuid.dart';
 
-import 'package:omi/backend/http/api/messages.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/services/ella_chat_service.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/ella/ella_theme.dart';
 import 'package:omi/ella/services/elevenlabs_tts.dart';
+import 'package:omi/ella/services/unified_memory_service.dart';
 import 'package:omi/ella/services/v2v_client.dart';
 import 'package:omi/ella/widgets/ella_voice_orb.dart';
 import 'package:omi/providers/capture_provider.dart';
@@ -70,6 +70,10 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   /// V2V client for WebSocket-based voice-to-voice mode
   V2VClient? _v2vClient;
   bool _isV2VMode = false;
+  String? _voiceSessionId;
+  DateTime? _voiceSessionStartedAt;
+  String _voiceSessionProvider = 'elevenlabs';
+  int _voiceTurnIndex = 0;
 
   /// Track whether we've injected chat messages for the current V2V turn
   bool _v2vTurnInjected = false;
@@ -195,6 +199,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     if (_speech.isListening) {
       _speech.stop();
     }
+    _completeUnifiedVoiceSession();
     _v2vClient?.disconnect();
     _v2vClient = null;
     super.dispose();
@@ -448,6 +453,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   Future<void> _startV2V(String provider) async {
     debugPrint('[VoiceChat] Starting V2V mode with provider: $provider');
     _isV2VMode = true;
+    _startUnifiedVoiceSession(provider);
 
     // Stop any existing mic recording from CaptureProvider
     if (mounted) {
@@ -508,6 +514,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     debugPrint('[VoiceChat] Stopping V2V mode');
     await _v2vClient?.disconnect();
     _v2vClient = null;
+    await _completeUnifiedVoiceSession();
     _pauseVoiceMode();
   }
 
@@ -598,6 +605,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   void _injectV2VTurnIfReady() {
     if (_v2vTurnInjected || _lastUserText.trim().isEmpty || _lastEllaText.trim().isEmpty) return;
     _injectVoiceMessages(_lastUserText.trim(), _lastEllaText.trim());
+    _writeUnifiedVoiceTurn(_lastUserText.trim(), _lastEllaText.trim());
     _v2vTurnInjected = true;
   }
 
@@ -620,6 +628,8 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   Future<void> _processTranscript(String transcript) async {
     debugPrint('[VoiceChat] Processing transcript: "$transcript"');
     _currentWords = '';
+    final provider = SharedPreferencesUtil().ttsProvider;
+    _startUnifiedVoiceSession(provider);
 
     if (!mounted) return;
     setState(() {
@@ -659,6 +669,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
       // Inject both messages into chat history so Chat tab shows them
       _injectVoiceMessages(transcript, fullReply);
+      _writeUnifiedVoiceTurn(transcript, fullReply);
 
       // Store full reply and start typewriter reveal
       _lastEllaText = fullReply;
@@ -754,6 +765,46 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     } catch (e) {
       debugPrint('[VoiceChat] Failed to inject messages: $e');
     }
+  }
+
+  void _startUnifiedVoiceSession(String provider) {
+    final normalizedProvider = V2VClient.normalizeProvider(provider);
+    if (_voiceSessionId != null && _voiceSessionProvider == normalizedProvider) return;
+
+    _voiceSessionId = UnifiedMemoryService.createVoiceSessionId();
+    _voiceSessionStartedAt = DateTime.now();
+    _voiceSessionProvider = normalizedProvider;
+    _voiceTurnIndex = 0;
+    UnifiedMemoryService.retryPendingWrites();
+  }
+
+  Future<void> _completeUnifiedVoiceSession() async {
+    final sessionId = _voiceSessionId;
+    if (sessionId == null) return;
+
+    _voiceSessionId = null;
+    await UnifiedMemoryService.completeVoiceSession(
+      sessionId: sessionId,
+      provider: _voiceSessionProvider,
+      turnCount: _voiceTurnIndex,
+      startedAt: _voiceSessionStartedAt,
+      endedAt: DateTime.now(),
+    );
+    _voiceSessionStartedAt = null;
+  }
+
+  void _writeUnifiedVoiceTurn(String userText, String ellaReply) {
+    final sessionId = _voiceSessionId;
+    if (sessionId == null) return;
+
+    _voiceTurnIndex++;
+    UnifiedMemoryService.writeVoiceTurn(
+      sessionId: sessionId,
+      provider: _voiceSessionProvider,
+      turnIndex: _voiceTurnIndex,
+      userText: userText,
+      assistantText: ellaReply,
+    );
   }
 
   /// Progressively reveals text with a typewriter effect.

--- a/app/lib/ella/services/unified_memory_service.dart
+++ b/app/lib/ella/services/unified_memory_service.dart
@@ -11,20 +11,93 @@ import 'package:omi/utils/logger.dart';
 const _pendingWritesKey = 'ellaUnifiedMemoryPendingWrites';
 const _writeEnabledKey = 'ellaUnifiedMemoryWriteEnabled';
 const _mockAdapterKey = 'ellaUnifiedMemoryMockAdapter';
+const _liveCanonicalBaseUrl = 'https://api.ella-ai-care.com/';
 
 /// Staged adapter for the canonical event/timeline APIs tracked by ella-ai#789.
 ///
-/// The adapter is default-off and mock-backed so this PR can land without
-/// changing current production voice/chat routing before the backend contract
-/// is deployed.
+/// Writes are live by default now that ella-ai#793 is deployed. The
+/// SharedPreferences flags remain as a kill switch / local mock mode.
 class UnifiedMemoryService {
   UnifiedMemoryService._();
 
-  static bool get isWriteEnabled => SharedPreferencesUtil().getBool(_writeEnabledKey);
+  static bool get isWriteEnabled => SharedPreferencesUtil().getBool(_writeEnabledKey, defaultValue: true);
 
-  static bool get isMockAdapter => SharedPreferencesUtil().getBool(_mockAdapterKey, defaultValue: true);
+  static bool get isMockAdapter => SharedPreferencesUtil().getBool(_mockAdapterKey);
 
   static String createVoiceSessionId() => 'ios_voice_${const Uuid().v4()}';
+
+  static String createChatSessionId() => 'ios_chat_${const Uuid().v4()}';
+
+  static List<CanonicalEllaEvent> buildTurnEvents({
+    required String channel,
+    required String sessionId,
+    required String provider,
+    required int turnIndex,
+    required String userText,
+    required String assistantText,
+    DateTime? startedAt,
+    DateTime? endedAt,
+  }) {
+    final now = DateTime.now().toUtc();
+    final started = (startedAt ?? now).toUtc();
+    final ended = (endedAt ?? now).toUtc();
+    final trimmedUserText = userText.trim();
+    final trimmedAssistantText = assistantText.trim();
+    final events = <CanonicalEllaEvent>[
+      if (trimmedUserText.isNotEmpty)
+        CanonicalEllaEvent.turn(
+          channel: channel,
+          sessionId: sessionId,
+          provider: provider,
+          eventId: '$sessionId:$turnIndex:user',
+          role: 'user',
+          text: trimmedUserText,
+          startedAt: started,
+          endedAt: ended,
+          scanPolicy: 'immediate',
+          metadata: {'turn_index': turnIndex},
+        ),
+      if (trimmedAssistantText.isNotEmpty)
+        CanonicalEllaEvent.turn(
+          channel: channel,
+          sessionId: sessionId,
+          provider: provider,
+          eventId: '$sessionId:$turnIndex:assistant',
+          role: 'assistant',
+          text: trimmedAssistantText,
+          startedAt: started,
+          endedAt: ended,
+          scanPolicy: 'none',
+          metadata: {'turn_index': turnIndex},
+        ),
+    ];
+    return events;
+  }
+
+  static Future<void> writeChatTurn({
+    required String sessionId,
+    required String userText,
+    required String assistantText,
+    DateTime? startedAt,
+    DateTime? endedAt,
+  }) async {
+    if (!isWriteEnabled) return;
+    if (_uid.isEmpty) return;
+
+    final events = buildTurnEvents(
+      channel: 'ios_chat',
+      sessionId: sessionId,
+      provider: 'openclaw',
+      turnIndex: 1,
+      userText: userText,
+      assistantText: assistantText,
+      startedAt: startedAt,
+      endedAt: endedAt,
+    );
+
+    if (events.isEmpty) return;
+    await _writePayload({'events': events.map((event) => event.toJson()).toList()});
+  }
 
   static Future<void> writeVoiceTurn({
     required String sessionId,
@@ -38,37 +111,16 @@ class UnifiedMemoryService {
     if (!isWriteEnabled) return;
     if (_uid.isEmpty) return;
 
-    final now = DateTime.now().toUtc();
-    final started = (startedAt ?? now).toUtc();
-    final ended = (endedAt ?? now).toUtc();
-    final trimmedUserText = userText.trim();
-    final trimmedAssistantText = assistantText.trim();
-    final events = <CanonicalEllaEvent>[
-      if (trimmedUserText.isNotEmpty)
-        CanonicalEllaEvent.voice(
-          sessionId: sessionId,
-          provider: provider,
-          eventId: '$sessionId:$turnIndex:user',
-          role: 'user',
-          text: trimmedUserText,
-          startedAt: started,
-          endedAt: ended,
-          scanPolicy: 'completion',
-          metadata: {'turn_index': turnIndex},
-        ),
-      if (trimmedAssistantText.isNotEmpty)
-        CanonicalEllaEvent.voice(
-          sessionId: sessionId,
-          provider: provider,
-          eventId: '$sessionId:$turnIndex:assistant',
-          role: 'assistant',
-          text: trimmedAssistantText,
-          startedAt: started,
-          endedAt: ended,
-          scanPolicy: 'none',
-          metadata: {'turn_index': turnIndex},
-        ),
-    ];
+    final events = buildTurnEvents(
+      channel: 'ios_voice',
+      sessionId: sessionId,
+      provider: provider,
+      turnIndex: turnIndex,
+      userText: userText,
+      assistantText: assistantText,
+      startedAt: startedAt,
+      endedAt: endedAt,
+    );
 
     if (events.isEmpty) return;
     await _writePayload({'events': events.map((event) => event.toJson()).toList()});
@@ -115,8 +167,8 @@ class UnifiedMemoryService {
 
     try {
       final response = await makeApiCall(
-        url: '${Env.apiBaseUrl}v1/ella/timeline?uid=$uid&limit=$limit&channels=ios_voice,ios_chat',
-        headers: {'Content-Type': 'application/json'},
+        url: '${_canonicalBaseUrl}v1/ella/timeline?uid=$uid&limit=$limit&channels=ios_voice,ios_chat',
+        headers: await _canonicalHeaders(),
         method: 'GET',
         body: '',
         timeout: const Duration(seconds: 10),
@@ -179,8 +231,8 @@ class UnifiedMemoryService {
   static Future<bool> _post({required String path, required Map<String, dynamic> payload}) async {
     try {
       final response = await makeApiCall(
-        url: '${Env.apiBaseUrl}$path',
-        headers: {'Content-Type': 'application/json'},
+        url: _canonicalBaseUrl + path,
+        headers: await _canonicalHeaders(),
         method: 'POST',
         body: jsonEncode(payload),
         timeout: const Duration(seconds: 10),
@@ -231,6 +283,22 @@ class UnifiedMemoryService {
   }
 
   static String get _uid => SharedPreferencesUtil().uid;
+
+  static String get _canonicalBaseUrl {
+    final configured = Env.apiBaseUrl ?? '';
+    if (configured.contains('api.ella-ai-care.com')) return configured;
+    return _liveCanonicalBaseUrl;
+  }
+
+  static Future<Map<String, String>> _canonicalHeaders() async {
+    final headers = {'Content-Type': 'application/json'};
+    try {
+      headers['Authorization'] = await getAuthHeader();
+    } catch (e) {
+      Logger.debug('[UnifiedMemory] Auth header unavailable: $e');
+    }
+    return headers;
+  }
 
   static String get _canonicalIdentity {
     final ellaUserId = SharedPreferencesUtil().ellaUserId;
@@ -285,7 +353,8 @@ class CanonicalEllaEvent {
   final Map<String, String> sourceRef;
   final Map<String, dynamic> metadata;
 
-  factory CanonicalEllaEvent.voice({
+  factory CanonicalEllaEvent.turn({
+    required String channel,
     required String sessionId,
     required String provider,
     required String eventId,
@@ -302,7 +371,7 @@ class CanonicalEllaEvent {
       canonicalIdentity: UnifiedMemoryService._canonicalIdentity,
       eventId: eventId,
       sessionId: sessionId,
-      channel: 'ios_voice',
+      channel: channel,
       provider: UnifiedMemoryService._normalizeProvider(provider),
       role: role,
       text: text,
@@ -310,7 +379,11 @@ class CanonicalEllaEvent {
       endedAt: endedAt,
       privacyScope: 'user_private',
       scanPolicy: scanPolicy,
-      sourceRef: {'type': 'ios_voice_session', 'id': sessionId},
+      sourceRef: {
+        'type': channel == 'ios_voice' ? 'ios_voice_session' : 'ios_chat_turn',
+        'id': sessionId,
+        'source_identity': 'ios-app:$channel:$sessionId',
+      },
       metadata: {
         'client': 'ios-app',
         'voice_mode': UnifiedMemoryService._voiceMode(provider),

--- a/app/lib/ella/services/unified_memory_service.dart
+++ b/app/lib/ella/services/unified_memory_service.dart
@@ -1,0 +1,338 @@
+import 'dart:convert';
+
+import 'package:uuid/uuid.dart';
+
+import 'package:omi/backend/http/shared.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/message.dart';
+import 'package:omi/env/env.dart';
+import 'package:omi/utils/logger.dart';
+
+const _pendingWritesKey = 'ellaUnifiedMemoryPendingWrites';
+const _writeEnabledKey = 'ellaUnifiedMemoryWriteEnabled';
+const _mockAdapterKey = 'ellaUnifiedMemoryMockAdapter';
+
+/// Staged adapter for the canonical event/timeline APIs tracked by ella-ai#789.
+///
+/// The adapter is default-off and mock-backed so this PR can land without
+/// changing current production voice/chat routing before the backend contract
+/// is deployed.
+class UnifiedMemoryService {
+  UnifiedMemoryService._();
+
+  static bool get isWriteEnabled => SharedPreferencesUtil().getBool(_writeEnabledKey);
+
+  static bool get isMockAdapter => SharedPreferencesUtil().getBool(_mockAdapterKey, defaultValue: true);
+
+  static String createVoiceSessionId() => 'ios_voice_${const Uuid().v4()}';
+
+  static Future<void> writeVoiceTurn({
+    required String sessionId,
+    required String provider,
+    required int turnIndex,
+    required String userText,
+    required String assistantText,
+    DateTime? startedAt,
+    DateTime? endedAt,
+  }) async {
+    if (!isWriteEnabled) return;
+    if (_uid.isEmpty) return;
+
+    final now = DateTime.now().toUtc();
+    final started = (startedAt ?? now).toUtc();
+    final ended = (endedAt ?? now).toUtc();
+    final trimmedUserText = userText.trim();
+    final trimmedAssistantText = assistantText.trim();
+    final events = <CanonicalEllaEvent>[
+      if (trimmedUserText.isNotEmpty)
+        CanonicalEllaEvent.voice(
+          sessionId: sessionId,
+          provider: provider,
+          eventId: '$sessionId:$turnIndex:user',
+          role: 'user',
+          text: trimmedUserText,
+          startedAt: started,
+          endedAt: ended,
+          scanPolicy: 'completion',
+          metadata: {'turn_index': turnIndex},
+        ),
+      if (trimmedAssistantText.isNotEmpty)
+        CanonicalEllaEvent.voice(
+          sessionId: sessionId,
+          provider: provider,
+          eventId: '$sessionId:$turnIndex:assistant',
+          role: 'assistant',
+          text: trimmedAssistantText,
+          startedAt: started,
+          endedAt: ended,
+          scanPolicy: 'none',
+          metadata: {'turn_index': turnIndex},
+        ),
+    ];
+
+    if (events.isEmpty) return;
+    await _writePayload({'events': events.map((event) => event.toJson()).toList()});
+  }
+
+  static Future<void> completeVoiceSession({
+    required String sessionId,
+    required String provider,
+    required int turnCount,
+    DateTime? startedAt,
+    DateTime? endedAt,
+  }) async {
+    if (!isWriteEnabled) return;
+
+    final uid = _uid;
+    if (uid.isEmpty) return;
+
+    final payload = {
+      'uid': uid,
+      'canonical_identity': _canonicalIdentity,
+      'session_id': sessionId,
+      'channel': 'ios_voice',
+      'provider': _normalizeProvider(provider),
+      'started_at': (startedAt ?? endedAt ?? DateTime.now()).toUtc().toIso8601String(),
+      'ended_at': (endedAt ?? DateTime.now()).toUtc().toIso8601String(),
+      'privacy_scope': 'user_private',
+      'scan_policy': 'completion',
+      'source_ref': {'type': 'ios_voice_session', 'id': sessionId},
+      'metadata': {
+        'client': 'ios-app',
+        'turn_count': turnCount,
+        'voice_mode': _voiceMode(provider),
+      },
+    };
+
+    await _writePayload(payload, path: 'v1/ella/sessions/$sessionId/complete');
+  }
+
+  static Future<List<ServerMessage>> fetchTimelineMessages({int limit = 50}) async {
+    if (!isWriteEnabled || isMockAdapter) return [];
+
+    final uid = _uid;
+    if (uid.isEmpty) return [];
+
+    try {
+      final response = await makeApiCall(
+        url: '${Env.apiBaseUrl}v1/ella/timeline?uid=$uid&limit=$limit&channels=ios_voice,ios_chat',
+        headers: {'Content-Type': 'application/json'},
+        method: 'GET',
+        body: '',
+        timeout: const Duration(seconds: 10),
+      );
+      if (response == null || response.statusCode != 200) {
+        Logger.debug('[UnifiedMemory] Timeline fetch failed: ${response?.statusCode}');
+        return [];
+      }
+
+      final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+      final rawItems = (decoded['events'] ?? decoded['items'] ?? []) as List<dynamic>;
+      final messages = <ServerMessage>[];
+      for (final raw in rawItems) {
+        if (raw is! Map<String, dynamic>) continue;
+        final message = _messageFromTimelineEvent(raw);
+        if (message != null) messages.add(message);
+      }
+      messages.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+      return messages;
+    } catch (e) {
+      Logger.debug('[UnifiedMemory] Timeline fetch error: $e');
+      return [];
+    }
+  }
+
+  static Future<void> retryPendingWrites() async {
+    if (!isWriteEnabled || isMockAdapter) return;
+
+    final prefs = SharedPreferencesUtil();
+    final pending = prefs.getStringList(_pendingWritesKey);
+    if (pending.isEmpty) return;
+
+    final remaining = <String>[];
+    for (final encoded in pending) {
+      try {
+        final payload = jsonDecode(encoded) as Map<String, dynamic>;
+        final path = payload.remove('_path') as String? ?? 'v1/ella/events';
+        final ok = await _post(path: path, payload: payload);
+        if (!ok) remaining.add(encoded);
+      } catch (_) {
+        remaining.add(encoded);
+      }
+    }
+    await prefs.saveStringList(_pendingWritesKey, remaining);
+  }
+
+  static Future<void> _writePayload(Map<String, dynamic> payload, {String path = 'v1/ella/events'}) async {
+    if (isMockAdapter) {
+      await _queuePayload(path: path, payload: payload);
+      Logger.debug('[UnifiedMemory] Mock adapter queued $path');
+      return;
+    }
+
+    final ok = await _post(path: path, payload: payload);
+    if (!ok) {
+      await _queuePayload(path: path, payload: payload);
+    }
+  }
+
+  static Future<bool> _post({required String path, required Map<String, dynamic> payload}) async {
+    try {
+      final response = await makeApiCall(
+        url: '${Env.apiBaseUrl}$path',
+        headers: {'Content-Type': 'application/json'},
+        method: 'POST',
+        body: jsonEncode(payload),
+        timeout: const Duration(seconds: 10),
+      );
+      final status = response?.statusCode ?? 0;
+      if (status >= 200 && status < 300) return true;
+      Logger.debug('[UnifiedMemory] Write failed: $path status=$status');
+      return false;
+    } catch (e) {
+      Logger.debug('[UnifiedMemory] Write error: $e');
+      return false;
+    }
+  }
+
+  static Future<void> _queuePayload({required String path, required Map<String, dynamic> payload}) async {
+    final prefs = SharedPreferencesUtil();
+    final pending = List<String>.from(prefs.getStringList(_pendingWritesKey));
+    final queued = {...payload, '_path': path};
+    pending.add(jsonEncode(queued));
+    await prefs.saveStringList(_pendingWritesKey, pending);
+  }
+
+  static ServerMessage? _messageFromTimelineEvent(Map<String, dynamic> event) {
+    final text = event['text'] as String? ?? '';
+    if (text.trim().isEmpty) return null;
+
+    final role = event['role'] as String? ?? '';
+    if (role != 'user' && role != 'assistant') return null;
+
+    final startedAt = event['started_at'] as String? ?? event['created_at'] as String?;
+    final createdAt = DateTime.tryParse(startedAt ?? '')?.toLocal() ?? DateTime.now();
+    final channel = event['channel'] as String? ?? '';
+
+    return ServerMessage(
+      event['event_id'] as String? ?? const Uuid().v4(),
+      createdAt,
+      text,
+      role == 'user' ? MessageSender.human : MessageSender.ai,
+      MessageType.text,
+      null,
+      false,
+      [],
+      [],
+      [],
+      askForNps: false,
+      fromVoice: channel == 'ios_voice',
+    );
+  }
+
+  static String get _uid => SharedPreferencesUtil().uid;
+
+  static String get _canonicalIdentity {
+    final ellaUserId = SharedPreferencesUtil().ellaUserId;
+    if (ellaUserId.isNotEmpty) return ellaUserId;
+    return _uid;
+  }
+
+  static String _normalizeProvider(String provider) => switch (provider) {
+        'gemini-live' => 'gemini-native-live',
+        'openai-realtime' => 'openai-native-realtime',
+        _ => provider,
+      };
+
+  static String? _voiceMode(String provider) => switch (_normalizeProvider(provider)) {
+        'openclaw-direct' => 'openclaw-direct-v1',
+        'openai-native-realtime' => 'openai-native-realtime-v1',
+        'gemini-native-live' => 'gemini-native-live-v1',
+        _ => null,
+      };
+}
+
+class CanonicalEllaEvent {
+  CanonicalEllaEvent({
+    required this.uid,
+    required this.canonicalIdentity,
+    required this.eventId,
+    required this.sessionId,
+    required this.channel,
+    required this.provider,
+    required this.role,
+    required this.text,
+    required this.startedAt,
+    required this.endedAt,
+    required this.privacyScope,
+    required this.scanPolicy,
+    required this.sourceRef,
+    required this.metadata,
+  });
+
+  final String uid;
+  final String canonicalIdentity;
+  final String eventId;
+  final String sessionId;
+  final String channel;
+  final String provider;
+  final String role;
+  final String text;
+  final DateTime startedAt;
+  final DateTime endedAt;
+  final String privacyScope;
+  final String scanPolicy;
+  final Map<String, String> sourceRef;
+  final Map<String, dynamic> metadata;
+
+  factory CanonicalEllaEvent.voice({
+    required String sessionId,
+    required String provider,
+    required String eventId,
+    required String role,
+    required String text,
+    required DateTime startedAt,
+    required DateTime endedAt,
+    required String scanPolicy,
+    required Map<String, dynamic> metadata,
+  }) {
+    final uid = UnifiedMemoryService._uid;
+    return CanonicalEllaEvent(
+      uid: uid,
+      canonicalIdentity: UnifiedMemoryService._canonicalIdentity,
+      eventId: eventId,
+      sessionId: sessionId,
+      channel: 'ios_voice',
+      provider: UnifiedMemoryService._normalizeProvider(provider),
+      role: role,
+      text: text,
+      startedAt: startedAt,
+      endedAt: endedAt,
+      privacyScope: 'user_private',
+      scanPolicy: scanPolicy,
+      sourceRef: {'type': 'ios_voice_session', 'id': sessionId},
+      metadata: {
+        'client': 'ios-app',
+        'voice_mode': UnifiedMemoryService._voiceMode(provider),
+        ...metadata,
+      },
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'uid': uid,
+        'canonical_identity': canonicalIdentity,
+        'event_id': eventId,
+        'session_id': sessionId,
+        'channel': channel,
+        'provider': provider,
+        'role': role,
+        'text': text,
+        'started_at': startedAt.toUtc().toIso8601String(),
+        'ended_at': endedAt.toUtc().toIso8601String(),
+        'privacy_scope': privacyScope,
+        'scan_policy': scanPolicy,
+        'source_ref': sourceRef,
+        'metadata': metadata,
+      };
+}

--- a/app/lib/providers/message_provider.dart
+++ b/app/lib/providers/message_provider.dart
@@ -657,6 +657,8 @@ class MessageProvider extends ChangeNotifier {
     clearUploadedFiles();
     String textBuffer = '';
     Timer? timer;
+    final chatSessionId = UnifiedMemoryService.createChatSessionId();
+    final chatStartedAt = DateTime.now();
 
     void flushBuffer() {
       if (textBuffer.isNotEmpty) {
@@ -715,6 +717,14 @@ class MessageProvider extends ChangeNotifier {
     } finally {
       timer?.cancel();
       flushBuffer();
+      final assistantText = isEllaOperationalChatText(message.text) ? '' : message.text;
+      await UnifiedMemoryService.writeChatTurn(
+        sessionId: chatSessionId,
+        userText: text,
+        assistantText: assistantText,
+        startedAt: chatStartedAt,
+        endedAt: DateTime.now(),
+      );
       if (isEllaOperationalChatText(message.text) && aiIndex >= 0 && aiIndex < messages.length) {
         messages.removeAt(aiIndex);
         Logger.debug('[EllaChat] Suppressed operational streaming response');

--- a/app/lib/providers/message_provider.dart
+++ b/app/lib/providers/message_provider.dart
@@ -68,12 +68,27 @@ class MessageProvider extends ChangeNotifier {
     final timelineMessages = await UnifiedMemoryService.fetchTimelineMessages(limit: 50);
     if (timelineMessages.isEmpty) return baseMessages;
 
-    final merged = <String, ServerMessage>{
-      for (final message in baseMessages) message.id: message,
-      for (final message in timelineMessages) message.id: message,
-    }.values.toList();
+    final merged = <ServerMessage>[...baseMessages];
+    final seenIds = baseMessages.map((message) => message.id).toSet();
+    for (final timelineMessage in timelineMessages) {
+      if (seenIds.contains(timelineMessage.id)) continue;
+      if (_hasNearDuplicateMessage(merged, timelineMessage)) continue;
+      merged.add(timelineMessage);
+      seenIds.add(timelineMessage.id);
+    }
     merged.sort((a, b) => a.createdAt.compareTo(b.createdAt));
     return _withoutEllaOperationalMessages(merged);
+  }
+
+  bool _hasNearDuplicateMessage(List<ServerMessage> existingMessages, ServerMessage candidate) {
+    final normalizedText = candidate.text.trim();
+    if (normalizedText.isEmpty) return false;
+
+    return existingMessages.any((message) {
+      if (message.sender != candidate.sender) return false;
+      if (message.text.trim() != normalizedText) return false;
+      return message.createdAt.difference(candidate.createdAt).abs() <= const Duration(minutes: 2);
+    });
   }
 
   void updateAppProvider(AppProvider p) {

--- a/app/lib/providers/message_provider.dart
+++ b/app/lib/providers/message_provider.dart
@@ -14,6 +14,7 @@ import 'package:uuid/uuid.dart';
 import 'package:omi/backend/http/api/apps.dart';
 import 'package:omi/backend/http/api/messages.dart';
 import 'package:omi/ella/services/ella_chat_service.dart';
+import 'package:omi/ella/services/unified_memory_service.dart';
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/app.dart';
@@ -62,6 +63,18 @@ class MessageProvider extends ChangeNotifier {
 
   List<ServerMessage> _withoutEllaOperationalMessages(List<ServerMessage> source) =>
       source.where((message) => !isEllaOperationalChatText(message.text)).toList();
+
+  Future<List<ServerMessage>> _withUnifiedTimelineMessages(List<ServerMessage> baseMessages) async {
+    final timelineMessages = await UnifiedMemoryService.fetchTimelineMessages(limit: 50);
+    if (timelineMessages.isEmpty) return baseMessages;
+
+    final merged = <String, ServerMessage>{
+      for (final message in baseMessages) message.id: message,
+      for (final message in timelineMessages) message.id: message,
+    }.values.toList();
+    merged.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    return _withoutEllaOperationalMessages(merged);
+  }
 
   void updateAppProvider(AppProvider p) {
     appProvider = p;
@@ -415,6 +428,8 @@ class MessageProvider extends ChangeNotifier {
           setHasCachedMessages(true);
         }
       }
+      messages = await _withUnifiedTimelineMessages(messages);
+      SharedPreferencesUtil().cachedMessages = messages;
       messages.sort((a, b) => a.createdAt.compareTo(b.createdAt));
       setLoadingMessages(false);
       notifyListeners();

--- a/app/test/ella/services/unified_memory_service_test.dart
+++ b/app/test/ella/services/unified_memory_service_test.dart
@@ -38,9 +38,39 @@ void main() {
       expect(events.first['channel'], 'ios_voice');
       expect(events.first['provider'], 'gemini-native-live');
       expect(events.first['role'], 'user');
-      expect(events.first['scan_policy'], 'completion');
+      expect(events.first['scan_policy'], 'immediate');
       expect(events[1]['event_id'], 'ios_voice_test:1:assistant');
       expect(events[1]['scan_policy'], 'none');
+      expect(events.first['source_ref']['source_identity'], 'ios-app:ios_voice:ios_voice_test');
+    });
+
+    test('builds stable ios_chat event ids and source refs', () {
+      final events = UnifiedMemoryService.buildTurnEvents(
+        channel: 'ios_chat',
+        sessionId: 'ios_chat_test',
+        provider: 'openclaw',
+        turnIndex: 1,
+        userText: 'what did we discuss?',
+        assistantText: 'we discussed timing.',
+        startedAt: DateTime.utc(2026, 4, 28, 2),
+        endedAt: DateTime.utc(2026, 4, 28, 2, 0, 3),
+      );
+
+      final userEvent = events.first.toJson();
+      final assistantEvent = events[1].toJson();
+
+      expect(userEvent['event_id'], 'ios_chat_test:1:user');
+      expect(assistantEvent['event_id'], 'ios_chat_test:1:assistant');
+      expect(userEvent['channel'], 'ios_chat');
+      expect(userEvent['provider'], 'openclaw');
+      expect(userEvent['role'], 'user');
+      expect(userEvent['scan_policy'], 'immediate');
+      expect(assistantEvent['role'], 'assistant');
+      expect(assistantEvent['scan_policy'], 'none');
+      expect(userEvent['source_ref']['type'], 'ios_chat_turn');
+      expect(userEvent['source_ref']['source_identity'], 'ios-app:ios_chat:ios_chat_test');
+      expect(userEvent['privacy_scope'], 'user_private');
+      expect(userEvent['text'], 'what did we discuss?');
     });
 
     test('does nothing when writes are disabled', () async {

--- a/app/test/ella/services/unified_memory_service_test.dart
+++ b/app/test/ella/services/unified_memory_service_test.dart
@@ -1,0 +1,60 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/unified_memory_service.dart';
+
+void main() {
+  group('UnifiedMemoryService', () {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      await SharedPreferencesUtil.init();
+      SharedPreferencesUtil().uid = 'uid-123';
+      await SharedPreferencesUtil().saveBool('ellaUnifiedMemoryWriteEnabled', true);
+      await SharedPreferencesUtil().saveBool('ellaUnifiedMemoryMockAdapter', true);
+    });
+
+    test('queues canonical voice events in mock adapter mode', () async {
+      await UnifiedMemoryService.writeVoiceTurn(
+        sessionId: 'ios_voice_test',
+        provider: 'gemini-live',
+        turnIndex: 1,
+        userText: 'hello',
+        assistantText: 'hi there',
+        startedAt: DateTime.utc(2026, 4, 28, 1),
+        endedAt: DateTime.utc(2026, 4, 28, 1, 0, 1),
+      );
+
+      final pending = SharedPreferencesUtil().getStringList('ellaUnifiedMemoryPendingWrites');
+      expect(pending, hasLength(1));
+
+      final payload = jsonDecode(pending.single) as Map<String, dynamic>;
+      final events = payload['events'] as List<dynamic>;
+      expect(payload['_path'], 'v1/ella/events');
+      expect(events, hasLength(2));
+      expect(events.first['event_id'], 'ios_voice_test:1:user');
+      expect(events.first['channel'], 'ios_voice');
+      expect(events.first['provider'], 'gemini-native-live');
+      expect(events.first['role'], 'user');
+      expect(events.first['scan_policy'], 'completion');
+      expect(events[1]['event_id'], 'ios_voice_test:1:assistant');
+      expect(events[1]['scan_policy'], 'none');
+    });
+
+    test('does nothing when writes are disabled', () async {
+      await SharedPreferencesUtil().saveBool('ellaUnifiedMemoryWriteEnabled', false);
+
+      await UnifiedMemoryService.writeVoiceTurn(
+        sessionId: 'ios_voice_test',
+        provider: 'openai-native-realtime',
+        turnIndex: 1,
+        userText: 'hello',
+        assistantText: 'hi',
+      );
+
+      expect(SharedPreferencesUtil().getStringList('ellaUnifiedMemoryPendingWrites'), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the iOS write-side sink for ella-ai#791 using the live canonical event ledger from ella-ai#789/#793.

- Writes app chat turns as `ios_chat` events to `POST https://api.ella-ai-care.com/v1/ella/events`.
- Writes voice/V2V turns as `ios_voice` events with the existing cosmetic transcript rendering preserved.
- Uses stable idempotent event IDs: `{session_id}:{turn_index}:{role}`.
- Supplies stable `source_ref.source_identity`: `ios-app:{channel}:{session_id}`.
- Includes `uid`, `canonical_identity`, `session_id`, `provider`, `role`, raw `text`, `started_at`, `ended_at`, `privacy_scope=user_private`, and `scan_policy=immediate` for user turns / `none` for assistant turns.
- Keeps the live writer default-on now that #793 is deployed, with local kill switches still available: `ellaUnifiedMemoryWriteEnabled=false` disables writes and `ellaUnifiedMemoryMockAdapter=true` queues payloads locally.
- Preserves existing voice selectors, existing chat route behavior, and current UI transcript rendering.

## Validation

- `flutter test test/ella/services/unified_memory_service_test.dart test/ella/services/v2v_client_test.dart`
- `./test.sh`
- `git diff --check`

Focused `flutter analyze` was run against touched files. It exits nonzero only for existing legacy warnings/infos in `ella_voice_chat_page.dart` and `message_provider.dart`: unused `_didPauseCaptureRecording`, deprecated speech APIs/`withOpacity`, and `const isEllaApp` dead-code warnings. No new analyzer issue remains in `unified_memory_service.dart`.

## Notes

This PR does not change Firebase/auth/signing config and does not alter the visible voice-mode selector list.