### PR TITLE
Map Guardian TTS to server voice settings

### DIFF
--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -1162,35 +1162,53 @@ async def synthesize_audio(
 
     voice_settings = app_settings_db.get_voice_settings(req.uid)
     effective = build_effective_voice_settings(req.uid, voice_settings)["effective_voice_settings"]
-    provider = (req.provider or effective["one_shot_tts_provider"]).strip().lower()
-    if provider not in TTS_PROVIDERS:
-        raise HTTPException(status_code=422, detail=f"Provider {provider!r} cannot synthesize Guardian one-shot audio")
+    requested_provider = (req.provider or "").strip().lower()
+    provider_candidates = _guardian_tts_candidates(effective, requested_provider)
+    if not provider_candidates:
+        raise HTTPException(status_code=422, detail="No supported Guardian one-shot TTS providers available")
 
     payload = {"text": text}
     if req.voice_id:
         payload["voice_id"] = req.voice_id
 
     _start = time.time()
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                ELLA_INTERNAL_VOICE_TTS_URL,
-                json=payload,
-                headers={"X-TTS-Provider": provider},
-                timeout=30.0,
-            )
-    except httpx.TimeoutException:
-        raise HTTPException(status_code=504, detail=f"{provider} Guardian synthesis timed out")
-    except Exception as exc:
-        raise HTTPException(status_code=502, detail=f"{provider} Guardian synthesis failed: {exc}") from exc
+    attempts: list[dict[str, Any]] = []
+    response: httpx.Response | None = None
+    provider = provider_candidates[0]
+    async with httpx.AsyncClient() as client:
+        for candidate in provider_candidates:
+            provider = candidate
+            try:
+                response = await client.post(
+                    ELLA_INTERNAL_VOICE_TTS_URL,
+                    json=payload,
+                    headers={"X-TTS-Provider": candidate},
+                    timeout=30.0,
+                )
+            except httpx.TimeoutException:
+                attempts.append({"provider": candidate, "status": "timeout"})
+                continue
+            except Exception as exc:
+                attempts.append({"provider": candidate, "status": "error", "detail": str(exc)[:160]})
+                continue
+            if response.status_code < 400:
+                break
+            attempts.append({"provider": candidate, "status": response.status_code})
+        else:
+            response = None
 
     elapsed_ms = int((time.time() - _start) * 1000)
-    if response.status_code >= 400:
-        raise HTTPException(status_code=502, detail=f"{provider} Guardian synthesis error: {response.status_code}")
+    if response is None or response.status_code >= 400:
+        raise HTTPException(status_code=502, detail={"error": "Guardian synthesis failed", "attempts": attempts})
+
+    runtime_fallback_used = provider != provider_candidates[0]
+    if runtime_fallback_used:
+        attempts.append({"provider": provider, "status": response.status_code})
 
     print(
         f"[FLOW:GUARDIAN-SYNTHESIZE] uid={req.uid} trace={req.trace_id} "
-        f"provider={provider} voice_mode={effective['voice_mode']} bytes={len(response.content)} latency={elapsed_ms}ms",
+        f"provider={provider} candidates={provider_candidates} voice_mode={effective['voice_mode']} "
+        f"bytes={len(response.content)} latency={elapsed_ms}ms",
         flush=True,
     )
     return Response(
@@ -1200,10 +1218,26 @@ async def synthesize_audio(
             "X-Guardian-TTS-Provider": provider,
             "X-Guardian-Voice-Mode": effective["voice_mode"],
             "X-Guardian-Settings-Source": "server",
-            "X-Guardian-Fallback-Used": str(bool(effective.get("fallback_used"))).lower(),
+            "X-Guardian-TTS-Candidates": ",".join(provider_candidates),
+            "X-Guardian-Fallback-Used": str(bool(effective.get("fallback_used") or runtime_fallback_used)).lower(),
             "X-Guardian-Synthesis-Latency-Ms": str(elapsed_ms),
         },
     )
