### PR TITLE
Add Ella conversation tags and signal metadata

### DIFF
--- a/app/lib/backend/schema/conversation.dart
+++ b/app/lib/backend/schema/conversation.dart
@@ -190,6 +190,8 @@ class ServerConversation {
 
   final ConversationExternalData? externalIntegration;
   final Object? internalAssessment;
+  final List<String> ellaTags;
+  final Map<String, dynamic>? ellaSignal;
 
   ConversationStatus status;
   bool discarded;
@@ -219,6 +221,8 @@ class ServerConversation {
     this.language,
     this.externalIntegration,
     this.internalAssessment,
+    this.ellaTags = const [],
+    this.ellaSignal,
     this.status = ConversationStatus.completed,
     this.isLocked = false,
     this.starred = false,
@@ -251,6 +255,8 @@ class ServerConversation {
       externalIntegration:
           json['external_data'] != null ? ConversationExternalData.fromJson(json['external_data']) : null,
       internalAssessment: json['internal_assessment'],
+      ellaTags: ((json['ella_tags'] ?? []) as List<dynamic>).map((tag) => tag.toString()).toList(),
+      ellaSignal: json['ella_signal'] is Map ? Map<String, dynamic>.from(json['ella_signal']) : null,
       status: json['status'] != null
           ? ConversationStatus.values.asNameMap()[json['status']] ?? ConversationStatus.completed
           : ConversationStatus.completed,
@@ -278,6 +284,8 @@ class ServerConversation {
       'language': language,
       'external_data': externalIntegration?.toJson(),
       'internal_assessment': internalAssessment,
+      'ella_tags': ellaTags,
+      'ella_signal': ellaSignal,
       'status': status.toString().split('.').last,
       'is_locked': isLocked,
       'starred': starred,

--- a/app/test/backend/schema/conversation_test.dart
+++ b/app/test/backend/schema/conversation_test.dart
@@ -23,13 +23,27 @@ void main() {
           'score': 0.93,
           'reasons': ['low_confidence_title'],
         },
+        'ella_tags': ['omi', 'family', 'guardian_relevant'],
+        'ella_signal': {
+          'salience': 'high',
+          'memory_promotion': 'candidate',
+          'guardian_relevant': true,
+        },
       });
 
       expect(conversation.hasInternalAssessment, isTrue);
       expect(conversation.internalAssessmentDebugText, contains('"score": 0.93'));
+      expect(conversation.ellaTags, ['omi', 'family', 'guardian_relevant']);
+      expect(conversation.ellaSignal?['salience'], 'high');
       expect(conversation.toJson()['internal_assessment'], {
         'score': 0.93,
         'reasons': ['low_confidence_title'],
+      });
+      expect(conversation.toJson()['ella_tags'], ['omi', 'family', 'guardian_relevant']);
+      expect(conversation.toJson()['ella_signal'], {
+        'salience': 'high',
+        'memory_promotion': 'candidate',
+        'guardian_relevant': true,
       });
     });
   });

--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -30,7 +30,7 @@ import secrets
 import string
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import asyncpg
 import httpx
@@ -166,6 +166,20 @@ class ConversationSummaryUpdate(BaseModel):
     correction_id: Optional[str] = None
     based_on_version_id: Optional[str] = None
     set_active: bool = True
+    ella_tags: List[str] = Field(default_factory=list)
+    ella_signal: Optional[Dict[str, Any]] = None
+
+
+def _normalize_ella_tags(tags: List[str]) -> List[str]:
+    """Normalize bounded conversation tags for app filtering and recall ranking."""
+    normalized: list[str] = []
+    for tag in tags or []:
+        clean = str(tag).strip().lower().replace(" ", "_")
+        if not clean or len(clean) > 64:
+            continue
+        if clean not in normalized:
+            normalized.append(clean)
+    return normalized[:12]
 
 
 def _update_correction_audit(
@@ -338,6 +352,11 @@ async def update_conversation_summary(
     internal_assessment = await _fetch_internal_assessment(uid, conversation_id)
     if internal_assessment:
         update_data["internal_assessment"] = internal_assessment
+    ella_tags = _normalize_ella_tags(update.ella_tags)
+    if ella_tags:
+        update_data["ella_tags"] = ella_tags
+    if update.ella_signal is not None:
+        update_data["ella_signal"] = update.ella_signal
     if update.correction_id:
         existing_state = conversation.get("correction_state") or {}
         update_data["correction_state"] = {

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -239,6 +239,18 @@ class InternalAssessment(BaseModel):
     escalation_recommendation: Optional[str] = Field(default=None, description="Recommended escalation action")
     reason_codes: List[str] = Field(default_factory=list, description="Machine-readable internal assessment reasons")
     notes: Optional[str] = Field(default=None, description="Short internal notes for debug/operator use")
+
+
+class EllaSignal(BaseModel):
+    salience: Optional[str] = Field(default=None, description="low, medium, or high signal for recall/ranking")
+    memory_promotion: Optional[str] = Field(default=None, description="none, candidate, or promoted")
+    noise_level: Optional[str] = Field(default=None, description="none, low, medium, or high noise")
+    contains_media: bool = False
+    contains_user_speech: bool = False
+    guardian_relevant: bool = False
+    metadata: Dict[str, Any] = Field(default_factory=dict, description="Reserved signal metadata")
+
+
 class Geolocation(BaseModel):
     google_place_id: Optional[str] = None
     latitude: float
@@ -336,6 +348,8 @@ class Conversation(BaseModel):
     active_summary_version_id: Optional[str] = None
     correction_state: Optional[CorrectionState] = None
     internal_assessment: Optional[InternalAssessment] = None
+    ella_tags: List[str] = Field(default_factory=list)
+    ella_signal: Optional[EllaSignal] = None
     transcript_segments: List[TranscriptSegment] = []
     transcript_segments_compressed: Optional[bool] = False
     geolocation: Optional[Geolocation] = None


### PR DESCRIPTION
## Summary
- add backend conversation fields for `ella_tags` and `ella_signal`
- let the Ella summary callback persist bounded tag/signal metadata from Hermes enrichment
- parse/serialize those fields in the Flutter conversation schema for future iOS filtering

## Validation
- `python3 -m py_compile backend/models/conversation.py backend/ella/routers/callbacks.py`
- `./test.sh`
- `flutter test test/backend/schema/conversation_test.dart`

Tracks ellaaicare/ella-ai#815.