### PR TITLE
Fix voice search agent UID validation casing

### DIFF
--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -1199,16 +1199,18 @@ def _validate_agent_uid(agent_id: str, uid: str) -> bool:
         return True  # No agent_id means direct API call (trusted)
     if not uid:
         return False
+    agent_id_norm = agent_id.lower()
+    uid_norm = uid.lower()
     # Agent IDs should contain the uid as a suffix component
     # Patterns: ella-{uid}, ella-user-{uid}, ella-cg-{uid}, ella-scanner-{uid}
-    parts = agent_id.split("-")
+    parts = agent_id_norm.split("-")
     if len(parts) < 2:
         return False
     # The uid should appear as the last segment(s) of the agent_id
-    if agent_id.endswith(uid):
+    if agent_id_norm.endswith(uid_norm):
         return True
     # Also accept if uid appears anywhere in the agent_id (for flexibility)
-    if uid in agent_id:
+    if uid_norm in agent_id_norm:
         return True
     return False
 

--- a/backend/tests/unit/test_voice_search_agent_uid_validation.py
+++ b/backend/tests/unit/test_voice_search_agent_uid_validation.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import types
+
+
+def _load_validate_agent_uid():
+    voice_py = Path(__file__).resolve().parents[2] / "ella" / "routers" / "voice.py"
+    source = voice_py.read_text()
+    start = source.index("def _validate_agent_uid(")
+    end = source.index("\n\ndef _keyword_score(", start)
+    module = types.ModuleType("voice_validate_agent_uid_test")
+    exec(source[start:end], module.__dict__)
+    return module._validate_agent_uid
+
+
+def test_validate_agent_uid_accepts_case_mismatched_omi_agent_id():
+    validate = _load_validate_agent_uid()
+    uid = "5aGC5YE9BnhcSoTxxtT4ar6ILQy2"
+    agent_id = "ella-omi-5agc5ye9bnhcsotxxtt4ar6ilqy2"
+
+    assert validate(agent_id, uid) is True
+
+
+def test_validate_agent_uid_rejects_unrelated_agent_id():
+    validate = _load_validate_agent_uid()
+    uid = "5aGC5YE9BnhcSoTxxtT4ar6ILQy2"
+    agent_id = "ella-omi-someone-else"
+
+    assert validate(agent_id, uid) is False


### PR DESCRIPTION
## Summary
- make `/v1/voice/search` agent-to-UID validation case-insensitive
- cover the mixed-case OMI UID + lowercase `ella-omi-*` agent ID path with a unit test

## Why
Live voice retrieval for Grok/Gemini was failing with `403 agent_id does not belong to this uid` when the proxy sent the provisioned lowercase `userAgentId` and the request body used the mixed-case Firebase/OMI UID. That made voice memory/search look "brain dead" even though the data existed.

## Validation
- `python3 -m py_compile backend/ella/routers/voice.py`
- `pytest -q backend/tests/unit/test_voice_search_agent_uid_validation.py`
- live repro before fix:
  - mixed-case UID + lowercase agent ID => `403`
  - lowercased UID + same agent ID => `200`
