### PR TITLE
[codex] Add generic MCP onboarding role resolver

### DIFF
--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -320,6 +320,15 @@ def _register_routers(app) -> None:
     except ImportError as e:
         print(f"  ⚠️ Ella Plato MCP not available: {e}", flush=True)
 
+    # Generic MCP onboarding and profile-role resolution
+    try:
+        from ella.routers.mcp_onboarding import router as mcp_onboarding_router
+
+        app.include_router(mcp_onboarding_router, tags=["Ella MCP Onboarding"])
+        print("  🌐 /v1/ella/mcp/* - MCP onboarding and profile-role resolution", flush=True)
+    except ImportError as e:
+        print(f"  ⚠️ Ella MCP onboarding not available: {e}", flush=True)
+
     # Escalation policy resolver (classifier output -> deterministic delivery plan)
     try:
         from ella.routers.escalations import router as escalations_router

--- a/backend/ella/routers/mcp_onboarding.py
+++ b/backend/ella/routers/mcp_onboarding.py
@@ -1,0 +1,128 @@
+"""Generic MCP onboarding and account-role resolution endpoints."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Any, Optional
+
+from fastapi import APIRouter, Header, HTTPException, Query
+
+from ella.services.mcp_identity import (
+    ExternalConnectorIdentity,
+    MCPProfileGrant,
+    resolve_mcp_identity,
+)
+
+router = APIRouter(prefix="/v1/ella/mcp", tags=["Ella MCP Onboarding"])
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.getenv(name, default).strip()
+
+
+def _csv_env(name: str, default: str = "") -> list[str]:
+    raw = _env(name, default)
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _token_from_authorization(authorization: Optional[str]) -> str:
+    if not authorization:
+        return ""
+    authorization = authorization.strip()
+    if authorization.lower().startswith("bearer "):
+        return authorization[7:].strip()
+    return authorization
+
+
+def _fingerprint(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+
+
+def _allowed_static_tokens() -> set[str]:
+    tokens = _csv_env("ELLA_MCP_TOKENS", _env("ELLA_MCP_TOKEN"))
+    # Temporary compatibility while the existing test connector still uses the
+    # older env names. Do not add profile/platform assumptions to new clients.
+    tokens.extend(_csv_env("ELLA_PLATO_MCP_TOKENS", _env("ELLA_PLATO_MCP_TOKEN")))
+    return set(tokens)
+
+
+def _authenticate_static(authorization: Optional[str]) -> str:
+    tokens = _allowed_static_tokens()
+    if not tokens:
+        raise HTTPException(status_code=503, detail="MCP onboarding token is not configured")
+    token = _token_from_authorization(authorization)
+    if not token or token not in tokens:
+        raise HTTPException(status_code=401, detail="Invalid or missing MCP bearer token")
+    return _fingerprint(token)
+
+
+def _default_profile_uid() -> str:
+    # Prefer generic configuration. Legacy fallback keeps the current connector
+    # working until OAuth-backed grants are provisioned.
+    return _env("ELLA_MCP_DEFAULT_PROFILE_UID", _env("ELLA_PLATO_MCP_UID", _env("ELLA_PLATO_UID")))
+
+
+def _static_grants(token_fingerprint: str) -> list[MCPProfileGrant]:
+    profile_uid = _default_profile_uid()
+    if not profile_uid:
+        return []
+    role = _env("ELLA_MCP_DEFAULT_ROLE", "self")
+    scopes = _csv_env("ELLA_MCP_DEFAULT_SCOPES")
+    allowed_tools = _csv_env("ELLA_MCP_ALLOWED_TOOLS")
+    return [
+        MCPProfileGrant.from_mapping(
+            {
+                "grant_id": f"static:{token_fingerprint}",
+                "profile_uid": profile_uid,
+                "role": role,
+                "profile_label": _env("ELLA_MCP_DEFAULT_PROFILE_LABEL", "Default profile"),
+                "scopes": scopes,
+                "allowed_tools": allowed_tools,
+                "status": "active",
+            }
+        )
+    ]
+
+
+def _static_identity(token_fingerprint: str) -> ExternalConnectorIdentity:
+    return ExternalConnectorIdentity(
+        provider="static_bearer",
+        subject=token_fingerprint,
+        authenticated=True,
+    )
+
+
+def resolve_static_connector_session(token_fingerprint: str, selected_profile_uid: str = "") -> dict[str, Any]:
+    identity = _static_identity(token_fingerprint)
+    resolution = resolve_mcp_identity(
+        identity,
+        selected_profile_uid=selected_profile_uid,
+        grants=_static_grants(token_fingerprint),
+    )
+    return resolution.to_public_dict(include_claims=True)
+
+
+@router.get("/onboarding")
+async def get_mcp_onboarding(
+    authorization: Optional[str] = Header(None, alias="Authorization"),
+    selected_profile_uid: str = Query("", description="Optional profile UID selected after multi-profile mapping."),
+):
+    token_fingerprint = _authenticate_static(authorization)
+    return resolve_static_connector_session(token_fingerprint, selected_profile_uid)
+
+
+@router.get("/info")
+async def get_mcp_onboarding_info():
+    return {
+        "onboarding_endpoint": "/v1/ella/mcp/onboarding",
+        "auth": "Bearer token for dev/static fallback; OAuth-backed grants are resolved by the same identity service.",
+        "states": [
+            "authenticated_mapped",
+            "authenticated_needs_profile_selection",
+            "authenticated_needs_invite",
+            "unauthenticated",
+        ],
+        "write_tools_enabled": False,
+        "profile_neutral": True,
+    }

--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -890,6 +890,7 @@ async def plato_mcp_info(request: Request):
         "authentication": {
             "header": "Authorization",
             "format": "Bearer <ELLA_PLATO_MCP_TOKEN>",
+            "generic_onboarding_endpoint": f"{base_url}/v1/ella/mcp/onboarding",
             "oauth": {
                 "client_id": _oauth_client_id(),
                 "authorization_endpoint": f"{endpoint}/authorize",

--- a/backend/ella/services/mcp_identity.py
+++ b/backend/ella/services/mcp_identity.py
@@ -1,0 +1,304 @@
+"""Generic MCP connector identity and profile-role resolution.
+
+This module is intentionally independent of any one external client, agent,
+or profile name. It resolves an authenticated external identity into one
+selected Ella profile/role scope, or into an onboarding state that can be
+shown by connector setup.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Optional
+
+logger = logging.getLogger("ella.mcp_identity")
+
+STATE_AUTHENTICATED_MAPPED = "authenticated_mapped"
+STATE_AUTHENTICATED_NEEDS_PROFILE_SELECTION = "authenticated_needs_profile_selection"
+STATE_AUTHENTICATED_NEEDS_INVITE = "authenticated_needs_invite"
+STATE_UNAUTHENTICATED = "unauthenticated"
+
+ROLE_SELF = "self"
+ROLE_CAREGIVER = "caregiver"
+ROLE_ADMIN = "admin"
+
+READ_ONLY_SCOPES = {
+    "admin:read",
+    "care_context:read",
+    "context:read",
+    "memory:read",
+    "profile:read",
+    "startup:read",
+    "timeline:read",
+    "tools:read",
+}
+
+DEFAULT_ROLE_SCOPES = {
+    ROLE_SELF: ["context:read", "timeline:read", "memory:read", "profile:read", "startup:read", "tools:read"],
+    ROLE_CAREGIVER: ["care_context:read", "context:read", "profile:read", "startup:read", "timeline:read"],
+    ROLE_ADMIN: ["admin:read", "profile:read", "startup:read", "tools:read"],
+}
+
+
+def _clean_string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def normalize_email(email: Any) -> str:
+    return _clean_string(email).lower()
+
+
+def _normalized_role(role: Any) -> str:
+    value = _clean_string(role).lower()
+    if value in {ROLE_SELF, ROLE_CAREGIVER, ROLE_ADMIN}:
+        return value
+    return ROLE_SELF
+
+
+def _read_only_scopes(scopes: Iterable[Any], role: str) -> list[str]:
+    requested = [_clean_string(scope) for scope in scopes if _clean_string(scope)]
+    if not requested:
+        requested = DEFAULT_ROLE_SCOPES.get(role, DEFAULT_ROLE_SCOPES[ROLE_SELF])
+    return sorted(scope for scope in set(requested) if scope in READ_ONLY_SCOPES)
+
+
+@dataclass(frozen=True)
+class ExternalConnectorIdentity:
+    provider: str
+    subject: str
+    email: str = ""
+    email_verified: bool = False
+    authenticated: bool = True
+    display_name: str = ""
+
+    @classmethod
+    def unauthenticated(cls, provider: str = "") -> "ExternalConnectorIdentity":
+        return cls(provider=provider, subject="", authenticated=False)
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any]) -> "ExternalConnectorIdentity":
+        return cls(
+            provider=_clean_string(data.get("provider")),
+            subject=_clean_string(data.get("subject") or data.get("sub")),
+            email=normalize_email(data.get("email")),
+            email_verified=bool(data.get("email_verified")),
+            authenticated=bool(data.get("authenticated", True)),
+            display_name=_clean_string(data.get("display_name") or data.get("name")),
+        )
+
+    @property
+    def provider_subject(self) -> str:
+        return f"{self.provider}:{self.subject}" if self.provider and self.subject else ""
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "subject": self.subject,
+            "email": self.email if self.email_verified else "",
+            "email_verified": self.email_verified,
+            "authenticated": self.authenticated,
+            "display_name": self.display_name,
+        }
+
+
+@dataclass(frozen=True)
+class MCPProfileGrant:
+    grant_id: str
+    profile_uid: str
+    role: str = ROLE_SELF
+    profile_label: str = ""
+    status: str = "active"
+    scopes: list[str] = field(default_factory=list)
+    allowed_tools: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any]) -> "MCPProfileGrant":
+        role = _normalized_role(data.get("role"))
+        scopes = data.get("scopes") or data.get("allowed_scopes") or []
+        allowed_tools = data.get("allowed_tools") or data.get("tools") or []
+        return cls(
+            grant_id=_clean_string(data.get("grant_id") or data.get("id") or data.get("document_id")),
+            profile_uid=_clean_string(data.get("profile_uid") or data.get("uid") or data.get("user_id")),
+            role=role,
+            profile_label=_clean_string(data.get("profile_label") or data.get("display_name") or data.get("label")),
+            status=_clean_string(data.get("status") or "active").lower(),
+            scopes=_read_only_scopes(scopes, role),
+            allowed_tools=sorted({_clean_string(tool) for tool in allowed_tools if _clean_string(tool)}),
+            metadata=dict(data.get("metadata") or {}),
+        )
+
+    @property
+    def active(self) -> bool:
+        return self.status == "active" and bool(self.profile_uid)
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "grant_id": self.grant_id,
+            "profile_uid": self.profile_uid,
+            "role": self.role,
+            "profile_label": self.profile_label,
+            "scopes": list(self.scopes),
+            "allowed_tools": list(self.allowed_tools),
+        }
+
+
+@dataclass(frozen=True)
+class MCPIdentityResolution:
+    state: str
+    trace_id: str
+    identity: ExternalConnectorIdentity
+    selected_grant: Optional[MCPProfileGrant] = None
+    available_grants: list[MCPProfileGrant] = field(default_factory=list)
+    message: str = ""
+
+    @property
+    def mapped(self) -> bool:
+        return self.state == STATE_AUTHENTICATED_MAPPED and self.selected_grant is not None
+
+    def to_public_dict(self, include_claims: bool = False, ttl_seconds: int = 3600) -> dict[str, Any]:
+        payload = {
+            "state": self.state,
+            "trace_id": self.trace_id,
+            "identity": self.identity.to_public_dict(),
+            "selected_profile": self.selected_grant.to_public_dict() if self.selected_grant else None,
+            "available_profiles": [grant.to_public_dict() for grant in self.available_grants],
+            "message": self.message,
+        }
+        if include_claims and self.mapped:
+            payload["session_claims"] = build_session_claims(self, ttl_seconds=ttl_seconds)
+        return payload
+
+
+def load_identity_grants(identity: ExternalConnectorIdentity) -> list[MCPProfileGrant]:
+    """Load durable grants for an external identity from Firestore.
+
+    Collection shape is intentionally generic:
+    `mcp_identity_grants/{grant_id}` with fields such as provider_subject,
+    email_norm, profile_uid, role, scopes, allowed_tools, and status.
+    """
+    if not identity.authenticated:
+        return []
+
+    collection_name = os.getenv("ELLA_MCP_IDENTITY_GRANTS_COLLECTION", "mcp_identity_grants")
+    rows: dict[str, dict[str, Any]] = {}
+    try:
+        from database._client import db
+
+        if identity.provider_subject:
+            docs = (
+                db.collection(collection_name)
+                .where("provider_subject", "==", identity.provider_subject)
+                .where("status", "==", "active")
+                .stream()
+            )
+            for doc in docs:
+                row = doc.to_dict() or {}
+                row["document_id"] = doc.id
+                rows[doc.id] = row
+
+        if identity.email_verified and identity.email:
+            docs = (
+                db.collection(collection_name)
+                .where("email_norm", "==", identity.email)
+                .where("status", "==", "active")
+                .stream()
+            )
+            for doc in docs:
+                row = doc.to_dict() or {}
+                row["document_id"] = doc.id
+                rows[doc.id] = row
+    except Exception as exc:
+        logger.warning("mcp_identity grant lookup failed: %s", exc)
+        return []
+
+    return [grant for row in rows.values() if (grant := MCPProfileGrant.from_mapping(row)).active]
+
+
+def resolve_mcp_identity(
+    identity: ExternalConnectorIdentity,
+    *,
+    selected_profile_uid: str = "",
+    grants: Optional[list[MCPProfileGrant]] = None,
+    trace_id: str = "",
+) -> MCPIdentityResolution:
+    trace_id = trace_id or str(uuid.uuid4())
+    if not identity.authenticated or not identity.provider or not identity.subject:
+        return MCPIdentityResolution(
+            state=STATE_UNAUTHENTICATED,
+            trace_id=trace_id,
+            identity=identity,
+            message="Authentication is required before MCP tools can be exposed.",
+        )
+
+    active_grants = [grant for grant in (grants if grants is not None else load_identity_grants(identity)) if grant.active]
+    if not active_grants:
+        return MCPIdentityResolution(
+            state=STATE_AUTHENTICATED_NEEDS_INVITE,
+            trace_id=trace_id,
+            identity=identity,
+            message="Identity is authenticated but is not authorized for an Ella profile yet.",
+        )
+
+    selected_profile_uid = _clean_string(selected_profile_uid)
+    if selected_profile_uid:
+        selected = next((grant for grant in active_grants if grant.profile_uid == selected_profile_uid), None)
+        if selected:
+            return MCPIdentityResolution(
+                state=STATE_AUTHENTICATED_MAPPED,
+                trace_id=trace_id,
+                identity=identity,
+                selected_grant=selected,
+                available_grants=active_grants,
+                message="Identity is mapped to the selected profile.",
+            )
+        return MCPIdentityResolution(
+            state=STATE_AUTHENTICATED_NEEDS_PROFILE_SELECTION,
+            trace_id=trace_id,
+            identity=identity,
+            available_grants=active_grants,
+            message="Selected profile is not authorized for this identity.",
+        )
+
+    if len(active_grants) == 1:
+        return MCPIdentityResolution(
+            state=STATE_AUTHENTICATED_MAPPED,
+            trace_id=trace_id,
+            identity=identity,
+            selected_grant=active_grants[0],
+            available_grants=active_grants,
+            message="Identity is mapped to one profile.",
+        )
+
+    return MCPIdentityResolution(
+        state=STATE_AUTHENTICATED_NEEDS_PROFILE_SELECTION,
+        trace_id=trace_id,
+        identity=identity,
+        available_grants=active_grants,
+        message="Identity can access multiple profiles; select one before exposing profile context.",
+    )
+
+
+def build_session_claims(resolution: MCPIdentityResolution, *, ttl_seconds: int = 3600) -> dict[str, Any]:
+    if not resolution.mapped or resolution.selected_grant is None:
+        raise ValueError("Cannot build MCP session claims for an unmapped identity")
+    grant = resolution.selected_grant
+    now = int(time.time())
+    return {
+        "iss": "ella-mcp",
+        "sub": resolution.identity.provider_subject,
+        "aud": "ella-mcp-tools",
+        "iat": now,
+        "exp": now + max(60, ttl_seconds),
+        "trace_id": resolution.trace_id,
+        "profile_uid": grant.profile_uid,
+        "role": grant.role,
+        "scopes": list(grant.scopes),
+        "allowed_tools": list(grant.allowed_tools),
+        "grant_id": grant.grant_id,
+        "external_provider": resolution.identity.provider,
+    }

