### PR TITLE
[codex] Support Basic auth for Plato MCP OAuth token

### DIFF
--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -10,6 +10,7 @@ the bearer token from the runtime environment.
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import json
 import logging
@@ -728,11 +729,21 @@ async def plato_mcp_token(request: Request):
     except Exception as exc:
         raise HTTPException(status_code=400, detail="Invalid token request body") from exc
 
-    client_id = str(data.get("client_id") or "")
+    basic_client_id = ""
+    basic_client_secret = ""
+    auth_header = request.headers.get("authorization", "")
+    if auth_header.lower().startswith("basic "):
+        try:
+            decoded = base64.b64decode(auth_header[6:].strip()).decode("utf-8")
+            basic_client_id, basic_client_secret = decoded.split(":", 1)
+        except Exception:
+            raise HTTPException(status_code=401, detail="Invalid client authentication")
+
+    client_id = str(data.get("client_id") or basic_client_id or "")
     if client_id != _oauth_client_id():
         raise HTTPException(status_code=400, detail="Invalid client_id")
 
-    client_secret = str(data.get("client_secret") or "")
+    client_secret = str(data.get("client_secret") or basic_client_secret or "")
     if client_secret not in _allowed_tokens():
         raise HTTPException(status_code=401, detail="Invalid client_secret")
 

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -2,6 +2,7 @@ import importlib
 import json
 import sys
 import types
+import base64
 from unittest.mock import MagicMock
 
 from fastapi import FastAPI
@@ -209,6 +210,21 @@ def test_oauth_token_exchanges_client_secret_for_bearer(monkeypatch):
     assert payload["access_token"] == "test-token"
     assert payload["token_type"] == "Bearer"
     assert payload["scope"] == "plato:read"
+
+
+def test_oauth_token_accepts_basic_client_auth(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+    credentials = base64.b64encode(b"plato-grok:test-token").decode()
+
+    token_response = client.post(
+        "/v1/ella/plato/mcp/token",
+        headers={"Authorization": f"Basic {credentials}"},
+        data={"grant_type": "authorization_code", "code": "plato_mcp"},
+    )
+
+    assert token_response.status_code == 200
+    assert token_response.json()["access_token"] == "test-token"
 
 
 def test_oauth_authorize_redirects_with_code_and_state(monkeypatch):


### PR DESCRIPTION
## Summary

Follow-up compatibility for Grok OAuth connector setup. The Plato MCP token endpoint already accepts `client_secret` in the token request body; this also supports OAuth client authentication via HTTP Basic for connector UIs that use `client_secret_basic`.

## Validation

- `python3 -m pytest backend/tests/unit/test_ella_plato_mcp.py -q` -> 9 passed

## Deployment

Will hot-patch the VPS after merge to keep GitHub main and live code aligned.