### PR TITLE
[codex] Add Observer candidate extraction modes

### DIFF
--- a/backend/ella/routers/observer.py
+++ b/backend/ella/routers/observer.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 
 from ella.routers.canonical_events import CanonicalEventStore, PostgresCanonicalEventStore
 from ella.services.observer import observer_log_to_dict, run_observer
+from ella.services.observer_extractor import build_extraction_result, combined_extractor, normalize_extractor_mode
 from ella.services.observer_logs import ObserverRunLogStore, PostgresObserverRunLogStore
 
 DEFAULT_OBSERVER_LIMIT = 100
@@ -29,6 +30,9 @@ class ObserverRunRequest(BaseModel):
     dry_run: bool = True
     limit: int = DEFAULT_OBSERVER_LIMIT
     channels: list[str] = Field(default_factory=list)
+    extractor_mode: str = ""
+    extractor_limit: int = 60
+    extractor_timeout_seconds: float = 45.0
     model_metadata: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -103,14 +107,23 @@ def create_observer_router(
             limit=_sanitize_limit(request.limit),
             channels=request.channels or None,
         )
+        extractor_mode = normalize_extractor_mode(request.extractor_mode)
+        extraction = await build_extraction_result(
+            source_events,
+            mode=extractor_mode,
+            timeout_seconds=max(5.0, min(float(request.extractor_timeout_seconds or 45.0), 120.0)),
+            limit=max(1, min(int(request.extractor_limit or 60), 100)),
+        )
         log = run_observer(
             profile_uid=request.uid,
             canonical_identity=request.canonical_identity,
             cursor_before=request.cursor_before,
             dry_run=request.dry_run,
             events=source_events,
+            extractor=combined_extractor(extraction),
             model_metadata={
-                "extractor": "structured_candidate_extractor",
+                "extractor_mode": extractor_mode,
+                **(extraction.metadata or {}),
                 **(request.model_metadata or {}),
             },
         )
@@ -135,7 +148,12 @@ def create_observer_router(
         x_ella_observer_token: Optional[str] = Header(default=None, alias="X-Ella-Observer-Token"),
     ):
         _authenticate(authorization, x_ella_observer_token)
-        return {"ok": True, "mode": "proposal_only", "default_dry_run": True}
+        return {
+            "ok": True,
+            "mode": "proposal_only",
+            "default_dry_run": True,
+            "default_extractor_mode": normalize_extractor_mode(""),
+        }
 
     return router
 

