### PR TITLE
[codex] Add Plato read-only MCP bridge

### DIFF
--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -311,6 +311,15 @@ def _register_routers(app) -> None:
     except ImportError as e:
         print(f"  ⚠️ Ella canonical events not available: {e}", flush=True)
 
+    # Plato/Hermes read-only MCP bridge for Grok custom connector testing
+    try:
+        from ella.routers.plato_mcp import router as plato_mcp_router
+
+        app.include_router(plato_mcp_router, tags=["Ella Plato MCP"])
+        print("  🌐 /v1/ella/plato/mcp - Plato/Hermes read-only MCP bridge", flush=True)
+    except ImportError as e:
+        print(f"  ⚠️ Ella Plato MCP not available: {e}", flush=True)
+
     # Escalation policy resolver (classifier output -> deterministic delivery plan)
     try:
         from ella.routers.escalations import router as escalations_router

--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -1,0 +1,697 @@
+"""
+Authenticated read-only MCP bridge for Plato/Hermes.
+
+This endpoint is intentionally separate from the upstream OMI MCP endpoint.
+It is scoped to one configured Plato profile, exposes a small read-only tool
+surface for Grok custom MCP connector tests, and can be disabled by removing
+the bearer token from the runtime environment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import re
+import time
+import uuid
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import httpx
+from fastapi import APIRouter, Header, HTTPException, Request, Response
+from fastapi.responses import JSONResponse, StreamingResponse
+
+import database.conversations as conversations_db
+import database.memories as memories_db
+
+logger = logging.getLogger("ella.plato_mcp")
+
+router = APIRouter(prefix="/v1/ella/plato", tags=["Ella Plato MCP"])
+
+DEFAULT_PLATO_UID = "5aGC5YE9BnhcSoTxxtT4ar6ILQy2"
+DEFAULT_TIMELINE_URL = "https://api.ella-ai-care.com/v1/ella/timeline"
+DEFAULT_HERMES_GATEWAY_URL = "http://100.76.138.56:8642"
+DEFAULT_HERMES_AGENT_ID = "hermes"
+DEFAULT_PROVISION_API_URL = "http://100.76.138.56:8200"
+
+MAX_CONTEXT_LIMIT = 50
+MAX_SEARCH_RESULTS = 20
+MAX_PROMPT_CHARS = 4000
+RATE_LIMIT_WINDOW_SECONDS = 60
+
+_active_sessions: dict[str, "MCPSession"] = {}
+_rate_limits: dict[str, deque[float]] = defaultdict(deque)
+
+
+@dataclass
+class MCPSession:
+    session_id: str
+    token_fingerprint: str
+    created_at: datetime
+    initialized: bool = False
+
+
+class ToolExecutionError(Exception):
+    def __init__(self, message: str, code: int = -32000):
+        super().__init__(message)
+        self.message = message
+        self.code = code
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.getenv(name, default).strip()
+
+
+def _plato_uid() -> str:
+    return _env("ELLA_PLATO_MCP_UID", _env("ELLA_PLATO_UID", DEFAULT_PLATO_UID))
+
+
+def _plato_canonical_identity() -> str:
+    return _env("ELLA_PLATO_CANONICAL_IDENTITY", _plato_uid())
+
+
+def _plato_agent_id() -> str:
+    return _env("ELLA_PLATO_AGENT_ID", f"ella-omi-{_plato_uid().lower()}")
+
+
+def _allowed_tokens() -> set[str]:
+    raw = _env("ELLA_PLATO_MCP_TOKENS", _env("ELLA_PLATO_MCP_TOKEN", ""))
+    return {token.strip() for token in raw.split(",") if token.strip()}
+
+
+def _token_from_authorization(authorization: Optional[str]) -> str:
+    if not authorization:
+        return ""
+    authorization = authorization.strip()
+    if authorization.lower().startswith("bearer "):
+        return authorization[7:].strip()
+    return authorization
+
+
+def _fingerprint(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+
+
+def _authenticate(authorization: Optional[str]) -> str:
+    tokens = _allowed_tokens()
+    if not tokens:
+        raise HTTPException(status_code=503, detail="Plato MCP token is not configured")
+    token = _token_from_authorization(authorization)
+    if not token or token not in tokens:
+        raise HTTPException(status_code=401, detail="Invalid or missing Plato MCP bearer token")
+    _check_rate_limit(token)
+    return _fingerprint(token)
+
+
+def _check_rate_limit(token: str) -> None:
+    limit = int(_env("ELLA_PLATO_MCP_RATE_LIMIT_PER_MINUTE", "60"))
+    if limit <= 0:
+        return
+    now = time.monotonic()
+    fingerprint = _fingerprint(token)
+    bucket = _rate_limits[fingerprint]
+    while bucket and now - bucket[0] > RATE_LIMIT_WINDOW_SECONDS:
+        bucket.popleft()
+    if len(bucket) >= limit:
+        raise HTTPException(status_code=429, detail="Plato MCP token rate limit exceeded")
+    bucket.append(now)
+
+
+def _clamp_int(value: Any, default: int, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, parsed))
+
+
+def _parse_iso_datetime(value: Any) -> Optional[datetime]:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ToolExecutionError(f"Invalid datetime: {value}", code=-32602) from exc
+    else:
+        raise ToolExecutionError(f"Invalid datetime: {value}", code=-32602)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def _compact_text(value: Any, limit: int = 1200) -> str:
+    clean = re.sub(r"\s+", " ", str(value or "")).strip()
+    if len(clean) <= limit:
+        return clean
+    return clean[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _event_time(item: dict[str, Any]) -> str:
+    return str(
+        item.get("started_at") or item.get("finished_at") or item.get("created_at") or item.get("timestamp") or ""
+    )
+
+
+def _conversation_to_event(conversation: dict[str, Any]) -> dict[str, Any]:
+    structured = conversation.get("structured") or {}
+    title = structured.get("title") or conversation.get("title") or "OMI conversation"
+    overview = structured.get("overview") or conversation.get("overview") or ""
+    return {
+        "event_id": conversation.get("id"),
+        "channel": "omi",
+        "provider": "omi-backend",
+        "role": "user",
+        "started_at": _json_safe(conversation.get("started_at") or conversation.get("created_at")),
+        "ended_at": _json_safe(conversation.get("finished_at")),
+        "title": title,
+        "text": _compact_text(overview, 1600),
+        "source_ref": {"conversation_id": conversation.get("id")},
+    }
+
+
+def _memory_to_event(memory: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "event_id": memory.get("id"),
+        "channel": "memory",
+        "provider": "omi-backend",
+        "role": "memory",
+        "started_at": _json_safe(memory.get("created_at")),
+        "title": memory.get("category") or "memory",
+        "text": _compact_text(memory.get("content"), 1200),
+        "source_ref": {"memory_id": memory.get("id")},
+    }
+
+
+async def _fetch_canonical_timeline(limit: int, channels: list[str], since: Optional[str]) -> list[dict[str, Any]]:
+    timeline_url = _env("ELLA_PLATO_TIMELINE_URL", DEFAULT_TIMELINE_URL)
+    params: dict[str, Any] = {"uid": _plato_uid(), "limit": limit}
+    if channels:
+        params["channels"] = ",".join(channels)
+    if since:
+        params["since"] = since
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        response = await client.get(timeline_url, params=params)
+    if response.status_code != 200:
+        raise RuntimeError(f"timeline_http_{response.status_code}")
+    payload = response.json()
+    events = payload if isinstance(payload, list) else payload.get("events") or payload.get("timeline") or []
+    return [_json_safe(event) for event in events if isinstance(event, dict)]
+
+
+def _fallback_recent_context(limit: int, channels: list[str], since: Optional[str]) -> list[dict[str, Any]]:
+    since_dt = _parse_iso_datetime(since)
+    events: list[dict[str, Any]] = []
+    include_omi = not channels or "omi" in channels or "omi_transcript" in channels
+    include_memory = not channels or "memory" in channels or "memories" in channels
+    if include_omi:
+        conversations = conversations_db.get_conversations(
+            _plato_uid(),
+            limit=limit,
+            offset=0,
+            include_discarded=False,
+            statuses=["completed"],
+            start_date=since_dt,
+        )
+        events.extend(_conversation_to_event(conv) for conv in conversations)
+    if include_memory and len(events) < limit:
+        memories = memories_db.get_memories(_plato_uid(), limit=limit, offset=0, start_date=since_dt)
+        events.extend(_memory_to_event(memory) for memory in memories)
+    events.sort(key=_event_time, reverse=True)
+    return events[:limit]
+
+
+async def _recent_context(arguments: dict[str, Any]) -> dict[str, Any]:
+    limit = _clamp_int(arguments.get("limit"), 10, 1, MAX_CONTEXT_LIMIT)
+    raw_channels = arguments.get("channels") or []
+    channels = (
+        [str(item).strip() for item in raw_channels if str(item).strip()] if isinstance(raw_channels, list) else []
+    )
+    since = arguments.get("since")
+    try:
+        events = await _fetch_canonical_timeline(limit, channels, since)
+        source = "canonical_timeline"
+    except Exception as exc:
+        logger.warning("plato_mcp timeline fallback: %s", exc)
+        events = _fallback_recent_context(limit, channels, since)
+        source = "omi_firestore_fallback"
+    return {
+        "uid": _plato_uid(),
+        "canonical_identity": _plato_canonical_identity(),
+        "source": source,
+        "events": events[:limit],
+    }
+
+
+async def _latest_omi(arguments: dict[str, Any]) -> dict[str, Any]:
+    context = await _recent_context(
+        {"limit": _clamp_int(arguments.get("limit"), 10, 1, MAX_CONTEXT_LIMIT), "channels": ["omi"]}
+    )
+    events = [event for event in context.get("events", []) if str(event.get("channel", "")).startswith("omi")]
+    latest = events[0] if events else None
+    return {"latest": latest, "source": context.get("source"), "uid": _plato_uid()}
+
+
+def _tokens(text: str) -> set[str]:
+    return {token for token in re.findall(r"[a-zA-Z0-9][a-zA-Z0-9_-]{2,}", text.lower())}
+
+
+def _score_item(query_tokens: set[str], item: dict[str, Any]) -> int:
+    haystack = " ".join(str(item.get(key) or "") for key in ("title", "text", "summary", "overview"))
+    return len(query_tokens & _tokens(haystack))
+
+
+async def _search_memory(arguments: dict[str, Any]) -> dict[str, Any]:
+    query = _compact_text(arguments.get("query"), 500)
+    if not query:
+        raise ToolExecutionError("query is required", code=-32602)
+    max_results = _clamp_int(arguments.get("max_results"), 5, 1, MAX_SEARCH_RESULTS)
+    context = await _recent_context(
+        {
+            "limit": max(max_results * 5, 25),
+            "channels": arguments.get("channels") or [],
+            "since": arguments.get("since"),
+        }
+    )
+    query_tokens = _tokens(query)
+    ranked = [
+        (score, idx, item)
+        for idx, item in enumerate(context.get("events", []))
+        if (score := _score_item(query_tokens, item)) > 0
+    ]
+    ranked.sort(key=lambda row: (row[0], -row[1]), reverse=True)
+    return {
+        "query": query,
+        "source": context.get("source"),
+        "results": [item for _score, _idx, item in ranked[:max_results]],
+    }
+
+
+async def _scanner_rules(arguments: dict[str, Any]) -> dict[str, Any]:
+    provision_token = _env("ELLA_PROVISION_API_TOKEN")
+    if not provision_token:
+        raise ToolExecutionError("ELLA_PROVISION_API_TOKEN is not configured", code=-32003)
+    provision_url = _env("ELLA_PROVISION_API_URL", DEFAULT_PROVISION_API_URL).rstrip("/")
+    files = arguments.get("files") or ["scanner-presets.md", "scanner-tuning.md"]
+    if not isinstance(files, list):
+        raise ToolExecutionError("files must be a list", code=-32602)
+    results = []
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        for filename in files[:4]:
+            safe_name = str(filename).strip()
+            if not re.fullmatch(r"[A-Za-z0-9._/-]+", safe_name) or ".." in safe_name:
+                raise ToolExecutionError(f"Invalid scanner rules file: {safe_name}", code=-32602)
+            response = await client.get(
+                f"{provision_url}/workspace/{_plato_agent_id()}/files/{safe_name}",
+                headers={"Authorization": f"Bearer {provision_token}"},
+            )
+            if response.status_code == 404:
+                results.append({"file": safe_name, "found": False})
+                continue
+            if response.status_code != 200:
+                raise ToolExecutionError(f"Provision API returned HTTP {response.status_code}", code=-32004)
+            payload = response.json()
+            content = payload.get("content") if isinstance(payload, dict) else response.text
+            results.append({"file": safe_name, "found": True, "content": _compact_text(content, 5000)})
+    return {"agent_id": _plato_agent_id(), "files": results}
+
+
+async def _consult_plato(arguments: dict[str, Any]) -> dict[str, Any]:
+    prompt = _compact_text(arguments.get("prompt"), MAX_PROMPT_CHARS)
+    if not prompt:
+        raise ToolExecutionError("prompt is required", code=-32602)
+    mode = str(arguments.get("mode") or "brief")
+    if mode not in {"brief", "normal", "deep"}:
+        raise ToolExecutionError("mode must be one of: brief, normal, deep", code=-32602)
+    token = _env("HERMES_API_SERVER_KEY", _env("API_SERVER_KEY", ""))
+    if not token:
+        raise ToolExecutionError("HERMES_API_SERVER_KEY is not configured", code=-32003)
+    gateway_url = _env("HERMES_GATEWAY_URL", DEFAULT_HERMES_GATEWAY_URL).rstrip("/")
+    agent_id = _env("HERMES_AGENT_ID", DEFAULT_HERMES_AGENT_ID)
+    session_key = _env("ELLA_PLATO_MCP_HERMES_SESSION", f"grok-mcp:plato:{_plato_uid().lower()}")
+    system = (
+        "You are serving a read-only external MCP consult for Plato. "
+        "Answer from Hermes/canonical context when available. "
+        "Do not expose internal secrets, filesystem paths, tokens, or caregiver escalation controls."
+    )
+    if mode == "brief":
+        prompt = f"{prompt}\n\nAnswer in 1-3 concise sentences."
+    elif mode == "deep":
+        prompt = f"{prompt}\n\nUse relevant chronology and cite uncertainty clearly."
+    async with httpx.AsyncClient(timeout=90.0) as client:
+        response = await client.post(
+            f"{gateway_url}/v1/chat/completions",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                "X-Hermes-Session-Id": session_key,
+            },
+            json={
+                "model": f"openclaw:{agent_id}",
+                "messages": [{"role": "system", "content": system}, {"role": "user", "content": prompt}],
+                "stream": False,
+            },
+        )
+    if response.status_code != 200:
+        raise ToolExecutionError(f"Hermes returned HTTP {response.status_code}", code=-32005)
+    payload = response.json()
+    choices = payload.get("choices") or []
+    text = ""
+    if choices:
+        text = ((choices[0].get("message") or {}).get("content") or "").strip()
+    return {"answer": text, "mode": mode, "agent_id": agent_id, "session": session_key}
+
+
+MCP_TOOLS: list[dict[str, Any]] = [
+    {
+        "name": "plato_recent_context",
+        "description": "Read recent Plato timeline context from canonical events, with OMI Firestore fallback.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "default": 10, "minimum": 1, "maximum": MAX_CONTEXT_LIMIT},
+                "channels": {"type": "array", "items": {"type": "string"}, "default": []},
+                "since": {"type": "string", "description": "Optional ISO timestamp lower bound."},
+            },
+        },
+    },
+    {
+        "name": "plato_search_memory",
+        "description": "Search recent Plato context for matching timeline or memory snippets.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "since": {"type": "string"},
+                "channels": {"type": "array", "items": {"type": "string"}, "default": []},
+                "max_results": {"type": "integer", "default": 5, "minimum": 1, "maximum": MAX_SEARCH_RESULTS},
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "plato_latest_omi",
+        "description": "Return the latest indexed OMI/necklace conversation summary for Plato.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"limit": {"type": "integer", "default": 10, "minimum": 1, "maximum": MAX_CONTEXT_LIMIT}},
+        },
+    },
+    {
+        "name": "plato_get_scanner_rules",
+        "description": "Read Plato scanner rule files from the Hermes/OpenClaw workspace through the provision API.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"files": {"type": "array", "items": {"type": "string"}, "default": ["scanner-presets.md"]}},
+        },
+    },
+    {
+        "name": "plato_consult",
+        "description": "Ask the Hermes Plato agent for a constrained read-only answer.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "prompt": {"type": "string"},
+                "mode": {"type": "string", "enum": ["brief", "normal", "deep"], "default": "brief"},
+            },
+            "required": ["prompt"],
+        },
+    },
+]
+
+_TOOL_HANDLERS = {
+    "plato_recent_context": _recent_context,
+    "plato_search_memory": _search_memory,
+    "plato_latest_omi": _latest_omi,
+    "plato_get_scanner_rules": _scanner_rules,
+    "plato_consult": _consult_plato,
+}
+
+
+def _mcp_response(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+
+
+def _mcp_error(msg_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}}
+
+
+def _argument_summary(arguments: dict[str, Any]) -> dict[str, Any]:
+    summary: dict[str, Any] = {}
+    for key, value in arguments.items():
+        if key in {"prompt", "query", "correction_text", "fact"}:
+            summary[key] = {"chars": len(str(value or ""))}
+        elif isinstance(value, (str, int, float, bool)) or value is None:
+            summary[key] = value
+        elif isinstance(value, list):
+            summary[key] = {"items": len(value)}
+        elif isinstance(value, dict):
+            summary[key] = {"keys": sorted(str(k) for k in value.keys())[:10]}
+    return summary
+
+
+def _audit_tool_call(
+    *,
+    trace_id: str,
+    token_fingerprint: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+    started: float,
+    status: str,
+    error: str = "",
+) -> None:
+    logger.info(
+        "plato_mcp_tool_call %s",
+        json.dumps(
+            {
+                "trace_id": trace_id,
+                "caller": "grok_mcp",
+                "token_fingerprint": token_fingerprint,
+                "uid": _plato_uid(),
+                "tool": tool_name,
+                "arguments": _argument_summary(arguments),
+                "latency_ms": int((time.monotonic() - started) * 1000),
+                "status": status,
+                "error": error[:160],
+            },
+            sort_keys=True,
+        ),
+    )
+
+
+async def _handle_mcp_message(
+    token_fingerprint: str,
+    message: dict[str, Any],
+    session: Optional[MCPSession] = None,
+) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+    msg_id = message.get("id")
+    method = message.get("method")
+    params = message.get("params") or {}
+
+    if method == "initialize":
+        session_id = str(uuid.uuid4())
+        _active_sessions[session_id] = MCPSession(
+            session_id=session_id,
+            token_fingerprint=token_fingerprint,
+            created_at=datetime.now(timezone.utc),
+            initialized=True,
+        )
+        return (
+            _mcp_response(
+                msg_id,
+                {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "ella-plato-hermes-mcp", "version": "0.1.0"},
+                },
+            ),
+            session_id,
+        )
+
+    if method == "notifications/initialized":
+        return None, None
+
+    if method == "tools/list":
+        return _mcp_response(msg_id, {"tools": MCP_TOOLS}), None
+
+    if method == "tools/call":
+        tool_name = params.get("name")
+        arguments = params.get("arguments") or {}
+        trace_id = str(uuid.uuid4())
+        started = time.monotonic()
+        if not isinstance(arguments, dict):
+            return _mcp_error(msg_id, -32602, "Tool arguments must be an object"), None
+        if tool_name not in _TOOL_HANDLERS:
+            return _mcp_error(msg_id, -32601, f"Unknown tool: {tool_name}"), None
+        try:
+            result = await _TOOL_HANDLERS[tool_name](arguments)
+            _audit_tool_call(
+                trace_id=trace_id,
+                token_fingerprint=token_fingerprint,
+                tool_name=tool_name,
+                arguments=arguments,
+                started=started,
+                status="ok",
+            )
+            result = {"trace_id": trace_id, **result}
+            return _mcp_response(msg_id, {"content": [{"type": "text", "text": json.dumps(result, default=str)}]}), None
+        except ToolExecutionError as exc:
+            _audit_tool_call(
+                trace_id=trace_id,
+                token_fingerprint=token_fingerprint,
+                tool_name=tool_name,
+                arguments=arguments,
+                started=started,
+                status="error",
+                error=exc.message,
+            )
+            return _mcp_error(msg_id, exc.code, exc.message), None
+        except Exception as exc:
+            logger.exception("Unhandled Plato MCP tool error")
+            _audit_tool_call(
+                trace_id=trace_id,
+                token_fingerprint=token_fingerprint,
+                tool_name=tool_name,
+                arguments=arguments,
+                started=started,
+                status="error",
+                error=str(exc),
+            )
+            return _mcp_error(msg_id, -32000, "Internal Plato MCP tool error"), None
+
+    if method == "ping":
+        return _mcp_response(msg_id, {}), None
+
+    return _mcp_error(msg_id, -32601, f"Method not found: {method}"), None
+
+
+@router.post("/mcp")
+async def plato_mcp_streamable_http(
+    request: Request,
+    authorization: Optional[str] = Header(None, alias="Authorization"),
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id"),
+    accept: Optional[str] = Header(None, alias="Accept"),
+):
+    token_fingerprint = _authenticate(authorization)
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
+
+    session = None
+    if mcp_session_id:
+        session = _active_sessions.get(mcp_session_id)
+        if not session:
+            raise HTTPException(status_code=404, detail="MCP session not found")
+        if session.token_fingerprint != token_fingerprint:
+            raise HTTPException(status_code=403, detail="MCP session does not belong to this token")
+
+    messages = body if isinstance(body, list) else [body]
+    if not all(isinstance(message, dict) for message in messages):
+        raise HTTPException(status_code=400, detail="MCP body must be a JSON-RPC object or array")
+
+    if all(message.get("id") is None for message in messages):
+        for message in messages:
+            await _handle_mcp_message(token_fingerprint, message, session)
+        return Response(status_code=202)
+
+    responses = []
+    new_session_id = None
+    for message in messages:
+        response, session_id = await _handle_mcp_message(token_fingerprint, message, session)
+        if session_id:
+            new_session_id = session_id
+        if response:
+            responses.append(response)
+
+    headers = {}
+    if new_session_id:
+        headers["Mcp-Session-Id"] = new_session_id
+
+    if accept and "text/event-stream" in accept:
+
+        async def event_generator():
+            for response in responses:
+                yield f"event: message\ndata: {json.dumps(response, default=str)}\n\n"
+
+        return StreamingResponse(
+            event_generator(),
+            media_type="text/event-stream",
+            headers={**headers, "Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no"},
+        )
+
+    content: Any = responses[0] if len(responses) == 1 else responses
+    return JSONResponse(content=content, headers=headers)
+
+
+@router.get("/mcp")
+async def plato_mcp_sse_keepalive(
+    request: Request,
+    authorization: Optional[str] = Header(None, alias="Authorization"),
+):
+    _authenticate(authorization)
+
+    async def event_generator():
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+                yield "event: ping\ndata: {}\n\n"
+                await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            pass
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no"},
+    )
+
+
+@router.delete("/mcp")
+async def plato_mcp_delete_session(
+    authorization: Optional[str] = Header(None, alias="Authorization"),
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id"),
+):
+    token_fingerprint = _authenticate(authorization)
+    if not mcp_session_id:
+        raise HTTPException(status_code=400, detail="Mcp-Session-Id header required")
+    session = _active_sessions.get(mcp_session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="MCP session not found")
+    if session.token_fingerprint != token_fingerprint:
+        raise HTTPException(status_code=403, detail="MCP session does not belong to this token")
+    del _active_sessions[mcp_session_id]
+    return Response(status_code=204)
+
+
+@router.get("/mcp/info")
+async def plato_mcp_info(request: Request):
+    base_url = str(request.base_url).rstrip("/")
+    return {
+        "endpoint": f"{base_url}/v1/ella/plato/mcp",
+        "transport": "streamable-http",
+        "protocol_version": "2025-03-26",
+        "profile_scope": {"uid": _plato_uid(), "canonical_identity": _plato_canonical_identity()},
+        "authentication": {"header": "Authorization", "format": "Bearer <ELLA_PLATO_MCP_TOKEN>"},
+        "tools": [tool["name"] for tool in MCP_TOOLS],
+        "write_tools_enabled": False,
+        "rollback": "remove or rotate ELLA_PLATO_MCP_TOKEN / ELLA_PLATO_MCP_TOKENS",
+    }

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -1,0 +1,153 @@
+import importlib
+import json
+import sys
+import types
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _install_stubs():
+    conversations = types.ModuleType("database.conversations")
+    conversations.get_conversations = MagicMock(return_value=[])
+
+    memories = types.ModuleType("database.memories")
+    memories.get_memories = MagicMock(return_value=[])
+
+    database = sys.modules.setdefault("database", types.ModuleType("database"))
+    setattr(database, "conversations", conversations)
+    setattr(database, "memories", memories)
+    sys.modules["database.conversations"] = conversations
+    sys.modules["database.memories"] = memories
+
+
+def _load_module(monkeypatch):
+    _install_stubs()
+    monkeypatch.setenv("ELLA_PLATO_MCP_TOKEN", "test-token")
+    monkeypatch.setenv("ELLA_PLATO_MCP_RATE_LIMIT_PER_MINUTE", "0")
+    sys.modules.pop("ella.routers.plato_mcp", None)
+    module = importlib.import_module("ella.routers.plato_mcp")
+    module._rate_limits.clear()
+    return module
+
+
+def _client(module):
+    app = FastAPI()
+    app.include_router(module.router)
+    return TestClient(app)
+
+
+def _rpc(method, msg_id=1, params=None):
+    return {"jsonrpc": "2.0", "id": msg_id, "method": method, "params": params or {}}
+
+
+def _tool_result(response):
+    payload = response.json()
+    text = payload["result"]["content"][0]["text"]
+    return json.loads(text)
+
+
+def test_plato_mcp_rejects_missing_and_invalid_token(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    missing = client.post("/v1/ella/plato/mcp", json=_rpc("ping"))
+    assert missing.status_code == 401
+
+    invalid = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer wrong"},
+        json=_rpc("ping"),
+    )
+    assert invalid.status_code == 401
+
+
+def test_plato_mcp_lists_only_read_only_tools(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc("tools/list"),
+    )
+
+    assert response.status_code == 200
+    tool_names = {tool["name"] for tool in response.json()["result"]["tools"]}
+    assert tool_names == {
+        "plato_recent_context",
+        "plato_search_memory",
+        "plato_latest_omi",
+        "plato_get_scanner_rules",
+        "plato_consult",
+    }
+    assert "create_memory" not in tool_names
+    assert "delete_memory" not in tool_names
+    assert "update_conversation_summary" not in tool_names
+
+
+def test_plato_recent_context_uses_canonical_timeline(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    async def fake_timeline(limit, channels, since):
+        assert limit == 3
+        assert channels == ["omi"]
+        assert since is None
+        return [
+            {
+                "event_id": "evt-1",
+                "channel": "omi",
+                "text": "Latest OMI conversation about Whole Foods.",
+                "started_at": "2026-05-07T01:00:00Z",
+            }
+        ]
+
+    monkeypatch.setattr(module, "_fetch_canonical_timeline", fake_timeline)
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc(
+            "tools/call",
+            params={"name": "plato_recent_context", "arguments": {"limit": 3, "channels": ["omi"]}},
+        ),
+    )
+
+    assert response.status_code == 200
+    result = _tool_result(response)
+    assert result["source"] == "canonical_timeline"
+    assert result["events"][0]["event_id"] == "evt-1"
+    assert result["trace_id"]
+
+
+def test_plato_search_memory_rejects_missing_query(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc("tools/call", params={"name": "plato_search_memory", "arguments": {}}),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["error"]["code"] == -32602
+    assert "query is required" in payload["error"]["message"]
+
+
+def test_initialize_returns_session_header(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc("initialize"),
+    )
+
+    assert response.status_code == 200
+    assert response.headers["mcp-session-id"]
+    assert response.json()["result"]["serverInfo"]["name"] == "ella-plato-hermes-mcp"


### PR DESCRIPTION
## Summary

Adds a separate Ella extension MCP endpoint for the #854 Grok custom connector spike:

- `POST /v1/ella/plato/mcp` Streamable HTTP JSON-RPC endpoint
- `GET /v1/ella/plato/mcp` SSE keepalive endpoint
- `GET /v1/ella/plato/mcp/info` connector metadata
- static bearer-token auth via `ELLA_PLATO_MCP_TOKEN` or `ELLA_PLATO_MCP_TOKENS`
- Plato-only profile scope via `ELLA_PLATO_MCP_UID` / `ELLA_PLATO_CANONICAL_IDENTITY`
- read-only tools only: recent context, search, latest OMI, scanner rules read, constrained Hermes consult
- audit logging with trace id, token fingerprint, argument summaries, latency, and status
- simple per-token rate limiting

This intentionally does not modify the existing upstream `/v1/mcp/sse` endpoint because that endpoint exposes broad memory mutation tools and authenticates with normal OMI MCP keys.

## Routing

The new bridge is designed for:

`Grok custom MCP connector -> HTTPS api.ella-ai-care.com -> OMI backend -> Tailscale Hermes/provision APIs`

Hermes consult uses `HERMES_GATEWAY_URL` + `HERMES_API_SERVER_KEY` and defaults to the current Mac Mini Hermes gateway. Scanner-rule reads use `ELLA_PROVISION_API_URL` + `ELLA_PROVISION_API_TOKEN`.

## Validation

- `python3 -m pytest backend/tests/unit/test_ella_plato_mcp.py -q`
- `python3 -m pytest backend/tests/unit/test_ella_plato_mcp.py backend/tests/unit/test_ella_callbacks_summary_update.py -q`
- `python3 -m compileall -q backend/ella/routers/plato_mcp.py`

## Deployment Notes

Required before Grok can connect:

- set `ELLA_PLATO_MCP_TOKEN` or `ELLA_PLATO_MCP_TOKENS` in the API runtime secret env
- keep `ELLA_PLATO_MCP_UID=5aGC5YE9BnhcSoTxxtT4ar6ILQy2` unless testing another profile
- set/verify `HERMES_GATEWAY_URL=http://100.76.138.56:8642`
- set/verify `HERMES_API_SERVER_KEY`
- set/verify `ELLA_PROVISION_API_URL=http://100.76.138.56:8200`
- set/verify `ELLA_PROVISION_API_TOKEN`

The live API currently returns 404 for `/v1/ella/plato/mcp/info`, so this is not deployed yet.