### PR TITLE
[codex] Merge OMI fallback into Plato MCP context

### DIFF
--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -178,6 +178,35 @@ def _event_time(item: dict[str, Any]) -> str:
     )
 
 
+def _include_omi_channel(channels: list[str]) -> bool:
+    normalized = {str(channel).strip().lower() for channel in channels}
+    return not normalized or bool(normalized & {"omi", "omi_transcript", "omi_summary", "omi_conversation"})
+
+
+def _event_identity(item: dict[str, Any]) -> str:
+    source_ref = item.get("source_ref") or {}
+    if isinstance(source_ref, dict):
+        for key in ("conversation_id", "event_id", "id", "source_identity"):
+            if source_ref.get(key):
+                return f"source_ref:{key}:{source_ref[key]}"
+    for key in ("event_id", "id", "source_identity"):
+        if item.get(key):
+            return f"{key}:{item[key]}"
+    return f"{item.get('channel')}:{_event_time(item)}:{item.get('title')}:{item.get('text')}"
+
+
+def _merge_chronological_events(*event_lists: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
+    merged: dict[str, dict[str, Any]] = {}
+    for events in event_lists:
+        for event in events:
+            if not isinstance(event, dict):
+                continue
+            merged.setdefault(_event_identity(event), event)
+    ordered = list(merged.values())
+    ordered.sort(key=_event_time, reverse=True)
+    return ordered[:limit]
+
+
 def _conversation_to_event(conversation: dict[str, Any]) -> dict[str, Any]:
     structured = conversation.get("structured") or {}
     title = structured.get("title") or conversation.get("title") or "OMI conversation"
@@ -256,11 +285,23 @@ async def _recent_context(arguments: dict[str, Any]) -> dict[str, Any]:
     try:
         events = await _fetch_canonical_timeline(limit, channels, since)
         source = "canonical_timeline"
-        if not events:
+        if _include_omi_channel(channels):
+            # The canonical ledger is live, but OMI enriched summaries are not
+            # yet guaranteed to be written there. Until OMI ingestion/backfill is
+            # complete, merge the same enriched OMI conversations the app shows.
+            fallback_events = _fallback_recent_context(limit, ["omi"], since)
+            if fallback_events:
+                if events:
+                    events = _merge_chronological_events(events, fallback_events, limit=limit)
+                    source = "canonical_timeline_with_omi_firestore_fallback"
+                else:
+                    events = fallback_events[:limit]
+                    source = "canonical_timeline_empty_omi_firestore_fallback"
+        elif not events:
             fallback_events = _fallback_recent_context(limit, channels, since)
             if fallback_events:
-                events = fallback_events
-                source = "canonical_timeline_empty_omi_firestore_fallback"
+                events = fallback_events[:limit]
+                source = "canonical_timeline_empty_firestore_fallback"
     except Exception as exc:
         logger.warning("plato_mcp timeline fallback: %s", exc)
         events = _fallback_recent_context(limit, channels, since)

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -180,6 +180,103 @@ def test_plato_recent_context_falls_back_when_canonical_is_empty(monkeypatch):
     assert result["latest"]["event_id"] == "conv-1"
 
 
+def test_plato_recent_context_merges_omi_fallback_when_canonical_has_other_channels(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    async def voice_only_timeline(limit, channels, since):
+        assert channels == []
+        return [
+            {
+                "event_id": "voice-1",
+                "channel": "ios_voice",
+                "text": "Older voice turn about bookkeeping.",
+                "started_at": "2026-05-07T01:05:00Z",
+            }
+        ]
+
+    monkeypatch.setattr(module, "_fetch_canonical_timeline", voice_only_timeline)
+    monkeypatch.setattr(
+        module.conversations_db,
+        "get_conversations",
+        MagicMock(
+            return_value=[
+                {
+                    "id": "cafe-1",
+                    "started_at": "2026-05-07T18:56:59Z",
+                    "created_at": "2026-05-07T18:56:59Z",
+                    "structured": {
+                        "title": "Cafe Coffee and Waffle Stop",
+                        "overview": "Ordered a noah drink and a waffle with oat.",
+                    },
+                }
+            ]
+        ),
+    )
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc("tools/call", params={"name": "plato_recent_context", "arguments": {"limit": 10}}),
+    )
+
+    assert response.status_code == 200
+    result = _tool_result(response)
+    assert result["source"] == "canonical_timeline_with_omi_firestore_fallback"
+    assert result["events"][0]["event_id"] == "cafe-1"
+    assert result["events"][1]["event_id"] == "voice-1"
+
+
+def test_plato_search_memory_uses_merged_omi_fallback(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    async def voice_only_timeline(limit, channels, since):
+        return [
+            {
+                "event_id": "voice-1",
+                "channel": "ios_voice",
+                "text": "Older voice turn about bookkeeping.",
+                "started_at": "2026-05-07T01:05:00Z",
+            }
+        ]
+
+    monkeypatch.setattr(module, "_fetch_canonical_timeline", voice_only_timeline)
+    monkeypatch.setattr(
+        module.conversations_db,
+        "get_conversations",
+        MagicMock(
+            return_value=[
+                {
+                    "id": "cafe-1",
+                    "started_at": "2026-05-07T18:56:59Z",
+                    "structured": {
+                        "title": "Cafe Coffee and Waffle Stop",
+                        "overview": "Ordered a noah drink and a waffle with oat.",
+                    },
+                }
+            ]
+        ),
+    )
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc(
+            "tools/call",
+            params={
+                "name": "plato_search_memory",
+                "arguments": {"query": "cafe waffle order", "max_results": 5},
+            },
+        ),
+    )
+
+    assert response.status_code == 200
+    result = _tool_result(response)
+    assert result["source"] == "canonical_timeline_with_omi_firestore_fallback"
+    assert result["results"][0]["event_id"] == "cafe-1"
+
+
 def test_plato_search_memory_rejects_missing_query(monkeypatch):
     module = _load_module(monkeypatch)
     client = _client(module)


### PR DESCRIPTION
## Summary

Fixes the raw Plato MCP tool freshness failure Greg found: `plato_recent_context(limit=10)` and `plato_search_memory(...)` could return stale canonical `ios_voice` rows from early UTC morning and miss today's enriched OMI conversations, including `Cafe Coffee and Waffle Stop`.

Root cause:

- `_recent_context` only used the OMI Firestore fallback when canonical `/v1/ella/timeline` returned zero rows.
- Live canonical was non-empty, but only contained older `ios_voice`/`ios_chat` turns for this query window.
- The enriched OMI conversation objects shown in the iOS app were present in OMI Firestore but not yet ingested/backfilled into the canonical ledger.

Changes:

- Merge enriched OMI Firestore fallback events into canonical timeline results whenever the requested channel set includes OMI or is unconstrained.
- Deduplicate merged events by source ref / event id.
- Sort merged events chronologically descending before applying the final limit.
- Preserve strict channel behavior: non-OMI-only requests do not get OMI fallback events.
- Add regression coverage for both `plato_recent_context` and `plato_search_memory` when canonical has only non-OMI events but OMI fallback has a fresher cafe event.

## Validation

- `python3 -m pytest backend/tests/unit/test_ella_plato_mcp.py -q` -> 13 passed
- `python3 -m compileall -q backend/ella/routers/plato_mcp.py` -> passed

## Follow-up

This is an MCP-side mitigation. The durable fix remains canonical OMI enriched conversation ingestion/backfill so `/v1/ella/timeline` itself contains OMI summaries and raw/source metadata.