### PR TITLE
Fix V2V playback completion gating

### DIFF
--- a/app/lib/ella/services/v2v_client.dart
+++ b/app/lib/ella/services/v2v_client.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:audio_session/audio_session.dart';
-import 'package:just_audio/just_audio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_sound/flutter_sound.dart';
 import 'package:record/record.dart';
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -24,9 +24,18 @@ class V2VEvent {
 
 /// Voice-to-voice WebSocket client for half-duplex PCM16 audio streaming.
 ///
-/// Uses `record` package for mic input and `just_audio` for WAV playback.
-/// Mic is muted during playback to prevent echo→VAD interruption on Grok's side.
+/// Uses `record` package for mic input and FlutterSound for PCM playback.
+/// The mic recorder is suspended during playback so provider VAD cannot hear
+/// Ella's own response audio or post-turn background noise.
 class V2VClient {
+  static const int _pcmSampleRate = 24000;
+  static const int _pcmBytesPerSample = 2;
+  static const int _pcmChannels = 1;
+  static const Duration _postPlaybackMicCooldown = Duration(seconds: 2);
+  static const Duration _playbackFinishQuietPeriod = Duration(milliseconds: 900);
+
+  static V2VClient? _activeClient;
+
   WebSocketChannel? _channel;
   AudioRecorder? _recorder;
   StreamSubscription? _micSub;
@@ -34,13 +43,23 @@ class V2VClient {
   bool _isConnected = false;
   bool _isPlaying = false;
   bool _micMuted = false;
+  bool _micSuspendedForPlayback = false;
+  int _micChunksSent = 0;
+  int _micBytesSent = 0;
+  Future<void> _micGateFuture = Future.value();
 
   /// PCM buffer for accumulating audio chunks before WAV playback
   final BytesBuilder _pcmBuffer = BytesBuilder(copy: false);
   int _chunkCount = 0;
 
-  /// just_audio player for WAV playback
-  final AudioPlayer _audioPlayer = AudioPlayer();
+  /// Low-latency PCM stream player for provider-native V2V audio.
+  final FlutterSoundPlayer _streamPlayer = FlutterSoundPlayer();
+  bool _streamPlayerOpen = false;
+  bool _streamPlaybackStarted = false;
+  DateTime? _streamPlaybackStartedAt;
+  Future<void> _streamFeedFuture = Future.value();
+  Timer? _finishPlaybackTimer;
+  bool _finishingPlayback = false;
 
   /// Callback for JSON events (transcripts, errors, etc.)
   final void Function(V2VEvent event)? onEvent;
@@ -52,22 +71,60 @@ class V2VClient {
 
   bool get isConnected => _isConnected;
 
+  static String normalizeProvider(String provider) => switch (provider) {
+        // Legacy values may remain in SharedPreferences after TestFlight upgrades.
+        'gemini-live' => 'gemini-native-live',
+        'openai-realtime' => 'openai-native-realtime',
+        _ => provider,
+      };
+
+  static bool isSessionProvider(String provider) =>
+      normalizeProvider(provider) == 'openclaw-direct' ||
+      normalizeProvider(provider) == 'openai-native-realtime' ||
+      normalizeProvider(provider) == 'grok-voice' ||
+      normalizeProvider(provider) == 'gemini-native-live';
+
+  static String? sessionVoiceMode(String provider) => switch (normalizeProvider(provider)) {
+        'openclaw-direct' => 'openclaw-direct-v1',
+        'openai-native-realtime' => 'openai-native-realtime-v1',
+        'gemini-native-live' => 'gemini-native-live-v1',
+        _ => null,
+      };
+
   /// Start a V2V session: get session token, connect WebSocket, start audio.
   Future<bool> connect({required String provider}) async {
+    provider = normalizeProvider(provider);
+    if (_activeClient != null && _activeClient != this) {
+      Logger.debug('[V2V] Closing existing active V2V client before provider=$provider connect');
+      await _activeClient!.disconnect();
+    }
+    _activeClient = this;
+
+    if (_isConnected || _channel != null || _recorder != null) {
+      Logger.debug('[V2V] connect() called with existing session state, disconnecting first');
+      await disconnect();
+      _activeClient = this;
+    }
+
     final uid = SharedPreferencesUtil().uid;
     if (uid.isEmpty) {
       Logger.debug('[V2V] No uid, cannot connect');
+      if (_activeClient == this) _activeClient = null;
       return false;
     }
 
     // 1. Get session token from backend
     final sessionData = await _createSession(uid, provider);
-    if (sessionData == null) return false;
+    if (sessionData == null) {
+      if (_activeClient == this) _activeClient = null;
+      return false;
+    }
 
     final token = sessionData['session_token'] as String? ?? '';
     final endpoint = sessionData['voice_endpoint'] as String? ?? '';
     if (token.isEmpty || endpoint.isEmpty) {
       Logger.debug('[V2V] Invalid session data');
+      if (_activeClient == this) _activeClient = null;
       return false;
     }
 
@@ -75,8 +132,8 @@ class V2VClient {
     await _configureAudioSession();
 
     // 3. Connect WebSocket
-    final wsUrl = '$endpoint&token=$token';
-    Logger.debug('[V2V] Connecting to WebSocket...');
+    final wsUrl = _withSessionToken(endpoint, token);
+    Logger.debug('[V2V] Connecting to WebSocket for provider=$provider...');
 
     try {
       _channel = IOWebSocketChannel.connect(
@@ -104,16 +161,10 @@ class V2VClient {
       // 4. Start recording mic audio and streaming to WebSocket
       await _startMicStream();
 
-      // 5. Listen for playback completion
-      _audioPlayer.playerStateStream.listen((state) {
-        if (state.processingState == ProcessingState.completed && _isPlaying) {
-          _onPlaybackComplete();
-        }
-      });
-
       return true;
     } catch (e) {
       Logger.error('[V2V] WebSocket connect failed: $e');
+      await disconnect();
       return false;
     }
   }
@@ -122,6 +173,9 @@ class V2VClient {
   Future<void> disconnect() async {
     _isConnected = false;
     onConnectionChanged?.call(false);
+    if (_activeClient == this) {
+      _activeClient = null;
+    }
 
     _wsSub?.cancel();
     _wsSub = null;
@@ -131,24 +185,62 @@ class V2VClient {
     } catch (_) {}
     _channel = null;
 
-    await _stopMicStream();
+    await _stopMicStream(reason: 'disconnect');
     try {
-      await _audioPlayer.stop();
-      await _audioPlayer.dispose();
+      await _stopStreamingPlayback();
+      if (_streamPlayerOpen) {
+        await _streamPlayer.closePlayer();
+        _streamPlayerOpen = false;
+      }
     } catch (_) {}
+    _resetTurnState();
   }
 
   /// Interrupt current playback (e.g., user started speaking).
   Future<void> interruptPlayback() async {
     if (_isPlaying) {
       try {
-        await _audioPlayer.stop();
+        await _stopStreamingPlayback();
       } catch (_) {}
       _isPlaying = false;
     }
+    _micSuspendedForPlayback = false;
     _micMuted = false;
     _pcmBuffer.clear();
     _chunkCount = 0;
+    _streamPlaybackStartedAt = null;
+  }
+
+  void _suspendMicForPlayback(String reason) {
+    if (_micMuted && _micSuspendedForPlayback) return;
+    _micMuted = true;
+    _micSuspendedForPlayback = true;
+    Logger.debug('[V2V] Mic gate closed for playback: reason=$reason sent=$_micChunksSent chunks/$_micBytesSent bytes');
+    onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic gate closed: $reason'));
+
+    _micGateFuture = _micGateFuture.then((_) async {
+      await _stopMicStream(reason: 'playback_gate:$reason');
+    }).catchError((error) {
+      Logger.error('[V2V] Mic gate close failed: $error');
+      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic gate close failed: $error'));
+    });
+  }
+
+  void _resetTurnState() {
+    _isPlaying = false;
+    _micMuted = false;
+    _micSuspendedForPlayback = false;
+    _pcmBuffer.clear();
+    _chunkCount = 0;
+    _micChunksSent = 0;
+    _micBytesSent = 0;
+    _streamPlaybackStarted = false;
+    _streamPlaybackStartedAt = null;
+    _streamFeedFuture = Future.value();
+    _finishPlaybackTimer?.cancel();
+    _finishPlaybackTimer = null;
+    _finishingPlayback = false;
+    _micGateFuture = Future.value();
   }
 
   // --- Audio session ---
@@ -173,10 +265,18 @@ class V2VClient {
 
   Future<Map<String, dynamic>?> _createSession(String uid, String provider) async {
     try {
+      provider = normalizeProvider(provider);
+      final voiceMode = sessionVoiceMode(provider);
+      final requestBody = {
+        'uid': uid,
+        'provider': provider,
+        if (voiceMode != null) 'voice_mode': voiceMode,
+      };
+
       final response = await makeApiCall(
         url: '${Env.apiBaseUrl}v1/voice/session',
         headers: {'Content-Type': 'application/json'},
-        body: jsonEncode({'uid': uid, 'provider': provider}),
+        body: jsonEncode(requestBody),
         method: 'POST',
         timeout: const Duration(seconds: 10),
       );
@@ -187,7 +287,7 @@ class V2VClient {
       }
 
       final data = jsonDecode(response.body) as Map<String, dynamic>;
-      Logger.debug('[V2V] Session created: provider=$provider');
+      Logger.debug('[V2V] Session created: provider=$provider voice_mode=${voiceMode ?? "default"}');
       return data;
     } catch (e) {
       Logger.error('[V2V] Session create error: $e');
@@ -195,16 +295,103 @@ class V2VClient {
     }
   }
 
+  static String _withSessionToken(String endpoint, String token) {
+    final uri = Uri.parse(endpoint);
+    if (uri.queryParameters.containsKey('token')) {
+      return endpoint;
+    }
+    final separator = uri.hasQuery ? '&' : '?';
+    return '$endpoint${separator}token=$token';
+  }
+
+  static String? _eventText(Map<String, dynamic> json) {
+    for (final key in ['text', 'transcript', 'delta', 'content', 'message']) {
+      final value = json[key];
+      if (value is String && value.isNotEmpty) return value;
+    }
+
+    final response = json['response'];
+    if (response is Map<String, dynamic>) {
+      return _eventText(response);
+    }
+
+    final item = json['item'];
+    if (item is Map<String, dynamic>) {
+      return _eventText(item);
+    }
+
+    return null;
+  }
+
+  static bool _isUserTranscriptEvent(String type) {
+    final normalized = type.toLowerCase();
+    return normalized == 'user_transcript' ||
+        normalized == 'input_transcript' ||
+        normalized == 'input_audio_transcription.completed' ||
+        normalized.contains('input_audio_transcription') ||
+        (normalized.contains('user') && normalized.contains('transcript'));
+  }
+
+  static bool _isAssistantTranscriptEvent(String type) {
+    final normalized = type.toLowerCase();
+    return normalized == 'transcript' ||
+        normalized == 'transcript_delta' ||
+        normalized == 'assistant_transcript' ||
+        normalized == 'output_transcript' ||
+        normalized == 'response_text' ||
+        normalized == 'response.audio_transcript.delta' ||
+        normalized == 'response.audio_transcript.done' ||
+        normalized == 'response.text.delta' ||
+        normalized == 'response.text.done' ||
+        normalized.contains('output_audio_transcription') ||
+        (normalized.contains('assistant') && normalized.contains('transcript'));
+  }
+
+  @visibleForTesting
+  static bool treatsAsAssistantTranscriptEvent(String type) {
+    return _isAssistantTranscriptEvent(type);
+  }
+
+  static bool _isAudioDoneEvent(String type) {
+    final normalized = type.toLowerCase();
+    return normalized == 'audio_done' ||
+        normalized == 'response.audio.done' ||
+        normalized == 'output_audio.done' ||
+        normalized == 'audio.done';
+  }
+
+  static bool _isResponseCompleteEvent(String type) {
+    final normalized = type.toLowerCase();
+    return normalized == 'turn_complete' || normalized == 'response.done';
+  }
+
+  @visibleForTesting
+  static bool treatsAsAudioDoneEvent(String type) {
+    return _isAudioDoneEvent(type);
+  }
+
+  @visibleForTesting
+  static bool treatsAsResponseCompleteEvent(String type) {
+    return _isResponseCompleteEvent(type);
+  }
+
   // --- Mic recording (PCM16, 24kHz, mono) using `record` package ---
 
   Future<void> _startMicStream() async {
     try {
+      if (_recorder != null || _micSub != null) {
+        Logger.debug('[V2V] Mic stream already active, not starting duplicate recorder');
+        return;
+      }
+
       _recorder = AudioRecorder();
 
       final hasPermission = await _recorder!.hasPermission();
       if (!hasPermission) {
         Logger.error('[V2V] Mic permission denied');
         onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic permission denied'));
+        await _recorder?.dispose();
+        _recorder = null;
         return;
       }
 
@@ -217,14 +404,22 @@ class V2VClient {
         noiseSuppress: true,
       ));
 
+      _micChunksSent = 0;
+      _micBytesSent = 0;
       _micSub = stream.listen((data) {
-        if (_isConnected && _channel != null && !_micMuted) {
+        if (_isConnected && _channel != null && !_micMuted && !_isPlaying && !_micSuspendedForPlayback) {
           _channel!.sink.add(data);
+          _micChunksSent++;
+          _micBytesSent += data.length;
+          if (_micChunksSent % 50 == 0) {
+            Logger.debug('[V2V] Mic streamed $_micChunksSent chunks, $_micBytesSent bytes');
+          }
         }
       });
 
       _micMuted = false;
-      Logger.debug('[V2V] Mic recording started at 24kHz');
+      _micSuspendedForPlayback = false;
+      Logger.debug('[V2V] Mic gate open: recording at 24kHz');
       onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic active'));
     } catch (e) {
       Logger.error('[V2V] Mic start failed: $e');
@@ -232,156 +427,196 @@ class V2VClient {
     }
   }
 
-  Future<void> _stopMicStream() async {
-    _micSub?.cancel();
+  Future<void> _stopMicStream({required String reason}) async {
+    final hadMic = _micSub != null || _recorder != null;
+    if (hadMic) {
+      Logger.debug('[V2V] Mic stream stopping: reason=$reason');
+    }
+
+    await _micSub?.cancel();
     _micSub = null;
     try {
       await _recorder?.stop();
       await _recorder?.dispose();
     } catch (_) {}
     _recorder = null;
+
+    if (hadMic) {
+      Logger.debug('[V2V] Mic stream stopped: reason=$reason');
+    }
   }
 
-  // --- Audio playback using just_audio (WAV file) ---
+  Future<void> _resumeMicAfterPlayback() async {
+    if (!_micSuspendedForPlayback) {
+      _micMuted = false;
+      return;
+    }
 
-  /// Buffer incoming PCM16 audio chunk.
-  void _bufferAudioChunk(Uint8List pcmData) {
+    Logger.debug('[V2V] Mic gate cooldown: ${_postPlaybackMicCooldown.inMilliseconds}ms');
+    onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic gate cooldown'));
+    await Future.delayed(_postPlaybackMicCooldown);
+    await _micGateFuture;
+
+    if (!_isConnected || _channel == null) {
+      Logger.debug('[V2V] Mic gate remains closed: session disconnected');
+      _micSuspendedForPlayback = false;
+      _micMuted = false;
+      return;
+    }
+
+    if (_isPlaying || _streamPlaybackStarted) {
+      Logger.debug('[V2V] Mic gate remains closed: playback still active');
+      return;
+    }
+
+    Logger.debug('[V2V] Mic gate reopening after playback cooldown');
+    await _startMicStream();
+  }
+
+  // --- Low-latency PCM streaming playback ---
+
+  /// Stream incoming PCM16 audio chunk to the platform player.
+  void _streamAudioChunk(Uint8List pcmData) {
     if (pcmData.isEmpty) return;
 
+    // Gate the microphone before enqueueing playback so provider VAD cannot
+    // hear Ella's own response audio and interrupt the active turn.
+    _suspendMicForPlayback('audio_chunk');
+    _deferPendingPlaybackFinish('audio_chunk');
     _chunkCount++;
     _pcmBuffer.add(pcmData);
 
-    // Mute mic on first chunk
-    if (!_micMuted) {
-      _micMuted = true;
-      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Buffering audio (mic muted)'));
-      Logger.debug('[V2V] First audio chunk, mic muted');
+    _streamFeedFuture = _streamFeedFuture.then((_) async {
+      await _ensureStreamingPlaybackStarted();
+      _streamPlayer.uint8ListSink?.add(pcmData);
+    }).catchError((error) {
+      Logger.error('[V2V] Stream playback feed error: $error');
+      onEvent?.call(V2VEvent(type: 'error', text: 'Audio stream error: $error'));
+    });
+
+    if (_chunkCount == 1) {
+      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Streaming response audio'));
+      Logger.debug('[V2V] First audio chunk, streaming playback gate active');
     }
 
     if (_chunkCount % 20 == 0) {
-      Logger.debug('[V2V] Buffered $_chunkCount chunks, ${_pcmBuffer.length}B');
+      Logger.debug('[V2V] Streamed $_chunkCount chunks, ${_pcmBuffer.length}B');
     }
   }
 
-  /// Called on audio_done — write WAV and play with just_audio.
-  Future<void> _finishPlayback() async {
+  Future<void> _ensureStreamingPlaybackStarted() async {
+    if (!_streamPlayerOpen) {
+      await _streamPlayer.openPlayer();
+      _streamPlayerOpen = true;
+    }
+
+    if (_streamPlaybackStarted) return;
+
+    _isPlaying = true;
+    _streamPlaybackStarted = true;
+    await _streamPlayer.startPlayerFromStream(
+      codec: Codec.pcm16,
+      sampleRate: _pcmSampleRate,
+      numChannels: _pcmChannels,
+      bufferSize: 4096,
+    );
+    _streamPlaybackStartedAt = DateTime.now();
+    Logger.debug('[V2V] PCM stream player started');
+  }
+
+  Future<void> _stopStreamingPlayback() async {
+    if (!_streamPlaybackStarted) return;
+    try {
+      await _streamPlayer.stopPlayer();
+    } catch (_) {}
+    _streamPlaybackStarted = false;
+  }
+
+  void _scheduleFinishPlayback(String reason) {
+    _finishPlaybackTimer?.cancel();
+    Logger.debug('[V2V] Playback finish scheduled after quiet period: reason=$reason');
+    onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Playback finish pending: $reason'));
+    _finishPlaybackTimer = Timer(_playbackFinishQuietPeriod, () {
+      _finishPlaybackTimer = null;
+      Future<void>(() async {
+        await _finishPlayback(reason: reason);
+      });
+    });
+  }
+
+  void _deferPendingPlaybackFinish(String reason) {
+    if (_finishPlaybackTimer == null) return;
+    _scheduleFinishPlayback(reason);
+  }
+
+  /// Called after audio/output completion quiets — wait for queued PCM to drain,
+  /// then return to listening.
+  Future<void> _finishPlayback({required String reason}) async {
+    if (_finishingPlayback) {
+      Logger.debug('[V2V] Playback finish already in progress, ignoring reason=$reason');
+      return;
+    }
+    _finishingPlayback = true;
     final pcmBytes = _pcmBuffer.toBytes();
     final stats = '$_chunkCount chunks, ${(pcmBytes.length / 1024).toStringAsFixed(1)}KB';
-    Logger.debug('[V2V] Audio done: $stats');
-    onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Playing: $stats'));
+    Logger.debug('[V2V] Audio stream done: reason=$reason $stats');
+    onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Finishing audio: $stats'));
 
     _pcmBuffer.clear();
     _chunkCount = 0;
 
     if (pcmBytes.isEmpty) {
       Logger.debug('[V2V] No audio data to play');
-      _micMuted = false;
-      onEvent?.call(V2VEvent(type: 'playback_complete'));
+      await _onPlaybackComplete();
+      _finishingPlayback = false;
       return;
     }
 
-    // Stop mic recording before switching audio session to playback
-    await _stopMicStream();
-
-    // Write WAV file
-    final wavPath = '${Directory.systemTemp.path}/v2v_response.wav';
-    final wavBytes = _buildWav(Uint8List.fromList(pcmBytes), sampleRate: 24000, numChannels: 1, bitsPerSample: 16);
-    await File(wavPath).writeAsBytes(wavBytes);
-    final durationMs = (pcmBytes.length / (24000 * 2)) * 1000;
-    Logger.debug('[V2V] WAV written: ${wavBytes.length}B, ${durationMs.toStringAsFixed(0)}ms');
-
-    // Play with just_audio
     try {
-      _isPlaying = true;
-      await _audioPlayer.setVolume(1.0);
-      await _audioPlayer.setFilePath(wavPath);
-      await _audioPlayer.play();
-      Logger.debug('[V2V] Playback started');
+      await _streamFeedFuture.timeout(const Duration(seconds: 5));
 
-      // Safety timeout — if playerStateStream doesn't fire completion within
-      // expected duration + 3s buffer, force restart mic anyway
-      final timeoutMs = durationMs.toInt() + 3000;
-      Future.delayed(Duration(milliseconds: timeoutMs), () {
-        if (_isPlaying) {
-          Logger.debug('[V2V] Playback safety timeout after ${timeoutMs}ms, forcing mic restart');
-          _onPlaybackComplete();
-        }
-      });
+      // `audio_done` means the proxy finished sending bytes, not that the
+      // native PCM player has drained its internal queue. Stop too early and
+      // the user hears only the first words even though transcript is complete.
+      final startedAt = _streamPlaybackStartedAt;
+      final totalAudioMs = (pcmBytes.length / (_pcmSampleRate * _pcmBytesPerSample * _pcmChannels) * 1000).ceil();
+      final elapsedMs = startedAt == null ? 0 : DateTime.now().difference(startedAt).inMilliseconds;
+      final remainingMs = totalAudioMs - elapsedMs;
+      final drainDelayMs = remainingMs > 0 ? remainingMs + 300 : 300;
+      Logger.debug('[V2V] Waiting ${drainDelayMs}ms for PCM drain ($totalAudioMs ms audio, $elapsedMs ms elapsed)');
+      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Playing audio: ${(totalAudioMs / 1000).toStringAsFixed(1)}s'));
+      await Future.delayed(Duration(milliseconds: drainDelayMs.clamp(300, 30000)));
+      await _onPlaybackComplete();
     } catch (e) {
-      Logger.error('[V2V] Playback error: $e');
-      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Play error: $e'));
+      Logger.error('[V2V] Stream playback error: $e');
+      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Stream play error: $e'));
       _isPlaying = false;
-      _micMuted = false;
-      // Restart mic even on error
-      if (_isConnected) await _startMicStream();
+      _streamPlaybackStartedAt = null;
+      await _resumeMicAfterPlayback();
       onEvent?.call(V2VEvent(type: 'playback_complete'));
+    } finally {
+      _finishingPlayback = false;
     }
   }
 
-  /// Called when just_audio finishes playing.
+  /// Called when streaming playback finishes.
   Future<void> _onPlaybackComplete() async {
     if (!_isPlaying && !_micMuted) return; // Already handled
     Logger.debug('[V2V] Playback complete, restarting mic');
+    await _stopStreamingPlayback();
     _isPlaying = false;
-    _micMuted = false;
-
-    // Restart mic recording
-    if (_isConnected) {
-      await _startMicStream();
-    }
+    _streamPlaybackStartedAt = null;
+    await _resumeMicAfterPlayback();
 
     onEvent?.call(V2VEvent(type: 'playback_complete'));
-  }
-
-  /// Build a WAV file from raw PCM16 data.
-  static Uint8List _buildWav(Uint8List pcmData, {int sampleRate = 24000, int numChannels = 1, int bitsPerSample = 16}) {
-    final byteRate = sampleRate * numChannels * (bitsPerSample ~/ 8);
-    final blockAlign = numChannels * (bitsPerSample ~/ 8);
-    final dataSize = pcmData.length;
-    final fileSize = 36 + dataSize;
-
-    final header = ByteData(44);
-    // RIFF header
-    header.setUint8(0, 0x52); // R
-    header.setUint8(1, 0x49); // I
-    header.setUint8(2, 0x46); // F
-    header.setUint8(3, 0x46); // F
-    header.setUint32(4, fileSize, Endian.little);
-    header.setUint8(8, 0x57); // W
-    header.setUint8(9, 0x41); // A
-    header.setUint8(10, 0x56); // V
-    header.setUint8(11, 0x45); // E
-    // fmt chunk
-    header.setUint8(12, 0x66); // f
-    header.setUint8(13, 0x6D); // m
-    header.setUint8(14, 0x74); // t
-    header.setUint8(15, 0x20); // (space)
-    header.setUint32(16, 16, Endian.little); // chunk size
-    header.setUint16(20, 1, Endian.little); // PCM format
-    header.setUint16(22, numChannels, Endian.little);
-    header.setUint32(24, sampleRate, Endian.little);
-    header.setUint32(28, byteRate, Endian.little);
-    header.setUint16(32, blockAlign, Endian.little);
-    header.setUint16(34, bitsPerSample, Endian.little);
-    // data chunk
-    header.setUint8(36, 0x64); // d
-    header.setUint8(37, 0x61); // a
-    header.setUint8(38, 0x74); // t
-    header.setUint8(39, 0x61); // a
-    header.setUint32(40, dataSize, Endian.little);
-
-    final wav = Uint8List(44 + dataSize);
-    wav.setRange(0, 44, header.buffer.asUint8List());
-    wav.setRange(44, 44 + dataSize, pcmData);
-    return wav;
   }
 
   // --- WebSocket message handling ---
 
   void _handleMessage(dynamic message) {
     if (message is List<int>) {
-      // Binary frame = raw PCM16 audio from proxy — buffer for WAV playback
-      _bufferAudioChunk(Uint8List.fromList(message));
+      // Binary frame = raw PCM16 audio from proxy — stream directly to playback.
+      _streamAudioChunk(Uint8List.fromList(message));
       return;
     }
 
@@ -391,20 +626,38 @@ class V2VClient {
       try {
         final json = jsonDecode(message) as Map<String, dynamic>;
         final type = json['type'] as String? ?? 'unknown';
-        final text = json['text'] as String? ?? json['transcript'] as String?;
+        final text = _eventText(json);
+
+        if (_isUserTranscriptEvent(type)) {
+          onEvent?.call(V2VEvent(type: 'user_transcript', text: text));
+          return;
+        }
+
+        if (_isAssistantTranscriptEvent(type)) {
+          _suspendMicForPlayback(type);
+          _deferPendingPlaybackFinish(type);
+          onEvent?.call(V2VEvent(type: 'transcript', text: text));
+          return;
+        }
+
+        if (_isAudioDoneEvent(type)) {
+          _scheduleFinishPlayback(type);
+          onEvent?.call(V2VEvent(type: 'audio_done'));
+          return;
+        }
+
+        if (_isResponseCompleteEvent(type)) {
+          _scheduleFinishPlayback(type);
+          return;
+        }
 
         switch (type) {
-          case 'user_transcript':
-            onEvent?.call(V2VEvent(type: 'user_transcript', text: text));
-            break;
-          case 'transcript':
-            onEvent?.call(V2VEvent(type: 'transcript', text: text));
-            break;
-          case 'audio_done':
-            _finishPlayback();
-            onEvent?.call(V2VEvent(type: 'audio_done'));
-            break;
           case 'speech_started':
+            if (_isPlaying || _micMuted || _micSuspendedForPlayback || _streamPlaybackStarted) {
+              Logger.debug('[V2V] Ignoring speech_started while playback gate is active');
+              onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Ignoring speech_started during response'));
+              break;
+            }
             interruptPlayback();
             onEvent?.call(V2VEvent(type: 'speech_started'));
             break;

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.522+727
+version: 1.0.524+780
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/test/ella/services/v2v_client_test.dart
+++ b/app/test/ella/services/v2v_client_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/ella/services/v2v_client.dart';
+
+void main() {
+  group('V2VClient provider mapping', () {
+    test('treats realtime voice providers as session providers', () {
+      expect(V2VClient.isSessionProvider('grok-voice'), isTrue);
+      expect(V2VClient.isSessionProvider('openclaw-direct'), isTrue);
+      expect(V2VClient.isSessionProvider('openai-native-realtime'), isTrue);
+      expect(V2VClient.isSessionProvider('gemini-native-live'), isTrue);
+      expect(V2VClient.isSessionProvider('openai-realtime'), isTrue);
+      expect(V2VClient.isSessionProvider('gemini-live'), isTrue);
+      expect(V2VClient.isSessionProvider('elevenlabs'), isFalse);
+    });
+
+    test('sends explicit voice mode for backend-friendly provider variants', () {
+      expect(V2VClient.sessionVoiceMode('openclaw-direct'), 'openclaw-direct-v1');
+      expect(V2VClient.sessionVoiceMode('openai-native-realtime'), 'openai-native-realtime-v1');
+      expect(V2VClient.sessionVoiceMode('gemini-native-live'), 'gemini-native-live-v1');
+      expect(V2VClient.sessionVoiceMode('openai-realtime'), 'openai-native-realtime-v1');
+      expect(V2VClient.sessionVoiceMode('gemini-live'), 'gemini-native-live-v1');
+      expect(V2VClient.sessionVoiceMode('grok-voice'), isNull);
+    });
+
+    test('normalizes saved legacy realtime provider ids', () {
+      expect(V2VClient.normalizeProvider('openai-realtime'), 'openai-native-realtime');
+      expect(V2VClient.normalizeProvider('gemini-live'), 'gemini-native-live');
+      expect(V2VClient.normalizeProvider('openclaw-direct'), 'openclaw-direct');
+    });
+
+    test('maps proxy transcript_delta events as assistant transcripts', () {
+      expect(V2VClient.treatsAsAssistantTranscriptEvent('transcript'), isTrue);
+      expect(V2VClient.treatsAsAssistantTranscriptEvent('transcript_delta'), isTrue);
+      expect(V2VClient.treatsAsAssistantTranscriptEvent('response.audio_transcript.delta'), isTrue);
+      expect(V2VClient.treatsAsAssistantTranscriptEvent('user_transcript'), isFalse);
+    });
+
+    test('separates audio completion from generic response completion', () {
+      expect(V2VClient.treatsAsAudioDoneEvent('audio_done'), isTrue);
+      expect(V2VClient.treatsAsAudioDoneEvent('response.audio.done'), isTrue);
+      expect(V2VClient.treatsAsAudioDoneEvent('output_audio.done'), isTrue);
+      expect(V2VClient.treatsAsAudioDoneEvent('response.done'), isFalse);
+      expect(V2VClient.treatsAsAudioDoneEvent('turn_complete'), isFalse);
+
+      expect(V2VClient.treatsAsResponseCompleteEvent('response.done'), isTrue);
+      expect(V2VClient.treatsAsResponseCompleteEvent('turn_complete'), isTrue);
+      expect(V2VClient.treatsAsResponseCompleteEvent('audio_done'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Keeps V2V playback alive through provider completion-marker races by waiting for a quiet period before draining/stopping PCM playback.
- Separates actual audio completion events from generic response completion events such as `response.done` and `turn_complete`.
- Adds focused V2V provider/event classification tests.
- Bumps iOS build metadata to `1.0.524+780` on this clean main-target branch.

## Scope check
Changed files only:
- `app/lib/ella/services/v2v_client.dart`
- `app/test/ella/services/v2v_client_test.dart`
- `app/pubspec.yaml`

No backend changes.

## Validation
- `flutter analyze lib/ella/services/v2v_client.dart`
- `flutter test test/ella/services/v2v_client_test.dart`

## TestFlight
- Active release branch build `1.0.524+779` containing the same V2V playback completion gating fix was uploaded and imported successfully.
- Delivery UUID: `6766b85e-6b39-448c-9249-d6d635df69db`
- App Store Connect build status: `VALID`