### PR TITLE
Add iPhone mic capture fallback

### DIFF
--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -1,10 +1,7 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
-import 'package:flutter/services.dart';
 
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:provider/provider.dart';
@@ -47,7 +44,6 @@ import 'package:omi/services/notifications.dart';
 import 'package:omi/services/notifications/daily_reflection_notification.dart';
 import 'package:omi/utils/analytics/mixpanel.dart';
 import 'package:omi/utils/audio/foreground.dart';
-import 'package:omi/utils/enums.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:omi/utils/platform/platform_service.dart';
@@ -58,6 +54,7 @@ import 'package:omi/ella/ella_theme.dart';
 import 'package:omi/ella/widgets/ella_emergency_button.dart';
 import 'package:omi/ella/widgets/guardian_mode_button.dart';
 import 'widgets/battery_info_widget.dart';
+import 'widgets/phone_mic_capture_button.dart';
 
 class HomePageWrapper extends StatefulWidget {
   final String? navigateToRoute;
@@ -645,7 +642,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                                     const SizedBox(height: EllaSizes.buttonStackSpacing),
                                   ],
                                   // Always reserve space for nav bar
-                                  SizedBox(height: EllaSizes.navBarHeight),
+                                  const SizedBox(height: EllaSizes.navBarHeight),
                                 ],
                               ),
                             );
@@ -684,49 +681,65 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
     return AppBar(
       automaticallyImplyLeading: false,
       backgroundColor: Theme.of(context).colorScheme.primary,
-      leading: const Padding(
-        padding: EdgeInsets.only(left: 8),
-        child: Center(child: BatteryInfoWidget()),
-      ),
-      leadingWidth: 140,
-      title: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-            width: 28,
-            height: 28,
-            decoration: const BoxDecoration(
-              shape: BoxShape.circle,
-              gradient: LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: [Color(0xFF7AB5A8), Color(0xFF5A9E8F)],
+      titleSpacing: 8,
+      title: SizedBox(
+        height: 48,
+        width: double.infinity,
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            const Positioned(
+              left: 0,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  BatteryInfoWidget(),
+                  SizedBox(width: 8),
+                  PhoneMicCaptureButton(),
+                ],
               ),
             ),
-            child: const Center(
-              child: Text(
-                'e',
-                style: TextStyle(
-                  fontSize: 15,
-                  fontWeight: FontWeight.w300,
-                  color: Colors.white,
-                  fontFamily: 'Manrope',
-                  height: 1.1,
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 28,
+                  height: 28,
+                  decoration: const BoxDecoration(
+                    shape: BoxShape.circle,
+                    gradient: LinearGradient(
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                      colors: [Color(0xFF7AB5A8), Color(0xFF5A9E8F)],
+                    ),
+                  ),
+                  child: const Center(
+                    child: Text(
+                      'e',
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w300,
+                        color: Colors.white,
+                        fontFamily: 'Manrope',
+                        height: 1.1,
+                      ),
+                    ),
+                  ),
                 ),
-              ),
+                const SizedBox(width: 8),
+                const Text(
+                  'ella',
+                  style: TextStyle(
+                    fontSize: 22,
+                    fontWeight: FontWeight.w600,
+                    fontFamily: 'Manrope',
+                    letterSpacing: 1,
+                  ),
+                ),
+              ],
             ),
-          ),
-          const SizedBox(width: 8),
-          const Text(
-            'ella',
-            style: TextStyle(
-              fontSize: 22,
-              fontWeight: FontWeight.w600,
-              fontFamily: 'Manrope',
-              letterSpacing: 1,
-            ),
-          ),
-        ],
+          ],
+        ),
       ),
       centerTitle: true,
       elevation: 0,

