### PR TITLE
Add public MCP surface prompt JSON

### DIFF
--- a/backend/ella/routers/mcp_onboarding.py
+++ b/backend/ella/routers/mcp_onboarding.py
@@ -15,7 +15,7 @@ from ella.services.mcp_identity import (
     resolve_mcp_identity,
 )
 from ella.services.mcp_startup import build_startup_context
-from ella.services.mcp_surface_prompt import build_surface_prompt
+from ella.services.mcp_surface_prompt import build_public_surface_prompt, build_surface_prompt
 
 router = APIRouter(prefix="/v1/ella/mcp", tags=["Ella MCP Onboarding"])
 
@@ -207,6 +207,13 @@ async def get_mcp_surface_prompt(
     )
 
 
+@router.get("/surface-prompt/public")
+async def get_public_mcp_surface_prompt(
+    surface: str = Query("generic", description="External surface, e.g. grok, hosted-gpt, gemini."),
+):
+    return build_public_surface_prompt(surface=surface)
+
+
 @router.get("/info")
 async def get_mcp_onboarding_info():
     return {
@@ -214,6 +221,7 @@ async def get_mcp_onboarding_info():
         "oauth_onboarding_endpoint": "/v1/ella/mcp/onboarding/oauth",
         "start_here_endpoint": "/v1/ella/mcp/start_here",
         "surface_prompt_endpoint": "/v1/ella/mcp/surface-prompt",
+        "public_surface_prompt_endpoint": "/v1/ella/mcp/surface-prompt/public",
         "auth": "POST Firebase ID token to OAuth onboarding for production; Bearer token remains dev/static fallback.",
         "states": [
             "authenticated_mapped",

--- a/backend/ella/services/mcp_surface_prompt.py
+++ b/backend/ella/services/mcp_surface_prompt.py
@@ -6,6 +6,19 @@ from datetime import datetime, timezone
 from typing import Any
 
 SURFACE_PROMPT_VERSION = "2026-05-08.1"
+PUBLIC_PROFILE_UID = "selected-after-auth"
+PUBLIC_PROFILE_LABEL = "Ella companion profile"
+PUBLIC_ALLOWED_TOOLS = [
+    "companion_start_here",
+    "companion_surface_prompt",
+    "companion_get_proposal_status",
+    "companion_propose_change",
+    "plato_recent_context",
+    "plato_search_memory",
+    "plato_latest_omi",
+    "plato_omi_activity_window",
+    "plato_consult",
+]
 
 
 def _csv(values: list[str]) -> str:
@@ -95,3 +108,33 @@ Current allowed tools: {_csv(allowed_tools)}
             "token_visibility": "The assistant may see safe auth status and scopes, never raw secrets.",
         },
     }
+
+
+def build_public_surface_prompt(*, surface: str = "generic") -> dict[str, Any]:
+    """Return an unauthenticated bootstrap prompt safe to host as JSON.
+
+    This is meant for copy/paste or URL-based onboarding of hosted agents. It
+    intentionally contains no profile memory, no scoped claims, and no secrets.
+    Runtime profile context must still come from authenticated MCP tools.
+    """
+
+    payload = build_surface_prompt(
+        profile_uid=PUBLIC_PROFILE_UID,
+        profile_label=PUBLIC_PROFILE_LABEL,
+        surface=surface,
+        scopes=[],
+        allowed_tools=PUBLIC_ALLOWED_TOOLS,
+        proposal_write_enabled=False,
+    )
+    payload["schema_version"] = "ella.mcp.surface_prompt.public.v1"
+    payload["public"] = True
+    payload["usage"] = {
+        "copy_prompt": "Use the `prompt` value as the hosted assistant system/developer instructions.",
+        "connector_auth": "Configure the Ella MCP connector separately with OAuth or a scoped bearer token.",
+        "runtime_context": "After auth, the assistant must call companion_start_here before personalized work.",
+    }
+    payload["auth_policy"]["runtime_auth_required"] = True
+    payload["auth_policy"][
+        "public_prompt_boundary"
+    ] = "This public JSON is only onboarding guidance; it does not authorize tools or expose profile memory."
+    return payload

--- a/backend/tests/unit/test_ella_mcp_onboarding.py
+++ b/backend/tests/unit/test_ella_mcp_onboarding.py
@@ -265,6 +265,24 @@ def test_mcp_surface_prompt_returns_bootstrap_without_secret(monkeypatch):
     assert "test-token" not in payload["prompt"]
 
 
+def test_public_mcp_surface_prompt_is_unauthenticated_and_secret_free(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    response = client.get("/v1/ella/mcp/surface-prompt/public?surface=grok")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["schema_version"] == "ella.mcp.surface_prompt.public.v1"
+    assert payload["public"] is True
+    assert payload["surface"] == "grok"
+    assert payload["profile_uid"] == "selected-after-auth"
+    assert payload["auth_policy"]["prompt_contains_secrets"] is False
+    assert payload["auth_policy"]["runtime_auth_required"] is True
+    assert "companion_start_here" in payload["prompt"]
+    assert "test-token" not in payload["prompt"]
+
+
 def test_mcp_start_here_does_not_leak_context_when_unmapped(monkeypatch):
     module = _load_module(monkeypatch)
     monkeypatch.delenv("ELLA_MCP_DEFAULT_PROFILE_UID", raising=False)


### PR DESCRIPTION
## Summary

- Add unauthenticated public bootstrap JSON at `/v1/ella/mcp/surface-prompt/public`.
- Keep the existing authenticated `/surface-prompt` endpoint for scoped/profile-aware context.
- Public prompt contains only onboarding/tool-use guidance and auth boundaries; no profile memory, no claims, no secrets.

## Why

This gives us a simple URL we can paste into Grok, hosted GPTs, Gemini, Telegram agents, or other external surfaces so they can bootstrap into the same Ella MCP behavior without copying stale prompt text.

## Tests

- `pytest tests/unit/test_ella_mcp_onboarding.py tests/unit/test_ella_plato_mcp.py -q` -> 32 passed
- `python3 -m py_compile backend/ella/services/mcp_surface_prompt.py backend/ella/routers/mcp_onboarding.py`

## Related

- ellaaicare/ella-ai#863
