### PR TITLE
Handle Firestore sentinels in settings responses

### DIFF
--- a/backend/database/app_settings.py
+++ b/backend/database/app_settings.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from google.cloud.firestore_v1 import SERVER_TIMESTAMP
+from google.cloud.firestore_v1.transforms import Sentinel
 
 from database._client import db
 
@@ -45,4 +46,6 @@ def _json_safe(value: Any) -> Any:
         return [_json_safe(item) for item in value]
     if isinstance(value, datetime):
         return value.isoformat()
+    if isinstance(value, Sentinel):
+        return None
     return value

--- a/backend/ella/services/app_settings.py
+++ b/backend/ella/services/app_settings.py
@@ -4,6 +4,8 @@ import os
 from datetime import datetime, timezone
 from typing import Any
 
+from google.cloud.firestore_v1.transforms import Sentinel
+
 
 TTS_PROVIDERS = {"elevenlabs", "fish-audio", "fish-audio-s1", "fish-audio-s2", "kokoro", "inworld"}
 V2V_PROVIDERS = {"openclaw-direct", "grok-voice", "gemini-native-live", "openai-native-realtime"}
@@ -109,8 +111,8 @@ def extract_voice_settings(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def build_settings_response(uid: str, voice: dict[str, Any] | None = None) -> dict[str, Any]:
-    resolved_voice = extract_voice_settings({"settings": {"voice": voice or {}}})
-    return {
+    resolved_voice = _json_safe(extract_voice_settings({"settings": {"voice": voice or {}}}))
+    return _json_safe({
         "uid": uid,
         "voice_mode": resolved_voice["voice_mode"],
         "tts_provider": resolved_voice["tts_provider"],
@@ -119,11 +121,11 @@ def build_settings_response(uid: str, voice: dict[str, Any] | None = None) -> di
             "voice": resolved_voice,
         },
         "updated_at": resolved_voice.get("updated_at"),
-    }
+    })
 
 
 def build_effective_voice_settings(uid: str, voice: dict[str, Any] | None = None) -> dict[str, Any]:
-    resolved_voice = extract_voice_settings({"settings": {"voice": voice or {}}})
+    resolved_voice = _json_safe(extract_voice_settings({"settings": {"voice": voice or {}}}))
     voice_mode = resolved_voice["voice_mode"]
     fallback_used = voice_mode in V2V_PROVIDERS
     fallback_reason = None
@@ -138,7 +140,7 @@ def build_effective_voice_settings(uid: str, voice: dict[str, Any] | None = None
         "fallback_reason": fallback_reason,
         "resolved_at": utc_now_iso(),
     }
-    return {
+    return _json_safe({
         "uid": uid,
         "voice_mode": voice_mode,
         "tts_provider": resolved_voice["tts_provider"],
@@ -148,4 +150,16 @@ def build_effective_voice_settings(uid: str, voice: dict[str, Any] | None = None
             "voice": resolved_voice,
         },
         "effective_voice_settings": effective,
-    }
+    })
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Sentinel):
+        return None
+    return value

--- a/backend/tests/unit/test_ella_app_settings.py
+++ b/backend/tests/unit/test_ella_app_settings.py
@@ -4,6 +4,7 @@ import types
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from google.cloud.firestore_v1 import SERVER_TIMESTAMP
 
 from ella.services import app_settings as service
 from utils.other import endpoints as auth
@@ -55,7 +56,7 @@ def _load_router(monkeypatch, stored_voice=None):
 
     def save_voice_settings(uid, voice):
         assert uid == "uid-1"
-        state["voice"] = dict(voice)
+        state["voice"] = {**voice, "server_updated_at": SERVER_TIMESTAMP}
         return dict(state["voice"])
 
     fake_db.get_voice_settings = get_voice_settings
@@ -87,6 +88,7 @@ def test_settings_router_accepts_ios_patch_and_returns_effective(monkeypatch):
     payload = response.json()
     assert payload["voice_mode"] == "openai-native-realtime"
     assert state["voice"]["session_voice_mode"] == "openai-native-realtime-v1"
+    assert payload["settings"]["voice"]["server_updated_at"] is None
 
     effective = client.get("/v1/ella/settings/effective").json()
     assert effective["voice_mode"] == "openai-native-realtime"


### PR DESCRIPTION
## Summary
- sanitize Firestore SERVER_TIMESTAMP sentinels before returning Ella settings responses
- keep flexible voice settings payload JSON-serializable for iOS PATCH/GET
- add regression coverage for the iOS settings router response

## Validation
- python3 -m pytest backend/tests/unit/test_ella_app_settings.py backend/tests/unit/test_ella_guardian_delivery.py -q

## Live status
- hotpatched on api.ella-ai-care.com after Greg's build 780 test showed PATCH /v1/ella/settings returning 500 due PydanticSerializationError on Firestore Sentinel
- omi-backend restarted and /v1/health returns 200

Refs ellaaicare/ella-ai#862
Refs ellaaicare/ella-ai#998
