### PR TITLE
[codex] Add MCP startup context packet

### DIFF
--- a/backend/ella/routers/mcp_onboarding.py
+++ b/backend/ella/routers/mcp_onboarding.py
@@ -13,6 +13,7 @@ from ella.services.mcp_identity import (
     MCPProfileGrant,
     resolve_mcp_identity,
 )
+from ella.services.mcp_startup import build_startup_context
 
 router = APIRouter(prefix="/v1/ella/mcp", tags=["Ella MCP Onboarding"])
 
@@ -112,10 +113,24 @@ async def get_mcp_onboarding(
     return resolve_static_connector_session(token_fingerprint, selected_profile_uid)
 
 
+@router.get("/start_here")
+async def get_mcp_start_here(
+    authorization: Optional[str] = Header(None, alias="Authorization"),
+    selected_profile_uid: str = Query("", description="Optional profile UID selected after multi-profile mapping."),
+    limit: int = Query(12, ge=1, le=50),
+    channels: str = Query("", description="Optional comma-separated canonical channels."),
+):
+    token_fingerprint = _authenticate_static(authorization)
+    onboarding = resolve_static_connector_session(token_fingerprint, selected_profile_uid)
+    channel_list = [item.strip() for item in channels.split(",") if item.strip()] if channels else None
+    return await build_startup_context(onboarding=onboarding, limit=limit, channels=channel_list)
+
+
 @router.get("/info")
 async def get_mcp_onboarding_info():
     return {
         "onboarding_endpoint": "/v1/ella/mcp/onboarding",
+        "start_here_endpoint": "/v1/ella/mcp/start_here",
         "auth": "Bearer token for dev/static fallback; OAuth-backed grants are resolved by the same identity service.",
         "states": [
             "authenticated_mapped",

--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -30,6 +30,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 import database.conversations as conversations_db
 import database.memories as memories_db
+from ella.services.mcp_startup import build_startup_context
 
 logger = logging.getLogger("ella.plato_mcp")
 
@@ -460,7 +461,48 @@ async def _consult_plato(arguments: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+async def _companion_start_here(arguments: dict[str, Any]) -> dict[str, Any]:
+    channels = arguments.get("channels") or []
+    if channels and not isinstance(channels, list):
+        raise ToolExecutionError("channels must be a list", code=-32602)
+    onboarding = {
+        "state": "authenticated_mapped",
+        "trace_id": str(uuid.uuid4()),
+        "selected_profile": {
+            "profile_uid": _plato_uid(),
+            "role": "self",
+            "profile_label": _env("ELLA_MCP_DEFAULT_PROFILE_LABEL", "Plato"),
+            "scopes": ["context:read", "memory:read", "profile:read", "startup:read", "timeline:read", "tools:read"],
+            "allowed_tools": ["companion_start_here", "plato_recent_context", "plato_search_memory", "plato_consult"],
+        },
+        "available_profiles": [],
+        "session_claims": {
+            "profile_uid": _plato_uid(),
+            "role": "self",
+            "scopes": ["context:read", "memory:read", "profile:read", "startup:read", "timeline:read", "tools:read"],
+            "allowed_tools": ["companion_start_here", "plato_recent_context", "plato_search_memory", "plato_consult"],
+            "grant_id": "legacy-plato-mcp",
+        },
+    }
+    return await build_startup_context(
+        onboarding=onboarding,
+        limit=_clamp_int(arguments.get("limit"), 12, 1, MAX_CONTEXT_LIMIT),
+        channels=[str(channel).strip() for channel in channels if str(channel).strip()],
+    )
+
+
 MCP_TOOLS: list[dict[str, Any]] = [
+    {
+        "name": "companion_start_here",
+        "description": "Return the safe startup context packet for this authenticated companion profile.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "default": 12, "minimum": 1, "maximum": MAX_CONTEXT_LIMIT},
+                "channels": {"type": "array", "items": {"type": "string"}, "default": []},
+            },
+        },
+    },
     {
         "name": "plato_recent_context",
         "description": "Read recent Plato timeline context from canonical events, with OMI Firestore fallback.",
@@ -525,6 +567,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
 ]
 
 _TOOL_HANDLERS = {
+    "companion_start_here": _companion_start_here,
     "plato_recent_context": _recent_context,
     "plato_search_memory": _search_memory,
     "plato_latest_omi": _latest_omi,

--- a/backend/ella/services/mcp_startup.py
+++ b/backend/ella/services/mcp_startup.py
@@ -1,0 +1,184 @@
+"""Startup context packet for external Ella MCP clients."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Any
+
+from utils.ella.canonical_context import DEFAULT_CONTEXT_CHANNELS, fetch_canonical_timeline, format_canonical_context
+
+DEFAULT_STARTUP_LIMIT = 12
+MAX_STARTUP_LIMIT = 50
+
+READ_ONLY_TOOL_CATALOG = [
+    {
+        "name": "companion_start_here",
+        "status": "available",
+        "scope": "startup:read",
+        "description": "Return the safe startup packet for the authenticated profile.",
+    },
+    {
+        "name": "companion_recent_context",
+        "status": "planned",
+        "scope": "timeline:read",
+        "description": "Read recent canonical timeline events through the generic MCP surface.",
+    },
+    {
+        "name": "companion_search_memory",
+        "status": "planned",
+        "scope": "memory:read",
+        "description": "Search canonical timeline and memory representations.",
+    },
+]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _event_time(event: dict[str, Any]) -> str:
+    return str(event.get("started_at") or event.get("created_at") or event.get("timestamp") or "")
+
+
+def _event_title(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+    structured = metadata.get("structured") if isinstance(metadata.get("structured"), dict) else {}
+    return str(event.get("title") or structured.get("title") or event.get("channel") or "event")
+
+
+def _event_text(event: dict[str, Any], limit: int = 500) -> str:
+    text = str(event.get("text") or event.get("overview") or event.get("summary") or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "..."
+
+
+def _compact_event(event: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "event_id": event.get("event_id") or event.get("id"),
+        "channel": event.get("channel"),
+        "provider": event.get("provider"),
+        "role": event.get("role"),
+        "started_at": _event_time(event),
+        "title": _event_title(event),
+        "text": _event_text(event),
+        "source_identity": event.get("source_identity"),
+        "source_ref": event.get("source_ref") if isinstance(event.get("source_ref"), dict) else {},
+    }
+
+
+def _latest_by_channel(events: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    latest: dict[str, dict[str, Any]] = {}
+    for event in events:
+        channel = str(event.get("channel") or "unknown")
+        current = latest.get(channel)
+        if current is None or _event_time(event) > str(current.get("started_at") or ""):
+            latest[channel] = _compact_event(event)
+    return latest
+
+
+def _clamp_limit(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = DEFAULT_STARTUP_LIMIT
+    return max(1, min(parsed, MAX_STARTUP_LIMIT))
+
+
+def _allowed_tool_names(session_claims: dict[str, Any]) -> set[str]:
+    return {str(tool) for tool in session_claims.get("allowed_tools") or [] if str(tool)}
+
+
+def _startup_tools(session_claims: dict[str, Any]) -> list[dict[str, Any]]:
+    allowed = _allowed_tool_names(session_claims)
+    if not allowed:
+        return READ_ONLY_TOOL_CATALOG
+    return [
+        {**tool, "status": tool["status"] if tool["name"] in allowed else "hidden"}
+        for tool in READ_ONLY_TOOL_CATALOG
+        if tool["name"] in allowed or tool["status"] == "available"
+    ]
+
+
+async def build_startup_context(
+    *,
+    onboarding: dict[str, Any],
+    limit: int = DEFAULT_STARTUP_LIMIT,
+    channels: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a profile-neutral read-only startup packet.
+
+    The caller supplies the already-authenticated onboarding resolution from
+    `ella.services.mcp_identity`. Unmapped identities receive the onboarding
+    state only, so we never leak profile context before account-role mapping.
+    """
+    state = str(onboarding.get("state") or "")
+    selected_profile = (
+        onboarding.get("selected_profile") if isinstance(onboarding.get("selected_profile"), dict) else None
+    )
+    session_claims = onboarding.get("session_claims") if isinstance(onboarding.get("session_claims"), dict) else {}
+    if state != "authenticated_mapped" or not selected_profile:
+        return {
+            "schema_version": "ella.mcp.start_here.v1",
+            "generated_at": _utc_now(),
+            "onboarding": onboarding,
+            "startup_ready": False,
+            "reason": "identity_not_mapped",
+            "writeback_policy": _writeback_policy(session_claims),
+        }
+
+    uid = str(selected_profile.get("profile_uid") or session_claims.get("profile_uid") or "")
+    requested_channels = channels or DEFAULT_CONTEXT_CHANNELS
+    effective_limit = _clamp_limit(limit)
+    events = await fetch_canonical_timeline(uid, limit=effective_limit, channels=requested_channels)
+    compact_events = [_compact_event(event) for event in events]
+    channel_counts = Counter(str(event.get("channel") or "unknown") for event in events)
+    return {
+        "schema_version": "ella.mcp.start_here.v1",
+        "generated_at": _utc_now(),
+        "startup_ready": True,
+        "onboarding": {
+            "state": state,
+            "trace_id": onboarding.get("trace_id"),
+            "selected_profile": selected_profile,
+            "available_profiles": onboarding.get("available_profiles") or [],
+        },
+        "account": {
+            "profile_uid": uid,
+            "role": session_claims.get("role") or selected_profile.get("role"),
+            "grant_id": session_claims.get("grant_id"),
+            "scopes": session_claims.get("scopes") or [],
+        },
+        "memory": {
+            "source": "canonical_timeline",
+            "channels_requested": requested_channels,
+            "event_count": len(compact_events),
+            "channel_counts": dict(channel_counts),
+            "latest_by_channel": _latest_by_channel(events),
+            "recent_events": compact_events,
+            "summary": format_canonical_context(events, max_chars=5000),
+        },
+        "tools": {
+            "read_only": True,
+            "available": _startup_tools(session_claims),
+        },
+        "writeback_policy": _writeback_policy(session_claims),
+        "escalation_boundaries": {
+            "caregiver_delivery": "not_available_from_mcp",
+            "emergency_actions": "not_available_from_mcp",
+            "scanner_rule_changes": "proposal_only_future_scope",
+            "direct_memory_mutation": "disabled",
+        },
+    }
+
+
+def _writeback_policy(session_claims: dict[str, Any]) -> dict[str, Any]:
+    scopes = set(session_claims.get("scopes") or [])
+    return {
+        "mode": "read_only",
+        "proposal_tools_visible": "proposals:read" in scopes or "proposals:write" in scopes,
+        "direct_write_enabled": False,
+        "proposal_write_enabled": False,
+        "blocked_until": ["ella-ai#859 role-scoped proposal tools"],
+    }

--- a/backend/tests/unit/test_ella_mcp_onboarding.py
+++ b/backend/tests/unit/test_ella_mcp_onboarding.py
@@ -59,3 +59,70 @@ def test_mcp_onboarding_without_default_profile_returns_invite_state(monkeypatch
     assert payload["state"] == "authenticated_needs_invite"
     assert payload["selected_profile"] is None
     assert "session_claims" not in payload
+
+
+def test_mcp_start_here_returns_canonical_startup_packet(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    async def fake_timeline(uid, *, limit, channels, since=None, before=None, timeout=None):
+        assert uid == "user-1"
+        assert limit == 2
+        assert channels == ["omi", "ios_chat"]
+        return [
+            {
+                "event_id": "evt-omi",
+                "channel": "omi",
+                "provider": "omi",
+                "role": "user",
+                "started_at": "2026-05-07T18:00:00Z",
+                "title": "Cafe stop",
+                "text": "Plato ordered a waffle and coffee.",
+                "source_identity": "omi:evt-omi",
+            },
+            {
+                "event_id": "evt-chat",
+                "channel": "ios_chat",
+                "provider": "hermes",
+                "role": "assistant",
+                "started_at": "2026-05-07T19:00:00Z",
+                "title": "Chat",
+                "text": "The assistant remembered the cafe stop.",
+                "source_identity": "chat:evt-chat",
+            },
+        ]
+
+    startup = importlib.import_module("ella.services.mcp_startup")
+    monkeypatch.setattr(startup, "fetch_canonical_timeline", fake_timeline)
+
+    response = client.get(
+        "/v1/ella/mcp/start_here?limit=2&channels=omi,ios_chat",
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["schema_version"] == "ella.mcp.start_here.v1"
+    assert payload["startup_ready"] is True
+    assert payload["account"]["profile_uid"] == "user-1"
+    assert payload["memory"]["source"] == "canonical_timeline"
+    assert payload["memory"]["channel_counts"] == {"omi": 1, "ios_chat": 1}
+    assert payload["memory"]["latest_by_channel"]["omi"]["title"] == "Cafe stop"
+    assert payload["writeback_policy"]["mode"] == "read_only"
+    assert payload["escalation_boundaries"]["emergency_actions"] == "not_available_from_mcp"
+
+
+def test_mcp_start_here_does_not_leak_context_when_unmapped(monkeypatch):
+    module = _load_module(monkeypatch)
+    monkeypatch.delenv("ELLA_MCP_DEFAULT_PROFILE_UID", raising=False)
+    monkeypatch.delenv("ELLA_PLATO_MCP_UID", raising=False)
+    monkeypatch.delenv("ELLA_PLATO_UID", raising=False)
+    client = _client(module)
+
+    response = client.get("/v1/ella/mcp/start_here", headers={"Authorization": "Bearer test-token"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["startup_ready"] is False
+    assert payload["reason"] == "identity_not_mapped"
+    assert "memory" not in payload

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -78,6 +78,7 @@ def test_plato_mcp_lists_only_read_only_tools(monkeypatch):
     assert response.status_code == 200
     tool_names = {tool["name"] for tool in response.json()["result"]["tools"]}
     assert tool_names == {
+        "companion_start_here",
         "plato_recent_context",
         "plato_search_memory",
         "plato_latest_omi",
@@ -106,6 +107,42 @@ def test_streamable_http_prefers_json_when_client_accepts_json_and_sse(monkeypat
     assert response.headers["content-type"].startswith("application/json")
     tool_names = {tool["name"] for tool in response.json()["result"]["tools"]}
     assert "plato_consult" in tool_names
+    assert "companion_start_here" in tool_names
+
+
+def test_companion_start_here_tool_returns_generic_startup_packet(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    async def fake_startup_context(*, onboarding, limit, channels):
+        assert onboarding["state"] == "authenticated_mapped"
+        assert onboarding["selected_profile"]["profile_uid"] == module._plato_uid()
+        assert limit == 4
+        assert channels == ["omi"]
+        return {
+            "schema_version": "ella.mcp.start_here.v1",
+            "startup_ready": True,
+            "account": {"profile_uid": module._plato_uid(), "role": "self"},
+            "memory": {"source": "canonical_timeline", "event_count": 1},
+            "writeback_policy": {"mode": "read_only"},
+        }
+
+    monkeypatch.setattr(module, "build_startup_context", fake_startup_context)
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc(
+            "tools/call",
+            params={"name": "companion_start_here", "arguments": {"limit": 4, "channels": ["omi"]}},
+        ),
+    )
+
+    assert response.status_code == 200
+    result = _tool_result(response)
+    assert result["schema_version"] == "ella.mcp.start_here.v1"
+    assert result["startup_ready"] is True
+    assert result["account"]["role"] == "self"
 
 
 def test_plato_recent_context_uses_canonical_timeline(monkeypatch):


### PR DESCRIPTION
## Summary
- adds a generic `ella.services.mcp_startup` startup packet builder for external MCP clients
- exposes `GET /v1/ella/mcp/start_here` on the neutral MCP onboarding router
- adds `companion_start_here` to the existing Plato MCP surface for backward-compatible Grok/client testing
- keeps startup context read-only and marks writeback as disabled/proposal-future until #859 lands

## Contract
- schema: `ella.mcp.start_here.v1`
- source of memory context: canonical timeline via `/v1/ella/timeline`
- unmapped identities return onboarding state only and do not leak memory context
- escalation/caregiver/emergency actions are explicitly unavailable through this MCP startup tool

## Validation
- `python3 -m pytest backend/tests/unit/test_ella_mcp_identity.py backend/tests/unit/test_ella_mcp_onboarding.py backend/tests/unit/test_ella_plato_mcp.py -q` -> 26 passed
- `python3 -m pytest backend/tests/unit/test_ella_mcp_identity.py backend/tests/unit/test_ella_mcp_onboarding.py backend/tests/unit/test_ella_plato_mcp.py backend/tests/unit/test_ella_canonical_context.py -q` -> 31 passed
- `python3 -m compileall -q backend/ella/services/mcp_startup.py backend/ella/routers/mcp_onboarding.py backend/ella/routers/plato_mcp.py` -> passed

Related: ellaaicare/ella-ai#858, depends on merged ellaaicare/omi#170 and feeds ellaaicare/ella-ai#859.