--- a/backend/ella/services/observer_extractor.py
+++ b/backend/ella/services/observer_extractor.py
@@ -1,0 +1,419 @@
+"""Observer candidate extraction from canonical ledger events.
+
+This module is intentionally separate from the proposal runner. Extraction can
+use heuristics or a model, but the runner remains the only place that validates,
+dedupes, logs, and proposes mutations.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from ella.services.observer import ObserverCandidate, structured_candidate_extractor
+
+MAX_EXTRACTOR_EVENTS = 60
+MAX_EVENT_TEXT_CHARS = 1800
+SUPPORTED_EXTRACTOR_MODES = {"structured", "heuristic", "hermes"}
+
+_REMEMBER_RE = re.compile(
+    r"\b(?:please\s+)?(?:remember|note|keep track of|log this|save this)\b(?P<fact>.*)",
+    re.IGNORECASE | re.DOTALL,
+)
+_CORRECTION_RE = re.compile(
+    r"\b(?:actually|correction|correct(?:ion)?|it was|that was|the correct)\b(?P<fact>.*)",
+    re.IGNORECASE | re.DOTALL,
+)
+_REMINDER_RE = re.compile(r"\b(?:remind me|reminder|don't let me forget)\b(?P<fact>.*)", re.IGNORECASE | re.DOTALL)
+_SCANNER_RE = re.compile(
+    r"\b(?:watch for|listen for|scan for|alert me|tell me if|notify me if|guardian should|necklace should)\b(?P<fact>.*)",
+    re.IGNORECASE | re.DOTALL,
+)
+_LOW_SIGNAL_RE = re.compile(r"^\W*(?:ok|okay|yeah|yes|no|thanks|thank you|no problem|sixteen|not white)\W*$", re.I)
+
+
+@dataclass
+class ExtractionResult:
+    candidates_by_event_id: dict[str, list[ObserverCandidate]] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.getenv(name, default).strip()
+
+
+def normalize_extractor_mode(mode: str | None) -> str:
+    value = (mode or "").strip().lower() or _env("ELLA_OBSERVER_EXTRACTOR_MODE", "structured").lower()
+    if value not in SUPPORTED_EXTRACTOR_MODES:
+        return "structured"
+    return value
+
+
+def _event_id(event: dict[str, Any]) -> str:
+    return str(event.get("event_id") or "")
+
+
+def _event_text(event: dict[str, Any], max_chars: int = MAX_EVENT_TEXT_CHARS) -> str:
+    text = str(event.get("text") or "").replace("\x00", "").strip()
+    if len(text) > max_chars:
+        return text[:max_chars].rstrip()
+    return text
+
+
+def _event_title(event: dict[str, Any]) -> str:
+    metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+    for key in ("title", "summary_title", "conversation_title"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()[:160]
+    source_ref = event.get("source_ref") if isinstance(event.get("source_ref"), dict) else {}
+    value = source_ref.get("title")
+    if isinstance(value, str) and value.strip():
+        return value.strip()[:160]
+    return ""
+
+
+def _is_low_signal(event: dict[str, Any]) -> bool:
+    text = _event_text(event, max_chars=280)
+    if not text or _LOW_SIGNAL_RE.match(text):
+        return True
+    metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+    signal = metadata.get("ella_signal") if isinstance(metadata.get("ella_signal"), dict) else {}
+    salience = str(metadata.get("salience") or signal.get("salience") or "").lower()
+    if salience in {"none", "low"} and len(text) < 80:
+        return True
+    return False
+
+
+def _candidate(
+    *,
+    proposal_type: str,
+    title: str,
+    description: str,
+    requested_change: dict[str, Any],
+    event: dict[str, Any],
+    reason: str,
+    confidence: float,
+) -> ObserverCandidate:
+    return ObserverCandidate(
+        proposal_type=proposal_type,
+        title=title[:240],
+        description=description[:4000],
+        requested_change=requested_change,
+        target={"profile_uid": event.get("uid"), "canonical_identity": event.get("canonical_identity")},
+        reason=reason,
+        confidence=confidence,
+        evidence=[
+            {
+                "event_id": event.get("event_id"),
+                "channel": event.get("channel"),
+                "provider": event.get("provider"),
+                "started_at": event.get("started_at"),
+                "extractor": "heuristic",
+            }
+        ],
+    )
+
+
+def heuristic_candidate_extractor(event: dict[str, Any]) -> list[ObserverCandidate]:
+    """High-precision local extractor for explicit user commands/corrections."""
+    if not isinstance(event, dict) or str(event.get("role") or "").lower() not in {"user", "speaker", "system"}:
+        return []
+    if _is_low_signal(event):
+        return []
+
+    text = _event_text(event)
+    title = _event_title(event)
+    candidates: list[ObserverCandidate] = []
+
+    remember = _REMEMBER_RE.search(text)
+    if remember:
+        fact = (remember.group("fact") or text).strip(" .:-\n\t")
+        memory = fact or text
+        candidates.append(
+            _candidate(
+                proposal_type="memory_note",
+                title=f"Remembered context: {memory[:80]}",
+                description=f"The user explicitly asked Ella to remember this: {memory}",
+                requested_change={"memory": memory, "source_text": text, "category": "explicit_user_memory"},
+                event=event,
+                reason="User explicitly asked Ella to remember durable context.",
+                confidence=0.88,
+            )
+        )
+
+    correction = _CORRECTION_RE.search(text)
+    if correction and len(text) >= 12:
+        fact = (correction.group("fact") or text).strip(" .:-\n\t")
+        candidates.append(
+            _candidate(
+                proposal_type="summary_correction",
+                title=f"User correction: {(fact or title or text)[:90]}",
+                description=f"The user provided a correction that may affect summaries or memory: {text}",
+                requested_change={"correction_text": text, "corrected_fact": fact, "source_title": title},
+                event=event,
+                reason="User explicitly supplied a correction.",
+                confidence=0.86,
+            )
+        )
+
+    reminder = _REMINDER_RE.search(text)
+    if reminder:
+        request_text = (reminder.group("fact") or text).strip(" .:-\n\t")
+        candidates.append(
+            _candidate(
+                proposal_type="reminder_request",
+                title=f"Reminder request: {(request_text or text)[:90]}",
+                description=f"The user requested a reminder: {text}",
+                requested_change={"reminder_text": text, "request": request_text},
+                event=event,
+                reason="User explicitly requested a reminder.",
+                confidence=0.84,
+            )
+        )
+
+    scanner = _SCANNER_RE.search(text)
+    if scanner:
+        rule_text = (scanner.group("fact") or text).strip(" .:-\n\t")
+        candidates.append(
+            _candidate(
+                proposal_type="scanner_rule_change",
+                title=f"Scanner rule request: {(rule_text or text)[:90]}",
+                description=f"The user requested Guardian/scanner monitoring behavior: {text}",
+                requested_change={"rule_text": text, "request": rule_text, "scope": "user_requested"},
+                event=event,
+                reason="User explicitly requested scanner or Guardian behavior.",
+                confidence=0.82,
+            )
+        )
+
+    return candidates
+
+
+def _event_payload(event: dict[str, Any]) -> dict[str, Any]:
+    metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+    signal = metadata.get("ella_signal") if isinstance(metadata.get("ella_signal"), dict) else {}
+    return {
+        "event_id": event.get("event_id"),
+        "channel": event.get("channel"),
+        "provider": event.get("provider"),
+        "role": event.get("role"),
+        "started_at": event.get("started_at"),
+        "title": _event_title(event),
+        "salience": metadata.get("salience") or signal.get("salience"),
+        "tags": metadata.get("tags") or signal.get("tags") or [],
+        "text": _event_text(event),
+    }
+
+
+def _extract_json_object(text: str) -> dict[str, Any]:
+    raw = (text or "").strip()
+    if raw.startswith("```"):
+        raw = re.sub(r"^```(?:json)?\s*", "", raw)
+        raw = re.sub(r"\s*```$", "", raw)
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        start = raw.find("{")
+        end = raw.rfind("}")
+        if start < 0 or end <= start:
+            raise
+        value = json.loads(raw[start : end + 1])
+    return value if isinstance(value, dict) else {}
+
+
+def _candidate_from_model(raw: dict[str, Any], event_lookup: dict[str, dict[str, Any]]) -> ObserverCandidate | None:
+    if not isinstance(raw, dict):
+        return None
+    evidence_event_ids = raw.get("evidence_event_ids") or raw.get("event_ids") or []
+    if isinstance(evidence_event_ids, str):
+        evidence_event_ids = [evidence_event_ids]
+    if not isinstance(evidence_event_ids, list):
+        evidence_event_ids = []
+    event = event_lookup.get(str(evidence_event_ids[0])) if evidence_event_ids else None
+    if not event:
+        return None
+    try:
+        return ObserverCandidate(
+            proposal_type=str(raw.get("proposal_type") or "").strip(),
+            title=str(raw.get("title") or "").strip()[:240],
+            description=str(raw.get("description") or "").strip()[:4000],
+            requested_change=raw.get("requested_change") if isinstance(raw.get("requested_change"), dict) else {},
+            target=raw.get("target") if isinstance(raw.get("target"), dict) else {},
+            reason=str(raw.get("reason") or "model_candidate").strip()[:1000],
+            confidence=float(raw.get("confidence") or 0.0),
+            evidence=[
+                {
+                    "event_id": str(event_id),
+                    "channel": event_lookup.get(str(event_id), {}).get("channel"),
+                    "provider": event_lookup.get(str(event_id), {}).get("provider"),
+                    "started_at": event_lookup.get(str(event_id), {}).get("started_at"),
+                    "extractor": "hermes",
+                }
+                for event_id in evidence_event_ids
+                if str(event_id) in event_lookup
+            ],
+        )
+    except Exception:
+        return None
+
+
+async def hermes_candidate_extraction(
+    events: list[dict[str, Any]],
+    *,
+    gateway_url: str | None = None,
+    token: str | None = None,
+    model: str | None = None,
+    timeout_seconds: float = 45.0,
+    limit: int = MAX_EXTRACTOR_EVENTS,
+) -> ExtractionResult:
+    """Ask Hermes for proposal candidates using a strict JSON-only contract."""
+    selected = [event for event in events if isinstance(event, dict) and not _is_low_signal(event)]
+    selected = selected[-max(1, min(limit, MAX_EXTRACTOR_EVENTS)) :]
+    if not selected:
+        return ExtractionResult(metadata={"extractor": "hermes", "event_count": 0, "skipped": "no_signal_events"})
+
+    url = (gateway_url or _env("HERMES_GATEWAY_URL", "http://100.76.138.56:8642")).rstrip("/")
+    api_token = token if token is not None else _env("HERMES_API_SERVER_KEY", _env("API_SERVER_KEY", ""))
+    model_name = model or _env("HERMES_MODEL", "plato-eval")
+    if not api_token:
+        return ExtractionResult(
+            metadata={"extractor": "hermes", "event_count": len(selected), "error": "missing_hermes_token"}
+        )
+
+    payload_events = [_event_payload(event) for event in selected]
+    system = (
+        "You are Ella Observer's candidate extractor. Return only compact JSON. "
+        "You do not mutate memory, scanner rules, reminders, summaries, or caregiver state. "
+        "Find only high-confidence proposals from the supplied canonical events.\n\n"
+        "Allowed proposal_type values: memory_note, profile_update, scanner_rule_change, "
+        "reminder_request, summary_correction.\n"
+        "Create candidates only for explicit durable user facts, explicit corrections, explicit "
+        "reminder requests, or explicit scanner/Guardian instructions. Ignore TV, music, podcasts, "
+        "news, background chatter, third-party claims, and ambiguous fragments unless the user makes "
+        "them personally relevant. Every candidate must cite evidence_event_ids from the input.\n"
+        "Schema: {\"candidates\":[{\"proposal_type\":\"memory_note\",\"title\":\"...\","
+        "\"description\":\"...\",\"requested_change\":{},\"target\":{},\"reason\":\"...\","
+        "\"confidence\":0.0,\"evidence_event_ids\":[\"...\"]}]}"
+    )
+    user = "Canonical events to inspect:\n" + json.dumps(payload_events, ensure_ascii=False, separators=(",", ":"))
+    started = time.monotonic()
+    try:
+        async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+            response = await client.post(
+                f"{url}/v1/chat/completions",
+                headers={"Authorization": f"Bearer {api_token}"},
+                json={
+                    "model": model_name,
+                    "messages": [
+                        {"role": "system", "content": system},
+                        {"role": "user", "content": user},
+                    ],
+                    "temperature": 0,
+                    "max_tokens": 1200,
+                    "stream": False,
+                },
+            )
+        response.raise_for_status()
+        data = response.json()
+        content = str((data.get("choices") or [{}])[0].get("message", {}).get("content") or "")
+        parsed = _extract_json_object(content)
+    except Exception as exc:
+        return ExtractionResult(
+            metadata={
+                "extractor": "hermes",
+                "event_count": len(selected),
+                "latency_ms": int((time.monotonic() - started) * 1000),
+                "error": type(exc).__name__,
+                "error_detail": str(exc)[:240],
+            }
+        )
+
+    event_lookup = {_event_id(event): event for event in selected if _event_id(event)}
+    candidates_by_event_id: dict[str, list[ObserverCandidate]] = {}
+    raw_candidates = parsed.get("candidates") if isinstance(parsed.get("candidates"), list) else []
+    for raw in raw_candidates:
+        candidate = _candidate_from_model(raw, event_lookup)
+        if not candidate:
+            continue
+        for evidence in candidate.evidence or []:
+            event_id = str(evidence.get("event_id") or "")
+            if event_id:
+                candidates_by_event_id.setdefault(event_id, []).append(candidate)
+                break
+
+    return ExtractionResult(
+        candidates_by_event_id=candidates_by_event_id,
+        metadata={
+            "extractor": "hermes",
+            "model": model_name,
+            "event_count": len(selected),
+            "candidate_count": sum(len(items) for items in candidates_by_event_id.values()),
+            "latency_ms": int((time.monotonic() - started) * 1000),
+        },
+    )
+
+
+async def build_extraction_result(
+    events: list[dict[str, Any]],
+    *,
+    mode: str,
+    timeout_seconds: float = 45.0,
+    limit: int = MAX_EXTRACTOR_EVENTS,
+) -> ExtractionResult:
+    normalized = normalize_extractor_mode(mode)
+    if normalized == "structured":
+        return ExtractionResult(metadata={"extractor": "structured_candidate_extractor"})
+    if normalized == "heuristic":
+        return _heuristic_extraction_result(events)
+
+    heuristic = _heuristic_extraction_result(events)
+    hermes = await hermes_candidate_extraction(events, timeout_seconds=timeout_seconds, limit=limit)
+    merged = {event_id: list(candidates) for event_id, candidates in heuristic.candidates_by_event_id.items()}
+    for event_id, candidates in hermes.candidates_by_event_id.items():
+        merged.setdefault(event_id, []).extend(candidates)
+    return ExtractionResult(
+        candidates_by_event_id=merged,
+        metadata={
+            "extractor": "hermes_plus_heuristic",
+            "heuristic": heuristic.metadata,
+            "hermes": hermes.metadata,
+            "candidate_count": sum(len(items) for items in merged.values()),
+        },
+    )
+
+
+def _heuristic_extraction_result(events: list[dict[str, Any]]) -> ExtractionResult:
+    candidates_by_event_id = {
+        _event_id(event): candidates
+        for event in events
+        if _event_id(event)
+        if (candidates := heuristic_candidate_extractor(event))
+    }
+    return ExtractionResult(
+        candidates_by_event_id=candidates_by_event_id,
+        metadata={
+            "extractor": "heuristic_candidate_extractor",
+            "event_count": len(events),
+            "candidate_count": sum(len(items) for items in candidates_by_event_id.values()),
+        },
+    )
+
+
+def combined_extractor(result: ExtractionResult):
+    """Return an event extractor combining structured metadata and extracted candidates."""
+
+    def _extract(event: dict[str, Any]) -> list[ObserverCandidate]:
+        candidates = list(structured_candidate_extractor(event))
+        event_id = _event_id(event)
+        if event_id:
+            candidates.extend(result.candidates_by_event_id.get(event_id, []))
+        return candidates
+
+    return _extract

--- a/backend/scripts/ella_observer_cron.py
+++ b/backend/scripts/ella_observer_cron.py
@@ -33,6 +33,12 @@ def main() -> int:
     parser.add_argument("--lookback-minutes", type=int, default=int(_env("ELLA_OBSERVER_LOOKBACK_MINUTES", "30")))
     parser.add_argument("--limit", type=int, default=int(_env("ELLA_OBSERVER_LIMIT", "100")))
     parser.add_argument("--channels", default=_env("ELLA_OBSERVER_CHANNELS", ""))
+    parser.add_argument("--extractor-mode", default=_env("ELLA_OBSERVER_EXTRACTOR_MODE", "hermes"))
+    parser.add_argument(
+        "--extractor-timeout-seconds",
+        type=float,
+        default=float(_env("ELLA_OBSERVER_EXTRACTOR_TIMEOUT_SECONDS", "45")),
+    )
     parser.add_argument("--live", action="store_true", help="Create proposals instead of dry-running")
     args = parser.parse_args()
 
@@ -51,6 +57,8 @@ def main() -> int:
         "dry_run": not args.live,
         "limit": args.limit,
         "channels": [part.strip() for part in args.channels.split(",") if part.strip()],
+        "extractor_mode": args.extractor_mode,
+        "extractor_timeout_seconds": args.extractor_timeout_seconds,
         "model_metadata": {
             "invoked_by": "hermes_cron_script",
             "script": "backend/scripts/ella_observer_cron.py",

--- a/backend/tests/unit/test_ella_observer.py
+++ b/backend/tests/unit/test_ella_observer.py
@@ -149,6 +149,28 @@ def test_observer_logs_events_with_no_candidates():
     assert log.decisions[0].reason == "no_structured_observer_candidates"
 
 
+def test_heuristic_extractor_promotes_explicit_memory_and_scanner_requests():
+    service = _load_observer_service()
+    sys.modules.pop("ella.services.observer_extractor", None)
+    extractor_module = importlib.import_module("ella.services.observer_extractor")
+
+    event = _event(
+        event_id="evt-heuristic",
+        metadata={},
+        text="Hey Ella, please remember my spare glasses are in the blue backpack. Also alert me if I ask where they are.",
+    )
+    result = service.run_observer(
+        profile_uid="user-1",
+        dry_run=True,
+        events=[event],
+        extractor=extractor_module.heuristic_candidate_extractor,
+        run_id="run-heuristic",
+    )
+
+    assert result.proposal_count == 2
+    assert {decision.proposal_type for decision in result.decisions} == {"memory_note", "scanner_rule_change"}
+
+
 def test_observer_router_runs_against_in_memory_test_ledger(monkeypatch):
     _install_proposal_stubs()
     monkeypatch.setenv("ELLA_OBSERVER_ADMIN_TOKEN", "observer-token")
@@ -217,6 +239,68 @@ def test_observer_router_runs_against_in_memory_test_ledger(monkeypatch):
     )
     assert readback.status_code == 200
     assert readback.json()["observer_run"]["run_id"] == run_id
+
+
+def test_observer_router_can_use_extraction_result(monkeypatch):
+    _install_proposal_stubs()
+    monkeypatch.setenv("ELLA_OBSERVER_ADMIN_TOKEN", "observer-token")
+    sys.modules.pop("ella.routers.observer", None)
+    router_module = importlib.import_module("ella.routers.observer")
+    canonical_module = importlib.import_module("ella.routers.canonical_events")
+    logs_module = importlib.import_module("ella.services.observer_logs")
+    extractor_module = importlib.import_module("ella.services.observer_extractor")
+
+    event_store = canonical_module.InMemoryCanonicalEventStore()
+    log_store = logs_module.InMemoryObserverRunLogStore()
+
+    import asyncio
+
+    asyncio.run(
+        event_store.write_batch(
+            [
+                canonical_module.CanonicalEventIn(
+                    uid="user-1",
+                    canonical_identity="plato",
+                    event_id="evt-router-extracted",
+                    channel="ios_chat",
+                    provider="ella-ios",
+                    role="user",
+                    text="Please remember that the valet key is in the blue ceramic bowl.",
+                    started_at="2026-05-07T20:05:00+00:00",
+                    source_ref={"message_id": "m-2"},
+                    metadata={},
+                )
+            ]
+        )
+    )
+
+    async def fake_build_extraction_result(events, *, mode, timeout_seconds=45.0, limit=60):
+        assert mode == "heuristic"
+        return await extractor_module.build_extraction_result(
+            events,
+            mode=mode,
+            timeout_seconds=timeout_seconds,
+            limit=limit,
+        )
+
+    monkeypatch.setattr(router_module, "build_extraction_result", fake_build_extraction_result)
+
+    app = FastAPI()
+    app.include_router(router_module.create_observer_router(event_store=event_store, log_store=log_store))
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/ella/observer/run",
+        headers={"X-Ella-Observer-Token": "observer-token"},
+        json={"uid": "user-1", "dry_run": True, "extractor_mode": "heuristic", "limit": 10},
+    )
+
+    assert response.status_code == 200
+    body = response.json()["observer_run"]
+    assert body["source_event_count"] == 1
+    assert body["proposal_count"] == 1
+    assert body["model_metadata"]["extractor_mode"] == "heuristic"
+    assert body["model_metadata"]["extractor"] == "heuristic_candidate_extractor"
 
 
 def test_observer_log_store_keeps_datetimes_for_postgres(monkeypatch):


### PR DESCRIPTION
## Summary
- add an Observer extraction layer with structured, heuristic, and Hermes-backed modes
- keep the runner proposal-only while logging extractor mode, latency, candidate counts, and errors
- wire cron payloads to request Hermes extraction by default while falling back to high-precision heuristic candidates

## Validation
- python3 -m pytest tests/unit/test_ella_observer.py tests/unit/test_ella_canonical_context.py tests/unit/test_ella_canonical_omi.py