### PR TITLE
Handle caregiver invite email delivery failures

### DIFF
--- a/app/lib/ella/models/caregiver.dart
+++ b/app/lib/ella/models/caregiver.dart
@@ -1,3 +1,14 @@
+bool _readBool(dynamic value, {bool defaultValue = true}) {
+  if (value is bool) return value;
+  if (value is num) return value != 0;
+  if (value is String) {
+    final normalized = value.toLowerCase().trim();
+    if (normalized == 'true') return true;
+    if (normalized == 'false') return false;
+  }
+  return defaultValue;
+}
+
 class Caregiver {
   final String id;
   final String name;
@@ -67,23 +78,36 @@ class Caregiver {
 
 class InviteResponse {
   final String inviteId;
+  final String caregiverId;
   final String inviteCode;
   final String status;
   final DateTime expiresAt;
+  final bool emailSent;
+  final String? deliveryError;
+  final String? failureReason;
 
   InviteResponse.fromJson(Map<String, dynamic> json)
       : inviteId = json['invite_id'] ?? '',
+        caregiverId = json['caregiver_id'] ?? json['caregiverId'] ?? json['id'] ?? '',
         inviteCode = json['invite_code'] ?? '',
         status = json['status'] ?? '',
         expiresAt = json['expires_at'] != null
             ? DateTime.parse(json['expires_at'])
-            : DateTime.now().add(const Duration(days: 7));
+            : DateTime.now().add(const Duration(days: 7)),
+        emailSent = _readBool(json['email_sent'] ?? json['emailSent']),
+        deliveryError =
+            json['delivery_error']?.toString() ?? json['email_error']?.toString() ?? json['error']?.toString(),
+        failureReason = json['failure_reason']?.toString() ?? json['reason']?.toString();
+
+  bool get hasInviteRecovery => inviteCode.isNotEmpty || caregiverId.isNotEmpty || inviteId.isNotEmpty;
+  bool get emailDeliveryFailed => !emailSent;
 }
 
 class CaregiverApiException implements Exception {
   final int statusCode;
   final String message;
-  CaregiverApiException({required this.statusCode, required this.message});
+  final InviteResponse? inviteResponse;
+  CaregiverApiException({required this.statusCode, required this.message, this.inviteResponse});
 
   @override
   String toString() => 'CaregiverApiException($statusCode): $message';

--- a/app/lib/ella/pages/ella_add_caregiver_page.dart
+++ b/app/lib/ella/pages/ella_add_caregiver_page.dart
@@ -103,12 +103,34 @@ class _EllaAddCaregiverPageState extends State<EllaAddCaregiverPage> {
             email: _emailController.text.trim(),
             phone: _phoneController.text.trim().isNotEmpty ? _phoneController.text.trim() : null,
             inviteCode: inviteResponse.inviteCode,
+            caregiverId: inviteResponse.caregiverId,
+            emailSent: inviteResponse.emailSent,
+            deliveryError: inviteResponse.deliveryError ?? inviteResponse.failureReason,
           ),
         ),
       );
     } on CaregiverApiException catch (e) {
       if (!mounted) return;
       setState(() => _sending = false);
+
+      final inviteResponse = e.inviteResponse;
+      if (inviteResponse != null && inviteResponse.emailDeliveryFailed) {
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(
+            builder: (context) => EllaInviteSentScreen(
+              name: _nameController.text.trim(),
+              email: _emailController.text.trim(),
+              phone: _phoneController.text.trim().isNotEmpty ? _phoneController.text.trim() : null,
+              inviteCode: inviteResponse.inviteCode,
+              caregiverId: inviteResponse.caregiverId,
+              emailSent: false,
+              deliveryError: inviteResponse.deliveryError ?? inviteResponse.failureReason ?? e.message,
+            ),
+          ),
+        );
+        return;
+      }
 
       if (e.statusCode == 409) {
         setState(() => _phoneError = context.l10n.ellaInviteErrorDuplicate);
@@ -303,7 +325,7 @@ class _EllaAddCaregiverPageState extends State<EllaAddCaregiverPage> {
                   height: 64,
                   decoration: BoxDecoration(
                     color: _sending
-                        ? EllaColors.primary.withOpacity(0.6)
+                        ? EllaColors.primary.withValues(alpha: 0.6)
                         : _isValid
                             ? EllaColors.primary
                             : EllaColors.bgTertiary,

--- a/app/lib/ella/pages/ella_caregiver_detail_page.dart
+++ b/app/lib/ella/pages/ella_caregiver_detail_page.dart
@@ -6,6 +6,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/ella_theme.dart';
 import 'package:omi/ella/models/caregiver.dart';
+import 'package:omi/ella/pages/ella_invite_sent_screen.dart';
 import 'package:omi/ella/services/caregiver_api.dart' as caregiver_api;
 import 'package:omi/ella/widgets/ella_permission_toggle.dart';
 import 'package:omi/utils/l10n_extensions.dart';
@@ -89,15 +90,56 @@ class _EllaCaregiverDetailPageState extends State<EllaCaregiverDetailPage> {
     if (_resending) return;
     setState(() => _resending = true);
     try {
-      await caregiver_api.resendInvite(
+      final response = await caregiver_api.resendInvite(
         uid: SharedPreferencesUtil().uid,
         caregiverId: _caregiver.id,
       );
+      if (!response.emailSent) {
+        if (mounted) {
+          await Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => EllaInviteSentScreen(
+                name: _caregiver.name,
+                email: _caregiver.email ?? '',
+                phone: _caregiver.phone,
+                inviteCode: response.inviteCode,
+                caregiverId: _caregiver.id,
+                emailSent: false,
+                deliveryError: response.deliveryError ?? response.failureReason,
+              ),
+            ),
+          );
+        }
+        return;
+      }
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(context.l10n.ellaResendSuccess(_caregiver.name))),
         );
         await _refreshFromBackend();
+      }
+    } on CaregiverApiException catch (e) {
+      final inviteResponse = e.inviteResponse;
+      if (mounted && inviteResponse != null && inviteResponse.emailDeliveryFailed) {
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => EllaInviteSentScreen(
+              name: _caregiver.name,
+              email: _caregiver.email ?? '',
+              phone: _caregiver.phone,
+              inviteCode: inviteResponse.inviteCode,
+              caregiverId: inviteResponse.caregiverId.isNotEmpty ? inviteResponse.caregiverId : _caregiver.id,
+              emailSent: false,
+              deliveryError: inviteResponse.deliveryError ?? inviteResponse.failureReason ?? e.message,
+            ),
+          ),
+        );
+      } else if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(context.l10n.ellaInviteErrorNetwork)),
+        );
       }
     } catch (_) {
       if (mounted) {
@@ -105,8 +147,9 @@ class _EllaCaregiverDetailPageState extends State<EllaCaregiverDetailPage> {
           SnackBar(content: Text(context.l10n.ellaInviteErrorNetwork)),
         );
       }
+    } finally {
+      if (mounted) setState(() => _resending = false);
     }
