### PR TITLE
Return voice memory hits without fallback delay

### DIFF
--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -2055,6 +2055,27 @@ async def unified_search(request: Request):
 
     _start = time.time()
 
+    # Realtime voice needs a bounded fast path. If the compact Hermes memory
+    # pack has a high-confidence answer, return it immediately and avoid
+    # waiting on slower Firestore/workspace/Honcho fallback searches.
+    if agent_role == "voice" and not requested_sources:
+        fast_results = await _search_voice_memory_pack(uid, query, limit)
+        if fast_results and fast_results[0].get("score", 0) >= 120:
+            _elapsed = int((time.time() - _start) * 1000)
+            logger.info(
+                f"[FLOW:UNIFIED-SEARCH] uid={uid} role={agent_role} query=\"{query}\" "
+                f"sources=['voice_memory'] results={len(fast_results)} denied=[] "
+                f"latency={_elapsed}ms fast_path=true"
+            )
+            return {
+                "results": fast_results,
+                "sources_searched": ["voice_memory"],
+                "sources_denied": [],
+                "total_results": len(fast_results),
+                "query": query,
+                "fast_path": True,
+            }
+
     # Resolve agent_id from postgres if not provided
     if not agent_id:
         try:

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -59,6 +59,8 @@ GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 PROVISION_API_URL = os.getenv("ELLA_PROVISION_API_URL", "http://100.76.138.56:8200")
 PROVISION_API_TOKEN = os.getenv("ELLA_PROVISION_API_TOKEN", "")
+HERMES_VOICE_MEMORY_URL = os.getenv("HERMES_VOICE_MEMORY_URL", "http://100.76.138.56:8210/v1/voice/memory/lookup")
+HERMES_VOICE_MEMORY_TOKEN = os.getenv("HERMES_VOICE_MEMORY_TOKEN", PROVISION_API_TOKEN)
 DEFAULT_GATEWAY_URL = os.getenv("OPENCLAW_URL", "http://100.76.138.56:19001")
 OPENCLAW_GATEWAY_TOKEN = os.getenv("OPENCLAW_GATEWAY_TOKEN", "")
 
@@ -1397,6 +1399,58 @@ async def _search_canonical_timeline(uid: str, query: str, limit: int) -> list:
         return results
 
 
+async def _search_voice_memory_pack(uid: str, query: str, limit: int) -> list:
+    """Fast Hermes voice-memory lookup for realtime providers.
+
+    This is the preferred low-latency path for live V2V tools. It reads the
+    compact Hermes pack and returns quickly; heavier Firestore/workspace/Honcho
+    searches remain fallback sources in the merged /v1/voice/search response.
+    """
+    if not HERMES_VOICE_MEMORY_URL or not HERMES_VOICE_MEMORY_TOKEN:
+        return []
+    try:
+        async with httpx.AsyncClient(timeout=1.8) as client:
+            resp = await client.post(
+                HERMES_VOICE_MEMORY_URL,
+                headers={"Authorization": f"Bearer {HERMES_VOICE_MEMORY_TOKEN}"},
+                json={
+                    "uid": uid,
+                    "query": query,
+                    "scope": "recent",
+                    "detail": "brief",
+                    "top_k": min(max(limit, 1), 5),
+                },
+            )
+        if resp.status_code != 200:
+            logger.warning(f"[FLOW:VOICE-MEMORY] lookup returned {resp.status_code}: {resp.text[:200]}")
+            return []
+        data = resp.json()
+        answer = (data.get("answer") or "").strip()
+        if not answer or data.get("confidence") in {"low", "unknown"}:
+            return []
+        sources = data.get("sources") or []
+        top = sources[0] if sources else {}
+        confidence = data.get("confidence") or "medium"
+        score = 120 if confidence == "high" else 70
+        return [{
+            "source": "voice_memory",
+            "title": top.get("title") or "Hermes Voice Memory",
+            "content": answer[:900],
+            "timestamp": top.get("timestamp") or "",
+            "score": score,
+            "metadata": {
+                "path": data.get("path"),
+                "confidence": confidence,
+                "latency_ms": data.get("latency_ms"),
+                "source_ref": top.get("source_ref"),
+                "channel": top.get("channel"),
+            },
+        }]
+    except Exception as e:
+        logger.warning(f"[FLOW:VOICE-MEMORY] lookup error: {e}")
+        return []
+
+
 async def _fetch_recent_canonical_timeline(uid: str, limit: int = 30, max_chars: int = 9000) -> str:
     """Fetch the latest cross-channel turns for realtime voice startup context.
 
@@ -2032,6 +2086,10 @@ async def unified_search(request: Request):
     tasks = []
     task_source_names = []
 
+    if agent_role in {"voice", "user"} and (not requested_sources or "voice_memory" in requested_sources):
+        tasks.append(_search_voice_memory_pack(uid, query, limit))
+        task_source_names.append("voice_memory")
+
     if allowed.get("timeline"):
         tasks.append(_search_canonical_timeline(uid, query, limit))
         task_source_names.append("timeline")
@@ -2060,7 +2118,7 @@ async def unified_search(request: Request):
         task_source_names.append("scanner")
 
     # Determine which sources were denied
-    all_source_names = {"timeline", "workspace", "omi", "memories", "voice", "scanner"}
+    all_source_names = {"voice_memory", "timeline", "workspace", "omi", "memories", "voice", "scanner"}
     if requested_sources:
         requested_set = set(requested_sources)
     else:


### PR DESCRIPTION
## Summary\n- return immediately from /v1/voice/search when voice-role Hermes memory lookup is high confidence\n- keep existing legacy fan-out for misses, low confidence, and explicit source requests\n\n## Live validation\n- deployed to VPS and restarted omi-backend.service\n- backpack / Whole Foods probe returns fast_path=true, source=voice_memory, Hermes lookup latency_ms=8, total HTTP time 0.258s\n\nRollback: revert this commit; the prior merged voice_memory source still works but waits for fallback searches.