### PR TITLE
Add server-backed Ella voice settings

### DIFF
--- a/backend/database/app_settings.py
+++ b/backend/database/app_settings.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from google.cloud.firestore_v1 import SERVER_TIMESTAMP
+
+from database._client import db
+
+
+def _settings_collection(uid: str):
+    return db.collection("users").document(uid).collection("app_settings")
+
+
+def get_voice_settings(uid: str) -> dict[str, Any]:
+    if not uid:
+        return {}
+    doc = _settings_collection(uid).document("voice").get()
+    if not getattr(doc, "exists", False):
+        return {}
+    data = doc.to_dict() or {}
+    return _json_safe(data)
+
+
+def save_voice_settings(uid: str, voice: dict[str, Any]) -> dict[str, Any]:
+    if not uid:
+        raise ValueError("uid required")
+    data = {
+        **voice,
+        "updated_at": voice.get("updated_at") or datetime.now(timezone.utc).isoformat(),
+        "server_updated_at": SERVER_TIMESTAMP,
+    }
+    _settings_collection(uid).document("voice").set(data, merge=True)
+
+    # Mirror the effective user-facing settings onto the user doc for legacy
+    # operators/tools that inspect users/{uid}.settings without subcollections.
+    db.collection("users").document(uid).set({"settings": {"voice": data}}, merge=True)
+    return _json_safe(data)
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value

--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -347,6 +347,15 @@ def _register_routers(app) -> None:
     except ImportError as e:
         print(f"  ⚠️ Ella escalation policy not available: {e}", flush=True)
 
+    # Server-backed app settings used by iOS, voice, and Guardian routing
+    try:
+        from ella.routers.settings import router as settings_router
+
+        app.include_router(settings_router, tags=["Ella Settings"])
+        print("  🌐 /v1/ella/settings* - Server-backed app settings", flush=True)
+    except ImportError as e:
+        print(f"  ⚠️ Ella settings not available: {e}", flush=True)
+
     # Voice session management (token issuance for Ella Voice)
     if ELLA_VOICE_V2_ENABLED:
         try:

--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -24,10 +24,12 @@ from typing import Any, Optional
 
 import asyncpg
 import httpx
-from fastapi import APIRouter, File, Form, Header, HTTPException, Request, UploadFile
+from fastapi import APIRouter, File, Form, Header, HTTPException, Request, Response, UploadFile
 from pydantic import BaseModel, Field
 
 from ella.routers.resolve import resolve_user_routing
