### PR TITLE
iOS Guardian voice policy wiring

### DIFF
--- a/app/lib/ella/models/guardian_mode.dart
+++ b/app/lib/ella/models/guardian_mode.dart
@@ -63,9 +63,7 @@ enum GuardianModeKey {
   /// Returns true if this key is an "Intelligence Mode" override (exclusive,
   /// replaces care system entirely).
   bool get isOverride =>
-      this == GuardianModeKey.cyborg ||
-      this == GuardianModeKey.chatbot ||
-      this == GuardianModeKey.demo;
+      this == GuardianModeKey.cyborg || this == GuardianModeKey.chatbot || this == GuardianModeKey.demo;
 
   /// Returns true if this key is a composable "Care Feature" checkbox.
   bool get isCareFeature =>
@@ -131,14 +129,11 @@ class GuardianModeState {
       final rawFeatures = json['features'];
       return GuardianModeState(
         override: json['override'] as String?,
-        features: rawFeatures is List
-            ? List<String>.from(rawFeatures)
-            : const [],
+        features: rawFeatures is List ? List<String>.from(rawFeatures) : const [],
       );
     }
     // Legacy schema: {mode: 'ACTIVE_SUPPORT'}
-    final modeStr =
-        json['mode'] as String? ?? json['currentMode'] as String? ?? '';
+    final modeStr = json['mode'] as String? ?? json['currentMode'] as String? ?? '';
     final key = GuardianModeKey.fromString(modeStr);
     if (key.isOverride) {
       return GuardianModeState(override: key.toApiString());
@@ -246,5 +241,130 @@ class GuardianModeInfo {
       case GuardianModeKey.memorySupport:
         return const Color(0xFF10B981);
     }
+  }
+}
+
+enum GuardianVoicePolicy {
+  matchActiveProvider,
+  pinnedProvider,
+  fallbackOnly;
+
+  static GuardianVoicePolicy fromString(String? value) {
+    switch ((value ?? '').toLowerCase()) {
+      case 'pinned_provider':
+        return GuardianVoicePolicy.pinnedProvider;
+      case 'fallback_only':
+        return GuardianVoicePolicy.fallbackOnly;
+      case 'match_active_provider':
+      default:
+        return GuardianVoicePolicy.matchActiveProvider;
+    }
+  }
+
+  String toApiString() {
+    switch (this) {
+      case GuardianVoicePolicy.matchActiveProvider:
+        return 'match_active_provider';
+      case GuardianVoicePolicy.pinnedProvider:
+        return 'pinned_provider';
+      case GuardianVoicePolicy.fallbackOnly:
+        return 'fallback_only';
+    }
+  }
+
+  String get displayName {
+    switch (this) {
+      case GuardianVoicePolicy.matchActiveProvider:
+        return 'Match active voice provider';
+      case GuardianVoicePolicy.pinnedProvider:
+        return 'Pinned provider';
+      case GuardianVoicePolicy.fallbackOnly:
+        return 'Fallback only';
+    }
+  }
+}
+
+class GuardianVoiceConfig {
+  final GuardianVoicePolicy policy;
+  final String? provider;
+  final String? lastVoiceProvider;
+  final String? resolvedProvider;
+  final String? fallbackProvider;
+  final String? traceId;
+  final String? queueItemId;
+
+  const GuardianVoiceConfig({
+    this.policy = GuardianVoicePolicy.matchActiveProvider,
+    this.provider,
+    this.lastVoiceProvider,
+    this.resolvedProvider,
+    this.fallbackProvider,
+    this.traceId,
+    this.queueItemId,
+  });
+
+  factory GuardianVoiceConfig.fromJson(Map<String, dynamic> json) {
+    final data = json['data'] is Map<String, dynamic>
+        ? json['data'] as Map<String, dynamic>
+        : json['voice_config'] is Map<String, dynamic>
+            ? json['voice_config'] as Map<String, dynamic>
+            : json['config'] is Map<String, dynamic>
+                ? json['config'] as Map<String, dynamic>
+                : json;
+
+    return GuardianVoiceConfig(
+      policy: GuardianVoicePolicy.fromString(
+        data['guardian_voice_policy'] as String? ?? data['policy'] as String?,
+      ),
+      provider: _readString(data, 'guardian_voice_provider', 'provider'),
+      lastVoiceProvider: _readString(data, 'last_voice_provider', 'lastVoiceProvider'),
+      resolvedProvider: _readString(data, 'resolved_provider', 'resolvedProvider'),
+      fallbackProvider: _readString(data, 'fallback_provider', 'fallbackProvider'),
+      traceId: _readString(data, 'trace_id', 'traceId'),
+      queueItemId: _readString(data, 'queue_item_id', 'queueItemId'),
+    );
+  }
+
+  Map<String, dynamic> toJson({required String uid}) {
+    return {
+      'uid': uid,
+      'guardian_voice_policy': policy.toApiString(),
+      'guardian_voice_provider': policy == GuardianVoicePolicy.pinnedProvider ? provider : null,
+    };
+  }
+
+  GuardianVoiceConfig copyWith({
+    GuardianVoicePolicy? policy,
+    String? provider,
+    String? lastVoiceProvider,
+    String? resolvedProvider,
+    String? fallbackProvider,
+    String? traceId,
+    String? queueItemId,
+  }) {
+    return GuardianVoiceConfig(
+      policy: policy ?? this.policy,
+      provider: provider ?? this.provider,
+      lastVoiceProvider: lastVoiceProvider ?? this.lastVoiceProvider,
+      resolvedProvider: resolvedProvider ?? this.resolvedProvider,
+      fallbackProvider: fallbackProvider ?? this.fallbackProvider,
+      traceId: traceId ?? this.traceId,
+      queueItemId: queueItemId ?? this.queueItemId,
+    );
+  }
+
+  bool samePersistedValue(GuardianVoiceConfig other) {
+    return policy == other.policy && _normalizedProvider(provider) == _normalizedProvider(other.provider);
+  }
+
+  static String? _readString(Map<String, dynamic> json, String snakeKey, String camelKey) {
+    final value = json[snakeKey] ?? json[camelKey];
+    if (value is String && value.trim().isNotEmpty) return value;
+    return null;
+  }
+
+  static String? _normalizedProvider(String? value) {
+    final normalized = value?.trim();
+    return normalized == null || normalized.isEmpty ? null : normalized;
   }
 }

