### PR TITLE
[codex] Allow trusted MCP memory proposals to apply

### DIFF
--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -774,6 +774,13 @@ async def _companion_propose_change(arguments: dict[str, Any]) -> dict[str, Any]
         raise ToolExecutionError("target must be an object", code=-32602)
     if requested_change and not isinstance(requested_change, dict):
         raise ToolExecutionError("requested_change must be an object", code=-32602)
+    confidence = arguments.get("confidence")
+    parsed_confidence = None
+    if confidence is not None:
+        try:
+            parsed_confidence = max(0.0, min(float(confidence), 1.0))
+        except Exception as exc:
+            raise ToolExecutionError("confidence must be a number between 0 and 1", code=-32602) from exc
     payload = {
         "title": title,
         "description": description,
@@ -783,6 +790,8 @@ async def _companion_propose_change(arguments: dict[str, Any]) -> dict[str, Any]
         "source": "plato_mcp",
         "write_policy": "proposal_only",
     }
+    if parsed_confidence is not None:
+        payload["confidence"] = parsed_confidence
     try:
         return proposal_ingest.create_proposal(
             session_claims=_legacy_plato_onboarding()["session_claims"],
@@ -826,7 +835,8 @@ MCP_TOOLS: list[dict[str, Any]] = [
         "description": (
             "Create an auditable proposal only; this never directly changes scanner rules, reminders, profile data, "
             "memory, summaries, caregiver delivery, or other live state. Use for requested scanner, reminder, "
-            "profile, memory, or summary changes that need later approval/application."
+            "profile, memory, or summary changes that need later approval/application. Trusted memory_note and "
+            "profile_update proposals may be applied later by the Observer safe applier."
         ),
         "inputSchema": {
             "type": "object",
@@ -840,6 +850,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
                 "target": {"type": "object", "default": {}},
                 "evidence": {"type": "array", "items": {"type": "object"}, "default": []},
                 "requested_change": {"type": "object", "default": {}},
+                "confidence": {"type": "number", "minimum": 0, "maximum": 1},
                 "idempotency_key": {"type": "string"},
             },
             "required": ["proposal_type", "title", "description"],

--- a/backend/ella/services/observer_apply.py
+++ b/backend/ella/services/observer_apply.py
@@ -16,6 +16,9 @@ from models.proposals import Proposal, ProposalStatus
 
 AUTO_APPLY_TYPES = {"memory_note", "profile_update"}
 OBSERVER_SOURCE = "ella_observer_cron"
+MCP_SOURCE = "plato_mcp"
+MCP_TOOL_NAME = "companion_propose_change"
+TRUSTED_MCP_DEFAULT_CONFIDENCE = 0.92
 
 
 def _now() -> datetime:
@@ -43,6 +46,24 @@ def _observer_owned(proposal: Proposal) -> bool:
     return payload.get("source") == OBSERVER_SOURCE or proposal.tool_name == "ella_observer_fact_promotion"
 
 
+def _trusted_mcp_owned(proposal: Proposal) -> bool:
+    payload = _payload(proposal)
+    return payload.get("source") == MCP_SOURCE and proposal.tool_name == MCP_TOOL_NAME
+
+
+def _allowed_owner(proposal: Proposal) -> bool:
+    return _observer_owned(proposal) or _trusted_mcp_owned(proposal)
+
+
+def _effective_confidence(proposal: Proposal) -> float:
+    confidence = _confidence(proposal)
+    if confidence:
+        return confidence
+    if _trusted_mcp_owned(proposal) and _proposal_type(proposal) in AUTO_APPLY_TYPES:
+        return TRUSTED_MCP_DEFAULT_CONFIDENCE
+    return 0.0
+
+
 def _event_text(proposal: Proposal) -> str:
     payload = _payload(proposal)
     requested_change = payload.get("requested_change") if isinstance(payload.get("requested_change"), dict) else {}
@@ -64,7 +85,7 @@ def _decision(action: str, proposal: Proposal, reason: str = "", error: str = ""
         "proposal_id": proposal.proposal_id,
         "proposal_type": _proposal_type(proposal),
         "title": str(_payload(proposal).get("title") or ""),
-        "confidence": _confidence(proposal),
+        "confidence": _effective_confidence(proposal),
         "reason": reason,
         "error": error,
     }
@@ -86,13 +107,13 @@ async def apply_pending_observer_memory_proposals(
 
     for proposal in proposals:
         proposal_type = _proposal_type(proposal)
-        if not _observer_owned(proposal):
-            decisions.append(_decision("skip", proposal, "not_observer_owned"))
+        if not _allowed_owner(proposal):
+            decisions.append(_decision("skip", proposal, "not_observer_or_trusted_mcp_owned"))
             continue
         if proposal_type not in allowed_types:
             decisions.append(_decision("skip", proposal, "unsupported_auto_apply_type"))
             continue
-        confidence = _confidence(proposal)
+        confidence = _effective_confidence(proposal)
         if confidence < min_confidence:
             decisions.append(_decision("skip", proposal, "below_min_confidence"))
             continue
@@ -124,6 +145,7 @@ async def apply_pending_observer_memory_proposals(
                             "proposal_id": proposal.proposal_id,
                             "proposal_type": proposal_type,
                             "confidence": confidence,
+                            "proposal_source": _payload(proposal).get("source") or proposal.tool_name,
                             "source_run_id": _payload(proposal).get("observer_run_id"),
                             "requested_change": _payload(proposal).get("requested_change") or {},
                             "evidence": _payload(proposal).get("evidence") or [],

--- a/backend/tests/unit/test_ella_observer.py
+++ b/backend/tests/unit/test_ella_observer.py
@@ -457,6 +457,63 @@ def test_observer_apply_pending_writes_safe_memory_event(monkeypatch):
     assert "Spare glasses are in the blue backpack" in events[0]["text"]
 
 
+def test_observer_apply_pending_accepts_trusted_mcp_memory_proposal(monkeypatch):
+    _install_proposal_stubs()
+    monkeypatch.setenv("ELLA_OBSERVER_ADMIN_TOKEN", "observer-token")
+    sys.modules.pop("ella.routers.observer", None)
+    sys.modules.pop("ella.services.observer_apply", None)
+    router_module = importlib.import_module("ella.routers.observer")
+    canonical_module = importlib.import_module("ella.routers.canonical_events")
+    logs_module = importlib.import_module("ella.services.observer_logs")
+    proposals_db = importlib.import_module("database.proposals")
+    proposal_models = importlib.import_module("models.proposals")
+
+    proposal = proposal_models.Proposal.from_claims(
+        session_claims={
+            "profile_uid": "user-1",
+            "role": "self",
+            "external_provider": "static_bearer",
+            "trace_id": "mcp:test",
+        },
+        tool_name="companion_propose_change",
+        proposal_type="memory_note",
+        payload={
+            "title": "MCP memory test",
+            "description": "Remember the MCP test phrase copper sailboat.",
+            "source": "plato_mcp",
+            "requested_change": {"memory": "The MCP test phrase is copper sailboat."},
+            "target": {"canonical_identity": "plato"},
+        },
+        proposal_id="proposal-mcp-memory",
+    )
+    proposals_db.list_proposals.return_value = [proposal]
+
+    event_store = canonical_module.InMemoryCanonicalEventStore()
+    log_store = logs_module.InMemoryObserverRunLogStore()
+    app = FastAPI()
+    app.include_router(router_module.create_observer_router(event_store=event_store, log_store=log_store))
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/ella/observer/apply-pending",
+        headers={"X-Ella-Observer-Token": "observer-token"},
+        json={"uid": "user-1", "dry_run": False, "min_confidence": 0.9},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["applied_count"] == 1
+    assert body["decisions"][0]["action"] == "applied"
+    assert body["decisions"][0]["confidence"] == 0.92
+
+    import asyncio
+
+    events = asyncio.run(event_store.timeline(uid="user-1", since=None, limit=10, channels=["observer_memory"]))
+    assert len(events) == 1
+    assert events[0]["metadata"]["proposal_source"] == "plato_mcp"
+    assert "copper sailboat" in events[0]["text"]
+
+
 def test_observer_log_store_keeps_datetimes_for_postgres(monkeypatch):
     service = _load_observer_service()
     sys.modules.pop("ella.services.observer_logs", None)


### PR DESCRIPTION
## Summary
- allow trusted Plato MCP `companion_propose_change` proposals to flow through the safe memory applier
- keep auto-apply limited to `memory_note` and `profile_update`
- add optional MCP proposal confidence and expose it in the tool schema
- preserve scanner/reminder/summary correction as proposal-only

## Validation
- python3 -m py_compile backend/ella/services/observer_apply.py backend/ella/routers/plato_mcp.py backend/ella/routers/observer.py
- python3 -m pytest tests/unit/test_ella_observer.py tests/unit/test_ella_canonical_context.py tests/unit/test_ella_canonical_omi.py