### PR TITLE
Add Companion MCP proposal tool

### DIFF
--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -51,6 +51,13 @@ MAX_PROMPT_CHARS = 4000
 MAX_CONSULT_CONTEXT_CHARS = 7000
 RATE_LIMIT_WINDOW_SECONDS = 60
 SALIENCE_RANKS = {"none": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
+COMPANION_PROPOSAL_TYPES = {
+    "scanner_rule_change",
+    "reminder_request",
+    "profile_update",
+    "memory_note",
+    "summary_correction",
+}
 
 _active_sessions: dict[str, "MCPSession"] = {}
 _rate_limits: dict[str, deque[float]] = defaultdict(deque)
@@ -74,6 +81,11 @@ class ToolExecutionError(Exception):
 
 def _env(name: str, default: str = "") -> str:
     return os.getenv(name, default).strip()
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = _env(name, "true" if default else "false").lower()
+    return raw in {"1", "true", "yes", "on"}
 
 
 def _plato_uid() -> str:
@@ -678,6 +690,10 @@ async def _consult_plato(arguments: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _proposal_write_enabled() -> bool:
+    return _env_bool("ELLA_PLATO_MCP_ENABLE_PROPOSALS", False)
+
+
 def _legacy_plato_onboarding() -> dict[str, Any]:
     scopes = ["context:read", "memory:read", "profile:read", "startup:read", "timeline:read", "tools:read"]
     tools = [
@@ -685,9 +701,13 @@ def _legacy_plato_onboarding() -> dict[str, Any]:
         "companion_get_proposal_status",
         "plato_recent_context",
         "plato_search_memory",
+        "plato_latest_omi",
         "plato_omi_activity_window",
         "plato_consult",
     ]
+    if _proposal_write_enabled():
+        scopes.extend(["proposals:read", "proposals:write"])
+        tools.append("companion_propose_change")
     return {
         "state": "authenticated_mapped",
         "trace_id": str(uuid.uuid4()),
@@ -734,6 +754,52 @@ async def _companion_get_proposal_status(arguments: dict[str, Any]) -> dict[str,
         raise ToolExecutionError(str(exc), code=-32004) from exc
 
 
+async def _companion_propose_change(arguments: dict[str, Any]) -> dict[str, Any]:
+    proposal_type = str(arguments.get("proposal_type") or "").strip()
+    if proposal_type not in COMPANION_PROPOSAL_TYPES:
+        allowed = ", ".join(sorted(COMPANION_PROPOSAL_TYPES))
+        raise ToolExecutionError(f"proposal_type must be one of: {allowed}", code=-32602)
+    title = _compact_text(arguments.get("title"), 240)
+    description = _compact_text(arguments.get("description"), 4000)
+    if not title:
+        raise ToolExecutionError("title is required", code=-32602)
+    if not description:
+        raise ToolExecutionError("description is required", code=-32602)
+    evidence = arguments.get("evidence") or []
+    if evidence and not isinstance(evidence, list):
+        raise ToolExecutionError("evidence must be a list", code=-32602)
+    target = arguments.get("target") or {}
+    requested_change = arguments.get("requested_change") or {}
+    if target and not isinstance(target, dict):
+        raise ToolExecutionError("target must be an object", code=-32602)
+    if requested_change and not isinstance(requested_change, dict):
+        raise ToolExecutionError("requested_change must be an object", code=-32602)
+    payload = {
+        "title": title,
+        "description": description,
+        "target": target,
+        "evidence": evidence,
+        "requested_change": requested_change,
+        "source": "plato_mcp",
+        "write_policy": "proposal_only",
+    }
+    try:
+        return proposal_ingest.create_proposal(
+            session_claims=_legacy_plato_onboarding()["session_claims"],
+            tool_name="companion_propose_change",
+            proposal_type=proposal_type,
+            payload=payload,
+            idempotency_key=_compact_text(arguments.get("idempotency_key"), 240),
+        )
+    except proposal_ingest.ProposalIngestError as exc:
+        raise ToolExecutionError(str(exc), code=-32004) from exc
+
+
+def _visible_tools() -> list[dict[str, Any]]:
+    allowed = set(_legacy_plato_onboarding()["session_claims"].get("allowed_tools") or [])
+    return [tool for tool in MCP_TOOLS if tool["name"] in allowed or tool["name"] == "plato_get_scanner_rules"]
+
+
 MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "companion_start_here",
@@ -753,6 +819,30 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "type": "object",
             "properties": {"proposal_id": {"type": "string"}},
             "required": ["proposal_id"],
+        },
+    },
+    {
+        "name": "companion_propose_change",
+        "description": (
+            "Create an auditable proposal only; this never directly changes scanner rules, reminders, profile data, "
+            "memory, summaries, caregiver delivery, or other live state. Use for requested scanner, reminder, "
+            "profile, memory, or summary changes that need later approval/application."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "proposal_type": {
+                    "type": "string",
+                    "enum": sorted(COMPANION_PROPOSAL_TYPES),
+                },
+                "title": {"type": "string"},
+                "description": {"type": "string"},
+                "target": {"type": "object", "default": {}},
+                "evidence": {"type": "array", "items": {"type": "object"}, "default": []},
+                "requested_change": {"type": "object", "default": {}},
+                "idempotency_key": {"type": "string"},
+            },
+            "required": ["proposal_type", "title", "description"],
         },
     },
     {
@@ -844,6 +934,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
 _TOOL_HANDLERS = {
     "companion_start_here": _companion_start_here,
     "companion_get_proposal_status": _companion_get_proposal_status,
+    "companion_propose_change": _companion_propose_change,
     "plato_recent_context": _recent_context,
     "plato_search_memory": _search_memory,
     "plato_latest_omi": _latest_omi,
@@ -937,7 +1028,7 @@ async def _handle_mcp_message(
         return None, None
 
     if method == "tools/list":
-        return _mcp_response(msg_id, {"tools": MCP_TOOLS}), None
+        return _mcp_response(msg_id, {"tools": _visible_tools()}), None
 
     if method == "tools/call":
         tool_name = params.get("name")
@@ -946,7 +1037,8 @@ async def _handle_mcp_message(
         started = time.monotonic()
         if not isinstance(arguments, dict):
             return _mcp_error(msg_id, -32602, "Tool arguments must be an object"), None
-        if tool_name not in _TOOL_HANDLERS:
+        visible_tool_names = {tool["name"] for tool in _visible_tools()}
+        if tool_name not in _TOOL_HANDLERS or tool_name not in visible_tool_names:
             return _mcp_error(msg_id, -32601, f"Unknown tool: {tool_name}"), None
         try:
             result = await _TOOL_HANDLERS[tool_name](arguments)

--- a/backend/models/proposals.py
+++ b/backend/models/proposals.py
@@ -24,6 +24,11 @@ class ProposalType(str, Enum):
     preference = "preference"
     rule_change = "rule_change"
     external_context = "external_context"
+    scanner_rule_change = "scanner_rule_change"
+    reminder_request = "reminder_request"
+    profile_update = "profile_update"
+    memory_note = "memory_note"
+    summary_correction = "summary_correction"
 
 
 class ProposalEvent(BaseModel):

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -97,6 +97,23 @@ def test_plato_mcp_lists_only_read_only_tools(monkeypatch):
     assert "create_memory" not in tool_names
     assert "delete_memory" not in tool_names
     assert "update_conversation_summary" not in tool_names
+    assert "companion_propose_change" not in tool_names
+
+
+def test_plato_mcp_lists_proposal_tool_only_when_enabled(monkeypatch):
+    monkeypatch.setenv("ELLA_PLATO_MCP_ENABLE_PROPOSALS", "true")
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc("tools/list"),
+    )
+
+    assert response.status_code == 200
+    tool_names = {tool["name"] for tool in response.json()["result"]["tools"]}
+    assert "companion_propose_change" in tool_names
 
 
 def test_streamable_http_prefers_json_when_client_accepts_json_and_sse(monkeypatch):
@@ -178,6 +195,109 @@ def test_companion_get_proposal_status_tool_is_read_only(monkeypatch):
     result = _tool_result(response)
     assert result["proposal_id"] == "proposal-1"
     assert result["status"] == "submitted"
+
+
+def test_companion_propose_change_creates_proposal_when_enabled(monkeypatch):
+    monkeypatch.setenv("ELLA_PLATO_MCP_ENABLE_PROPOSALS", "true")
+    module = _load_module(monkeypatch)
+    client = _client(module)
+    captured = {}
+
+    def fake_create(*, session_claims, tool_name, proposal_type, payload, idempotency_key):
+        captured["session_claims"] = session_claims
+        captured["tool_name"] = tool_name
+        captured["proposal_type"] = proposal_type
+        captured["payload"] = payload
+        captured["idempotency_key"] = idempotency_key
+        return {
+            "created": True,
+            "deduped": False,
+            "proposal": {"proposal_id": "proposal-1", "status": "submitted"},
+        }
+
+    monkeypatch.setattr(module.proposal_ingest, "create_proposal", fake_create)
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc(
+            "tools/call",
+            params={
+                "name": "companion_propose_change",
+                "arguments": {
+                    "proposal_type": "scanner_rule_change",
+                    "title": "Temporarily watch for glasses",
+                    "description": "User asked Ella to remember where glasses are usually kept.",
+                    "target": {"file": "scanner-tuning.md"},
+                    "requested_change": {"add_phrase": "where are my glasses"},
+                    "idempotency_key": "glasses-1",
+                },
+            },
+        ),
+    )
+
+    assert response.status_code == 200
+    result = _tool_result(response)
+    assert result["created"] is True
+    assert result["proposal"]["proposal_id"] == "proposal-1"
+    assert captured["tool_name"] == "companion_propose_change"
+    assert captured["proposal_type"] == "scanner_rule_change"
+    assert "proposals:write" in captured["session_claims"]["scopes"]
+    assert "companion_propose_change" in captured["session_claims"]["allowed_tools"]
+    assert captured["payload"]["write_policy"] == "proposal_only"
+    assert captured["idempotency_key"] == "glasses-1"
+
+
+def test_companion_propose_change_is_unknown_when_disabled(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc(
+            "tools/call",
+            params={
+                "name": "companion_propose_change",
+                "arguments": {
+                    "proposal_type": "scanner_rule_change",
+                    "title": "Nope",
+                    "description": "Disabled",
+                },
+            },
+        ),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["error"]["code"] == -32601
+
+
+def test_companion_propose_change_rejects_unsupported_type(monkeypatch):
+    monkeypatch.setenv("ELLA_PLATO_MCP_ENABLE_PROPOSALS", "true")
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc(
+            "tools/call",
+            params={
+                "name": "companion_propose_change",
+                "arguments": {
+                    "proposal_type": "direct_mutation",
+                    "title": "Bad",
+                    "description": "Should not be accepted.",
+                },
+            },
+        ),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["error"]["code"] == -32602
+    assert "proposal_type must be one of" in payload["error"]["message"]
 
 
 def test_plato_recent_context_uses_canonical_timeline(monkeypatch):


### PR DESCRIPTION
## Summary
- add gated `companion_propose_change` MCP tool for proposal-only writeback
- keep default Plato MCP surface read-only unless `ELLA_PLATO_MCP_ENABLE_PROPOSALS=true`
- add explicit proposal types for scanner, reminders, profile updates, memory notes, and summary corrections
- block direct mutation by routing all writes through existing proposal ingestion/audit storage

## Validation
- `pytest tests/unit/test_ella_plato_mcp.py tests/unit/test_ella_mcp_proposals.py -q`
- `python3 -m py_compile ella/routers/plato_mcp.py models/proposals.py`

## Related
- ellaaicare/ella-ai#860
- ellaaicare/ella-ai#859