### PR TITLE
Avoid eager Ella router imports

### DIFF
--- a/backend/ella/routers/__init__.py
+++ b/backend/ella/routers/__init__.py
@@ -1,35 +1,8 @@
-"""
-Ella Routers - Ella-specific API endpoints.
+"""Ella-specific API endpoint package.
 
-Routers:
-- callbacks: Receives callbacks from Ella n8n/Letta agents
-- chat: Streaming chat via Grok (xAI)
-- voice: Voice session management (token issuance)
-- guardian: Guardian Mode audio delivery queue for iOS
-- resolve: User identity to OpenClaw agent resolution
-- corrections: Authenticated iOS summary correction submission
-
-These add endpoints that don't exist in vanilla OMI:
-- /v1/ella/* - Callback endpoints for Letta agents
-- /v1/ella/chat/* - Grok streaming chat
-- /v1/ella/guardian/* - Guardian Mode audio queue
-- /v1/ella/resolve - User-to-agent resolution
-- /v1/ella/conversations/{id}/corrections - iOS Correct Summary
-- /v1/voice/* - Voice session management
+Routers are intentionally imported by their concrete module paths in
+``ella.__init__``. Avoid importing them here: package-level side effects make
+one optional router dependency block unrelated endpoints such as chat.
 """
 
-from .callbacks import router as callbacks_router
-from .chat import router as chat_router
-from .corrections import router as corrections_router
-from .guardian import router as guardian_router
-from .resolve import router as resolve_router
-from .voice import router as voice_router
-
-__all__ = [
-    "callbacks_router",
-    "chat_router",
-    "corrections_router",
-    "guardian_router",
-    "resolve_router",
-    "voice_router",
-]
+__all__: list[str] = []


### PR DESCRIPTION
## Summary
- Stop `backend/ella/routers/__init__.py` from importing every optional router as a package side effect.
- Keeps `/v1/ella/chat/stream` from being blocked by unrelated optional dependencies when only the chat router is imported.

## Validation
- `python3 -m py_compile backend/ella/routers/__init__.py backend/ella/routers/chat.py`
- Live VPS smoke: `/v1/ella/chat/stream` returned `HERMES_CHAT_SMOKE_OK`; logs show `FLOW:CHAT-HERMES` with stable `ella:omi:<uid>:ios-chat` session.

Closes part of ellaaicare/ella-ai#997.