--- a/app/lib/pages/home/widgets/phone_mic_capture_button.dart
+++ b/app/lib/pages/home/widgets/phone_mic_capture_button.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/providers/capture_provider.dart';
+import 'package:omi/utils/alerts/app_snackbar.dart';
+import 'package:omi/utils/analytics/mixpanel.dart';
+import 'package:omi/utils/enums.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/utils/platform/platform_service.dart';
+
+class PhoneMicCaptureButton extends StatefulWidget {
+  const PhoneMicCaptureButton({super.key});
+
+  @override
+  State<PhoneMicCaptureButton> createState() => _PhoneMicCaptureButtonState();
+}
+
+class _PhoneMicCaptureButtonState extends State<PhoneMicCaptureButton> {
+  bool _busy = false;
+
+  Future<void> _togglePhoneMic(CaptureProvider captureProvider) async {
+    if (_busy || !captureProvider.canUsePhoneMicCapture) {
+      return;
+    }
+
+    setState(() => _busy = true);
+    HapticFeedback.mediumImpact();
+
+    try {
+      if (captureProvider.isPhoneMicRecording) {
+        await captureProvider.stopStreamRecording();
+        MixpanelManager().phoneMicRecordingStopped();
+      } else {
+        await captureProvider.streamRecording();
+        if (captureProvider.recordingState == RecordingState.record) {
+          MixpanelManager().phoneMicRecordingStarted();
+        }
+      }
+    } catch (e) {
+      if (!mounted) return;
+      AppSnackbar.showSnackbarError(context.l10n.captureRecordingError(e.toString()));
+    } finally {
+      if (mounted) {
+        setState(() => _busy = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!PlatformService.isMobile) {
+      return const SizedBox.shrink();
+    }
+
+    return Selector<CaptureProvider, (RecordingState, bool, bool)>(
+      selector: (_, provider) =>
+          (provider.recordingState, provider.isPhoneMicRecording, provider.canUsePhoneMicCapture),
+      builder: (context, data, child) {
+        final (recordingState, isPhoneMicRecording, canUsePhoneMicCapture) = data;
+        final isInitialising = recordingState == RecordingState.initialising;
+        final enabled = !_busy && canUsePhoneMicCapture && !isInitialising;
+        final active = isPhoneMicRecording && recordingState == RecordingState.record;
+        final tooltip = active
+            ? context.l10n.stopRecording
+            : '${context.l10n.startRecording}: ${context.l10n.phone} ${context.l10n.mic}';
+
+        return Tooltip(
+          message: tooltip,
+          child: Semantics(
+            button: true,
+            enabled: enabled,
+            label: tooltip,
+            child: GestureDetector(
+              onTap: enabled ? () => _togglePhoneMic(context.read<CaptureProvider>()) : null,
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 180),
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: enabled
+                      ? active
+                          ? EllaColors.error
+                          : EllaColors.primary
+                      : EllaColors.bgTertiary,
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: enabled ? Colors.transparent : EllaColors.textDisabled.withValues(alpha: 0.35),
+                  ),
+                ),
+                child: Center(
+                  child: _busy || isInitialising
+                      ? const SizedBox(
+                          width: 15,
+                          height: 15,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: Colors.white,
+                          ),
+                        )
+                      : FaIcon(
+                          active
+                              ? FontAwesomeIcons.stop
+                              : enabled
+                                  ? FontAwesomeIcons.microphone
+                                  : FontAwesomeIcons.microphoneSlash,
+                          color: enabled ? Colors.white : EllaColors.textDisabled,
+                          size: 15,
+                        ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -10,7 +9,6 @@ import 'package:collection/collection.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:flutter_provider_utilities/flutter_provider_utilities.dart';
 import 'package:geolocator/geolocator.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import 'package:omi/backend/http/api/conversations.dart';
@@ -24,7 +22,6 @@ import 'package:omi/backend/schema/person.dart';
 import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/backend/schema/transcript_segment.dart';
 import 'package:omi/models/custom_stt_config.dart';
-import 'package:omi/models/stt_provider.dart';
 import 'package:omi/providers/calendar_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/providers/message_provider.dart';
@@ -40,7 +37,6 @@ import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/enums.dart';
 import 'package:omi/utils/image/image_utils.dart';
 import 'package:omi/utils/l10n_extensions.dart';
-import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 import 'package:omi/main.dart';
@@ -347,6 +343,23 @@ class CaptureProvider extends ChangeNotifier
   bool get havingRecordingDevice => _recordingDevice != null;
 
   BtDevice? get recordingDevice => _recordingDevice;
+
+  bool get isPhoneMicRecording =>
+      _recordingDevice == null &&
+      (recordingState == RecordingState.record ||
+          recordingState == RecordingState.initialising ||
+          recordingState == RecordingState.pause);
+
+  bool get isDeviceRecording =>
+      _recordingDevice != null &&
+      (recordingState == RecordingState.deviceRecord ||
+          recordingState == RecordingState.pause ||
+          recordingState == RecordingState.initialising);
+
+  bool get canUsePhoneMicCapture =>
+      !isDeviceRecording &&
+      recordingState != RecordingState.systemAudioRecord &&
+      recordingState != RecordingState.initialising;
 
   void setHasTranscripts(bool value) {
     hasTranscripts = value;
@@ -967,7 +980,15 @@ class CaptureProvider extends ChangeNotifier
 
   streamRecording() async {
     updateRecordingState(RecordingState.initialising);
-    await Permission.microphone.request();
+    final microphoneStatus = await Permission.microphone.request();
+    if (!microphoneStatus.isGranted) {
+      updateRecordingState(RecordingState.stop);
+      AppSnackbar.showSnackbarError(
+        MyApp.navigatorKey.currentContext?.l10n.microphonePermissionRequired ??
+            'Microphone permission is required for voice recording.',
+      );
+      return;
+    }
 
     // Send current location when conversation starts
     _sendCurrentGeolocation();

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+768
+version: 1.0.524+769
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -1,15 +1,18 @@
 import 'dart:async';
 
+// ignore: depend_on_referenced_packages
 import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/message_event.dart';
 import 'package:omi/backend/schema/transcript_segment.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/people_provider.dart';
 import 'package:omi/services/services.dart';
+import 'package:omi/utils/enums.dart';
 
 /// Mock PeopleProvider that tracks setPeople calls
 class MockPeopleProvider extends PeopleProvider {
@@ -88,6 +91,38 @@ void main() {
     expect(provider.suggestionsBySegmentId.containsKey('a'), false);
     expect(provider.taggingSegmentIds.contains('a'), false);
     expect(provider.hasTranscripts, true);
+  });
+
+  group('phone mic capture fallback state', () {
+    test('allows phone mic when no device capture is active', () {
+      final provider = CaptureProvider();
+
+      expect(provider.isPhoneMicRecording, false);
+      expect(provider.isDeviceRecording, false);
+      expect(provider.canUsePhoneMicCapture, true);
+
+      provider.recordingState = RecordingState.record;
+
+      expect(provider.isPhoneMicRecording, true);
+      expect(provider.canUsePhoneMicCapture, true);
+    });
+
+    test('disables phone mic while device capture owns recording', () {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(
+        BtDevice(
+          name: 'Omi',
+          id: 'device-1',
+          type: DeviceType.omi,
+          rssi: -45,
+        ),
+      );
+      provider.recordingState = RecordingState.deviceRecord;
+
+      expect(provider.isDeviceRecording, true);
+      expect(provider.isPhoneMicRecording, false);
+      expect(provider.canUsePhoneMicCapture, false);
+    });
   });
 
   group('metricsNotifyEnabled', () {
@@ -346,7 +381,7 @@ void main() {
   });
 
   group('People cache refresh', () {
-    TranscriptSegment _segmentWithPerson(String id, String? personId) {
+    TranscriptSegment segmentWithPerson(String id, String? personId) {
       return TranscriptSegment(
         id: id,
         text: 'text',
@@ -365,10 +400,10 @@ void main() {
       provider.peopleProvider = mockPeopleProvider;
 
       // Pre-populate segments to skip platform-specific initialization code
-      provider.segments = [_segmentWithPerson('seed', null)];
+      provider.segments = [segmentWithPerson('seed', null)];
 
       // Segment with personId that's not in cache (cachedPeople is empty)
-      final segments = [_segmentWithPerson('seg1', 'unknown-person-id')];
+      final segments = [segmentWithPerson('seg1', 'unknown-person-id')];
 
       provider.onSegmentReceived(segments);
 
@@ -382,9 +417,9 @@ void main() {
       provider.peopleProvider = mockPeopleProvider;
 
       // Pre-populate segments to skip platform-specific initialization code
-      provider.segments = [_segmentWithPerson('seed', null)];
+      provider.segments = [segmentWithPerson('seed', null)];
 
-      final segments = [_segmentWithPerson('seg2', null)];
+      final segments = [segmentWithPerson('seg2', null)];
 
       provider.onSegmentReceived(segments);
 
@@ -403,17 +438,17 @@ void main() {
       provider.peopleProvider = mockPeopleProvider;
 
       // Pre-populate segments to skip platform-specific initialization code
-      provider.segments = [_segmentWithPerson('seed', null)];
+      provider.segments = [segmentWithPerson('seed', null)];
 
       // First segment with unknown personId
-      final segments1 = [_segmentWithPerson('seg-a', 'unknown-1')];
+      final segments1 = [segmentWithPerson('seg-a', 'unknown-1')];
       provider.onSegmentReceived(segments1);
 
       // Should trigger first call
       expect(mockPeopleProvider.setPeopleCallCount, 1);
 
       // Second segment with different unknown personId while first is still in-flight
-      final segments2 = [_segmentWithPerson('seg-b', 'unknown-2')];
+      final segments2 = [segmentWithPerson('seg-b', 'unknown-2')];
       provider.onSegmentReceived(segments2);
 
       // Should NOT trigger another call (first is still in-flight)
@@ -424,7 +459,7 @@ void main() {
       await Future.delayed(Duration.zero); // Let the future complete
 
       // Third segment - now a new call should be allowed
-      final segments3 = [_segmentWithPerson('seg-c', 'unknown-3')];
+      final segments3 = [segmentWithPerson('seg-c', 'unknown-3')];
       provider.onSegmentReceived(segments3);
 
       // Should trigger a new call


### PR DESCRIPTION
## Summary
- Adds a compact iPhone mic capture control to the Home app bar near the device status area.
- Reuses the existing `CaptureProvider.streamRecording()` path: PCM16 16 kHz into the normal conversation transcription socket with `source=phone`.
- Disables/greys the phone mic control while device capture owns recording to avoid socket/audio-session contention.
- Surfaces microphone permission denial instead of silently failing.

Tracking: ellaaicare/ella-ai#994

## Tests
- `flutter analyze lib/providers/capture_provider.dart lib/pages/home/page.dart lib/pages/home/widgets/phone_mic_capture_button.dart test/providers/capture_provider_test.dart`
- `flutter test test/providers/capture_provider_test.dart`
- `./test.sh`

## TestFlight
- Uploaded build `1.0.524+769`.
- Delivery UUID: `a70e6d60-45b4-4002-8aae-4a9747f8303b`.
- Prod preflight confirmed bundle `com.ellaaicare.ella` and Firebase project `omi-dev-ca005`.