--- a/app/lib/ella/pages/guardian_mode_page.dart
+++ b/app/lib/ella/pages/guardian_mode_page.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 
+import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/ella_theme.dart';
 import 'package:omi/ella/models/guardian_mode.dart';
 import 'package:omi/ella/pages/ella_demo_scenarios_page.dart';
 import 'package:omi/ella/services/guardian_mode_api.dart' as guardian_api;
+import 'package:omi/ella/services/v2v_client.dart';
 
 class GuardianModePage extends StatefulWidget {
   /// When true, show the Demo intelligence mode option.
@@ -30,6 +32,10 @@ class _GuardianModePageState extends State<GuardianModePage> {
   bool _loading = true;
   bool _saving = false;
 
+  GuardianVoiceConfig _currentVoiceConfig = const GuardianVoiceConfig();
+  GuardianVoicePolicy _selectedVoicePolicy = GuardianVoicePolicy.matchActiveProvider;
+  String _selectedVoiceProvider = 'openai';
+
   @override
   void initState() {
     super.initState();
@@ -41,9 +47,11 @@ class _GuardianModePageState extends State<GuardianModePage> {
     final results = await Future.wait([
       guardian_api.getGuardianPresets(),
       guardian_api.getGuardianMode(),
+      guardian_api.getGuardianVoiceConfig(),
     ]);
     final presets = results[0] as List<GuardianPreset>;
     final modeInfo = results[1] as GuardianModeInfo?;
+    final voiceConfig = results[2] as GuardianVoiceConfig? ?? const GuardianVoiceConfig();
 
     if (mounted) {
       setState(() {
@@ -69,6 +77,9 @@ class _GuardianModePageState extends State<GuardianModePage> {
         _currentState = state;
         _selectedOverride = state.override;
         _selectedFeatures = Set<String>.from(state.features);
+        _currentVoiceConfig = voiceConfig;
+        _selectedVoicePolicy = voiceConfig.policy;
+        _selectedVoiceProvider = voiceConfig.provider ?? _defaultPinnedVoiceProvider;
         _loading = false;
       });
     }
@@ -81,7 +92,33 @@ class _GuardianModePageState extends State<GuardianModePage> {
 
   bool get _hasChanges {
     final pending = _pendingState;
-    return pending.override != _currentState.override || !_sameFeatures(pending.features, _currentState.features);
+    return pending.override != _currentState.override ||
+        !_sameFeatures(pending.features, _currentState.features) ||
+        !_pendingVoiceConfig.samePersistedValue(_currentVoiceConfig);
+  }
+
+  GuardianVoiceConfig get _pendingVoiceConfig => GuardianVoiceConfig(
+        policy: _selectedVoicePolicy,
+        provider: _selectedVoicePolicy == GuardianVoicePolicy.pinnedProvider ? _selectedVoiceProvider : null,
+      );
+
+  String get _defaultPinnedVoiceProvider => _guardianProviderForActiveVoiceProvider ?? 'openai';
+
+  String? get _guardianProviderForActiveVoiceProvider {
+    switch (V2VClient.normalizeProvider(SharedPreferencesUtil().ttsProvider)) {
+      case 'grok-voice':
+        return 'xai-tts';
+      case 'gemini-native-live':
+      case 'openai-native-realtime':
+      case 'openclaw-direct':
+        return 'openai';
+      case 'elevenlabs':
+        return 'elevenlabs';
+      case 'kokoro':
+        return 'kokoro';
+      default:
+        return null;
+    }
   }
 
   bool _sameFeatures(List<String> a, List<String> b) {
@@ -102,15 +139,29 @@ class _GuardianModePageState extends State<GuardianModePage> {
     }
 
     setState(() => _saving = true);
-    final success = await guardian_api.setGuardianModeTwoTier(_pendingState);
+    final modeChanged = _pendingState.override != _currentState.override ||
+        !_sameFeatures(_pendingState.features, _currentState.features);
+    final voiceChanged = !_pendingVoiceConfig.samePersistedValue(_currentVoiceConfig);
+
+    bool modeSuccess = true;
+    GuardianVoiceConfig? savedVoiceConfig = _currentVoiceConfig;
+    if (modeChanged) {
+      modeSuccess = await guardian_api.setGuardianModeTwoTier(_pendingState);
+    }
+    if (voiceChanged) {
+      savedVoiceConfig = await guardian_api.setGuardianVoiceConfig(_pendingVoiceConfig);
+    }
     if (!mounted) return;
     setState(() => _saving = false);
 
-    if (success) {
-      setState(() => _currentState = _pendingState);
+    if (modeSuccess && (!voiceChanged || savedVoiceConfig != null)) {
+      setState(() {
+        if (modeChanged) _currentState = _pendingState;
+        if (savedVoiceConfig != null) _currentVoiceConfig = savedVoiceConfig;
+      });
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
-          content: Text('Guardian mode updated'),
+          content: Text('Guardian settings updated'),
           backgroundColor: EllaColors.success,
           behavior: SnackBarBehavior.floating,
           duration: Duration(seconds: 3),
@@ -211,6 +262,27 @@ class _GuardianModePageState extends State<GuardianModePage> {
       default:
         return key;
     }
+  }
+
+  static const Map<String, String> _guardianVoiceProviders = {
+    'xai-tts': 'xAI TTS / Grok family',
+    'openai': 'OpenAI',
+    'elevenlabs': 'ElevenLabs',
+    'kokoro': 'Kokoro',
+  };
+
+  static String _formatProviderLabel(String? provider) {
+    if (provider == null || provider.isEmpty) return 'Unknown';
+    return _guardianVoiceProviders[provider] ??
+        switch (provider) {
+          'grok-voice' => 'Grok Native Realtime',
+          'openai-native-realtime' => 'OpenAI Native Realtime',
+          'gemini-native-live' => 'Gemini Native Live',
+          'openclaw-direct' => 'OpenClaw Direct',
+          'fish-audio-s2' => 'Fish Audio S2',
+          'inworld' => 'Inworld',
+          _ => provider,
+        };
   }
 
   // ── Intelligence mode rows (exclusive radio) ──────────────────────────────
@@ -318,28 +390,28 @@ class _GuardianModePageState extends State<GuardianModePage> {
                           borderRadius: BorderRadius.circular(
                             EllaSizes.radiusMedium,
                           ),
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(
+                          child: const Padding(
+                            padding: EdgeInsets.symmetric(
                               horizontal: 4,
                               vertical: 10,
                             ),
                             child: Row(
                               children: [
-                                const Icon(
+                                Icon(
                                   Icons.list_alt,
                                   color: EllaColors.primary,
                                   size: 20,
                                 ),
-                                const SizedBox(width: 10),
-                                const Text(
+                                SizedBox(width: 10),
+                                Text(
                                   'View Demo Scenarios',
                                   style: TextStyle(
                                     fontSize: 16,
                                     color: EllaColors.primary,
                                   ),
                                 ),
-                                const Spacer(),
-                                const Icon(
+                                Spacer(),
+                                Icon(
                                   Icons.chevron_right,
                                   color: EllaColors.textTertiary,
                                   size: 20,
@@ -348,6 +420,41 @@ class _GuardianModePageState extends State<GuardianModePage> {
                             ),
                           ),
                         ),
+
+                      const SizedBox(height: 20),
+
+                      const _SectionHeader(label: 'GUARDIAN VOICE'),
+                      const Padding(
+                        padding: EdgeInsets.only(left: 4, bottom: 10),
+                        child: Text(
+                          'Controls which backend voice family generates Guardian alerts. App chat and V2V voice selection stay separate.',
+                          style: TextStyle(
+                            fontSize: 13,
+                            color: EllaColors.textTertiary,
+                          ),
+                        ),
+                      ),
+                      _GuardianVoicePolicyCard(
+                        policy: _selectedVoicePolicy,
+                        provider: _selectedVoiceProvider,
+                        activeProviderLabel:
+                            _formatProviderLabel(V2VClient.normalizeProvider(SharedPreferencesUtil().ttsProvider)),
+                        resolvedProvider: _currentVoiceConfig.resolvedProvider,
+                        fallbackProvider: _currentVoiceConfig.fallbackProvider,
+                        lastVoiceProvider: _currentVoiceConfig.lastVoiceProvider,
+                        onPolicyChanged: (policy) {
+                          setState(() {
+                            _selectedVoicePolicy = policy;
+                            if (policy == GuardianVoicePolicy.pinnedProvider &&
+                                !_guardianVoiceProviders.containsKey(_selectedVoiceProvider)) {
+                              _selectedVoiceProvider = _defaultPinnedVoiceProvider;
+                            }
+                          });
+                        },
+                        onProviderChanged: (provider) {
+                          setState(() => _selectedVoiceProvider = provider);
+                        },
+                      ),
 
                       const SizedBox(height: 20),
 
@@ -409,6 +516,179 @@ class _GuardianModePageState extends State<GuardianModePage> {
                 ),
               ],
             ),
+    );
+  }
+}
+
+class _GuardianVoicePolicyCard extends StatelessWidget {
+  final GuardianVoicePolicy policy;
+  final String provider;
+  final String activeProviderLabel;
+  final String? resolvedProvider;
+  final String? fallbackProvider;
+  final String? lastVoiceProvider;
+  final ValueChanged<GuardianVoicePolicy> onPolicyChanged;
+  final ValueChanged<String> onProviderChanged;
+
+  const _GuardianVoicePolicyCard({
+    required this.policy,
+    required this.provider,
+    required this.activeProviderLabel,
+    required this.resolvedProvider,
+    required this.fallbackProvider,
+    required this.lastVoiceProvider,
+    required this.onPolicyChanged,
+    required this.onProviderChanged,
+  });
+
+  static const Map<String, String> _providerLabels = {
+    'xai-tts': 'xAI TTS / Grok family',
+    'openai': 'OpenAI',
+    'elevenlabs': 'ElevenLabs',
+    'kokoro': 'Kokoro',
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: EllaColors.bgSecondary,
+        borderRadius: BorderRadius.circular(EllaSizes.radiusLarge),
+        border: Border.all(color: EllaColors.bgTertiary),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _PolicyOption(
+            title: GuardianVoicePolicy.matchActiveProvider.displayName,
+            subtitle:
+                'Use the active voice provider where Guardian can support it. Current app voice: $activeProviderLabel.',
+            selected: policy == GuardianVoicePolicy.matchActiveProvider,
+            onTap: () => onPolicyChanged(GuardianVoicePolicy.matchActiveProvider),
+          ),
+          const SizedBox(height: 8),
+          _PolicyOption(
+            title: GuardianVoicePolicy.pinnedProvider.displayName,
+            subtitle: 'Always ask the backend to generate Guardian alerts with a specific provider.',
+            selected: policy == GuardianVoicePolicy.pinnedProvider,
+            onTap: () => onPolicyChanged(GuardianVoicePolicy.pinnedProvider),
+          ),
+          if (policy == GuardianVoicePolicy.pinnedProvider) ...[
+            const SizedBox(height: 10),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              decoration: BoxDecoration(
+                color: EllaColors.bgPrimary,
+                borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+                border: Border.all(color: EllaColors.bgTertiary),
+              ),
+              child: DropdownButton<String>(
+                value: _providerLabels.containsKey(provider) ? provider : 'openai',
+                isExpanded: true,
+                underline: const SizedBox.shrink(),
+                dropdownColor: Colors.white,
+                style: const TextStyle(color: EllaColors.textPrimary, fontSize: 15),
+                iconEnabledColor: EllaColors.textSecondary,
+                items: _providerLabels.entries
+                    .map((entry) => DropdownMenuItem(value: entry.key, child: Text(entry.value)))
+                    .toList(),
+                onChanged: (value) {
+                  if (value != null) onProviderChanged(value);
+                },
+              ),
+            ),
+          ],
+          if (resolvedProvider != null || fallbackProvider != null || lastVoiceProvider != null) ...[
+            const SizedBox(height: 12),
+            Text(
+              [
+                if (resolvedProvider != null) 'Resolved: ${_formatProviderLabel(resolvedProvider!)}',
+                if (fallbackProvider != null) 'Fallback: ${_formatProviderLabel(fallbackProvider!)}',
+                if (lastVoiceProvider != null) 'Last active: ${_formatProviderLabel(lastVoiceProvider!)}',
+              ].join('  |  '),
+              style: const TextStyle(
+                fontSize: 12,
+                color: EllaColors.textTertiary,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  static String _formatProviderLabel(String provider) {
+    return _providerLabels[provider] ?? provider;
+  }
+}
+
+class _PolicyOption extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _PolicyOption({
+    required this.title,
+    required this.subtitle,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: selected ? EllaColors.primarySubtle : EllaColors.bgPrimary,
+          borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+          border: Border.all(color: selected ? EllaColors.primary : EllaColors.bgTertiary),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: 20,
+              height: 20,
+              margin: const EdgeInsets.only(top: 1),
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: selected ? EllaColors.primary : Colors.transparent,
+                border: Border.all(color: selected ? EllaColors.primary : EllaColors.bgTertiary, width: 2),
+              ),
+              child: selected ? const Icon(Icons.check, size: 12, color: Colors.white) : null,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w700,
+                      color: EllaColors.textPrimary,
+                    ),
+                  ),
+                  const SizedBox(height: 3),
+                  Text(
+                    subtitle,
+                    style: const TextStyle(
+                      fontSize: 13,
+                      color: EllaColors.textSecondary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/app/lib/ella/services/guardian_mode_api.dart
+++ b/app/lib/ella/services/guardian_mode_api.dart
@@ -2,8 +2,10 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart' show Color;
 import 'package:http/http.dart' as http;
+import 'package:omi/backend/http/shared.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/models/guardian_mode.dart';
+import 'package:omi/env/env.dart';
 import 'package:omi/utils/logger.dart';
 
 const String _dashboardBase = 'https://ella-ai-care.com';
@@ -101,6 +103,60 @@ Future<bool> setGuardianMode(GuardianModeKey mode) async {
   }
 }
 
+/// GET /v1/ella/guardian/voice-config?uid=...
+Future<GuardianVoiceConfig?> getGuardianVoiceConfig() async {
+  final uid = _userId;
+  final apiBaseUrl = Env.apiBaseUrl;
+  if (uid.isEmpty || apiBaseUrl == null) return null;
+
+  try {
+    final response = await makeApiCall(
+      url: '${apiBaseUrl}v1/ella/guardian/voice-config?uid=${Uri.encodeQueryComponent(uid)}',
+      headers: {'Content-Type': 'application/json'},
+      method: 'GET',
+      body: '',
+      timeout: const Duration(seconds: 10),
+    );
+
+    if (response?.statusCode == 200) {
+      final data = jsonDecode(response!.body) as Map<String, dynamic>;
+      return GuardianVoiceConfig.fromJson(data);
+    }
+    Logger.debug('getGuardianVoiceConfig: ${response?.statusCode} ${response?.body}');
+    return const GuardianVoiceConfig();
+  } catch (e) {
+    Logger.debug('getGuardianVoiceConfig error: $e');
+    return const GuardianVoiceConfig();
+  }
+}
+
+/// PUT /v1/ella/guardian/voice-config
+Future<GuardianVoiceConfig?> setGuardianVoiceConfig(GuardianVoiceConfig config) async {
+  final uid = _userId;
+  final apiBaseUrl = Env.apiBaseUrl;
+  if (uid.isEmpty || apiBaseUrl == null) return null;
+
+  try {
+    final response = await makeApiCall(
+      url: '${apiBaseUrl}v1/ella/guardian/voice-config',
+      headers: {'Content-Type': 'application/json'},
+      method: 'PUT',
+      body: jsonEncode(config.toJson(uid: uid)),
+      timeout: const Duration(seconds: 10),
+    );
+
+    if (response?.statusCode == 200) {
+      final data = jsonDecode(response!.body) as Map<String, dynamic>;
+      return GuardianVoiceConfig.fromJson(data);
+    }
+    Logger.debug('setGuardianVoiceConfig: ${response?.statusCode} ${response?.body}');
+    return null;
+  } catch (e) {
+    Logger.debug('setGuardianVoiceConfig error: $e');
+    return null;
+  }
+}
+
 /// GET /api/guardian/presets  (no auth required, cached in memory)
 Future<List<GuardianPreset>> getGuardianPresets() async {
   if (_cachedPresets != null) return _cachedPresets!;
@@ -126,13 +182,13 @@ Future<List<GuardianPreset>> getGuardianPresets() async {
 }
 
 /// Hard-coded fallback so the UI works even if the presets endpoint is down.
-List<GuardianPreset> _fallbackPresets() => [
+List<GuardianPreset> _fallbackPresets() => const [
       GuardianPreset(
         presetKey: 'EMERGENCY_ONLY',
         name: 'Emergency Alerts',
         description: 'Critical alerts only — fall detection, medical emergencies, fire/smoke.',
         detailsBullets: ['Medical emergencies', 'Fall detection', 'Fire/smoke'],
-        color: const Color(0xFFF59E0B),
+        color: Color(0xFFF59E0B),
       ),
       GuardianPreset(
         presetKey: 'ACTIVE_SUPPORT',
@@ -143,7 +199,7 @@ List<GuardianPreset> _fallbackPresets() => [
           'Wake words (always active)',
           'Recall assistance',
         ],
-        color: const Color(0xFF14B8A6),
+        color: Color(0xFF14B8A6),
       ),
       GuardianPreset(
         presetKey: 'MAXIMUM_AWARENESS',
@@ -155,7 +211,7 @@ List<GuardianPreset> _fallbackPresets() => [
           'Lower alert thresholds',
           'Helpful during outings or recovery',
         ],
-        color: const Color(0xFF6366F1),
+        color: Color(0xFF6366F1),
       ),
       GuardianPreset(
         presetKey: 'MEMORY_SUPPORT',
@@ -166,7 +222,7 @@ List<GuardianPreset> _fallbackPresets() => [
           'Daily routine reminders',
           'Cognitive pattern monitoring',
         ],
-        color: const Color(0xFF10B981),
+        color: Color(0xFF10B981),
       ),
       GuardianPreset(
         presetKey: 'CYBORG',
@@ -178,7 +234,7 @@ List<GuardianPreset> _fallbackPresets() => [
           'Useful companion asides',
           'Experimental brain-enhancer mode',
         ],
-        color: const Color(0xFFEC4899),
+        color: Color(0xFFEC4899),
       ),
       GuardianPreset(
         presetKey: 'CHATBOT',
@@ -189,13 +245,13 @@ List<GuardianPreset> _fallbackPresets() => [
           'Suppresses media/background audio',
           'Best for direct voice chat',
         ],
-        color: const Color(0xFFF97316),
+        color: Color(0xFFF97316),
       ),
       GuardianPreset(
         presetKey: 'DEMO',
         name: 'Demo',
         description: 'Demonstration mode with scripted responses for showcasing Ella.',
         detailsBullets: ['Scripted demo responses', 'Showcase mode'],
-        color: const Color(0xFF3B82F6),
+        color: Color(0xFF3B82F6),
       ),
     ];

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+765
+version: 1.0.524+766
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/test/ella/models/guardian_voice_config_test.dart
+++ b/app/test/ella/models/guardian_voice_config_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/ella/models/guardian_mode.dart';
+
+void main() {
+  group('GuardianVoiceConfig', () {
+    test('defaults to match active provider', () {
+      const config = GuardianVoiceConfig();
+
+      expect(config.policy, GuardianVoicePolicy.matchActiveProvider);
+      expect(config.provider, isNull);
+      expect(
+        config.toJson(uid: 'uid-1'),
+        {
+          'uid': 'uid-1',
+          'guardian_voice_policy': 'match_active_provider',
+          'guardian_voice_provider': null,
+        },
+      );
+    });
+
+    test('parses backend snake case fields', () {
+      final config = GuardianVoiceConfig.fromJson({
+        'guardian_voice_policy': 'pinned_provider',
+        'guardian_voice_provider': 'xai-tts',
+        'last_voice_provider': 'grok-voice',
+        'resolved_provider': 'xai-tts',
+        'fallback_provider': 'openai',
+        'trace_id': 'trace-1',
+        'queue_item_id': 'guardian_1',
+      });
+
+      expect(config.policy, GuardianVoicePolicy.pinnedProvider);
+      expect(config.provider, 'xai-tts');
+      expect(config.lastVoiceProvider, 'grok-voice');
+      expect(config.resolvedProvider, 'xai-tts');
+      expect(config.fallbackProvider, 'openai');
+      expect(config.traceId, 'trace-1');
+      expect(config.queueItemId, 'guardian_1');
+    });
+
+    test('parses nested response wrappers', () {
+      final config = GuardianVoiceConfig.fromJson({
+        'success': true,
+        'data': {
+          'policy': 'match_active_provider',
+          'provider': 'elevenlabs',
+          'resolvedProvider': 'elevenlabs',
+        },
+      });
+
+      expect(config.policy, GuardianVoicePolicy.matchActiveProvider);
+      expect(config.provider, 'elevenlabs');
+      expect(config.resolvedProvider, 'elevenlabs');
+    });
+
+    test('only persists provider for pinned policy', () {
+      final pinned = const GuardianVoiceConfig(
+        policy: GuardianVoicePolicy.pinnedProvider,
+        provider: 'kokoro',
+      ).toJson(uid: 'uid-1');
+      final matching = const GuardianVoiceConfig(
+        policy: GuardianVoicePolicy.matchActiveProvider,
+        provider: 'kokoro',
+      ).toJson(uid: 'uid-1');
+
+      expect(pinned['guardian_voice_provider'], 'kokoro');
+      expect(matching['guardian_voice_provider'], isNull);
+    });
+  });
+}


### PR DESCRIPTION
Implements iOS side of ellaaicare/ella-ai#993.

Changes:
- Adds Guardian voice policy/config model for `match_active_provider` and `pinned_provider` payloads.
- Wires authenticated `GET /v1/ella/guardian/voice-config?uid=...` and `PUT /v1/ella/guardian/voice-config` calls.
- Adds a Guardian Voice section to the Guardian Mode screen, with default match-active behavior, pinned provider override, and resolved/fallback/last-provider diagnostics.
- Keeps the existing app chat/V2V `TTS Provider` preference separate.
- Adds focused model tests for payload construction and backend response parsing.

Validation:
- `flutter test test/ella/models/guardian_voice_config_test.dart`
- `flutter analyze lib/ella/models/guardian_mode.dart lib/ella/services/guardian_mode_api.dart lib/ella/pages/guardian_mode_page.dart test/ella/models/guardian_voice_config_test.dart`
- `./test.sh`