### PR TITLE
[codex] Harden Observer heuristic extraction scope

### DIFF
--- a/backend/ella/services/observer_extractor.py
+++ b/backend/ella/services/observer_extractor.py
@@ -21,15 +21,13 @@ from ella.services.observer import ObserverCandidate, structured_candidate_extra
 MAX_EXTRACTOR_EVENTS = 60
 MAX_EVENT_TEXT_CHARS = 1800
 SUPPORTED_EXTRACTOR_MODES = {"structured", "heuristic", "hermes"}
+HEURISTIC_USER_CHANNELS = {"ios_chat", "ios_voice", "imessage", "telegram"}
 
 _REMEMBER_RE = re.compile(
     r"\b(?:please\s+)?(?:remember|note|keep track of|log this|save this)\b(?P<fact>.*)",
     re.IGNORECASE | re.DOTALL,
 )
-_CORRECTION_RE = re.compile(
-    r"\b(?:actually|correction|correct(?:ion)?|it was|that was|the correct)\b(?P<fact>.*)",
-    re.IGNORECASE | re.DOTALL,
-)
+_CORRECTION_RE = re.compile(r"\b(?:actually|correction|it was|that was|the correct)\b(?P<fact>.*)", re.I | re.S)
 _REMINDER_RE = re.compile(r"\b(?:remind me|reminder|don't let me forget)\b(?P<fact>.*)", re.IGNORECASE | re.DOTALL)
 _SCANNER_RE = re.compile(
     r"\b(?:watch for|listen for|scan for|alert me|tell me if|notify me if|guardian should|necklace should)\b(?P<fact>.*)",
@@ -123,7 +121,9 @@ def _candidate(
 
 def heuristic_candidate_extractor(event: dict[str, Any]) -> list[ObserverCandidate]:
     """High-precision local extractor for explicit user commands/corrections."""
-    if not isinstance(event, dict) or str(event.get("role") or "").lower() not in {"user", "speaker", "system"}:
+    if not isinstance(event, dict) or str(event.get("role") or "").lower() not in {"user", "speaker"}:
+        return []
+    if str(event.get("channel") or "") not in HEURISTIC_USER_CHANNELS:
         return []
     if _is_low_signal(event):
         return []

--- a/backend/tests/unit/test_ella_observer.py
+++ b/backend/tests/unit/test_ella_observer.py
@@ -171,6 +171,30 @@ def test_heuristic_extractor_promotes_explicit_memory_and_scanner_requests():
     assert {decision.proposal_type for decision in result.decisions} == {"memory_note", "scanner_rule_change"}
 
 
+def test_heuristic_extractor_ignores_omi_summary_language():
+    service = _load_observer_service()
+    sys.modules.pop("ella.services.observer_extractor", None)
+    extractor_module = importlib.import_module("ella.services.observer_extractor")
+
+    event = _event(
+        event_id="evt-omi-summary",
+        channel="omi",
+        role="system",
+        metadata={},
+        text="[Ella] This summary says Ella should remember that the voice memory fix worked.",
+    )
+    result = service.run_observer(
+        profile_uid="user-1",
+        dry_run=True,
+        events=[event],
+        extractor=extractor_module.heuristic_candidate_extractor,
+        run_id="run-omi-summary",
+    )
+
+    assert result.proposal_count == 0
+    assert result.decisions[0].reason == "no_structured_observer_candidates"
+
+
 def test_observer_router_runs_against_in_memory_test_ledger(monkeypatch):
     _install_proposal_stubs()
     monkeypatch.setenv("ELLA_OBSERVER_ADMIN_TOKEN", "observer-token")


### PR DESCRIPTION
## Summary
- restrict deterministic Observer heuristics to explicit user-turn channels only
- keep OMI summaries out of heuristic extraction to avoid treating generated summary language as user commands
- tighten correction matching and add regression coverage

## Validation
- python3 -m pytest tests/unit/test_ella_observer.py tests/unit/test_ella_canonical_context.py tests/unit/test_ella_canonical_omi.py