### PR TITLE
[codex] Apply safe Observer memory proposals to ledger

### DIFF
--- a/backend/ella/routers/observer.py
+++ b/backend/ella/routers/observer.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, Header, HTTPException
 from pydantic import BaseModel, Field
 
 from ella.routers.canonical_events import CanonicalEventStore, PostgresCanonicalEventStore
+from ella.services.observer_apply import apply_pending_observer_memory_proposals
 from ella.services.observer import observer_log_to_dict, run_observer
 from ella.services.observer_extractor import build_extraction_result, combined_extractor, normalize_extractor_mode
 from ella.services.observer_logs import ObserverRunLogStore, PostgresObserverRunLogStore
@@ -34,6 +35,14 @@ class ObserverRunRequest(BaseModel):
     extractor_limit: int = 60
     extractor_timeout_seconds: float = 45.0
     model_metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ObserverApplyRequest(BaseModel):
+    uid: str
+    dry_run: bool = True
+    limit: int = 20
+    min_confidence: float = 0.9
+    proposal_types: list[str] = Field(default_factory=list)
 
 
 def _env(name: str, default: str = "") -> str:
@@ -129,6 +138,24 @@ def create_observer_router(
         )
         await logs.save(log)
         return {"ok": True, "observer_run": observer_log_to_dict(log)}
