### PR TITLE
Allow wake-word support enqueue in emergency-only mode

### DIFF
--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -560,7 +560,7 @@ def _enqueue_allows_guardian_audio(mode: str, req: "EnqueueRequest") -> tuple[bo
         "gas leak",
     )
 
-    if trigger == "wake_word":
+    if trigger == "wake_word" or trigger.startswith("wake_word_"):
         return True, None
     if trigger == "safety" and (severity in {"critical", "urgent", "high"} or req.priority == "urgent"):
         return True, None


### PR DESCRIPTION
## Summary
- allows `wake_word_*` trigger variants through the Guardian enqueue secondary gate while in Emergency Only mode
- preserves blocking for routine non-wake support in Emergency Only

## Why
The physical OMI necklace test reached scanner/Hermes/TTS, but `/v1/ella/guardian/enqueue` rejected the audio item because n8n sends `wake_word_user_support` while the backend gate only allowed exact `wake_word`.

Trace from live physical test:
- conversation/trace: `554fa972-8928-4fc2-b40d-875e1121920a`
- policy: `ask_user_first`
- TTS: succeeded
- enqueue: rejected with `guardian_mode_emergency_only`

## Validation
- deployed hotfix to VPS `/root/omi/backend/ella/routers/guardian.py`
- `python3 -m py_compile /root/omi/backend/ella/routers/guardian.py`
- restarted `backend__open-wearables`
- direct enqueue smoke with `trigger=wake_word_user_support` under Plato Emergency Only returned `{"ok":true,"queued":1}`
- app poller consumed the smoke item immediately, confirming polling is active

## Rollback
Restore backup from VPS:
`/root/ella-live-backups/guardian.py-before-847-wake-trigger-*.py`

Related: ellaaicare/ella-ai#847