### PR TITLE
Fix Guardian poller lifecycle and playback readiness

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -42,38 +42,28 @@ extension FlutterError: Error {}
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
 
-    // Configure audio session for background recording
-    do {
-        let audioSession = AVAudioSession.sharedInstance()
-        try audioSession.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker, .allowBluetooth, .mixWithOthers])
-        try audioSession.setActive(true, options: [])
-        print("AppDelegate: Audio session configured for background recording")
+    let audioSession = AVAudioSession.sharedInstance()
+    NotificationCenter.default.addObserver(
+        self,
+        selector: #selector(handleAudioSessionInterruption),
+        name: AVAudioSession.interruptionNotification,
+        object: audioSession
+    )
 
-        // Observe audio session interruptions
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleAudioSessionInterruption),
-            name: AVAudioSession.interruptionNotification,
-            object: audioSession
-        )
+    NotificationCenter.default.addObserver(
+        self,
+        selector: #selector(handleAudioSessionRouteChange),
+        name: AVAudioSession.routeChangeNotification,
+        object: audioSession
+    )
 
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleAudioSessionRouteChange),
-            name: AVAudioSession.routeChangeNotification,
-            object: audioSession
-        )
-
-        // Reactivate audio session when app becomes active
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleApplicationDidBecomeActive),
-            name: UIApplication.didBecomeActiveNotification,
-            object: nil
-        )
-    } catch {
-        print("AppDelegate: Failed to configure audio session: \(error.localizedDescription)")
-    }
+    NotificationCenter.default.addObserver(
+        self,
+        selector: #selector(handleApplicationDidBecomeActive),
+        name: UIApplication.didBecomeActiveNotification,
+        object: nil
+    )
+    print("AppDelegate: Audio session observers registered without activating session")
 
 
       // Get Flutter view controller
@@ -215,13 +205,6 @@ extension FlutterError: Error {}
           print("AppDelegate: Audio session interrupted")
       case .ended:
           print("AppDelegate: Audio session interruption ended")
-          // Reactivate audio session
-          do {
-              try AVAudioSession.sharedInstance().setActive(true)
-              print("AppDelegate: Audio session reactivated after interruption")
-          } catch {
-              print("AppDelegate: Failed to reactivate audio session: \(error)")
-          }
           GuardianModeManager.shared.repairIfActive(reason: "audio_interruption_ended")
       @unknown default:
           break
@@ -237,34 +220,10 @@ extension FlutterError: Error {}
 
       print("AppDelegate: Audio route changed - reason: \(reason.rawValue)")
 
-      // When headphones or Bluetooth are removed, iOS defaults .playAndRecord back to the
-      // earpiece. Override to the loudspeaker so guardian audio stays audible.
-      if reason == .oldDeviceUnavailable {
-          DispatchQueue.main.async {
-              do {
-                  try AVAudioSession.sharedInstance().overrideOutputAudioPort(.speaker)
-                  print("AppDelegate: Forced output to loudspeaker after device removal")
-              } catch {
-                  print("AppDelegate: Failed to override output port: \(error)")
-              }
-          }
-      }
-
-      // Report new route to backend so consolidator knows current echo risk
-      GuardianModeManager.shared.reportPlaybackEvent()
+      GuardianModeManager.shared.handleAudioRouteChange(reason: reason.rawValue)
   }
 
   @objc private func handleApplicationDidBecomeActive(notification: Notification) {
-      // Ensure audio session is active when app becomes active
-      do {
-          let audioSession = AVAudioSession.sharedInstance()
-          if !audioSession.isOtherAudioPlaying {
-              try audioSession.setActive(true)
-              print("AppDelegate: Audio session reactivated on app becoming active")
-          }
-      } catch {
-          print("AppDelegate: Failed to reactivate audio session on app active: \(error)")
-      }
       GuardianModeManager.shared.repairIfActive(reason: "app_did_become_active")
   }
 

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -222,6 +222,7 @@ extension FlutterError: Error {}
           } catch {
               print("AppDelegate: Failed to reactivate audio session: \(error)")
           }
+          GuardianModeManager.shared.repairIfActive(reason: "audio_interruption_ended")
       @unknown default:
           break
       }
@@ -264,6 +265,7 @@ extension FlutterError: Error {}
       } catch {
           print("AppDelegate: Failed to reactivate audio session on app active: \(error)")
       }
+      GuardianModeManager.shared.repairIfActive(reason: "app_did_become_active")
   }
 
   // MARK: - Notification Authorization
