### PR TITLE
[codex] Prefer canonical context for chat and Guardian

### DIFF
--- a/backend/ella/routers/chat.py
+++ b/backend/ella/routers/chat.py
@@ -33,6 +33,12 @@ from pydantic import BaseModel
 from ella.config import ELLA_CONFIG
 from ella.routers.resolve import resolve_user_routing
 from ella.routers.trace import RouteTrace, record_trace
+from utils.ella.canonical_context import (
+    DEFAULT_CONTEXT_CHANNELS,
+    canonical_events_to_server_messages,
+    fetch_canonical_timeline,
+    format_canonical_context,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +55,13 @@ HERMES_GATEWAY_URL = os.getenv("HERMES_GATEWAY_URL", "http://100.76.138.56:8642"
 HERMES_GATEWAY_TOKEN = os.getenv("HERMES_API_SERVER_KEY", os.getenv("API_SERVER_KEY", ""))
 HERMES_AGENT_ID = os.getenv("HERMES_AGENT_ID", "hermes")
 HERMES_MODEL = os.getenv("HERMES_MODEL", "plato-eval")
+CHAT_CONTEXT_LIMIT = int(os.getenv("ELLA_CHAT_CANONICAL_CONTEXT_LIMIT", "25"))
+CHAT_CONTEXT_MAX_CHARS = int(os.getenv("ELLA_CHAT_CANONICAL_CONTEXT_MAX_CHARS", "6000"))
+CHAT_CONTEXT_CHANNELS = [
+    channel.strip()
+    for channel in os.getenv("ELLA_CHAT_CANONICAL_CHANNELS", ",".join(DEFAULT_CONTEXT_CHANNELS)).split(",")
+    if channel.strip()
+]
 
 ELLA_SYSTEM_PROMPT = (
     "You are Ella, a warm and caring AI companion for elderly users. "
@@ -76,6 +89,25 @@ def _resolve_debug_level(header_value: str = None) -> int:
         except (ValueError, TypeError):
             logger.warning(f"[FLOW:CHAT] Non-integer debug level in header: {header_value}, using config default")
     return ELLA_CONFIG.debug_level
+
+
+async def _fetch_chat_canonical_events(uid: str, *, limit: int, before: str = None) -> list[dict]:
+    try:
+        events = await fetch_canonical_timeline(
+            uid,
+            limit=limit,
+            channels=CHAT_CONTEXT_CHANNELS,
+            before=before,
+        )
+        logger.info("[FLOW:CANONICAL-CONTEXT] uid=%s events=%s source=timeline", uid, len(events))
+        return events
+    except Exception as e:
+        logger.warning(
+            "[FLOW:CANONICAL-CONTEXT] uid=%s unavailable=%s fallback=migration_legacy_history",
+            uid,
+            e,
+        )
+        return []
 
 
 async def _stream_level_1_ack(user_message: str):
@@ -277,6 +309,28 @@ async def _stream_level_4_openclaw(user_message: str, uid: str, client_info: dic
         _l4_trace.notes.append("WARNING: No cluster found, using fallback")
         print(f"[FLOW:CHAT-L4] provider=openclaw uid={uid} agent=main source=FALLBACK (no cluster)", flush=True)
 
+    canonical_events = await _fetch_chat_canonical_events(uid, limit=CHAT_CONTEXT_LIMIT)
+    canonical_context = format_canonical_context(canonical_events, max_chars=CHAT_CONTEXT_MAX_CHARS)
+    messages = []
+    if canonical_context:
+        messages.append(
+            {
+                "role": "system",
+                "content": (
+                    "Use this canonical timeline as the freshest available user context. "
+                    "It may include OMI, iOS chat, voice, iMessage, Guardian, Telegram, and memory events. "
+                    "Prefer it over older OpenClaw session history when answering.\n\n"
+                    f"{canonical_context}"
+                ),
+            }
+        )
+    else:
+        print(
+            f"[FLOW:CHAT-L4] uid={uid} canonical_context=empty fallback=openclaw_session_history_migration",
+            flush=True,
+        )
+    messages.append({"role": "user", "content": user_message})
+
     # Use asyncio.Task so we can yield keep-alives while waiting
     async def _call_openclaw():
         async with httpx.AsyncClient() as client:
@@ -290,9 +344,7 @@ async def _stream_level_4_openclaw(user_message: str, uid: str, client_info: dic
                 },
                 json={
                     "model": f"openclaw:{agent_id}",
-                    "messages": [
-                        {"role": "user", "content": user_message},
-                    ],
+                    "messages": messages,
                     "stream": False,
                     "user": session_key,
                 },
@@ -387,7 +439,31 @@ async def _stream_hermes_chat(user_message: str, uid: str, client_info: dict = N
 
     session_key = f"ella:omi:{uid.lower()}:ios-chat"
     text = []
-    print(f"[FLOW:CHAT-HERMES] uid={uid} gateway={HERMES_GATEWAY_URL} session={session_key}", flush=True)
+    canonical_events = await _fetch_chat_canonical_events(uid, limit=CHAT_CONTEXT_LIMIT)
+    canonical_context = format_canonical_context(canonical_events, max_chars=CHAT_CONTEXT_MAX_CHARS)
+    messages = []
+    if canonical_context:
+        messages.append(
+            {
+                "role": "system",
+                "content": (
+                    "Use this canonical timeline as the freshest available user context. "
+                    "It may include OMI, iOS chat, voice, iMessage, Guardian, Telegram, and memory events. "
+                    "Prefer it over older Hermes/OpenClaw session history when answering.\n\n"
+                    f"{canonical_context}"
+                ),
+            }
+        )
+    else:
+        print(
+            f"[FLOW:CHAT-HERMES] uid={uid} canonical_context=empty fallback=hermes_session_history_migration",
+            flush=True,
+        )
+    messages.append({"role": "user", "content": user_message})
+    print(
+        f"[FLOW:CHAT-HERMES] uid={uid} gateway={HERMES_GATEWAY_URL} session={session_key} canonical_events={len(canonical_events)}",
+        flush=True,
+    )
 
     try:
         async with httpx.AsyncClient(timeout=None) as client:
@@ -401,7 +477,7 @@ async def _stream_hermes_chat(user_message: str, uid: str, client_info: dict = N
                 },
                 json={
                     "model": HERMES_MODEL,
-                    "messages": [{"role": "user", "content": user_message}],
+                    "messages": messages,
                     "stream": True,
                 },
             ) as response:
@@ -610,10 +686,10 @@ async def ella_chat_history(
     limit: int = 50,
     before: str = None,
 ):
-    """Return recent chat messages for a user from OpenClaw session history.
+    """Return recent chat/context messages for a user from canonical timeline.
 
-    Resolves the user's agent routing, then proxies to the Mac Mini provision
-    API which reads JSONL session files directly.
+    Canonical timeline is primary. The Mac Mini provision/OpenClaw session
+    history path is kept only as a logged migration fallback.
 
     Returns messages in reverse-chronological order (newest first) in the
     iOS ServerMessage schema format.
@@ -629,16 +705,37 @@ async def ella_chat_history(
 
     limit = min(limit, 200)
 
-    # Resolve user to get their OpenClaw user ID
+    canonical_events = await _fetch_chat_canonical_events(uid, limit=limit, before=before)
+    if canonical_events:
+        _elapsed = int((_time.time() - _start) * 1000)
+        logger.info(
+            "[FLOW:HISTORY] uid=%s source=canonical_timeline messages=%s latency=%sms",
+            uid,
+            len(canonical_events),
+            _elapsed,
+        )
+        return {
+            "messages": canonical_events_to_server_messages(canonical_events, limit=limit),
+            "hasMore": len(canonical_events) >= limit,
+            "source": "canonical_timeline",
+            "fallback": False,
+        }
+
+    logger.warning(
+        "[FLOW:HISTORY] uid=%s source=canonical_timeline empty fallback=provision_openclaw_history_migration",
+        uid,
+    )
+
+    # Resolve user to get their OpenClaw user ID for migration fallback only.
     resolved = await resolve_user_routing(uid)
     if not resolved:
         logger.warning(f"[FLOW:HISTORY] uid={uid} user_not_found")
-        return {"messages": [], "hasMore": False}
+        return {"messages": [], "hasMore": False, "source": "canonical_timeline_empty", "fallback": False}
 
     routing = resolved.get("routing")
     if not routing:
         logger.warning(f"[FLOW:HISTORY] uid={uid} no_routing")
-        return {"messages": [], "hasMore": False}
+        return {"messages": [], "hasMore": False, "source": "canonical_timeline_empty", "fallback": False}
 
     # Extract the OpenClaw user ID from the workspace path or agent ID
     agent_id = routing.get("agentId", "")
@@ -675,22 +772,30 @@ async def ella_chat_history(
         if response.status_code == 200:
             result = response.json()
             msg_count = len(result.get("messages", []))
-            logger.info(f"[FLOW:HISTORY] uid={uid} agent={agent_id} messages={msg_count} latency={_elapsed}ms")
+            logger.warning(
+                "[FLOW:HISTORY] uid=%s agent=%s messages=%s latency=%sms source=provision_openclaw_history_migration",
+                uid,
+                agent_id,
+                msg_count,
+                _elapsed,
+            )
+            result["source"] = "provision_openclaw_history_migration"
+            result["fallback"] = True
             return result
         elif response.status_code == 404:
             logger.warning(f"[FLOW:HISTORY] uid={uid} agent={agent_id} no_sessions latency={_elapsed}ms")
-            return {"messages": [], "hasMore": False}
+            return {"messages": [], "hasMore": False, "source": "provision_openclaw_history_migration", "fallback": True}
         else:
             logger.error(
                 f"[FLOW:HISTORY] uid={uid} agent={agent_id} status={response.status_code} latency={_elapsed}ms"
             )
-            return {"messages": [], "hasMore": False}
+            return {"messages": [], "hasMore": False, "source": "provision_openclaw_history_migration", "fallback": True}
 
     except httpx.TimeoutException:
         _elapsed = int((_time.time() - _start) * 1000)
         logger.error(f"[FLOW:HISTORY] uid={uid} timeout latency={_elapsed}ms")
-        return {"messages": [], "hasMore": False}
+        return {"messages": [], "hasMore": False, "source": "provision_openclaw_history_migration", "fallback": True}
     except Exception as e:
         _elapsed = int((_time.time() - _start) * 1000)
         logger.error(f"[FLOW:HISTORY] uid={uid} error={e} latency={_elapsed}ms")
-        return {"messages": [], "hasMore": False}
+        return {"messages": [], "hasMore": False, "source": "provision_openclaw_history_migration", "fallback": True}

--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -37,6 +37,11 @@ from ella.services.escalation_policy import (
     _normalize_mode,
     evaluate_escalation_policy,
 )
+from utils.ella.canonical_context import (
+    DEFAULT_CONTEXT_CHANNELS,
+    canonical_events_to_chat_turns,
+    fetch_canonical_timeline,
+)
 
 router = APIRouter(prefix="/v1/ella/guardian", tags=["Guardian Mode"])
 
@@ -59,6 +64,11 @@ CONSOLIDATION_THRESHOLD = int(os.getenv("CONSOLIDATION_THRESHOLD", "3"))
 # Provision API for chat history lookups
 _PROVISION_API_URL = os.getenv("ELLA_PROVISION_API_URL", "http://100.76.138.56:8200")
 _PROVISION_API_TOKEN = os.getenv("ELLA_PROVISION_API_TOKEN", "")
+_GUARDIAN_CONTEXT_CHANNELS = [
+    channel.strip()
+    for channel in os.getenv("ELLA_GUARDIAN_CANONICAL_CHANNELS", ",".join(DEFAULT_CONTEXT_CHANNELS)).split(",")
+    if channel.strip()
+]
 
 # LLM settings for consolidator — prefers OpenRouter, falls back to XAI direct
 _OPENROUTER_KEY = os.getenv("OPENROUTER_API_KEY", "")
@@ -607,10 +617,34 @@ async def _log_pipeline_event(
 
 
 async def _get_recent_chat_turns(uid: str, limit: int = 5) -> list[dict]:
-    """Fetch recent conversation turns for a UID from the chat history endpoint.
+    """Fetch recent turns for Guardian consolidation from canonical timeline.
 
+    Provision/OpenClaw history is retained only as a logged migration fallback.
     Returns list of {role, content} dicts, newest first. Returns [] on any error.
     """
+    try:
+        events = await fetch_canonical_timeline(
+            uid,
+            limit=max(limit, 10),
+            channels=_GUARDIAN_CONTEXT_CHANNELS,
+        )
+        if events:
+            turns = canonical_events_to_chat_turns(events, limit=limit)
+            print(
+                f"[FLOW:GUARDIAN-CONTEXT] uid={uid} source=canonical_timeline events={len(events)} turns={len(turns)}",
+                flush=True,
+            )
+            return turns
+        print(
+            f"[FLOW:GUARDIAN-CONTEXT] uid={uid} source=canonical_timeline empty fallback=provision_openclaw_history_migration",
+            flush=True,
+        )
+    except Exception as e:
+        print(
+            f"[FLOW:GUARDIAN-CONTEXT] uid={uid} canonical_error={e} fallback=provision_openclaw_history_migration",
+            flush=True,
+        )
+
     try:
         resolved = await resolve_user_routing(uid)
         if not resolved:
@@ -648,6 +682,10 @@ async def _get_recent_chat_turns(uid: str, limit: int = 5) -> list[dict]:
             content = m.get("content", m.get("text", ""))
             if content:
                 turns.append({"role": role, "content": str(content)[:500]})
+        print(
+            f"[FLOW:GUARDIAN-CONTEXT] uid={uid} source=provision_openclaw_history_migration turns={len(turns)}",
+            flush=True,
+        )
         return turns
     except Exception as e:
         print(f"[CONSOLIDATOR] chat history fetch error: {e}", flush=True)

--- a/backend/tests/unit/test_ella_canonical_context.py
+++ b/backend/tests/unit/test_ella_canonical_context.py
@@ -1,0 +1,94 @@
+import asyncio
+import sys
+import types
+
+sys.modules.setdefault("python_multipart", types.SimpleNamespace(__version__="0.0.20"))
+
+from ella.routers import chat as ella_chat
+from ella.routers import guardian
+from utils.ella.canonical_context import (
+    canonical_events_to_server_messages,
+    canonical_events_to_chat_turns,
+    format_canonical_context,
+)
+
+
+def _cafe_event():
+    return {
+        "uid": "uid-1",
+        "canonical_identity": "uid-1",
+        "event_id": "omi:cafe-123:summary",
+        "source_identity": "omi:cafe-123",
+        "channel": "omi",
+        "provider": "omi-backend",
+        "role": "user",
+        "text": "Cafe Coffee and Waffle Stop\n\nOrdered a noah drink and a waffle with oat.",
+        "started_at": "2026-05-07T18:56:59.312831+00:00",
+        "metadata": {"structured": {"title": "Cafe Coffee and Waffle Stop"}},
+    }
+
+
+def test_format_canonical_context_includes_latest_omi_summary():
+    context = format_canonical_context([_cafe_event()])
+
+    assert "Recent canonical timeline context" in context
+    assert "Cafe Coffee and Waffle Stop" in context
+    assert "waffle with oat" in context
+
+
+def test_canonical_events_to_server_messages_maps_ios_history_shape():
+    messages = canonical_events_to_server_messages([_cafe_event()])
+
+    assert messages[0]["id"] == "omi:cafe-123:summary"
+    assert messages[0]["sender"] == "human"
+    assert messages[0]["metadata"]["source"] == "canonical_timeline"
+    assert messages[0]["metadata"]["channel"] == "omi"
+    assert "Cafe Coffee and Waffle Stop" in messages[0]["metadata"]["title"]
+
+
+def test_chat_history_prefers_canonical_timeline(monkeypatch):
+    async def fake_events(uid, *, limit, before=None):
+        assert uid == "uid-1"
+        assert limit == 5
+        assert before is None
+        return [_cafe_event()]
+
+    async def fail_resolve(_uid):
+        raise AssertionError("legacy routing fallback should not be used when canonical has events")
+
+    monkeypatch.setattr(ella_chat, "_fetch_chat_canonical_events", fake_events)
+    monkeypatch.setattr(ella_chat, "resolve_user_routing", fail_resolve)
+
+    result = asyncio.run(ella_chat.ella_chat_history("uid-1", limit=5))
+
+    assert result["source"] == "canonical_timeline"
+    assert result["fallback"] is False
+    assert result["messages"][0]["id"] == "omi:cafe-123:summary"
+
+
+def test_guardian_recent_turns_prefers_canonical_timeline(monkeypatch):
+    async def fake_timeline(uid, **kwargs):
+        assert uid == "uid-1"
+        return [_cafe_event()]
+
+    async def fail_resolve(_uid):
+        raise AssertionError("legacy routing fallback should not be used when canonical has events")
+
+    monkeypatch.setattr(guardian, "fetch_canonical_timeline", fake_timeline)
+    monkeypatch.setattr(guardian, "resolve_user_routing", fail_resolve)
+
+    turns = asyncio.run(guardian._get_recent_chat_turns("uid-1", limit=3))
+
+    assert turns == [{"role": "user", "content": _cafe_event()["text"]}]
+
+
+def test_canonical_events_to_chat_turns_newest_first_for_guardian():
+    first = {**_cafe_event(), "event_id": "first", "text": "first"}
+    second = {**_cafe_event(), "event_id": "second", "text": "second", "role": "assistant"}
+
+    turns = canonical_events_to_chat_turns([first, second], limit=2)
+
+    assert turns == [
+        {"role": "assistant", "content": "second"},
+        {"role": "user", "content": "first"},
+    ]

--- a/backend/utils/ella/canonical_context.py
+++ b/backend/utils/ella/canonical_context.py
@@ -1,0 +1,158 @@
+"""Canonical timeline context helpers for Ella chat and Guardian paths."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import httpx
+
+DEFAULT_TIMELINE_URL = os.getenv("ELLA_CANONICAL_TIMELINE_URL", "http://127.0.0.1:8000/v1/ella/timeline")
+DEFAULT_TIMEOUT_SECONDS = float(os.getenv("ELLA_CANONICAL_TIMELINE_TIMEOUT", "5"))
+DEFAULT_CONTEXT_CHANNELS = [
+    "omi",
+    "ios_chat",
+    "ios_voice",
+    "imessage",
+    "telegram",
+    "guardian",
+    "memory",
+]
+
+
+def _parse_iso(value: Any) -> Optional[datetime]:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    else:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _event_time(event: dict[str, Any]) -> str:
+    return str(event.get("started_at") or event.get("created_at") or event.get("timestamp") or "")
+
+
+def _event_title(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+    structured = metadata.get("structured") if isinstance(metadata.get("structured"), dict) else {}
+    return str(event.get("title") or structured.get("title") or event.get("channel") or "event")
+
+
+def _event_text(event: dict[str, Any], max_chars: int = 900) -> str:
+    text = str(event.get("text") or event.get("overview") or event.get("summary") or "").strip()
+    if len(text) <= max_chars:
+        return text
+    return text[: max(0, max_chars - 1)].rstrip() + "..."
+
+
+def _role_for_event(event: dict[str, Any]) -> str:
+    role = str(event.get("role") or "").lower()
+    if role in {"assistant", "ai"}:
+        return "assistant"
+    return "user"
+
+
+async def fetch_canonical_timeline(
+    uid: str,
+    *,
+    limit: int = 50,
+    channels: Optional[list[str]] = None,
+    since: Optional[str] = None,
+    before: Optional[str] = None,
+    timeout: Optional[float] = None,
+) -> list[dict[str, Any]]:
+    """Read canonical timeline over HTTP per the unified memory contract."""
+    if not uid:
+        return []
+
+    effective_limit = max(1, min(int(limit or 50), 500))
+    fetch_limit = effective_limit
+    before_dt = None
+    if before:
+        before_dt = _parse_iso(before)
+        fetch_limit = min(max(effective_limit * 3, effective_limit), 500)
+
+    params: dict[str, Any] = {"uid": uid, "limit": fetch_limit}
+    if channels:
+        params["channels"] = ",".join(channel for channel in channels if channel)
+    if since:
+        params["since"] = since
+
+    async with httpx.AsyncClient(timeout=timeout or DEFAULT_TIMEOUT_SECONDS) as client:
+        response = await client.get(DEFAULT_TIMELINE_URL, params=params)
+    response.raise_for_status()
+
+    payload = response.json()
+    events = payload if isinstance(payload, list) else payload.get("events") or payload.get("timeline") or []
+    normalized = [event for event in events if isinstance(event, dict)]
+    if before_dt:
+        normalized = [
+            event
+            for event in normalized
+            if (event_dt := _parse_iso(_event_time(event))) is not None and event_dt < before_dt
+        ]
+    return normalized[-effective_limit:]
+
+
+def format_canonical_context(events: list[dict[str, Any]], *, max_chars: int = 6000) -> str:
+    if not events:
+        return ""
+    lines = ["Recent canonical timeline context, oldest to newest:"]
+    for event in events:
+        timestamp = _event_time(event)
+        channel = str(event.get("channel") or "unknown")
+        title = _event_title(event)
+        text = _event_text(event)
+        if text:
+            lines.append(f"- {timestamp} [{channel}] {title}: {text}")
+        else:
+            lines.append(f"- {timestamp} [{channel}] {title}")
+    context = "\n".join(lines)
+    if len(context) <= max_chars:
+        return context
+    return context[-max_chars:]
+
+
+def canonical_events_to_chat_turns(events: list[dict[str, Any]], *, limit: int = 5) -> list[dict[str, str]]:
+    turns: list[dict[str, str]] = []
+    for event in list(events)[-limit:]:
+        content = _event_text(event, max_chars=500)
+        if not content:
+            continue
+        turns.append({"role": _role_for_event(event), "content": content})
+    turns.reverse()
+    return turns
+
+
+def canonical_events_to_server_messages(events: list[dict[str, Any]], *, limit: int = 50) -> list[dict[str, Any]]:
+    messages: list[dict[str, Any]] = []
+    for event in reversed(list(events)[-limit:]):
+        messages.append(
+            {
+                "id": str(event.get("event_id") or event.get("id") or ""),
+                "created_at": _event_time(event),
+                "text": _event_text(event, max_chars=2000),
+                "sender": "ai" if _role_for_event(event) == "assistant" else "human",
+                "type": "text",
+                "plugin_id": None,
+                "from_integration": False,
+                "memories": [],
+                "files": [],
+                "metadata": {
+                    "source": "canonical_timeline",
+                    "channel": event.get("channel"),
+                    "provider": event.get("provider"),
+                    "source_identity": event.get("source_identity"),
+                    "title": _event_title(event),
+                },
+            }
+        )
+    return messages
+


### PR DESCRIPTION
## Summary

Implements #856 Slice A/D backend changes:

- Adds shared `utils.ella.canonical_context` helpers for canonical timeline fetch/format/mapping.
- Makes `/v1/ella/chat/stream` fetch `GET /v1/ella/timeline` first and inject the formatted canonical context into Hermes/OpenClaw chat calls.
- Makes `/v1/ella/chat/history` canonical-first and returns iOS-compatible messages from canonical timeline with `source=canonical_timeline` and `fallback=false`.
- Keeps provision/OpenClaw session history only as an explicit migration fallback with `source=provision_openclaw_history_migration` and warning logs.
- Makes Guardian consolidation context use canonical timeline first; provision history remains a logged migration fallback.
- Adds regression coverage using a known OMI/cafe-style canonical event.

## Validation

Local:

- `python3 -m pytest backend/tests/unit/test_ella_canonical_context.py backend/tests/unit/test_ella_guardian_delivery.py -q` -> 10 passed
- `python3 -m compileall -q backend/utils/ella/canonical_context.py backend/ella/routers/chat.py backend/ella/routers/guardian.py` -> passed

Live VPS smoke after surgical deploy:

- Backup: `/root/omi/backend-backups/canonical-chat-guardian-20260507T213528Z`
- `omi-backend` restarted and active.
- Before patch: `GET /v1/ella/chat/history?...&limit=5` returned `count=0`, no source marker.
- After patch: `GET /v1/ella/chat/history?uid=5aGC5YE9BnhcSoTxxtT4ar6ILQy2&limit=10` returned:
  - `source=canonical_timeline`
  - `fallback=false`
  - `count=10`
  - includes `omi:cccdcba2-89e9-4a3a-a196-9752f7fe8c72:summary` (`Cafe Coffee and Waffle Stop`)
- Live `/v1/ella/chat/stream` smoke asked `What was the latest OMI conversation you can see?` and Hermes answered from a newer canonical OMI event. Log shows `canonical_events=25` injected into Hermes.

## Notes

This does not touch iOS. It changes backend context hydration so iOS chat can stay thin and still receive canonical memory context.