--- a/backend/tests/unit/test_ella_mcp_identity.py
+++ b/backend/tests/unit/test_ella_mcp_identity.py
@@ -1,0 +1,114 @@
+import pytest
+
+from ella.services.mcp_identity import (
+    ExternalConnectorIdentity,
+    MCPProfileGrant,
+    STATE_AUTHENTICATED_MAPPED,
+    STATE_AUTHENTICATED_NEEDS_INVITE,
+    STATE_AUTHENTICATED_NEEDS_PROFILE_SELECTION,
+    STATE_UNAUTHENTICATED,
+    build_session_claims,
+    resolve_mcp_identity,
+)
+
+
+def _identity():
+    return ExternalConnectorIdentity(
+        provider="google",
+        subject="google-sub-1",
+        email="person@example.com",
+        email_verified=True,
+        display_name="Test Person",
+    )
+
+
+def _grant(profile_uid="user-1", role="self", **overrides):
+    data = {
+        "grant_id": f"grant-{profile_uid}",
+        "profile_uid": profile_uid,
+        "role": role,
+        "profile_label": f"Profile {profile_uid}",
+        "scopes": overrides.pop("scopes", []),
+        "allowed_tools": overrides.pop("allowed_tools", ["companion_start_here", "companion_recent_context"]),
+        "status": overrides.pop("status", "active"),
+        **overrides,
+    }
+    return MCPProfileGrant.from_mapping(data)
+
+
+def test_resolve_unauthenticated_identity():
+    resolution = resolve_mcp_identity(ExternalConnectorIdentity.unauthenticated("google"), grants=[])
+
+    assert resolution.state == STATE_UNAUTHENTICATED
+    assert not resolution.mapped
+    assert "Authentication is required" in resolution.message
+
+
+def test_resolve_authenticated_unknown_identity_needs_invite():
+    resolution = resolve_mcp_identity(_identity(), grants=[])
+
+    assert resolution.state == STATE_AUTHENTICATED_NEEDS_INVITE
+    assert not resolution.mapped
+    assert resolution.available_grants == []
+
+
+def test_single_grant_maps_and_builds_read_only_claims():
+    grant = _grant(scopes=["context:read", "startup:read", "memory:write", "delete:memory"])
+    resolution = resolve_mcp_identity(_identity(), grants=[grant], trace_id="trace-1")
+
+    assert resolution.state == STATE_AUTHENTICATED_MAPPED
+    assert resolution.selected_grant.profile_uid == "user-1"
+
+    claims = build_session_claims(resolution, ttl_seconds=600)
+    assert claims["sub"] == "google:google-sub-1"
+    assert claims["profile_uid"] == "user-1"
+    assert claims["role"] == "self"
+    assert claims["trace_id"] == "trace-1"
+    assert claims["scopes"] == ["context:read", "startup:read"]
+    assert "memory:write" not in claims["scopes"]
+    assert "delete:memory" not in claims["scopes"]
+
+
+def test_multiple_grants_require_profile_selection():
+    resolution = resolve_mcp_identity(_identity(), grants=[_grant("user-1"), _grant("mom-1", "caregiver")])
+
+    assert resolution.state == STATE_AUTHENTICATED_NEEDS_PROFILE_SELECTION
+    assert not resolution.mapped
+    assert [grant.profile_uid for grant in resolution.available_grants] == ["user-1", "mom-1"]
+
+
+def test_selected_caregiver_profile_maps_to_caregiver_claims():
+    resolution = resolve_mcp_identity(
+        _identity(),
+        selected_profile_uid="mom-1",
+        grants=[_grant("user-1"), _grant("mom-1", "caregiver")],
+        trace_id="trace-2",
+    )
+
+    assert resolution.state == STATE_AUTHENTICATED_MAPPED
+    assert resolution.selected_grant.role == "caregiver"
+
+    claims = build_session_claims(resolution, ttl_seconds=600)
+    assert claims["profile_uid"] == "mom-1"
+    assert claims["role"] == "caregiver"
+    assert "care_context:read" in claims["scopes"]
+    assert all(not scope.endswith(":write") for scope in claims["scopes"])
+
+
+def test_invalid_selected_profile_still_requires_selection():
+    resolution = resolve_mcp_identity(
+        _identity(),
+        selected_profile_uid="not-authorized",
+        grants=[_grant("user-1"), _grant("mom-1", "caregiver")],
+    )
+
+    assert resolution.state == STATE_AUTHENTICATED_NEEDS_PROFILE_SELECTION
+    assert resolution.selected_grant is None
+    assert "not authorized" in resolution.message
+
+
+def test_cannot_build_claims_for_unmapped_identity():
+    resolution = resolve_mcp_identity(_identity(), grants=[])
+
+    with pytest.raises(ValueError):
+        build_session_claims(resolution)

