### PR TITLE
Add MCP surface prompt and harden memory smoke

### DIFF
--- a/backend/ella/routers/mcp_onboarding.py
+++ b/backend/ella/routers/mcp_onboarding.py
@@ -15,6 +15,7 @@ from ella.services.mcp_identity import (
     resolve_mcp_identity,
 )
 from ella.services.mcp_startup import build_startup_context
+from ella.services.mcp_surface_prompt import build_surface_prompt
 
 router = APIRouter(prefix="/v1/ella/mcp", tags=["Ella MCP Onboarding"])
 
@@ -184,12 +185,35 @@ async def get_mcp_start_here(
     return await build_startup_context(onboarding=onboarding, limit=limit, channels=channel_list)
 
 
+@router.get("/surface-prompt")
+async def get_mcp_surface_prompt(
+    authorization: Optional[str] = Header(None, alias="Authorization"),
+    selected_profile_uid: str = Query("", description="Optional profile UID selected after multi-profile mapping."),
+    surface: str = Query("generic", description="External surface, e.g. grok, hosted-gpt, gemini."),
+):
+    token_fingerprint = _authenticate_static(authorization)
+    onboarding = resolve_static_connector_session(token_fingerprint, selected_profile_uid)
+    selected = onboarding.get("selected_profile") or {}
+    claims = onboarding.get("session_claims") or {}
+    if onboarding.get("state") != "authenticated_mapped" or not selected:
+        raise HTTPException(status_code=403, detail="No mapped Ella profile for this connector session")
+    return build_surface_prompt(
+        profile_uid=str(selected.get("profile_uid") or claims.get("profile_uid") or ""),
+        profile_label=str(selected.get("profile_label") or "Ella profile"),
+        surface=surface,
+        scopes=[str(item) for item in (claims.get("scopes") or selected.get("scopes") or [])],
+        allowed_tools=[str(item) for item in (claims.get("allowed_tools") or selected.get("allowed_tools") or [])],
+        proposal_write_enabled="proposals:write" in set(claims.get("scopes") or selected.get("scopes") or []),
+    )
+
+
 @router.get("/info")
 async def get_mcp_onboarding_info():
     return {
         "onboarding_endpoint": "/v1/ella/mcp/onboarding",
         "oauth_onboarding_endpoint": "/v1/ella/mcp/onboarding/oauth",
         "start_here_endpoint": "/v1/ella/mcp/start_here",
+        "surface_prompt_endpoint": "/v1/ella/mcp/surface-prompt",
         "auth": "POST Firebase ID token to OAuth onboarding for production; Bearer token remains dev/static fallback.",
         "states": [
             "authenticated_mapped",

--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -33,6 +33,7 @@ import database.conversations as conversations_db
 import database.memories as memories_db
 from ella.services import proposal_ingest
 from ella.services.mcp_startup import build_startup_context
+from ella.services.mcp_surface_prompt import build_surface_prompt
 from utils.ella.time_context import annotate_event_time, build_time_context, local_time_fields, timezone_name
 
 logger = logging.getLogger("ella.plato_mcp")
@@ -698,6 +699,7 @@ def _legacy_plato_onboarding() -> dict[str, Any]:
     scopes = ["context:read", "memory:read", "profile:read", "startup:read", "timeline:read", "tools:read"]
     tools = [
         "companion_start_here",
+        "companion_surface_prompt",
         "companion_get_proposal_status",
         "plato_recent_context",
         "plato_search_memory",
@@ -738,6 +740,20 @@ async def _companion_start_here(arguments: dict[str, Any]) -> dict[str, Any]:
         onboarding=_legacy_plato_onboarding(),
         limit=_clamp_int(arguments.get("limit"), 12, 1, MAX_CONTEXT_LIMIT),
         channels=[str(channel).strip() for channel in channels if str(channel).strip()],
+    )
+
+
+async def _companion_surface_prompt(arguments: dict[str, Any]) -> dict[str, Any]:
+    onboarding = _legacy_plato_onboarding()
+    selected = onboarding["selected_profile"]
+    claims = onboarding["session_claims"]
+    return build_surface_prompt(
+        profile_uid=str(selected.get("profile_uid") or _plato_uid()),
+        profile_label=str(selected.get("profile_label") or "Plato"),
+        surface=_compact_text(arguments.get("surface") or "generic", 80),
+        scopes=[str(item) for item in (claims.get("scopes") or [])],
+        allowed_tools=[str(item) for item in (claims.get("allowed_tools") or [])],
+        proposal_write_enabled=_proposal_write_enabled(),
     )
 
 
@@ -819,6 +835,17 @@ MCP_TOOLS: list[dict[str, Any]] = [
                 "limit": {"type": "integer", "default": 12, "minimum": 1, "maximum": MAX_CONTEXT_LIMIT},
                 "channels": {"type": "array", "items": {"type": "string"}, "default": []},
             },
+        },
+    },
+    {
+        "name": "companion_surface_prompt",
+        "description": (
+            "Return the current hosted-surface bootstrap prompt and tool/writeback policy for this profile. "
+            "Use this when configuring Grok, hosted GPTs, Gemini, or other external companion surfaces."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {"surface": {"type": "string", "default": "generic"}},
         },
     },
     {
@@ -944,6 +971,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
 
 _TOOL_HANDLERS = {
     "companion_start_here": _companion_start_here,
+    "companion_surface_prompt": _companion_surface_prompt,
     "companion_get_proposal_status": _companion_get_proposal_status,
     "companion_propose_change": _companion_propose_change,
     "plato_recent_context": _recent_context,

--- a/backend/ella/services/mcp_surface_prompt.py
+++ b/backend/ella/services/mcp_surface_prompt.py
@@ -1,0 +1,97 @@
+"""Hosted bootstrap prompt for external MCP companion surfaces."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+SURFACE_PROMPT_VERSION = "2026-05-08.1"
+
+
+def _csv(values: list[str]) -> str:
+    return ", ".join(sorted(str(value) for value in values if str(value))) or "none"
+
+
+def build_surface_prompt(
+    *,
+    profile_uid: str,
+    profile_label: str,
+    surface: str,
+    scopes: list[str],
+    allowed_tools: list[str],
+    proposal_write_enabled: bool,
+) -> dict[str, Any]:
+    """Return a safe system/developer prompt for hosted external assistants.
+
+    The prompt contains no secrets. Authentication remains the responsibility
+    of the hosting surface's action/MCP connector layer.
+    """
+
+    safe_surface = (surface or "generic").strip().lower()[:80] or "generic"
+    safe_label = (profile_label or "Plato").strip()[:120] or "Plato"
+    tool_policy = {
+        "startup": "Call companion_start_here before profile/context-sensitive work.",
+        "recall": [
+            "plato_recent_context",
+            "plato_search_memory",
+            "plato_latest_omi",
+            "plato_omi_activity_window",
+            "plato_consult",
+        ],
+        "writeback": "Use companion_propose_change for durable memory, profile, correction, scanner, and reminder changes.",
+        "persistence_claim": "Never say something was saved unless a write/proposal tool returned an id.",
+        "secrets": "Never ask for, display, infer, or store raw auth tokens or API keys.",
+        "proposal_write_enabled": proposal_write_enabled,
+    }
+    writeback_policy = {
+        "memory_note": "Use for explicit durable facts, preferences, relationships, environment updates, or user-requested memory.",
+        "profile_update": "Use for stable identity/profile changes.",
+        "summary_correction": "Use for corrections; treat as pending until status says applied.",
+        "scanner_rule_change": "Use for Guardian/scanner behavior requests; do not claim active until status confirms.",
+        "reminder_request": "Use for reminders/schedule requests; do not claim scheduled until status confirms.",
+        "skip": "Do not write low-signal fragments, TV/media background, vague chatter, or sensitive medical detail unless explicitly relevant.",
+    }
+    prompt = f"""You are an external Ella/Plato companion surface running on {safe_surface}.
+
+Profile:
+- profile_label: {safe_label}
+- profile_uid: {profile_uid}
+
+Use the Plato-Hermes MCP tools as the source of truth for memory, OMI summaries, scanner state, and proposal writeback. Your platform account login does not by itself persist anything into Ella. Persistence only happens through confirmed Ella MCP tool calls.
+
+Startup and context:
+1. For any personalized answer, first call companion_start_here unless the current turn is clearly generic.
+2. For factual recall, use plato_recent_context, plato_search_memory, plato_latest_omi, or plato_omi_activity_window before answering.
+3. Prefer recent canonical timeline, observer_memory, iMessage/app-chat/voice events, and enriched OMI summaries over stale chat memory.
+4. Be explicit about uncertainty when the tools return weak or missing evidence.
+
+Writeback:
+1. If the user explicitly says to remember, correct, update, watch for, remind, or store something, call companion_propose_change.
+2. For durable facts, preferences, relationships, environment changes, or important corrections, propose the change when confidence is high.
+3. Never claim a fact was saved, scheduled, corrected, or activated unless the tool returns a proposal_id or a status confirms application.
+4. Summary corrections, scanner changes, and reminders are proposal-first. Say they were submitted, not completed, unless status confirms otherwise.
+5. Do not write back low-signal fragments, media/background speech, or one-off chatter.
+
+Security:
+1. Do not ask the user to paste Ella/Hermes/MCP bearer tokens.
+2. Do not reveal auth headers, token fingerprints, internal service URLs, or secrets.
+3. Use only the tools exposed to this authenticated session.
+
+Current allowed scopes: {_csv(scopes)}
+Current allowed tools: {_csv(allowed_tools)}
+"""
+    return {
+        "version": SURFACE_PROMPT_VERSION,
+        "updated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "surface": safe_surface,
+        "profile_uid": profile_uid,
+        "profile_label": safe_label,
+        "prompt": prompt.strip(),
+        "tool_policy": tool_policy,
+        "writeback_policy": writeback_policy,
+        "auth_policy": {
+            "prompt_contains_secrets": False,
+            "auth_transport": "Use platform connector/action/MCP auth. Static bearer tokens are dev fallback only.",
+            "token_visibility": "The assistant may see safe auth status and scopes, never raw secrets.",
+        },
+    }

--- a/backend/ella/services/observer_extractor.py
+++ b/backend/ella/services/observer_extractor.py
@@ -89,6 +89,25 @@ def _is_low_signal(event: dict[str, Any]) -> bool:
     return False
 
 
+def _is_synthetic_or_test_event(event: dict[str, Any]) -> bool:
+    metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+    source_ref = event.get("source_ref") if isinstance(event.get("source_ref"), dict) else {}
+    if metadata.get("synthetic") is True or metadata.get("test") is True:
+        return True
+    for value in (
+        metadata.get("test"),
+        metadata.get("source"),
+        metadata.get("fixture"),
+        event.get("provider"),
+        event.get("event_id"),
+        source_ref.get("source_id"),
+    ):
+        text = str(value or "").lower()
+        if any(marker in text for marker in ("ella_memory_e2e", "ella-memory-e2e", "automated_e2e_smoke")):
+            return True
+    return False
+
+
 def _is_memory_instruction(text: str, match: re.Match[str]) -> bool:
     lower = text.lower().strip()
     prefix = lower[: match.start()].strip()
@@ -139,6 +158,8 @@ def _candidate(
 def heuristic_candidate_extractor(event: dict[str, Any]) -> list[ObserverCandidate]:
     """High-precision local extractor for explicit user commands/corrections."""
     if not isinstance(event, dict) or str(event.get("role") or "").lower() not in {"user", "speaker"}:
+        return []
+    if _is_synthetic_or_test_event(event):
         return []
     if str(event.get("channel") or "") not in HEURISTIC_USER_CHANNELS:
         return []
@@ -293,7 +314,11 @@ async def hermes_candidate_extraction(
     limit: int = MAX_EXTRACTOR_EVENTS,
 ) -> ExtractionResult:
     """Ask Hermes for proposal candidates using a strict JSON-only contract."""
-    selected = [event for event in events if isinstance(event, dict) and not _is_low_signal(event)]
+    selected = [
+        event
+        for event in events
+        if isinstance(event, dict) and not _is_low_signal(event) and not _is_synthetic_or_test_event(event)
+    ]
     selected = selected[-max(1, min(limit, MAX_EXTRACTOR_EVENTS)) :]
     if not selected:
         return ExtractionResult(metadata={"extractor": "hermes", "event_count": 0, "skipped": "no_signal_events"})
@@ -429,6 +454,8 @@ def combined_extractor(result: ExtractionResult):
     """Return an event extractor combining structured metadata and extracted candidates."""
 
     def _extract(event: dict[str, Any]) -> list[ObserverCandidate]:
+        if _is_synthetic_or_test_event(event):
+            return []
         candidates = list(structured_candidate_extractor(event))
         event_id = _event_id(event)
         if event_id:

--- a/backend/scripts/ella_memory_e2e_smoke.py
+++ b/backend/scripts/ella_memory_e2e_smoke.py
@@ -71,6 +71,14 @@ class MemorySmoke:
         self.metrics: dict[str, int] = {}
         self.artifacts: dict[str, Any] = {}
 
+    def enforce_profile_safety(self) -> None:
+        writes_real_plato = self.args.uid == DEFAULT_PLATO_UID or self.args.canonical_identity.lower() == "plato"
+        if writes_real_plato and not self.args.allow_real_profile:
+            raise SmokeFailure(
+                "Refusing to write live memory smoke data to Plato without --allow-real-profile. "
+                "Use an ephemeral test uid/profile for routine regression runs."
+            )
+
     def _mcp_call(self, method: str, params: dict[str, Any] | None = None, request_id: int = 1) -> dict[str, Any]:
         if not self.args.mcp_token:
             raise SmokeFailure("MCP token is required for MCP smoke")
@@ -134,7 +142,7 @@ class MemorySmoke:
                     "description": f"Remember the E2E memory smoke phrase: {phrase}.",
                     "requested_change": {"memory": f"The E2E memory smoke phrase is {phrase}."},
                     "target": {"canonical_identity": self.args.canonical_identity},
-                    "evidence": [{"kind": "automated_e2e_smoke", "at": _now_iso()}],
+                    "evidence": [{"kind": "automated_e2e_smoke", "synthetic": True, "at": _now_iso()}],
                     "confidence": 0.96,
                     "idempotency_key": f"ella-memory-e2e:{phrase}",
                 },
@@ -223,7 +231,7 @@ class MemorySmoke:
                     "text": f"E2E multichannel memory continuity phrase for {channel}: {phrase}.",
                     "started_at": _now_iso(),
                     "source_ref": {"source_id": f"ella-memory-e2e:{channel}:{phrase}"},
-                    "metadata": {"test": "ella_memory_e2e_smoke", "phrase": phrase},
+                    "metadata": {"test": "ella_memory_e2e_smoke", "synthetic": True, "phrase": phrase},
                 }
             )
         response, elapsed = _json_request("POST", self.backend_url + "/v1/ella/events", {"events": batch})
@@ -250,6 +258,7 @@ class MemorySmoke:
             raise SmokeFailure(f"latency threshold exceeded: {slow}")
 
     def run(self) -> dict[str, Any]:
+        self.enforce_profile_safety()
         self.check_health()
         self.check_mcp_tools()
         proposal_id = self.create_memory_proposal()
@@ -283,6 +292,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--seed-multichannel", action="store_true")
     parser.add_argument("--enforce-latency", action="store_true")
     parser.add_argument("--max-latency-ms", type=int, default=5000)
+    parser.add_argument(
+        "--allow-real-profile",
+        action="store_true",
+        help="Allow writes to the real Plato profile. Required because this smoke creates durable proposals/events.",
+    )
     return parser.parse_args(argv)
 
 

--- a/backend/tests/unit/test_ella_mcp_onboarding.py
+++ b/backend/tests/unit/test_ella_mcp_onboarding.py
@@ -247,6 +247,24 @@ def test_mcp_start_here_returns_canonical_startup_packet(monkeypatch):
     assert payload["escalation_boundaries"]["emergency_actions"] == "not_available_from_mcp"
 
 
+def test_mcp_surface_prompt_returns_bootstrap_without_secret(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    response = client.get(
+        "/v1/ella/mcp/surface-prompt?surface=hosted-gpt",
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["surface"] == "hosted-gpt"
+    assert payload["profile_uid"] == "user-1"
+    assert payload["auth_policy"]["prompt_contains_secrets"] is False
+    assert "companion_start_here" in payload["prompt"]
+    assert "test-token" not in payload["prompt"]
+
+
 def test_mcp_start_here_does_not_leak_context_when_unmapped(monkeypatch):
     module = _load_module(monkeypatch)
     monkeypatch.delenv("ELLA_MCP_DEFAULT_PROFILE_UID", raising=False)

--- a/backend/tests/unit/test_ella_observer.py
+++ b/backend/tests/unit/test_ella_observer.py
@@ -237,6 +237,56 @@ def test_heuristic_extractor_does_not_treat_memory_questions_as_instructions():
     assert instruction_log.decisions[0].proposal_type == "memory_note"
 
 
+def test_observer_extractors_ignore_synthetic_e2e_events():
+    service = _load_observer_service()
+    sys.modules.pop("ella.services.observer_extractor", None)
+    extractor_module = importlib.import_module("ella.services.observer_extractor")
+
+    synthetic = _event(
+        event_id="e2e:ios_chat:123",
+        channel="ios_chat",
+        provider="ella-memory-e2e",
+        role="user",
+        text="Please remember the E2E phrase synthetic anchor.",
+        metadata={"synthetic": True, "test": "ella_memory_e2e_smoke"},
+    )
+    structured_synthetic = _event(
+        event_id="e2e:structured",
+        metadata={
+            "synthetic": True,
+            "observer": {
+                "proposals": [
+                    {
+                        "proposal_type": "memory_note",
+                        "title": "Synthetic",
+                        "description": "Synthetic",
+                        "requested_change": {"memory": "synthetic"},
+                        "confidence": 0.95,
+                    }
+                ]
+            },
+        },
+    )
+
+    heuristic_log = service.run_observer(
+        profile_uid="user-1",
+        dry_run=True,
+        events=[synthetic],
+        extractor=extractor_module.heuristic_candidate_extractor,
+        run_id="run-synthetic-heuristic",
+    )
+    structured_log = service.run_observer(
+        profile_uid="user-1",
+        dry_run=True,
+        events=[structured_synthetic],
+        extractor=extractor_module.combined_extractor(extractor_module.ExtractionResult()),
+        run_id="run-synthetic-structured",
+    )
+
+    assert heuristic_log.proposal_count == 0
+    assert structured_log.proposal_count == 0
+
+
 def test_observer_router_runs_against_in_memory_test_ledger(monkeypatch):
     _install_proposal_stubs()
     monkeypatch.setenv("ELLA_OBSERVER_ADMIN_TOKEN", "observer-token")

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -86,6 +86,7 @@ def test_plato_mcp_lists_only_read_only_tools(monkeypatch):
     tool_names = {tool["name"] for tool in response.json()["result"]["tools"]}
     assert tool_names == {
         "companion_start_here",
+        "companion_surface_prompt",
         "companion_get_proposal_status",
         "plato_recent_context",
         "plato_search_memory",
@@ -98,6 +99,28 @@ def test_plato_mcp_lists_only_read_only_tools(monkeypatch):
     assert "delete_memory" not in tool_names
     assert "update_conversation_summary" not in tool_names
     assert "companion_propose_change" not in tool_names
+
+
+def test_companion_surface_prompt_returns_no_secret_bootstrap(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc(
+            "tools/call",
+            params={"name": "companion_surface_prompt", "arguments": {"surface": "grok"}},
+        ),
+    )
+
+    assert response.status_code == 200
+    payload = _tool_result(response)
+    assert payload["surface"] == "grok"
+    assert payload["auth_policy"]["prompt_contains_secrets"] is False
+    assert "companion_start_here" in payload["prompt"]
+    assert "Never claim" in payload["prompt"]
+    assert "test-token" not in payload["prompt"]
 
 
 def test_plato_mcp_lists_proposal_tool_only_when_enabled(monkeypatch):


### PR DESCRIPTION
## Summary

- Add a hosted MCP surface bootstrap prompt builder.
- Expose it from generic MCP onboarding at `GET /v1/ella/mcp/surface-prompt`.
- Expose it to Plato MCP clients as `companion_surface_prompt`.
- Teach Observer extraction to ignore synthetic/test E2E events.
- Require `--allow-real-profile` before the live memory smoke harness writes to the real Plato profile.

## Why

External surfaces like Grok custom MCP and hosted GPTs need a canonical prompt/tool policy so they do not falsely claim persistence and know when to call `companion_propose_change`. During live testing, the E2E harness also promoted synthetic test phrases into Plato's real memory, so this adds guardrails.

## Tests

- `pytest tests/unit/test_ella_plato_mcp.py tests/unit/test_ella_mcp_onboarding.py tests/unit/test_ella_observer.py -q` -> 45 passed
- `python3 -m py_compile backend/ella/services/mcp_surface_prompt.py backend/ella/routers/mcp_onboarding.py backend/ella/routers/plato_mcp.py backend/ella/services/observer_extractor.py backend/scripts/ella_memory_e2e_smoke.py`
- `python3 scripts/ella_memory_e2e_smoke.py --backend-url http://127.0.0.1:1 --mcp-token dummy --observer-token dummy` -> refuses real Plato writes without `--allow-real-profile`

## Related

- ellaaicare/ella-ai#863
- ellaaicare/ella-ai#861
- ellaaicare/ella-ai#860
