### PR TITLE
[codex] Feed fresh MCP context into Plato consult

### DIFF
--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -44,6 +44,7 @@ DEFAULT_PROVISION_API_URL = "http://100.76.138.56:8200"
 MAX_CONTEXT_LIMIT = 50
 MAX_SEARCH_RESULTS = 20
 MAX_PROMPT_CHARS = 4000
+MAX_CONSULT_CONTEXT_CHARS = 7000
 RATE_LIMIT_WINDOW_SECONDS = 60
 
 _active_sessions: dict[str, "MCPSession"] = {}
@@ -290,6 +291,20 @@ def _score_item(query_tokens: set[str], item: dict[str, Any]) -> int:
     return len(query_tokens & _tokens(haystack))
 
 
+def _format_consult_context(context: dict[str, Any], limit: int) -> str:
+    lines = [
+        f"source={context.get('source') or 'unknown'}",
+        f"uid={context.get('uid') or _plato_uid()}",
+    ]
+    for event in (context.get("events") or [])[:limit]:
+        timestamp = event.get("started_at") or event.get("created_at") or event.get("timestamp") or ""
+        channel = event.get("channel") or ""
+        title = event.get("title") or "Untitled"
+        text = _compact_text(event.get("text") or event.get("overview") or event.get("summary") or "", 700)
+        lines.append(f"- {timestamp} [{channel}] {title}: {text}")
+    return _compact_text("\n".join(lines), MAX_CONSULT_CONTEXT_CHARS)
+
+
 async def _search_memory(arguments: dict[str, Any]) -> dict[str, Any]:
     query = _compact_text(arguments.get("query"), 500)
     if not query:
@@ -352,6 +367,9 @@ async def _consult_plato(arguments: dict[str, Any]) -> dict[str, Any]:
     mode = str(arguments.get("mode") or "brief")
     if mode not in {"brief", "normal", "deep"}:
         raise ToolExecutionError("mode must be one of: brief, normal, deep", code=-32602)
+    context_limit = _clamp_int(arguments.get("context_limit"), 15, 1, MAX_CONTEXT_LIMIT)
+    context = await _recent_context({"limit": context_limit})
+    context_block = _format_consult_context(context, context_limit)
     token = _env("HERMES_API_SERVER_KEY", _env("API_SERVER_KEY", ""))
     if not token:
         raise ToolExecutionError("HERMES_API_SERVER_KEY is not configured", code=-32003)
@@ -360,9 +378,12 @@ async def _consult_plato(arguments: dict[str, Any]) -> dict[str, Any]:
     session_key = _env("ELLA_PLATO_MCP_HERMES_SESSION", f"grok-mcp:plato:{_plato_uid().lower()}")
     system = (
         "You are serving a read-only external MCP consult for Plato. "
-        "Answer from Hermes/canonical context when available. "
+        "Use the supplied current MCP context as the freshest available evidence, "
+        "then use Hermes memory only to fill gaps. "
+        "If current MCP context conflicts with older memory, prefer current MCP context. "
         "Do not expose internal secrets, filesystem paths, tokens, or caregiver escalation controls."
     )
+    prompt = f"Current MCP context:\n{context_block}\n\nUser request:\n{prompt}"
     if mode == "brief":
         prompt = f"{prompt}\n\nAnswer in 1-3 concise sentences."
     elif mode == "deep":
@@ -388,7 +409,14 @@ async def _consult_plato(arguments: dict[str, Any]) -> dict[str, Any]:
     text = ""
     if choices:
         text = ((choices[0].get("message") or {}).get("content") or "").strip()
-    return {"answer": text, "mode": mode, "agent_id": agent_id, "session": session_key}
+    return {
+        "answer": text,
+        "mode": mode,
+        "agent_id": agent_id,
+        "session": session_key,
+        "context_source": context.get("source"),
+        "context_events": len(context.get("events") or []),
+    }
 
 
 MCP_TOOLS: list[dict[str, Any]] = [
@@ -442,6 +470,13 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "properties": {
                 "prompt": {"type": "string"},
                 "mode": {"type": "string", "enum": ["brief", "normal", "deep"], "default": "brief"},
+                "context_limit": {
+                    "type": "integer",
+                    "default": 15,
+                    "minimum": 1,
+                    "maximum": MAX_CONTEXT_LIMIT,
+                    "description": "Number of freshest MCP context events to include before consulting Hermes.",
+                },
             },
             "required": ["prompt"],
         },

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -1,4 +1,5 @@
 import importlib
+import asyncio
 import json
 import sys
 import types
@@ -193,6 +194,61 @@ def test_plato_search_memory_rejects_missing_query(monkeypatch):
     payload = response.json()
     assert payload["error"]["code"] == -32602
     assert "query is required" in payload["error"]["message"]
+
+
+def test_plato_consult_includes_fresh_mcp_context(monkeypatch):
+    module = _load_module(monkeypatch)
+    monkeypatch.setenv("HERMES_API_SERVER_KEY", "hermes-test-token")
+    captured = {}
+
+    async def fake_recent_context(arguments):
+        assert arguments["limit"] == 15
+        return {
+            "uid": "test-uid",
+            "source": "canonical_timeline_empty_omi_firestore_fallback",
+            "events": [
+                {
+                    "channel": "omi",
+                    "started_at": "2026-05-07T18:56:59Z",
+                    "title": "Cafe Coffee and Waffle Stop",
+                    "text": "Ordered a noah drink and a waffle with oat.",
+                }
+            ],
+        }
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"choices": [{"message": {"content": "The cafe order is in the fresh MCP context."}}]}
+
+    class FakeAsyncClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, headers, json):
+            captured["url"] = url
+            captured["json"] = json
+            return FakeResponse()
+
+    monkeypatch.setattr(module, "_recent_context", fake_recent_context)
+    monkeypatch.setattr(module.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = asyncio.run(module._consult_plato({"prompt": "Did I order at a cafe today?", "mode": "normal"}))
+
+    user_message = captured["json"]["messages"][1]["content"]
+    assert "Current MCP context" in user_message
+    assert "Cafe Coffee and Waffle Stop" in user_message
+    assert "Ordered a noah drink and a waffle" in user_message
+    assert "freshest available evidence" in captured["json"]["messages"][0]["content"]
+    assert result["context_source"] == "canonical_timeline_empty_omi_firestore_fallback"
+    assert result["context_events"] == 1
 
 
 def test_initialize_returns_session_header(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes the stale-data behavior Greg saw through the Grok Plato-Hermes connector: the direct MCP memory/context tools could see today's cafe stop, but `plato_consult` forwarded the prompt to Hermes without including that fresh MCP context, so Hermes could answer from older memory.

Changes:

- Builds a bounded fresh context pack from the same MCP recent-context path before calling Hermes.
- Adds that context to the user prompt under `Current MCP context`.
- Updates the system instruction to prefer supplied current MCP context over older Hermes memory when they conflict.
- Returns `context_source` and `context_events` in the consult response for observability.
- Adds optional `context_limit` input to `plato_consult`.
- Adds regression coverage that a cafe event from the fresh MCP fallback is passed into the Hermes request.

## Validation

- `python3 -m pytest backend/tests/unit/test_ella_plato_mcp.py -q` -> 11 passed
- `python3 -m compileall -q backend/ella/routers/plato_mcp.py` -> passed

## Notes

The canonical timeline is still empty for OMI in this path, so the bridge is currently relying on the OMI Firestore fallback. This PR does not solve the broader canonical-ledger unification gap; it makes `plato_consult` use the freshest data the MCP bridge can currently see.