### PR TITLE
[codex] Avoid Observer memory-question false positives

### DIFF
--- a/backend/ella/services/observer_extractor.py
+++ b/backend/ella/services/observer_extractor.py
@@ -24,7 +24,7 @@ SUPPORTED_EXTRACTOR_MODES = {"structured", "heuristic", "hermes"}
 HEURISTIC_USER_CHANNELS = {"ios_chat", "ios_voice", "imessage", "telegram"}
 
 _REMEMBER_RE = re.compile(
-    r"\b(?:please\s+)?(?:remember|note|keep track of|log this|save this)\b(?P<fact>.*)",
+    r"\b(?:(?:please\s+)?remember|note(?:\s+that)?|keep track of|log this|save this)\b(?P<fact>.*)",
     re.IGNORECASE | re.DOTALL,
 )
 _CORRECTION_RE = re.compile(r"\b(?:actually|correction|it was|that was|the correct)\b(?P<fact>.*)", re.I | re.S)
@@ -89,6 +89,23 @@ def _is_low_signal(event: dict[str, Any]) -> bool:
     return False
 
 
+def _is_memory_instruction(text: str, match: re.Match[str]) -> bool:
+    lower = text.lower().strip()
+    prefix = lower[: match.start()].strip()
+    fact = (match.group("fact") or "").strip(" .:-\n\t").lower()
+    if re.search(r"\b(?:do you|can you|could you|what do you|what did i|did i)\s+$", prefix):
+        return False
+    if prefix.endswith(("what", "where", "when", "why", "how")):
+        return False
+    if fact.startswith(("what ", "who ", "when ", "why ", "how ", "anything ", "the last ")):
+        return False
+    if "?" in text and not re.search(
+        r"\b(?:please remember|remember that|remember this|remember my|remember where)\b", lower
+    ):
+        return False
+    return bool(fact)
+
+
 def _candidate(
     *,
     proposal_type: str,
@@ -133,7 +150,7 @@ def heuristic_candidate_extractor(event: dict[str, Any]) -> list[ObserverCandida
     candidates: list[ObserverCandidate] = []
 
     remember = _REMEMBER_RE.search(text)
-    if remember:
+    if remember and _is_memory_instruction(text, remember):
         fact = (remember.group("fact") or text).strip(" .:-\n\t")
         memory = fact or text
         candidates.append(

--- a/backend/tests/unit/test_ella_observer.py
+++ b/backend/tests/unit/test_ella_observer.py
@@ -195,6 +195,46 @@ def test_heuristic_extractor_ignores_omi_summary_language():
     assert result.decisions[0].reason == "no_structured_observer_candidates"
 
 
+def test_heuristic_extractor_does_not_treat_memory_questions_as_instructions():
+    service = _load_observer_service()
+    sys.modules.pop("ella.services.observer_extractor", None)
+    extractor_module = importlib.import_module("ella.services.observer_extractor")
+
+    question = _event(
+        event_id="evt-memory-question",
+        metadata={},
+        channel="ios_chat",
+        role="user",
+        text="Hey Ella, do you remember what I ordered for breakfast this morning?",
+    )
+    instruction = _event(
+        event_id="evt-memory-instruction",
+        metadata={},
+        channel="ios_chat",
+        role="user",
+        text="Hey Ella, please remember where I put the valet key.",
+    )
+
+    question_log = service.run_observer(
+        profile_uid="user-1",
+        dry_run=True,
+        events=[question],
+        extractor=extractor_module.heuristic_candidate_extractor,
+        run_id="run-memory-question",
+    )
+    instruction_log = service.run_observer(
+        profile_uid="user-1",
+        dry_run=True,
+        events=[instruction],
+        extractor=extractor_module.heuristic_candidate_extractor,
+        run_id="run-memory-instruction",
+    )
+
+    assert question_log.proposal_count == 0
+    assert instruction_log.proposal_count == 1
+    assert instruction_log.decisions[0].proposal_type == "memory_note"
+
+
 def test_observer_router_runs_against_in_memory_test_ledger(monkeypatch):
     _install_proposal_stubs()
     monkeypatch.setenv("ELLA_OBSERVER_ADMIN_TOKEN", "observer-token")


### PR DESCRIPTION
## Summary
- keep explicit remember/save/note requests eligible for Observer proposals
- avoid treating questions like 'do you remember what I ordered?' as memory mutation requests
- add regression coverage for the question vs instruction split

## Validation
- python3 -m pytest tests/unit/test_ella_observer.py tests/unit/test_ella_canonical_context.py tests/unit/test_ella_canonical_omi.py