### PR TITLE
[codex] Fix Observer log datetime persistence

### DIFF
--- a/backend/ella/services/observer_logs.py
+++ b/backend/ella/services/observer_logs.py
@@ -13,6 +13,12 @@ from ella.services.observer import ObserverRunLog, observer_log_to_dict
 _pool: Optional[asyncpg.Pool] = None
 
 
+def _log_to_python(log: ObserverRunLog) -> dict[str, Any]:
+    if hasattr(log, "model_dump"):
+        return log.model_dump(mode="python")
+    return log.dict()
+
+
 async def _get_pool() -> asyncpg.Pool:
     global _pool
     if _pool is None:
@@ -78,7 +84,7 @@ class PostgresObserverRunLogStore(ObserverRunLogStore):
 
     async def save(self, log: ObserverRunLog) -> ObserverRunLog:
         await self._ensure_table()
-        data = observer_log_to_dict(log)
+        data = _log_to_python(log)
         pool = await _get_pool()
         await pool.execute(
             """

--- a/backend/tests/unit/test_ella_observer.py
+++ b/backend/tests/unit/test_ella_observer.py
@@ -217,3 +217,16 @@ def test_observer_router_runs_against_in_memory_test_ledger(monkeypatch):
     )
     assert readback.status_code == 200
     assert readback.json()["observer_run"]["run_id"] == run_id
+
+
+def test_observer_log_store_keeps_datetimes_for_postgres(monkeypatch):
+    service = _load_observer_service()
+    sys.modules.pop("ella.services.observer_logs", None)
+    logs_module = importlib.import_module("ella.services.observer_logs")
+
+    log = service.run_observer(profile_uid="user-1", dry_run=True, events=[_event()], run_id="run-python-dates")
+    data = logs_module._log_to_python(log)
+
+    assert hasattr(data["started_at"], "isoformat")
+    assert hasattr(data["completed_at"], "isoformat")
+    assert isinstance(service.observer_log_to_dict(log)["started_at"], str)


### PR DESCRIPTION
## Summary

Fixes the Observer run log Postgres write path to preserve Python `datetime` objects for `TIMESTAMPTZ` columns. The API response path still uses JSON-safe serialization.

## Validation

- `python3 -m pytest tests/unit/test_ella_observer.py`
- `python3 -m py_compile ella/services/observer_logs.py`
- `git diff --check`

## Related

Follow-up to #180 / ellaaicare/ella-ai#860 after live dry-run exposed the asyncpg type error.
