### PR TITLE
Preserve recent transcript context for scanner wake-word recovery

### DIFF
--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -13,6 +13,7 @@ Audio files: /var/www/ella-ai-care.com/audio/{uid}/*.mp3
 
 import json
 import os
+import re
 import time
 import uuid
 from typing import Optional
@@ -32,12 +33,12 @@ router = APIRouter(prefix="/v1/ella/guardian", tags=["Guardian Mode"])
 
 AUDIO_BASE_DIR = "/var/www/ella-ai-care.com/audio"
 AUDIO_PUBLIC_URL = "https://ella-ai-care.com/audio"
-GUARDIAN_WEBHOOK_KEY = os.getenv(
-    "GUARDIAN_WEBHOOK_KEY", "4f13699d8462adf71e35d2098e6a791f"
-)
+GUARDIAN_WEBHOOK_KEY = os.getenv("GUARDIAN_WEBHOOK_KEY", "4f13699d8462adf71e35d2098e6a791f")
 
 # Consolidate queue when this many non-debug items are pending
 CONSOLIDATION_THRESHOLD = int(os.getenv("CONSOLIDATION_THRESHOLD", "3"))
+QUEUE_DEDUPE_WINDOW_SECONDS = int(os.getenv("GUARDIAN_QUEUE_DEDUPE_WINDOW_SECONDS", "90"))
+WAKE_WORD_ACK_TEXT = os.getenv("GUARDIAN_WAKE_WORD_ACK_TEXT", "I heard you. Give me a moment.")
 
 # Provision API for chat history lookups
 _PROVISION_API_URL = os.getenv("ELLA_PROVISION_API_URL", "http://100.76.138.56:8200")
@@ -61,17 +62,18 @@ _playback_events: dict[str, dict] = {}
 
 # Echo risk by iOS AVAudioSession portType rawValue
 _ECHO_RISK = {
-    "Speaker": "high",        # builtInSpeaker
-    "Receiver": "none",       # builtInReceiver
-    "Headphones": "none",     # headphones
-    "BluetoothHFP": "none",   # BT headset (hands-free)
+    "Speaker": "high",  # builtInSpeaker
+    "Receiver": "none",  # builtInReceiver
+    "Headphones": "none",  # headphones
+    "BluetoothHFP": "none",  # BT headset (hands-free)
     "BluetoothA2DP": "high",  # BT speaker/headphones
     "BluetoothLE": "medium",  # BT LE audio
-    "AirPlay": "very_high",   # AirPlay / Apple TV
+    "AirPlay": "very_high",  # AirPlay / Apple TV
     "HDMI": "very_high",
     "CarAudio": "high",
     "USBAudio": "low",
 }
+
 
 async def _get_pool() -> asyncpg.Pool:
     """Get or create the asyncpg connection pool."""
@@ -106,19 +108,21 @@ def _verify_key(
 
 class PlaybackEventRequest(BaseModel):
     """JSON body for /playback-event endpoint."""
+
     uid: str
     queue_item_id: Optional[str] = None
     trace_id: Optional[str] = None
     event_type: str = "started"  # started, completed, failed
-    port_type: str       # AVAudioSession portType rawValue (e.g. "Speaker", "BluetoothA2DP")
+    port_type: str  # AVAudioSession portType rawValue (e.g. "Speaker", "BluetoothA2DP")
     port_name: str = ""  # human-readable device name (e.g. "AirPods Pro")
-    device_uid: str = "" # unique device ID from AVAudioSessionPortDescription
-    duration_ms: int = 0 # estimated audio duration in ms
+    device_uid: str = ""  # unique device ID from AVAudioSessionPortDescription
+    duration_ms: int = 0  # estimated audio duration in ms
     metadata: Optional[dict] = None
 
 
 class EnqueueRequest(BaseModel):
     """JSON body for enqueue endpoint."""
+
     uid: Optional[str] = None
     userID: Optional[str] = None  # alias accepted from n8n
     url: str
@@ -137,6 +141,31 @@ def _trace_id_from_metadata(metadata: Optional[dict], fallback: str) -> str:
             if value:
                 return str(value)
     return fallback
+
+
+def _coerce_metadata_dict(metadata: Optional[dict]) -> dict:
+    """Return queue metadata as a plain dict."""
+    if isinstance(metadata, dict):
+        return metadata
+    if isinstance(metadata, str):
+        try:
+            parsed = json.loads(metadata)
+        except (TypeError, ValueError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _normalize_guardian_message(message: Optional[str]) -> str:
+    """Normalize queue text for duplicate detection."""
+    if not message:
+        return ""
+    normalized = str(message).strip().lower()
+    if normalized.startswith("i heard you. i am checking that now:"):
+        normalized = normalized.split(":", 1)[1].strip()
+    normalized = re.sub(r"\s+", " ", normalized)
+    normalized = re.sub(r"[^a-z0-9 ]+", "", normalized)
+    return normalized.strip()
 
 
 async def _log_pipeline_event(
@@ -425,11 +454,13 @@ async def next_audio(uid: str):
                 WHERE id = $1
                 """,
                 new_id,
-                json.dumps({
-                    "trace_id": source_trace_id,
-                    "queue_item_id": new_id,
-                    "consolidated_from": pending_ids,
-                }),
+                json.dumps(
+                    {
+                        "trace_id": source_trace_id,
+                        "queue_item_id": new_id,
+                        "consolidated_from": pending_ids,
+                    }
+                ),
             )
             # Fall through to pop the newly-inserted consolidated item
 
@@ -464,7 +495,10 @@ async def next_audio(uid: str):
         # Don't log empty polls (too noisy — iOS polls every 3s)
         return {"url": None}
 
-    print(f"[FLOW:GUARDIAN-POLL] uid={uid} popped id={row['id']} priority={row['priority']} latency={_elapsed}ms", flush=True)
+    print(
+        f"[FLOW:GUARDIAN-POLL] uid={uid} popped id={row['id']} priority={row['priority']} latency={_elapsed}ms",
+        flush=True,
+    )
 
     meta = row["metadata"]
     if isinstance(meta, str):
@@ -526,6 +560,14 @@ async def enqueue(
 
     item_id = req.id or f"guardian_{uuid.uuid4().hex[:12]}"
     trace_id = _trace_id_from_metadata(req.metadata, item_id)
+    trigger_type = (req.trigger or "").strip()
+    priority = (req.priority or "normal").strip()
+    message = req.message
+
+    # Wake-word acknowledgements should be deterministic and never quote
+    # transcript fragments back to the user.
+    if trigger_type == "wake_word":
+        message = WAKE_WORD_ACK_TEXT
 
     pool = await _get_pool()
     mode_row = await pool.fetchrow(
@@ -567,7 +609,109 @@ async def enqueue(
     metadata = dict(req.metadata or {})
     metadata.setdefault("trace_id", trace_id)
     metadata.setdefault("queue_item_id", item_id)
+    metadata.setdefault("dedupe_window_seconds", QUEUE_DEDUPE_WINDOW_SECONDS)
     metadata_str = json.dumps(metadata)
+
+    recent_rows = await pool.fetch(
+        """
+        SELECT id, priority, message, trigger_type, metadata, consumed_at, created_at
+        FROM guardian_queue
+        WHERE uid = $1
+          AND created_at > NOW() - make_interval(secs => $2)
+        ORDER BY created_at DESC
+        LIMIT 25
+        """,
+        uid,
+        QUEUE_DEDUPE_WINDOW_SECONDS,
+    )
+
+    normalized_message = _normalize_guardian_message(message)
+    same_trace_rows = []
+    pending_same_trace_rows = []
+    for row in recent_rows:
+        row_meta = _coerce_metadata_dict(row["metadata"])
+        row_trace_id = _trace_id_from_metadata(row_meta, row["id"])
+        if row_trace_id != trace_id:
+            continue
+        same_trace_rows.append(row)
+        if row["consumed_at"] is None:
+            pending_same_trace_rows.append(row)
+
+    duplicate_row = next(
+        (
+            row
+            for row in same_trace_rows
+            if row["trigger_type"] == trigger_type and _normalize_guardian_message(row["message"]) == normalized_message
+        ),
+        None,
+    )
+    if duplicate_row is not None:
+        _elapsed = int((time.time() - _start) * 1000)
+        await _log_pipeline_event(
+            trace_id=trace_id,
+            uid=uid,
+            stage="queue_rejected",
+            status="skipped",
+            latency_ms=_elapsed,
+            metadata={
+                "queue_item_id": item_id,
+                "priority": priority,
+                "trigger_type": trigger_type,
+                "reason": "duplicate_message_same_trace",
+                "existing_queue_item_id": duplicate_row["id"],
+            },
+        )
+        return {
+            "ok": True,
+            "skipped": True,
+            "reason": "duplicate_message_same_trace",
+            "existing_id": duplicate_row["id"],
+            "trace_id": trace_id,
+        }
+
+    if trigger_type == "wake_word":
+        actionable_pending_row = next(
+            (
+                row
+                for row in pending_same_trace_rows
+                if row["trigger_type"] in ("policy_dispatch", "scanner-escalation", "consolidated")
+            ),
+            None,
+        )
+        if actionable_pending_row is not None:
+            _elapsed = int((time.time() - _start) * 1000)
+            await _log_pipeline_event(
+                trace_id=trace_id,
+                uid=uid,
+                stage="queue_rejected",
+                status="skipped",
+                latency_ms=_elapsed,
+                metadata={
+                    "queue_item_id": item_id,
+                    "priority": priority,
+                    "trigger_type": trigger_type,
+                    "reason": "wake_word_suppressed_same_trace_has_actionable_audio",
+                    "existing_queue_item_id": actionable_pending_row["id"],
+                    "existing_trigger_type": actionable_pending_row["trigger_type"],
+                },
+            )
+            return {
+                "ok": True,
+                "skipped": True,
+                "reason": "wake_word_suppressed_same_trace_has_actionable_audio",
+                "existing_id": actionable_pending_row["id"],
+                "trace_id": trace_id,
+            }
+
+    if priority == "urgent" and trigger_type in ("policy_dispatch", "scanner-escalation", "consolidated"):
+        superseded_ids = [row["id"] for row in pending_same_trace_rows if row["trigger_type"] == "wake_word"]
+        if superseded_ids:
+            await pool.execute(
+                "UPDATE guardian_queue SET consumed_at = NOW() WHERE id = ANY($1::text[])",
+                superseded_ids,
+            )
+            metadata["superseded_wake_word_ids"] = superseded_ids
+            metadata_str = json.dumps(metadata)
 
     await pool.execute(
         """
@@ -578,9 +722,9 @@ async def enqueue(
         item_id,
         uid,
         req.url,
-        req.priority,
-        req.message,
-        req.trigger,
+        priority,
+        message,
+        trigger_type,
         metadata_str,
     )
 
@@ -599,14 +743,14 @@ async def enqueue(
         latency_ms=_elapsed,
         metadata={
             "queue_item_id": item_id,
-            "priority": req.priority,
-            "trigger_type": req.trigger,
+            "priority": priority,
+            "trigger_type": trigger_type,
             "queued": count,
         },
     )
     print(
-        f"[FLOW:GUARDIAN-ENQUEUE] uid={uid} id={item_id} priority={req.priority} "
-        f"trigger={req.trigger} trace={trace_id} queued={count} latency={_elapsed}ms",
+        f"[FLOW:GUARDIAN-ENQUEUE] uid={uid} id={item_id} priority={priority} "
+        f"trigger={trigger_type} trace={trace_id} queued={count} latency={_elapsed}ms",
         flush=True,
     )
 
@@ -648,7 +792,10 @@ async def upload_audio(
     public_url = f"{AUDIO_PUBLIC_URL}/{uid}/{fname}"
 
     _elapsed = int((time.time() - _start) * 1000)
-    print(f"[FLOW:GUARDIAN-UPLOAD] uid={uid} file={fname} size={len(content)}B latency={_elapsed}ms url={public_url}", flush=True)
+    print(
+        f"[FLOW:GUARDIAN-UPLOAD] uid={uid} file={fname} size={len(content)}B latency={_elapsed}ms url={public_url}",
+        flush=True,
+    )
 
     return {
         "url": public_url,
@@ -700,6 +847,7 @@ async def view_queue(uid: str):
     print(f"[FLOW:GUARDIAN-QUEUE] uid={uid} pending={len(items)}", flush=True)
 
     return {"uid": uid, "count": len(items), "items": items}
+
 
 # ---------------------------------------------------------------------------
 # POST /v1/ella/guardian/activate
@@ -800,13 +948,15 @@ async def get_pipeline_trace(conversation_id: str):
         stages = []
         for r in rows:
             meta = _parse_meta(r["metadata"])
-            stages.append({
-                "stage": r["stage"],
-                "status": r["status"],
-                "latency_ms": r["latency_ms"],
-                "metadata": meta,
-                "at": r["created_at"].isoformat() if r["created_at"] else None,
-            })
+            stages.append(
+                {
+                    "stage": r["stage"],
+                    "status": r["status"],
+                    "latency_ms": r["latency_ms"],
+                    "metadata": meta,
+                    "at": r["created_at"].isoformat() if r["created_at"] else None,
+                }
+            )
 
         # Calculate total latency
         first_ts = rows[0]["created_at"]
@@ -815,18 +965,17 @@ async def get_pipeline_trace(conversation_id: str):
         if first_ts and last_ts:
             total_ms = int((last_ts - first_ts).total_seconds() * 1000)
 
-        escalated = any(
-            _parse_meta(r["metadata"]).get("escalate") is True
-            for r in rows
-        )
+        escalated = any(_parse_meta(r["metadata"]).get("escalate") is True for r in rows)
         audio_delivered = any(
-            r["stage"] in ("audio_consumed", "ios_playback_started", "ios_playback_completed")
-            for r in rows
+            r["stage"] in ("audio_consumed", "ios_playback_started", "ios_playback_completed") for r in rows
         )
 
         uid = rows[0]["uid"] if rows else ""
 
-        print(f"[FLOW:GUARDIAN-TRACE] conv={conversation_id} uid={uid} stages={len(stages)} total_ms={total_ms} escalated={escalated}", flush=True)
+        print(
+            f"[FLOW:GUARDIAN-TRACE] conv={conversation_id} uid={uid} stages={len(stages)} total_ms={total_ms} escalated={escalated}",
+            flush=True,
+        )
 
         return {
             "trace_id": conversation_id,
@@ -872,7 +1021,10 @@ async def log_pipeline_event(request: Request):
         metadata=metadata,
     )
 
-    print(f"[FLOW:GUARDIAN-TRACE-LOG] trace={trace_id} uid={uid} stage={stage} status={status} latency={latency_ms}ms", flush=True)
+    print(
+        f"[FLOW:GUARDIAN-TRACE-LOG] trace={trace_id} uid={uid} stage={stage} status={status} latency={latency_ms}ms",
+        flush=True,
+    )
 
     return {"logged": True, "trace_id": trace_id, "stage": stage}
 

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -1444,9 +1444,13 @@ async def _stream_handler(
         except Exception as e:
             print(f"Speaker ID: match error for speaker {speaker_id}: {e}", uid, session_id)
 
+    pending_scanner_wake_prefix_segments: List[dict] = []
+    pending_scanner_wake_prefix_since: Optional[float] = None
+
     async def stream_transcript_process():
         nonlocal websocket_active, realtime_segment_buffers, realtime_photo_buffers, websocket
         nonlocal current_conversation_id, translation_enabled, speaker_to_person_map, suggested_segments, words_transcribed_since_last_record, last_transcript_time
+        nonlocal pending_scanner_wake_prefix_segments, pending_scanner_wake_prefix_since
 
         while websocket_active or len(realtime_segment_buffers) > 0 or len(realtime_photo_buffers) > 0:
             await asyncio.sleep(0.6)
@@ -1539,11 +1543,41 @@ async def _stream_handler(
                 # ====== ELLA INTEGRATION: Send chunks to scanner ======
                 try:
                     from utils.ella import send_to_scanner
-                    send_to_scanner(
-                        uid=uid,
-                        conversation_id=str(current_conversation_id),
-                        segments=[s.dict() for s in transcript_segments],
+                    from utils.ella.scanner import prepare_scanner_segments_for_dispatch, scanner_payload_preview
+
+                    scanner_input_segments = [s.dict() for s in transcript_segments]
+                    (
+                        scanner_dispatch_segments,
+                        pending_scanner_wake_prefix_segments,
+                        pending_scanner_wake_prefix_since,
+                        scanner_dispatch_meta,
+                    ) = prepare_scanner_segments_for_dispatch(
+                        scanner_input_segments,
+                        pending_wake_prefix_segments=pending_scanner_wake_prefix_segments,
+                        pending_wake_prefix_since=pending_scanner_wake_prefix_since,
+                        now=time.time(),
                     )
+
+                    if scanner_dispatch_segments:
+                        print(
+                            f"[TRANSCRIPT-RECV] Scanner dispatch action={scanner_dispatch_meta['action']} "
+                            f"prepended={scanner_dispatch_meta['prepended_count']} "
+                            f"payload={scanner_payload_preview(scanner_dispatch_segments)}",
+                            uid,
+                            session_id,
+                        )
+                        send_to_scanner(
+                            uid=uid,
+                            conversation_id=str(current_conversation_id),
+                            segments=scanner_dispatch_segments,
+                        )
+                    else:
+                        print(
+                            f"[TRANSCRIPT-RECV] Scanner dispatch skipped action={scanner_dispatch_meta['action']} "
+                            f"payload={scanner_payload_preview(scanner_input_segments)}",
+                            uid,
+                            session_id,
+                        )
                 except ImportError:
                     pass
 

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -1446,11 +1446,13 @@ async def _stream_handler(
 
     pending_scanner_wake_prefix_segments: List[dict] = []
     pending_scanner_wake_prefix_since: Optional[float] = None
+    recent_scanner_context_segments: List[dict] = []
 
     async def stream_transcript_process():
         nonlocal websocket_active, realtime_segment_buffers, realtime_photo_buffers, websocket
         nonlocal current_conversation_id, translation_enabled, speaker_to_person_map, suggested_segments, words_transcribed_since_last_record, last_transcript_time
         nonlocal pending_scanner_wake_prefix_segments, pending_scanner_wake_prefix_since
+        nonlocal recent_scanner_context_segments
 
         while websocket_active or len(realtime_segment_buffers) > 0 or len(realtime_photo_buffers) > 0:
             await asyncio.sleep(0.6)
@@ -1543,7 +1545,11 @@ async def _stream_handler(
                 # ====== ELLA INTEGRATION: Send chunks to scanner ======
                 try:
                     from utils.ella import send_to_scanner
-                    from utils.ella.scanner import prepare_scanner_segments_for_dispatch, scanner_payload_preview
+                    from utils.ella.scanner import (
+                        build_scanner_context_window,
+                        prepare_scanner_segments_for_dispatch,
+                        scanner_payload_preview,
+                    )
 
                     scanner_input_segments = [s.dict() for s in transcript_segments]
                     (
@@ -1559,10 +1565,18 @@ async def _stream_handler(
                     )
 
                     if scanner_dispatch_segments:
+                        scanner_context = build_scanner_context_window(
+                            scanner_dispatch_segments,
+                            recent_segments=recent_scanner_context_segments,
+                            now=time.time(),
+                        )
+                        recent_scanner_context_segments = scanner_context["updated_recent_cache"]
                         print(
                             f"[TRANSCRIPT-RECV] Scanner dispatch action={scanner_dispatch_meta['action']} "
                             f"prepended={scanner_dispatch_meta['prepended_count']} "
-                            f"payload={scanner_payload_preview(scanner_dispatch_segments)}",
+                            f"payload={scanner_payload_preview(scanner_dispatch_segments)} "
+                            f"recent={scanner_payload_preview(scanner_context['recent_segments'])} "
+                            f"wake_prefix_recent={scanner_context['wake_prefix_recent']}",
                             uid,
                             session_id,
                         )
@@ -1570,6 +1584,9 @@ async def _stream_handler(
                             uid=uid,
                             conversation_id=str(current_conversation_id),
                             segments=scanner_dispatch_segments,
+                            recent_segments=scanner_context["recent_segments"],
+                            scanner_window_text=scanner_context["scanner_window_text"],
+                            wake_prefix_recent=scanner_context["wake_prefix_recent"],
                         )
                     else:
                         print(

--- a/backend/tests/unit/test_ella_guardian_queue.py
+++ b/backend/tests/unit/test_ella_guardian_queue.py
@@ -1,0 +1,240 @@
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("asyncpg", MagicMock())
+multipart_module = types.ModuleType("multipart")
+multipart_module.__version__ = "0.0-test"
+multipart_submodule = types.ModuleType("multipart.multipart")
+multipart_submodule.parse_options_header = lambda value: (value, {})
+sys.modules["multipart"] = multipart_module
+sys.modules["multipart.multipart"] = multipart_submodule
+
+ella_module = types.ModuleType("ella")
+routers_module = types.ModuleType("ella.routers")
+resolve_module = types.ModuleType("ella.routers.resolve")
+
+
+async def _fake_resolve_user_routing(uid):
+    return {"routing": {"agentId": f"ella-{uid}"}}
+
+
+resolve_module.resolve_user_routing = _fake_resolve_user_routing
+sys.modules["ella"] = ella_module
+sys.modules["ella.routers"] = routers_module
+sys.modules["ella.routers.resolve"] = resolve_module
+
+_backend_path = Path(__file__).resolve().parents[2]
+if str(_backend_path) not in sys.path:
+    sys.path.insert(0, str(_backend_path))
+
+_module_path = _backend_path / "ella" / "routers" / "guardian.py"
+_spec = importlib.util.spec_from_file_location("ella_guardian_test_module", _module_path)
+guardian = importlib.util.module_from_spec(_spec)
+assert _spec is not None and _spec.loader is not None
+_spec.loader.exec_module(guardian)
+
+
+class FakePool:
+    def __init__(self, guardian_mode="CUSTOM", recent_rows=None, pending_count=1):
+        self.guardian_mode = guardian_mode
+        self.recent_rows = list(recent_rows or [])
+        self.pending_count = pending_count
+        self.executed = []
+
+    async def fetchrow(self, query, *args):
+        if "SELECT guardian_mode FROM users" in query:
+            return {"guardian_mode": self.guardian_mode}
+        return None
+
+    async def fetch(self, query, *args):
+        if "FROM guardian_queue" in query and "created_at > NOW() - make_interval" in query:
+            return self.recent_rows
+        return []
+
+    async def fetchval(self, query, *args):
+        if "SELECT COUNT(*) FROM guardian_queue WHERE uid = $1 AND consumed_at IS NULL" in query:
+            return self.pending_count
+        return 0
+
+    async def execute(self, query, *args):
+        self.executed.append((query, args))
+        return "OK"
+
+
+def _load_insert_args(pool):
+    for query, args in pool.executed:
+        if "INSERT INTO guardian_queue" in query:
+            return args
+    raise AssertionError("guardian_queue insert not found")
+
+
+def test_wake_word_enqueue_rewrites_message(monkeypatch):
+    pool = FakePool()
+    logged = []
+
+    async def fake_get_pool():
+        return pool
+
+    async def fake_log_pipeline_event(**kwargs):
+        logged.append(kwargs)
+
+    monkeypatch.setattr(guardian, "_get_pool", fake_get_pool)
+    monkeypatch.setattr(guardian, "_log_pipeline_event", fake_log_pipeline_event)
+    monkeypatch.setattr(guardian, "_verify_key", lambda *args, **kwargs: None)
+
+    req = guardian.EnqueueRequest(
+        uid="uid-1",
+        url="",
+        priority="normal",
+        message="I heard you. I am checking that now: hey ella what time is it",
+        trigger="wake_word",
+        metadata={"trace_id": "trace-1"},
+    )
+
+    result = asyncio.run(guardian.enqueue(req))
+    insert_args = _load_insert_args(pool)
+
+    assert result["ok"] is True
+    assert insert_args[4] == guardian.WAKE_WORD_ACK_TEXT
+    assert json.loads(insert_args[6])["trace_id"] == "trace-1"
+    assert any(event["stage"] == "queue_inserted" for event in logged)
+
+
+def test_enqueue_skips_duplicate_message_for_same_trace(monkeypatch):
+    pool = FakePool(
+        recent_rows=[
+            {
+                "id": "guardian_existing",
+                "priority": "normal",
+                "message": guardian.WAKE_WORD_ACK_TEXT,
+                "trigger_type": "wake_word",
+                "metadata": {"trace_id": "trace-dup"},
+                "consumed_at": None,
+                "created_at": None,
+            }
+        ]
+    )
+    logged = []
+
+    async def fake_get_pool():
+        return pool
+
+    async def fake_log_pipeline_event(**kwargs):
+        logged.append(kwargs)
+
+    monkeypatch.setattr(guardian, "_get_pool", fake_get_pool)
+    monkeypatch.setattr(guardian, "_log_pipeline_event", fake_log_pipeline_event)
+    monkeypatch.setattr(guardian, "_verify_key", lambda *args, **kwargs: None)
+
+    req = guardian.EnqueueRequest(
+        uid="uid-1",
+        url="",
+        priority="normal",
+        message="something quoted from transcript",
+        trigger="wake_word",
+        metadata={"trace_id": "trace-dup"},
+    )
+
+    result = asyncio.run(guardian.enqueue(req))
+
+    assert result["skipped"] is True
+    assert result["reason"] == "duplicate_message_same_trace"
+    assert not any("INSERT INTO guardian_queue" in query for query, _ in pool.executed)
+    assert logged[-1]["stage"] == "queue_rejected"
+
+
+def test_enqueue_skips_wake_word_when_actionable_audio_already_pending(monkeypatch):
+    pool = FakePool(
+        recent_rows=[
+            {
+                "id": "guardian_urgent",
+                "priority": "urgent",
+                "message": "I need you to respond right now.",
+                "trigger_type": "policy_dispatch",
+                "metadata": {"trace_id": "trace-pending"},
+                "consumed_at": None,
+                "created_at": None,
+            }
+        ]
+    )
+    logged = []
+
+    async def fake_get_pool():
+        return pool
+
+    async def fake_log_pipeline_event(**kwargs):
+        logged.append(kwargs)
+
+    monkeypatch.setattr(guardian, "_get_pool", fake_get_pool)
+    monkeypatch.setattr(guardian, "_log_pipeline_event", fake_log_pipeline_event)
+    monkeypatch.setattr(guardian, "_verify_key", lambda *args, **kwargs: None)
+
+    req = guardian.EnqueueRequest(
+        uid="uid-1",
+        url="",
+        priority="normal",
+        message="some wake text",
+        trigger="wake_word",
+        metadata={"trace_id": "trace-pending"},
+    )
+
+    result = asyncio.run(guardian.enqueue(req))
+
+    assert result["skipped"] is True
+    assert result["reason"] == "wake_word_suppressed_same_trace_has_actionable_audio"
+    assert not any("INSERT INTO guardian_queue" in query for query, _ in pool.executed)
+    assert logged[-1]["metadata"]["existing_trigger_type"] == "policy_dispatch"
+
+
+def test_urgent_enqueue_supersedes_pending_wake_word(monkeypatch):
+    pool = FakePool(
+        recent_rows=[
+            {
+                "id": "guardian_old_wake",
+                "priority": "normal",
+                "message": guardian.WAKE_WORD_ACK_TEXT,
+                "trigger_type": "wake_word",
+                "metadata": {"trace_id": "trace-urgent"},
+                "consumed_at": None,
+                "created_at": None,
+            }
+        ],
+        pending_count=1,
+    )
+    logged = []
+
+    async def fake_get_pool():
+        return pool
+
+    async def fake_log_pipeline_event(**kwargs):
+        logged.append(kwargs)
+
+    monkeypatch.setattr(guardian, "_get_pool", fake_get_pool)
+    monkeypatch.setattr(guardian, "_log_pipeline_event", fake_log_pipeline_event)
+    monkeypatch.setattr(guardian, "_verify_key", lambda *args, **kwargs: None)
+
+    req = guardian.EnqueueRequest(
+        uid="uid-1",
+        url="https://example.test/audio.mp3",
+        priority="urgent",
+        message="This is the real urgent alert.",
+        trigger="policy_dispatch",
+        metadata={"trace_id": "trace-urgent"},
+    )
+
+    result = asyncio.run(guardian.enqueue(req))
+    insert_args = _load_insert_args(pool)
+    insert_metadata = json.loads(insert_args[6])
+
+    assert result["ok"] is True
+    assert any(
+        "UPDATE guardian_queue SET consumed_at = NOW()" in query and args[0] == ["guardian_old_wake"]
+        for query, args in pool.executed
+    )
+    assert insert_metadata["superseded_wake_word_ids"] == ["guardian_old_wake"]
+    assert any(event["stage"] == "queue_inserted" for event in logged)

--- a/backend/tests/unit/test_scanner_wakeword_carry_forward.py
+++ b/backend/tests/unit/test_scanner_wakeword_carry_forward.py
@@ -1,4 +1,5 @@
 from utils.ella.scanner import (
+    build_scanner_context_window,
     contains_wake_phrase,
     is_short_wake_prefix_only,
     prepare_scanner_segments_for_dispatch,
@@ -68,3 +69,39 @@ def test_direct_wake_phrase_in_current_batch_dispatches_normally():
 def test_ela_variant_is_treated_as_short_wake_prefix():
     assert contains_wake_phrase("Ela")
     assert is_short_wake_prefix_only([_segment("Ela", "SPEAKER_00")])
+
+
+def test_punctuated_wake_prefix_is_still_held():
+    dispatch, pending, pending_since, meta = prepare_scanner_segments_for_dispatch(
+        [_segment("Hey Ella.", "SPEAKER_00")],
+        now=100.0,
+    )
+
+    assert dispatch == []
+    assert [segment["text"] for segment in pending] == ["Hey Ella."]
+    assert pending_since == 100.0
+    assert meta["action"] == "hold_wake_prefix"
+
+
+def test_scanner_context_window_merges_recent_segments_and_sets_wake_flag():
+    context = build_scanner_context_window(
+        [_segment("What time is my appointment today?", "SPEAKER_02")],
+        recent_segments=[
+            {"observed_at": 99.0, "segment": _segment("Hey Ella.", "SPEAKER_00")},
+            {"observed_at": 96.5, "segment": _segment("Old segment", "SPEAKER_01")},
+        ],
+        now=100.0,
+        window_s=2.0,
+    )
+
+    assert [segment["text"] for segment in context["recent_segments"]] == ["Hey Ella."]
+    assert [segment["text"] for segment in context["scanner_window_segments"]] == [
+        "Hey Ella.",
+        "What time is my appointment today?",
+    ]
+    assert context["scanner_window_text"] == "Hey Ella. What time is my appointment today?"
+    assert context["wake_prefix_recent"] is True
+    assert [item["segment"]["text"] for item in context["updated_recent_cache"]] == [
+        "Hey Ella.",
+        "What time is my appointment today?",
+    ]

--- a/backend/tests/unit/test_scanner_wakeword_carry_forward.py
+++ b/backend/tests/unit/test_scanner_wakeword_carry_forward.py
@@ -1,0 +1,70 @@
+from utils.ella.scanner import (
+    contains_wake_phrase,
+    is_short_wake_prefix_only,
+    prepare_scanner_segments_for_dispatch,
+)
+
+
+def _segment(text: str, speaker: str = "SPEAKER_00") -> dict:
+    return {"text": text, "speaker": speaker}
+
+
+def test_short_wake_prefix_is_held_for_next_dispatch():
+    dispatch, pending, pending_since, meta = prepare_scanner_segments_for_dispatch(
+        [_segment("Hey Ella", "SPEAKER_00")],
+        now=100.0,
+    )
+
+    assert dispatch == []
+    assert [segment["text"] for segment in pending] == ["Hey Ella"]
+    assert pending_since == 100.0
+    assert meta["action"] == "hold_wake_prefix"
+
+
+def test_pending_wake_prefix_is_prepended_to_next_batch():
+    dispatch, pending, pending_since, meta = prepare_scanner_segments_for_dispatch(
+        [_segment("What time is my appointment today?", "SPEAKER_02")],
+        pending_wake_prefix_segments=[_segment("Hey Ella", "SPEAKER_00")],
+        pending_wake_prefix_since=100.0,
+        now=101.0,
+    )
+
+    assert [segment["text"] for segment in dispatch] == [
+        "Hey Ella",
+        "What time is my appointment today?",
+    ]
+    assert pending == []
+    assert pending_since is None
+    assert meta["action"] == "prepend_pending_wake_prefix"
+    assert meta["prepended_count"] == 1
+
+
+def test_expired_pending_wake_prefix_is_dropped():
+    dispatch, pending, pending_since, meta = prepare_scanner_segments_for_dispatch(
+        [_segment("What time is my appointment today?", "SPEAKER_02")],
+        pending_wake_prefix_segments=[_segment("Hey Ella", "SPEAKER_00")],
+        pending_wake_prefix_since=100.0,
+        now=103.5,
+    )
+
+    assert [segment["text"] for segment in dispatch] == ["What time is my appointment today?"]
+    assert pending == []
+    assert pending_since is None
+    assert meta["action"] == "direct_dispatch"
+
+
+def test_direct_wake_phrase_in_current_batch_dispatches_normally():
+    dispatch, pending, pending_since, meta = prepare_scanner_segments_for_dispatch(
+        [_segment("Hey Ella what time is my appointment today?", "SPEAKER_00")],
+        now=100.0,
+    )
+
+    assert [segment["text"] for segment in dispatch] == ["Hey Ella what time is my appointment today?"]
+    assert pending == []
+    assert pending_since is None
+    assert meta["action"] == "direct_dispatch"
+
+
+def test_ela_variant_is_treated_as_short_wake_prefix():
+    assert contains_wake_phrase("Ela")
+    assert is_short_wake_prefix_only([_segment("Ela", "SPEAKER_00")])

--- a/backend/utils/ella/scanner.py
+++ b/backend/utils/ella/scanner.py
@@ -3,16 +3,31 @@
 # Sends real-time transcript segments to n8n scanner for urgency detection.
 # Fire-and-forget with short timeout - doesn't block transcription flow.
 
-import requests
 import os
+import re
 import time
 from typing import List, Optional
+
+import requests
 
 from .config import ELLA_CONFIG
 
 GUARDIAN_TRACE_LOG_URL = os.getenv(
     "ELLA_GUARDIAN_TRACE_LOG_URL",
     "http://127.0.0.1:8000/v1/ella/guardian/trace/log",
+)
+WAKE_WORD_PREFIX_MAX_WORDS = 4
+WAKE_WORD_PENDING_WINDOW_S = 2.0
+WAKE_WORD_ALIASES = (
+    "hey ella",
+    "ella",
+    "ela",
+    "ellah",
+    "ellaa",
+    "ask ella",
+    "ask ela",
+    "tell ella",
+    "tell ela",
 )
 
 
@@ -22,6 +37,94 @@ def _trace_id_for(conversation_id: str) -> str:
     if trace_id and trace_id.lower() != "unknown":
         return trace_id
     return f"scanner-{int(time.time() * 1000)}"
+
+
+def _normalize_text(text: str) -> str:
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9\s]", " ", (text or "").lower())).strip()
+
+
+def _combined_segment_text(segments: List[dict]) -> str:
+    return " ".join((segment.get("text") or "").strip() for segment in segments if segment.get("text")).strip()
+
+
+def contains_wake_phrase(text: str) -> bool:
+    normalized = _normalize_text(text)
+    if not normalized:
+        return False
+    return any(alias in normalized for alias in WAKE_WORD_ALIASES)
+
+
+def is_short_wake_prefix_only(segments: List[dict]) -> bool:
+    combined = _combined_segment_text(segments)
+    if not combined:
+        return False
+    normalized = _normalize_text(combined)
+    if not contains_wake_phrase(normalized):
+        return False
+    # Only hold very short prefix-like utterances such as "Hey Ella".
+    if any(punct in combined for punct in ".?!"):
+        return False
+    return len(normalized.split()) <= WAKE_WORD_PREFIX_MAX_WORDS
+
+
+def prepare_scanner_segments_for_dispatch(
+    current_segments: List[dict],
+    pending_wake_prefix_segments: Optional[List[dict]] = None,
+    pending_wake_prefix_since: Optional[float] = None,
+    *,
+    now: Optional[float] = None,
+    max_pending_window_s: float = WAKE_WORD_PENDING_WINDOW_S,
+):
+    """
+    Hold very short wake-word-only batches briefly and prepend them to the next batch.
+
+    This preserves "Hey Ella" / "Ela" prefixes when diarization or STT flushes the
+    prefix separately from the actual question.
+    """
+    now = now if now is not None else time.time()
+    pending_wake_prefix_segments = list(pending_wake_prefix_segments or [])
+
+    if pending_wake_prefix_segments and pending_wake_prefix_since is not None:
+        if now - pending_wake_prefix_since > max_pending_window_s:
+            pending_wake_prefix_segments = []
+            pending_wake_prefix_since = None
+
+    if not current_segments:
+        return [], pending_wake_prefix_segments, pending_wake_prefix_since, {
+            "action": "empty",
+            "prepended_count": 0,
+        }
+
+    if is_short_wake_prefix_only(current_segments):
+        return [], list(current_segments), now, {
+            "action": "hold_wake_prefix",
+            "prepended_count": 0,
+        }
+
+    dispatch_segments = list(current_segments)
+    prepended_count = 0
+    if pending_wake_prefix_segments and not contains_wake_phrase(_combined_segment_text(current_segments)):
+        dispatch_segments = pending_wake_prefix_segments + dispatch_segments
+        prepended_count = len(pending_wake_prefix_segments)
+        pending_wake_prefix_segments = []
+        pending_wake_prefix_since = None
+
+    return dispatch_segments, pending_wake_prefix_segments, pending_wake_prefix_since, {
+        "action": "prepend_pending_wake_prefix" if prepended_count else "direct_dispatch",
+        "prepended_count": prepended_count,
+    }
+
+
+def scanner_payload_preview(segments: List[dict], *, limit: int = 4) -> List[dict]:
+    preview = []
+    for segment in segments[:limit]:
+        preview.append(
+            {
+                "speaker": segment.get("speaker") or f"SPEAKER_{segment.get('speaker_id', 0)}",
+                "text": (segment.get("text") or "")[:120],
+            }
+        )
+    return preview
 
 
 def _log_trace_event(
@@ -130,9 +233,14 @@ def send_to_scanner(
                 "device_type": device_type,
                 "segment_count": len(scanner_segments),
                 "scanner_status_code": resp.status_code,
+                "segments_preview": scanner_payload_preview(scanner_segments),
             },
         )
-        print(f"📡 Scanner: trace={trace_id} {len(scanner_segments)} segments → {resp.status_code}", flush=True)
+        print(
+            f"📡 Scanner: trace={trace_id} {len(scanner_segments)} segments → {resp.status_code} "
+            f"payload={scanner_payload_preview(scanner_segments)}",
+            flush=True,
+        )
         return resp.status_code
 
     except requests.Timeout:
@@ -146,6 +254,7 @@ def send_to_scanner(
                 "device_type": device_type,
                 "segment_count": len(scanner_segments),
                 "timeout_s": timeout,
+                "segments_preview": scanner_payload_preview(scanner_segments),
             },
         )
         print(f"📡 Scanner timeout trace={trace_id} ({timeout}s)", flush=True)
@@ -162,6 +271,7 @@ def send_to_scanner(
                 "device_type": device_type,
                 "segment_count": len(scanner_segments),
                 "error": str(e)[:200],
+                "segments_preview": scanner_payload_preview(scanner_segments),
             },
         )
         print(f"📡 Scanner error trace={trace_id}: {e}", flush=True)

--- a/backend/utils/ella/scanner.py
+++ b/backend/utils/ella/scanner.py
@@ -18,6 +18,7 @@ GUARDIAN_TRACE_LOG_URL = os.getenv(
 )
 WAKE_WORD_PREFIX_MAX_WORDS = 4
 WAKE_WORD_PENDING_WINDOW_S = 2.0
+SCANNER_CONTEXT_WINDOW_S = 2.0
 WAKE_WORD_ALIASES = (
     "hey ella",
     "ella",
@@ -58,12 +59,13 @@ def is_short_wake_prefix_only(segments: List[dict]) -> bool:
     combined = _combined_segment_text(segments)
     if not combined:
         return False
-    normalized = _normalize_text(combined)
+    candidate = combined.strip()
+    if re.fullmatch(r".*[.?!]+", candidate):
+        candidate = re.sub(r"[.?!]+\s*$", "", candidate).strip()
+    normalized = _normalize_text(candidate)
     if not contains_wake_phrase(normalized):
         return False
     # Only hold very short prefix-like utterances such as "Hey Ella".
-    if any(punct in combined for punct in ".?!"):
-        return False
     return len(normalized.split()) <= WAKE_WORD_PREFIX_MAX_WORDS
 
 
@@ -127,6 +129,49 @@ def scanner_payload_preview(segments: List[dict], *, limit: int = 4) -> List[dic
     return preview
 
 
+def build_scanner_context_window(
+    current_segments: List[dict],
+    recent_segments: Optional[List[dict]] = None,
+    *,
+    now: Optional[float] = None,
+    window_s: float = SCANNER_CONTEXT_WINDOW_S,
+):
+    """
+    Build a short recent context window for the scanner payload.
+
+    recent_segments items are expected to be dicts like:
+      {"observed_at": <float>, "segment": <segment-dict>}
+    """
+    now = now if now is not None else time.time()
+    cleaned_recent = []
+    recent_context_segments: List[dict] = []
+    for item in recent_segments or []:
+        observed_at = item.get("observed_at")
+        segment = item.get("segment")
+        if observed_at is None or not segment:
+            continue
+        if now - float(observed_at) <= window_s:
+            cleaned_recent.append({"observed_at": float(observed_at), "segment": segment})
+            recent_context_segments.append(segment)
+
+    scanner_window_segments = recent_context_segments + list(current_segments or [])
+    scanner_window_text = _combined_segment_text(scanner_window_segments)
+    wake_prefix_recent = contains_wake_phrase(_combined_segment_text(recent_context_segments))
+    updated_recent_cache = cleaned_recent + [
+        {"observed_at": now, "segment": segment}
+        for segment in current_segments or []
+        if segment.get("text")
+    ]
+
+    return {
+        "recent_segments": recent_context_segments,
+        "scanner_window_segments": scanner_window_segments,
+        "scanner_window_text": scanner_window_text,
+        "wake_prefix_recent": wake_prefix_recent,
+        "updated_recent_cache": updated_recent_cache,
+    }
+
+
 def _log_trace_event(
     trace_id: str,
     uid: str,
@@ -158,7 +203,10 @@ def send_to_scanner(
     conversation_id: str,
     segments: List[dict],
     device_type: str = "omi",
-    timeout: Optional[float] = None
+    timeout: Optional[float] = None,
+    recent_segments: Optional[List[dict]] = None,
+    scanner_window_text: Optional[str] = None,
+    wake_prefix_recent: Optional[bool] = None,
 ) -> Optional[int]:
     """
     Send transcript segments to Ella scanner agent.
@@ -213,6 +261,20 @@ def send_to_scanner(
             "contract": "ella-ai#600",
         },
     }
+    if recent_segments is not None:
+        payload["recent_segments"] = [
+            {
+                "speaker": s.get("speaker") or f"SPEAKER_{s.get('speaker_id', 0)}",
+                "text": s.get("text", ""),
+                "stt_source": s.get("source"),
+            }
+            for s in recent_segments
+            if s.get("text")
+        ]
+    if scanner_window_text is not None:
+        payload["scanner_window_text"] = scanner_window_text
+    if wake_prefix_recent is not None:
+        payload["wake_prefix_recent"] = wake_prefix_recent
 
     try:
         start = time.time()
@@ -234,11 +296,15 @@ def send_to_scanner(
                 "segment_count": len(scanner_segments),
                 "scanner_status_code": resp.status_code,
                 "segments_preview": scanner_payload_preview(scanner_segments),
+                "recent_segments_preview": scanner_payload_preview(payload.get("recent_segments", [])),
+                "wake_prefix_recent": payload.get("wake_prefix_recent"),
             },
         )
         print(
             f"📡 Scanner: trace={trace_id} {len(scanner_segments)} segments → {resp.status_code} "
-            f"payload={scanner_payload_preview(scanner_segments)}",
+            f"payload={scanner_payload_preview(scanner_segments)} "
+            f"recent={scanner_payload_preview(payload.get('recent_segments', []))} "
+            f"wake_prefix_recent={payload.get('wake_prefix_recent')}",
             flush=True,
         )
         return resp.status_code
@@ -255,6 +321,8 @@ def send_to_scanner(
                 "segment_count": len(scanner_segments),
                 "timeout_s": timeout,
                 "segments_preview": scanner_payload_preview(scanner_segments),
+                "recent_segments_preview": scanner_payload_preview(payload.get("recent_segments", [])),
+                "wake_prefix_recent": payload.get("wake_prefix_recent"),
             },
         )
         print(f"📡 Scanner timeout trace={trace_id} ({timeout}s)", flush=True)
@@ -272,6 +340,8 @@ def send_to_scanner(
                 "segment_count": len(scanner_segments),
                 "error": str(e)[:200],
                 "segments_preview": scanner_payload_preview(scanner_segments),
+                "recent_segments_preview": scanner_payload_preview(payload.get("recent_segments", [])),
+                "wake_prefix_recent": payload.get("wake_prefix_recent"),
             },
         )
         print(f"📡 Scanner error trace={trace_id}: {e}", flush=True)


### PR DESCRIPTION
## Summary
- keep a short recent scanner context window in `/v4/listen`
- send `recent_segments`, `scanner_window_text`, and `wake_prefix_recent` to the scanner webhook
- extend wake-word unit coverage for punctuated prefixes and merged recent-window behavior

## Testing
- `pytest -q backend/tests/unit/test_scanner_wakeword_carry_forward.py`
- `python3 -m py_compile backend/utils/ella/scanner.py backend/routers/transcribe.py`