-    if (mounted) setState(() => _resending = false);
   }
 
   Future<void> _removeCaregiver() async {

--- a/app/lib/ella/pages/ella_invite_sent_screen.dart
+++ b/app/lib/ella/pages/ella_invite_sent_screen.dart
@@ -4,6 +4,8 @@ import 'package:share_plus/share_plus.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/ella/models/caregiver.dart';
+import 'package:omi/ella/services/caregiver_api.dart' as caregiver_api;
 import 'package:omi/utils/l10n_extensions.dart';
 
 class EllaInviteSentScreen extends StatefulWidget {
@@ -11,6 +13,9 @@ class EllaInviteSentScreen extends StatefulWidget {
   final String? phone;
   final String email;
   final String? inviteCode;
+  final String? caregiverId;
+  final bool emailSent;
+  final String? deliveryError;
 
   const EllaInviteSentScreen({
     super.key,
@@ -18,6 +23,9 @@ class EllaInviteSentScreen extends StatefulWidget {
     this.phone,
     required this.email,
     this.inviteCode,
+    this.caregiverId,
+    this.emailSent = true,
+    this.deliveryError,
   });
 
   @override
@@ -28,10 +36,17 @@ class _EllaInviteSentScreenState extends State<EllaInviteSentScreen> with Single
   final GlobalKey _shareButtonKey = GlobalKey();
   late AnimationController _scaleController;
   late Animation<double> _scaleAnimation;
+  late bool _emailSent;
+  late String? _inviteCode;
+  String? _deliveryError;
+  bool _retryingEmail = false;
 
   @override
   void initState() {
     super.initState();
+    _emailSent = widget.emailSent;
+    _inviteCode = widget.inviteCode;
+    _deliveryError = widget.deliveryError;
     _scaleController = AnimationController(
       duration: const Duration(milliseconds: 300),
       vsync: this,
@@ -53,17 +68,73 @@ class _EllaInviteSentScreenState extends State<EllaInviteSentScreen> with Single
     super.dispose();
   }
 
+  Future<void> _retryEmail() async {
+    final caregiverId = widget.caregiverId;
+    if (_retryingEmail || caregiverId == null || caregiverId.isEmpty) return;
+
+    setState(() => _retryingEmail = true);
+    try {
+      final response = await caregiver_api.resendInvite(
+        uid: SharedPreferencesUtil().uid,
+        caregiverId: caregiverId,
+      );
+      if (!mounted) return;
+      if (response.inviteCode.isNotEmpty) {
+        _inviteCode = response.inviteCode;
+      }
+      if (response.emailSent) {
+        setState(() {
+          _emailSent = true;
+          _deliveryError = null;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(context.l10n.ellaRetryEmailSuccess)),
+        );
+      } else {
+        setState(() {
+          _emailSent = false;
+          _deliveryError = response.deliveryError ?? response.failureReason;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(context.l10n.ellaRetryEmailFailed)),
+        );
+      }
+    } on CaregiverApiException catch (e) {
+      if (!mounted) return;
+      final inviteResponse = e.inviteResponse;
+      setState(() {
+        _emailSent = false;
+        _deliveryError = inviteResponse?.deliveryError ?? inviteResponse?.failureReason ?? e.message;
+        if (inviteResponse?.inviteCode.isNotEmpty == true) {
+          _inviteCode = inviteResponse!.inviteCode;
+        }
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(context.l10n.ellaRetryEmailFailed)),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(context.l10n.ellaRetryEmailFailed)),
+      );
+    } finally {
+      if (mounted) setState(() => _retryingEmail = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
+    final hasCode = _inviteCode != null && _inviteCode!.isNotEmpty;
+    final canRetryEmail = widget.caregiverId != null && widget.caregiverId!.isNotEmpty;
+
     return Scaffold(
       backgroundColor: EllaColors.bgPrimary,
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
+          child: ListView(
             children: [
-              const Spacer(),
+              const SizedBox(height: 32),
 
               // Checkmark circle with animation
               ScaleTransition(
@@ -71,11 +142,15 @@ class _EllaInviteSentScreenState extends State<EllaInviteSentScreen> with Single
                 child: Container(
                   width: 80,
                   height: 80,
-                  decoration: const BoxDecoration(
+                  decoration: BoxDecoration(
                     shape: BoxShape.circle,
-                    color: EllaColors.primary,
+                    color: _emailSent ? EllaColors.primary : EllaColors.warning,
                   ),
-                  child: const Icon(Icons.check, size: 36, color: EllaColors.textPrimary),
+                  child: Icon(
+                    _emailSent ? Icons.check : Icons.mark_email_unread_outlined,
+                    size: 36,
+                    color: EllaColors.textPrimary,
+                  ),
                 ),
               ),
 
@@ -83,7 +158,7 @@ class _EllaInviteSentScreenState extends State<EllaInviteSentScreen> with Single
 
               // Title
               Text(
-                context.l10n.ellaInviteSentTitle(widget.name),
+                _emailSent ? context.l10n.ellaInviteSentTitle(widget.name) : context.l10n.ellaInviteEmailFailedTitle,
                 textAlign: TextAlign.center,
                 style: const TextStyle(
                   fontSize: 28,
@@ -96,7 +171,9 @@ class _EllaInviteSentScreenState extends State<EllaInviteSentScreen> with Single
 
               // Description
               Text(
-                context.l10n.ellaInviteSentDescription(widget.email),
+                _emailSent
+                    ? context.l10n.ellaInviteSentDescription(widget.email)
+                    : context.l10n.ellaInviteEmailFailedDescription(widget.email),
                 textAlign: TextAlign.center,
                 style: const TextStyle(
                   fontSize: 18,
@@ -106,8 +183,22 @@ class _EllaInviteSentScreenState extends State<EllaInviteSentScreen> with Single
                 ),
               ),
 
+              if (!_emailSent && _deliveryError != null && _deliveryError!.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                Text(
+                  context.l10n.ellaInviteEmailFailedReason(_deliveryError!),
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w400,
+                    color: EllaColors.textTertiary,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+
               // Invite code display
-              if (widget.inviteCode != null && widget.inviteCode!.isNotEmpty) ...[
+              if (hasCode) ...[
                 const SizedBox(height: 24),
                 Container(
                   padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
@@ -128,7 +219,7 @@ class _EllaInviteSentScreenState extends State<EllaInviteSentScreen> with Single
                       const SizedBox(height: 8),
                       GestureDetector(
                         onTap: () {
-                          Clipboard.setData(ClipboardData(text: widget.inviteCode!));
+                          Clipboard.setData(ClipboardData(text: _inviteCode!));
                           HapticFeedback.lightImpact();
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
@@ -141,7 +232,7 @@ class _EllaInviteSentScreenState extends State<EllaInviteSentScreen> with Single
                           mainAxisSize: MainAxisSize.min,
                           children: [
                             Text(
-                              widget.inviteCode!,
+                              _inviteCode!,
                               style: const TextStyle(
                                 fontSize: 36,
                                 fontWeight: FontWeight.w700,
@@ -173,7 +264,7 @@ class _EllaInviteSentScreenState extends State<EllaInviteSentScreen> with Single
                 ),
               ),
 
-              const Spacer(),
+              const SizedBox(height: 32),
 
               // Share button -- always show, with or without invite code
               Semantics(
@@ -184,10 +275,9 @@ class _EllaInviteSentScreenState extends State<EllaInviteSentScreen> with Single
                     final elderName = SharedPreferencesUtil().givenName.isNotEmpty
                         ? SharedPreferencesUtil().givenName
                         : 'Your loved one';
-                    final hasCode = widget.inviteCode != null && widget.inviteCode!.isNotEmpty;
                     final shareText = hasCode
                         ? '$elderName invited you to join their Ella care team!\n\n'
-                            'Your invite code: ${widget.inviteCode}\n\n'
+                            'Your invite code: $_inviteCode\n\n'
                             'Join at: https://ella-ai-care.com/join'
                         : '$elderName invited you to join their Ella care team!\n\n'
                             'Download Ella: https://ella-ai-care.com';
@@ -198,16 +288,14 @@ class _EllaInviteSentScreenState extends State<EllaInviteSentScreen> with Single
                         final position = box.localToGlobal(Offset.zero);
                         sharePositionOrigin = Rect.fromLTWH(position.dx, position.dy, box.size.width, box.size.height);
                       }
-                      await Share.share(
-                        shareText,
-                        sharePositionOrigin: sharePositionOrigin,
+                      await SharePlus.instance.share(
+                        ShareParams(text: shareText, sharePositionOrigin: sharePositionOrigin),
                       );
                     } catch (e) {
-                      if (mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(content: Text('Could not open share sheet: $e')),
-                        );
-                      }
+                      if (!context.mounted) return;
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text(context.l10n.ellaInviteErrorNetwork)),
+                      );
                     }
                   },
                   borderRadius: BorderRadius.circular(EllaSizes.radiusLarge),
@@ -241,6 +329,42 @@ class _EllaInviteSentScreenState extends State<EllaInviteSentScreen> with Single
                 ),
               ),
               const SizedBox(height: 12),
+
+              if (!_emailSent && canRetryEmail) ...[
+                Semantics(
+                  button: true,
+                  label: context.l10n.ellaRetryEmail,
+                  child: InkWell(
+                    onTap: _retryingEmail ? null : _retryEmail,
+                    borderRadius: BorderRadius.circular(EllaSizes.radiusLarge),
+                    child: Container(
+                      height: 64,
+                      width: double.infinity,
+                      decoration: BoxDecoration(
+                        color: EllaColors.primary,
+                        borderRadius: BorderRadius.circular(EllaSizes.radiusLarge),
+                      ),
+                      child: Center(
+                        child: _retryingEmail
+                            ? const SizedBox(
+                                width: 20,
+                                height: 20,
+                                child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                              )
+                            : Text(
+                                context.l10n.ellaRetryEmail,
+                                style: const TextStyle(
+                                  fontSize: 20,
+                                  fontWeight: FontWeight.w600,
+                                  color: Colors.white,
+                                ),
+                              ),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+              ],
 
               // Done button
               Semantics(

--- a/app/lib/ella/services/caregiver_api.dart
+++ b/app/lib/ella/services/caregiver_api.dart
@@ -11,6 +11,31 @@ const String _n8nBase = 'https://n8n.ella-ai-care.com/webhook';
 
 String get _uid => SharedPreferencesUtil().uid;
 
+Map<String, dynamic>? _decodeObject(String body) {
+  try {
+    final data = jsonDecode(body);
+    return data is Map<String, dynamic> ? data : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+InviteResponse? _decodeInviteResponse(String body) {
+  final data = _decodeObject(body);
+  if (data == null) return null;
+  final invitePayload = data['invite'] is Map<String, dynamic> ? data['invite'] as Map<String, dynamic> : data;
+  return InviteResponse.fromJson(invitePayload);
+}
+
+CaregiverApiException _inviteException(http.Response response, String message) {
+  final inviteResponse = _decodeInviteResponse(response.body);
+  return CaregiverApiException(
+    statusCode: response.statusCode,
+    message: inviteResponse?.deliveryError ?? inviteResponse?.failureReason ?? message,
+    inviteResponse: inviteResponse?.hasInviteRecovery == true ? inviteResponse : null,
+  );
+}
+
 /// GET caregiver list via n8n webhook
 Future<List<Caregiver>> getCaregivers() async {
   try {
@@ -55,12 +80,13 @@ Future<InviteResponse> sendCaregiverInvite({
   );
   if (response.statusCode != 200 && response.statusCode != 201) {
     Logger.debug('Caregiver invite failed: ${response.statusCode} ${response.body}');
-    throw CaregiverApiException(
-      statusCode: response.statusCode,
-      message: 'Failed to send invite',
-    );
+    throw _inviteException(response, 'Failed to send invite');
   }
-  return InviteResponse.fromJson(jsonDecode(response.body));
+  final inviteResponse = _decodeInviteResponse(response.body);
+  if (inviteResponse == null) {
+    throw CaregiverApiException(statusCode: response.statusCode, message: 'Invalid invite response');
+  }
+  return inviteResponse;
 }
 
 /// POST remove caregiver via n8n webhook
@@ -146,16 +172,18 @@ Future<String?> getEmergencyContactId() async {
 }
 
 /// POST resend caregiver invite via n8n webhook
-Future<void> resendInvite({required String uid, required String caregiverId}) async {
+Future<InviteResponse> resendInvite({required String uid, required String caregiverId}) async {
   final response = await http.post(
     Uri.parse('$_n8nBase/caregiver-resend-invite'),
     headers: {'Content-Type': 'application/json'},
     body: jsonEncode({'uid': uid, 'caregiver_id': caregiverId}),
   );
   if (response.statusCode != 200) {
-    throw CaregiverApiException(
-      statusCode: response.statusCode,
-      message: 'Failed to resend invite',
-    );
+    throw _inviteException(response, 'Failed to resend invite');
   }
+  final inviteResponse = _decodeInviteResponse(response.body);
+  if (inviteResponse == null) {
+    throw CaregiverApiException(statusCode: response.statusCode, message: 'Invalid resend response');
+  }
+  return inviteResponse;
 }

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -2570,5 +2570,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -2572,5 +2572,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -2572,5 +2572,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -2572,5 +2572,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -2612,5 +2612,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2571,5 +2571,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -2603,5 +2603,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10140,5 +10140,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -2604,5 +2604,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -2603,5 +2603,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -2603,5 +2603,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -2638,5 +2638,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -2604,5 +2604,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -2699,5 +2699,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -2645,5 +2645,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -2603,5 +2603,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -2604,5 +2604,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2603,5 +2603,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -15920,6 +15920,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Gemini Native Live'**
   String get geminiNativeLiveVoiceMode;
+
+  /// Title shown when caregiver invite row exists but invite email delivery failed
+  ///
+  /// In en, this message translates to:
+  /// **'Invite created, email not sent'**
+  String get ellaInviteEmailFailedTitle;
+
+  /// Description shown when caregiver invite email delivery failed after row creation
+  ///
+  /// In en, this message translates to:
+  /// **'The invite for {email} exists, but email delivery failed. Share the code below or retry email.'**
+  String ellaInviteEmailFailedDescription(String email);
+
+  /// Delivery failure reason for caregiver invite email
+  ///
+  /// In en, this message translates to:
+  /// **'Delivery error: {reason}'**
+  String ellaInviteEmailFailedReason(String reason);
+
+  /// Button label to retry caregiver invite email delivery
+  ///
+  /// In en, this message translates to:
+  /// **'Retry Email'**
+  String get ellaRetryEmail;
+
+  /// Snackbar shown when caregiver invite email retry succeeds
+  ///
+  /// In en, this message translates to:
+  /// **'Invite email sent.'**
+  String get ellaRetryEmailSuccess;
+
+  /// Snackbar shown when caregiver invite email retry fails
+  ///
+  /// In en, this message translates to:
+  /// **'Email still could not be sent. You can share the invite code instead.'**
+  String get ellaRetryEmailFailed;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8473,4 +8473,26 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8561,4 +8561,26 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8577,4 +8577,26 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8524,4 +8524,26 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8513,4 +8513,26 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8595,4 +8595,26 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8586,4 +8586,26 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8526,4 +8526,26 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8543,4 +8543,26 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8528,4 +8528,26 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8527,4 +8527,26 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8602,4 +8602,26 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8509,4 +8509,26 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8566,4 +8566,26 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8541,4 +8541,26 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8578,4 +8578,26 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8395,4 +8395,26 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8397,4 +8397,26 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8534,4 +8534,26 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8546,4 +8546,26 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8552,4 +8552,26 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8554,4 +8554,26 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8524,4 +8524,26 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8547,4 +8547,26 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8529,4 +8529,26 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8567,4 +8567,26 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8554,4 +8554,26 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8519,4 +8519,26 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8534,4 +8534,26 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8491,4 +8491,26 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8542,4 +8542,26 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8541,4 +8541,26 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8531,4 +8531,26 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8385,4 +8385,26 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get geminiNativeLiveVoiceMode => 'Gemini Native Live';
+
+  @override
+  String get ellaInviteEmailFailedTitle => 'Invite created, email not sent';
+
+  @override
+  String ellaInviteEmailFailedDescription(String email) {
+    return 'The invite for $email exists, but email delivery failed. Share the code below or retry email.';
+  }
+
+  @override
+  String ellaInviteEmailFailedReason(String reason) {
+    return 'Delivery error: $reason';
+  }
+
+  @override
+  String get ellaRetryEmail => 'Retry Email';
+
+  @override
+  String get ellaRetryEmailSuccess => 'Invite email sent.';
+
+  @override
+  String get ellaRetryEmailFailed => 'Email still could not be sent. You can share the invite code instead.';
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -2603,5 +2603,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -2603,5 +2603,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -2603,5 +2603,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -2603,5 +2603,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -2603,5 +2603,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -2638,5 +2638,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -2639,5 +2639,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -2603,5 +2603,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -2638,5 +2638,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -2608,5 +2608,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -2603,5 +2603,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -2603,5 +2603,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -2638,5 +2638,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -2603,5 +2603,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -2608,5 +2608,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -2625,5 +2625,39 @@
   "openClawDirectVoiceMode": "OpenClaw Direct (STT -> OpenClaw -> TTS)",
   "openAIRealtimeVoiceMode": "OpenAI Native Realtime",
   "grokNativeRealtimeVoiceMode": "Grok Native Realtime",
-  "geminiNativeLiveVoiceMode": "Gemini Native Live"
+  "geminiNativeLiveVoiceMode": "Gemini Native Live",
+  "ellaInviteEmailFailedTitle": "Invite created, email not sent",
+  "@ellaInviteEmailFailedTitle": {
+    "description": "Title shown when caregiver invite row exists but invite email delivery failed"
+  },
+  "ellaInviteEmailFailedDescription": "The invite for {email} exists, but email delivery failed. Share the code below or retry email.",
+  "@ellaInviteEmailFailedDescription": {
+    "description": "Description shown when caregiver invite email delivery failed after row creation",
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaInviteEmailFailedReason": "Delivery error: {reason}",
+  "@ellaInviteEmailFailedReason": {
+    "description": "Delivery failure reason for caregiver invite email",
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "ellaRetryEmail": "Retry Email",
+  "@ellaRetryEmail": {
+    "description": "Button label to retry caregiver invite email delivery"
+  },
+  "ellaRetryEmailSuccess": "Invite email sent.",
+  "@ellaRetryEmailSuccess": {
+    "description": "Snackbar shown when caregiver invite email retry succeeds"
+  },
+  "ellaRetryEmailFailed": "Email still could not be sent. You can share the invite code instead.",
+  "@ellaRetryEmailFailed": {
+    "description": "Snackbar shown when caregiver invite email retry fails"
+  }
 }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+769
+version: 1.0.524+770
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/test/ella/models/caregiver_test.dart
+++ b/app/test/ella/models/caregiver_test.dart
@@ -83,5 +83,34 @@ void main() {
       expect(caregiver.isActive, isTrue);
       expect(caregiver.isExpired, isFalse);
     });
+
+    test('invite response preserves failed email delivery recovery fields', () {
+      final response = InviteResponse.fromJson({
+        'caregiver_id': 'cg-1',
+        'invite_id': 'inv-1',
+        'invite_code': '123456',
+        'status': 'created',
+        'email_sent': false,
+        'failure_reason': 'gmail_auth',
+      });
+
+      expect(response.caregiverId, 'cg-1');
+      expect(response.inviteCode, '123456');
+      expect(response.emailSent, isFalse);
+      expect(response.emailDeliveryFailed, isTrue);
+      expect(response.hasInviteRecovery, isTrue);
+      expect(response.failureReason, 'gmail_auth');
+    });
+
+    test('invite response accepts string email_sent values', () {
+      final response = InviteResponse.fromJson({
+        'caregiver_id': 'cg-1',
+        'invite_code': '123456',
+        'email_sent': 'false',
+      });
+
+      expect(response.emailSent, isFalse);
+      expect(response.emailDeliveryFailed, isTrue);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Preserves invite response payloads when n8n returns non-2xx / `email_sent:false`, so DB-row creation is not treated as delivered email.
- Routes invite-created/email-failed responses into the invite recovery screen with invite code, copy/share, and retry email.
- Updates resend handling to return delivery status and clear the failed state after successful retry.
- Adds delivery-status fields and tests for invite response parsing.

Tracking:
- ellaaicare/ella-ai#843
- Related: ellaaicare/ella-ai#626

Safety:
- App-side UX only.
- No real caregiver delivery/emergency path tests were run.
- Real caregiver testing remains blocked pending Jack/test-contact coordination from #843.

## Tests
- `flutter analyze lib/ella/models/caregiver.dart lib/ella/services/caregiver_api.dart lib/ella/pages/ella_add_caregiver_page.dart lib/ella/pages/ella_invite_sent_screen.dart lib/ella/pages/ella_caregiver_detail_page.dart test/ella/models/caregiver_test.dart`
- `flutter test test/ella/models/caregiver_test.dart`
- `./test.sh`

## TestFlight
- Build `1.0.524+770` uploaded successfully.
- Delivery UUID: `213f0328-3ce0-45a1-948a-2dbaea1a79a0`.
- Upload completed with no altool errors; Apple processing/availability may still be pending in App Store Connect.