### PR TITLE
[codex] Add auditable Observer cron runner

### DIFF
--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -311,6 +311,15 @@ def _register_routers(app) -> None:
     except ImportError as e:
         print(f"  ⚠️ Ella canonical events not available: {e}", flush=True)
 
+    # Observer cron runner (proposal-only fact promotion)
+    try:
+        from ella.routers.observer import router as observer_router
+
+        app.include_router(observer_router, tags=["Ella Observer"])
+        print("  🌐 /v1/ella/observer/* - Proposal-only Observer runner", flush=True)
+    except ImportError as e:
+        print(f"  ⚠️ Ella Observer not available: {e}", flush=True)
+
     # Plato/Hermes read-only MCP bridge for Grok custom connector testing
     try:
         from ella.routers.plato_mcp import router as plato_mcp_router

--- a/backend/ella/routers/observer.py
+++ b/backend/ella/routers/observer.py
@@ -1,0 +1,143 @@
+"""Admin Observer runner endpoints.
+
+These endpoints are intended for the Hermes cron/no-agent job and operational
+smoke tests. They are token-gated and default to dry-run behavior.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel, Field
+
+from ella.routers.canonical_events import CanonicalEventStore, PostgresCanonicalEventStore
+from ella.services.observer import observer_log_to_dict, run_observer
+from ella.services.observer_logs import ObserverRunLogStore, PostgresObserverRunLogStore
+
+DEFAULT_OBSERVER_LIMIT = 100
+MAX_OBSERVER_LIMIT = 500
+
+
+class ObserverRunRequest(BaseModel):
+    uid: str
+    canonical_identity: str = ""
+    since: Optional[datetime | str] = None
+    cursor_before: str = ""
+    dry_run: bool = True
+    limit: int = DEFAULT_OBSERVER_LIMIT
+    channels: list[str] = Field(default_factory=list)
+    model_metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.getenv(name, default).strip()
+
+
+def _observer_token() -> str:
+    return _env("ELLA_OBSERVER_ADMIN_TOKEN", _env("ELLA_ADMIN_TOKEN", ""))
+
+
+def _token_from_authorization(authorization: Optional[str]) -> str:
+    if not authorization:
+        return ""
+    value = authorization.strip()
+    if value.lower().startswith("bearer "):
+        return value[7:].strip()
+    return value
+
+
+def _authenticate(authorization: Optional[str], x_ella_observer_token: Optional[str]) -> None:
+    configured = _observer_token()
+    if not configured:
+        raise HTTPException(status_code=503, detail="Observer admin token is not configured")
+    supplied = (x_ella_observer_token or "").strip() or _token_from_authorization(authorization)
+    if supplied != configured:
+        raise HTTPException(status_code=401, detail="Invalid observer admin token")
+
+
+def _parse_datetime(value: datetime | str | None) -> Optional[datetime]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=f"Invalid since timestamp: {value}") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _sanitize_limit(limit: int) -> int:
+    if limit < 1:
+        raise HTTPException(status_code=400, detail="limit must be >= 1")
+    return min(limit, MAX_OBSERVER_LIMIT)
+
+
+def create_observer_router(
+    *,
+    event_store: Optional[CanonicalEventStore] = None,
+    log_store: Optional[ObserverRunLogStore] = None,
+) -> APIRouter:
+    router = APIRouter(prefix="/v1/ella/observer", tags=["Ella Observer"])
+    events = event_store or PostgresCanonicalEventStore()
+    logs = log_store or PostgresObserverRunLogStore()
+
+    @router.post("/run")
+    async def run(
+        request: ObserverRunRequest,
+        authorization: Optional[str] = Header(default=None),
+        x_ella_observer_token: Optional[str] = Header(default=None, alias="X-Ella-Observer-Token"),
+    ):
+        _authenticate(authorization, x_ella_observer_token)
+        if not request.uid:
+            raise HTTPException(status_code=400, detail="uid is required")
+        source_events = await events.timeline(
+            uid=request.uid,
+            since=_parse_datetime(request.since),
+            limit=_sanitize_limit(request.limit),
+            channels=request.channels or None,
+        )
+        log = run_observer(
+            profile_uid=request.uid,
+            canonical_identity=request.canonical_identity,
+            cursor_before=request.cursor_before,
+            dry_run=request.dry_run,
+            events=source_events,
+            model_metadata={
+                "extractor": "structured_candidate_extractor",
+                **(request.model_metadata or {}),
+            },
+        )
+        await logs.save(log)
+        return {"ok": True, "observer_run": observer_log_to_dict(log)}
+
+    @router.get("/runs/{run_id}")
+    async def get_run(
+        run_id: str,
+        authorization: Optional[str] = Header(default=None),
+        x_ella_observer_token: Optional[str] = Header(default=None, alias="X-Ella-Observer-Token"),
+    ):
+        _authenticate(authorization, x_ella_observer_token)
+        log = await logs.get(run_id)
+        if not log:
+            raise HTTPException(status_code=404, detail="Observer run not found")
+        return {"ok": True, "observer_run": log}
+
+    @router.get("/health")
+    async def health(
+        authorization: Optional[str] = Header(default=None),
+        x_ella_observer_token: Optional[str] = Header(default=None, alias="X-Ella-Observer-Token"),
+    ):
+        _authenticate(authorization, x_ella_observer_token)
+        return {"ok": True, "mode": "proposal_only", "default_dry_run": True}
+
+    return router
+
+
+router = create_observer_router()

--- a/backend/ella/services/observer.py
+++ b/backend/ella/services/observer.py
@@ -1,0 +1,340 @@
+"""Ella Observer fact-promotion runner.
+
+The Observer is the domain worker that reads canonical ledger events and turns
+safe, structured findings into auditable proposals. It intentionally does not
+directly mutate memory, scanner rules, reminders, summaries, or caregiver state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import uuid
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from pydantic import BaseModel, Field
+
+from ella.services import proposal_ingest
+
+OBSERVER_TOOL_NAME = "ella_observer_fact_promotion"
+SUPPORTED_PROPOSAL_TYPES = {
+    "memory_note",
+    "profile_update",
+    "scanner_rule_change",
+    "reminder_request",
+    "summary_correction",
+}
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _compact_text(value: Any, max_chars: int = 4000) -> str:
+    text = str(value or "").replace("\x00", "").strip()
+    if len(text) > max_chars:
+        return text[:max_chars].rstrip()
+    return text
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value or {}, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _stable_hash(value: Any) -> str:
+    return hashlib.sha256(_stable_json(value).encode("utf-8")).hexdigest()[:16]
+
+
+def _event_time(event: dict[str, Any]) -> str:
+    return str(event.get("started_at") or event.get("created_at") or event.get("timestamp") or "")
+
+
+def _cursor_from_events(events: list[dict[str, Any]]) -> str:
+    if not events:
+        return ""
+    return max(_event_time(event) for event in events if isinstance(event, dict)) if events else ""
+
+
+def _event_ref(event: dict[str, Any]) -> dict[str, Any]:
+    source_ref = event.get("source_ref") if isinstance(event.get("source_ref"), dict) else {}
+    return {
+        "event_id": event.get("event_id"),
+        "source_identity": event.get("source_identity"),
+        "channel": event.get("channel"),
+        "provider": event.get("provider"),
+        "started_at": _event_time(event),
+        "source_ref": source_ref,
+    }
+
+
+class ObserverCandidate(BaseModel):
+    proposal_type: str
+    title: str
+    description: str
+    requested_change: dict[str, Any] = Field(default_factory=dict)
+    target: dict[str, Any] = Field(default_factory=dict)
+    reason: str = ""
+    confidence: float = 0.0
+    evidence: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class ObserverDecision(BaseModel):
+    action: str
+    reason: str
+    event_id: str = ""
+    proposal_type: str = ""
+    title: str = ""
+    confidence: float = 0.0
+    idempotency_key: str = ""
+    proposal_id: str = ""
+    error: str = ""
+
+
+class ObserverRunLog(BaseModel):
+    run_id: str
+    profile_uid: str
+    canonical_identity: str = ""
+    dry_run: bool = True
+    status: str = "success"
+    cursor_before: str = ""
+    cursor_after: str = ""
+    started_at: datetime
+    completed_at: datetime
+    latency_ms: int = 0
+    source_event_count: int = 0
+    source_counts: dict[str, int] = Field(default_factory=dict)
+    candidate_count: int = 0
+    proposal_count: int = 0
+    skipped_count: int = 0
+    error_count: int = 0
+    proposal_ids: list[str] = Field(default_factory=list)
+    decisions: list[ObserverDecision] = Field(default_factory=list)
+    model_metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+def structured_candidate_extractor(event: dict[str, Any]) -> list[ObserverCandidate]:
+    """Read structured Observer candidate proposals from event metadata.
+
+    This is the first safe extraction boundary. Upstream Hermes/Honcho/LLM
+    extraction can write candidates into event metadata; this runner validates,
+    dedupes, proposes, and logs. Free-text extraction is intentionally not done
+    here until it is model-backed and separately evaluated.
+    """
+    metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+    observer = metadata.get("observer") if isinstance(metadata.get("observer"), dict) else {}
+    raw_candidates = observer.get("proposals") or metadata.get("observer_proposals") or []
+    if isinstance(raw_candidates, dict):
+        raw_candidates = [raw_candidates]
+    if not isinstance(raw_candidates, list):
+        return []
+
+    candidates: list[ObserverCandidate] = []
+    for raw in raw_candidates:
+        if not isinstance(raw, dict):
+            continue
+        candidate = ObserverCandidate(
+            proposal_type=_compact_text(raw.get("proposal_type"), 80),
+            title=_compact_text(raw.get("title"), 240),
+            description=_compact_text(raw.get("description"), 4000),
+            requested_change=raw.get("requested_change") if isinstance(raw.get("requested_change"), dict) else {},
+            target=raw.get("target") if isinstance(raw.get("target"), dict) else {},
+            reason=_compact_text(raw.get("reason"), 1000),
+            confidence=float(raw.get("confidence") or 0.0),
+            evidence=raw.get("evidence") if isinstance(raw.get("evidence"), list) else [],
+        )
+        candidates.append(candidate)
+    return candidates
+
+
+def _observer_claims(profile_uid: str, run_id: str) -> dict[str, Any]:
+    return {
+        "sub": "ella-observer-cron",
+        "profile_uid": profile_uid,
+        "role": "system_observer",
+        "external_provider": "ella_backend",
+        "grant_id": "ella-observer-cron",
+        "trace_id": f"observer:{run_id}",
+        "scopes": ["proposals:write"],
+        "allowed_tools": [OBSERVER_TOOL_NAME],
+    }
+
+
+def _proposal_payload(candidate: ObserverCandidate, event: dict[str, Any], run_id: str) -> dict[str, Any]:
+    evidence = list(candidate.evidence)
+    evidence.append(_event_ref(event))
+    return {
+        "title": candidate.title,
+        "description": candidate.description,
+        "target": candidate.target,
+        "evidence": evidence,
+        "requested_change": candidate.requested_change,
+        "source": "ella_observer_cron",
+        "observer_run_id": run_id,
+        "reason": candidate.reason,
+        "confidence": candidate.confidence,
+        "write_policy": "proposal_only",
+    }
+
+
+def run_observer(
+    *,
+    profile_uid: str,
+    events: list[dict[str, Any]],
+    canonical_identity: str = "",
+    cursor_before: str = "",
+    dry_run: bool = True,
+    run_id: str | None = None,
+    extractor: Callable[[dict[str, Any]], list[ObserverCandidate]] = structured_candidate_extractor,
+    create_proposal: Callable[..., dict[str, Any]] = proposal_ingest.create_proposal,
+    model_metadata: dict[str, Any] | None = None,
+) -> ObserverRunLog:
+    started = _now()
+    monotonic_start = time.monotonic()
+    actual_run_id = run_id or str(uuid.uuid4())
+    decisions: list[ObserverDecision] = []
+    proposal_ids: list[str] = []
+    source_counts = Counter(str(event.get("channel") or "unknown") for event in events if isinstance(event, dict))
+
+    for event in events:
+        if not isinstance(event, dict):
+            decisions.append(ObserverDecision(action="skip", reason="invalid_event_shape"))
+            continue
+        event_id = str(event.get("event_id") or "")
+        try:
+            candidates = extractor(event)
+        except Exception as exc:
+            decisions.append(
+                ObserverDecision(action="error", reason="extractor_failed", event_id=event_id, error=str(exc))
+            )
+            continue
+        if not candidates:
+            decisions.append(
+                ObserverDecision(action="skip", reason="no_structured_observer_candidates", event_id=event_id)
+            )
+            continue
+        for candidate in candidates:
+            if candidate.proposal_type not in SUPPORTED_PROPOSAL_TYPES:
+                decisions.append(
+                    ObserverDecision(
+                        action="skip",
+                        reason="unsupported_proposal_type",
+                        event_id=event_id,
+                        proposal_type=candidate.proposal_type,
+                        title=candidate.title,
+                        confidence=candidate.confidence,
+                    )
+                )
+                continue
+            if not candidate.title or not candidate.description:
+                decisions.append(
+                    ObserverDecision(
+                        action="skip",
+                        reason="missing_title_or_description",
+                        event_id=event_id,
+                        proposal_type=candidate.proposal_type,
+                        title=candidate.title,
+                        confidence=candidate.confidence,
+                    )
+                )
+                continue
+
+            payload = _proposal_payload(candidate, event, actual_run_id)
+            idempotency_key = (
+                f"observer:{profile_uid}:{event_id or _stable_hash(_event_ref(event))}:"
+                f"{candidate.proposal_type}:{_stable_hash(payload)}"
+            )
+            if dry_run:
+                decisions.append(
+                    ObserverDecision(
+                        action="would_create_proposal",
+                        reason=candidate.reason or "structured_candidate_valid",
+                        event_id=event_id,
+                        proposal_type=candidate.proposal_type,
+                        title=candidate.title,
+                        confidence=candidate.confidence,
+                        idempotency_key=idempotency_key,
+                    )
+                )
+                continue
+            try:
+                result = create_proposal(
+                    session_claims=_observer_claims(profile_uid, actual_run_id),
+                    tool_name=OBSERVER_TOOL_NAME,
+                    proposal_type=candidate.proposal_type,
+                    payload=payload,
+                    idempotency_key=idempotency_key,
+                )
+                proposal = result.get("proposal") or {}
+                proposal_id = str(proposal.get("proposal_id") or "")
+                if proposal_id:
+                    proposal_ids.append(proposal_id)
+                decisions.append(
+                    ObserverDecision(
+                        action="created_proposal" if result.get("created") else "deduped_proposal",
+                        reason=candidate.reason or "structured_candidate_valid",
+                        event_id=event_id,
+                        proposal_type=candidate.proposal_type,
+                        title=candidate.title,
+                        confidence=candidate.confidence,
+                        idempotency_key=idempotency_key,
+                        proposal_id=proposal_id,
+                    )
+                )
+            except Exception as exc:
+                decisions.append(
+                    ObserverDecision(
+                        action="error",
+                        reason="proposal_create_failed",
+                        event_id=event_id,
+                        proposal_type=candidate.proposal_type,
+                        title=candidate.title,
+                        confidence=candidate.confidence,
+                        idempotency_key=idempotency_key,
+                        error=str(exc),
+                    )
+                )
+
+    completed = _now()
+    error_count = sum(1 for decision in decisions if decision.action == "error")
+    skipped_count = sum(1 for decision in decisions if decision.action == "skip")
+    proposal_count = sum(
+        1
+        for decision in decisions
+        if decision.action in {"would_create_proposal", "created_proposal", "deduped_proposal"}
+    )
+    candidate_count = proposal_count + sum(
+        1
+        for decision in decisions
+        if decision.action == "skip"
+        and decision.reason in {"unsupported_proposal_type", "missing_title_or_description"}
+    )
+    return ObserverRunLog(
+        run_id=actual_run_id,
+        profile_uid=profile_uid,
+        canonical_identity=canonical_identity,
+        dry_run=dry_run,
+        status="error" if error_count else "success",
+        cursor_before=cursor_before,
+        cursor_after=_cursor_from_events(events),
+        started_at=started,
+        completed_at=completed,
+        latency_ms=int((time.monotonic() - monotonic_start) * 1000),
+        source_event_count=len(events),
+        source_counts=dict(source_counts),
+        candidate_count=candidate_count,
+        proposal_count=proposal_count,
+        skipped_count=skipped_count,
+        error_count=error_count,
+        proposal_ids=proposal_ids,
+        decisions=decisions,
+        model_metadata=model_metadata or {"extractor": "structured_candidate_extractor"},
+    )
+
+
+def observer_log_to_dict(log: ObserverRunLog) -> dict[str, Any]:
+    if hasattr(log, "model_dump"):
+        return log.model_dump(mode="json")
+    return log.dict()

