### PR TITLE
[codex] Add user-local time context to MCP timeline

### DIFF
--- a/backend/ella/routers/canonical_events.py
+++ b/backend/ella/routers/canonical_events.py
@@ -16,6 +16,7 @@ from typing import Any, Optional
 import asyncpg
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
+from utils.ella.time_context import annotate_event_time, build_time_context
 
 logger = logging.getLogger("ella.canonical_events")
 
@@ -440,6 +441,7 @@ class InMemoryCanonicalEventStore(CanonicalEventStore):
             if channel_set and event["channel"] not in channel_set:
                 continue
             events.append(event)
+
         def role_order(item: dict[str, Any]) -> int:
             if item["role"] == "user":
                 return 0
@@ -473,24 +475,26 @@ def _row_to_event(row: Any) -> dict[str, Any]:
             return raw.astimezone(timezone.utc).isoformat()
         return str(raw)
 
-    return {
-        "uid": value("uid"),
-        "canonical_identity": value("canonical_identity"),
-        "event_id": value("event_id"),
-        "source_identity": value("source_identity"),
-        "session_id": value("session_id"),
-        "channel": value("channel"),
-        "provider": value("provider"),
-        "role": value("role"),
-        "text": value("text"),
-        "started_at": iso("started_at"),
-        "ended_at": iso("ended_at"),
-        "privacy_scope": value("privacy_scope"),
-        "scan_policy": value("scan_policy"),
-        "source_ref": json_value("source_ref"),
-        "metadata": json_value("metadata"),
-        "raw_event": json_value("raw_event"),
-    }
+    return annotate_event_time(
+        {
+            "uid": value("uid"),
+            "canonical_identity": value("canonical_identity"),
+            "event_id": value("event_id"),
+            "source_identity": value("source_identity"),
+            "session_id": value("session_id"),
+            "channel": value("channel"),
+            "provider": value("provider"),
+            "role": value("role"),
+            "text": value("text"),
+            "started_at": iso("started_at"),
+            "ended_at": iso("ended_at"),
+            "privacy_scope": value("privacy_scope"),
+            "scan_policy": value("scan_policy"),
+            "source_ref": json_value("source_ref"),
+            "metadata": json_value("metadata"),
+            "raw_event": json_value("raw_event"),
+        }
+    )
 
 
 def _parse_channels(channels: Optional[str]) -> Optional[list[str]]:
@@ -534,6 +538,7 @@ def create_canonical_events_router(store: Optional[CanonicalEventStore] = None) 
         since: Optional[str] = None,
         limit: int = Query(default=DEFAULT_TIMELINE_LIMIT),
         channels: Optional[str] = None,