+from database import app_settings as app_settings_db
+from ella.services.app_settings import TTS_PROVIDERS, build_effective_voice_settings
 from ella.services.escalation_policy import (
     CaregiverPolicyContext,
     EscalationEvent,
@@ -57,6 +59,8 @@ N8N_GUARDIAN_DELIVER_WEBHOOK = os.getenv(
     "N8N_GUARDIAN_DELIVER_WEBHOOK",
     "https://n8n.ella-ai-care.com/webhook/guardian-deliver",
 )
+ELLA_API_BASE = os.getenv("ELLA_API_BASE", "https://api.ella-ai-care.com")
+ELLA_INTERNAL_VOICE_TTS_URL = os.getenv("ELLA_INTERNAL_VOICE_TTS_URL", "http://127.0.0.1:8000/v1/voice/tts")
 
 # Consolidate queue when this many non-debug items are pending
 CONSOLIDATION_THRESHOLD = int(os.getenv("CONSOLIDATION_THRESHOLD", "3"))
@@ -460,6 +464,16 @@ class UploadJsonRequest(BaseModel):
     uid: str
     audio_base64: str
     filename: Optional[str] = None
+
+
+class SynthesizeRequest(BaseModel):
+    """JSON body for provider-aware Guardian synthesis."""
+
+    uid: str
+    text: str
+    voice_id: Optional[str] = None
+    provider: Optional[str] = None
+    trace_id: Optional[str] = None
 
 
 def _trace_id_from_metadata(metadata: Optional[dict], fallback: str) -> str:
@@ -1132,6 +1146,64 @@ async def enqueue(
 # POST /v1/ella/guardian/upload
 # n8n uploads TTS audio binary (multipart form).
 # ---------------------------------------------------------------------------
+
+
+@router.post("/synthesize")
+async def synthesize_audio(
+    req: SynthesizeRequest,
+    x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
+    key: Optional[str] = None,
+):
+    """Resolve user voice settings and synthesize Guardian one-shot audio."""
+    _verify_key(x_guardian_key, key)
+    text = req.text.strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="text required")
+
+    voice_settings = app_settings_db.get_voice_settings(req.uid)
+    effective = build_effective_voice_settings(req.uid, voice_settings)["effective_voice_settings"]
+    provider = (req.provider or effective["one_shot_tts_provider"]).strip().lower()
+    if provider not in TTS_PROVIDERS:
+        raise HTTPException(status_code=422, detail=f"Provider {provider!r} cannot synthesize Guardian one-shot audio")
+
+    payload = {"text": text}
+    if req.voice_id:
+        payload["voice_id"] = req.voice_id
+
+    _start = time.time()
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                ELLA_INTERNAL_VOICE_TTS_URL,
+                json=payload,
+                headers={"X-TTS-Provider": provider},
+                timeout=30.0,
+            )
+    except httpx.TimeoutException:
+        raise HTTPException(status_code=504, detail=f"{provider} Guardian synthesis timed out")
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"{provider} Guardian synthesis failed: {exc}") from exc
+
+    elapsed_ms = int((time.time() - _start) * 1000)
+    if response.status_code >= 400:
+        raise HTTPException(status_code=502, detail=f"{provider} Guardian synthesis error: {response.status_code}")
+
+    print(
+        f"[FLOW:GUARDIAN-SYNTHESIZE] uid={req.uid} trace={req.trace_id} "
+        f"provider={provider} voice_mode={effective['voice_mode']} bytes={len(response.content)} latency={elapsed_ms}ms",
+        flush=True,
+    )
+    return Response(
+        content=response.content,
+        media_type=response.headers.get("content-type", "audio/mpeg"),
+        headers={
+            "X-Guardian-TTS-Provider": provider,
+            "X-Guardian-Voice-Mode": effective["voice_mode"],
+            "X-Guardian-Settings-Source": "server",
+            "X-Guardian-Fallback-Used": str(bool(effective.get("fallback_used"))).lower(),
+            "X-Guardian-Synthesis-Latency-Ms": str(elapsed_ms),
+        },
+    )
 
 
 def _store_audio_content(uid: str, content: bytes, filename: Optional[str] = None) -> dict:

--- a/backend/ella/routers/settings.py
+++ b/backend/ella/routers/settings.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from database import app_settings as app_settings_db
+from ella.services.app_settings import (
+    build_effective_voice_settings,
+    build_settings_response,
+    extract_voice_settings,
+)
+from utils.other import endpoints as auth
+
+router = APIRouter(prefix="/v1/ella/settings", tags=["Ella Settings"])
+
+
+@router.get("")
+def get_settings(uid: str = Depends(auth.get_current_user_uid)) -> dict[str, Any]:
+    """Return server-backed Ella app settings for the authenticated user."""
+    voice = app_settings_db.get_voice_settings(uid)
+    return build_settings_response(uid, voice)
+
+
+@router.patch("")
+def patch_settings(payload: dict[str, Any], uid: str = Depends(auth.get_current_user_uid)) -> dict[str, Any]:
+    """Persist app settings from iOS. First slice stores effective voice mode."""
+    voice = extract_voice_settings(payload)
+    saved_voice = app_settings_db.save_voice_settings(uid, voice)
+    return build_settings_response(uid, saved_voice)
+
+
+@router.get("/effective")
+def get_effective_settings(uid: str = Depends(auth.get_current_user_uid)) -> dict[str, Any]:
+    """Return settings plus backend-resolved routing fields for services like Guardian."""
+    voice = app_settings_db.get_voice_settings(uid)
+    return build_effective_voice_settings(uid, voice)
+
+
+@router.get("/effective/voice")
+def get_effective_voice_settings(uid: str = Depends(auth.get_current_user_uid)) -> dict[str, Any]:
+    """Return only the effective voice resolver payload."""
+    voice = app_settings_db.get_voice_settings(uid)
+    return build_effective_voice_settings(uid, voice)["effective_voice_settings"]

