### PR TITLE
Add MCP OAuth session token flow

### DIFF
--- a/backend/ella/routers/mcp_onboarding.py
+++ b/backend/ella/routers/mcp_onboarding.py
@@ -4,14 +4,21 @@ from __future__ import annotations
 
 import hashlib
 import os
+import time
+import urllib.parse
+import uuid
 from typing import Any, Optional
 
-from fastapi import APIRouter, Header, HTTPException, Query
+from fastapi import APIRouter, Header, HTTPException, Query, Request, Response
 from pydantic import BaseModel, Field
 
 from ella.services.mcp_identity import (
     ExternalConnectorIdentity,
+    MCPIdentityResolution,
     MCPProfileGrant,
+    issue_mcp_session_token,
+    session_claims_to_public_resolution,
+    validate_mcp_session_token,
     resolve_mcp_identity,
 )
 from ella.services.mcp_startup import build_startup_context
@@ -24,6 +31,9 @@ class MCPOAuthOnboardingRequest(BaseModel):
     firebase_id_token: str = Field(..., min_length=1)
     selected_profile_uid: str = ""
     ttl_seconds: int = Field(default=3600, ge=60, le=24 * 60 * 60)
+
+
+_auth_codes: dict[str, dict[str, Any]] = {}
 
 
 def _env(name: str, default: str = "") -> str:
