### PR TITLE
Use stable Hermes app-chat ledger sessions

### DIFF
--- a/app/lib/ella/services/unified_memory_service.dart
+++ b/app/lib/ella/services/unified_memory_service.dart
@@ -11,6 +11,8 @@ import 'package:omi/utils/logger.dart';
 const _pendingWritesKey = 'ellaUnifiedMemoryPendingWrites';
 const _writeEnabledKey = 'ellaUnifiedMemoryWriteEnabled';
 const _mockAdapterKey = 'ellaUnifiedMemoryMockAdapter';
+const _chatSessionIdKey = 'ellaUnifiedMemoryChatSessionId';
+const _chatTurnIndexKeyPrefix = 'ellaUnifiedMemoryChatTurnIndex:';
 const _liveCanonicalBaseUrl = 'https://api.ella-ai-care.com/';
 
 /// Staged adapter for the canonical event/timeline APIs tracked by ella-ai#789.
@@ -26,7 +28,17 @@ class UnifiedMemoryService {
 
   static String createVoiceSessionId() => 'ios_voice_${const Uuid().v4()}';
 
-  static String createChatSessionId() => 'ios_chat_${const Uuid().v4()}';
+  static String createChatSessionId() {
+    final prefs = SharedPreferencesUtil();
+    final existing = prefs.getString(_chatSessionIdKey);
+    if (existing.isNotEmpty) return existing;
+
+    final uid = _uid.trim();
+    final safeUid = uid.replaceAll(RegExp(r'[^a-zA-Z0-9_-]'), '_').toLowerCase();
+    final sessionId = safeUid.isNotEmpty ? 'ios_chat_$safeUid' : 'ios_chat_${const Uuid().v4()}';
+    prefs.saveString(_chatSessionIdKey, sessionId);
+    return sessionId;
+  }
 
   static List<CanonicalEllaEvent> buildTurnEvents({
     required String channel,
@@ -84,11 +96,12 @@ class UnifiedMemoryService {
     if (!isWriteEnabled) return;
     if (_uid.isEmpty) return;
 
+    final turnIndex = await _nextChatTurnIndex(sessionId);
     final events = buildTurnEvents(
       channel: 'ios_chat',
       sessionId: sessionId,
-      provider: 'openclaw',
-      turnIndex: 1,
+      provider: 'hermes',
+      turnIndex: turnIndex,
       userText: userText,
       assistantText: assistantText,
       startedAt: startedAt,
@@ -97,6 +110,14 @@ class UnifiedMemoryService {
 
     if (events.isEmpty) return;
     await _writePayload({'events': events.map((event) => event.toJson()).toList()});
+  }
+
+  static Future<int> _nextChatTurnIndex(String sessionId) async {
+    final prefs = SharedPreferencesUtil();
+    final key = '$_chatTurnIndexKeyPrefix$sessionId';
+    final next = prefs.getInt(key) + 1;
+    await prefs.saveInt(key, next);
+    return next;
   }
 
   static Future<void> writeVoiceTurn({

--- a/app/test/ella/services/unified_memory_service_test.dart
+++ b/app/test/ella/services/unified_memory_service_test.dart
@@ -48,7 +48,7 @@ void main() {
       final events = UnifiedMemoryService.buildTurnEvents(
         channel: 'ios_chat',
         sessionId: 'ios_chat_test',
-        provider: 'openclaw',
+        provider: 'hermes',
         turnIndex: 1,
         userText: 'what did we discuss?',
         assistantText: 'we discussed timing.',
@@ -62,7 +62,7 @@ void main() {
       expect(userEvent['event_id'], 'ios_chat_test:1:user');
       expect(assistantEvent['event_id'], 'ios_chat_test:1:assistant');
       expect(userEvent['channel'], 'ios_chat');
-      expect(userEvent['provider'], 'openclaw');
+      expect(userEvent['provider'], 'hermes');
       expect(userEvent['role'], 'user');
       expect(userEvent['scan_policy'], 'immediate');
       expect(assistantEvent['role'], 'assistant');
@@ -71,6 +71,44 @@ void main() {
       expect(userEvent['source_ref']['source_identity'], 'ios-app:ios_chat:ios_chat_test');
       expect(userEvent['privacy_scope'], 'user_private');
       expect(userEvent['text'], 'what did we discuss?');
+    });
+
+    test('uses one stable Hermes chat session with increasing turn ids', () async {
+      final firstSessionId = UnifiedMemoryService.createChatSessionId();
+      final secondSessionId = UnifiedMemoryService.createChatSessionId();
+
+      expect(firstSessionId, secondSessionId);
+      expect(firstSessionId, 'ios_chat_uid-123');
+
+      await UnifiedMemoryService.writeChatTurn(
+        sessionId: firstSessionId,
+        userText: 'first',
+        assistantText: 'reply one',
+        startedAt: DateTime.utc(2026, 4, 28, 3),
+        endedAt: DateTime.utc(2026, 4, 28, 3, 0, 1),
+      );
+      await UnifiedMemoryService.writeChatTurn(
+        sessionId: firstSessionId,
+        userText: 'second',
+        assistantText: 'reply two',
+        startedAt: DateTime.utc(2026, 4, 28, 3, 0, 2),
+        endedAt: DateTime.utc(2026, 4, 28, 3, 0, 3),
+      );
+
+      final pending = SharedPreferencesUtil().getStringList('ellaUnifiedMemoryPendingWrites');
+      expect(pending, hasLength(2));
+
+      final firstPayload = jsonDecode(pending[0]) as Map<String, dynamic>;
+      final secondPayload = jsonDecode(pending[1]) as Map<String, dynamic>;
+      final firstEvents = firstPayload['events'] as List<dynamic>;
+      final secondEvents = secondPayload['events'] as List<dynamic>;
+
+      expect(firstEvents.first['provider'], 'hermes');
+      expect(firstEvents.first['event_id'], '$firstSessionId:1:user');
+      expect(firstEvents[1]['event_id'], '$firstSessionId:1:assistant');
+      expect(secondEvents.first['provider'], 'hermes');
+      expect(secondEvents.first['event_id'], '$firstSessionId:2:user');
+      expect(secondEvents[1]['event_id'], '$firstSessionId:2:assistant');
     });
 
     test('does nothing when writes are disabled', () async {


### PR DESCRIPTION
## Summary
- changes iOS app-chat canonical writes from `provider=openclaw` to `provider=hermes`
- makes app chat reuse one stable `ios_chat_<uid>` session id instead of generating a new UUID for every send
- adds per-session increasing turn indexes so stable sessions do not dedupe new turns

## Validation
- `flutter test test/ella/services/unified_memory_service_test.dart`

Completes the iOS side of ellaaicare/ella-ai#997. This targets the current active TestFlight branch rather than `main`, because the unified-memory iOS files are not present on `main` yet.