### PR TITLE
Add hosted MCP OAuth handoff page

### DIFF
--- a/backend/ella/routers/mcp_onboarding.py
+++ b/backend/ella/routers/mcp_onboarding.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import hashlib
+import html
+import json
 import os
 import time
 import urllib.parse
@@ -75,6 +77,19 @@ def _mcp_session_ttl_seconds(value: Any = None) -> int:
     except (TypeError, ValueError):
         requested = 3600
     return max(60, min(24 * 60 * 60, requested))
+
+
+def _firebase_web_config() -> dict[str, str]:
+    return {
+        "apiKey": _env("FIREBASE_API_KEY"),
+        "authDomain": _env("FIREBASE_AUTH_DOMAIN"),
+        "projectId": _env("FIREBASE_PROJECT_ID"),
+    }
+
+
+def _firebase_web_configured() -> bool:
+    config = _firebase_web_config()
+    return bool(config["apiKey"] and config["authDomain"] and config["projectId"])
 
 
 def _allowed_static_tokens() -> set[str]:
@@ -268,6 +283,149 @@ def _redirect_with_params(redirect_uri: str, params: dict[str, Any]) -> Response
     return Response(status_code=302, headers={"Location": f"{redirect_uri}{separator}{query}"})
 
 
+def _render_mcp_oauth_page(
+    *,
+    response_type: str,
+    client_id: str,
+    redirect_uri: str,
+    state: str = "",
+    scope: str = "",
+) -> Response:
+    if not _firebase_web_configured():
+        return Response(
+            content=(
+                "<!doctype html><html><head><title>Ella MCP OAuth</title></head>"
+                "<body><h1>OAuth setup incomplete</h1>"
+                "<p>Firebase web auth is not configured for this backend.</p></body></html>"
+            ),
+            status_code=503,
+            media_type="text/html",
+        )
+
+    page_data = {
+        "responseType": response_type,
+        "clientId": client_id,
+        "redirectUri": redirect_uri,
+        "state": state,
+        "scope": scope,
+        "authorizeUrl": "/v1/ella/mcp/authorize",
+        "onboardingUrl": "/v1/ella/mcp/onboarding/oauth",
+        "firebaseConfig": _firebase_web_config(),
+    }
+    page_json = json.dumps(page_data, separators=(",", ":"))
+    escaped_client = html.escape(client_id)
+    html_body = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Connect Ella MCP</title>
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
+  <style>
+    :root {{ color-scheme: light; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }}
+    body {{ margin: 0; min-height: 100vh; display: grid; place-items: center; background: #f6f7f9; color: #111827; }}
+    main {{ width: min(440px, calc(100vw - 32px)); background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; padding: 28px; box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08); }}
+    h1 {{ margin: 0 0 8px; font-size: 24px; line-height: 1.2; letter-spacing: 0; }}
+    p {{ margin: 0 0 18px; color: #4b5563; line-height: 1.45; }}
+    button {{ width: 100%; min-height: 44px; border: 0; border-radius: 6px; background: #111827; color: #fff; font-size: 15px; font-weight: 600; cursor: pointer; }}
+    button:disabled {{ opacity: .55; cursor: wait; }}
+    .profiles {{ display: grid; gap: 8px; margin-top: 12px; }}
+    .profile {{ background: #f9fafb; color: #111827; border: 1px solid #d1d5db; }}
+    .status {{ min-height: 20px; margin-top: 14px; color: #374151; font-size: 14px; }}
+    .error {{ color: #b91c1c; }}
+    .meta {{ margin-top: 18px; font-size: 12px; color: #6b7280; }}
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Connect Ella</h1>
+    <p>Sign in with Google to connect this MCP client to an authorized Ella profile.</p>
+    <button id="sign-in">Continue with Google</button>
+    <div id="profiles" class="profiles"></div>
+    <div id="status" class="status"></div>
+    <div class="meta">Client: {escaped_client}</div>
+  </main>
+  <script>
+    const page = {page_json};
+    const statusEl = document.getElementById("status");
+    const signInButton = document.getElementById("sign-in");
+    const profilesEl = document.getElementById("profiles");
+
+    firebase.initializeApp(page.firebaseConfig);
+
+    function setStatus(message, isError) {{
+      statusEl.textContent = message || "";
+      statusEl.className = isError ? "status error" : "status";
+    }}
+
+    function authorizeRedirect(idToken, selectedProfileUid) {{
+      const params = new URLSearchParams({{
+        response_type: page.responseType,
+        client_id: page.clientId,
+        redirect_uri: page.redirectUri,
+        firebase_id_token: idToken
+      }});
+      if (page.state) params.set("state", page.state);
+      if (page.scope) params.set("scope", page.scope);
+      if (selectedProfileUid) params.set("selected_profile_uid", selectedProfileUid);
+      window.location.href = page.authorizeUrl + "?" + params.toString();
+    }}
+
+    function renderProfiles(idToken, profiles) {{
+      signInButton.style.display = "none";
+      profilesEl.innerHTML = "";
+      setStatus("Choose which Ella profile to connect.", false);
+      profiles.forEach((profile) => {{
+        const button = document.createElement("button");
+        button.className = "profile";
+        button.textContent = (profile.profile_label || profile.profile_uid) + " (" + profile.role + ")";
+        button.onclick = () => authorizeRedirect(idToken, profile.profile_uid);
+        profilesEl.appendChild(button);
+      }});
+    }}
+
+    async function handleToken(idToken) {{
+      setStatus("Checking Ella profile access...", false);
+      const response = await fetch(page.onboardingUrl, {{
+        method: "POST",
+        headers: {{ "Content-Type": "application/json" }},
+        body: JSON.stringify({{ firebase_id_token: idToken }})
+      }});
+      const payload = await response.json();
+      if (!response.ok) throw new Error(payload.detail || "Authorization failed");
+      if (payload.state === "authenticated_mapped") {{
+        authorizeRedirect(idToken, payload.selected_profile && payload.selected_profile.profile_uid);
+        return;
+      }}
+      if (payload.state === "authenticated_needs_profile_selection" && payload.available_profiles && payload.available_profiles.length) {{
+        renderProfiles(idToken, payload.available_profiles);
+        return;
+      }}
+      throw new Error(payload.message || "This Google account is not authorized for an Ella profile yet.");
+    }}
+
+    signInButton.onclick = async () => {{
+      signInButton.disabled = true;
+      setStatus("Opening Google sign-in...", false);
+      try {{
+        const provider = new firebase.auth.GoogleAuthProvider();
+        provider.setCustomParameters({{ prompt: "select_account" }});
+        const result = await firebase.auth().signInWithPopup(provider);
+        const idToken = await result.user.getIdToken();
+        await handleToken(idToken);
+      }} catch (error) {{
+        console.error(error);
+        signInButton.disabled = false;
+        setStatus(error.message || "Sign-in failed.", true);
+      }}
+    }};
+  </script>
+</body>
+</html>"""
+    return Response(content=html_body, media_type="text/html")
+
+
 @router.get("/onboarding")
 async def get_mcp_onboarding(
     authorization: Optional[str] = Header(None, alias="Authorization"),
@@ -300,13 +458,12 @@ async def get_mcp_authorize(
     if client_id != _oauth_client_id():
         raise HTTPException(status_code=400, detail="Invalid client_id")
     if not firebase_id_token:
-        return _redirect_with_params(
-            redirect_uri,
-            {
-                "error": "login_required",
-                "error_description": "A Firebase/Google auth handoff must authenticate the user before code issue.",
-                "state": state,
-            },
+        return _render_mcp_oauth_page(
+            response_type=response_type,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            state=state or "",
+            scope=scope or "",
         )
 
     resolution = resolve_oauth_connector_resolution(

--- a/backend/tests/unit/test_ella_mcp_onboarding.py
+++ b/backend/tests/unit/test_ella_mcp_onboarding.py
@@ -14,6 +14,9 @@ def _load_module(monkeypatch):
     monkeypatch.setenv("ELLA_MCP_TOKEN", "test-token")
     monkeypatch.setenv("ELLA_MCP_SESSION_SECRET", "test-session-secret-with-32-bytes-minimum")
     monkeypatch.setenv("ELLA_MCP_OAUTH_CLIENT_ID", "ella-mcp-test")
+    monkeypatch.setenv("FIREBASE_API_KEY", "firebase-api-key")
+    monkeypatch.setenv("FIREBASE_AUTH_DOMAIN", "example.firebaseapp.com")
+    monkeypatch.setenv("FIREBASE_PROJECT_ID", "example-project")
     monkeypatch.setenv("ELLA_MCP_DEFAULT_PROFILE_UID", "user-1")
     monkeypatch.setenv("ELLA_MCP_DEFAULT_PROFILE_LABEL", "Test User")
     monkeypatch.setenv("ELLA_MCP_ALLOWED_TOOLS", "companion_start_here,companion_recent_context")
@@ -320,6 +323,45 @@ def test_authorize_code_flow_selected_profile_success(monkeypatch):
 
     assert token.status_code == 200
     assert token.json()["profile_uid"] == "mom-1"
+
+
+def test_authorize_without_firebase_token_renders_google_handoff_page(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    response = client.get(
+        "/v1/ella/mcp/authorize",
+        params={
+            "response_type": "code",
+            "client_id": "ella-mcp-test",
+            "redirect_uri": "https://connector.example/callback",
+            "state": "state-1",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "Continue with Google" in response.text
+    assert "firebase-api-key" in response.text
+    assert "/v1/ella/mcp/onboarding/oauth" in response.text
+
+
+def test_authorize_page_fails_closed_when_firebase_web_config_missing(monkeypatch):
+    module = _load_module(monkeypatch)
+    monkeypatch.delenv("FIREBASE_API_KEY", raising=False)
+    client = _client(module)
+
+    response = client.get(
+        "/v1/ella/mcp/authorize",
+        params={
+            "response_type": "code",
+            "client_id": "ella-mcp-test",
+            "redirect_uri": "https://connector.example/callback",
+        },
+    )
+
+    assert response.status_code == 503
+    assert "OAuth setup incomplete" in response.text
 
 
 def test_oauth_token_exchange_rejects_invalid_firebase_token(monkeypatch):


### PR DESCRIPTION
## Summary
- render a hosted Google/Firebase sign-in page from `/v1/ella/mcp/authorize` when no Firebase token is present
- page obtains Firebase ID token in browser, checks MCP grant state, supports multi-profile selection, and redirects back through `/authorize` to issue an auth code
- fail closed with a setup page when Firebase web config is missing

## Safety
- no scanner, caregiver, Guardian, memory, or proposal/write behavior changes
- keeps token exchange and static bearer fallback from #197 intact
- no secrets are rendered; Firebase web config only uses public web auth fields

## Validation
- `python3 -m pytest backend/tests/unit/test_ella_mcp_onboarding.py backend/tests/unit/test_ella_mcp_identity.py backend/tests/unit/test_ella_plato_mcp.py backend/tests/unit/test_ella_mcp_proposals.py -q` -> 56 passed
- `python3 -m compileall -q backend/ella/routers/mcp_onboarding.py backend/ella/services/mcp_identity.py backend/ella/routers/plato_mcp.py`

## Deploy notes
- requires `FIREBASE_API_KEY`, `FIREBASE_AUTH_DOMAIN`, and `FIREBASE_PROJECT_ID` on the backend
- requires Firebase Auth authorized domain to include `api.ella-ai-care.com` if served there
- Grok config can keep using authorization endpoint `/v1/ella/mcp/authorize` and token endpoint `/v1/ella/mcp/token`

Refs ellaaicare/ella-ai#857
