### PR TITLE
[codex] Fix Plato MCP tool discovery compatibility

### DIFF
--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -20,7 +20,7 @@ import time
 import urllib.parse
 import uuid
 from collections import defaultdict, deque
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -56,6 +56,7 @@ class MCPSession:
     token_fingerprint: str
     created_at: datetime
     initialized: bool = False
+    sse_queue: asyncio.Queue[dict[str, Any] | None] = field(default_factory=asyncio.Queue)
 
 
 class ToolExecutionError(Exception):
@@ -636,7 +637,8 @@ async def plato_mcp_streamable_http(
     if new_session_id:
         headers["Mcp-Session-Id"] = new_session_id
 
-    if accept and "text/event-stream" in accept:
+    accepts_sse_only = accept and "text/event-stream" in accept and "application/json" not in accept
+    if accepts_sse_only:
 
         async def event_generator():
             for response in responses:
@@ -657,23 +659,68 @@ async def plato_mcp_sse_keepalive(
     request: Request,
     authorization: Optional[str] = Header(None, alias="Authorization"),
 ):
-    _authenticate(authorization)
+    token_fingerprint = _authenticate(authorization)
+    session_id = str(uuid.uuid4())
+    session = MCPSession(
+        session_id=session_id,
+        token_fingerprint=token_fingerprint,
+        created_at=datetime.now(timezone.utc),
+    )
+    _active_sessions[session_id] = session
+    endpoint = f"/v1/ella/plato/mcp/sse/message?session_id={urllib.parse.quote(session_id)}"
 
     async def event_generator():
         try:
+            yield f"event: endpoint\ndata: {endpoint}\n\n"
             while True:
                 if await request.is_disconnected():
                     break
-                yield "event: ping\ndata: {}\n\n"
-                await asyncio.sleep(30)
+                try:
+                    response = await asyncio.wait_for(session.sse_queue.get(), timeout=30)
+                except asyncio.TimeoutError:
+                    yield "event: ping\ndata: {}\n\n"
+                    continue
+                if response is None:
+                    break
+                yield f"event: message\ndata: {json.dumps(response, default=str)}\n\n"
         except asyncio.CancelledError:
             pass
+        finally:
+            _active_sessions.pop(session_id, None)
 
     return StreamingResponse(
         event_generator(),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no"},
     )
+
+
+@router.post("/mcp/sse/message")
+async def plato_mcp_sse_message(
+    request: Request,
+    session_id: str,
+    authorization: Optional[str] = Header(None, alias="Authorization"),
+):
+    token_fingerprint = _authenticate(authorization)
+    session = _active_sessions.get(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="MCP session not found")
+    if session.token_fingerprint != token_fingerprint:
+        raise HTTPException(status_code=403, detail="MCP session does not belong to this token")
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
+
+    messages = body if isinstance(body, list) else [body]
+    if not all(isinstance(message, dict) for message in messages):
+        raise HTTPException(status_code=400, detail="MCP body must be a JSON-RPC object or array")
+
+    for message in messages:
+        response, _ = await _handle_mcp_message(token_fingerprint, message, session)
+        if response:
+            await session.sse_queue.put(response)
+    return Response(status_code=202)
 
 
 @router.delete("/mcp")

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -88,6 +88,25 @@ def test_plato_mcp_lists_only_read_only_tools(monkeypatch):
     assert "update_conversation_summary" not in tool_names
 
 
+def test_streamable_http_prefers_json_when_client_accepts_json_and_sse(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={
+            "Authorization": "Bearer test-token",
+            "Accept": "application/json, text/event-stream",
+        },
+        json=_rpc("tools/list"),
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    tool_names = {tool["name"] for tool in response.json()["result"]["tools"]}
+    assert "plato_consult" in tool_names
+
+
 def test_plato_recent_context_uses_canonical_timeline(monkeypatch):
     module = _load_module(monkeypatch)
     client = _client(module)


### PR DESCRIPTION
## Summary

Fixes the live Plato/Hermes MCP connector compatibility path after Grok reported a connected custom connector with zero tools.

Root cause candidates from live smoke:

- `POST /v1/ella/plato/mcp` returned `text/event-stream` whenever the client sent `Accept: application/json, text/event-stream`, which can break clients that support both but expect the Streamable HTTP JSON response for `tools/list`.
- `GET /v1/ella/plato/mcp` looked like an SSE transport, but only emitted keepalive pings and never advertised a legacy MCP message endpoint.

Changes:

- Prefer JSON for Streamable HTTP when the client accepts both JSON and SSE.
- Keep SSE only for clients that explicitly accept only `text/event-stream`.
- Add a minimal legacy SSE message endpoint:
  - `GET /v1/ella/plato/mcp` now emits an `endpoint` event.
  - `POST /v1/ella/plato/mcp/sse/message?session_id=...` handles JSON-RPC messages and queues responses back to the SSE stream.
- Add regression coverage for the mixed `Accept: application/json, text/event-stream` tool discovery case.

## Validation

- `python3 -m pytest backend/tests/unit/test_ella_plato_mcp.py -q` -> 10 passed
- `python3 -m compileall -q backend/ella/routers/plato_mcp.py` -> passed

## Deployment note

This should be safe to deploy surgically to the VPS because it only touches the Plato-only MCP router and tests. It does not add write tools or change the existing token/auth scope.