--- a/backend/ella/services/observer_logs.py
+++ b/backend/ella/services/observer_logs.py
@@ -1,0 +1,172 @@
+"""Durable Observer run logs."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Optional
+
+import asyncpg
+
+from ella.services.observer import ObserverRunLog, observer_log_to_dict
+
+_pool: Optional[asyncpg.Pool] = None
+
+
+async def _get_pool() -> asyncpg.Pool:
+    global _pool
+    if _pool is None:
+        _pool = await asyncpg.create_pool(
+            host=os.getenv("ELLA_POSTGRES_HOST", "127.0.0.1"),
+            port=int(os.getenv("ELLA_POSTGRES_PORT", "5433")),
+            user=os.getenv("ELLA_POSTGRES_USER", "postgres"),
+            password=os.getenv("ELLA_POSTGRES_PASSWORD", "postgres"),
+            database=os.getenv("ELLA_POSTGRES_DB", "ella_ai"),
+            min_size=1,
+            max_size=5,
+        )
+    return _pool
+
+
+class ObserverRunLogStore:
+    async def save(self, log: ObserverRunLog) -> ObserverRunLog:
+        raise NotImplementedError
+
+    async def get(self, run_id: str) -> dict[str, Any] | None:
+        raise NotImplementedError
+
+
+class InMemoryObserverRunLogStore(ObserverRunLogStore):
+    def __init__(self) -> None:
+        self.logs: dict[str, dict[str, Any]] = {}
+
+    async def save(self, log: ObserverRunLog) -> ObserverRunLog:
+        self.logs[log.run_id] = observer_log_to_dict(log)
+        return log
+
+    async def get(self, run_id: str) -> dict[str, Any] | None:
+        return self.logs.get(run_id)
+
+
+class PostgresObserverRunLogStore(ObserverRunLogStore):
+    async def _ensure_table(self) -> None:
+        pool = await _get_pool()
+        await pool.execute("""
+            CREATE TABLE IF NOT EXISTS observer_run_logs (
+                run_id TEXT PRIMARY KEY,
+                profile_uid TEXT NOT NULL,
+                canonical_identity TEXT,
+                dry_run BOOLEAN NOT NULL DEFAULT TRUE,
+                status TEXT NOT NULL,
+                cursor_before TEXT,
+                cursor_after TEXT,
+                source_event_count INTEGER NOT NULL DEFAULT 0,
+                candidate_count INTEGER NOT NULL DEFAULT 0,
+                proposal_count INTEGER NOT NULL DEFAULT 0,
+                skipped_count INTEGER NOT NULL DEFAULT 0,
+                error_count INTEGER NOT NULL DEFAULT 0,
+                source_counts JSONB NOT NULL DEFAULT '{}'::jsonb,
+                proposal_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+                decisions JSONB NOT NULL DEFAULT '[]'::jsonb,
+                model_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+                started_at TIMESTAMPTZ NOT NULL,
+                completed_at TIMESTAMPTZ NOT NULL,
+                latency_ms INTEGER NOT NULL DEFAULT 0,
+                inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """)
+
+    async def save(self, log: ObserverRunLog) -> ObserverRunLog:
+        await self._ensure_table()
+        data = observer_log_to_dict(log)
+        pool = await _get_pool()
+        await pool.execute(
+            """
+            INSERT INTO observer_run_logs (
+                run_id, profile_uid, canonical_identity, dry_run, status,
+                cursor_before, cursor_after, source_event_count, candidate_count,
+                proposal_count, skipped_count, error_count, source_counts,
+                proposal_ids, decisions, model_metadata, started_at, completed_at,
+                latency_ms
+            )
+            VALUES (
+                $1, $2, $3, $4, $5,
+                $6, $7, $8, $9,
+                $10, $11, $12, $13::jsonb,
+                $14::jsonb, $15::jsonb, $16::jsonb, $17, $18,
+                $19
+            )
+            ON CONFLICT (run_id) DO UPDATE SET
+                status = EXCLUDED.status,
+                cursor_after = EXCLUDED.cursor_after,
+                source_event_count = EXCLUDED.source_event_count,
+                candidate_count = EXCLUDED.candidate_count,
+                proposal_count = EXCLUDED.proposal_count,
+                skipped_count = EXCLUDED.skipped_count,
+                error_count = EXCLUDED.error_count,
+                source_counts = EXCLUDED.source_counts,
+                proposal_ids = EXCLUDED.proposal_ids,
+                decisions = EXCLUDED.decisions,
+                model_metadata = EXCLUDED.model_metadata,
+                completed_at = EXCLUDED.completed_at,
+                latency_ms = EXCLUDED.latency_ms
+            """,
+            data["run_id"],
+            data["profile_uid"],
+            data.get("canonical_identity") or "",
+            data["dry_run"],
+            data["status"],
+            data.get("cursor_before") or "",
+            data.get("cursor_after") or "",
+            data["source_event_count"],
+            data["candidate_count"],
+            data["proposal_count"],
+            data["skipped_count"],
+            data["error_count"],
+            json.dumps(data.get("source_counts") or {}),
+            json.dumps(data.get("proposal_ids") or []),
+            json.dumps(data.get("decisions") or []),
+            json.dumps(data.get("model_metadata") or {}),
+            data["started_at"],
+            data["completed_at"],
+            data["latency_ms"],
+        )
+        return log
+
+    async def get(self, run_id: str) -> dict[str, Any] | None:
+        await self._ensure_table()
+        pool = await _get_pool()
+        row = await pool.fetchrow("SELECT * FROM observer_run_logs WHERE run_id = $1", run_id)
+        if not row:
+            return None
+
+        def json_value(name: str, default: Any) -> Any:
+            raw = row[name]
+            if raw is None:
+                return default
+            if isinstance(raw, str):
+                return json.loads(raw)
+            return raw
+
+        return {
+            "run_id": row["run_id"],
+            "profile_uid": row["profile_uid"],
+            "canonical_identity": row["canonical_identity"] or "",
+            "dry_run": row["dry_run"],
+            "status": row["status"],
+            "cursor_before": row["cursor_before"] or "",
+            "cursor_after": row["cursor_after"] or "",
+            "source_event_count": row["source_event_count"],
+            "candidate_count": row["candidate_count"],
+            "proposal_count": row["proposal_count"],
+            "skipped_count": row["skipped_count"],
+            "error_count": row["error_count"],
+            "source_counts": json_value("source_counts", {}),
+            "proposal_ids": json_value("proposal_ids", []),
+            "decisions": json_value("decisions", []),
+            "model_metadata": json_value("model_metadata", {}),
+            "started_at": row["started_at"].isoformat(),
+            "completed_at": row["completed_at"].isoformat(),
+            "latency_ms": row["latency_ms"],
+            "inserted_at": row["inserted_at"].isoformat(),
+        }

--- a/backend/scripts/ella_observer_cron.py
+++ b/backend/scripts/ella_observer_cron.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Hermes cron entrypoint for Ella Observer.
+
+This script calls the backend Observer endpoint. Install it as a Hermes
+no-agent cron job so the existing Hermes scheduler/ticker owns execution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+import httpx
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.getenv(name, default).strip()
+
+
+def _default_since(minutes: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(minutes=minutes)).isoformat()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run Ella Observer through the backend API")
+    parser.add_argument("--backend-url", default=_env("ELLA_BACKEND_URL", "http://127.0.0.1:8000"))
+    parser.add_argument("--uid", default=_env("ELLA_OBSERVER_UID", _env("ELLA_PLATO_UID", "")))
+    parser.add_argument("--canonical-identity", default=_env("ELLA_OBSERVER_CANONICAL_IDENTITY", ""))
+    parser.add_argument("--since", default="")
+    parser.add_argument("--lookback-minutes", type=int, default=int(_env("ELLA_OBSERVER_LOOKBACK_MINUTES", "30")))
+    parser.add_argument("--limit", type=int, default=int(_env("ELLA_OBSERVER_LIMIT", "100")))
+    parser.add_argument("--channels", default=_env("ELLA_OBSERVER_CHANNELS", ""))
+    parser.add_argument("--live", action="store_true", help="Create proposals instead of dry-running")
+    args = parser.parse_args()
+
+    token = _env("ELLA_OBSERVER_ADMIN_TOKEN", _env("ELLA_ADMIN_TOKEN", ""))
+    if not token:
+        print("ELLA_OBSERVER_ADMIN_TOKEN is required", file=sys.stderr)
+        return 2
+    if not args.uid:
+        print("--uid or ELLA_OBSERVER_UID is required", file=sys.stderr)
+        return 2
+
+    payload = {
+        "uid": args.uid,
+        "canonical_identity": args.canonical_identity,
+        "since": args.since or _default_since(args.lookback_minutes),
+        "dry_run": not args.live,
+        "limit": args.limit,
+        "channels": [part.strip() for part in args.channels.split(",") if part.strip()],
+        "model_metadata": {
+            "invoked_by": "hermes_cron_script",
+            "script": "backend/scripts/ella_observer_cron.py",
+        },
+    }
+    url = args.backend_url.rstrip("/") + "/v1/ella/observer/run"
+    with httpx.Client(timeout=60.0) as client:
+        response = client.post(url, headers={"X-Ella-Observer-Token": token}, json=payload)
+    if response.status_code >= 400:
+        print(f"Observer request failed: HTTP {response.status_code} {response.text[:500]}", file=sys.stderr)
+        return 1
+    data = response.json()
+    print(json.dumps(data.get("observer_run") or data, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/unit/test_ella_observer.py
+++ b/backend/tests/unit/test_ella_observer.py
@@ -1,0 +1,219 @@
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _install_proposal_stubs():
+    proposals = types.ModuleType("database.proposals")
+    proposals.get_proposal = MagicMock(return_value=None)
+    proposals.get_proposal_by_idempotency_key = MagicMock(return_value=None)
+    proposals.save_proposal = MagicMock(side_effect=lambda proposal: proposal)
+    database = sys.modules.setdefault("database", types.ModuleType("database"))
+    setattr(database, "proposals", proposals)
+    sys.modules["database.proposals"] = proposals
+
+
+def _load_observer_service():
+    _install_proposal_stubs()
+    sys.modules.pop("ella.services.observer", None)
+    return importlib.import_module("ella.services.observer")
+
+
+def _event(**overrides):
+    metadata = overrides.pop("metadata", None)
+    if metadata is None:
+        metadata = {
+            "observer": {
+                "proposals": [
+                    {
+                        "proposal_type": "memory_note",
+                        "title": "Spare glasses location",
+                        "description": "Plato said the spare glasses are in the blue backpack pocket.",
+                        "requested_change": {
+                            "memory": "Spare glasses are in the blue backpack pocket.",
+                            "entity": "spare glasses",
+                        },
+                        "reason": "User explicitly provided a durable location fact.",
+                        "confidence": 0.94,
+                    }
+                ]
+            }
+        }
+    return {
+        "uid": "user-1",
+        "canonical_identity": "plato",
+        "event_id": "evt-1",
+        "source_identity": "ios_voice:call-1",
+        "channel": "ios_voice",
+        "provider": "gemini-live",
+        "role": "user",
+        "text": "I put the spare glasses in the blue backpack pocket.",
+        "started_at": "2026-05-07T20:00:00+00:00",
+        "metadata": metadata,
+        **overrides,
+    }
+
+
+def test_observer_dry_run_logs_candidate_without_mutating():
+    service = _load_observer_service()
+    created = []
+
+    log = service.run_observer(
+        profile_uid="user-1",
+        canonical_identity="plato",
+        cursor_before="2026-05-07T19:55:00+00:00",
+        dry_run=True,
+        events=[_event()],
+        create_proposal=lambda **kwargs: created.append(kwargs) or {},
+        run_id="run-1",
+    )
+
+    assert created == []
+    assert log.run_id == "run-1"
+    assert log.dry_run is True
+    assert log.status == "success"
+    assert log.source_counts == {"ios_voice": 1}
+    assert log.cursor_after == "2026-05-07T20:00:00+00:00"
+    assert log.candidate_count == 1
+    assert log.proposal_count == 1
+    assert log.decisions[0].action == "would_create_proposal"
+    assert log.decisions[0].reason == "User explicitly provided a durable location fact."
+    assert log.decisions[0].idempotency_key.startswith("observer:user-1:evt-1:memory_note:")
+
+
+def test_observer_live_creates_proposal_with_observer_claims():
+    service = _load_observer_service()
+    captured = []
+
+    def fake_create(**kwargs):
+        captured.append(kwargs)
+        return {"created": True, "proposal": {"proposal_id": "proposal-1", "status": "submitted"}}
+
+    log = service.run_observer(
+        profile_uid="user-1",
+        dry_run=False,
+        events=[_event()],
+        create_proposal=fake_create,
+        run_id="run-2",
+    )
+
+    assert log.proposal_ids == ["proposal-1"]
+    assert log.decisions[0].action == "created_proposal"
+    assert captured[0]["session_claims"]["sub"] == "ella-observer-cron"
+    assert captured[0]["session_claims"]["allowed_tools"] == ["ella_observer_fact_promotion"]
+    assert captured[0]["tool_name"] == "ella_observer_fact_promotion"
+    assert captured[0]["proposal_type"] == "memory_note"
+    assert captured[0]["payload"]["write_policy"] == "proposal_only"
+    assert captured[0]["payload"]["observer_run_id"] == "run-2"
+
+
+def test_observer_skips_malformed_or_unsupported_candidates():
+    service = _load_observer_service()
+    event = _event(
+        event_id="evt-bad",
+        metadata={
+            "observer_proposals": [
+                {"proposal_type": "direct_mutation", "title": "Bad", "description": "Should not pass"},
+                {"proposal_type": "memory_note", "description": "Missing title"},
+            ]
+        },
+    )
+
+    log = service.run_observer(profile_uid="user-1", dry_run=False, events=[event], run_id="run-3")
+
+    assert log.proposal_count == 0
+    assert log.skipped_count == 2
+    assert [decision.reason for decision in log.decisions] == [
+        "unsupported_proposal_type",
+        "missing_title_or_description",
+    ]
+
+
+def test_observer_logs_events_with_no_candidates():
+    service = _load_observer_service()
+
+    log = service.run_observer(
+        profile_uid="user-1",
+        dry_run=True,
+        events=[_event(event_id="evt-empty", metadata={})],
+        run_id="run-4",
+    )
+
+    assert log.candidate_count == 0
+    assert log.proposal_count == 0
+    assert log.skipped_count == 1
+    assert log.decisions[0].reason == "no_structured_observer_candidates"
+
+
+def test_observer_router_runs_against_in_memory_test_ledger(monkeypatch):
+    _install_proposal_stubs()
+    monkeypatch.setenv("ELLA_OBSERVER_ADMIN_TOKEN", "observer-token")
+    sys.modules.pop("ella.routers.observer", None)
+    router_module = importlib.import_module("ella.routers.observer")
+    canonical_module = importlib.import_module("ella.routers.canonical_events")
+    logs_module = importlib.import_module("ella.services.observer_logs")
+
+    event_store = canonical_module.InMemoryCanonicalEventStore()
+    log_store = logs_module.InMemoryObserverRunLogStore()
+
+    import asyncio
+
+    asyncio.run(
+        event_store.write_batch(
+            [
+                canonical_module.CanonicalEventIn(
+                    uid="user-1",
+                    canonical_identity="plato",
+                    event_id="evt-router",
+                    channel="ios_chat",
+                    provider="ella-ios",
+                    role="user",
+                    text="Please remember the doctor is Dr. Pu.",
+                    started_at="2026-05-07T20:05:00+00:00",
+                    source_ref={"message_id": "m-1"},
+                    metadata={
+                        "observer": {
+                            "proposals": [
+                                {
+                                    "proposal_type": "profile_update",
+                                    "title": "Doctor name correction",
+                                    "description": "The doctor name should be Dr. Pu.",
+                                    "requested_change": {"doctor_name": "Dr. Pu"},
+                                    "reason": "User corrected a relationship/entity fact.",
+                                    "confidence": 0.98,
+                                }
+                            ]
+                        }
+                    },
+                )
+            ]
+        )
+    )
+
+    app = FastAPI()
+    app.include_router(router_module.create_observer_router(event_store=event_store, log_store=log_store))
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/ella/observer/run",
+        headers={"X-Ella-Observer-Token": "observer-token"},
+        json={"uid": "user-1", "dry_run": True, "channels": ["ios_chat"], "limit": 10},
+    )
+
+    assert response.status_code == 200
+    body = response.json()["observer_run"]
+    assert body["source_event_count"] == 1
+    assert body["proposal_count"] == 1
+    assert body["decisions"][0]["action"] == "would_create_proposal"
+
+    run_id = body["run_id"]
+    readback = client.get(
+        f"/v1/ella/observer/runs/{run_id}",
+        headers={"Authorization": "Bearer observer-token"},
+    )
+    assert readback.status_code == 200
+    assert readback.json()["observer_run"]["run_id"] == run_id


### PR DESCRIPTION
## Summary

Adds the first auditable Ella Observer cron runner slice:

- token-gated `/v1/ella/observer/*` admin endpoints
- proposal-only Observer service that reads canonical ledger events and creates auditable proposals from structured Observer candidates
- durable `observer_run_logs` Postgres store with run IDs, cursors, source counts, decisions, reasons, proposal IDs, errors, latency, and model metadata
- Hermes cron/no-agent entrypoint script for calling the backend runner
- unit coverage with an in-memory canonical ledger and log store

This intentionally does not add free-text keyword extraction or direct memory/scanner/reminder mutation. Those should be added behind the same audit surface once the extractor is model-backed and evaluated.

## Validation

- `python3 -m pytest tests/unit/test_ella_observer.py tests/unit/test_ella_mcp_proposals.py tests/unit/test_ella_conversation_corrections.py tests/unit/test_ella_plato_mcp.py`
- `python3 -m py_compile ella/services/observer.py ella/services/observer_logs.py ella/routers/observer.py scripts/ella_observer_cron.py`
- `git diff --check`

## Related

- ellaaicare/ella-ai#860
