### PR TITLE
[codex] Add Firebase MCP grant onboarding

### DIFF
--- a/backend/ella/routers/mcp_onboarding.py
+++ b/backend/ella/routers/mcp_onboarding.py
@@ -7,6 +7,7 @@ import os
 from typing import Any, Optional
 
 from fastapi import APIRouter, Header, HTTPException, Query
+from pydantic import BaseModel, Field
 
 from ella.services.mcp_identity import (
     ExternalConnectorIdentity,
@@ -16,6 +17,12 @@ from ella.services.mcp_identity import (
 from ella.services.mcp_startup import build_startup_context
 
 router = APIRouter(prefix="/v1/ella/mcp", tags=["Ella MCP Onboarding"])
+
+
+class MCPOAuthOnboardingRequest(BaseModel):
+    firebase_id_token: str = Field(..., min_length=1)
+    selected_profile_uid: str = ""
+    ttl_seconds: int = Field(default=3600, ge=60, le=24 * 60 * 60)
 
 
 def _env(name: str, default: str = "") -> str:
@@ -94,6 +101,37 @@ def _static_identity(token_fingerprint: str) -> ExternalConnectorIdentity:
     )
 
 
+def _identity_from_firebase_claims(decoded: dict[str, Any]) -> ExternalConnectorIdentity:
+    firebase_info = decoded.get("firebase") if isinstance(decoded.get("firebase"), dict) else {}
+    identities = firebase_info.get("identities") if isinstance(firebase_info.get("identities"), dict) else {}
+    google_subjects = identities.get("google.com") if isinstance(identities.get("google.com"), list) else []
+    google_subject = str(google_subjects[0]).strip() if google_subjects else ""
+    firebase_uid = str(decoded.get("uid") or decoded.get("user_id") or decoded.get("sub") or "").strip()
+    provider = "google" if google_subject or firebase_info.get("sign_in_provider") == "google.com" else "firebase"
+    subject = google_subject or firebase_uid
+    return ExternalConnectorIdentity(
+        provider=provider,
+        subject=subject,
+        email=str(decoded.get("email") or "").strip().lower(),
+        email_verified=bool(decoded.get("email_verified")),
+        authenticated=bool(subject),
+        display_name=str(decoded.get("name") or "").strip(),
+    )
+
+
+def _verify_firebase_identity(firebase_id_token: str) -> ExternalConnectorIdentity:
+    try:
+        from firebase_admin import auth as firebase_auth
+
+        decoded = firebase_auth.verify_id_token(firebase_id_token)
+    except Exception as exc:
+        raise HTTPException(status_code=401, detail="Invalid Firebase ID token") from exc
+    identity = _identity_from_firebase_claims(decoded or {})
+    if not identity.authenticated:
+        raise HTTPException(status_code=401, detail="Firebase token did not contain a usable subject")
+    return identity
+
+
 def resolve_static_connector_session(token_fingerprint: str, selected_profile_uid: str = "") -> dict[str, Any]:
     identity = _static_identity(token_fingerprint)
     resolution = resolve_mcp_identity(
@@ -104,6 +142,17 @@ def resolve_static_connector_session(token_fingerprint: str, selected_profile_ui
     return resolution.to_public_dict(include_claims=True)
 
 
+def resolve_oauth_connector_session(
+    firebase_id_token: str,
+    *,
+    selected_profile_uid: str = "",
+    ttl_seconds: int = 3600,
+) -> dict[str, Any]:
+    identity = _verify_firebase_identity(firebase_id_token)
+    resolution = resolve_mcp_identity(identity, selected_profile_uid=selected_profile_uid)
+    return resolution.to_public_dict(include_claims=True, ttl_seconds=ttl_seconds)
+
+
 @router.get("/onboarding")
 async def get_mcp_onboarding(
     authorization: Optional[str] = Header(None, alias="Authorization"),
@@ -111,6 +160,15 @@ async def get_mcp_onboarding(
 ):
     token_fingerprint = _authenticate_static(authorization)
     return resolve_static_connector_session(token_fingerprint, selected_profile_uid)
+
+
+@router.post("/onboarding/oauth")
+async def post_mcp_oauth_onboarding(request: MCPOAuthOnboardingRequest):
+    return resolve_oauth_connector_session(
+        request.firebase_id_token,
+        selected_profile_uid=request.selected_profile_uid,
+        ttl_seconds=request.ttl_seconds,
+    )
 
 
 @router.get("/start_here")
@@ -130,8 +188,9 @@ async def get_mcp_start_here(
 async def get_mcp_onboarding_info():
     return {
         "onboarding_endpoint": "/v1/ella/mcp/onboarding",
+        "oauth_onboarding_endpoint": "/v1/ella/mcp/onboarding/oauth",
         "start_here_endpoint": "/v1/ella/mcp/start_here",
-        "auth": "Bearer token for dev/static fallback; OAuth-backed grants are resolved by the same identity service.",
+        "auth": "POST Firebase ID token to OAuth onboarding for production; Bearer token remains dev/static fallback.",
         "states": [
             "authenticated_mapped",
             "authenticated_needs_profile_selection",

--- a/backend/ella/services/mcp_identity.py
+++ b/backend/ella/services/mcp_identity.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 
 import logging
 import os
+import hashlib
 import time
 import uuid
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any, Iterable, Optional
 
 logger = logging.getLogger("ella.mcp_identity")
@@ -223,6 +225,106 @@ def load_identity_grants(identity: ExternalConnectorIdentity) -> list[MCPProfile
         return []
 
     return [grant for row in rows.values() if (grant := MCPProfileGrant.from_mapping(row)).active]
+
+
+def _grant_document_id(identity: ExternalConnectorIdentity, profile_uid: str, role: str) -> str:
+    seed = f"{identity.provider_subject}:{profile_uid}:{_normalized_role(role)}"
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:32]
+
+
+def grant_to_firestore_data(
+    *,
+    identity: ExternalConnectorIdentity,
+    profile_uid: str,
+    role: str = ROLE_SELF,
+    profile_label: str = "",
+    scopes: Optional[list[str]] = None,
+    allowed_tools: Optional[list[str]] = None,
+    status: str = "active",
+    grant_id: str = "",
+    created_by: str = "",
+) -> dict[str, Any]:
+    """Build the durable grant record stored in `mcp_identity_grants`.
+
+    Proposal/write scopes are intentionally filtered out by `MCPProfileGrant`.
+    A later writeback PR must explicitly add role-scoped proposal permissions.
+    """
+    normalized_role = _normalized_role(role)
+    grant = MCPProfileGrant.from_mapping(
+        {
+            "grant_id": grant_id or _grant_document_id(identity, profile_uid, normalized_role),
+            "profile_uid": profile_uid,
+            "role": normalized_role,
+            "profile_label": profile_label,
+            "scopes": scopes or [],
+            "allowed_tools": allowed_tools or [],
+            "status": status,
+        }
+    )
+    if not identity.authenticated or not identity.provider_subject:
+        raise ValueError("authenticated external identity with provider and subject is required")
+    if not grant.active:
+        raise ValueError("active profile_uid is required")
+
+    now = datetime.now(timezone.utc)
+    data = {
+        "grant_id": grant.grant_id,
+        "provider": identity.provider,
+        "subject": identity.subject,
+        "provider_subject": identity.provider_subject,
+        "email_norm": identity.email if identity.email_verified else "",
+        "email_verified": identity.email_verified,
+        "display_name": identity.display_name,
+        "profile_uid": grant.profile_uid,
+        "profile_label": grant.profile_label,
+        "role": grant.role,
+        "scopes": grant.scopes,
+        "allowed_tools": grant.allowed_tools,
+        "status": status,
+        "created_by": created_by,
+        "updated_at": now,
+    }
+    return data
+
+
+def provision_identity_grant(
+    *,
+    identity: ExternalConnectorIdentity,
+    profile_uid: str,
+    role: str = ROLE_SELF,
+    profile_label: str = "",
+    scopes: Optional[list[str]] = None,
+    allowed_tools: Optional[list[str]] = None,
+    status: str = "active",
+    grant_id: str = "",
+    created_by: str = "",
+) -> MCPProfileGrant:
+    """Create or update a durable MCP identity grant.
+
+    This is a backend/admin helper, not an external MCP tool. It only writes
+    grant metadata and does not enable proposal writeback, delivery, scanner,
+    or memory mutation.
+    """
+    data = grant_to_firestore_data(
+        identity=identity,
+        profile_uid=profile_uid,
+        role=role,
+        profile_label=profile_label,
+        scopes=scopes,
+        allowed_tools=allowed_tools,
+        status=status,
+        grant_id=grant_id,
+        created_by=created_by,
+    )
+    collection_name = os.getenv("ELLA_MCP_IDENTITY_GRANTS_COLLECTION", "mcp_identity_grants")
+    from database._client import db
+
+    ref = db.collection(collection_name).document(data["grant_id"])
+    snapshot = ref.get()
+    if not getattr(snapshot, "exists", False):
+        data["created_at"] = data["updated_at"]
+    ref.set(data, merge=True)
+    return MCPProfileGrant.from_mapping(data)
 
 
 def resolve_mcp_identity(

--- a/backend/tests/unit/test_ella_mcp_identity.py
+++ b/backend/tests/unit/test_ella_mcp_identity.py
@@ -1,4 +1,6 @@
 import pytest
+import sys
+import types
 
 from ella.services.mcp_identity import (
     ExternalConnectorIdentity,
@@ -8,6 +10,8 @@ from ella.services.mcp_identity import (
     STATE_AUTHENTICATED_NEEDS_PROFILE_SELECTION,
     STATE_UNAUTHENTICATED,
     build_session_claims,
+    grant_to_firestore_data,
+    provision_identity_grant,
     resolve_mcp_identity,
 )
 
@@ -112,3 +116,70 @@ def test_cannot_build_claims_for_unmapped_identity():
 
     with pytest.raises(ValueError):
         build_session_claims(resolution)
+
+
+def test_grant_to_firestore_data_filters_write_scopes():
+    data = grant_to_firestore_data(
+        identity=_identity(),
+        profile_uid="user-1",
+        role="self",
+        scopes=["context:read", "proposals:write", "rules:propose"],
+        allowed_tools=["companion_start_here", "companion_submit_note"],
+        profile_label="Test User",
+        created_by="unit-test",
+    )
+
+    assert data["provider_subject"] == "google:google-sub-1"
+    assert data["email_norm"] == "person@example.com"
+    assert data["profile_uid"] == "user-1"
+    assert data["role"] == "self"
+    assert data["scopes"] == ["context:read"]
+    assert "proposals:write" not in data["scopes"]
+    assert data["allowed_tools"] == ["companion_start_here", "companion_submit_note"]
+    assert data["created_by"] == "unit-test"
+
+
+def test_provision_identity_grant_writes_durable_record(monkeypatch):
+    writes = {}
+
+    class FakeSnapshot:
+        exists = False
+
+    class FakeDocument:
+        def __init__(self, doc_id):
+            self.doc_id = doc_id
+
+        def get(self):
+            return FakeSnapshot()
+
+        def set(self, data, merge=False):
+            writes[self.doc_id] = {"data": data, "merge": merge}
+
+    class FakeCollection:
+        def document(self, doc_id):
+            return FakeDocument(doc_id)
+
+    class FakeDb:
+        def collection(self, name):
+            assert name == "mcp_identity_grants"
+            return FakeCollection()
+
+    fake_client = types.ModuleType("database._client")
+    fake_client.db = FakeDb()
+    monkeypatch.setitem(sys.modules, "database._client", fake_client)
+
+    grant = provision_identity_grant(
+        identity=_identity(),
+        profile_uid="user-1",
+        role="self",
+        scopes=["startup:read", "proposals:write"],
+        allowed_tools=["companion_start_here"],
+    )
+
+    assert grant.profile_uid == "user-1"
+    assert grant.scopes == ["startup:read"]
+    assert len(writes) == 1
+    write = next(iter(writes.values()))
+    assert write["merge"] is True
+    assert write["data"]["provider_subject"] == "google:google-sub-1"
+    assert write["data"]["created_at"] == write["data"]["updated_at"]

--- a/backend/tests/unit/test_ella_mcp_onboarding.py
+++ b/backend/tests/unit/test_ella_mcp_onboarding.py
@@ -1,8 +1,11 @@
 import importlib
 import sys
+import types
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
+from ella.services.mcp_identity import MCPProfileGrant
 
 
 def _load_module(monkeypatch):
@@ -18,6 +21,45 @@ def _client(module):
     app = FastAPI()
     app.include_router(module.router)
     return TestClient(app)
+
+
+def _install_firebase_stub(monkeypatch, decoded=None, error=None):
+    firebase_admin = types.ModuleType("firebase_admin")
+    firebase_auth = types.ModuleType("firebase_admin.auth")
+
+    def verify_id_token(token):
+        if error:
+            raise error
+        assert token == "firebase-token"
+        return decoded or {
+            "uid": "firebase-uid",
+            "email": "person@example.com",
+            "email_verified": True,
+            "name": "Test Person",
+            "firebase": {
+                "sign_in_provider": "google.com",
+                "identities": {"google.com": ["google-sub-1"]},
+            },
+        }
+
+    firebase_auth.verify_id_token = verify_id_token
+    firebase_admin.auth = firebase_auth
+    monkeypatch.setitem(sys.modules, "firebase_admin", firebase_admin)
+    monkeypatch.setitem(sys.modules, "firebase_admin.auth", firebase_auth)
+
+
+def _grant(profile_uid="user-1", role="self"):
+    return MCPProfileGrant.from_mapping(
+        {
+            "grant_id": f"grant-{profile_uid}",
+            "profile_uid": profile_uid,
+            "role": role,
+            "profile_label": profile_uid,
+            "scopes": ["context:read", "startup:read", "proposals:write"],
+            "allowed_tools": ["companion_start_here", "companion_recent_context"],
+            "status": "active",
+        }
+    )
 
 
 def test_mcp_onboarding_rejects_missing_or_invalid_static_token(monkeypatch):
@@ -59,6 +101,93 @@ def test_mcp_onboarding_without_default_profile_returns_invite_state(monkeypatch
     assert payload["state"] == "authenticated_needs_invite"
     assert payload["selected_profile"] is None
     assert "session_claims" not in payload
+
+
+def test_oauth_onboarding_maps_verified_google_identity_to_grant(monkeypatch):
+    module = _load_module(monkeypatch)
+    _install_firebase_stub(monkeypatch)
+
+    service = importlib.import_module("ella.services.mcp_identity")
+
+    def fake_grants(identity):
+        assert identity.provider == "google"
+        assert identity.subject == "google-sub-1"
+        assert identity.email == "person@example.com"
+        assert identity.email_verified is True
+        return [_grant()]
+
+    monkeypatch.setattr(service, "load_identity_grants", fake_grants)
+    client = _client(module)
+
+    response = client.post(
+        "/v1/ella/mcp/onboarding/oauth",
+        json={"firebase_id_token": "firebase-token", "ttl_seconds": 600},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "authenticated_mapped"
+    assert payload["identity"]["provider"] == "google"
+    assert payload["selected_profile"]["profile_uid"] == "user-1"
+    claims = payload["session_claims"]
+    assert claims["sub"] == "google:google-sub-1"
+    assert claims["profile_uid"] == "user-1"
+    assert claims["role"] == "self"
+    assert "startup:read" in claims["scopes"]
+    assert "proposals:write" not in claims["scopes"]
+
+
+def test_oauth_onboarding_unknown_identity_needs_invite(monkeypatch):
+    module = _load_module(monkeypatch)
+    _install_firebase_stub(monkeypatch)
+    service = importlib.import_module("ella.services.mcp_identity")
+    monkeypatch.setattr(service, "load_identity_grants", lambda _identity: [])
+    client = _client(module)
+
+    response = client.post("/v1/ella/mcp/onboarding/oauth", json={"firebase_id_token": "firebase-token"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "authenticated_needs_invite"
+    assert payload["selected_profile"] is None
+    assert "session_claims" not in payload
+
+
+def test_oauth_onboarding_requires_profile_selection_for_multiple_grants(monkeypatch):
+    module = _load_module(monkeypatch)
+    _install_firebase_stub(monkeypatch)
+    service = importlib.import_module("ella.services.mcp_identity")
+    monkeypatch.setattr(service, "load_identity_grants", lambda _identity: [_grant("user-1"), _grant("mom-1", "caregiver")])
+    client = _client(module)
+
+    response = client.post("/v1/ella/mcp/onboarding/oauth", json={"firebase_id_token": "firebase-token"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "authenticated_needs_profile_selection"
+    assert "session_claims" not in payload
+    assert [item["profile_uid"] for item in payload["available_profiles"]] == ["user-1", "mom-1"]
+
+    selected = client.post(
+        "/v1/ella/mcp/onboarding/oauth",
+        json={"firebase_id_token": "firebase-token", "selected_profile_uid": "mom-1"},
+    )
+
+    assert selected.status_code == 200
+    selected_payload = selected.json()
+    assert selected_payload["state"] == "authenticated_mapped"
+    assert selected_payload["session_claims"]["profile_uid"] == "mom-1"
+    assert selected_payload["session_claims"]["role"] == "caregiver"
+
+
+def test_oauth_onboarding_rejects_invalid_firebase_token(monkeypatch):
+    module = _load_module(monkeypatch)
+    _install_firebase_stub(monkeypatch, error=ValueError("bad token"))
+    client = _client(module)
+
+    response = client.post("/v1/ella/mcp/onboarding/oauth", json={"firebase_id_token": "firebase-token"})
+
+    assert response.status_code == 401
 
 
 def test_mcp_start_here_returns_canonical_startup_packet(monkeypatch):


### PR DESCRIPTION
## Summary
- adds production-safe Firebase/Google identity resolution for generic MCP onboarding
- adds `POST /v1/ella/mcp/onboarding/oauth` to verify a Firebase ID token, lookup durable `mcp_identity_grants`, and return mapped onboarding state plus scoped claims
- adds durable grant provisioning helpers for backend/admin use, keyed by provider subject/email and profile role
- preserves static bearer onboarding fallback for current dev/test connector
- keeps proposal write scopes filtered from session claims; no write tools are enabled

## Safety
- no Guardian/caregiver delivery changes
- no scanner mutation
- no memory/proposal write tool exposure
- unknown OAuth users receive `authenticated_needs_invite`
- multi-profile grants require explicit selected profile before claims are issued

## Validation
- `python3 -m pytest backend/tests/unit/test_ella_mcp_identity.py backend/tests/unit/test_ella_mcp_onboarding.py backend/tests/unit/test_ella_mcp_proposals.py backend/tests/unit/test_ella_plato_mcp.py backend/tests/unit/test_ella_canonical_context.py -q` -> 44 passed
- `python3 -m compileall -q backend/ella/services/mcp_identity.py backend/ella/routers/mcp_onboarding.py` -> passed

## Remaining for full OAuth connector UX
- wire the external connector OAuth authorize/token UX to call this resolver and mint the final MCP bearer/session token
- provision real `mcp_identity_grants` records for approved Google identities
- keep proposal write grants disabled until #859 explicitly enables role-scoped proposal tools