--- a/backend/ella/services/app_settings.py
+++ b/backend/ella/services/app_settings.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+
+TTS_PROVIDERS = {"elevenlabs", "fish-audio", "fish-audio-s1", "fish-audio-s2", "kokoro", "inworld"}
+V2V_PROVIDERS = {"openclaw-direct", "grok-voice", "gemini-native-live", "openai-native-realtime"}
+VOICE_MODE_ALIASES = {
+    "gemini-live": "gemini-native-live",
+    "openai-realtime": "openai-native-realtime",
+}
+SUPPORTED_VOICE_MODES = TTS_PROVIDERS | V2V_PROVIDERS | set(VOICE_MODE_ALIASES)
+NORMALIZED_SUPPORTED_VOICE_MODES = (TTS_PROVIDERS | V2V_PROVIDERS) - set(VOICE_MODE_ALIASES)
+
+_DEFAULT_VOICE_MODE = os.getenv("ELLA_DEFAULT_VOICE_MODE", "elevenlabs")
+_DEFAULT_ONE_SHOT_TTS_PROVIDER = os.getenv("ELLA_DEFAULT_GUARDIAN_TTS_PROVIDER", "kokoro")
+
+_SESSION_MODE_BY_PROVIDER = {
+    "openclaw-direct": "openclaw-direct-v1",
+    "gemini-native-live": "gemini-native-live-v1",
+    "openai-native-realtime": "openai-native-realtime-v1",
+}
+
+_ONE_SHOT_PROVIDER_BY_VOICE_MODE = {
+    "elevenlabs": "elevenlabs",
+    "fish-audio": "fish-audio",
+    "fish-audio-s1": "fish-audio-s1",
+    "fish-audio-s2": "fish-audio-s2",
+    "kokoro": "kokoro",
+    "inworld": "inworld",
+    # V2V modes keep conversation routing intact, but Guardian one-shots need
+    # explicit TTS routing until provider-native one-shot adapters are wired in.
+    "openclaw-direct": _DEFAULT_ONE_SHOT_TTS_PROVIDER,
+    "grok-voice": os.getenv("ELLA_GROK_VOICE_ONE_SHOT_TTS_PROVIDER", _DEFAULT_ONE_SHOT_TTS_PROVIDER),
+    "gemini-native-live": os.getenv("ELLA_GEMINI_LIVE_ONE_SHOT_TTS_PROVIDER", _DEFAULT_ONE_SHOT_TTS_PROVIDER),
+    "openai-native-realtime": os.getenv("ELLA_OPENAI_REALTIME_ONE_SHOT_TTS_PROVIDER", _DEFAULT_ONE_SHOT_TTS_PROVIDER),
+}
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def normalize_voice_mode(value: Any) -> str:
+    if not isinstance(value, str):
+        return _normalized_default_voice_mode()
+    candidate = value.strip().lower()
+    candidate = VOICE_MODE_ALIASES.get(candidate, candidate)
+    if candidate not in NORMALIZED_SUPPORTED_VOICE_MODES:
+        return _normalized_default_voice_mode()
+    return candidate
+
+
+def _normalized_default_voice_mode() -> str:
+    candidate = VOICE_MODE_ALIASES.get(str(_DEFAULT_VOICE_MODE).strip().lower(), str(_DEFAULT_VOICE_MODE).strip().lower())
+    return candidate if candidate in NORMALIZED_SUPPORTED_VOICE_MODES else "elevenlabs"
+
+
+def is_v2v_voice_mode(value: str) -> bool:
+    return normalize_voice_mode(value) in V2V_PROVIDERS
+
+
+def session_voice_mode(value: str) -> str | None:
+    return _SESSION_MODE_BY_PROVIDER.get(normalize_voice_mode(value))
+
+
+def one_shot_tts_provider(value: str) -> str:
+    provider = _ONE_SHOT_PROVIDER_BY_VOICE_MODE.get(normalize_voice_mode(value), _DEFAULT_ONE_SHOT_TTS_PROVIDER)
+    if provider not in TTS_PROVIDERS:
+        return _DEFAULT_ONE_SHOT_TTS_PROVIDER
+    return provider
+
+
+def extract_voice_settings(payload: dict[str, Any]) -> dict[str, Any]:
+    """Extract and normalize iOS voice settings from the flexible sync payload."""
+    settings = payload.get("settings") if isinstance(payload.get("settings"), dict) else {}
+    nested_voice = settings.get("voice") if isinstance(settings.get("voice"), dict) else {}
+
+    raw_mode = (
+        nested_voice.get("voice_mode")
+        or payload.get("voice_mode")
+        or nested_voice.get("tts_provider")
+        or payload.get("tts_provider")
+        or nested_voice.get("conversation_provider")
+        or payload.get("conversation_provider")
+        or _DEFAULT_VOICE_MODE
+    )
+    voice_mode = normalize_voice_mode(raw_mode)
+
+    voice = {
+        **nested_voice,
+        "voice_mode": voice_mode,
+        "tts_provider": voice_mode,
+        "conversation_provider": voice_mode,
+        "uses_v2v_session": is_v2v_voice_mode(voice_mode),
+        "source_client": payload.get("source_client") or nested_voice.get("source_client") or "unknown",
+        "source_setting": payload.get("source_setting") or nested_voice.get("source_setting") or "unknown",
+        "client_version": payload.get("client_version") or nested_voice.get("client_version") or "unknown",
+        "updated_at": payload.get("updated_at") or nested_voice.get("updated_at") or utc_now_iso(),
+    }
+    mode = session_voice_mode(voice_mode)
+    if mode:
+        voice["session_voice_mode"] = nested_voice.get("session_voice_mode") or mode
+    else:
+        voice.pop("session_voice_mode", None)
+    return voice
+
+
+def build_settings_response(uid: str, voice: dict[str, Any] | None = None) -> dict[str, Any]:
+    resolved_voice = extract_voice_settings({"settings": {"voice": voice or {}}})
+    return {
+        "uid": uid,
+        "voice_mode": resolved_voice["voice_mode"],
+        "tts_provider": resolved_voice["tts_provider"],
+        "conversation_provider": resolved_voice["conversation_provider"],
+        "settings": {
+            "voice": resolved_voice,
+        },
+        "updated_at": resolved_voice.get("updated_at"),
+    }
+
+
+def build_effective_voice_settings(uid: str, voice: dict[str, Any] | None = None) -> dict[str, Any]:
+    resolved_voice = extract_voice_settings({"settings": {"voice": voice or {}}})
+    voice_mode = resolved_voice["voice_mode"]
+    fallback_used = voice_mode in V2V_PROVIDERS
+    fallback_reason = None
+    if fallback_used:
+        fallback_reason = f"{voice_mode} is a V2V mode; Guardian one-shots require a TTS provider"
+
+    effective = {
+        **resolved_voice,
+        "one_shot_tts_provider": one_shot_tts_provider(voice_mode),
+        "provider_type": "v2v" if is_v2v_voice_mode(voice_mode) else "tts",
+        "fallback_used": fallback_used,
+        "fallback_reason": fallback_reason,
+        "resolved_at": utc_now_iso(),
+    }
+    return {
+        "uid": uid,
+        "voice_mode": voice_mode,
+        "tts_provider": resolved_voice["tts_provider"],
+        "conversation_provider": resolved_voice["conversation_provider"],
+        "one_shot_tts_provider": effective["one_shot_tts_provider"],
+        "settings": {
+            "voice": resolved_voice,
+        },
+        "effective_voice_settings": effective,
+    }