@@ -787,7 +789,10 @@ extension AppDelegate: WCSessionDelegate {
 
         case "getState":
             let state = GuardianModeManager.shared.getState()
-            result(["status": state])
+            result([
+                "status": state,
+                "poller": GuardianModePollingService.shared.statusSnapshot()
+            ])
 
         case "injectRemoteAudioClip":
             guard let args = call.arguments as? [String: Any],

--- a/app/ios/Runner/GuardianMode/GuardianModeManager.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModeManager.swift
@@ -354,86 +354,80 @@ class GuardianModeManager: NSObject {
             return
         }
 
-        let player = ensureAudioPlayer()
         let audioItem = AVPlayerItem(url: remoteURL)
 
         let itemQueuedAt = Date()
         let itemId = ObjectIdentifier(audioItem)
+        let player: AVQueuePlayer
+        let position: String
 
-        // Insert to play next, not at the end of the silence buffer. This restores
-        // the original audible-alert behavior while still triggering remote loading.
-        let afterItem = player.currentItem
-        if player.canInsert(audioItem, after: afterItem) {
-            player.insert(audioItem, after: afterItem)
-            NSLog("INJECT_OK #\(seq) (\(filename)) position=after_current depth=\(player.items().count) ts=\(Date().timeIntervalSince1970)")
-            recordPlaybackDebugEvent(
-                "inject_ok",
-                queueItemId: eventId,
-                traceId: traceId,
-                triggerType: triggerType,
-                metadata: metadata,
-                extra: [
-                    "position": "after_current",
-                    "depth": player.items().count,
-                    "player_rate": player.rate,
-                    "url": remoteURL.absoluteString,
-                    "is_current_item": player.currentItem === audioItem
-                ]
-            )
-            scheduleCurrentItemProbes(
-                player: player,
-                audioItem: audioItem,
-                itemId: itemId,
-                itemQueuedAt: itemQueuedAt,
-                eventId: eventId,
-                traceId: traceId,
-                triggerType: triggerType,
-                metadata: metadata
-            )
-        } else if player.canInsert(audioItem, after: nil) {
-            player.insert(audioItem, after: nil)
-            NSLog("INJECT_OK #\(seq) (\(filename)) position=end depth=\(player.items().count) ts=\(Date().timeIntervalSince1970)")
-            recordPlaybackDebugEvent(
-                "inject_ok",
-                queueItemId: eventId,
-                traceId: traceId,
-                triggerType: triggerType,
-                metadata: metadata,
-                extra: [
-                    "position": "end",
-                    "depth": player.items().count,
-                    "player_rate": player.rate,
-                    "url": remoteURL.absoluteString,
-                    "is_current_item": player.currentItem === audioItem
-                ]
-            )
-            scheduleCurrentItemProbes(
-                player: player,
-                audioItem: audioItem,
-                itemId: itemId,
-                itemQueuedAt: itemQueuedAt,
-                eventId: eventId,
-                traceId: traceId,
-                triggerType: triggerType,
-                metadata: metadata
-            )
+        // With the idle silence queue removed, an empty AVQueuePlayer must be
+        // created with the remote item already loaded. Inserting into an empty
+        // existing queue can leave the item non-current and stuck at .unknown.
+        if let existingPlayer = self.audioPlayer,
+           existingPlayer.currentItem != nil || !existingPlayer.items().isEmpty {
+            player = existingPlayer
+            let afterItem = player.currentItem
+            if player.canInsert(audioItem, after: afterItem) {
+                player.insert(audioItem, after: afterItem)
+                position = afterItem == nil ? "end" : "after_current"
+            } else if player.canInsert(audioItem, after: nil) {
+                player.insert(audioItem, after: nil)
+                position = "end"
+            } else {
+                NSLog("INJECT_FAILED #\(seq) (\(filename)) reason=cannot_insert")
+                var failureMetadata = metadata ?? [:]
+                failureMetadata["url"] = remoteURL.absoluteString
+                failureMetadata["queue_depth"] = player.items().count
+                failureMetadata["player_rate"] = player.rate
+                failureMetadata["current_item_present"] = player.currentItem != nil
+                reportGuardianPlaybackFailure(
+                    queueItemId: eventId,
+                    traceId: traceId,
+                    triggerType: triggerType,
+                    metadata: failureMetadata,
+                    error: "cannot_insert"
+                )
+                deactivateGuardianAudioSessionIfIdle(reason: "cannot_insert")
+                await MainActor.run { self.failedInjections += 1 }
+                return
+            }
         } else {
-            NSLog("INJECT_FAILED #\(seq) (\(filename)) reason=cannot_insert")
-            var failureMetadata = metadata ?? [:]
-            failureMetadata["url"] = remoteURL.absoluteString
-            failureMetadata["queue_depth"] = player.items().count
-            failureMetadata["player_rate"] = player.rate
-            failureMetadata["current_item_present"] = player.currentItem != nil
-            reportGuardianPlaybackFailure(
-                queueItemId: eventId,
-                traceId: traceId,
-                triggerType: triggerType,
-                metadata: failureMetadata,
-                error: "cannot_insert"
-            )
-            await MainActor.run { self.failedInjections += 1 }
-            return
+            let queuePlayer = AVQueuePlayer(items: [audioItem])
+            queuePlayer.actionAtItemEnd = .advance
+            self.audioPlayer = queuePlayer
+            player = queuePlayer
+            position = "new_player_current"
         }
+
+        player.play()
+
+        NSLog("INJECT_OK #\(seq) (\(filename)) position=\(position) depth=\(player.items().count) ts=\(Date().timeIntervalSince1970)")
+        recordPlaybackDebugEvent(
+            "inject_ok",
+            queueItemId: eventId,
+            traceId: traceId,
+            triggerType: triggerType,
+            metadata: metadata,
+            extra: [
+                "position": position,
+                "depth": player.items().count,
+                "player_rate": player.rate,
+                "url": remoteURL.absoluteString,
+                "is_current_item": player.currentItem === audioItem,
+                "current_item_present": player.currentItem != nil
+            ]
+        )
+        scheduleCurrentItemProbes(
+            player: player,
+            audioItem: audioItem,
+            itemId: itemId,
+            itemQueuedAt: itemQueuedAt,
+            eventId: eventId,
+            traceId: traceId,
+            triggerType: triggerType,
+            metadata: metadata
+        )
 
         player.publisher(for: \.currentItem)
             .sink { [weak self, weak audioItem] currentItem in
@@ -689,17 +683,6 @@ class GuardianModeManager: NSObject {
         if player.rate == 0 {
             player.play()
         }
-    }
-
-    private func ensureAudioPlayer() -> AVQueuePlayer {
-        if let audioPlayer = audioPlayer {
-            return audioPlayer
-        }
-
-        let queuePlayer = AVQueuePlayer()
-        queuePlayer.actionAtItemEnd = .advance
-        audioPlayer = queuePlayer
-        return queuePlayer
     }
 
     private func activateGuardianAudioSessionForPlayback() throws {

--- a/app/ios/Runner/GuardianMode/GuardianModeManager.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModeManager.swift
@@ -9,7 +9,7 @@ import Combine
 /// - Activates AVAudioSession only while a real Guardian playback item is queued
 /// - Serializes player mutations on a single DispatchQueue
 /// - Reports playback events only for concrete queue items
-class GuardianModeManager: NSObject {
+class GuardianModeManager: NSObject, AVSpeechSynthesizerDelegate {
     static let shared = GuardianModeManager()
 
     private var audioPlayer: AVQueuePlayer?
@@ -25,6 +25,8 @@ class GuardianModeManager: NSObject {
     private var injectionSequence: Int = 0  // Sequential counter for easy log tracking
     private var playbackStartedItems = Set<ObjectIdentifier>()
     private var playbackContexts: [ObjectIdentifier: PlaybackContext] = [:]
+    private let speechSynthesizer = AVSpeechSynthesizer()
+    private var fallbackTTSContexts: [ObjectIdentifier: (context: PlaybackContext, startedAt: Date)] = [:]
 
     private struct PlaybackContext {
         let queueItemId: String
@@ -42,6 +44,7 @@ class GuardianModeManager: NSObject {
 
     private override init() {
         super.init()
+        speechSynthesizer.delegate = self
     }
 
     // MARK: - Public API
@@ -254,7 +257,8 @@ class GuardianModeManager: NSObject {
         eventId: String,
         traceId: String? = nil,
         triggerType: String? = nil,
-        metadata: [String: Any]? = nil
+        metadata: [String: Any]? = nil,
+        fallbackText: String? = nil
     ) {
         // Increment sequence counter on queue for thread-safety
         queue.async { [weak self] in
@@ -276,6 +280,7 @@ class GuardianModeManager: NSObject {
                     traceId: traceId,
                     triggerType: triggerType,
                     metadata: playbackMetadata,
+                    fallbackText: fallbackText,
                     seq: seq,
                     filename: filename,
                     attempt: 1
@@ -292,6 +297,7 @@ class GuardianModeManager: NSObject {
         traceId: String?,
         triggerType: String?,
         metadata: [String: Any]?,
+        fallbackText: String?,
         seq: Int,
         filename: String,
         attempt: Int
@@ -336,19 +342,28 @@ class GuardianModeManager: NSObject {
             return
         }
 
+        let activationPath: String
         do {
-            try activateGuardianAudioSessionForPlayback()
+            activationPath = try activateGuardianAudioSessionForPlayback()
         } catch {
             NSLog("INJECT_FAILED #\(seq) (\(filename)) reason=audio_session_activate_failed error=\(error.localizedDescription)")
             var failureMetadata = metadata ?? [:]
             failureMetadata["url"] = remoteURL.absoluteString
             failureMetadata["audio_session_error"] = error.localizedDescription
+            failureMetadata["fallback_tts_attempted"] = true
             reportGuardianPlaybackFailure(
                 queueItemId: eventId,
                 traceId: traceId,
                 triggerType: triggerType,
                 metadata: failureMetadata,
                 error: "audio_session_activate_failed"
+            )
+            speakFallbackText(
+                fallbackText ?? extractFallbackText(from: metadata),
+                queueItemId: eventId,
+                traceId: traceId,
+                triggerType: triggerType,
+                metadata: failureMetadata
             )
             await MainActor.run { self.failedInjections += 1 }
             return
@@ -414,6 +429,7 @@ class GuardianModeManager: NSObject {
                 "depth": player.items().count,
                 "player_rate": player.rate,
                 "url": remoteURL.absoluteString,
+                "audio_session_activation_path": activationPath,
                 "is_current_item": player.currentItem === audioItem,
                 "current_item_present": player.currentItem != nil
             ]
@@ -685,15 +701,126 @@ class GuardianModeManager: NSObject {
         }
     }
 
-    private func activateGuardianAudioSessionForPlayback() throws {
+    @discardableResult
+    private func activateGuardianAudioSessionForPlayback() throws -> String {
         let audioSession = AVAudioSession.sharedInstance()
-        try audioSession.setCategory(
-            .playback,
-            mode: .default,
-            options: [.mixWithOthers, .allowBluetoothA2DP, .allowAirPlay]
+        let attempts: [(label: String, category: AVAudioSession.Category, mode: AVAudioSession.Mode, options: AVAudioSession.CategoryOptions)] = [
+            ("playback_mix", .playback, .default, [.mixWithOthers]),
+            ("playback_plain", .playback, .default, []),
+            ("ambient_mix", .ambient, .default, [.mixWithOthers])
+        ]
+        var attemptErrors: [String] = []
+
+        for attempt in attempts {
+            do {
+                try audioSession.setCategory(attempt.category, mode: attempt.mode, options: attempt.options)
+                try audioSession.setActive(true, options: [])
+                NSLog("GuardianMode: Audio session activated path=\(attempt.label)")
+                return attempt.label
+            } catch {
+                let errorMessage = "\(attempt.label): \(error.localizedDescription)"
+                attemptErrors.append(errorMessage)
+                NSLog("GuardianMode: Audio session activation attempt failed \(errorMessage)")
+            }
+        }
+
+        throw NSError(domain: "GuardianMode", code: -50, userInfo: [
+            NSLocalizedDescriptionKey: attemptErrors.joined(separator: " | ")
+        ])
+    }
+
+    private func extractFallbackText(from metadata: [String: Any]?) -> String? {
+        let keys = ["message", "text", "response_text", "response", "content", "transcript"]
+        for key in keys {
+            if let value = metadata?[key] as? String, !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private func speakFallbackText(
+        _ text: String?,
+        queueItemId: String,
+        traceId: String?,
+        triggerType: String?,
+        metadata: [String: Any]?
+    ) {
+        let fallback = text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let spokenText = (fallback?.isEmpty == false)
+            ? fallback!
+            : "Ella has a Guardian response, but the audio could not be played."
+        var fallbackMetadata = metadata ?? [:]
+        fallbackMetadata["fallback_tts"] = true
+        fallbackMetadata["fallback_tts_text_available"] = fallback?.isEmpty == false
+
+        let utterance = AVSpeechUtterance(string: spokenText)
+        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+        utterance.rate = 0.5
+
+        let utteranceId = ObjectIdentifier(utterance)
+        fallbackTTSContexts[utteranceId] = (
+            context: PlaybackContext(
+                queueItemId: queueItemId,
+                traceId: traceId,
+                triggerType: triggerType,
+                metadata: fallbackMetadata
+            ),
+            startedAt: Date()
         )
-        try audioSession.setActive(true, options: [])
-        NSLog("GuardianMode: Audio session activated for Guardian playback")
+
+        recordPlaybackDebugEvent(
+            "fallback_tts_start",
+            queueItemId: queueItemId,
+            traceId: traceId,
+            triggerType: triggerType,
+            metadata: fallbackMetadata,
+            extra: ["text_length": spokenText.count]
+        )
+        reportPlaybackEvent(
+            eventType: "fallback_tts_started",
+            queueItemId: queueItemId,
+            traceId: traceId,
+            triggerType: triggerType,
+            durationMs: 0,
+            metadata: fallbackMetadata
+        )
+        speechSynthesizer.speak(utterance)
+    }
+
+    func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
+        finishFallbackTTS(utterance, eventType: "fallback_tts_completed")
+    }
+
+    func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didCancel utterance: AVSpeechUtterance) {
+        finishFallbackTTS(utterance, eventType: "fallback_tts_cancelled")
+    }
+
+    private func finishFallbackTTS(_ utterance: AVSpeechUtterance, eventType: String) {
+        let utteranceId = ObjectIdentifier(utterance)
+        queue.async { [weak self] in
+            guard let self = self,
+                  let ttsContext = self.fallbackTTSContexts.removeValue(forKey: utteranceId) else { return }
+
+            let durationMs = Int(Date().timeIntervalSince(ttsContext.startedAt) * 1000)
+            self.recordPlaybackDebugEvent(
+                eventType,
+                queueItemId: ttsContext.context.queueItemId,
+                traceId: ttsContext.context.traceId,
+                triggerType: ttsContext.context.triggerType,
+                metadata: ttsContext.context.metadata,
+                extra: ["duration_ms": durationMs]
+            )
+            self.reportPlaybackEvent(
+                eventType: eventType,
+                queueItemId: ttsContext.context.queueItemId,
+                traceId: ttsContext.context.traceId,
+                triggerType: ttsContext.context.triggerType,
+                durationMs: durationMs,
+                metadata: ttsContext.context.metadata
+            )
+            self.deactivateGuardianAudioSessionIfIdle(reason: eventType)
+        }
     }
 
     private func finishPlaybackItem(_ itemId: ObjectIdentifier, reason: String) {
@@ -703,7 +830,7 @@ class GuardianModeManager: NSObject {
     }
 
     private func deactivateGuardianAudioSessionIfIdle(reason: String) {
-        guard playbackStartedItems.isEmpty, playbackContexts.isEmpty else { return }
+        guard playbackStartedItems.isEmpty, playbackContexts.isEmpty, fallbackTTSContexts.isEmpty else { return }
 
         if let player = audioPlayer, player.items().isEmpty {
             player.pause()

--- a/app/ios/Runner/GuardianMode/GuardianModeManager.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModeManager.swift
@@ -48,7 +48,9 @@ class GuardianModeManager: NSObject {
     func start() throws {
         try queue.sync {
             guard !isActive else {
-                NSLog("GuardianMode: Already active, ignoring start()")
+                NSLog("GuardianMode: Already active, repairing poller/player if needed")
+                GuardianModePollingService.shared.ensurePolling(reason: "guardian_start_already_active")
+                audioPlayer?.play()
                 return
             }
 
@@ -132,6 +134,28 @@ class GuardianModeManager: NSObject {
         }
     }
 
+    /// Called from app lifecycle hooks. If Guardian Mode is still active, make
+    /// sure both the silent playback loop and network poller survived app
+    /// suspension, backend downtime, and audio-session interruptions.
+    func repairIfActive(reason: String) {
+        queue.async { [weak self] in
+            guard let self = self, self.isActive else { return }
+
+            do {
+                try AVAudioSession.sharedInstance().setActive(true)
+            } catch {
+                NSLog("GuardianMode: Failed to reactivate audio session during repair reason=\(reason): \(error.localizedDescription)")
+            }
+
+            if let player = self.audioPlayer, player.rate == 0 {
+                NSLog("GuardianMode: Repair restarting stalled player reason=\(reason)")
+                player.play()
+            }
+
+            GuardianModePollingService.shared.ensurePolling(reason: reason)
+        }
+    }
+
     // MARK: - Queue Management (Progressive Buffering)
 
     private func setupItemEndObserver() {
@@ -199,6 +223,8 @@ class GuardianModeManager: NSObject {
     private func healthCheck() {
         // Must be called on self.queue
         guard let player = self.audioPlayer, self.isActive else { return }
+
+        GuardianModePollingService.shared.ensurePolling(reason: "guardian_health_check")
 
         let depth = player.items().count
         let rate = player.rate

--- a/app/ios/Runner/GuardianMode/GuardianModeManager.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModeManager.swift
@@ -2,14 +2,13 @@ import Foundation
 import AVFoundation
 import Combine
 
-/// GuardianModeManager - Progressive Buffering for 99.9% Reliability
+/// GuardianModeManager - Guardian audio playback and polling coordinator
 ///
 /// Architecture:
-/// - Deep silence queue (50 items, batch-refill at 20) prevents starvation
-/// - All queue mutations serialized on a single DispatchQueue
-/// - Remote audio pre-downloaded to local cache before injection
-/// - Failed injections retried with exponential backoff (max 3 attempts)
-/// - Periodic health monitor detects and recovers from queue stalls
+/// - Polls while Guardian Mode is active without owning the system audio route
+/// - Activates AVAudioSession only while a real Guardian playback item is queued
+/// - Serializes player mutations on a single DispatchQueue
+/// - Reports playback events only for concrete queue items
 class GuardianModeManager: NSObject {
     static let shared = GuardianModeManager()
 
@@ -19,17 +18,20 @@ class GuardianModeManager: NSObject {
     private var cancellables = Set<AnyCancellable>()
     private var healthTimer: DispatchSourceTimer?
 
-    // Buffer configuration
-    private let initialQueueDepth = 50
-    private let refillThreshold = 20
-    private let batchRefillCount = 30
-
     // Stats for monitoring
     private var totalInjections: Int = 0
     private var successfulInjections: Int = 0
     private var failedInjections: Int = 0
     private var injectionSequence: Int = 0  // Sequential counter for easy log tracking
     private var playbackStartedItems = Set<ObjectIdentifier>()
+    private var playbackContexts: [ObjectIdentifier: PlaybackContext] = [:]
+
+    private struct PlaybackContext {
+        let queueItemId: String
+        let traceId: String?
+        let triggerType: String?
+        let metadata: [String: Any]?
+    }
 
     // Download cache directory
     private lazy var cacheDir: URL = {
@@ -44,59 +46,29 @@ class GuardianModeManager: NSObject {
 
     // MARK: - Public API
 
-    /// Start Guardian Mode - begins silent audio loop with progressive buffering
+    /// Start Guardian Mode - begins network polling only. Audio starts later when
+    /// a real Guardian queue item is ready to play.
     func start() throws {
         try queue.sync {
             guard !isActive else {
-                NSLog("GuardianMode: Already active, repairing poller/player if needed")
+                NSLog("GuardianMode: Already active, repairing poller if needed")
                 GuardianModePollingService.shared.ensurePolling(reason: "guardian_start_already_active")
-                audioPlayer?.play()
                 return
             }
 
-            // Activate audio session (configured in AppDelegate, activated here before playback)
-            let audioSession = AVAudioSession.sharedInstance()
-            try audioSession.setActive(true)
-
-            // Detailed audio session diagnostics
-            NSLog("🔊 SESSION_STATE_DETAILED:")
-            NSLog("   Category: \(audioSession.category.rawValue)")
-            NSLog("   Mode: \(audioSession.mode.rawValue)")
-            NSLog("   Options: \(audioSession.categoryOptions.rawValue)")
-            NSLog("   Output: \(audioSession.currentRoute.outputs.map { $0.portType.rawValue }.joined(separator: ", "))")
-            NSLog("   Sample Rate: \(audioSession.sampleRate)")
-            NSLog("   IO Buffer Duration: \(audioSession.ioBufferDuration)")
-            NSLog("   Other audio playing: \(audioSession.isOtherAudioPlaying)")
-
-            guard let silenceURL = Bundle.main.url(forResource: "silence_100ms", withExtension: "wav") else {
-                throw NSError(domain: "GuardianMode", code: 1, userInfo: [
-                    NSLocalizedDescriptionKey: "Silent audio file not found"
-                ])
-            }
-
-            // Deep initial queue - 50 silence items for robust buffering
-            let silenceItems = (0..<initialQueueDepth).map { _ in AVPlayerItem(url: silenceURL) }
-            let queuePlayer = AVQueuePlayer(items: silenceItems)
-
-            // Prevent player from pausing at end of queue
-            queuePlayer.actionAtItemEnd = .advance
-
-            self.audioPlayer = queuePlayer
             self.isActive = true
             self.totalInjections = 0
             self.successfulInjections = 0
             self.failedInjections = 0
             self.injectionSequence = 0
             self.playbackStartedItems.removeAll()
+            self.playbackContexts.removeAll()
 
-            setupItemEndObserver()
             startHealthMonitor()
-
-            queuePlayer.play()
 
             GuardianModePollingService.shared.startPolling()
 
-            NSLog("GuardianMode: Started - progressive buffering active (queue: \(silenceItems.count) items)")
+            NSLog("GuardianMode: Started - polling active, audio session idle until playback")
         }
     }
 
@@ -116,6 +88,7 @@ class GuardianModeManager: NSObject {
             audioPlayer = nil
             cancellables.removeAll()
             playbackStartedItems.removeAll()
+            playbackContexts.removeAll()
             isActive = false
 
             let rate = totalInjections > 0
@@ -123,7 +96,7 @@ class GuardianModeManager: NSObject {
                 : "N/A"
             NSLog("GuardianMode: Stopped (injections: \(successfulInjections)/\(totalInjections), success rate: \(rate))")
 
-            // Don't deactivate audio session - it's shared with other app components (recording, etc.)
+            deactivateGuardianAudioSessionIfIdle(reason: "guardian_stop")
         }
     }
 
@@ -135,71 +108,19 @@ class GuardianModeManager: NSObject {
     }
 
     /// Called from app lifecycle hooks. If Guardian Mode is still active, make
-    /// sure both the silent playback loop and network poller survived app
-    /// suspension, backend downtime, and audio-session interruptions.
+    /// sure the network poller survived app suspension or backend downtime. Do
+    /// not reactivate AVAudioSession unless a real Guardian item is playing.
     func repairIfActive(reason: String) {
         queue.async { [weak self] in
             guard let self = self, self.isActive else { return }
 
-            do {
-                try AVAudioSession.sharedInstance().setActive(true)
-            } catch {
-                NSLog("GuardianMode: Failed to reactivate audio session during repair reason=\(reason): \(error.localizedDescription)")
-            }
-
-            if let player = self.audioPlayer, player.rate == 0 {
+            if !self.playbackStartedItems.isEmpty, let player = self.audioPlayer, player.rate == 0 {
                 NSLog("GuardianMode: Repair restarting stalled player reason=\(reason)")
                 player.play()
             }
 
             GuardianModePollingService.shared.ensurePolling(reason: reason)
         }
-    }
-
-    // MARK: - Queue Management (Progressive Buffering)
-
-    private func setupItemEndObserver() {
-        NotificationCenter.default
-            .publisher(for: .AVPlayerItemDidPlayToEndTime)
-            .sink { [weak self] _ in
-                self?.onItemFinished()
-            }
-            .store(in: &cancellables)
-    }
-
-    /// Called when any queued item finishes playing
-    private func onItemFinished() {
-        queue.async { [weak self] in
-            guard let self = self,
-                  let player = self.audioPlayer,
-                  self.isActive else { return }
-
-            let depth = player.items().count
-
-            // Batch refill when below threshold — prevents starvation
-            if depth < self.refillThreshold {
-                self.batchQueueSilence(count: self.batchRefillCount)
-            }
-        }
-    }
-
-    /// Queue multiple silence items atomically
-    private func batchQueueSilence(count: Int) {
-        // Must be called on self.queue
-        guard let player = self.audioPlayer,
-              let silenceURL = Bundle.main.url(forResource: "silence_100ms", withExtension: "wav"),
-              self.isActive else { return }
-
-        var added = 0
-        for _ in 0..<count {
-            let silenceItem = AVPlayerItem(url: silenceURL)
-            if player.canInsert(silenceItem, after: nil) {
-                player.insert(silenceItem, after: nil)
-                added += 1
-            }
-        }
-
-        NSLog("GuardianMode: Batch queued \(added) silence items (depth: \(player.items().count))")
     }
 
     // MARK: - Health Monitor
@@ -222,42 +143,24 @@ class GuardianModeManager: NSObject {
 
     private func healthCheck() {
         // Must be called on self.queue
-        guard let player = self.audioPlayer, self.isActive else { return }
+        guard self.isActive else { return }
 
         GuardianModePollingService.shared.ensurePolling(reason: "guardian_health_check")
 
-        let depth = player.items().count
-        let rate = player.rate
-
-        // Detect stalled player
-        if rate == 0 && isActive {
-            NSLog("GuardianMode: HEALTH WARNING - Player stalled, restarting playback")
-            player.play()
-        }
-
-        // Detect dangerously low queue
-        if depth < 5 {
-            NSLog("GuardianMode: HEALTH WARNING - Queue critically low (\(depth)), emergency refill")
-            batchQueueSilence(count: initialQueueDepth)
-        }
-
-        // Detect empty queue
-        if depth == 0 {
-            NSLog("GuardianMode: HEALTH CRITICAL - Queue empty, rebuilding")
-            guard let silenceURL = Bundle.main.url(forResource: "silence_100ms", withExtension: "wav") else { return }
-            let items = (0..<initialQueueDepth).map { _ in AVPlayerItem(url: silenceURL) }
-            for item in items {
-                if player.canInsert(item, after: nil) {
-                    player.insert(item, after: nil)
-                }
-            }
+        if !playbackStartedItems.isEmpty, let player = audioPlayer, player.rate == 0 {
+            NSLog("GuardianMode: HEALTH WARNING - Active Guardian playback stalled, restarting playback")
             player.play()
         }
 
         let stats = totalInjections > 0
             ? "\(successfulInjections)/\(totalInjections)"
             : "0/0"
-        NSLog("GuardianMode: Health OK (depth: \(depth), rate: \(rate), injections: \(stats))")
+        NSLog(
+            "GuardianMode: Health OK " +
+            "(poller=\(GuardianModePollingService.shared.statusSnapshot()), " +
+            "active_playback_items=\(playbackStartedItems.count), " +
+            "queued_items=\(audioPlayer?.items().count ?? 0), injections=\(stats))"
+        )
     }
 
     // MARK: - Playback Route Reporting
@@ -272,6 +175,11 @@ class GuardianModeManager: NSObject {
         durationMs: Int = 0,
         metadata: [String: Any]? = nil
     ) {
+        guard let queueItemId = queueItemId, !queueItemId.isEmpty else {
+            NSLog("PLAYBACK_EVENT_SKIP type=\(eventType) reason=no_queue_item")
+            return
+        }
+
         let session = AVAudioSession.sharedInstance()
         guard let port = session.currentRoute.outputs.first else { return }
 
@@ -305,9 +213,7 @@ class GuardianModeManager: NSObject {
             "device_uid": deviceUID,
             "duration_ms": durationMs
         ]
-        if let queueItemId = queueItemId {
-            body["queue_item_id"] = queueItemId
-        }
+        body["queue_item_id"] = queueItemId
         if let traceId = traceId {
             body["trace_id"] = traceId
         }
@@ -318,7 +224,26 @@ class GuardianModeManager: NSObject {
         request.httpBody = data
 
         URLSession.shared.dataTask(with: request) { _, _, _ in }.resume()
-        NSLog("PLAYBACK_EVENT type=\(eventType) trace=\(traceId ?? "none") item=\(queueItemId ?? "none") port=\(portType) device=\(portName.isEmpty ? "unknown" : portName) uid=\(uid)")
+        NSLog("PLAYBACK_EVENT type=\(eventType) trace=\(traceId ?? "none") item=\(queueItemId) port=\(portType) device=\(portName.isEmpty ? "unknown" : portName) uid=\(uid)")
+    }
+
+    func handleAudioRouteChange(reason: UInt) {
+        queue.async { [weak self] in
+            guard let self = self,
+                  let context = self.playbackContexts.values.first else {
+                NSLog("GuardianMode: Route change ignored because no Guardian item is playing")
+                return
+            }
+
+            self.reportPlaybackEvent(
+                eventType: "route_changed",
+                queueItemId: context.queueItemId,
+                traceId: context.traceId,
+                triggerType: context.triggerType,
+                metadata: context.metadata
+            )
+            NSLog("GuardianMode: Route change reported for active Guardian playback reason=\(reason)")
+        }
     }
 
     // MARK: - Audio Injection with Pre-download + Retry
@@ -391,7 +316,7 @@ class GuardianModeManager: NSObject {
             ]
         )
 
-        guard let player = self.audioPlayer, self.isActive else {
+        guard self.isActive else {
             NSLog("INJECT_FAILED #\(seq) (\(filename)) reason=not_active")
             var failureMetadata = metadata ?? [:]
             failureMetadata["url"] = remoteURL.absoluteString
@@ -411,6 +336,25 @@ class GuardianModeManager: NSObject {
             return
         }
 
+        do {
+            try activateGuardianAudioSessionForPlayback()
+        } catch {
+            NSLog("INJECT_FAILED #\(seq) (\(filename)) reason=audio_session_activate_failed error=\(error.localizedDescription)")
+            var failureMetadata = metadata ?? [:]
+            failureMetadata["url"] = remoteURL.absoluteString
+            failureMetadata["audio_session_error"] = error.localizedDescription
+            reportGuardianPlaybackFailure(
+                queueItemId: eventId,
+                traceId: traceId,
+                triggerType: triggerType,
+                metadata: failureMetadata,
+                error: "audio_session_activate_failed"
+            )
+            await MainActor.run { self.failedInjections += 1 }
+            return
+        }
+
+        let player = ensureAudioPlayer()
         let audioItem = AVPlayerItem(url: remoteURL)
 
         let itemQueuedAt = Date()
@@ -497,6 +441,12 @@ class GuardianModeManager: NSObject {
                 self.queue.async {
                     guard !self.playbackStartedItems.contains(itemId) else { return }
                     self.playbackStartedItems.insert(itemId)
+                    self.playbackContexts[itemId] = PlaybackContext(
+                        queueItemId: eventId,
+                        traceId: traceId,
+                        triggerType: triggerType,
+                        metadata: metadata
+                    )
                     var eventMetadata = metadata ?? [:]
                     let queuedLatencyMs = Int(Date().timeIntervalSince(itemQueuedAt) * 1000)
                     eventMetadata["queued_latency_ms"] = queuedLatencyMs
@@ -552,6 +502,10 @@ class GuardianModeManager: NSObject {
                     metadata: metadata,
                     error: error.localizedDescription
                 )
+                self.queue.async {
+                    player.remove(audioItem)
+                    self.finishPlaybackItem(itemId, reason: "item_error")
+                }
                 await MainActor.run { self.failedInjections += 1 }
                 return
             }
@@ -578,6 +532,10 @@ class GuardianModeManager: NSObject {
                     metadata: metadata,
                     error: "ready_timeout"
                 )
+                self.queue.async {
+                    player.remove(audioItem)
+                    self.finishPlaybackItem(itemId, reason: "ready_timeout")
+                }
                 await MainActor.run { self.failedInjections += 1 }
                 return
             }
@@ -610,6 +568,10 @@ class GuardianModeManager: NSObject {
                 metadata: metadata,
                 error: errorMsg
             )
+            self.queue.async {
+                player.remove(audioItem)
+                self.finishPlaybackItem(itemId, reason: "item_failed")
+            }
             await MainActor.run { self.failedInjections += 1 }
             return
         }
@@ -631,6 +593,10 @@ class GuardianModeManager: NSObject {
                 metadata: metadata,
                 error: "unexpected_status_\(audioItem.status.rawValue)"
             )
+            self.queue.async {
+                player.remove(audioItem)
+                self.finishPlaybackItem(itemId, reason: "unexpected_status")
+            }
             await MainActor.run { self.failedInjections += 1 }
             return
         }
@@ -684,7 +650,7 @@ class GuardianModeManager: NSObject {
                     metadata: metadata
                 )
                 self.queue.async {
-                    self.playbackStartedItems.remove(itemId)
+                    self.finishPlaybackItem(itemId, reason: "completed")
                     self.successfulInjections += 1
                 }
             }
@@ -713,13 +679,62 @@ class GuardianModeManager: NSObject {
                     metadata: metadata,
                     error: error
                 )
-                self.queue.async { self.playbackStartedItems.remove(itemId) }
+                self.queue.async {
+                    self.finishPlaybackItem(itemId, reason: "failed_to_play_to_end")
+                }
             }
             .store(in: &cancellables)
 
         // Ensure player is actually playing
         if player.rate == 0 {
             player.play()
+        }
+    }
+
+    private func ensureAudioPlayer() -> AVQueuePlayer {
+        if let audioPlayer = audioPlayer {
+            return audioPlayer
+        }
+
+        let queuePlayer = AVQueuePlayer()
+        queuePlayer.actionAtItemEnd = .advance
+        audioPlayer = queuePlayer
+        return queuePlayer
+    }
+
+    private func activateGuardianAudioSessionForPlayback() throws {
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(
+            .playback,
+            mode: .default,
+            options: [.mixWithOthers, .allowBluetoothA2DP, .allowAirPlay]
+        )
+        try audioSession.setActive(true, options: [])
+        NSLog("GuardianMode: Audio session activated for Guardian playback")
+    }
+
+    private func finishPlaybackItem(_ itemId: ObjectIdentifier, reason: String) {
+        playbackStartedItems.remove(itemId)
+        playbackContexts.removeValue(forKey: itemId)
+        deactivateGuardianAudioSessionIfIdle(reason: reason)
+    }
+
+    private func deactivateGuardianAudioSessionIfIdle(reason: String) {
+        guard playbackStartedItems.isEmpty, playbackContexts.isEmpty else { return }
+
+        if let player = audioPlayer, player.items().isEmpty {
+            player.pause()
+            player.removeAllItems()
+            audioPlayer = nil
+        } else if audioPlayer?.items().isEmpty == false {
+            return
+        }
+
+        do {
+            try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+            NSLog("GuardianMode: Audio session deactivated reason=\(reason)")
+        } catch {
+            NSLog("GuardianMode: Audio session deactivate failed reason=\(reason) error=\(error.localizedDescription)")
         }
     }
 

--- a/app/ios/Runner/GuardianMode/GuardianModePollingService.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModePollingService.swift
@@ -333,7 +333,8 @@ class GuardianModePollingService {
                         eventId: eventId,
                         traceId: traceId,
                         triggerType: result.triggerType,
-                        metadata: metadata
+                        metadata: metadata,
+                        fallbackText: result.message
                     )
                 } else if result.priority == "debug" {
                     // Metadata-only debug items never play audio; debug items with a URL are injected above.

--- a/app/ios/Runner/GuardianMode/GuardianModePollingService.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModePollingService.swift
@@ -20,6 +20,10 @@ class GuardianModePollingService {
 
     var pollInterval: TimeInterval = 3.0
     var backendURL: String = "https://api.ella-ai-care.com"
+    private let stateLock = NSLock()
+    private var lastPollAttemptAt: Date?
+    private var lastPollSuccessAt: Date?
+    private var lastPollErrorAt: Date?
 
     struct PollResponse: Codable {
         let url: String?
@@ -86,6 +90,9 @@ class GuardianModePollingService {
     // MARK: - Public Methods
 
     func startPolling() {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
         guard !isPolling else {
             NSLog("GuardianPolling: Already polling")
             return
@@ -95,10 +102,13 @@ class GuardianModePollingService {
         consecutiveErrors = 0
         NSLog("GuardianPolling: Starting poll timer (interval: \(pollInterval)s)")
 
-        createPollTimer()
+        createPollTimerLocked()
     }
 
     func stopPolling() {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
         guard isPolling else { return }
 
         NSLog("GuardianPolling: Stopping poll timer")
@@ -106,6 +116,48 @@ class GuardianModePollingService {
         pollTimer?.cancel()
         pollTimer = nil
         isPolling = false
+    }
+
+    /// Keep the poller alive while Guardian Mode is active. Dispatch timers can
+    /// stop firing across app suspension or service downtime without the user
+    /// explicitly disabling Guardian Mode; foreground and health checks call
+    /// this to repair that state.
+    func ensurePolling(reason: String) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        let now = Date()
+        let staleAfter = max(pollInterval * 5, 20.0)
+        let isStale = lastPollAttemptAt.map { now.timeIntervalSince($0) > staleAfter } ?? true
+
+        guard !isPolling || pollTimer == nil || isStale else {
+            return
+        }
+
+        NSLog(
+            "GuardianPolling: Restarting poll timer reason=\(reason) " +
+            "isPolling=\(isPolling) hasTimer=\(pollTimer != nil) stale=\(isStale)"
+        )
+
+        pollTimer?.cancel()
+        pollTimer = nil
+        isPolling = true
+        consecutiveErrors = 0
+        createPollTimerLocked()
+    }
+
+    func statusSnapshot() -> [String: Any] {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        return [
+            "is_polling": isPolling,
+            "has_timer": pollTimer != nil,
+            "consecutive_errors": consecutiveErrors,
+            "last_poll_attempt_at": lastPollAttemptAt?.timeIntervalSince1970 ?? 0,
+            "last_poll_success_at": lastPollSuccessAt?.timeIntervalSince1970 ?? 0,
+            "last_poll_error_at": lastPollErrorAt?.timeIntervalSince1970 ?? 0
+        ]
     }
 
     func pollForNewAudio() async throws -> PollResponse? {
@@ -183,7 +235,7 @@ class GuardianModePollingService {
 
     // MARK: - Private Methods
 
-    private func createPollTimer() {
+    private func createPollTimerLocked() {
         let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .background))
 
         timer.schedule(deadline: .now(), repeating: pollInterval)
@@ -199,11 +251,22 @@ class GuardianModePollingService {
     }
 
     private func executePoll() async {
-        guard isPolling else { return }
+        stateLock.lock()
+        let active = isPolling
+        if active {
+            lastPollAttemptAt = Date()
+        }
+        stateLock.unlock()
+
+        guard active else { return }
 
         do {
             if let result = try await pollForNewAudio() {
+                stateLock.lock()
                 consecutiveErrors = 0
+                lastPollSuccessAt = Date()
+                stateLock.unlock()
+
                 let metadata = result.metadata?.dict ?? [:]
                 let traceId = result.traceId
                     ?? metadata["trace_id"] as? String
@@ -256,11 +319,21 @@ class GuardianModePollingService {
                     )
                     speakText(message)
                 }
+            } else {
+                stateLock.lock()
+                consecutiveErrors = 0
+                lastPollSuccessAt = Date()
+                stateLock.unlock()
             }
         } catch {
+            stateLock.lock()
             consecutiveErrors += 1
-            if consecutiveErrors <= 3 || consecutiveErrors % 10 == 0 {
-                NSLog("GuardianPolling: Poll error (\(consecutiveErrors)x): \(error.localizedDescription)")
+            lastPollErrorAt = Date()
+            let errors = consecutiveErrors
+            stateLock.unlock()
+
+            if errors <= 3 || errors % 10 == 0 {
+                NSLog("GuardianPolling: Poll error (\(errors)x): \(error.localizedDescription)")
             }
         }
 

--- a/app/ios/Runner/GuardianMode/GuardianModePollingService.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModePollingService.swift
@@ -24,6 +24,9 @@ class GuardianModePollingService {
     private var lastPollAttemptAt: Date?
     private var lastPollSuccessAt: Date?
     private var lastPollErrorAt: Date?
+    private var isPollInFlight = false
+    private var pollGeneration: UInt = 0
+    private var lastScheduledDelay: TimeInterval = 0
 
     struct PollResponse: Codable {
         let url: String?
@@ -98,11 +101,15 @@ class GuardianModePollingService {
             return
         }
 
+        pollTimer?.cancel()
+        pollTimer = nil
+        pollGeneration += 1
         isPolling = true
+        isPollInFlight = false
         consecutiveErrors = 0
-        NSLog("GuardianPolling: Starting poll timer (interval: \(pollInterval)s)")
+        NSLog("GuardianPolling: Starting poll timer generation=\(pollGeneration) interval=\(pollInterval)s")
 
-        createPollTimerLocked()
+        scheduleNextPollLocked(after: 0, reason: "start")
     }
 
     func stopPolling() {
@@ -111,11 +118,13 @@ class GuardianModePollingService {
 
         guard isPolling else { return }
 
-        NSLog("GuardianPolling: Stopping poll timer")
+        pollGeneration += 1
+        NSLog("GuardianPolling: Stopping poll timer generation=\(pollGeneration)")
 
         pollTimer?.cancel()
         pollTimer = nil
         isPolling = false
+        isPollInFlight = false
     }
 
     /// Keep the poller alive while Guardian Mode is active. Dispatch timers can
@@ -130,7 +139,7 @@ class GuardianModePollingService {
         let staleAfter = max(pollInterval * 5, 20.0)
         let isStale = lastPollAttemptAt.map { now.timeIntervalSince($0) > staleAfter } ?? true
 
-        guard !isPolling || pollTimer == nil || isStale else {
+        guard !isPolling || pollTimer == nil || (isStale && !isPollInFlight) else {
             return
         }
 
@@ -141,9 +150,11 @@ class GuardianModePollingService {
 
         pollTimer?.cancel()
         pollTimer = nil
+        pollGeneration += 1
         isPolling = true
+        isPollInFlight = false
         consecutiveErrors = 0
-        createPollTimerLocked()
+        scheduleNextPollLocked(after: 0, reason: reason)
     }
 
     func statusSnapshot() -> [String: Any] {
@@ -153,6 +164,9 @@ class GuardianModePollingService {
         return [
             "is_polling": isPolling,
             "has_timer": pollTimer != nil,
+            "is_poll_in_flight": isPollInFlight,
+            "poll_generation": pollGeneration,
+            "last_scheduled_delay": lastScheduledDelay,
             "consecutive_errors": consecutiveErrors,
             "last_poll_attempt_at": lastPollAttemptAt?.timeIntervalSince1970 ?? 0,
             "last_poll_success_at": lastPollSuccessAt?.timeIntervalSince1970 ?? 0,
@@ -235,34 +249,61 @@ class GuardianModePollingService {
 
     // MARK: - Private Methods
 
-    private func createPollTimerLocked() {
-        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .background))
+    private func scheduleNextPollLocked(after delay: TimeInterval, reason: String) {
+        pollTimer?.cancel()
+        pollTimer = nil
 
-        timer.schedule(deadline: .now(), repeating: pollInterval)
+        guard isPolling else { return }
+
+        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .background))
+        let generation = pollGeneration
+        lastScheduledDelay = delay
+
+        timer.schedule(deadline: .now() + delay)
 
         timer.setEventHandler { [weak self] in
             Task {
-                await self?.executePoll()
+                await self?.executePoll(generation: generation)
             }
         }
 
         timer.resume()
         pollTimer = timer
+        NSLog("GuardianPolling: Scheduled next poll generation=\(generation) delay=\(String(format: "%.2f", delay)) reason=\(reason)")
     }
 
-    private func executePoll() async {
-        stateLock.lock()
-        let active = isPolling
-        if active {
-            lastPollAttemptAt = Date()
-        }
-        stateLock.unlock()
+    private func nextPollDelayLocked() -> TimeInterval {
+        let cappedErrors = min(consecutiveErrors, 5)
+        let backoff = cappedErrors == 0 ? 0 : min(30.0, pow(2.0, Double(cappedErrors)))
+        let jitter = Double.random(in: 0...0.75)
+        return pollInterval + backoff + jitter
+    }
 
-        guard active else { return }
+    private func executePoll(generation: UInt) async {
+        stateLock.lock()
+        guard isPolling, generation == pollGeneration else {
+            stateLock.unlock()
+            return
+        }
+
+        guard !isPollInFlight else {
+            let delay = nextPollDelayLocked()
+            scheduleNextPollLocked(after: delay, reason: "in_flight_skip")
+            stateLock.unlock()
+            return
+        }
+        isPollInFlight = true
+        lastPollAttemptAt = Date()
+        stateLock.unlock()
 
         do {
             if let result = try await pollForNewAudio() {
                 stateLock.lock()
+                let isCurrentGeneration = isPolling && generation == pollGeneration
+                guard isCurrentGeneration else {
+                    stateLock.unlock()
+                    return
+                }
                 consecutiveErrors = 0
                 lastPollSuccessAt = Date()
                 stateLock.unlock()
@@ -321,14 +362,18 @@ class GuardianModePollingService {
                 }
             } else {
                 stateLock.lock()
-                consecutiveErrors = 0
-                lastPollSuccessAt = Date()
+                if isPolling && generation == pollGeneration {
+                    consecutiveErrors = 0
+                    lastPollSuccessAt = Date()
+                }
                 stateLock.unlock()
             }
         } catch {
             stateLock.lock()
-            consecutiveErrors += 1
-            lastPollErrorAt = Date()
+            if isPolling && generation == pollGeneration {
+                consecutiveErrors += 1
+                lastPollErrorAt = Date()
+            }
             let errors = consecutiveErrors
             stateLock.unlock()
 
@@ -341,5 +386,13 @@ class GuardianModePollingService {
         if Int.random(in: 0..<60) == 0 {
             GuardianModeManager.shared.cleanCache()
         }
+
+        stateLock.lock()
+        if isPolling && generation == pollGeneration {
+            isPollInFlight = false
+            let delay = nextPollDelayLocked()
+            scheduleNextPollLocked(after: delay, reason: consecutiveErrors == 0 ? "poll_complete" : "poll_error")
+        }
+        stateLock.unlock()
     }
 }

--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -70,6 +70,8 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   /// V2V client for WebSocket-based voice-to-voice mode
   V2VClient? _v2vClient;
   bool _isV2VMode = false;
+  bool _isStartingV2V = false;
+  int _v2vClientGeneration = 0;
   String? _voiceSessionId;
   DateTime? _voiceSessionStartedAt;
   String _voiceSessionProvider = 'elevenlabs';
@@ -452,66 +454,104 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
   Future<void> _startV2V(String provider) async {
     debugPrint('[VoiceChat] Starting V2V mode with provider: $provider');
-    _isV2VMode = true;
-    _startUnifiedVoiceSession(provider);
-
-    // Stop any existing mic recording from CaptureProvider
-    if (mounted) {
-      final captureProvider = Provider.of<CaptureProvider>(context, listen: false);
-      if (captureProvider.recordingState == RecordingState.record) {
-        debugPrint('[VoiceChat] Pausing capture recording for V2V');
-        await captureProvider.stopStreamRecording();
-        _didPauseCaptureRecording = true;
-      }
-    }
-
-    setState(() {
-      _orbState = VoiceOrbState.processing;
-      _statusText = 'Connecting...';
-      _audioLevel = 0.0;
-    });
-
-    // Stop any playing audio
-    try {
-      await _audioPlayer.stop();
-    } catch (_) {}
-
-    _v2vClient = V2VClient(
-      onEvent: _onV2VEvent,
-      onConnectionChanged: (connected) {
-        if (!mounted) return;
-        if (!connected && _isV2VMode) {
-          debugPrint('[VoiceChat] V2V disconnected unexpectedly');
-          setState(() {
-            _orbState = VoiceOrbState.idle;
-            _statusText = 'Disconnected — Tap to Reconnect';
-            _isV2VMode = false;
-            _voiceModeActive = false;
-          });
-        }
-      },
-    );
-
-    final success = await _v2vClient!.connect(provider: provider);
-    if (!mounted) return;
-
-    if (!success) {
-      debugPrint('[VoiceChat] V2V connect failed, falling back to STT mode');
-      _isV2VMode = false;
-      _v2vClient = null;
-      // Fall back to standard STT→LLM→TTS
-      _startListening();
+    if (_isStartingV2V) {
+      debugPrint('[VoiceChat] V2V start already in progress, ignoring duplicate start');
       return;
     }
 
-    setState(() {
-      _orbState = VoiceOrbState.listening;
-      _statusText = 'V2V Active — Tap to Stop';
-    });
+    _isStartingV2V = true;
+    final generation = ++_v2vClientGeneration;
+    _isV2VMode = true;
+    _startUnifiedVoiceSession(provider);
+
+    try {
+      // A reconnect must not leave the previous socket or recorder alive.
+      final previousClient = _v2vClient;
+      _v2vClient = null;
+      if (previousClient != null) {
+        debugPrint('[VoiceChat] Closing previous V2V client before reconnect');
+        await previousClient.disconnect();
+      }
+
+      // Stop any existing mic recording from CaptureProvider
+      if (mounted) {
+        final captureProvider = Provider.of<CaptureProvider>(context, listen: false);
+        if (captureProvider.recordingState == RecordingState.record) {
+          debugPrint('[VoiceChat] Pausing capture recording for V2V');
+          await captureProvider.stopStreamRecording();
+          _didPauseCaptureRecording = true;
+        }
+      }
+
+      if (!mounted || generation != _v2vClientGeneration) return;
+      setState(() {
+        _orbState = VoiceOrbState.processing;
+        _statusText = 'Connecting...';
+        _audioLevel = 0.0;
+        _lastUserText = '';
+        _lastEllaText = '';
+        _ellaDisplayText = '';
+      });
+
+      // Stop any playing audio
+      try {
+        await _audioPlayer.stop();
+      } catch (_) {}
+
+      final client = V2VClient(
+        onEvent: (event) {
+          if (generation == _v2vClientGeneration) {
+            _onV2VEvent(event);
+          }
+        },
+        onConnectionChanged: (connected) {
+          if (!mounted || generation != _v2vClientGeneration) return;
+          if (!connected && _isV2VMode) {
+            debugPrint('[VoiceChat] V2V disconnected unexpectedly');
+            setState(() {
+              _orbState = VoiceOrbState.idle;
+              _statusText = 'Disconnected — Tap to Reconnect';
+              _isV2VMode = false;
+              _voiceModeActive = false;
+            });
+          }
+        },
+      );
+      _v2vClient = client;
+
+      final success = await client.connect(provider: provider);
+      if (!mounted || generation != _v2vClientGeneration) {
+        await client.disconnect();
+        return;
+      }
+
+      if (!success) {
+        debugPrint('[VoiceChat] V2V connect failed');
+        _isV2VMode = false;
+        _v2vClient = null;
+        setState(() {
+          _orbState = VoiceOrbState.idle;
+          _statusText = 'Voice provider unavailable. Tap to retry or choose another provider.';
+          _voiceModeActive = false;
+        });
+        return;
+      }
+
+      setState(() {
+        _orbState = VoiceOrbState.listening;
+        _statusText = 'V2V Active — Tap to Stop';
+      });
+    } finally {
+      if (generation == _v2vClientGeneration) {
+        _isStartingV2V = false;
+      }
+    }
   }
 
   Future<void> _stopV2V() async {
     debugPrint('[VoiceChat] Stopping V2V mode');
+    _v2vClientGeneration++;
+    _isStartingV2V = false;
     await _v2vClient?.disconnect();
     _v2vClient = null;
     await _completeUnifiedVoiceSession();

--- a/app/lib/ella/services/ella_chat_service.dart
+++ b/app/lib/ella/services/ella_chat_service.dart
@@ -11,11 +11,13 @@ import 'package:omi/env/env.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 
-/// Feature flag — production Ella chat uses Pattern C direct OpenClaw.
+/// Feature flag for direct gateway streaming.
 ///
-/// Any backend proxy fallback must also force OpenClaw; Level 0 is the legacy
-/// OMI/Grok path and is not valid for Ella chat.
-const bool _useDirectChat = true;
+/// Keep this disabled for MVP: the backend proxy owns Hermes routing, session
+/// continuity, and fallback behavior. Direct gateway failures can be swallowed
+/// by the streaming HTTP helper before the proxy fallback gets a chance to run.
+/// Cached direct gateway endpoints are cleared when chat is sent.
+const bool _useDirectChat = false;
 
 bool isEllaOperationalChatText(String text) {
   final normalized = text.trim();
@@ -255,7 +257,9 @@ Future<List<ServerMessage>> fetchEllaChatHistory({int limit = 50}) async {
 Stream<ServerMessageChunk> sendEllaChatStream(String text) async* {
   // Feature flag — delegate to existing proxy path if disabled
   if (!_useDirectChat) {
-    yield* sendEllaMessageStream(text, headers: _ellaDebugHeaders(routeSource: 'proxy-flag-off'));
+    _invalidateResolveCache();
+    Logger.debug('[EllaChat] Direct gateway disabled, forcing proxy chat stream');
+    yield* sendEllaMessageStream(text, headers: _ellaDebugHeaders(routeSource: 'proxy-forced'));
     return;
   }
 

--- a/app/lib/ella/services/unified_memory_service.dart
+++ b/app/lib/ella/services/unified_memory_service.dart
@@ -11,6 +11,8 @@ import 'package:omi/utils/logger.dart';
 const _pendingWritesKey = 'ellaUnifiedMemoryPendingWrites';
 const _writeEnabledKey = 'ellaUnifiedMemoryWriteEnabled';
 const _mockAdapterKey = 'ellaUnifiedMemoryMockAdapter';
+const _chatSessionIdKey = 'ellaUnifiedMemoryChatSessionId';
+const _chatTurnIndexKeyPrefix = 'ellaUnifiedMemoryChatTurnIndex:';
 const _liveCanonicalBaseUrl = 'https://api.ella-ai-care.com/';
 
 /// Staged adapter for the canonical event/timeline APIs tracked by ella-ai#789.
@@ -26,7 +28,17 @@ class UnifiedMemoryService {
 
   static String createVoiceSessionId() => 'ios_voice_${const Uuid().v4()}';
 
-  static String createChatSessionId() => 'ios_chat_${const Uuid().v4()}';
+  static String createChatSessionId() {
+    final prefs = SharedPreferencesUtil();
+    final existing = prefs.getString(_chatSessionIdKey);
+    if (existing.isNotEmpty) return existing;
+
+    final uid = _uid.trim();
+    final safeUid = uid.replaceAll(RegExp(r'[^a-zA-Z0-9_-]'), '_').toLowerCase();
+    final sessionId = safeUid.isNotEmpty ? 'ios_chat_$safeUid' : 'ios_chat_${const Uuid().v4()}';
+    prefs.saveString(_chatSessionIdKey, sessionId);
+    return sessionId;
+  }
 
   static List<CanonicalEllaEvent> buildTurnEvents({
     required String channel,
@@ -84,11 +96,12 @@ class UnifiedMemoryService {
     if (!isWriteEnabled) return;
     if (_uid.isEmpty) return;
 
+    final turnIndex = await _nextChatTurnIndex(sessionId);
     final events = buildTurnEvents(
       channel: 'ios_chat',
       sessionId: sessionId,
-      provider: 'openclaw',
-      turnIndex: 1,
+      provider: 'hermes',
+      turnIndex: turnIndex,
       userText: userText,
       assistantText: assistantText,
       startedAt: startedAt,
@@ -97,6 +110,14 @@ class UnifiedMemoryService {
 
     if (events.isEmpty) return;
     await _writePayload({'events': events.map((event) => event.toJson()).toList()});
+  }
+
+  static Future<int> _nextChatTurnIndex(String sessionId) async {
+    final prefs = SharedPreferencesUtil();
+    final key = '$_chatTurnIndexKeyPrefix$sessionId';
+    final next = prefs.getInt(key) + 1;
+    await prefs.saveInt(key, next);
+    return next;
   }
 
   static Future<void> writeVoiceTurn({

--- a/app/lib/ella/services/v2v_client.dart
+++ b/app/lib/ella/services/v2v_client.dart
@@ -24,12 +24,16 @@ class V2VEvent {
 
 /// Voice-to-voice WebSocket client for half-duplex PCM16 audio streaming.
 ///
-/// Uses `record` package for mic input and `just_audio` for WAV playback.
-/// Mic is muted during playback to prevent echo→VAD interruption on Grok's side.
+/// Uses `record` package for mic input and FlutterSound for PCM playback.
+/// The mic recorder is suspended during playback so provider VAD cannot hear
+/// Ella's own response audio or post-turn background noise.
 class V2VClient {
   static const int _pcmSampleRate = 24000;
   static const int _pcmBytesPerSample = 2;
   static const int _pcmChannels = 1;
+  static const Duration _postPlaybackMicCooldown = Duration(seconds: 2);
+
+  static V2VClient? _activeClient;
 
   WebSocketChannel? _channel;
   AudioRecorder? _recorder;
@@ -38,8 +42,10 @@ class V2VClient {
   bool _isConnected = false;
   bool _isPlaying = false;
   bool _micMuted = false;
+  bool _micSuspendedForPlayback = false;
   int _micChunksSent = 0;
   int _micBytesSent = 0;
+  Future<void> _micGateFuture = Future.value();
 
   /// PCM buffer for accumulating audio chunks before WAV playback
   final BytesBuilder _pcmBuffer = BytesBuilder(copy: false);
@@ -85,25 +91,37 @@ class V2VClient {
   /// Start a V2V session: get session token, connect WebSocket, start audio.
   Future<bool> connect({required String provider}) async {
     provider = normalizeProvider(provider);
+    if (_activeClient != null && _activeClient != this) {
+      Logger.debug('[V2V] Closing existing active V2V client before provider=$provider connect');
+      await _activeClient!.disconnect();
+    }
+    _activeClient = this;
+
     if (_isConnected || _channel != null || _recorder != null) {
       Logger.debug('[V2V] connect() called with existing session state, disconnecting first');
       await disconnect();
+      _activeClient = this;
     }
 
     final uid = SharedPreferencesUtil().uid;
     if (uid.isEmpty) {
       Logger.debug('[V2V] No uid, cannot connect');
+      if (_activeClient == this) _activeClient = null;
       return false;
     }
 
     // 1. Get session token from backend
     final sessionData = await _createSession(uid, provider);
-    if (sessionData == null) return false;
+    if (sessionData == null) {
+      if (_activeClient == this) _activeClient = null;
+      return false;
+    }
 
     final token = sessionData['session_token'] as String? ?? '';
     final endpoint = sessionData['voice_endpoint'] as String? ?? '';
     if (token.isEmpty || endpoint.isEmpty) {
       Logger.debug('[V2V] Invalid session data');
+      if (_activeClient == this) _activeClient = null;
       return false;
     }
 
@@ -152,6 +170,9 @@ class V2VClient {
   Future<void> disconnect() async {
     _isConnected = false;
     onConnectionChanged?.call(false);
+    if (_activeClient == this) {
+      _activeClient = null;
+    }
 
     _wsSub?.cancel();
     _wsSub = null;
@@ -161,7 +182,7 @@ class V2VClient {
     } catch (_) {}
     _channel = null;
 
-    await _stopMicStream();
+    await _stopMicStream(reason: 'disconnect');
     try {
       await _stopStreamingPlayback();
       if (_streamPlayerOpen) {
@@ -180,22 +201,32 @@ class V2VClient {
       } catch (_) {}
       _isPlaying = false;
     }
+    _micSuspendedForPlayback = false;
     _micMuted = false;
     _pcmBuffer.clear();
     _chunkCount = 0;
     _streamPlaybackStartedAt = null;
   }
 
-  void _muteMicForPlayback(String reason) {
-    if (_micMuted) return;
+  void _suspendMicForPlayback(String reason) {
+    if (_micMuted && _micSuspendedForPlayback) return;
     _micMuted = true;
-    Logger.debug('[V2V] Mic muted for playback/assistant response: $reason');
-    onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic muted during response'));
+    _micSuspendedForPlayback = true;
+    Logger.debug('[V2V] Mic gate closed for playback: reason=$reason sent=$_micChunksSent chunks/$_micBytesSent bytes');
+    onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic gate closed: $reason'));
+
+    _micGateFuture = _micGateFuture.then((_) async {
+      await _stopMicStream(reason: 'playback_gate:$reason');
+    }).catchError((error) {
+      Logger.error('[V2V] Mic gate close failed: $error');
+      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic gate close failed: $error'));
+    });
   }
 
   void _resetTurnState() {
     _isPlaying = false;
     _micMuted = false;
+    _micSuspendedForPlayback = false;
     _pcmBuffer.clear();
     _chunkCount = 0;
     _micChunksSent = 0;
@@ -203,6 +234,7 @@ class V2VClient {
     _streamPlaybackStarted = false;
     _streamPlaybackStartedAt = null;
     _streamFeedFuture = Future.value();
+    _micGateFuture = Future.value();
   }
 
   // --- Audio session ---
@@ -327,12 +359,19 @@ class V2VClient {
 
   Future<void> _startMicStream() async {
     try {
+      if (_recorder != null || _micSub != null) {
+        Logger.debug('[V2V] Mic stream already active, not starting duplicate recorder');
+        return;
+      }
+
       _recorder = AudioRecorder();
 
       final hasPermission = await _recorder!.hasPermission();
       if (!hasPermission) {
         Logger.error('[V2V] Mic permission denied');
         onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic permission denied'));
+        await _recorder?.dispose();
+        _recorder = null;
         return;
       }
 
@@ -348,7 +387,7 @@ class V2VClient {
       _micChunksSent = 0;
       _micBytesSent = 0;
       _micSub = stream.listen((data) {
-        if (_isConnected && _channel != null && !_micMuted && !_isPlaying) {
+        if (_isConnected && _channel != null && !_micMuted && !_isPlaying && !_micSuspendedForPlayback) {
           _channel!.sink.add(data);
           _micChunksSent++;
           _micBytesSent += data.length;
@@ -359,7 +398,8 @@ class V2VClient {
       });
 
       _micMuted = false;
-      Logger.debug('[V2V] Mic recording started at 24kHz');
+      _micSuspendedForPlayback = false;
+      Logger.debug('[V2V] Mic gate open: recording at 24kHz');
       onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic active'));
     } catch (e) {
       Logger.error('[V2V] Mic start failed: $e');
@@ -367,14 +407,50 @@ class V2VClient {
     }
   }
 
-  Future<void> _stopMicStream() async {
-    _micSub?.cancel();
+  Future<void> _stopMicStream({required String reason}) async {
+    final hadMic = _micSub != null || _recorder != null;
+    if (hadMic) {
+      Logger.debug('[V2V] Mic stream stopping: reason=$reason');
+    }
+
+    await _micSub?.cancel();
     _micSub = null;
     try {
       await _recorder?.stop();
       await _recorder?.dispose();
     } catch (_) {}
     _recorder = null;
+
+    if (hadMic) {
+      Logger.debug('[V2V] Mic stream stopped: reason=$reason');
+    }
+  }
+
+  Future<void> _resumeMicAfterPlayback() async {
+    if (!_micSuspendedForPlayback) {
+      _micMuted = false;
+      return;
+    }
+
+    Logger.debug('[V2V] Mic gate cooldown: ${_postPlaybackMicCooldown.inMilliseconds}ms');
+    onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic gate cooldown'));
+    await Future.delayed(_postPlaybackMicCooldown);
+    await _micGateFuture;
+
+    if (!_isConnected || _channel == null) {
+      Logger.debug('[V2V] Mic gate remains closed: session disconnected');
+      _micSuspendedForPlayback = false;
+      _micMuted = false;
+      return;
+    }
+
+    if (_isPlaying || _streamPlaybackStarted) {
+      Logger.debug('[V2V] Mic gate remains closed: playback still active');
+      return;
+    }
+
+    Logger.debug('[V2V] Mic gate reopening after playback cooldown');
+    await _startMicStream();
   }
 
   // --- Low-latency PCM streaming playback ---
@@ -385,7 +461,7 @@ class V2VClient {
 
     // Gate the microphone before enqueueing playback so provider VAD cannot
     // hear Ella's own response audio and interrupt the active turn.
-    _muteMicForPlayback('audio_chunk');
+    _suspendMicForPlayback('audio_chunk');
     _chunkCount++;
     _pcmBuffer.add(pcmData);
 
@@ -470,8 +546,8 @@ class V2VClient {
       Logger.error('[V2V] Stream playback error: $e');
       onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Stream play error: $e'));
       _isPlaying = false;
-      _micMuted = false;
       _streamPlaybackStartedAt = null;
+      await _resumeMicAfterPlayback();
       onEvent?.call(V2VEvent(type: 'playback_complete'));
     }
   }
@@ -482,8 +558,8 @@ class V2VClient {
     Logger.debug('[V2V] Playback complete, restarting mic');
     await _stopStreamingPlayback();
     _isPlaying = false;
-    _micMuted = false;
     _streamPlaybackStartedAt = null;
+    await _resumeMicAfterPlayback();
 
     onEvent?.call(V2VEvent(type: 'playback_complete'));
   }
@@ -511,7 +587,7 @@ class V2VClient {
         }
 
         if (_isAssistantTranscriptEvent(type)) {
-          _muteMicForPlayback(type);
+          _suspendMicForPlayback(type);
           onEvent?.call(V2VEvent(type: 'transcript', text: text));
           return;
         }
@@ -524,7 +600,7 @@ class V2VClient {
 
         switch (type) {
           case 'speech_started':
-            if (_isPlaying || _micMuted || _streamPlaybackStarted) {
+            if (_isPlaying || _micMuted || _micSuspendedForPlayback || _streamPlaybackStarted) {
               Logger.debug('[V2V] Ignoring speech_started while playback gate is active');
               onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Ignoring speech_started during response'));
               break;

--- a/app/lib/ella/services/v2v_client.dart
+++ b/app/lib/ella/services/v2v_client.dart
@@ -38,6 +38,8 @@ class V2VClient {
   bool _isConnected = false;
   bool _isPlaying = false;
   bool _micMuted = false;
+  int _micChunksSent = 0;
+  int _micBytesSent = 0;
 
   /// PCM buffer for accumulating audio chunks before WAV playback
   final BytesBuilder _pcmBuffer = BytesBuilder(copy: false);
@@ -83,6 +85,11 @@ class V2VClient {
   /// Start a V2V session: get session token, connect WebSocket, start audio.
   Future<bool> connect({required String provider}) async {
     provider = normalizeProvider(provider);
+    if (_isConnected || _channel != null || _recorder != null) {
+      Logger.debug('[V2V] connect() called with existing session state, disconnecting first');
+      await disconnect();
+    }
+
     final uid = SharedPreferencesUtil().uid;
     if (uid.isEmpty) {
       Logger.debug('[V2V] No uid, cannot connect');
@@ -136,6 +143,7 @@ class V2VClient {
       return true;
     } catch (e) {
       Logger.error('[V2V] WebSocket connect failed: $e');
+      await disconnect();
       return false;
     }
   }
@@ -161,6 +169,7 @@ class V2VClient {
         _streamPlayerOpen = false;
       }
     } catch (_) {}
+    _resetTurnState();
   }
 
   /// Interrupt current playback (e.g., user started speaking).
@@ -175,6 +184,25 @@ class V2VClient {
     _pcmBuffer.clear();
     _chunkCount = 0;
     _streamPlaybackStartedAt = null;
+  }
+
+  void _muteMicForPlayback(String reason) {
+    if (_micMuted) return;
+    _micMuted = true;
+    Logger.debug('[V2V] Mic muted for playback/assistant response: $reason');
+    onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic muted during response'));
+  }
+
+  void _resetTurnState() {
+    _isPlaying = false;
+    _micMuted = false;
+    _pcmBuffer.clear();
+    _chunkCount = 0;
+    _micChunksSent = 0;
+    _micBytesSent = 0;
+    _streamPlaybackStarted = false;
+    _streamPlaybackStartedAt = null;
+    _streamFeedFuture = Future.value();
   }
 
   // --- Audio session ---
@@ -317,9 +345,16 @@ class V2VClient {
         noiseSuppress: true,
       ));
 
+      _micChunksSent = 0;
+      _micBytesSent = 0;
       _micSub = stream.listen((data) {
-        if (_isConnected && _channel != null && !_micMuted) {
+        if (_isConnected && _channel != null && !_micMuted && !_isPlaying) {
           _channel!.sink.add(data);
+          _micChunksSent++;
+          _micBytesSent += data.length;
+          if (_micChunksSent % 50 == 0) {
+            Logger.debug('[V2V] Mic streamed $_micChunksSent chunks, $_micBytesSent bytes');
+          }
         }
       });
 
@@ -348,6 +383,9 @@ class V2VClient {
   void _streamAudioChunk(Uint8List pcmData) {
     if (pcmData.isEmpty) return;
 
+    // Gate the microphone before enqueueing playback so provider VAD cannot
+    // hear Ella's own response audio and interrupt the active turn.
+    _muteMicForPlayback('audio_chunk');
     _chunkCount++;
     _pcmBuffer.add(pcmData);
 
@@ -359,11 +397,9 @@ class V2VClient {
       onEvent?.call(V2VEvent(type: 'error', text: 'Audio stream error: $error'));
     });
 
-    // Mute mic on first chunk to avoid echo/VAD self-interrupt.
-    if (!_micMuted) {
-      _micMuted = true;
+    if (_chunkCount == 1) {
       onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Streaming response audio'));
-      Logger.debug('[V2V] First audio chunk, streaming playback started, mic muted');
+      Logger.debug('[V2V] First audio chunk, streaming playback gate active');
     }
 
     if (_chunkCount % 20 == 0) {
@@ -435,6 +471,7 @@ class V2VClient {
       onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Stream play error: $e'));
       _isPlaying = false;
       _micMuted = false;
+      _streamPlaybackStartedAt = null;
       onEvent?.call(V2VEvent(type: 'playback_complete'));
     }
   }
@@ -474,6 +511,7 @@ class V2VClient {
         }
 
         if (_isAssistantTranscriptEvent(type)) {
+          _muteMicForPlayback(type);
           onEvent?.call(V2VEvent(type: 'transcript', text: text));
           return;
         }
@@ -486,6 +524,11 @@ class V2VClient {
 
         switch (type) {
           case 'speech_started':
+            if (_isPlaying || _micMuted || _streamPlaybackStarted) {
+              Logger.debug('[V2V] Ignoring speech_started while playback gate is active');
+              onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Ignoring speech_started during response'));
+              break;
+            }
             interruptPlayback();
             onEvent?.call(V2VEvent(type: 'speech_started'));
             break;

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+776
+version: 1.0.524+777
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+775
+version: 1.0.524+776
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+772
+version: 1.0.524+773
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+771
+version: 1.0.524+772
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+773
+version: 1.0.524+774
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+770
+version: 1.0.524+771
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+777
+version: 1.0.524+778
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+774
+version: 1.0.524+775
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/test/ella/services/unified_memory_service_test.dart
+++ b/app/test/ella/services/unified_memory_service_test.dart
@@ -48,7 +48,7 @@ void main() {
       final events = UnifiedMemoryService.buildTurnEvents(
         channel: 'ios_chat',
         sessionId: 'ios_chat_test',
-        provider: 'openclaw',
+        provider: 'hermes',
         turnIndex: 1,
         userText: 'what did we discuss?',
         assistantText: 'we discussed timing.',
@@ -62,7 +62,7 @@ void main() {
       expect(userEvent['event_id'], 'ios_chat_test:1:user');
       expect(assistantEvent['event_id'], 'ios_chat_test:1:assistant');
       expect(userEvent['channel'], 'ios_chat');
-      expect(userEvent['provider'], 'openclaw');
+      expect(userEvent['provider'], 'hermes');
       expect(userEvent['role'], 'user');
       expect(userEvent['scan_policy'], 'immediate');
       expect(assistantEvent['role'], 'assistant');
@@ -71,6 +71,44 @@ void main() {
       expect(userEvent['source_ref']['source_identity'], 'ios-app:ios_chat:ios_chat_test');
       expect(userEvent['privacy_scope'], 'user_private');
       expect(userEvent['text'], 'what did we discuss?');
+    });
+
+    test('uses one stable Hermes chat session with increasing turn ids', () async {
+      final firstSessionId = UnifiedMemoryService.createChatSessionId();
+      final secondSessionId = UnifiedMemoryService.createChatSessionId();
+
+      expect(firstSessionId, secondSessionId);
+      expect(firstSessionId, 'ios_chat_uid-123');
+
+      await UnifiedMemoryService.writeChatTurn(
+        sessionId: firstSessionId,
+        userText: 'first',
+        assistantText: 'reply one',
+        startedAt: DateTime.utc(2026, 4, 28, 3),
+        endedAt: DateTime.utc(2026, 4, 28, 3, 0, 1),
+      );
+      await UnifiedMemoryService.writeChatTurn(
+        sessionId: firstSessionId,
+        userText: 'second',
+        assistantText: 'reply two',
+        startedAt: DateTime.utc(2026, 4, 28, 3, 0, 2),
+        endedAt: DateTime.utc(2026, 4, 28, 3, 0, 3),
+      );
+
+      final pending = SharedPreferencesUtil().getStringList('ellaUnifiedMemoryPendingWrites');
+      expect(pending, hasLength(2));
+
+      final firstPayload = jsonDecode(pending[0]) as Map<String, dynamic>;
+      final secondPayload = jsonDecode(pending[1]) as Map<String, dynamic>;
+      final firstEvents = firstPayload['events'] as List<dynamic>;
+      final secondEvents = secondPayload['events'] as List<dynamic>;
+
+      expect(firstEvents.first['provider'], 'hermes');
+      expect(firstEvents.first['event_id'], '$firstSessionId:1:user');
+      expect(firstEvents[1]['event_id'], '$firstSessionId:1:assistant');
+      expect(secondEvents.first['provider'], 'hermes');
+      expect(secondEvents.first['event_id'], '$firstSessionId:2:user');
+      expect(secondEvents[1]['event_id'], '$firstSessionId:2:assistant');
     });
 
     test('does nothing when writes are disabled', () async {


### PR DESCRIPTION
## Summary
- Restarts Guardian polling when an active Guardian session returns to foreground or recovers from an audio interruption.
- Replaces repeating poll timer with generation-scoped one-shot scheduling so stale foreground/repair timers cannot create parallel poll loops.
- Adds in-flight poll tracking, backoff/jitter, last scheduled delay, generation, and timestamps to the native poller debug payload.
- Removes idle Guardian silent-audio ownership: Guardian Mode now polls without activating AVAudioSession or running a silence queue.
- Activates AVAudioSession only when a real Guardian queue item is about to play, and deactivates/restores after playback/failure when idle.
- Stops AppDelegate from activating `.playAndRecord` at app launch, foreground, or interruption recovery.
- Stops playback-event posts without a concrete `queue_item_id`; route-change events are only reported while a Guardian item is actively playing.
- Fixes remote audio readiness after removing the silence queue: an empty Guardian player is now created with the remote item as the current item and `play()` is requested immediately so the MP3 can load and become ready.
- Fixes physical `OSStatus -50` activation failure by removing invalid Bluetooth/AirPlay category options, retrying conservative activation paths, preserving activation errors in playback-debug metadata, and falling back to on-device TTS if remote MP3 activation still fails.
- Bumps TestFlight build to `1.0.524+774`.

Tracking:
- ellaaicare/ella-ai#847
- ellaaicare/ella-ai#995

Safety:
- iOS Guardian polling/playback/audio-session lifecycle only.
- No caregiver, emergency delivery, Firebase, auth, or signing config changes.
- Base is the current TestFlight line branch `codex/caregiver-invite-delivery-status` to keep this diff isolated.

## Validation
- `flutter build ios --flavor prod --release --no-codesign`
- `./test.sh`
- `SKIP_PULL=1 FLAVOR=prod ./ios/build-and-upload.sh`

## TestFlight
- Build `1.0.524+771` uploaded previously for #847.
- Build `1.0.524+772` uploaded successfully with the ellaaicare/ella-ai#995 audio/poller hardening.
- Build `1.0.524+773` uploaded successfully with the Guardian remote MP3 ready-timeout fix.
- Build `1.0.524+774` uploaded successfully with the OSStatus -50 activation retry/TTS fallback fix.
- Latest delivery UUID: `544a10de-8cf7-4bd5-81e5-32b29aa97bff`.
- Upload completed with no altool errors; App Store Connect processing/availability may still lag.