@@ -48,6 +58,25 @@ def _fingerprint(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
 
 
+def _oauth_client_id() -> str:
+    return _env("ELLA_MCP_OAUTH_CLIENT_ID", "ella-mcp")
+
+
+def _oauth_code_ttl_seconds() -> int:
+    try:
+        return max(60, min(600, int(_env("ELLA_MCP_OAUTH_CODE_TTL_SECONDS", "300"))))
+    except ValueError:
+        return 300
+
+
+def _mcp_session_ttl_seconds(value: Any = None) -> int:
+    try:
+        requested = int(value if value is not None else _env("ELLA_MCP_SESSION_TTL_SECONDS", "3600"))
+    except (TypeError, ValueError):
+        requested = 3600
+    return max(60, min(24 * 60 * 60, requested))
+
+
 def _allowed_static_tokens() -> set[str]:
     tokens = _csv_env("ELLA_MCP_TOKENS", _env("ELLA_MCP_TOKEN"))
     # Temporary compatibility while the existing test connector still uses the
@@ -64,6 +93,27 @@ def _authenticate_static(authorization: Optional[str]) -> str:
     if not token or token not in tokens:
         raise HTTPException(status_code=401, detail="Invalid or missing MCP bearer token")
     return _fingerprint(token)
+
+
+def _authenticate_connector_session(
+    authorization: Optional[str],
+    *,
+    selected_profile_uid: str = "",
+) -> dict[str, Any]:
+    token = _token_from_authorization(authorization)
+    if not token:
+        raise HTTPException(status_code=401, detail="Invalid or missing MCP bearer token")
+
+    try:
+        claims = validate_mcp_session_token(token)
+        return session_claims_to_public_resolution(claims)
+    except ValueError as session_error:
+        tokens = _allowed_static_tokens()
+        if token in tokens:
+            return resolve_static_connector_session(_fingerprint(token), selected_profile_uid)
+        if not tokens and "not configured" in str(session_error):
+            raise HTTPException(status_code=503, detail="MCP bearer authentication is not configured") from session_error
+        raise HTTPException(status_code=401, detail="Invalid or expired MCP bearer token") from session_error
 
 
 def _default_profile_uid() -> str:
@@ -143,15 +193,79 @@ def resolve_static_connector_session(token_fingerprint: str, selected_profile_ui
     return resolution.to_public_dict(include_claims=True)
 
 
+def resolve_oauth_connector_resolution(
+    firebase_id_token: str,
+    *,
+    selected_profile_uid: str = "",
+) -> MCPIdentityResolution:
+    identity = _verify_firebase_identity(firebase_id_token)
+    return resolve_mcp_identity(identity, selected_profile_uid=selected_profile_uid)
+
+
 def resolve_oauth_connector_session(
     firebase_id_token: str,
     *,
     selected_profile_uid: str = "",
     ttl_seconds: int = 3600,
 ) -> dict[str, Any]:
-    identity = _verify_firebase_identity(firebase_id_token)
-    resolution = resolve_mcp_identity(identity, selected_profile_uid=selected_profile_uid)
+    resolution = resolve_oauth_connector_resolution(firebase_id_token, selected_profile_uid=selected_profile_uid)
     return resolution.to_public_dict(include_claims=True, ttl_seconds=ttl_seconds)
+
+
+def _issue_oauth_token_response(resolution: MCPIdentityResolution, *, ttl_seconds: int) -> dict[str, Any]:
+    if not resolution.mapped:
+        raise HTTPException(status_code=403, detail=resolution.to_public_dict(include_claims=False))
+    token, claims = issue_mcp_session_token(resolution, ttl_seconds=ttl_seconds)
+    return {
+        "access_token": token,
+        "token_type": "Bearer",
+        "expires_in": max(0, int(claims["exp"]) - int(time.time())),
+        "scope": " ".join(claims.get("scopes") or []),
+        "trace_id": claims["trace_id"],
+        "profile_uid": claims["profile_uid"],
+        "role": claims["role"],
+        "scopes": claims.get("scopes") or [],
+        "allowed_tools": claims.get("allowed_tools") or [],
+        "grant_id": claims["grant_id"],
+        "session_claims": claims,
+    }
+
+
+def _store_authorization_code(resolution: MCPIdentityResolution) -> str:
+    code = uuid.uuid4().hex
+    _auth_codes[code] = {
+        "resolution": resolution,
+        "expires_at": time.time() + _oauth_code_ttl_seconds(),
+    }
+    return code
+
+
+def _consume_authorization_code(code: str) -> MCPIdentityResolution:
+    item = _auth_codes.pop(code, None)
+    if not item:
+        raise HTTPException(status_code=400, detail="Invalid authorization code")
+    if time.time() > float(item.get("expires_at") or 0):
+        raise HTTPException(status_code=400, detail="Expired authorization code")
+    return item["resolution"]
+
+
+async def _parse_token_request(request: Request) -> dict[str, Any]:
+    try:
+        content_type = request.headers.get("content-type", "")
+        if "application/json" in content_type:
+            data = await request.json()
+            return data if isinstance(data, dict) else {}
+        raw_body = (await request.body()).decode("utf-8")
+        parsed = urllib.parse.parse_qs(raw_body, keep_blank_values=True)
+        return {key: values[-1] if values else "" for key, values in parsed.items()}
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid token request body") from exc
+
+
+def _redirect_with_params(redirect_uri: str, params: dict[str, Any]) -> Response:
+    query = urllib.parse.urlencode({key: value for key, value in params.items() if value not in {None, ""}})
+    separator = "&" if "?" in redirect_uri else "?"
+    return Response(status_code=302, headers={"Location": f"{redirect_uri}{separator}{query}"})
 
 
 @router.get("/onboarding")
@@ -159,8 +273,7 @@ async def get_mcp_onboarding(
     authorization: Optional[str] = Header(None, alias="Authorization"),
     selected_profile_uid: str = Query("", description="Optional profile UID selected after multi-profile mapping."),
 ):
-    token_fingerprint = _authenticate_static(authorization)
-    return resolve_static_connector_session(token_fingerprint, selected_profile_uid)
+    return _authenticate_connector_session(authorization, selected_profile_uid=selected_profile_uid)
 
 
 @router.post("/onboarding/oauth")
@@ -172,6 +285,79 @@ async def post_mcp_oauth_onboarding(request: MCPOAuthOnboardingRequest):
     )
 
 
+@router.get("/authorize")
+async def get_mcp_authorize(
+    response_type: str,
+    client_id: str,
+    redirect_uri: str,
+    state: Optional[str] = None,
+    scope: Optional[str] = None,
+    firebase_id_token: str = Query("", description="Verified Firebase ID token supplied by the auth handoff page."),
+    selected_profile_uid: str = Query("", description="Selected Ella profile UID for multi-profile identities."),
+):
+    if response_type != "code":
+        raise HTTPException(status_code=400, detail="response_type must be code")
+    if client_id != _oauth_client_id():
+        raise HTTPException(status_code=400, detail="Invalid client_id")
+    if not firebase_id_token:
+        return _redirect_with_params(
+            redirect_uri,
+            {
+                "error": "login_required",
+                "error_description": "A Firebase/Google auth handoff must authenticate the user before code issue.",
+                "state": state,
+            },
+        )
+
+    resolution = resolve_oauth_connector_resolution(
+        firebase_id_token,
+        selected_profile_uid=selected_profile_uid,
+    )
+    if not resolution.mapped:
+        payload = resolution.to_public_dict(include_claims=False)
+        return _redirect_with_params(
+            redirect_uri,
+            {
+                "error": payload["state"],
+                "error_description": payload["message"],
+                "trace_id": payload["trace_id"],
+                "state": state,
+            },
+        )
+    code = _store_authorization_code(resolution)
+    return _redirect_with_params(redirect_uri, {"code": code, "state": state})
+
+
+@router.post("/token")
+async def post_mcp_token(request: Request):
+    data = await _parse_token_request(request)
+    client_id = str(data.get("client_id") or "")
+    if client_id and client_id != _oauth_client_id():
+        raise HTTPException(status_code=400, detail="Invalid client_id")
+
+    ttl_seconds = _mcp_session_ttl_seconds(data.get("ttl_seconds") or data.get("expires_in"))
+    grant_type = str(data.get("grant_type") or "").strip()
+    if grant_type in {"authorization_code", ""} and data.get("code"):
+        resolution = _consume_authorization_code(str(data.get("code") or ""))
+        return _issue_oauth_token_response(resolution, ttl_seconds=ttl_seconds)
+
+    if grant_type in {
+        "urn:ietf:params:oauth:grant-type:token-exchange",
+        "firebase_id_token",
+        "",
+    }:
+        firebase_id_token = str(data.get("firebase_id_token") or data.get("subject_token") or "").strip()
+        if not firebase_id_token:
+            raise HTTPException(status_code=400, detail="firebase_id_token or subject_token is required")
+        resolution = resolve_oauth_connector_resolution(
+            firebase_id_token,
+            selected_profile_uid=str(data.get("selected_profile_uid") or ""),
+        )
+        return _issue_oauth_token_response(resolution, ttl_seconds=ttl_seconds)
+
+    raise HTTPException(status_code=400, detail="Unsupported grant_type")
+
+
 @router.get("/start_here")
 async def get_mcp_start_here(
     authorization: Optional[str] = Header(None, alias="Authorization"),
@@ -179,8 +365,7 @@ async def get_mcp_start_here(
     limit: int = Query(12, ge=1, le=50),
     channels: str = Query("", description="Optional comma-separated canonical channels."),
 ):
-    token_fingerprint = _authenticate_static(authorization)
-    onboarding = resolve_static_connector_session(token_fingerprint, selected_profile_uid)
+    onboarding = _authenticate_connector_session(authorization, selected_profile_uid=selected_profile_uid)
     channel_list = [item.strip() for item in channels.split(",") if item.strip()] if channels else None
     return await build_startup_context(onboarding=onboarding, limit=limit, channels=channel_list)
 
@@ -191,8 +376,7 @@ async def get_mcp_surface_prompt(
     selected_profile_uid: str = Query("", description="Optional profile UID selected after multi-profile mapping."),
     surface: str = Query("generic", description="External surface, e.g. grok, hosted-gpt, gemini."),
 ):
-    token_fingerprint = _authenticate_static(authorization)
-    onboarding = resolve_static_connector_session(token_fingerprint, selected_profile_uid)
+    onboarding = _authenticate_connector_session(authorization, selected_profile_uid=selected_profile_uid)
     selected = onboarding.get("selected_profile") or {}
     claims = onboarding.get("session_claims") or {}
     if onboarding.get("state") != "authenticated_mapped" or not selected:
@@ -219,10 +403,14 @@ async def get_mcp_onboarding_info():
     return {
         "onboarding_endpoint": "/v1/ella/mcp/onboarding",
         "oauth_onboarding_endpoint": "/v1/ella/mcp/onboarding/oauth",
+        "authorization_endpoint": "/v1/ella/mcp/authorize",
+        "token_endpoint": "/v1/ella/mcp/token",
         "start_here_endpoint": "/v1/ella/mcp/start_here",
         "surface_prompt_endpoint": "/v1/ella/mcp/surface-prompt",
         "public_surface_prompt_endpoint": "/v1/ella/mcp/surface-prompt/public",
-        "auth": "POST Firebase ID token to OAuth onboarding for production; Bearer token remains dev/static fallback.",
+        "auth": "Exchange a verified Firebase/Google identity for a short-lived MCP bearer token; static Bearer token remains dev/static fallback.",
+        "token_lifetime": "Default 3600s, bounded 60s to 86400s; configure ELLA_MCP_SESSION_TTL_SECONDS.",
+        "revocation": "Disable or mark mcp_identity_grants inactive to prevent future token issue; rotate ELLA_MCP_SESSION_SECRET to revoke issued sessions before expiry.",
         "states": [
             "authenticated_mapped",
             "authenticated_needs_profile_selection",

--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -32,6 +32,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 import database.conversations as conversations_db
 import database.memories as memories_db
 from ella.services import proposal_ingest
+from ella.services.mcp_identity import validate_mcp_session_token
 from ella.services.mcp_startup import build_startup_context
 from ella.services.mcp_surface_prompt import build_surface_prompt
 from utils.ella.time_context import annotate_event_time, build_time_context, local_time_fields, timezone_name
@@ -140,12 +141,24 @@ def _fingerprint(token: str) -> str:
 
 
 def _authenticate(authorization: Optional[str]) -> str:
-    tokens = _allowed_tokens()
-    if not tokens:
-        raise HTTPException(status_code=503, detail="Plato MCP token is not configured")
     token = _token_from_authorization(authorization)
-    if not token or token not in tokens:
+    if not token:
         raise HTTPException(status_code=401, detail="Invalid or missing Plato MCP bearer token")
+
+    tokens = _allowed_tokens()
+    if token in tokens:
+        _check_rate_limit(token)
+        return _fingerprint(token)
+
+    try:
+        claims = validate_mcp_session_token(token)
+    except ValueError as exc:
+        if not tokens and "not configured" in str(exc):
+            raise HTTPException(status_code=503, detail="Plato MCP token is not configured") from exc
+        raise HTTPException(status_code=401, detail="Invalid or missing Plato MCP bearer token") from exc
+
+    if "tools:read" not in set(claims.get("scopes") or []):
+        raise HTTPException(status_code=403, detail="MCP bearer token is missing tools:read scope")
     _check_rate_limit(token)
     return _fingerprint(token)
 
@@ -1343,10 +1356,10 @@ async def plato_mcp_info(request: Request):
             "format": "Bearer <ELLA_PLATO_MCP_TOKEN>",
             "generic_onboarding_endpoint": f"{base_url}/v1/ella/mcp/onboarding",
             "oauth": {
-                "client_id": _oauth_client_id(),
-                "authorization_endpoint": f"{endpoint}/authorize",
-                "token_endpoint": f"{endpoint}/token",
-                "scopes": ["plato:read"],
+                "client_id": _env("ELLA_MCP_OAUTH_CLIENT_ID", "ella-mcp"),
+                "authorization_endpoint": f"{base_url}/v1/ella/mcp/authorize",
+                "token_endpoint": f"{base_url}/v1/ella/mcp/token",
+                "scopes": ["tools:read", "startup:read", "timeline:read", "memory:read"],
             },
         },
         "tools": [tool["name"] for tool in MCP_TOOLS],

--- a/backend/ella/services/mcp_identity.py
+++ b/backend/ella/services/mcp_identity.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Iterable, Optional
 
+import jwt
+
 logger = logging.getLogger("ella.mcp_identity")
 
 STATE_AUTHENTICATED_MAPPED = "authenticated_mapped"
@@ -50,6 +52,9 @@ DEFAULT_ROLE_SCOPES = {
     ROLE_CAREGIVER: ["care_context:read", "context:read", "profile:read", "startup:read", "timeline:read"],
     ROLE_ADMIN: ["admin:read", "profile:read", "startup:read", "tools:read"],
 }
+
+MCP_SESSION_ISSUER = "ella-mcp"
+MCP_SESSION_AUDIENCE = "ella-mcp-tools"
 
 
 def _clean_string(value: Any) -> str:
@@ -399,16 +404,96 @@ def build_session_claims(resolution: MCPIdentityResolution, *, ttl_seconds: int 
     grant = resolution.selected_grant
     now = int(time.time())
     return {
-        "iss": "ella-mcp",
+        "iss": MCP_SESSION_ISSUER,
         "sub": resolution.identity.provider_subject,
-        "aud": "ella-mcp-tools",
+        "aud": MCP_SESSION_AUDIENCE,
         "iat": now,
         "exp": now + max(60, ttl_seconds),
+        "jti": str(uuid.uuid4()),
         "trace_id": resolution.trace_id,
         "profile_uid": grant.profile_uid,
+        "profile_label": grant.profile_label,
         "role": grant.role,
         "scopes": list(grant.scopes),
         "allowed_tools": list(grant.allowed_tools),
         "grant_id": grant.grant_id,
         "external_provider": resolution.identity.provider,
+    }
+
+
+def mcp_session_secret() -> str:
+    """Return the signing key for short-lived external MCP bearer sessions."""
+    return os.getenv("ELLA_MCP_SESSION_SECRET") or os.getenv("ELLA_SESSION_SECRET", "")
+
+
+def issue_mcp_session_token(resolution: MCPIdentityResolution, *, ttl_seconds: int = 3600) -> tuple[str, dict[str, Any]]:
+    secret = mcp_session_secret()
+    if not secret:
+        raise RuntimeError("ELLA_MCP_SESSION_SECRET or ELLA_SESSION_SECRET must be configured")
+    claims = build_session_claims(resolution, ttl_seconds=ttl_seconds)
+    return jwt.encode(claims, secret, algorithm="HS256"), claims
+
+
+def validate_mcp_session_token(token: str) -> dict[str, Any]:
+    secret = mcp_session_secret()
+    if not secret:
+        raise ValueError("MCP session token verification is not configured")
+    try:
+        claims = jwt.decode(
+            token,
+            secret,
+            algorithms=["HS256"],
+            audience=MCP_SESSION_AUDIENCE,
+            issuer=MCP_SESSION_ISSUER,
+        )
+    except jwt.ExpiredSignatureError as exc:
+        raise ValueError("MCP session token expired") from exc
+    except jwt.InvalidTokenError as exc:
+        raise ValueError("Invalid MCP session token") from exc
+
+    if not claims.get("profile_uid") or not claims.get("role") or not isinstance(claims.get("allowed_tools"), list):
+        raise ValueError("MCP session token missing required claims")
+    return claims
+
+
+def session_claims_to_public_resolution(claims: dict[str, Any]) -> dict[str, Any]:
+    profile_uid = _clean_string(claims.get("profile_uid"))
+    role = _normalized_role(claims.get("role"))
+    scopes = [scope for scope in claims.get("scopes") or [] if _clean_string(scope)]
+    allowed_tools = [tool for tool in claims.get("allowed_tools") or [] if _clean_string(tool)]
+    grant_id = _clean_string(claims.get("grant_id"))
+    external_provider = _clean_string(claims.get("external_provider"))
+    subject = _clean_string(claims.get("sub"))
+    selected_profile = {
+        "grant_id": grant_id,
+        "profile_uid": profile_uid,
+        "role": role,
+        "profile_label": _clean_string(claims.get("profile_label")),
+        "scopes": scopes,
+        "allowed_tools": allowed_tools,
+    }
+    return {
+        "state": STATE_AUTHENTICATED_MAPPED,
+        "trace_id": _clean_string(claims.get("trace_id")),
+        "identity": {
+            "provider": external_provider,
+            "subject": subject.split(":", 1)[1] if ":" in subject else subject,
+            "email": "",
+            "email_verified": False,
+            "authenticated": True,
+            "display_name": "",
+        },
+        "selected_profile": selected_profile,
+        "available_profiles": [selected_profile],
+        "session_claims": {
+            "profile_uid": profile_uid,
+            "role": role,
+            "scopes": scopes,
+            "allowed_tools": allowed_tools,
+            "grant_id": grant_id,
+            "external_provider": external_provider,
+            "trace_id": _clean_string(claims.get("trace_id")),
+            "exp": claims.get("exp"),
+        },
+        "message": "Identity is mapped through a short-lived MCP session token.",
     }

--- a/backend/tests/unit/test_ella_mcp_onboarding.py
+++ b/backend/tests/unit/test_ella_mcp_onboarding.py
@@ -1,15 +1,19 @@
 import importlib
 import sys
+import time
 import types
 
+import jwt
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from ella.services.mcp_identity import MCPProfileGrant
+from ella.services.mcp_identity import MCPProfileGrant, MCP_SESSION_AUDIENCE, MCP_SESSION_ISSUER
 
 
 def _load_module(monkeypatch):
     monkeypatch.setenv("ELLA_MCP_TOKEN", "test-token")
+    monkeypatch.setenv("ELLA_MCP_SESSION_SECRET", "test-session-secret-with-32-bytes-minimum")
+    monkeypatch.setenv("ELLA_MCP_OAUTH_CLIENT_ID", "ella-mcp-test")
     monkeypatch.setenv("ELLA_MCP_DEFAULT_PROFILE_UID", "user-1")
     monkeypatch.setenv("ELLA_MCP_DEFAULT_PROFILE_LABEL", "Test User")
     monkeypatch.setenv("ELLA_MCP_ALLOWED_TOOLS", "companion_start_here,companion_recent_context")
@@ -188,6 +192,186 @@ def test_oauth_onboarding_rejects_invalid_firebase_token(monkeypatch):
     client = _client(module)
 
     response = client.post("/v1/ella/mcp/onboarding/oauth", json={"firebase_id_token": "firebase-token"})
+
+    assert response.status_code == 401
+
+
+def test_oauth_token_exchange_unknown_identity_needs_invite(monkeypatch):
+    module = _load_module(monkeypatch)
+    _install_firebase_stub(monkeypatch)
+    service = importlib.import_module("ella.services.mcp_identity")
+    monkeypatch.setattr(service, "load_identity_grants", lambda _identity: [])
+    client = _client(module)
+
+    response = client.post(
+        "/v1/ella/mcp/token",
+        json={
+            "client_id": "ella-mcp-test",
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": "firebase-token",
+        },
+    )
+
+    assert response.status_code == 403
+    detail = response.json()["detail"]
+    assert detail["state"] == "authenticated_needs_invite"
+    assert "access_token" not in response.text
+
+
+def test_oauth_token_exchange_requires_profile_selection(monkeypatch):
+    module = _load_module(monkeypatch)
+    _install_firebase_stub(monkeypatch)
+    service = importlib.import_module("ella.services.mcp_identity")
+    monkeypatch.setattr(
+        service, "load_identity_grants", lambda _identity: [_grant("user-1"), _grant("mom-1", "caregiver")]
+    )
+    client = _client(module)
+
+    response = client.post(
+        "/v1/ella/mcp/token",
+        json={
+            "client_id": "ella-mcp-test",
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": "firebase-token",
+        },
+    )
+
+    assert response.status_code == 403
+    detail = response.json()["detail"]
+    assert detail["state"] == "authenticated_needs_profile_selection"
+    assert [item["profile_uid"] for item in detail["available_profiles"]] == ["user-1", "mom-1"]
+
+
+def test_oauth_token_exchange_selected_profile_issues_scoped_session(monkeypatch):
+    module = _load_module(monkeypatch)
+    _install_firebase_stub(monkeypatch)
+    service = importlib.import_module("ella.services.mcp_identity")
+    monkeypatch.setattr(
+        service, "load_identity_grants", lambda _identity: [_grant("user-1"), _grant("mom-1", "caregiver")]
+    )
+    client = _client(module)
+
+    response = client.post(
+        "/v1/ella/mcp/token",
+        json={
+            "client_id": "ella-mcp-test",
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": "firebase-token",
+            "selected_profile_uid": "mom-1",
+            "ttl_seconds": 600,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["token_type"] == "Bearer"
+    assert payload["profile_uid"] == "mom-1"
+    assert payload["role"] == "caregiver"
+    assert payload["allowed_tools"] == ["companion_recent_context", "companion_start_here"]
+    assert "proposals:write" not in payload["scopes"]
+    claims = jwt.decode(
+        payload["access_token"],
+        "test-session-secret-with-32-bytes-minimum",
+        algorithms=["HS256"],
+        audience=MCP_SESSION_AUDIENCE,
+        issuer=MCP_SESSION_ISSUER,
+    )
+    assert claims["profile_uid"] == "mom-1"
+    assert claims["profile_label"] == "mom-1"
+    assert claims["role"] == "caregiver"
+    assert claims["grant_id"] == "grant-mom-1"
+
+    session_response = client.get("/v1/ella/mcp/onboarding", headers={"Authorization": f"Bearer {payload['access_token']}"})
+    assert session_response.status_code == 200
+    assert session_response.json()["session_claims"]["profile_uid"] == "mom-1"
+
+
+def test_authorize_code_flow_selected_profile_success(monkeypatch):
+    module = _load_module(monkeypatch)
+    _install_firebase_stub(monkeypatch)
+    service = importlib.import_module("ella.services.mcp_identity")
+    monkeypatch.setattr(
+        service, "load_identity_grants", lambda _identity: [_grant("user-1"), _grant("mom-1", "caregiver")]
+    )
+    client = _client(module)
+
+    authorize = client.get(
+        "/v1/ella/mcp/authorize",
+        params={
+            "response_type": "code",
+            "client_id": "ella-mcp-test",
+            "redirect_uri": "https://connector.example/callback",
+            "state": "state-1",
+            "firebase_id_token": "firebase-token",
+            "selected_profile_uid": "mom-1",
+        },
+        follow_redirects=False,
+    )
+
+    assert authorize.status_code == 302
+    location = authorize.headers["location"]
+    assert "state=state-1" in location
+    code = location.split("code=", 1)[1].split("&", 1)[0]
+
+    token = client.post(
+        "/v1/ella/mcp/token",
+        data={"client_id": "ella-mcp-test", "grant_type": "authorization_code", "code": code},
+    )
+
+    assert token.status_code == 200
+    assert token.json()["profile_uid"] == "mom-1"
+
+
+def test_oauth_token_exchange_rejects_invalid_firebase_token(monkeypatch):
+    module = _load_module(monkeypatch)
+    _install_firebase_stub(monkeypatch, error=ValueError("bad token"))
+    client = _client(module)
+
+    response = client.post(
+        "/v1/ella/mcp/token",
+        json={
+            "client_id": "ella-mcp-test",
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": "firebase-token",
+        },
+    )
+
+    assert response.status_code == 401
+
+
+def test_expired_mcp_session_token_is_rejected(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+    now = int(time.time())
+    token = jwt.encode(
+        {
+            "iss": MCP_SESSION_ISSUER,
+            "aud": MCP_SESSION_AUDIENCE,
+            "sub": "google:google-sub-1",
+            "iat": now - 120,
+            "exp": now - 60,
+            "trace_id": "trace-expired",
+            "profile_uid": "user-1",
+            "role": "self",
+            "scopes": ["tools:read", "startup:read"],
+            "allowed_tools": ["companion_start_here"],
+            "grant_id": "grant-user-1",
+            "external_provider": "google",
+        },
+        "test-session-secret-with-32-bytes-minimum",
+        algorithm="HS256",
+    )
+
+    response = client.get("/v1/ella/mcp/onboarding", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 401
+
+
+def test_invalid_mcp_session_token_is_rejected(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    response = client.get("/v1/ella/mcp/onboarding", headers={"Authorization": "Bearer not-a-valid-session"})
 
     assert response.status_code == 401
 


### PR DESCRIPTION
## Summary
- add generic connector-facing `/v1/ella/mcp/authorize` and `/v1/ella/mcp/token` endpoints
- exchange verified Firebase/Google identity grants into short-lived signed MCP bearer/session tokens
- include profile_uid, role, scopes, allowed_tools, grant_id, expiry, trace_id, and external provider in token claims
- allow generic MCP onboarding/start_here/surface_prompt and Plato MCP transport to accept short-lived MCP bearer tokens while preserving static bearer fallback
- document lifetime/revocation notes in `/v1/ella/mcp/info`

## Safety
- no scanner, caregiver, Guardian, memory, or live write behavior changes
- no proposal/write scope expansion; existing read-only/proposal gates remain in place
- static `ELLA_MCP_TOKEN` / `ELLA_PLATO_MCP_TOKEN` fallback still works

## Validation
- `python3 -m pytest backend/tests/unit/test_ella_mcp_identity.py backend/tests/unit/test_ella_mcp_onboarding.py backend/tests/unit/test_ella_plato_mcp.py backend/tests/unit/test_ella_mcp_proposals.py -q` -> 54 passed
- `python3 -m compileall -q backend/ella/services/mcp_identity.py backend/ella/routers/mcp_onboarding.py backend/ella/routers/plato_mcp.py`

## Deploy notes
- configure `ELLA_MCP_SESSION_SECRET` in prod; fallback is `ELLA_SESSION_SECRET` if present
- default session lifetime is 3600s, bounded 60s-86400s; set `ELLA_MCP_SESSION_TTL_SECONDS` if needed
- revocation before token expiry requires rotating `ELLA_MCP_SESSION_SECRET`; disabling `mcp_identity_grants` prevents future token issue
- hosted Google/Firebase auth handoff page is still needed for one-click Grok onboarding; this PR supplies the backend authorize/token/session layer it will call

Refs ellaaicare/ella-ai#857
