### PR TITLE
[codex] Add OAuth shim for Plato MCP

### DIFF
--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -16,6 +16,7 @@ import logging
 import os
 import re
 import time
+import urllib.parse
 import uuid
 from collections import defaultdict, deque
 from dataclasses import dataclass
@@ -77,6 +78,10 @@ def _plato_canonical_identity() -> str:
 
 def _plato_agent_id() -> str:
     return _env("ELLA_PLATO_AGENT_ID", f"ella-omi-{_plato_uid().lower()}")
+
+
+def _oauth_client_id() -> str:
+    return _env("ELLA_PLATO_MCP_OAUTH_CLIENT_ID", "plato-grok")
 
 
 def _allowed_tokens() -> set[str]:
@@ -687,15 +692,77 @@ async def plato_mcp_delete_session(
     return Response(status_code=204)
 
 
+@router.get("/mcp/authorize")
+async def plato_mcp_authorize(
+    response_type: str,
+    client_id: str,
+    redirect_uri: str,
+    state: Optional[str] = None,
+    scope: Optional[str] = None,
+    code_challenge: Optional[str] = None,
+    code_challenge_method: Optional[str] = None,
+):
+    if response_type != "code":
+        raise HTTPException(status_code=400, detail="response_type must be code")
+    if client_id != _oauth_client_id():
+        raise HTTPException(status_code=400, detail="Invalid client_id")
+
+    query = {"code": "plato_mcp"}
+    if state:
+        query["state"] = state
+    location = f"{redirect_uri}{'&' if '?' in redirect_uri else '?'}{urllib.parse.urlencode(query)}"
+    return Response(status_code=302, headers={"Location": location})
+
+
+@router.post("/mcp/token")
+async def plato_mcp_token(request: Request):
+    data: dict[str, Any]
+    try:
+        content_type = request.headers.get("content-type", "")
+        if "application/json" in content_type:
+            data = await request.json()
+        else:
+            raw_body = (await request.body()).decode("utf-8")
+            parsed = urllib.parse.parse_qs(raw_body, keep_blank_values=True)
+            data = {key: values[-1] if values else "" for key, values in parsed.items()}
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid token request body") from exc
+
+    client_id = str(data.get("client_id") or "")
+    if client_id != _oauth_client_id():
+        raise HTTPException(status_code=400, detail="Invalid client_id")
+
+    client_secret = str(data.get("client_secret") or "")
+    if client_secret not in _allowed_tokens():
+        raise HTTPException(status_code=401, detail="Invalid client_secret")
+
+    return {
+        "access_token": client_secret,
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "scope": "plato:read",
+    }
+
+
 @router.get("/mcp/info")
 async def plato_mcp_info(request: Request):
     base_url = str(request.base_url).rstrip("/")
+    endpoint = f"{base_url}/v1/ella/plato/mcp"
     return {
-        "endpoint": f"{base_url}/v1/ella/plato/mcp",
+        "endpoint": endpoint,
         "transport": "streamable-http",
         "protocol_version": "2025-03-26",
         "profile_scope": {"uid": _plato_uid(), "canonical_identity": _plato_canonical_identity()},
-        "authentication": {"header": "Authorization", "format": "Bearer <ELLA_PLATO_MCP_TOKEN>"},
+        "authentication": {
+            "header": "Authorization",
+            "format": "Bearer <ELLA_PLATO_MCP_TOKEN>",
+            "oauth": {
+                "client_id": _oauth_client_id(),
+                "authorization_endpoint": f"{endpoint}/authorize",
+                "token_endpoint": f"{endpoint}/token",
+                "scopes": ["plato:read"],
+            },
+        },
         "tools": [tool["name"] for tool in MCP_TOOLS],
         "write_tools_enabled": False,
         "rollback": "remove or rotate ELLA_PLATO_MCP_TOKEN / ELLA_PLATO_MCP_TOKENS",

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -188,3 +188,43 @@ def test_initialize_returns_session_header(monkeypatch):
     assert response.status_code == 200
     assert response.headers["mcp-session-id"]
     assert response.json()["result"]["serverInfo"]["name"] == "ella-plato-hermes-mcp"
+
+
+def test_oauth_token_exchanges_client_secret_for_bearer(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    token_response = client.post(
+        "/v1/ella/plato/mcp/token",
+        data={
+            "client_id": "plato-grok",
+            "client_secret": "test-token",
+            "grant_type": "authorization_code",
+            "code": "plato_mcp",
+        },
+    )
+
+    assert token_response.status_code == 200
+    payload = token_response.json()
+    assert payload["access_token"] == "test-token"
+    assert payload["token_type"] == "Bearer"
+    assert payload["scope"] == "plato:read"
+
+
+def test_oauth_authorize_redirects_with_code_and_state(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    response = client.get(
+        "/v1/ella/plato/mcp/authorize",
+        params={
+            "response_type": "code",
+            "client_id": "plato-grok",
+            "redirect_uri": "https://grok.example/callback",
+            "state": "abc",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "https://grok.example/callback?code=plato_mcp&state=abc"


### PR DESCRIPTION
## Summary

Grok's custom connector UI prompts for OAuth credentials after the MCP URL is entered. This adds a minimal OAuth compatibility shim under the Plato MCP route:

- `GET /v1/ella/plato/mcp/authorize`
- `POST /v1/ella/plato/mcp/token`

The token endpoint validates the configured Plato MCP token as the OAuth client secret and returns it as a Bearer access token. The MCP tool surface remains read-only and scoped to Plato.

## Validation

- `python3 -m pytest backend/tests/unit/test_ella_plato_mcp.py -q` -> 8 passed

## Deployment

Will hot-patch the VPS after merge to keep GitHub main and live code aligned.