### PR TITLE
Sync iOS voice settings with server

### DIFF
--- a/app/lib/core/app_shell.dart
+++ b/app/lib/core/app_shell.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/desktop/desktop_app.dart';
+import 'package:omi/ella/services/settings_sync_service.dart';
 import 'package:omi/mobile/mobile_app.dart';
 import 'package:omi/pages/apps/app_detail/app_detail.dart';
 import 'package:omi/pages/settings/asana_settings_page.dart';
@@ -316,6 +317,7 @@ class _AppShellState extends State<AppShell> {
       context.read<MessageProvider>().refreshMessages();
       context.read<UsageProvider>().fetchSubscription();
       context.read<TaskIntegrationProvider>().loadFromBackend();
+      unawaited(EllaSettingsSyncService.syncOnAppStart());
 
       NotificationService.instance.saveNotificationToken();
     } else {

--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -17,6 +17,7 @@ import 'package:omi/ella/services/ella_chat_service.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/ella/ella_theme.dart';
 import 'package:omi/ella/services/elevenlabs_tts.dart';
+import 'package:omi/ella/services/settings_sync_service.dart';
 import 'package:omi/ella/services/unified_memory_service.dart';
 import 'package:omi/ella/services/v2v_client.dart';
 import 'package:omi/ella/widgets/ella_voice_orb.dart';
@@ -135,7 +136,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
         final provider = SharedPreferencesUtil().ttsProvider;
         final normalizedProvider = V2VClient.normalizeProvider(provider);
         if (normalizedProvider != provider) {
-          SharedPreferencesUtil().ttsProvider = normalizedProvider;
+          unawaited(EllaSettingsSyncService.setVoiceMode(normalizedProvider));
         }
         Future.delayed(const Duration(milliseconds: 300), () {
           if (mounted && _orbState == VoiceOrbState.idle) {
@@ -231,7 +232,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       final provider = SharedPreferencesUtil().ttsProvider;
       final normalizedProvider = V2VClient.normalizeProvider(provider);
       if (normalizedProvider != provider) {
-        SharedPreferencesUtil().ttsProvider = normalizedProvider;
+        unawaited(EllaSettingsSyncService.setVoiceMode(normalizedProvider));
       }
       if (_isV2VProvider(normalizedProvider)) {
         await _startV2V(normalizedProvider);

--- a/app/lib/ella/services/settings_sync_service.dart
+++ b/app/lib/ella/services/settings_sync_service.dart
@@ -1,0 +1,293 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:omi/backend/http/shared.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/env/env.dart';
+import 'package:omi/utils/logger.dart';
+import 'package:omi/utils/platform/platform_manager.dart';
+
+const _voiceModeDirtyKey = 'ellaSettingsVoiceModeDirty';
+const _pendingVoiceModeKey = 'ellaSettingsPendingVoiceMode';
+const _lastSyncedVoiceModeKey = 'ellaSettingsLastSyncedVoiceMode';
+const _lastSyncedAtKey = 'ellaSettingsLastSyncedAt';
+const _lastSyncErrorKey = 'ellaSettingsLastSyncError';
+
+class EllaSettingsSyncResponse {
+  const EllaSettingsSyncResponse({required this.statusCode, required this.body});
+
+  final int statusCode;
+  final Map<String, dynamic> body;
+
+  bool get isSuccess => statusCode >= 200 && statusCode < 300;
+}
+
+abstract class EllaSettingsSyncTransport {
+  Future<EllaSettingsSyncResponse?> get(String path);
+
+  Future<EllaSettingsSyncResponse?> patch(String path, Map<String, dynamic> payload);
+}
+
+class _EllaSettingsSyncHttpTransport implements EllaSettingsSyncTransport {
+  @override
+  Future<EllaSettingsSyncResponse?> get(String path) async {
+    final response = await makeApiCall(
+      url: '${Env.apiBaseUrl}$path',
+      headers: {'Content-Type': 'application/json'},
+      method: 'GET',
+      body: '',
+      timeout: const Duration(seconds: 10),
+      retries: 0,
+    );
+    if (response == null) return null;
+    return EllaSettingsSyncResponse(statusCode: response.statusCode, body: _decodeBody(response.body));
+  }
+
+  @override
+  Future<EllaSettingsSyncResponse?> patch(String path, Map<String, dynamic> payload) async {
+    final response = await makeApiCall(
+      url: '${Env.apiBaseUrl}$path',
+      headers: {'Content-Type': 'application/json'},
+      method: 'PATCH',
+      body: jsonEncode(payload),
+      timeout: const Duration(seconds: 10),
+      retries: 0,
+    );
+    if (response == null) return null;
+    return EllaSettingsSyncResponse(statusCode: response.statusCode, body: _decodeBody(response.body));
+  }
+
+  static Map<String, dynamic> _decodeBody(String raw) {
+    if (raw.trim().isEmpty) return {};
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic>) return decoded;
+    } catch (_) {}
+    return {};
+  }
+}
+
+class EllaSettingsSyncService {
+  EllaSettingsSyncService._();
+
+  @visibleForTesting
+  static EllaSettingsSyncTransport transport = _EllaSettingsSyncHttpTransport();
+
+  static const supportedVoiceModes = {
+    'elevenlabs',
+    'fish-audio-s2',
+    'kokoro',
+    'inworld',
+    'openclaw-direct',
+    'grok-voice',
+    'openai-native-realtime',
+    'gemini-native-live',
+  };
+
+  static String normalizeVoiceMode(String provider) => switch (provider) {
+        'gemini-live' => 'gemini-native-live',
+        'openai-realtime' => 'openai-native-realtime',
+        _ => provider,
+      };
+
+  static bool isV2VVoiceMode(String provider) {
+    final normalized = normalizeVoiceMode(provider);
+    return normalized == 'openclaw-direct' ||
+        normalized == 'openai-native-realtime' ||
+        normalized == 'grok-voice' ||
+        normalized == 'gemini-native-live';
+  }
+
+  static String? sessionVoiceMode(String provider) => switch (normalizeVoiceMode(provider)) {
+        'openclaw-direct' => 'openclaw-direct-v1',
+        'openai-native-realtime' => 'openai-native-realtime-v1',
+        'gemini-native-live' => 'gemini-native-live-v1',
+        _ => null,
+      };
+
+  static bool get hasPendingVoiceMode => SharedPreferencesUtil().getBool(_voiceModeDirtyKey);
+
+  static String get lastSyncedVoiceMode => SharedPreferencesUtil().getString(_lastSyncedVoiceModeKey);
+
+  static DateTime? get lastSyncedAt => DateTime.tryParse(SharedPreferencesUtil().getString(_lastSyncedAtKey));
+
+  static String get lastSyncError => SharedPreferencesUtil().getString(_lastSyncErrorKey);
+
+  /// Fetch server-backed settings and retry any pending local voice-mode change.
+  ///
+  /// Local SharedPreferences remains the offline source of truth when there is a
+  /// dirty local change. Server values only merge into local state when no local
+  /// voice mode is waiting to sync.
+  static Future<void> syncOnAppStart() async {
+    if (!_hasUserAndApiBase) return;
+
+    if (hasPendingVoiceMode) {
+      await retryPendingVoiceMode();
+      if (hasPendingVoiceMode) return;
+    }
+
+    final serverVoiceMode = await _fetchServerVoiceMode();
+    if (serverVoiceMode == null) return;
+
+    final local = normalizeVoiceMode(SharedPreferencesUtil().ttsProvider);
+    if (serverVoiceMode != local) {
+      Logger.debug('[SettingsSync] Applying server voice mode: $serverVoiceMode (was $local)');
+      SharedPreferencesUtil().ttsProvider = serverVoiceMode;
+    }
+    await _markSynced(serverVoiceMode);
+  }
+
+  static Future<bool> setVoiceMode(String provider) async {
+    final normalized = normalizeVoiceMode(provider);
+    if (!supportedVoiceModes.contains(normalized)) {
+      Logger.debug('[SettingsSync] Ignoring unsupported voice mode: $provider');
+      return false;
+    }
+
+    SharedPreferencesUtil().ttsProvider = normalized;
+    await _markDirty(normalized);
+    return retryPendingVoiceMode();
+  }
+
+  static Future<bool> retryPendingVoiceMode() async {
+    if (!_hasUserAndApiBase) return false;
+    if (!hasPendingVoiceMode) return true;
+
+    final prefs = SharedPreferencesUtil();
+    final pending = normalizeVoiceMode(
+      prefs.getString(_pendingVoiceModeKey, defaultValue: prefs.ttsProvider),
+    );
+    if (!supportedVoiceModes.contains(pending)) {
+      await prefs.saveString(_lastSyncErrorKey, 'unsupported_pending_voice_mode:$pending');
+      return false;
+    }
+
+    final payload = buildVoiceSettingsPatchPayload(voiceMode: pending);
+    try {
+      final response = await transport.patch('v1/ella/settings', payload);
+      if (response != null && response.isSuccess) {
+        await _markSynced(pending);
+        Logger.debug('[SettingsSync] Synced voice mode: $pending');
+        return true;
+      }
+
+      final status = response?.statusCode ?? 0;
+      await prefs.saveString(_lastSyncErrorKey, 'patch_status:$status');
+      Logger.debug('[SettingsSync] Voice mode sync failed: status=$status');
+      return false;
+    } catch (e) {
+      await prefs.saveString(_lastSyncErrorKey, 'patch_error:$e');
+      Logger.debug('[SettingsSync] Voice mode sync error: $e');
+      return false;
+    }
+  }
+
+  @visibleForTesting
+  static Map<String, dynamic> buildVoiceSettingsPatchPayload({
+    required String voiceMode,
+    DateTime? updatedAt,
+    String? clientVersion,
+  }) {
+    final normalized = normalizeVoiceMode(voiceMode);
+    final now = (updatedAt ?? DateTime.now()).toUtc().toIso8601String();
+    final version = clientVersion ?? _clientVersion;
+    final voice = {
+      'voice_mode': normalized,
+      'tts_provider': normalized,
+      'conversation_provider': normalized,
+      'uses_v2v_session': isV2VVoiceMode(normalized),
+      if (sessionVoiceMode(normalized) != null) 'session_voice_mode': sessionVoiceMode(normalized),
+      'source_client': 'ios-app',
+      'source_setting': 'devTtsProvider',
+      'client_version': version,
+      'updated_at': now,
+    };
+
+    return {
+      'voice_mode': normalized,
+      'tts_provider': normalized,
+      'conversation_provider': normalized,
+      'settings': {'voice': voice},
+      'source_client': 'ios-app',
+      'source_setting': 'devTtsProvider',
+      'client_version': version,
+      'updated_at': now,
+    };
+  }
+
+  static Future<String?> _fetchServerVoiceMode() async {
+    for (final path in const ['v1/ella/settings/effective', 'v1/ella/settings']) {
+      try {
+        final response = await transport.get(path);
+        if (response == null) continue;
+        if (response.statusCode == 404 || response.statusCode == 501) continue;
+        if (!response.isSuccess) {
+          Logger.debug('[SettingsSync] Settings fetch failed: $path status=${response.statusCode}');
+          continue;
+        }
+
+        final voiceMode = _extractVoiceMode(response.body);
+        if (voiceMode == null) continue;
+        return voiceMode;
+      } catch (e) {
+        Logger.debug('[SettingsSync] Settings fetch error: $path $e');
+      }
+    }
+    return null;
+  }
+
+  static String? _extractVoiceMode(Map<String, dynamic> data) {
+    final candidates = <Map<String, dynamic>>[data];
+
+    void addMap(dynamic value) {
+      if (value is Map<String, dynamic>) candidates.add(value);
+    }
+
+    addMap(data['voice']);
+    addMap(data['voice_settings']);
+    addMap(data['effective_voice_settings']);
+    addMap(data['effective']);
+
+    final settings = data['settings'];
+    if (settings is Map<String, dynamic>) {
+      addMap(settings);
+      addMap(settings['voice']);
+    }
+
+    for (final candidate in candidates) {
+      final raw = candidate['voice_mode'] ?? candidate['tts_provider'] ?? candidate['selected_voice_mode'];
+      if (raw is! String || raw.trim().isEmpty) continue;
+      final normalized = normalizeVoiceMode(raw.trim());
+      if (supportedVoiceModes.contains(normalized)) return normalized;
+      Logger.debug('[SettingsSync] Server returned unsupported voice mode: $raw');
+    }
+    return null;
+  }
+
+  static Future<void> _markDirty(String voiceMode) async {
+    final prefs = SharedPreferencesUtil();
+    await prefs.saveString(_pendingVoiceModeKey, voiceMode);
+    await prefs.saveBool(_voiceModeDirtyKey, true);
+  }
+
+  static Future<void> _markSynced(String voiceMode) async {
+    final prefs = SharedPreferencesUtil();
+    final now = DateTime.now().toUtc().toIso8601String();
+    await prefs.saveString(_lastSyncedVoiceModeKey, voiceMode);
+    await prefs.saveString(_lastSyncedAtKey, now);
+    await prefs.saveString(_lastSyncErrorKey, '');
+    await prefs.saveString(_pendingVoiceModeKey, voiceMode);
+    await prefs.saveBool(_voiceModeDirtyKey, false);
+  }
+
+  static bool get _hasUserAndApiBase => SharedPreferencesUtil().uid.isNotEmpty && (Env.apiBaseUrl ?? '').isNotEmpty;
+
+  static String get _clientVersion {
+    try {
+      return PlatformManager.instance.appVersion;
+    } catch (_) {
+      return 'unknown';
+    }
+  }
+}

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -22,6 +22,7 @@ import 'package:window_manager/window_manager.dart';
 import 'package:omi/backend/http/shared.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/core/app_shell.dart';
+import 'package:omi/ella/services/settings_sync_service.dart';
 import 'package:omi/env/dev_env.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/env/prod_env.dart';
@@ -306,6 +307,8 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
 
     if (state == AppLifecycleState.paused) {
       _onAppPaused();
+    } else if (state == AppLifecycleState.resumed) {
+      unawaited(EllaSettingsSyncService.retryPendingVoiceMode());
     } else if (state == AppLifecycleState.detached) {
       _deinit();
     }

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -15,6 +16,7 @@ import 'package:omi/backend/http/api/knowledge_graph_api.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/ella/services/settings_sync_service.dart';
 import 'package:omi/ella/services/v2v_client.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/models/stt_provider.dart';
@@ -817,8 +819,9 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                           onChanged: (value) {
                             if (value != null) {
                               setState(() {
-                                SharedPreferencesUtil().ttsProvider = value;
+                                SharedPreferencesUtil().ttsProvider = EllaSettingsSyncService.normalizeVoiceMode(value);
                               });
+                              unawaited(EllaSettingsSyncService.setVoiceMode(value));
                             }
                           },
                         );

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+779
+version: 1.0.524+780
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/test/ella/services/settings_sync_service_test.dart
+++ b/app/test/ella/services/settings_sync_service_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/settings_sync_service.dart';
+import 'package:omi/env/env.dart';
+
+class _TestEnv implements EnvFields {
+  @override
+  String? get apiBaseUrl => 'https://api.ella-ai-care.com/';
+
+  @override
+  String? get googleClientId => null;
+
+  @override
+  String? get googleClientSecret => null;
+
+  @override
+  String? get googleMapsApiKey => null;
+
+  @override
+  String? get growthbookApiKey => null;
+
+  @override
+  String? get intercomAndroidApiKey => null;
+
+  @override
+  String? get intercomAppId => null;
+
+  @override
+  String? get intercomIOSApiKey => null;
+
+  @override
+  String? get mixpanelProjectToken => null;
+
+  @override
+  String? get openAIAPIKey => null;
+
+  @override
+  bool? get useAuthCustomToken => false;
+
+  @override
+  bool? get useWebAuth => false;
+}
+
+class _FakeSettingsTransport implements EllaSettingsSyncTransport {
+  final List<String> getPaths = [];
+  final List<String> patchPaths = [];
+  final List<Map<String, dynamic>> patchPayloads = [];
+  EllaSettingsSyncResponse? getResponse;
+  EllaSettingsSyncResponse? patchResponse;
+
+  @override
+  Future<EllaSettingsSyncResponse?> get(String path) async {
+    getPaths.add(path);
+    return getResponse;
+  }
+
+  @override
+  Future<EllaSettingsSyncResponse?> patch(String path, Map<String, dynamic> payload) async {
+    patchPaths.add(path);
+    patchPayloads.add(payload);
+    return patchResponse;
+  }
+}
+
+void main() {
+  group('EllaSettingsSyncService', () {
+    late _FakeSettingsTransport transport;
+
+    setUpAll(() {
+      Env.init(_TestEnv());
+    });
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      await SharedPreferencesUtil.init();
+      SharedPreferencesUtil().uid = 'uid-123';
+      SharedPreferencesUtil().ttsProvider = 'elevenlabs';
+      transport = _FakeSettingsTransport();
+      EllaSettingsSyncService.transport = transport;
+    });
+
+    test('builds backend-friendly voice settings payload', () {
+      final payload = EllaSettingsSyncService.buildVoiceSettingsPatchPayload(
+        voiceMode: 'gemini-live',
+        updatedAt: DateTime.utc(2026, 5, 8, 18),
+        clientVersion: '1.0.524+780',
+      );
+      final voice = (payload['settings'] as Map<String, dynamic>)['voice'] as Map<String, dynamic>;
+
+      expect(payload['voice_mode'], 'gemini-native-live');
+      expect(payload['tts_provider'], 'gemini-native-live');
+      expect(payload['source_setting'], 'devTtsProvider');
+      expect(voice['conversation_provider'], 'gemini-native-live');
+      expect(voice['uses_v2v_session'], isTrue);
+      expect(voice['session_voice_mode'], 'gemini-native-live-v1');
+      expect(voice['client_version'], '1.0.524+780');
+    });
+
+    test('setVoiceMode stores local cache and clears dirty flag after patch succeeds', () async {
+      transport.patchResponse = const EllaSettingsSyncResponse(statusCode: 200, body: {});
+
+      final ok = await EllaSettingsSyncService.setVoiceMode('openai-realtime');
+
+      expect(ok, isTrue);
+      expect(SharedPreferencesUtil().ttsProvider, 'openai-native-realtime');
+      expect(EllaSettingsSyncService.hasPendingVoiceMode, isFalse);
+      expect(EllaSettingsSyncService.lastSyncedVoiceMode, 'openai-native-realtime');
+      expect(transport.patchPaths, ['v1/ella/settings']);
+      expect(transport.patchPayloads.single['voice_mode'], 'openai-native-realtime');
+    });
+
+    test('keeps dirty local voice mode when patch fails', () async {
+      transport.patchResponse = const EllaSettingsSyncResponse(statusCode: 404, body: {});
+
+      final ok = await EllaSettingsSyncService.setVoiceMode('grok-voice');
+
+      expect(ok, isFalse);
+      expect(SharedPreferencesUtil().ttsProvider, 'grok-voice');
+      expect(EllaSettingsSyncService.hasPendingVoiceMode, isTrue);
+      expect(EllaSettingsSyncService.lastSyncError, 'patch_status:404');
+    });
+
+    test('syncOnAppStart merges server voice mode when no local dirty change exists', () async {
+      transport.patchResponse = const EllaSettingsSyncResponse(statusCode: 200, body: {});
+      transport.getResponse = const EllaSettingsSyncResponse(
+        statusCode: 200,
+        body: {
+          'settings': {
+            'voice': {'voice_mode': 'gemini-live'},
+          },
+        },
+      );
+
+      await EllaSettingsSyncService.syncOnAppStart();
+
+      expect(SharedPreferencesUtil().ttsProvider, 'gemini-native-live');
+      expect(EllaSettingsSyncService.lastSyncedVoiceMode, 'gemini-native-live');
+      expect(transport.getPaths, ['v1/ella/settings/effective']);
+    });
+
+    test('syncOnAppStart preserves dirty local voice mode if retry still fails', () async {
+      await SharedPreferencesUtil().saveString('ellaSettingsPendingVoiceMode', 'grok-voice');
+      await SharedPreferencesUtil().saveBool('ellaSettingsVoiceModeDirty', true);
+      SharedPreferencesUtil().ttsProvider = 'grok-voice';
+      transport.patchResponse = const EllaSettingsSyncResponse(statusCode: 500, body: {});
+      transport.getResponse = const EllaSettingsSyncResponse(
+        statusCode: 200,
+        body: {
+          'voice_mode': 'elevenlabs',
+        },
+      );
+
+      await EllaSettingsSyncService.syncOnAppStart();
+
+      expect(SharedPreferencesUtil().ttsProvider, 'grok-voice');
+      expect(EllaSettingsSyncService.hasPendingVoiceMode, isTrue);
+      expect(transport.getPaths, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add an authenticated Ella settings sync client for the iOS voice/TTS selector.
- Fetch `/v1/ella/settings/effective` then `/v1/ella/settings` on signed-in app start and merge server voice mode only when no dirty local change exists.
- PATCH `/v1/ella/settings` when `devTtsProvider` changes, keeping SharedPreferences as the immediate offline cache and retrying pending writes on foreground resume.
- Preserve existing voice routing: traditional providers continue using `/v1/voice/tts`; V2V providers continue using `/v1/voice/session`.

## Payload contract
PATCH `/v1/ella/settings` with normalized `voice_mode`, `tts_provider`, `conversation_provider`, and nested `settings.voice` metadata including `uses_v2v_session`, optional `session_voice_mode`, `source_client=ios-app`, `source_setting=devTtsProvider`, `client_version`, and `updated_at`.

## Validation
- `flutter test test/ella/services/settings_sync_service_test.dart test/ella/services/v2v_client_test.dart`
- `flutter analyze --no-fatal-infos --no-fatal-warnings lib/ella/services/settings_sync_service.dart lib/pages/settings/developer.dart lib/ella/pages/ella_voice_chat_page.dart lib/core/app_shell.dart lib/main.dart test/ella/services/settings_sync_service_test.dart`
- `./test.sh`

Refs ellaaicare/ella-ai#862, ellaaicare/ella-ai#998.