--- a/backend/tests/unit/test_ella_mcp_onboarding.py
+++ b/backend/tests/unit/test_ella_mcp_onboarding.py
@@ -1,0 +1,61 @@
+import importlib
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _load_module(monkeypatch):
+    monkeypatch.setenv("ELLA_MCP_TOKEN", "test-token")
+    monkeypatch.setenv("ELLA_MCP_DEFAULT_PROFILE_UID", "user-1")
+    monkeypatch.setenv("ELLA_MCP_DEFAULT_PROFILE_LABEL", "Test User")
+    monkeypatch.setenv("ELLA_MCP_ALLOWED_TOOLS", "companion_start_here,companion_recent_context")
+    sys.modules.pop("ella.routers.mcp_onboarding", None)
+    return importlib.import_module("ella.routers.mcp_onboarding")
+
+
+def _client(module):
+    app = FastAPI()
+    app.include_router(module.router)
+    return TestClient(app)
+
+
+def test_mcp_onboarding_rejects_missing_or_invalid_static_token(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    assert client.get("/v1/ella/mcp/onboarding").status_code == 401
+    assert client.get("/v1/ella/mcp/onboarding", headers={"Authorization": "Bearer wrong"}).status_code == 401
+
+
+def test_mcp_onboarding_maps_static_token_to_generic_profile_claims(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    response = client.get("/v1/ella/mcp/onboarding", headers={"Authorization": "Bearer test-token"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "authenticated_mapped"
+    assert payload["selected_profile"]["profile_uid"] == "user-1"
+    assert payload["selected_profile"]["role"] == "self"
+    assert payload["session_claims"]["profile_uid"] == "user-1"
+    assert payload["session_claims"]["role"] == "self"
+    assert payload["session_claims"]["allowed_tools"] == ["companion_recent_context", "companion_start_here"]
+    assert "startup:read" in payload["session_claims"]["scopes"]
+
+
+def test_mcp_onboarding_without_default_profile_returns_invite_state(monkeypatch):
+    module = _load_module(monkeypatch)
+    monkeypatch.delenv("ELLA_MCP_DEFAULT_PROFILE_UID", raising=False)
+    monkeypatch.delenv("ELLA_PLATO_MCP_UID", raising=False)
+    monkeypatch.delenv("ELLA_PLATO_UID", raising=False)
+    client = _client(module)
+
+    response = client.get("/v1/ella/mcp/onboarding", headers={"Authorization": "Bearer test-token"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "authenticated_needs_invite"
+    assert payload["selected_profile"] is None
+    assert "session_claims" not in payload


### PR DESCRIPTION
## Summary
- adds a generic MCP identity resolver for external identity -> Ella profile/role onboarding states
- adds neutral `/v1/ella/mcp/onboarding` and `/v1/ella/mcp/info` endpoints for static-token fallback and future OAuth-backed grants
- registers the onboarding router and links the current legacy test connector info to the generic onboarding endpoint
- keeps writeback permissions out of this slice; emitted session claims are read-only scoped

## Resolution States
- `authenticated_mapped`
- `authenticated_needs_profile_selection`
- `authenticated_needs_invite`
- `unauthenticated`

## Validation
- `python3 -m pytest backend/tests/unit/test_ella_mcp_identity.py backend/tests/unit/test_ella_mcp_onboarding.py backend/tests/unit/test_ella_plato_mcp.py -q` -> 23 passed
- `python3 -m compileall -q backend/ella/services/mcp_identity.py backend/ella/routers/mcp_onboarding.py backend/ella/__init__.py backend/ella/routers/plato_mcp.py` -> passed

## Notes
- The durable grant loader is generic and expects `mcp_identity_grants` records keyed by `provider_subject` and/or verified `email_norm`.
- Existing static-token connector behavior remains available for dev/test while Google OAuth token verification and grant provisioning are wired in a follow-up.