--- a/backend/tests/unit/test_ella_app_settings.py
+++ b/backend/tests/unit/test_ella_app_settings.py
@@ -1,0 +1,102 @@
+import importlib
+import sys
+import types
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ella.services import app_settings as service
+from utils.other import endpoints as auth
+
+
+def test_extract_voice_settings_normalizes_ios_payload():
+    voice = service.extract_voice_settings(
+        {
+            "voice_mode": "gemini-live",
+            "tts_provider": "gemini-live",
+            "conversation_provider": "gemini-live",
+            "settings": {
+                "voice": {
+                    "uses_v2v_session": True,
+                    "source_client": "ios-app",
+                    "source_setting": "devTtsProvider",
+                    "client_version": "1.0.524+780",
+                    "updated_at": "2026-05-08T18:00:00Z",
+                }
+            },
+        }
+    )
+
+    assert voice["voice_mode"] == "gemini-native-live"
+    assert voice["tts_provider"] == "gemini-native-live"
+    assert voice["conversation_provider"] == "gemini-native-live"
+    assert voice["uses_v2v_session"] is True
+    assert voice["session_voice_mode"] == "gemini-native-live-v1"
+    assert voice["source_client"] == "ios-app"
+
+
+def test_effective_settings_maps_v2v_to_explicit_one_shot_fallback():
+    effective = service.build_effective_voice_settings("uid-1", {"voice_mode": "grok-voice"})
+
+    assert effective["voice_mode"] == "grok-voice"
+    assert effective["one_shot_tts_provider"] == "kokoro"
+    assert effective["effective_voice_settings"]["provider_type"] == "v2v"
+    assert effective["effective_voice_settings"]["fallback_used"] is True
+    assert "Guardian one-shots" in effective["effective_voice_settings"]["fallback_reason"]
+
+
+def _load_router(monkeypatch, stored_voice=None):
+    fake_db = types.ModuleType("database.app_settings")
+    state = {"voice": stored_voice or {}}
+
+    def get_voice_settings(uid):
+        assert uid == "uid-1"
+        return dict(state["voice"])
+
+    def save_voice_settings(uid, voice):
+        assert uid == "uid-1"
+        state["voice"] = dict(voice)
+        return dict(state["voice"])
+
+    fake_db.get_voice_settings = get_voice_settings
+    fake_db.save_voice_settings = save_voice_settings
+    monkeypatch.setitem(sys.modules, "database.app_settings", fake_db)
+    sys.modules.pop("ella.routers.settings", None)
+    if not hasattr(sys.modules.get("ella.routers"), "__path__"):
+        sys.modules.pop("ella.routers", None)
+    module = importlib.import_module("ella.routers.settings")
+
+    app = FastAPI()
+    app.include_router(module.router)
+    app.dependency_overrides[auth.get_current_user_uid] = lambda: "uid-1"
+    return TestClient(app), state
+
+
+def test_settings_router_accepts_ios_patch_and_returns_effective(monkeypatch):
+    client, state = _load_router(monkeypatch)
+
+    response = client.patch(
+        "/v1/ella/settings",
+        json={
+            "voice_mode": "openai-realtime",
+            "settings": {"voice": {"source_client": "ios-app", "source_setting": "devTtsProvider"}},
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["voice_mode"] == "openai-native-realtime"
+    assert state["voice"]["session_voice_mode"] == "openai-native-realtime-v1"
+
+    effective = client.get("/v1/ella/settings/effective").json()
+    assert effective["voice_mode"] == "openai-native-realtime"
+    assert effective["effective_voice_settings"]["one_shot_tts_provider"] == "kokoro"
+
+
+def test_settings_router_returns_default_when_no_server_setting(monkeypatch):
+    client, _state = _load_router(monkeypatch)
+
+    response = client.get("/v1/ella/settings")
+
+    assert response.status_code == 200
+    assert response.json()["voice_mode"] == "elevenlabs"

--- a/backend/tests/unit/test_ella_guardian_delivery.py
+++ b/backend/tests/unit/test_ella_guardian_delivery.py
@@ -26,6 +26,11 @@ resolve_module = types.ModuleType("ella.routers.resolve")
 resolve_module.resolve_user_routing = None
 sys.modules["ella.routers.resolve"] = resolve_module
 
+app_settings_module = types.ModuleType("database.app_settings")
+app_settings_module.get_voice_settings = lambda _uid: {}
+app_settings_module.save_voice_settings = lambda _uid, voice: voice
+sys.modules["database.app_settings"] = app_settings_module
+
 _ROUTER_PATH = _BACKEND / "ella" / "routers" / "guardian.py"
 _ROUTER_SPEC = importlib.util.spec_from_file_location("ella_guardian_under_test", _ROUTER_PATH)
 guardian = importlib.util.module_from_spec(_ROUTER_SPEC)
@@ -61,6 +66,8 @@ class _FakePool:
 class _FakeResponse:
     status_code = 200
     text = "ok"
+    content = b"mp3-bytes"
+    headers = {"content-type": "audio/mpeg"}
 
 
 class _FakeAsyncClient:
@@ -187,6 +194,27 @@ def test_deliver_dispatches_pending_backend_resolved_recipient(monkeypatch):
     step = kwargs["json"]["delivery_plan"][0]
     assert step["target"] == "user"
     assert step["recipient_phone"] == "+15550000001"
+
+
+def test_synthesize_audio_resolves_server_voice_settings(monkeypatch):
+    _FakeAsyncClient.posts = []
+    monkeypatch.setattr(guardian.httpx, "AsyncClient", _FakeAsyncClient)
+    monkeypatch.setattr(guardian.app_settings_db, "get_voice_settings", lambda uid: {"voice_mode": "grok-voice"})
+
+    response = asyncio.run(
+        guardian.synthesize_audio(
+            guardian.SynthesizeRequest(uid="uid-1", text="Hello", trace_id="trace-1"),
+            x_guardian_key=guardian.GUARDIAN_WEBHOOK_KEY,
+        )
+    )
+
+    assert response.body == b"mp3-bytes"
+    url, kwargs = _FakeAsyncClient.posts[0]
+    assert url == guardian.ELLA_INTERNAL_VOICE_TTS_URL
+    assert kwargs["headers"]["X-TTS-Provider"] == "kokoro"
+    assert kwargs["json"]["text"] == "Hello"
+    assert response.headers["x-guardian-tts-provider"] == "kokoro"
+    assert response.headers["x-guardian-voice-mode"] == "grok-voice"
 
 
 def test_trace_log_allows_missing_key_but_rejects_bad_key(monkeypatch):


### PR DESCRIPTION
## Summary
- Add authenticated `/v1/ella/settings`, `/v1/ella/settings/effective`, and `/v1/ella/settings/effective/voice` endpoints for server-backed app settings.
- Persist the first critical iOS setting, voice/TTS mode, under `users/{uid}/app_settings/voice` and mirror it to `users/{uid}.settings.voice` for operator/debug visibility.
- Normalize iOS payload aliases such as `gemini-live` and `openai-realtime`, preserve the nested `settings.voice` contract from omi#190, and return effective voice routing metadata.
- Add `/v1/ella/guardian/synthesize` so n8n/Guardian can call the backend resolver instead of hardcoding a vendor; V2V modes resolve to explicit one-shot TTS fallback metadata.

## Contract
- iOS PATCH: `PATCH /v1/ella/settings` with top-level `voice_mode`, `tts_provider`, `conversation_provider`, and nested `settings.voice` metadata.
- iOS GET: `GET /v1/ella/settings/effective` returns top-level `voice_mode`, `settings.voice`, and `effective_voice_settings`.
- Guardian TTS: `POST /v1/ella/guardian/synthesize` with `X-Guardian-Key`, `{ "uid", "text", "trace_id" }`, returns audio and provider provenance headers.

## Validation
- `python3 -m pytest backend/tests/unit/test_ella_app_settings.py backend/tests/unit/test_ella_guardian_delivery.py -q` -> 10 passed
- `python3 -m compileall -q backend/ella/services/app_settings.py backend/ella/routers/settings.py backend/database/app_settings.py backend/ella/routers/guardian.py backend/ella/__init__.py`

Refs ellaaicare/ella-ai#862, ellaaicare/ella-ai#998, ellaaicare/omi#190.