### PR TITLE
Route summary corrections into proposal pipeline

### DIFF
--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -18,6 +18,7 @@ from pydantic import AliasChoices, BaseModel, Field, field_validator
 import database.conversations as conversations_db
 from database._client import db
 from ella.config import ELLA_CONFIG
+from ella.services import proposal_ingest
 from utils.other import endpoints as auth
 
 logger = logging.getLogger(__name__)
@@ -57,6 +58,7 @@ class ConversationCorrectionResponse(BaseModel):
     trace_id: str
     status: str
     queued: bool
+    proposal_id: Optional[str] = None
 
 
 def _now_iso() -> str:
@@ -146,6 +148,73 @@ def _append_correction_event(
     events = list((existing or {}).get("events") or [])
     events.append(event)
     ref.set({"events": events, "updated_at": event.get("at") or _now_iso()}, merge=True)
+
+
+def _summary_correction_claims(*, uid: str, trace_id: str) -> dict[str, Any]:
+    return {
+        "sub": f"omi-user:{uid}",
+        "profile_uid": uid,
+        "role": "self",
+        "external_provider": "omi-ios-correction",
+        "grant_id": "conversation-correction-widget",
+        "trace_id": trace_id,
+        "scopes": ["proposals:write"],
+        "allowed_tools": ["conversation_correction_submit"],
+    }
+
+
+def _create_summary_correction_proposal(
+    *,
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+    trace_id: str,
+    request: ConversationCorrectionRequest,
+    structured: dict[str, Any],
+    transcript: str,
+    segment_count: int,
+    active_summary_version_id: Optional[str],
+) -> Optional[str]:
+    result = proposal_ingest.create_proposal(
+        session_claims=_summary_correction_claims(uid=uid, trace_id=trace_id),
+        tool_name="conversation_correction_submit",
+        proposal_type="summary_correction",
+        payload={
+            "title": f"Summary correction for conversation {conversation_id}",
+            "description": request.correction_text,
+            "target": {
+                "kind": "omi_conversation_summary",
+                "conversation_id": conversation_id,
+                "correction_id": correction_id,
+                "active_summary_version_id": active_summary_version_id,
+            },
+            "evidence": [
+                {
+                    "kind": "current_summary",
+                    "content": structured,
+                },
+                {
+                    "kind": "summary_context",
+                    "content": request.summary_context.model_dump(),
+                },
+                {
+                    "kind": "transcript_excerpt",
+                    "content": transcript[:4000],
+                    "segment_count": segment_count,
+                },
+            ],
+            "requested_change": {
+                "correction_text": request.correction_text,
+                "correction_type": _correction_category(request.correction_text, request.summary_context),
+                "source": request.source,
+            },
+            "source": "conversation_correction_widget",
+            "write_policy": "proposal_only",
+        },
+        idempotency_key=f"summary-correction:{uid}:{conversation_id}:{correction_id}",
+    )
+    proposal = result.get("proposal") or {}
+    return proposal.get("proposal_id")
 
 
 def _n8n_correction_response_is_accepted(response_body: Any) -> bool:
@@ -258,6 +327,53 @@ async def _submit_conversation_correction(
     }
     _persist_correction_audit(uid, conversation_id, correction_id, audit_payload)
 
+    proposal_id = None
+    try:
+        proposal_id = _create_summary_correction_proposal(
+            uid=uid,
+            conversation_id=conversation_id,
+            correction_id=correction_id,
+            trace_id=trace_id,
+            request=request,
+            structured=structured,
+            transcript=transcript,
+            segment_count=segment_count,
+            active_summary_version_id=submitted_state.get("active_summary_version_id"),
+        )
+        if proposal_id:
+            _persist_correction_audit(
+                uid,
+                conversation_id,
+                correction_id,
+                {
+                    "proposal_id": proposal_id,
+                    "updated_at": _now_iso(),
+                },
+            )
+            _append_correction_event(
+                uid,
+                conversation_id,
+                correction_id,
+                {
+                    "stage": "proposal_created",
+                    "status": "ok",
+                    "at": _now_iso(),
+                    "trace_id": trace_id,
+                    "proposal_id": proposal_id,
+                },
+            )
+    except Exception as exc:
+        logger.exception(
+            "Failed to create summary correction proposal",
+            extra={"uid": uid, "conversation_id": conversation_id, "correction_id": correction_id},
+        )
+        _append_correction_event(
+            uid,
+            conversation_id,
+            correction_id,
+            {"stage": "proposal_failed", "status": "error", "at": _now_iso(), "trace_id": trace_id, "error": str(exc)},
+        )
+
     try:
         queue_result = await _submit_correction_to_n8n(
             uid=uid,
@@ -313,6 +429,7 @@ async def _submit_conversation_correction(
             trace_id=trace_id,
             status="queue_failed",
             queued=False,
+            proposal_id=proposal_id,
         )
 
     queued_at = _now_iso()
@@ -345,6 +462,7 @@ async def _submit_conversation_correction(
         trace_id=trace_id,
         status="queued",
         queued=True,
+        proposal_id=proposal_id,
     )
 
 

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -46,6 +46,7 @@ def test_submit_correction_accepts_ios_payload_and_queues(monkeypatch):
     events = []
     submitted = {}
     conversation_updates = []
+    proposals = []
 
     monkeypatch.setattr(corrections.conversations_db, "get_conversation", lambda uid, conversation_id: _conversation())
     monkeypatch.setattr(
@@ -75,6 +76,11 @@ def test_submit_correction_accepts_ios_payload_and_queues(monkeypatch):
         "_append_correction_event",
         lambda uid, conversation_id, correction_id, event: events.append(event),
     )
+    monkeypatch.setattr(
+        corrections,
+        "_create_summary_correction_proposal",
+        lambda **kwargs: proposals.append(kwargs) or "proposal-123",
+    )
 
     async def fake_submit_to_n8n(**kwargs):
         submitted.update(kwargs)
@@ -100,6 +106,7 @@ def test_submit_correction_accepts_ios_payload_and_queues(monkeypatch):
 
     assert result.status == "queued"
     assert result.queued is True
+    assert result.proposal_id == "proposal-123"
     assert result.conversation_id == "conv-123"
     assert result.correction_id
     assert result.trace_id.startswith("correction:conv-123:")
@@ -111,6 +118,9 @@ def test_submit_correction_accepts_ios_payload_and_queues(monkeypatch):
     assert submitted["conversation_id"] == "conv-123"
     assert "The podcast said memory can be tricky." in submitted["transcript"]
     assert submitted["request"].summary_context.app_summary == "The app summary was too clinical."
+    assert proposals[0]["conversation_id"] == "conv-123"
+    assert proposals[0]["request"].correction_text == "This was background TV audio, not a real memory concern."
+    assert any(event["stage"] == "proposal_created" for event in events)
     assert events[-1]["stage"] == "queued"
     assert conversation_updates[0]["correction_state"]["status"] == "submitted"
     assert conversation_updates[0]["active_summary_version_id"] == "legacy-v1"
@@ -180,6 +190,7 @@ def test_submit_correction_persists_n8n_failure_trace_and_still_returns_202(monk
         "_append_correction_event",
         lambda uid, conversation_id, correction_id, event: events.append(event),
     )
+    monkeypatch.setattr(corrections, "_create_summary_correction_proposal", lambda **kwargs: "proposal-123")
 
     async def failing_submit_to_n8n(**kwargs):
         raise RuntimeError("n8n offline")
@@ -196,6 +207,7 @@ def test_submit_correction_persists_n8n_failure_trace_and_still_returns_202(monk
 
     assert result.status == "queue_failed"
     assert result.queued is False
+    assert result.proposal_id == "proposal-123"
     assert audits[-1]["status"] == "queue_failed"
     assert audits[-1]["queue_error"] == "n8n offline"
     assert events[-1]["stage"] == "queue_failed"
@@ -216,6 +228,44 @@ def test_submit_correction_accepts_text_alias():
     request = corrections.ConversationCorrectionRequest(text="Please fix the doctor name.")
 
     assert request.correction_text == "Please fix the doctor name."
+
+
+def test_create_summary_correction_proposal_uses_proposal_only_policy(monkeypatch):
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return {"proposal": {"proposal_id": "proposal-123"}}
+
+    monkeypatch.setattr(corrections.proposal_ingest, "create_proposal", fake_create)
+
+    proposal_id = corrections._create_summary_correction_proposal(
+        uid="user-123",
+        conversation_id="conv-123",
+        correction_id="corr-123",
+        trace_id="trace-123",
+        request=corrections.ConversationCorrectionRequest(
+            correction_text="Actually, that was Dr. Pu, not Dr. Cuu.",
+            source="ios",
+            summary_context={"title": "Doctor visit"},
+        ),
+        structured={"title": "Doctor visit", "overview": "Mentioned Dr. Cuu."},
+        transcript="Speaker: Dr. Pu helped.",
+        segment_count=1,
+        active_summary_version_id="version-1",
+    )
+
+    assert proposal_id == "proposal-123"
+    assert captured["tool_name"] == "conversation_correction_submit"
+    assert captured["proposal_type"] == "summary_correction"
+    assert captured["idempotency_key"] == "summary-correction:user-123:conv-123:corr-123"
+    assert captured["session_claims"]["profile_uid"] == "user-123"
+    assert captured["session_claims"]["scopes"] == ["proposals:write"]
+    assert captured["payload"]["write_policy"] == "proposal_only"
+    assert captured["payload"]["target"]["conversation_id"] == "conv-123"
+    assert captured["payload"]["target"]["active_summary_version_id"] == "version-1"
+    assert captured["payload"]["requested_change"]["correction_text"] == "Actually, that was Dr. Pu, not Dr. Cuu."
+    assert captured["payload"]["evidence"][2]["kind"] == "transcript_excerpt"
 
 
 def test_submit_to_n8n_posts_single_structured_workflow_payload(monkeypatch):


### PR DESCRIPTION
## Summary
- create `summary_correction` proposal records when the iOS/app correction endpoint is submitted
- keep existing immediate n8n correction/reprocess queue unchanged
- return `proposal_id` in correction responses when proposal creation succeeds
- keep proposal creation non-blocking so correction queue still works if proposal creation has a transient failure

## Validation
- `pytest tests/unit/test_ella_conversation_corrections.py -q`
- `pytest tests/unit/test_ella_plato_mcp.py tests/unit/test_ella_mcp_proposals.py -q`
- `python3 -m py_compile ella/routers/corrections.py ella/routers/plato_mcp.py models/proposals.py`

## Related
- ellaaicare/ella-ai#860
- ellaaicare/ella-ai#859