### PR TITLE
[codex] Ingest OMI summaries into canonical ledger

### DIFF
--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -28,6 +28,7 @@ import logging
 import os
 import secrets
 import string
+import asyncio
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
@@ -48,6 +49,7 @@ from database.ella_contacts import create_contact, delete_contact, get_contact, 
 from ella.config import ELLA_CONFIG
 from ella.services.summary_sanitizer import SummarySanitizationError, sanitize_summary_update
 from utils.notifications import send_notification
+from utils.ella.canonical_omi import write_omi_canonical_event
 from utils.other.storage import storage_client
 
 logger = logging.getLogger(__name__)
@@ -419,6 +421,43 @@ async def update_conversation_summary(
     except Exception as e:
         logging.error(f"Failed to update conversation summary: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+    canonical_base = dict(conversation) if isinstance(conversation, dict) else {}
+    canonical_conversation = {
+        **canonical_base,
+        "id": conversation_id,
+        "structured": structured,
+        "summary_versions": version_update["summary_versions"],
+        "active_summary_version_id": version_update["active_summary_version_id"],
+        "enrichment_state": update_data.get("enrichment_state"),
+        "internal_assessment": update_data.get("internal_assessment", canonical_base.get("internal_assessment")),
+        "ella_tags": update_data.get("ella_tags", canonical_base.get("ella_tags") or []),
+        "ella_signal": update_data.get("ella_signal", canonical_base.get("ella_signal")),
+    }
+    try:
+        canonical_result = await asyncio.to_thread(
+            write_omi_canonical_event,
+            uid,
+            canonical_conversation,
+            summary_source=update.summary_source,
+            summary_kind=update.summary_kind,
+            trace_id=update.trace_id,
+        )
+        logger.info(
+            "Wrote OMI summary to canonical ledger",
+            extra={
+                "uid": uid,
+                "conversation_id": conversation_id,
+                "inserted": canonical_result.get("inserted"),
+                "duplicates": canonical_result.get("duplicates"),
+            },
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to write OMI summary to canonical ledger",
+            extra={"uid": uid, "conversation_id": conversation_id},
+        )
+        logger.warning(str(e))
 
     if update.correction_id:
         try:

--- a/backend/ella/routers/canonical_events.py
+++ b/backend/ella/routers/canonical_events.py
@@ -71,6 +71,17 @@ def _stable_json(value: Any) -> str:
     return json.dumps(value or {}, sort_keys=True, separators=(",", ":"), default=str)
 
 
+def _should_replace_existing_event(item: dict[str, Any]) -> bool:
+    """Allow derived OMI summary rows to refresh while preserving raw source data.
+
+    Normal turn events remain immutable. OMI summary events are app-facing
+    derived summaries; Observer corrections/enrichment should update the single
+    canonical summary row instead of creating duplicate timeline entries.
+    """
+    metadata = item.get("metadata") or {}
+    return item.get("channel") == "omi" and metadata.get("adapter") == "omi-enriched-conversation"
+
+
 def _derive_source_identity(
     *,
     uid: str,
@@ -209,8 +220,29 @@ class PostgresCanonicalEventStore(CanonicalEventStore):
             async with conn.transaction():
                 for event in events:
                     item = event.normalized()
-                    inserted = await conn.fetchval(
+                    conflict_clause = (
                         """
+                        DO UPDATE SET
+                            uid = EXCLUDED.uid,
+                            canonical_identity = EXCLUDED.canonical_identity,
+                            session_id = EXCLUDED.session_id,
+                            channel = EXCLUDED.channel,
+                            provider = EXCLUDED.provider,
+                            role = EXCLUDED.role,
+                            text = EXCLUDED.text,
+                            started_at = EXCLUDED.started_at,
+                            ended_at = EXCLUDED.ended_at,
+                            privacy_scope = EXCLUDED.privacy_scope,
+                            scan_policy = EXCLUDED.scan_policy,
+                            source_ref = EXCLUDED.source_ref,
+                            metadata = EXCLUDED.metadata,
+                            raw_event = EXCLUDED.raw_event
+                        """
+                        if _should_replace_existing_event(item)
+                        else "DO NOTHING"
+                    )
+                    row = await conn.fetchrow(
+                        f"""
                         INSERT INTO canonical_events (
                             uid, canonical_identity, event_id, source_identity,
                             session_id, channel, provider, role, text,
@@ -221,8 +253,8 @@ class PostgresCanonicalEventStore(CanonicalEventStore):
                             $1, $2, $3, $4, $5, $6, $7, $8, $9,
                             $10, $11, $12, $13, $14::jsonb, $15::jsonb, $16::jsonb
                         )
-                        ON CONFLICT (event_id, source_identity) DO NOTHING
-                        RETURNING id
+                        ON CONFLICT (event_id, source_identity) {conflict_clause}
+                        RETURNING id, (xmax = 0) AS inserted
                         """,
                         item["uid"],
                         item["canonical_identity"],
@@ -245,15 +277,18 @@ class PostgresCanonicalEventStore(CanonicalEventStore):
                         {
                             "event_id": item["event_id"],
                             "source_identity": item["source_identity"],
-                            "inserted": inserted is not None,
+                            "inserted": bool(row and row["inserted"]),
+                            "updated": bool(row and not row["inserted"]),
                         }
                     )
 
         inserted_count = sum(1 for status in statuses if status["inserted"])
+        updated_count = sum(1 for status in statuses if status.get("updated"))
         return {
             "ok": True,
             "inserted": inserted_count,
-            "duplicates": len(statuses) - inserted_count,
+            "updated": updated_count,
+            "duplicates": len(statuses) - inserted_count - updated_count,
             "events": statuses,
         }
 

--- a/backend/scripts/backfill_omi_canonical_events.py
+++ b/backend/scripts/backfill_omi_canonical_events.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Backfill enriched OMI conversations into the Ella canonical ledger."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+import database.conversations as conversations_db  # noqa: E402
+from utils.ella.canonical_omi import build_omi_canonical_event, write_omi_canonical_event  # noqa: E402
+
+DEFAULT_PLATO_UID = "5aGC5YE9BnhcSoTxxtT4ar6ILQy2"
+
+
+def _parse_iso(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _has_enriched_summary(conversation: dict[str, Any]) -> bool:
+    versions = conversation.get("summary_versions") or []
+    active_id = conversation.get("active_summary_version_id")
+    for version in versions:
+        if active_id and version.get("id") != active_id:
+            continue
+        if version.get("source") == "observer" and version.get("kind") in {
+            "observer_enriched",
+            "corrected_enriched",
+        }:
+            return True
+    state = conversation.get("enrichment_state") or {}
+    if state.get("status") == "writeback_applied":
+        return True
+    structured = conversation.get("structured") or {}
+    return bool(str(structured.get("title") or "").strip() and str(structured.get("overview") or "").strip())
+
+
+def _conversation_label(conversation: dict[str, Any]) -> str:
+    structured = conversation.get("structured") or {}
+    return str(structured.get("title") or conversation.get("id") or "untitled")
+
+
+def backfill_uid(
+    *,
+    uid: str,
+    limit: int,
+    since: Optional[datetime],
+    apply: bool,
+    sleep_seconds: float,
+) -> dict[str, Any]:
+    conversations = conversations_db.get_conversations(
+        uid,
+        limit=limit,
+        offset=0,
+        include_discarded=False,
+        statuses=["completed"],
+        start_date=since,
+    )
+    results: list[dict[str, Any]] = []
+    for conversation in conversations:
+        conversation_id = conversation.get("id")
+        if not conversation_id:
+            results.append({"conversation_id": None, "status": "skipped", "reason": "missing_id"})
+            continue
+        if not _has_enriched_summary(conversation):
+            results.append(
+                {
+                    "conversation_id": conversation_id,
+                    "status": "skipped",
+                    "reason": "missing_enriched_summary",
+                    "title": _conversation_label(conversation),
+                }
+            )
+            continue
+
+        try:
+            event = build_omi_canonical_event(uid, conversation, summary_source="backfill", summary_kind="omi_enriched")
+            if apply:
+                write_result = write_omi_canonical_event(
+                    uid,
+                    conversation,
+                    summary_source="backfill",
+                    summary_kind="omi_enriched",
+                )
+                status = (
+                    "inserted"
+                    if write_result.get("inserted")
+                    else "updated"
+                    if write_result.get("updated")
+                    else "duplicate"
+                )
+                results.append(
+                    {
+                        "conversation_id": conversation_id,
+                        "event_id": event["event_id"],
+                        "status": status,
+                        "inserted": write_result.get("inserted"),
+                        "updated": write_result.get("updated"),
+                        "duplicates": write_result.get("duplicates"),
+                        "title": _conversation_label(conversation),
+                    }
+                )
+                if sleep_seconds > 0:
+                    time.sleep(sleep_seconds)
+            else:
+                results.append(
+                    {
+                        "conversation_id": conversation_id,
+                        "event_id": event["event_id"],
+                        "status": "dry_run",
+                        "title": _conversation_label(conversation),
+                        "started_at": event["started_at"],
+                    }
+                )
+        except Exception as exc:
+            results.append(
+                {
+                    "conversation_id": conversation_id,
+                    "status": "error",
+                    "title": _conversation_label(conversation),
+                    "error": str(exc),
+                }
+            )
+    return {
+        "uid": uid,
+        "apply": apply,
+        "requested_limit": limit,
+        "fetched": len(conversations),
+        "results": results,
+        "summary": {
+            "dry_run": sum(1 for item in results if item["status"] == "dry_run"),
+            "inserted": sum(int(item.get("inserted") or 0) for item in results),
+            "updated": sum(int(item.get("updated") or 0) for item in results),
+            "duplicates": sum(int(item.get("duplicates") or 0) for item in results),
+            "skipped": sum(1 for item in results if item["status"] == "skipped"),
+            "errors": sum(1 for item in results if item["status"] == "error"),
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--uid", action="append", dest="uids", help="OMI uid to backfill. Repeatable.")
+    parser.add_argument("--limit", type=int, default=100, help="Max completed conversations per uid.")
+    parser.add_argument("--since", help="Optional ISO lower bound for Firestore created_at.")
+    parser.add_argument("--apply", action="store_true", help="Write events. Default is dry-run.")
+    parser.add_argument("--sleep", type=float, default=0.05, help="Delay between apply writes.")
+    args = parser.parse_args()
+
+    uids = args.uids or [DEFAULT_PLATO_UID]
+    since = _parse_iso(args.since)
+    any_errors = False
+    for uid in uids:
+        result = backfill_uid(uid=uid, limit=args.limit, since=since, apply=args.apply, sleep_seconds=args.sleep)
+        print(json.dumps(result, indent=2, sort_keys=True, default=str))
+        any_errors = any_errors or result["summary"]["errors"] > 0
+    return 1 if any_errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -31,6 +31,15 @@ assert _callbacks_spec is not None and _callbacks_spec.loader is not None
 _callbacks_spec.loader.exec_module(callbacks)
 
 
+@pytest.fixture(autouse=True)
+def disable_canonical_omi_network(monkeypatch):
+    monkeypatch.setattr(
+        callbacks,
+        "write_omi_canonical_event",
+        lambda *args, **kwargs: {"ok": True, "inserted": 1, "duplicates": 0},
+    )
+
+
 def test_update_conversation_summary_clears_stale_app_results(monkeypatch):
     captured = {}
 
@@ -332,3 +341,70 @@ def test_update_conversation_summary_persists_internal_assessment_when_available
 
     assert captured["update_data"]["internal_assessment"]["media_likelihood"] == 0.92
     assert captured["update_data"]["internal_assessment"]["reason_codes"] == ["likely_media_or_background_audio"]
+
+
+def test_update_conversation_summary_writes_enriched_omi_to_canonical(monkeypatch):
+    canonical_writes = []
+
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: {
+            "id": conversation_id,
+            "created_at": "2026-05-07T18:56:59Z",
+            "started_at": "2026-05-07T18:56:59Z",
+            "finished_at": "2026-05-07T18:58:12Z",
+            "structured": {
+                "title": "Original cafe title",
+                "overview": "[Ella] Original cafe overview with enough detail.",
+                "emoji": "☕",
+                "category": callbacks.CategoryEnum.other,
+            },
+            "transcript_segments": [{"is_user": True, "text": "I ordered a waffle."}],
+        },
+    )
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "build_summary_version_update",
+        lambda conversation, **kwargs: {
+            "summary_versions": [{"id": "obs-v2", "title": kwargs["next_structured"]["title"]}],
+            "active_summary_version_id": "obs-v2",
+            "new_summary_version_id": "obs-v2",
+        },
+    )
+    monkeypatch.setattr(callbacks.conversations_db, "update_conversation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        callbacks,
+        "write_omi_canonical_event",
+        lambda uid, conversation, **kwargs: canonical_writes.append(
+            {"uid": uid, "conversation": conversation, "kwargs": kwargs}
+        )
+        or {"ok": True, "inserted": 1, "duplicates": 0},
+    )
+
+    asyncio.run(
+        callbacks.update_conversation_summary(
+            "cafe-123",
+            callbacks.ConversationSummaryUpdate(
+                title="Cafe Coffee and Waffle Stop",
+                overview="[Ella] You ordered a noah drink and a waffle with oat.",
+                summary_source="observer",
+                summary_kind="observer_enriched",
+                trace_id="trace-cafe",
+            ),
+            uid="user-123",
+        )
+    )
+
+    assert canonical_writes[0]["uid"] == "user-123"
+    assert canonical_writes[0]["conversation"]["id"] == "cafe-123"
+    assert canonical_writes[0]["conversation"]["structured"]["title"] == "Cafe Coffee and Waffle Stop"
+    assert canonical_writes[0]["conversation"]["structured"]["overview"] == (
+        "[Ella] You ordered a noah drink and a waffle with oat."
+    )
+    assert canonical_writes[0]["conversation"]["active_summary_version_id"] == "obs-v2"
+    assert canonical_writes[0]["kwargs"] == {
+        "summary_source": "observer",
+        "summary_kind": "observer_enriched",
+        "trace_id": "trace-cafe",
+    }

--- a/backend/tests/unit/test_ella_canonical_omi.py
+++ b/backend/tests/unit/test_ella_canonical_omi.py
@@ -1,0 +1,75 @@
+import json
+from datetime import datetime, timezone
+
+from utils.ella.canonical_omi import build_omi_canonical_event
+
+
+def test_build_omi_canonical_event_preserves_enriched_summary_and_transcript():
+    conversation = {
+        "id": "cafe-123",
+        "created_at": datetime(2026, 5, 7, 18, 56, 59, tzinfo=timezone.utc),
+        "started_at": datetime(2026, 5, 7, 18, 56, 59, tzinfo=timezone.utc),
+        "finished_at": datetime(2026, 5, 7, 18, 58, 12, tzinfo=timezone.utc),
+        "structured": {
+            "title": "Cafe Coffee and Waffle Stop",
+            "overview": "[Ella] You ordered a noah drink and a waffle with oat.",
+            "emoji": "☕",
+            "category": "other",
+        },
+        "summary_versions": [{"id": "obs-v2", "source": "observer", "kind": "observer_enriched"}],
+        "active_summary_version_id": "obs-v2",
+        "enrichment_state": {"status": "writeback_applied"},
+        "transcript_segments": [
+            {
+                "id": "seg-1",
+                "is_user": True,
+                "text": "Can I get the waffle?",
+                "start": 0.0,
+                "end": 1.5,
+            }
+        ],
+    }
+
+    event = build_omi_canonical_event(
+        "5aGC5YE9BnhcSoTxxtT4ar6ILQy2",
+        conversation,
+        summary_source="observer",
+        summary_kind="observer_enriched",
+        trace_id="trace-cafe",
+    )
+
+    assert event["event_id"] == "omi:cafe-123:summary"
+    assert event["source_ref"]["source_identity"] == "omi:cafe-123"
+    assert event["channel"] == "omi"
+    assert event["provider"] == "omi-backend"
+    assert event["started_at"] == "2026-05-07T18:56:59Z"
+    assert event["ended_at"] == "2026-05-07T18:58:12Z"
+    assert "Cafe Coffee and Waffle Stop" in event["text"]
+    assert "waffle with oat" in event["text"]
+    assert event["metadata"]["summary_versions"][0]["id"] == "obs-v2"
+    assert event["metadata"]["active_summary_version_id"] == "obs-v2"
+    assert event["metadata"]["transcript_segments"][0]["text"] == "Can I get the waffle?"
+    assert event["metadata"]["trace_id"] == "trace-cafe"
+
+
+def test_build_omi_canonical_event_json_normalizes_nested_timestamps():
+    nested_time = datetime(2026, 5, 7, 18, 57, 12, tzinfo=timezone.utc)
+    conversation = {
+        "id": "nested-123",
+        "created_at": nested_time,
+        "started_at": nested_time,
+        "structured": {
+            "title": "Nested timestamp test",
+            "overview": "A summary with nested metadata.",
+            "events": [{"observed_at": nested_time}],
+        },
+        "summary_versions": [{"id": "obs-v2", "created_at": nested_time}],
+        "transcript_segments": [{"id": "seg-1", "text": "Hello", "timestamp": nested_time}],
+    }
+
+    event = build_omi_canonical_event("uid-123", conversation)
+
+    json.dumps(event)
+    assert event["metadata"]["structured"]["events"][0]["observed_at"] == "2026-05-07T18:57:12Z"
+    assert event["metadata"]["summary_versions"][0]["created_at"] == "2026-05-07T18:57:12Z"
+    assert event["metadata"]["transcript_segments"][0]["timestamp"] == "2026-05-07T18:57:12Z"

--- a/backend/utils/ella/canonical_omi.py
+++ b/backend/utils/ella/canonical_omi.py
@@ -1,0 +1,211 @@
+"""Canonical ledger adapter for OMI enriched conversations."""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import requests
+
+CANONICAL_EVENTS_URL = os.getenv("ELLA_CANONICAL_EVENTS_URL", "http://127.0.0.1:8000/v1/ella/events")
+CANONICAL_OMI_WRITE_ENABLED = os.getenv("ELLA_CANONICAL_OMI_WRITE_ENABLED", "true").lower() == "true"
+CANONICAL_OMI_TIMEOUT = float(os.getenv("ELLA_CANONICAL_OMI_TIMEOUT", "5"))
+
+
+def _enum_value(value: Any) -> Any:
+    return getattr(value, "value", value)
+
+
+def _iso(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        return str(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _model_to_dict(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if hasattr(value, "dict"):
+        return value.dict()
+    return {}
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return _iso(value)
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if hasattr(value, "model_dump"):
+        return _json_safe(value.model_dump(mode="json"))
+    if hasattr(value, "dict"):
+        return _json_safe(value.dict())
+    enum_value = _enum_value(value)
+    if enum_value is not value:
+        return _json_safe(enum_value)
+    return value
+
+
+def _object_get(value: Any, key: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _structured_dict(conversation: Any) -> dict[str, Any]:
+    structured = _object_get(conversation, "structured") or {}
+    data = _model_to_dict(structured)
+    if not data and isinstance(structured, dict):
+        data = dict(structured)
+    if data.get("category") is not None:
+        data["category"] = _enum_value(data["category"])
+    return data
+
+
+def _segment_dict(segment: Any) -> dict[str, Any]:
+    data = _model_to_dict(segment)
+    if not data and isinstance(segment, dict):
+        data = dict(segment)
+    return {
+        "id": data.get("id"),
+        "text": data.get("text") or "",
+        "speaker": data.get("speaker"),
+        "speaker_id": data.get("speaker_id"),
+        "is_user": data.get("is_user"),
+        "person_id": data.get("person_id"),
+        "start": data.get("start"),
+        "end": data.get("end"),
+        "timestamp": data.get("timestamp"),
+    }
+
+
+def _transcript_segments(conversation: Any) -> list[dict[str, Any]]:
+    segments = _object_get(conversation, "transcript_segments") or []
+    return [_segment_dict(segment) for segment in segments]
+
+
+def _summary_versions(conversation: Any) -> list[dict[str, Any]]:
+    versions = _object_get(conversation, "summary_versions") or []
+    return [_model_to_dict(version) if not isinstance(version, dict) else dict(version) for version in versions]
+
+
+def _active_summary_version_id(conversation: Any) -> Optional[str]:
+    value = _object_get(conversation, "active_summary_version_id")
+    return str(value) if value else None
+
+
+def _summary_text(structured: dict[str, Any]) -> str:
+    title = str(structured.get("title") or "").strip()
+    overview = str(structured.get("overview") or "").strip()
+    if title and overview:
+        return f"{title}\n\n{overview}"
+    return title or overview
+
+
+def build_omi_canonical_event(
+    uid: str,
+    conversation: Any,
+    *,
+    summary_source: str = "observer",
+    summary_kind: str = "observer_enriched",
+    trace_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build one idempotent canonical event for the active OMI summary."""
+    conversation_id = str(_object_get(conversation, "id") or "")
+    if not conversation_id:
+        raise ValueError("conversation id is required")
+
+    structured = _structured_dict(conversation)
+    started_at = _object_get(conversation, "started_at") or _object_get(conversation, "created_at")
+    if not started_at:
+        started_at = datetime.now(timezone.utc)
+    finished_at = _object_get(conversation, "finished_at")
+    active_summary_version_id = _active_summary_version_id(conversation)
+    transcript_segments = _transcript_segments(conversation)
+
+    event = {
+        "uid": uid,
+        "canonical_identity": uid,
+        "event_id": f"omi:{conversation_id}:summary",
+        "session_id": conversation_id,
+        "channel": "omi",
+        "provider": "omi-backend",
+        "role": "user",
+        "text": _summary_text(structured),
+        "started_at": _iso(started_at),
+        "ended_at": _iso(finished_at),
+        "privacy_scope": "user_private",
+        "scan_policy": "none",
+        "source_ref": {
+            "source_identity": f"omi:{conversation_id}",
+            "conversation_id": conversation_id,
+            "active_summary_version_id": active_summary_version_id,
+        },
+        "metadata": {
+            "adapter": "omi-enriched-conversation",
+            "summary_source": summary_source,
+            "summary_kind": summary_kind,
+            "trace_id": trace_id,
+            "structured": structured,
+            "summary_versions": _summary_versions(conversation),
+            "active_summary_version_id": active_summary_version_id,
+            "enrichment_state": _model_to_dict(_object_get(conversation, "enrichment_state")),
+            "internal_assessment": _model_to_dict(_object_get(conversation, "internal_assessment")),
+            "ella_tags": _object_get(conversation, "ella_tags") or [],
+            "ella_signal": _model_to_dict(_object_get(conversation, "ella_signal")),
+            "transcript_segments": transcript_segments,
+            "segment_count": len(transcript_segments),
+            "created_at": _iso(_object_get(conversation, "created_at")),
+            "source": _enum_value(_object_get(conversation, "source")),
+            "status": _enum_value(_object_get(conversation, "status")),
+        },
+    }
+    return _json_safe(event)
+
+
+def write_omi_canonical_event(
+    uid: str,
+    conversation: Any,
+    *,
+    summary_source: str = "observer",
+    summary_kind: str = "observer_enriched",
+    trace_id: Optional[str] = None,
+    timeout: Optional[float] = None,
+) -> dict[str, Any]:
+    """Best-effort synchronous write to the local canonical ledger endpoint."""
+    if not CANONICAL_OMI_WRITE_ENABLED:
+        return {"ok": False, "skipped": True, "reason": "disabled"}
+
+    event = build_omi_canonical_event(
+        uid,
+        conversation,
+        summary_source=summary_source,
+        summary_kind=summary_kind,
+        trace_id=trace_id,
+    )
+    started = time.time()
+    response = requests.post(
+        CANONICAL_EVENTS_URL,
+        json={"events": [event]},
+        headers={"Content-Type": "application/json"},
+        timeout=timeout if timeout is not None else CANONICAL_OMI_TIMEOUT,
+    )
+    elapsed_ms = int((time.time() - started) * 1000)
+    if response.status_code >= 400:
+        raise RuntimeError(f"canonical_events_http_{response.status_code}: {response.text[:200]}")
+    payload = response.json()
+    payload["latency_ms"] = elapsed_ms
+    return payload


### PR DESCRIPTION
## Summary

Implements the durable #855 source-adapter path for enriched OMI conversations.

Changes:

- Adds `utils.ella.canonical_omi` to build/write a stable `channel=omi` canonical event from an enriched OMI conversation.
- Hooks Observer/n8n summary writeback (`PATCH /v1/ella/conversation/{id}/summary`) so the enriched app-visible summary is written to `/v1/ella/events` after Firestore update.
- Keeps the canonical key stable:
  - `event_id=omi:<conversation_id>:summary`
  - `source_identity=omi:<conversation_id>`
- Preserves source metadata in the canonical payload, including structured summary, summary versions, active version id, enrichment state, internal assessment, Ella tags/signal, transcript segments, and timestamps.
- Allows only derived OMI summary rows to update on conflict, so corrected/enriched summaries refresh one canonical row instead of creating duplicate timeline entries. Normal turn events remain immutable/no-op on duplicate.
- Adds `backend/scripts/backfill_omi_canonical_events.py` for dry-run/apply backfill from Firestore conversations into the canonical ledger.
- Adds unit coverage for event construction and summary writeback canonical emission.

## Validation

- `python3 -m pytest backend/tests/unit/test_ella_canonical_omi.py backend/tests/unit/test_ella_callbacks_summary_update.py -q` -> 12 passed
- `python3 -m compileall -q backend/utils/ella/canonical_omi.py backend/ella/routers/callbacks.py backend/ella/routers/canonical_events.py backend/scripts/backfill_omi_canonical_events.py` -> passed

Note: a combined run including `test_ella_plato_mcp.py` hit the local Python 3.14 FastAPI/Starlette `TestClient` metaclass conflict during collection; the Plato MCP tests were not part of this code path.

## Deployment plan

Deploy surgically to the VPS, then run:

```bash
cd /root/omi/backend
python3 scripts/backfill_omi_canonical_events.py --uid 5aGC5YE9BnhcSoTxxtT4ar6ILQy2 --limit 50 --apply
```

Smoke:

```bash
curl 'https://api.ella-ai-care.com/v1/ella/timeline?uid=5aGC5YE9BnhcSoTxxtT4ar6ILQy2&channels=omi&limit=10'
```

Expected: latest enriched OMI summaries, including the May 7 cafe event if still in the latest window.