### PR TITLE
[codex] Fallback when Plato canonical context is empty

### DIFF
--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -248,6 +248,11 @@ async def _recent_context(arguments: dict[str, Any]) -> dict[str, Any]:
     try:
         events = await _fetch_canonical_timeline(limit, channels, since)
         source = "canonical_timeline"
+        if not events:
+            fallback_events = _fallback_recent_context(limit, channels, since)
+            if fallback_events:
+                events = fallback_events
+                source = "canonical_timeline_empty_omi_firestore_fallback"
     except Exception as exc:
         logger.warning("plato_mcp timeline fallback: %s", exc)
         events = _fallback_recent_context(limit, channels, since)

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -122,6 +122,43 @@ def test_plato_recent_context_uses_canonical_timeline(monkeypatch):
     assert result["trace_id"]
 
 
+def test_plato_recent_context_falls_back_when_canonical_is_empty(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    async def empty_timeline(limit, channels, since):
+        return []
+
+    monkeypatch.setattr(module, "_fetch_canonical_timeline", empty_timeline)
+    monkeypatch.setattr(
+        module.conversations_db,
+        "get_conversations",
+        MagicMock(
+            return_value=[
+                {
+                    "id": "conv-1",
+                    "created_at": "2026-05-07T01:00:00Z",
+                    "structured": {"title": "Latest OMI", "overview": "Discussed the last OMI conversation."},
+                }
+            ]
+        ),
+    )
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc(
+            "tools/call",
+            params={"name": "plato_latest_omi", "arguments": {"limit": 3}},
+        ),
+    )
+
+    assert response.status_code == 200
+    result = _tool_result(response)
+    assert result["source"] == "canonical_timeline_empty_omi_firestore_fallback"
+    assert result["latest"]["event_id"] == "conv-1"
+
+
 def test_plato_search_memory_rejects_missing_query(monkeypatch):
     module = _load_module(monkeypatch)
     client = _client(module)


### PR DESCRIPTION
## Summary

Follow-up from live smoke testing PR #158. `plato_latest_omi` asked canonical timeline for `omi`, but the current canonical ledger can return HTTP 200 with no OMI rows. This patch falls back to the OMI Firestore context path when canonical timeline returns an empty result set.

## Validation

- `python3 -m pytest backend/tests/unit/test_ella_plato_mcp.py -q` -> 6 passed

## Deployment

This is already hot-patched on the VPS for validation; merge keeps GitHub main aligned with the deployed code.