+
+
+def _guardian_tts_candidates(effective: dict[str, Any], requested_provider: str = "") -> list[str]:
+    raw_candidates = []
+    if requested_provider:
+        raw_candidates.append(requested_provider)
+    raw_candidates.extend(effective.get("one_shot_tts_candidates") or [])
+    raw_candidates.append(effective.get("one_shot_tts_provider"))
+
+    candidates: list[str] = []
+    for provider in raw_candidates:
+        normalized = str(provider or "").strip().lower()
+        if normalized in TTS_PROVIDERS and normalized not in candidates:
+            candidates.append(normalized)
+    return candidates
 
 
 def _store_audio_content(uid: str, content: bytes, filename: Optional[str] = None) -> dict:

--- a/backend/ella/services/app_settings.py
+++ b/backend/ella/services/app_settings.py
@@ -18,6 +18,7 @@ NORMALIZED_SUPPORTED_VOICE_MODES = (TTS_PROVIDERS | V2V_PROVIDERS) - set(VOICE_M
 
 _DEFAULT_VOICE_MODE = os.getenv("ELLA_DEFAULT_VOICE_MODE", "elevenlabs")
 _DEFAULT_ONE_SHOT_TTS_PROVIDER = os.getenv("ELLA_DEFAULT_GUARDIAN_TTS_PROVIDER", "kokoro")
+_DEFAULT_ONE_SHOT_TTS_FALLBACK_CHAIN = os.getenv("ELLA_GUARDIAN_TTS_FALLBACK_CHAIN", "kokoro,elevenlabs")
 
 _SESSION_MODE_BY_PROVIDER = {
     "openclaw-direct": "openclaw-direct-v1",
@@ -25,19 +26,19 @@ _SESSION_MODE_BY_PROVIDER = {
     "openai-native-realtime": "openai-native-realtime-v1",
 }
 
-_ONE_SHOT_PROVIDER_BY_VOICE_MODE = {
-    "elevenlabs": "elevenlabs",
-    "fish-audio": "fish-audio",
-    "fish-audio-s1": "fish-audio-s1",
-    "fish-audio-s2": "fish-audio-s2",
-    "kokoro": "kokoro",
-    "inworld": "inworld",
+_ONE_SHOT_CANDIDATES_BY_VOICE_MODE = {
+    "elevenlabs": ["elevenlabs", "kokoro"],
+    "fish-audio": ["fish-audio", "fish-audio-s2", "kokoro", "elevenlabs"],
+    "fish-audio-s1": ["fish-audio-s1", "fish-audio", "fish-audio-s2", "kokoro", "elevenlabs"],
+    "fish-audio-s2": ["fish-audio-s2", "fish-audio", "kokoro", "elevenlabs"],
+    "kokoro": ["kokoro", "fish-audio-s2", "elevenlabs"],
+    "inworld": ["inworld", "kokoro", "elevenlabs"],
     # V2V modes keep conversation routing intact, but Guardian one-shots need
     # explicit TTS routing until provider-native one-shot adapters are wired in.
-    "openclaw-direct": _DEFAULT_ONE_SHOT_TTS_PROVIDER,
-    "grok-voice": os.getenv("ELLA_GROK_VOICE_ONE_SHOT_TTS_PROVIDER", _DEFAULT_ONE_SHOT_TTS_PROVIDER),
-    "gemini-native-live": os.getenv("ELLA_GEMINI_LIVE_ONE_SHOT_TTS_PROVIDER", _DEFAULT_ONE_SHOT_TTS_PROVIDER),
-    "openai-native-realtime": os.getenv("ELLA_OPENAI_REALTIME_ONE_SHOT_TTS_PROVIDER", _DEFAULT_ONE_SHOT_TTS_PROVIDER),
+    "openclaw-direct": [os.getenv("ELLA_OPENCLAW_ONE_SHOT_TTS_PROVIDER", _DEFAULT_ONE_SHOT_TTS_PROVIDER)],
+    "grok-voice": [os.getenv("ELLA_GROK_VOICE_ONE_SHOT_TTS_PROVIDER", _DEFAULT_ONE_SHOT_TTS_PROVIDER)],
+    "gemini-native-live": [os.getenv("ELLA_GEMINI_LIVE_ONE_SHOT_TTS_PROVIDER", _DEFAULT_ONE_SHOT_TTS_PROVIDER)],
+    "openai-native-realtime": [os.getenv("ELLA_OPENAI_REALTIME_ONE_SHOT_TTS_PROVIDER", _DEFAULT_ONE_SHOT_TTS_PROVIDER)],
 }
 
 
@@ -69,10 +70,29 @@ def session_voice_mode(value: str) -> str | None:
 
 
 def one_shot_tts_provider(value: str) -> str:
-    provider = _ONE_SHOT_PROVIDER_BY_VOICE_MODE.get(normalize_voice_mode(value), _DEFAULT_ONE_SHOT_TTS_PROVIDER)
-    if provider not in TTS_PROVIDERS:
-        return _DEFAULT_ONE_SHOT_TTS_PROVIDER
-    return provider
+    return one_shot_tts_candidates(value)[0]
+
+
+def one_shot_tts_candidates(value: str) -> list[str]:
+    """Return ordered Guardian one-shot providers, closest match first."""
+    voice_mode = normalize_voice_mode(value)
+    candidates = list(_ONE_SHOT_CANDIDATES_BY_VOICE_MODE.get(voice_mode, []))
+    candidates.extend(_split_provider_chain(_DEFAULT_ONE_SHOT_TTS_FALLBACK_CHAIN))
+    candidates.extend([_DEFAULT_ONE_SHOT_TTS_PROVIDER, "kokoro", "elevenlabs"])
+    return _dedupe_supported_tts(candidates)
+
+
+def _split_provider_chain(value: str) -> list[str]:
+    return [item.strip().lower() for item in str(value or "").split(",") if item.strip()]
+
+
+def _dedupe_supported_tts(candidates: list[str]) -> list[str]:
+    result: list[str] = []
+    for provider in candidates:
+        normalized = str(provider or "").strip().lower()
+        if normalized in TTS_PROVIDERS and normalized not in result:
+            result.append(normalized)
+    return result or ["kokoro"]
 
 
 def extract_voice_settings(payload: dict[str, Any]) -> dict[str, Any]:
@@ -135,6 +155,7 @@ def build_effective_voice_settings(uid: str, voice: dict[str, Any] | None = None
     effective = {
         **resolved_voice,
         "one_shot_tts_provider": one_shot_tts_provider(voice_mode),
+        "one_shot_tts_candidates": one_shot_tts_candidates(voice_mode),
         "provider_type": "v2v" if is_v2v_voice_mode(voice_mode) else "tts",
         "fallback_used": fallback_used,
         "fallback_reason": fallback_reason,

--- a/backend/tests/unit/test_ella_app_settings.py
+++ b/backend/tests/unit/test_ella_app_settings.py
@@ -41,9 +41,23 @@ def test_effective_settings_maps_v2v_to_explicit_one_shot_fallback():
 
     assert effective["voice_mode"] == "grok-voice"
     assert effective["one_shot_tts_provider"] == "kokoro"
+    assert effective["effective_voice_settings"]["one_shot_tts_candidates"] == ["kokoro", "elevenlabs"]
     assert effective["effective_voice_settings"]["provider_type"] == "v2v"
     assert effective["effective_voice_settings"]["fallback_used"] is True
     assert "Guardian one-shots" in effective["effective_voice_settings"]["fallback_reason"]
+
+
+def test_effective_settings_maps_tts_mode_to_closest_guardian_candidates():
+    effective = service.build_effective_voice_settings("uid-1", {"voice_mode": "fish-audio-s2"})
+
+    assert effective["one_shot_tts_provider"] == "fish-audio-s2"
+    assert effective["effective_voice_settings"]["one_shot_tts_candidates"] == [
+        "fish-audio-s2",
+        "fish-audio",
+        "kokoro",
+        "elevenlabs",
+    ]
+    assert effective["effective_voice_settings"]["fallback_used"] is False
 
 
 def _load_router(monkeypatch, stored_voice=None):

--- a/backend/tests/unit/test_ella_guardian_delivery.py
+++ b/backend/tests/unit/test_ella_guardian_delivery.py
@@ -215,6 +215,69 @@ def test_synthesize_audio_resolves_server_voice_settings(monkeypatch):
     assert kwargs["json"]["text"] == "Hello"
     assert response.headers["x-guardian-tts-provider"] == "kokoro"
     assert response.headers["x-guardian-voice-mode"] == "grok-voice"
+    assert response.headers["x-guardian-tts-candidates"] == "kokoro,elevenlabs"
+
+
+def test_synthesize_audio_uses_matching_tts_provider(monkeypatch):
+    _FakeAsyncClient.posts = []
+    monkeypatch.setattr(guardian.httpx, "AsyncClient", _FakeAsyncClient)
+    monkeypatch.setattr(guardian.app_settings_db, "get_voice_settings", lambda uid: {"voice_mode": "fish-audio-s2"})
+
+    response = asyncio.run(
+        guardian.synthesize_audio(
+            guardian.SynthesizeRequest(uid="uid-1", text="Hello", trace_id="trace-1"),
+            x_guardian_key=guardian.GUARDIAN_WEBHOOK_KEY,
+        )
+    )
+
+    assert response.body == b"mp3-bytes"
+    _url, kwargs = _FakeAsyncClient.posts[0]
+    assert kwargs["headers"]["X-TTS-Provider"] == "fish-audio-s2"
+    assert response.headers["x-guardian-tts-provider"] == "fish-audio-s2"
+    assert response.headers["x-guardian-tts-candidates"] == "fish-audio-s2,fish-audio,kokoro,elevenlabs"
+
+
+def test_synthesize_audio_falls_back_to_next_candidate(monkeypatch):
+    class _FallbackResponse:
+        text = "ok"
+        headers = {"content-type": "audio/mpeg"}
+
+        def __init__(self, status_code, content=b"mp3-bytes"):
+            self.status_code = status_code
+            self.content = content
+
+    class _FallbackAsyncClient:
+        posts = []
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def post(self, url, **kwargs):
+            self.posts.append((url, kwargs))
+            provider = kwargs["headers"]["X-TTS-Provider"]
+            if provider == "fish-audio-s2":
+                return _FallbackResponse(502, b"")
+            return _FallbackResponse(200, b"fallback-mp3")
+
+    _FallbackAsyncClient.posts = []
+    monkeypatch.setattr(guardian.httpx, "AsyncClient", _FallbackAsyncClient)
+    monkeypatch.setattr(guardian.app_settings_db, "get_voice_settings", lambda uid: {"voice_mode": "fish-audio-s2"})
+
+    response = asyncio.run(
+        guardian.synthesize_audio(
+            guardian.SynthesizeRequest(uid="uid-1", text="Hello", trace_id="trace-1"),
+            x_guardian_key=guardian.GUARDIAN_WEBHOOK_KEY,
+        )
+    )
+
+    assert response.body == b"fallback-mp3"
+    attempted = [kwargs["headers"]["X-TTS-Provider"] for _url, kwargs in _FallbackAsyncClient.posts]
+    assert attempted == ["fish-audio-s2", "fish-audio"]
+    assert response.headers["x-guardian-tts-provider"] == "fish-audio"
+    assert response.headers["x-guardian-fallback-used"] == "true"
 
 
 def test_trace_log_allows_missing_key_but_rejects_bad_key(monkeypatch):


### PR DESCRIPTION
## Summary
- add ordered Guardian one-shot TTS candidate lists from server voice settings
- make `/v1/ella/guardian/synthesize` try closest provider first and fall back through supported TTS providers
- expose chosen provider/candidate/fallback headers for n8n/debugging
- cover exact `fish-audio-s2` matching and provider fallback behavior in tests

## Mapping
- TTS modes use exact provider first: `fish-audio-s2` -> `fish-audio-s2,fish-audio,kokoro,elevenlabs`
- V2V modes keep their conversation routing but map Guardian one-shots through configured/default TTS fallbacks
- Global fallback chain can be tuned with `ELLA_GUARDIAN_TTS_FALLBACK_CHAIN`

## Validation
- python3 -m pytest backend/tests/unit/test_ella_app_settings.py backend/tests/unit/test_ella_guardian_delivery.py -q
- python3 -m compileall -q backend/ella/services/app_settings.py backend/ella/routers/guardian.py

Refs ellaaicare/ella-ai#862
Refs ellaaicare/omi#190
