### PR TITLE
[codex] Require user evidence for Observer model proposals

### DIFF
--- a/backend/ella/services/observer_extractor.py
+++ b/backend/ella/services/observer_extractor.py
@@ -256,6 +256,8 @@ def _candidate_from_model(raw: dict[str, Any], event_lookup: dict[str, dict[str,
     event = event_lookup.get(str(evidence_event_ids[0])) if evidence_event_ids else None
     if not event:
         return None
+    if str(event.get("channel") or "") != "omi" and str(event.get("role") or "").lower() not in {"user", "speaker"}:
+        return None
     try:
         return ObserverCandidate(
             proposal_type=str(raw.get("proposal_type") or "").strip(),

--- a/backend/tests/unit/test_ella_observer.py
+++ b/backend/tests/unit/test_ella_observer.py
@@ -367,6 +367,34 @@ def test_observer_router_can_use_extraction_result(monkeypatch):
     assert body["model_metadata"]["extractor"] == "heuristic_candidate_extractor"
 
 
+def test_model_extractor_rejects_assistant_only_evidence():
+    sys.modules.pop("ella.services.observer_extractor", None)
+    extractor_module = importlib.import_module("ella.services.observer_extractor")
+
+    event_lookup = {
+        "assistant-event": _event(
+            event_id="assistant-event",
+            channel="ios_chat",
+            role="assistant",
+            metadata={},
+            text="I will remind you every evening.",
+        )
+    }
+    candidate = extractor_module._candidate_from_model(
+        {
+            "proposal_type": "reminder_request",
+            "title": "Evening reminder",
+            "description": "Assistant said it would remind the user.",
+            "requested_change": {"reminder_text": "evening reminder"},
+            "confidence": 0.9,
+            "evidence_event_ids": ["assistant-event"],
+        },
+        event_lookup,
+    )
+
+    assert candidate is None
+
+
 def test_observer_log_store_keeps_datetimes_for_postgres(monkeypatch):
     service = _load_observer_service()
     sys.modules.pop("ella.services.observer_logs", None)


### PR DESCRIPTION
## Summary
- reject model-extracted proposals that cite assistant-only non-OMI events
- keep OMI summaries eligible because they are derived transcript/session records
- add regression coverage for assistant-only reminder evidence

## Validation
- python3 -m pytest tests/unit/test_ella_observer.py tests/unit/test_ella_canonical_context.py tests/unit/test_ella_canonical_omi.py