+
+    @router.post("/apply-pending")
+    async def apply_pending(
+        request: ObserverApplyRequest,
+        authorization: Optional[str] = Header(default=None),
+        x_ella_observer_token: Optional[str] = Header(default=None, alias="X-Ella-Observer-Token"),
+    ):
+        _authenticate(authorization, x_ella_observer_token)
+        if not request.uid:
+            raise HTTPException(status_code=400, detail="uid is required")
+        return await apply_pending_observer_memory_proposals(
+            profile_uid=request.uid,
+            event_store=events,
+            dry_run=request.dry_run,
+            limit=_sanitize_limit(request.limit),
+            min_confidence=max(0.0, min(float(request.min_confidence), 1.0)),
+            proposal_types={str(item) for item in request.proposal_types if str(item)} or None,
+        )
 
     @router.get("/runs/{run_id}")
     async def get_run(

--- a/backend/ella/services/observer_apply.py
+++ b/backend/ella/services/observer_apply.py
@@ -1,0 +1,172 @@
+"""Safe Observer proposal application.
+
+This applier deliberately handles only low-risk memory/profile proposals. It
+does not edit scanner files, reminders, summaries, caregiver routing, or any
+external delivery surface.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from database import proposals as proposals_db
+from ella.routers.canonical_events import CanonicalEventIn, CanonicalEventStore
+from models.proposals import Proposal, ProposalStatus
+
+AUTO_APPLY_TYPES = {"memory_note", "profile_update"}
+OBSERVER_SOURCE = "ella_observer_cron"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _proposal_type(proposal: Proposal) -> str:
+    value = proposal.proposal_type
+    return getattr(value, "value", str(value))
+
+
+def _payload(proposal: Proposal) -> dict[str, Any]:
+    return proposal.payload if isinstance(proposal.payload, dict) else {}
+
+
+def _confidence(proposal: Proposal) -> float:
+    try:
+        return float(_payload(proposal).get("confidence") or 0.0)
+    except Exception:
+        return 0.0
+
+
+def _observer_owned(proposal: Proposal) -> bool:
+    payload = _payload(proposal)
+    return payload.get("source") == OBSERVER_SOURCE or proposal.tool_name == "ella_observer_fact_promotion"
+
+
+def _event_text(proposal: Proposal) -> str:
+    payload = _payload(proposal)
+    requested_change = payload.get("requested_change") if isinstance(payload.get("requested_change"), dict) else {}
+    memory = requested_change.get("memory") or requested_change.get("profile_update") or requested_change
+    title = str(payload.get("title") or "").strip()
+    description = str(payload.get("description") or "").strip()
+    return "\n".join(part for part in [title, description, f"Requested change: {memory}"] if part)[:6000]
+
+
+def _canonical_identity(proposal: Proposal) -> str:
+    payload = _payload(proposal)
+    target = payload.get("target") if isinstance(payload.get("target"), dict) else {}
+    return str(target.get("canonical_identity") or proposal.session_claims.get("canonical_identity") or "")
+
+
+def _decision(action: str, proposal: Proposal, reason: str = "", error: str = "") -> dict[str, Any]:
+    return {
+        "action": action,
+        "proposal_id": proposal.proposal_id,
+        "proposal_type": _proposal_type(proposal),
+        "title": str(_payload(proposal).get("title") or ""),
+        "confidence": _confidence(proposal),
+        "reason": reason,
+        "error": error,
+    }
+
+
+async def apply_pending_observer_memory_proposals(
+    *,
+    profile_uid: str,
+    event_store: CanonicalEventStore,
+    dry_run: bool = True,
+    limit: int = 20,
+    min_confidence: float = 0.9,
+    proposal_types: set[str] | None = None,
+) -> dict[str, Any]:
+    allowed_types = proposal_types or AUTO_APPLY_TYPES
+    proposals = proposals_db.list_proposals(profile_uid, status=ProposalStatus.submitted.value, limit=limit)
+    decisions: list[dict[str, Any]] = []
+    applied_event_ids: list[str] = []
+
+    for proposal in proposals:
+        proposal_type = _proposal_type(proposal)
+        if not _observer_owned(proposal):
+            decisions.append(_decision("skip", proposal, "not_observer_owned"))
+            continue
+        if proposal_type not in allowed_types:
+            decisions.append(_decision("skip", proposal, "unsupported_auto_apply_type"))
+            continue
+        confidence = _confidence(proposal)
+        if confidence < min_confidence:
+            decisions.append(_decision("skip", proposal, "below_min_confidence"))
+            continue
+
+        event_id = f"observer:proposal:{proposal.proposal_id}:applied"
+        if dry_run:
+            decisions.append(_decision("would_apply", proposal, "safe_memory_event"))
+            continue
+
+        try:
+            await event_store.write_batch(
+                [
+                    CanonicalEventIn(
+                        uid=profile_uid,
+                        canonical_identity=_canonical_identity(proposal),
+                        event_id=event_id,
+                        channel="observer_memory",
+                        provider="ella-observer",
+                        role="system",
+                        text=_event_text(proposal),
+                        started_at=_now(),
+                        scan_policy="none",
+                        source_ref={
+                            "proposal_id": proposal.proposal_id,
+                            "source_identity": f"ella-observer:proposal:{proposal.proposal_id}",
+                        },
+                        metadata={
+                            "adapter": "observer-memory-applier",
+                            "proposal_id": proposal.proposal_id,
+                            "proposal_type": proposal_type,
+                            "confidence": confidence,
+                            "source_run_id": _payload(proposal).get("observer_run_id"),
+                            "requested_change": _payload(proposal).get("requested_change") or {},
+                            "evidence": _payload(proposal).get("evidence") or [],
+                        },
+                    )
+                ]
+            )
+            proposals_db.update_proposal_status(
+                profile_uid,
+                proposal.proposal_id,
+                status=ProposalStatus.applied.value,
+                event={
+                    "stage": "applied",
+                    "status": "ok",
+                    "actor": "ella-observer-memory-applier",
+                    "trace_id": proposal.trace_id,
+                    "detail": {"canonical_event_id": event_id, "channel": "observer_memory"},
+                },
+            )
+            applied_event_ids.append(event_id)
+            decisions.append(_decision("applied", proposal, "safe_memory_event"))
+        except Exception as exc:
+            proposals_db.update_proposal_status(
+                profile_uid,
+                proposal.proposal_id,
+                status=ProposalStatus.apply_failed.value,
+                event={
+                    "stage": "apply_failed",
+                    "status": "error",
+                    "actor": "ella-observer-memory-applier",
+                    "trace_id": proposal.trace_id,
+                    "detail": {"error": str(exc)[:500]},
+                },
+            )
+            decisions.append(_decision("error", proposal, "apply_failed", str(exc)[:500]))
+
+    return {
+        "ok": True,
+        "profile_uid": profile_uid,
+        "dry_run": dry_run,
+        "proposal_count": len(proposals),
+        "applied_count": sum(1 for decision in decisions if decision["action"] in {"would_apply", "applied"}),
+        "error_count": sum(1 for decision in decisions if decision["action"] == "error"),
+        "applied_event_ids": applied_event_ids,
+        "decisions": decisions,
+    }

--- a/backend/tests/unit/test_ella_observer.py
+++ b/backend/tests/unit/test_ella_observer.py
@@ -11,7 +11,9 @@ def _install_proposal_stubs():
     proposals = types.ModuleType("database.proposals")
     proposals.get_proposal = MagicMock(return_value=None)
     proposals.get_proposal_by_idempotency_key = MagicMock(return_value=None)
+    proposals.list_proposals = MagicMock(return_value=[])
     proposals.save_proposal = MagicMock(side_effect=lambda proposal: proposal)
+    proposals.update_proposal_status = MagicMock(return_value=None)
     database = sys.modules.setdefault("database", types.ModuleType("database"))
     setattr(database, "proposals", proposals)
     sys.modules["database.proposals"] = proposals
@@ -239,6 +241,7 @@ def test_observer_router_runs_against_in_memory_test_ledger(monkeypatch):
     _install_proposal_stubs()
     monkeypatch.setenv("ELLA_OBSERVER_ADMIN_TOKEN", "observer-token")
     sys.modules.pop("ella.routers.observer", None)
+    sys.modules.pop("ella.services.observer_apply", None)
     router_module = importlib.import_module("ella.routers.observer")
     canonical_module = importlib.import_module("ella.routers.canonical_events")
     logs_module = importlib.import_module("ella.services.observer_logs")
@@ -309,6 +312,7 @@ def test_observer_router_can_use_extraction_result(monkeypatch):
     _install_proposal_stubs()
     monkeypatch.setenv("ELLA_OBSERVER_ADMIN_TOKEN", "observer-token")
     sys.modules.pop("ella.routers.observer", None)
+    sys.modules.pop("ella.services.observer_apply", None)
     router_module = importlib.import_module("ella.routers.observer")
     canonical_module = importlib.import_module("ella.routers.canonical_events")
     logs_module = importlib.import_module("ella.services.observer_logs")
@@ -393,6 +397,64 @@ def test_model_extractor_rejects_assistant_only_evidence():
     )
 
     assert candidate is None
+
+
+def test_observer_apply_pending_writes_safe_memory_event(monkeypatch):
+    _install_proposal_stubs()
+    monkeypatch.setenv("ELLA_OBSERVER_ADMIN_TOKEN", "observer-token")
+    sys.modules.pop("ella.routers.observer", None)
+    sys.modules.pop("ella.services.observer_apply", None)
+    router_module = importlib.import_module("ella.routers.observer")
+    canonical_module = importlib.import_module("ella.routers.canonical_events")
+    logs_module = importlib.import_module("ella.services.observer_logs")
+    proposals_db = importlib.import_module("database.proposals")
+    proposal_models = importlib.import_module("models.proposals")
+
+    proposal = proposal_models.Proposal.from_claims(
+        session_claims={
+            "profile_uid": "user-1",
+            "role": "system_observer",
+            "external_provider": "ella_backend",
+            "trace_id": "observer:test",
+        },
+        tool_name="ella_observer_fact_promotion",
+        proposal_type="memory_note",
+        payload={
+            "title": "Spare glasses location",
+            "description": "Spare glasses are in the blue backpack.",
+            "source": "ella_observer_cron",
+            "confidence": 0.94,
+            "requested_change": {"memory": "Spare glasses are in the blue backpack."},
+            "target": {"canonical_identity": "plato"},
+        },
+        proposal_id="proposal-safe-memory",
+    )
+    proposals_db.list_proposals.return_value = [proposal]
+
+    event_store = canonical_module.InMemoryCanonicalEventStore()
+    log_store = logs_module.InMemoryObserverRunLogStore()
+    app = FastAPI()
+    app.include_router(router_module.create_observer_router(event_store=event_store, log_store=log_store))
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/ella/observer/apply-pending",
+        headers={"X-Ella-Observer-Token": "observer-token"},
+        json={"uid": "user-1", "dry_run": False, "min_confidence": 0.9},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["applied_count"] == 1
+    assert body["decisions"][0]["action"] == "applied"
+    proposals_db.update_proposal_status.assert_called_once()
+
+    import asyncio
+
+    events = asyncio.run(event_store.timeline(uid="user-1", since=None, limit=10, channels=["observer_memory"]))
+    assert len(events) == 1
+    assert events[0]["channel"] == "observer_memory"
+    assert "Spare glasses are in the blue backpack" in events[0]["text"]
 
 
 def test_observer_log_store_keeps_datetimes_for_postgres(monkeypatch):


### PR DESCRIPTION
## Summary
- add /v1/ella/observer/apply-pending for token-gated proposal application
- auto-apply only high-confidence Observer-owned memory_note/profile_update proposals
- write applied facts back as canonical observer_memory events for unified timeline hydration
- leave scanner rules, reminders, and summary corrections proposal-only

## Validation
- python3 -m pytest tests/unit/test_ella_observer.py tests/unit/test_ella_canonical_context.py tests/unit/test_ella_canonical_omi.py