+        timezone: Optional[str] = Query(default=None, alias="timezone"),
     ):
         """
         Read a single chronological timeline across channels for one uid.
@@ -550,7 +555,9 @@ def create_canonical_events_router(store: Optional[CanonicalEventStore] = None) 
             limit=_sanitize_limit(limit),
             channels=_parse_channels(channels),
         )
-        return {"ok": True, "uid": uid, "events": events}
+        if timezone:
+            events = [annotate_event_time(event, tz_name=timezone) for event in events]
+        return {"ok": True, "uid": uid, "time_context": build_time_context(timezone), "events": events}
 
     return router
 

--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -32,6 +32,7 @@ import database.conversations as conversations_db
 import database.memories as memories_db
 from ella.services import proposal_ingest
 from ella.services.mcp_startup import build_startup_context
+from utils.ella.time_context import annotate_event_time, build_time_context, timezone_name
 
 logger = logging.getLogger("ella.plato_mcp")
 
@@ -83,6 +84,10 @@ def _plato_canonical_identity() -> str:
 
 def _plato_agent_id() -> str:
     return _env("ELLA_PLATO_AGENT_ID", f"ella-omi-{_plato_uid().lower()}")
+
+
+def _plato_timezone() -> str:
+    return timezone_name(_env("ELLA_PLATO_TIMEZONE", _env("ELLA_USER_TIMEZONE", "")))
 
 
 def _oauth_client_id() -> str:
@@ -213,30 +218,36 @@ def _conversation_to_event(conversation: dict[str, Any]) -> dict[str, Any]:
     structured = conversation.get("structured") or {}
     title = structured.get("title") or conversation.get("title") or "OMI conversation"
     overview = structured.get("overview") or conversation.get("overview") or ""
-    return {
-        "event_id": conversation.get("id"),
-        "channel": "omi",
-        "provider": "omi-backend",
-        "role": "user",
-        "started_at": _json_safe(conversation.get("started_at") or conversation.get("created_at")),
-        "ended_at": _json_safe(conversation.get("finished_at")),
-        "title": title,
-        "text": _compact_text(overview, 1600),
-        "source_ref": {"conversation_id": conversation.get("id")},
-    }
+    return annotate_event_time(
+        {
+            "event_id": conversation.get("id"),
+            "channel": "omi",
+            "provider": "omi-backend",
+            "role": "user",
+            "started_at": _json_safe(conversation.get("started_at") or conversation.get("created_at")),
+            "ended_at": _json_safe(conversation.get("finished_at")),
+            "title": title,
+            "text": _compact_text(overview, 1600),
+            "source_ref": {"conversation_id": conversation.get("id")},
+        },
+        tz_name=_plato_timezone(),
+    )
 
 
 def _memory_to_event(memory: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "event_id": memory.get("id"),
-        "channel": "memory",
-        "provider": "omi-backend",
-        "role": "memory",
-        "started_at": _json_safe(memory.get("created_at")),
-        "title": memory.get("category") or "memory",
-        "text": _compact_text(memory.get("content"), 1200),
-        "source_ref": {"memory_id": memory.get("id")},
-    }
+    return annotate_event_time(
+        {
+            "event_id": memory.get("id"),
+            "channel": "memory",
+            "provider": "omi-backend",
+            "role": "memory",
+            "started_at": _json_safe(memory.get("created_at")),
+            "title": memory.get("category") or "memory",
+            "text": _compact_text(memory.get("content"), 1200),
+            "source_ref": {"memory_id": memory.get("id")},
+        },
+        tz_name=_plato_timezone(),
+    )
 
 
 async def _fetch_canonical_timeline(limit: int, channels: list[str], since: Optional[str]) -> list[dict[str, Any]]:
@@ -246,13 +257,16 @@ async def _fetch_canonical_timeline(limit: int, channels: list[str], since: Opti
         params["channels"] = ",".join(channels)
     if since:
         params["since"] = since
+    params["timezone"] = _plato_timezone()
     async with httpx.AsyncClient(timeout=20.0) as client:
         response = await client.get(timeline_url, params=params)
     if response.status_code != 200:
         raise RuntimeError(f"timeline_http_{response.status_code}")
     payload = response.json()
     events = payload if isinstance(payload, list) else payload.get("events") or payload.get("timeline") or []
-    return [_json_safe(event) for event in events if isinstance(event, dict)]
+    return [
+        annotate_event_time(_json_safe(event), tz_name=_plato_timezone()) for event in events if isinstance(event, dict)
+    ]
 
 
 def _fallback_recent_context(limit: int, channels: list[str], since: Optional[str]) -> list[dict[str, Any]]:
@@ -312,6 +326,7 @@ async def _recent_context(arguments: dict[str, Any]) -> dict[str, Any]:
         "uid": _plato_uid(),
         "canonical_identity": _plato_canonical_identity(),
         "source": source,
+        "time_context": build_time_context(_plato_timezone()),
         "events": events[:limit],
     }
 
@@ -322,7 +337,12 @@ async def _latest_omi(arguments: dict[str, Any]) -> dict[str, Any]:
     )
     events = [event for event in context.get("events", []) if str(event.get("channel", "")).startswith("omi")]
     latest = events[0] if events else None
-    return {"latest": latest, "source": context.get("source"), "uid": _plato_uid()}
+    return {
+        "latest": latest,
+        "source": context.get("source"),
+        "uid": _plato_uid(),
+        "time_context": context.get("time_context") or build_time_context(_plato_timezone()),
+    }
 
 
 def _tokens(text: str) -> set[str]:
@@ -341,10 +361,14 @@ def _format_consult_context(context: dict[str, Any], limit: int) -> str:
     ]
     for event in (context.get("events") or [])[:limit]:
         timestamp = event.get("started_at") or event.get("created_at") or event.get("timestamp") or ""
+        local = event.get("started_at_local") or timestamp
+        relative = event.get("relative_to_now") or ""
         channel = event.get("channel") or ""
         title = event.get("title") or "Untitled"
         text = _compact_text(event.get("text") or event.get("overview") or event.get("summary") or "", 700)
-        lines.append(f"- {timestamp} [{channel}] {title}: {text}")
+        lines.append(
+            f"- {local} ({event.get('started_at_timezone') or _plato_timezone()}; UTC {timestamp}; {relative}) [{channel}] {title}: {text}"
+        )
     return _compact_text("\n".join(lines), MAX_CONSULT_CONTEXT_CHARS)
 
 
@@ -370,6 +394,7 @@ async def _search_memory(arguments: dict[str, Any]) -> dict[str, Any]:
     return {
         "query": query,
         "source": context.get("source"),
+        "time_context": context.get("time_context") or build_time_context(_plato_timezone()),
         "results": [item for _score, _idx, item in ranked[:max_results]],
     }
 

--- a/backend/ella/services/mcp_startup.py
+++ b/backend/ella/services/mcp_startup.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from utils.ella.canonical_context import DEFAULT_CONTEXT_CHANNELS, fetch_canonical_timeline, format_canonical_context
+from utils.ella.time_context import annotate_event_time, build_time_context, timezone_name
 
 DEFAULT_STARTUP_LIMIT = 12
 MAX_STARTUP_LIMIT = 50
@@ -67,6 +68,14 @@ def _compact_event(event: dict[str, Any]) -> dict[str, Any]:
         "provider": event.get("provider"),
         "role": event.get("role"),
         "started_at": _event_time(event),
+        "started_at_utc": event.get("started_at_utc") or _event_time(event),
+        "started_at_local": event.get("started_at_local"),
+        "started_at_local_date": event.get("started_at_local_date"),
+        "started_at_local_time": event.get("started_at_local_time"),
+        "started_at_timezone": event.get("started_at_timezone"),
+        "relative_to_now": event.get("relative_to_now"),
+        "seconds_from_now": event.get("seconds_from_now"),
+        "time": event.get("time") if isinstance(event.get("time"), dict) else {},
         "title": _event_title(event),
         "text": _event_text(event),
         "source_identity": event.get("source_identity"),
@@ -128,6 +137,7 @@ async def build_startup_context(
         return {
             "schema_version": "ella.mcp.start_here.v1",
             "generated_at": _utc_now(),
+            "time_context": build_time_context(),
             "onboarding": onboarding,
             "startup_ready": False,
             "reason": "identity_not_mapped",
@@ -135,14 +145,30 @@ async def build_startup_context(
         }
 
     uid = str(selected_profile.get("profile_uid") or session_claims.get("profile_uid") or "")
+    user_tz = timezone_name(
+        str(
+            selected_profile.get("timezone")
+            or selected_profile.get("time_zone")
+            or session_claims.get("timezone")
+            or session_claims.get("time_zone")
+            or ""
+        )
+    )
     requested_channels = channels or DEFAULT_CONTEXT_CHANNELS
     effective_limit = _clamp_limit(limit)
-    events = await fetch_canonical_timeline(uid, limit=effective_limit, channels=requested_channels)
+    events = await fetch_canonical_timeline(
+        uid,
+        limit=effective_limit,
+        channels=requested_channels,
+        user_timezone=user_tz,
+    )
+    events = [annotate_event_time(event, tz_name=user_tz) for event in events]
     compact_events = [_compact_event(event) for event in events]
     channel_counts = Counter(str(event.get("channel") or "unknown") for event in events)
     return {
         "schema_version": "ella.mcp.start_here.v1",
         "generated_at": _utc_now(),
+        "time_context": build_time_context(user_tz),
         "startup_ready": True,
         "onboarding": {
             "state": state,
@@ -163,7 +189,7 @@ async def build_startup_context(
             "channel_counts": dict(channel_counts),
             "latest_by_channel": _latest_by_channel(events),
             "recent_events": compact_events,
-            "summary": format_canonical_context(events, max_chars=5000),
+            "summary": format_canonical_context(events, max_chars=5000, user_timezone=user_tz),
         },
         "tools": {
             "read_only": True,

--- a/backend/tests/unit/test_ella_canonical_context.py
+++ b/backend/tests/unit/test_ella_canonical_context.py
@@ -29,9 +29,12 @@ def _cafe_event():
 
 
 def test_format_canonical_context_includes_latest_omi_summary():
-    context = format_canonical_context([_cafe_event()])
+    context = format_canonical_context([_cafe_event()], user_timezone="America/Los_Angeles")
 
     assert "Recent canonical timeline context" in context
+    assert "Current user-local time" in context
+    assert "America/Los_Angeles" in context
+    assert "2026-05-07T11:56:59" in context
     assert "Cafe Coffee and Waffle Stop" in context
     assert "waffle with oat" in context
 

--- a/backend/tests/unit/test_ella_mcp_onboarding.py
+++ b/backend/tests/unit/test_ella_mcp_onboarding.py
@@ -157,7 +157,9 @@ def test_oauth_onboarding_requires_profile_selection_for_multiple_grants(monkeyp
     module = _load_module(monkeypatch)
     _install_firebase_stub(monkeypatch)
     service = importlib.import_module("ella.services.mcp_identity")
-    monkeypatch.setattr(service, "load_identity_grants", lambda _identity: [_grant("user-1"), _grant("mom-1", "caregiver")])
+    monkeypatch.setattr(
+        service, "load_identity_grants", lambda _identity: [_grant("user-1"), _grant("mom-1", "caregiver")]
+    )
     client = _client(module)
 
     response = client.post("/v1/ella/mcp/onboarding/oauth", json={"firebase_id_token": "firebase-token"})
@@ -194,10 +196,11 @@ def test_mcp_start_here_returns_canonical_startup_packet(monkeypatch):
     module = _load_module(monkeypatch)
     client = _client(module)
 
-    async def fake_timeline(uid, *, limit, channels, since=None, before=None, timeout=None):
+    async def fake_timeline(uid, *, limit, channels, since=None, before=None, user_timezone=None, timeout=None):
         assert uid == "user-1"
         assert limit == 2
         assert channels == ["omi", "ios_chat"]
+        assert user_timezone == "America/Los_Angeles"
         return [
             {
                 "event_id": "evt-omi",
@@ -233,10 +236,13 @@ def test_mcp_start_here_returns_canonical_startup_packet(monkeypatch):
     payload = response.json()
     assert payload["schema_version"] == "ella.mcp.start_here.v1"
     assert payload["startup_ready"] is True
+    assert payload["time_context"]["user_timezone"] == "America/Los_Angeles"
     assert payload["account"]["profile_uid"] == "user-1"
     assert payload["memory"]["source"] == "canonical_timeline"
     assert payload["memory"]["channel_counts"] == {"omi": 1, "ios_chat": 1}
     assert payload["memory"]["latest_by_channel"]["omi"]["title"] == "Cafe stop"
+    assert payload["memory"]["latest_by_channel"]["omi"]["started_at_local"].startswith("2026-05-07T11:00:00")
+    assert "Current user-local time" in payload["memory"]["summary"]
     assert payload["writeback_policy"]["mode"] == "read_only"
     assert payload["escalation_boundaries"]["emergency_actions"] == "not_available_from_mcp"
 

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -17,11 +17,18 @@ def _install_stubs():
     memories = types.ModuleType("database.memories")
     memories.get_memories = MagicMock(return_value=[])
 
+    proposals = types.ModuleType("database.proposals")
+    proposals.get_proposal = MagicMock(return_value=None)
+    proposals.get_proposal_by_idempotency_key = MagicMock(return_value=None)
+    proposals.save_proposal = MagicMock(side_effect=lambda proposal: proposal)
+
     database = sys.modules.setdefault("database", types.ModuleType("database"))
     setattr(database, "conversations", conversations)
     setattr(database, "memories", memories)
+    setattr(database, "proposals", proposals)
     sys.modules["database.conversations"] = conversations
     sys.modules["database.memories"] = memories
+    sys.modules["database.proposals"] = proposals
 
 
 def _load_module(monkeypatch):

--- a/backend/utils/ella/canonical_context.py
+++ b/backend/utils/ella/canonical_context.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 import httpx
+from utils.ella.time_context import annotate_event_time, build_time_context, timezone_name
 
 DEFAULT_TIMELINE_URL = os.getenv("ELLA_CANONICAL_TIMELINE_URL", "http://127.0.0.1:8000/v1/ella/timeline")
 DEFAULT_TIMEOUT_SECONDS = float(os.getenv("ELLA_CANONICAL_TIMELINE_TIMEOUT", "5"))
@@ -66,6 +67,7 @@ async def fetch_canonical_timeline(
     channels: Optional[list[str]] = None,
     since: Optional[str] = None,
     before: Optional[str] = None,
+    user_timezone: Optional[str] = None,
     timeout: Optional[float] = None,
 ) -> list[dict[str, Any]]:
     """Read canonical timeline over HTTP per the unified memory contract."""
@@ -84,6 +86,8 @@ async def fetch_canonical_timeline(
         params["channels"] = ",".join(channel for channel in channels if channel)
     if since:
         params["since"] = since
+    if user_timezone:
+        params["timezone"] = user_timezone
 
     async with httpx.AsyncClient(timeout=timeout or DEFAULT_TIMEOUT_SECONDS) as client:
         response = await client.get(DEFAULT_TIMELINE_URL, params=params)
@@ -91,7 +95,7 @@ async def fetch_canonical_timeline(
 
     payload = response.json()
     events = payload if isinstance(payload, list) else payload.get("events") or payload.get("timeline") or []
-    normalized = [event for event in events if isinstance(event, dict)]
+    normalized = [annotate_event_time(event, tz_name=user_timezone) for event in events if isinstance(event, dict)]
     if before_dt:
         normalized = [
             event
@@ -101,19 +105,38 @@ async def fetch_canonical_timeline(
     return normalized[-effective_limit:]
 
 
-def format_canonical_context(events: list[dict[str, Any]], *, max_chars: int = 6000) -> str:
+def format_canonical_context(
+    events: list[dict[str, Any]],
+    *,
+    max_chars: int = 6000,
+    user_timezone: Optional[str] = None,
+) -> str:
     if not events:
         return ""
-    lines = ["Recent canonical timeline context, oldest to newest:"]
+    time_context = build_time_context(user_timezone)
+    tz_name = time_context["user_timezone"]
+    lines = [
+        "Recent canonical timeline context, oldest to newest.",
+        (
+            f"Current user-local time: {time_context['now_local']} "
+            f"({tz_name}); current UTC: {time_context['now_utc']}."
+        ),
+        "Each event includes user-local time first, then canonical UTC.",
+    ]
     for event in events:
+        if not event.get("started_at_local"):
+            event = annotate_event_time(event, tz_name=user_timezone)
         timestamp = _event_time(event)
+        local = event.get("started_at_local") or timestamp
+        relative = event.get("relative_to_now") or ""
         channel = str(event.get("channel") or "unknown")
         title = _event_title(event)
         text = _event_text(event)
+        prefix = f"- {local} ({tz_name}; UTC {timestamp}; {relative}) [{channel}] {title}"
         if text:
-            lines.append(f"- {timestamp} [{channel}] {title}: {text}")
+            lines.append(f"{prefix}: {text}")
         else:
-            lines.append(f"- {timestamp} [{channel}] {title}")
+            lines.append(prefix)
     context = "\n".join(lines)
     if len(context) <= max_chars:
         return context
@@ -155,4 +178,3 @@ def canonical_events_to_server_messages(events: list[dict[str, Any]], *, limit: 
             }
         )
     return messages
-

--- a/backend/utils/ella/time_context.py
+++ b/backend/utils/ella/time_context.py
@@ -1,0 +1,132 @@
+"""User-local time annotations for Ella timeline/context payloads."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+DEFAULT_USER_TIMEZONE = os.getenv("ELLA_DEFAULT_USER_TIMEZONE", "America/Los_Angeles")
+
+
+def user_timezone(tz_name: str | None = None) -> ZoneInfo:
+    name = (tz_name or DEFAULT_USER_TIMEZONE or "UTC").strip()
+    try:
+        return ZoneInfo(name)
+    except ZoneInfoNotFoundError:
+        return ZoneInfo("UTC")
+
+
+def timezone_name(tz_name: str | None = None) -> str:
+    return user_timezone(tz_name).key
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def parse_datetime(value: Any) -> datetime | None:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def iso_utc(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def relative_human(dt: datetime, now: datetime | None = None) -> str:
+    now_utc = (now or utc_now()).astimezone(timezone.utc)
+    delta_seconds = int((now_utc - dt.astimezone(timezone.utc)).total_seconds())
+    future = delta_seconds < 0
+    seconds = abs(delta_seconds)
+    if seconds < 90:
+        value = f"{seconds} seconds"
+    elif seconds < 90 * 60:
+        value = f"{round(seconds / 60)} minutes"
+    elif seconds < 36 * 3600:
+        value = f"{round(seconds / 3600, 1):g} hours"
+    else:
+        value = f"{round(seconds / 86400, 1):g} days"
+    return f"in {value}" if future else f"{value} ago"
+
+
+def local_time_fields(
+    value: Any,
+    *,
+    tz_name: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    dt = parse_datetime(value)
+    tz = user_timezone(tz_name)
+    if dt is None:
+        return {
+            "utc": None,
+            "timezone": tz.key,
+            "local": None,
+            "local_date": None,
+            "local_time": None,
+            "relative_to_now": None,
+            "seconds_from_now": None,
+        }
+    local = dt.astimezone(tz)
+    now_utc = (now or utc_now()).astimezone(timezone.utc)
+    return {
+        "utc": iso_utc(dt),
+        "timezone": tz.key,
+        "local": local.isoformat(),
+        "local_date": local.strftime("%Y-%m-%d"),
+        "local_time": local.strftime("%H:%M:%S %Z"),
+        "relative_to_now": relative_human(dt, now_utc),
+        "seconds_from_now": int((dt - now_utc).total_seconds()),
+    }
+
+
+def build_time_context(tz_name: str | None = None, *, now: datetime | None = None) -> dict[str, str]:
+    tz = user_timezone(tz_name)
+    now_utc = (now or utc_now()).astimezone(timezone.utc)
+    now_local = now_utc.astimezone(tz)
+    return {
+        "now_utc": iso_utc(now_utc),
+        "user_timezone": tz.key,
+        "now_local": now_local.isoformat(),
+        "now_local_date": now_local.strftime("%Y-%m-%d"),
+        "now_local_time": now_local.strftime("%H:%M:%S %Z"),
+    }
+
+
+def annotate_event_time(
+    event: dict[str, Any],
+    *,
+    tz_name: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    annotated = dict(event)
+    started_at = (
+        annotated.get("started_at")
+        or annotated.get("created_at")
+        or annotated.get("timestamp")
+        or annotated.get("finished_at")
+    )
+    fields = local_time_fields(started_at, tz_name=tz_name, now=now)
+    annotated["started_at_utc"] = fields["utc"]
+    annotated["started_at_local"] = fields["local"]
+    annotated["started_at_local_date"] = fields["local_date"]
+    annotated["started_at_local_time"] = fields["local_time"]
+    annotated["started_at_timezone"] = fields["timezone"]
+    annotated["relative_to_now"] = fields["relative_to_now"]
+    annotated["seconds_from_now"] = fields["seconds_from_now"]
+    annotated["time"] = fields
+    return annotated


### PR DESCRIPTION
## Summary
- Adds shared Ella time-context helpers that annotate timeline events with UTC, user-local time, timezone, and relative-to-now fields.
- Adds `time_context` to `/v1/ella/timeline`, MCP `companion_start_here`, Plato MCP recent/latest/search responses, and consult context formatting.
- Formats canonical context with user-local time first and canonical UTC second so external agents do not mistake fresh events for 7-8 hour old events.

## Safety
- Read-only/context payload change only.
- No Guardian, caregiver, scanner mutation, proposal writeback, auth scope, or memory mutation behavior changed.
- Defaults to `America/Los_Angeles`, overridable with `ELLA_DEFAULT_USER_TIMEZONE`, `ELLA_PLATO_TIMEZONE`, or request `timezone`.

## Validation
- `python3 -m pytest backend/tests/unit/test_ella_canonical_context.py backend/tests/unit/test_ella_mcp_onboarding.py backend/tests/unit/test_ella_plato_mcp.py -q` -> 29 passed
- `python3 -m compileall -q backend/utils/ella/time_context.py backend/utils/ella/canonical_context.py backend/ella/routers/canonical_events.py backend/ella/services/mcp_startup.py backend/ella/routers/plato_mcp.py` -> passed
