### PR TITLE
Suppress Guardian playback echo loops

### DIFF
--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -16,6 +16,7 @@ import base64
 import binascii
 import json
 import os
+import re
 import time
 import uuid
 from email.mime.text import MIMEText
@@ -103,6 +104,20 @@ _ECHO_RISK = {
     "CarAudio": "high",
     "USBAudio": "low",
 }
+_ECHO_RISKY_OUTPUTS = {"medium", "high", "very_high"}
+_GUARDIAN_ECHO_SUPPRESSION_SECONDS = int(os.getenv("ELLA_GUARDIAN_ECHO_SUPPRESSION_SECONDS", "45"))
+_GUARDIAN_ECHO_MARKERS = (
+    "hi greg",
+    "heard my name",
+    "i heard my name",
+    "i'm here with you",
+    "im here with you",
+    "here with you",
+    "tell me what you need",
+    "just talking about names",
+    "just talking about me",
+    "i heard you. i am checking that now",
+)
 
 
 async def _get_pool() -> asyncpg.Pool:
@@ -512,13 +527,69 @@ def _queue_trace_id(row: dict[str, Any]) -> str:
     return _trace_id_from_metadata(_coerce_metadata_dict(row.get("metadata")), str(row.get("id") or ""))
 
 
+def _normalize_for_echo_match(text: str) -> str:
+    normalized = text.lower().replace("’", "'")
+    normalized = re.sub(r"[^a-z0-9' ]+", " ", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return normalized
+
+
+def _looks_like_guardian_echo_text(text: str) -> bool:
+    normalized = _normalize_for_echo_match(text)
+    if not normalized:
+        return False
+
+    marker_hits = sum(1 for marker in _GUARDIAN_ECHO_MARKERS if marker in normalized)
+    if marker_hits >= 2:
+        return True
+    if "hi greg" in normalized and "heard my name" in normalized:
+        return True
+    if "tell me what you need" in normalized and ("just talking about" in normalized or "here with you" in normalized):
+        return True
+    return False
+
+
+def _recent_risky_playback_event(uid: str) -> dict | None:
+    event = get_playback_event(uid)
+    if not event:
+        return None
+    if event.get("echo_risk") not in _ECHO_RISKY_OUTPUTS:
+        return None
+    recorded_at = event.get("recorded_at")
+    if isinstance(recorded_at, (int, float)) and time.time() - recorded_at > _GUARDIAN_ECHO_SUPPRESSION_SECONDS:
+        return None
+    return event
+
+
+def _enqueue_rejects_guardian_echo(uid: str, req: "EnqueueRequest") -> tuple[bool, Optional[str]]:
+    """Reject scanner wake fallback audio that is the app hearing its own Guardian response."""
+    metadata = _coerce_metadata_dict(req.metadata)
+    trigger = str(
+        req.trigger or metadata.get("trigger_type") or metadata.get("event_type") or metadata.get("category") or ""
+    ).lower()
+    if "wake_word" not in trigger:
+        return False, None
+
+    message = str(req.message or metadata.get("message") or "")
+    if not _looks_like_guardian_echo_text(message):
+        return False, None
+
+    if trigger.endswith("_fallback") or trigger == "wake_word_fallback":
+        return True, "guardian_playback_echo"
+    if _recent_risky_playback_event(uid):
+        return True, "guardian_playback_echo"
+    return False, None
+
+
 def _is_wake_word_row(row: dict[str, Any]) -> bool:
     metadata = _coerce_metadata_dict(row.get("metadata"))
     trigger = str(row.get("trigger_type") or metadata.get("trigger_type") or metadata.get("category") or "").lower()
-    return trigger == "wake_word"
+    return trigger == "wake_word" or trigger.startswith("wake_word_")
 
 
-def _select_same_trace_supersede_rows(pending_rows: list[dict[str, Any]]) -> tuple[Optional[dict[str, Any]], list[dict[str, Any]]]:
+def _select_same_trace_supersede_rows(
+    pending_rows: list[dict[str, Any]],
+) -> tuple[Optional[dict[str, Any]], list[dict[str, Any]]]:
     """Pick one primary same-trace row to keep and return superseded siblings."""
     groups: dict[str, list[dict[str, Any]]] = {}
     for row in pending_rows:
@@ -560,11 +631,7 @@ def _enqueue_allows_guardian_audio(mode: str, req: "EnqueueRequest") -> tuple[bo
 
     metadata = _coerce_metadata_dict(req.metadata)
     trigger = str(
-        req.trigger
-        or metadata.get("trigger_type")
-        or metadata.get("event_type")
-        or metadata.get("category")
-        or ""
+        req.trigger or metadata.get("trigger_type") or metadata.get("event_type") or metadata.get("category") or ""
     ).lower()
     severity = str(metadata.get("severity") or metadata.get("urgency") or req.priority or "").lower()
     message = str(req.message or metadata.get("message") or "").lower()
@@ -1063,6 +1130,34 @@ async def enqueue(
 
     # --- guardian_mode gate: reject inserts when guardian is OFF / suppressed ---
     if req.priority != "debug":
+        echo_rejected, echo_reason = _enqueue_rejects_guardian_echo(uid, req)
+        if echo_rejected:
+            _elapsed = int((time.time() - _start) * 1000)
+            print(
+                f"[FLOW:GUARDIAN-ENQUEUE] uid={uid} REJECTED reason={echo_reason} "
+                f"trigger={req.trigger} trace={trace_id} latency={_elapsed}ms",
+                flush=True,
+            )
+            await _log_pipeline_event(
+                trace_id=trace_id,
+                uid=uid,
+                stage="queue_rejected",
+                status="rejected",
+                latency_ms=_elapsed,
+                metadata={
+                    "queue_item_id": item_id,
+                    "priority": req.priority,
+                    "trigger_type": req.trigger,
+                    "reason": echo_reason,
+                    "guardian_mode": normalized_mode,
+                },
+            )
+            return {
+                "ok": False,
+                "rejected": True,
+                "reason": echo_reason,
+            }
+
         allowed, reject_reason = _enqueue_allows_guardian_audio(guardian_mode, req)
         if not allowed:
             _elapsed = int((time.time() - _start) * 1000)

--- a/backend/tests/unit/test_ella_guardian_delivery.py
+++ b/backend/tests/unit/test_ella_guardian_delivery.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import pytest
 from fastapi import HTTPException
 
-
 sys.modules.setdefault("asyncpg", types.SimpleNamespace(Pool=object, create_pool=None))
 sys.modules.setdefault("python_multipart", types.SimpleNamespace(__version__="0.0.20"))
 
@@ -20,6 +19,23 @@ sys.modules.setdefault("ella", types.ModuleType("ella"))
 sys.modules.setdefault("ella.services", types.ModuleType("ella.services"))
 sys.modules["ella.services.escalation_policy"] = policy
 _POLICY_SPEC.loader.exec_module(policy)
+
+ella_app_settings_module = types.ModuleType("ella.services.app_settings")
+ella_app_settings_module.TTS_PROVIDERS = {"kokoro", "elevenlabs", "fish-audio", "fish-audio-s2"}
+ella_app_settings_module.build_effective_voice_settings = lambda _uid, voice: {
+    "effective_voice_settings": {
+        "voice_mode": voice.get("voice_mode", "elevenlabs") if isinstance(voice, dict) else "elevenlabs",
+        "one_shot_tts_provider": {
+            "fish-audio-s2": "fish-audio-s2",
+            "grok-voice": "kokoro",
+        }.get(voice.get("voice_mode") if isinstance(voice, dict) else None, "kokoro"),
+        "one_shot_tts_candidates": {
+            "fish-audio-s2": ["fish-audio-s2", "fish-audio", "kokoro", "elevenlabs"],
+            "grok-voice": ["kokoro", "elevenlabs"],
+        }.get(voice.get("voice_mode") if isinstance(voice, dict) else None, ["kokoro", "elevenlabs"]),
+    }
+}
+sys.modules["ella.services.app_settings"] = ella_app_settings_module
 
 sys.modules.setdefault("ella.routers", types.ModuleType("ella.routers"))
 resolve_module = types.ModuleType("ella.routers.resolve")
@@ -278,6 +294,40 @@ def test_synthesize_audio_falls_back_to_next_candidate(monkeypatch):
     assert attempted == ["fish-audio-s2", "fish-audio"]
     assert response.headers["x-guardian-tts-provider"] == "fish-audio"
     assert response.headers["x-guardian-fallback-used"] == "true"
+
+
+def test_enqueue_rejects_guardian_wake_fallback_echo_message():
+    rejected, reason = guardian._enqueue_rejects_guardian_echo(
+        "uid-1",
+        guardian.EnqueueRequest(
+            uid="uid-1",
+            url="https://example.test/audio.mp3",
+            trigger="wake_word_fallback",
+            message="I heard you. I am checking that now: Hi, Greg. I heard my name. I'm here with you.",
+        ),
+    )
+
+    assert rejected is True
+    assert reason == "guardian_playback_echo"
+
+
+def test_enqueue_does_not_reject_real_wake_word_question():
+    rejected, reason = guardian._enqueue_rejects_guardian_echo(
+        "uid-1",
+        guardian.EnqueueRequest(
+            uid="uid-1",
+            url="https://example.test/audio.mp3",
+            trigger="wake_word_fallback",
+            message="I heard you. I am checking that now: Hey Ella, where did I put my glasses?",
+        ),
+    )
+
+    assert rejected is False
+    assert reason is None
+
+
+def test_wake_word_row_matches_fallback_variants():
+    assert guardian._is_wake_word_row({"trigger_type": "wake_word_fallback", "metadata": {}})
 
 
 def test_trace_log_allows_missing_key_but_rejects_bad_key(monkeypatch):

--- a/backend/tests/unit/test_ella_scanner_echo_suppression.py
+++ b/backend/tests/unit/test_ella_scanner_echo_suppression.py
@@ -1,0 +1,32 @@
+from utils.ella.scanner import should_suppress_guardian_echo
+
+
+def test_suppresses_recent_high_risk_guardian_playback_echo():
+    segments = [
+        {
+            "speaker": "SPEAKER_2",
+            "text": "Hi, Greg. I heard my name. I'm here with you. Tell me what you need.",
+        }
+    ]
+
+    assert should_suppress_guardian_echo(
+        "uid-1",
+        segments,
+        playback_event={"echo_risk": "high", "recorded_at": 1},
+    )
+
+
+def test_does_not_suppress_real_wake_word_question():
+    segments = [{"speaker": "SPEAKER_1", "text": "Hey Ella, where did I put my glasses?"}]
+
+    assert not should_suppress_guardian_echo(
+        "uid-1",
+        segments,
+        playback_event={"echo_risk": "high", "recorded_at": 1},
+    )
+
+
+def test_does_not_suppress_echo_like_text_without_risky_playback_event():
+    segments = [{"speaker": "SPEAKER_1", "text": "Why did it say hi Greg I heard my name?"}]
+
+    assert not should_suppress_guardian_echo("uid-1", segments, playback_event={})

--- a/backend/utils/ella/scanner.py
+++ b/backend/utils/ella/scanner.py
@@ -3,8 +3,9 @@
 # Sends real-time transcript segments to n8n scanner for urgency detection.
 # Fire-and-forget with short timeout - doesn't block transcription flow.
 
-import requests
 import os
+import re
+import requests
 import time
 from typing import List, Optional
 
@@ -14,6 +15,73 @@ GUARDIAN_TRACE_LOG_URL = os.getenv(
     "ELLA_GUARDIAN_TRACE_LOG_URL",
     "http://127.0.0.1:8000/v1/ella/guardian/trace/log",
 )
+GUARDIAN_ECHO_SUPPRESSION_SECONDS = int(os.getenv("ELLA_GUARDIAN_ECHO_SUPPRESSION_SECONDS", "45"))
+_ECHO_RISKY_OUTPUTS = {"medium", "high", "very_high"}
+_GUARDIAN_ECHO_MARKERS = (
+    "hi greg",
+    "heard my name",
+    "i heard my name",
+    "i'm here with you",
+    "im here with you",
+    "here with you",
+    "tell me what you need",
+    "just talking about names",
+    "just talking about me",
+    "i heard you. i am checking that now",
+)
+
+
+def _normalize_for_echo_match(text: str) -> str:
+    normalized = text.lower().replace("’", "'")
+    normalized = re.sub(r"[^a-z0-9' ]+", " ", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return normalized
+
+
+def _looks_like_guardian_echo_text(text: str) -> bool:
+    normalized = _normalize_for_echo_match(text)
+    if not normalized:
+        return False
+
+    marker_hits = sum(1 for marker in _GUARDIAN_ECHO_MARKERS if marker in normalized)
+    if marker_hits >= 2:
+        return True
+    if "hi greg" in normalized and "heard my name" in normalized:
+        return True
+    if "tell me what you need" in normalized and ("just talking about" in normalized or "here with you" in normalized):
+        return True
+    return False
+
+
+def _recent_risky_playback_event(uid: str) -> dict | None:
+    try:
+        from ella.routers.guardian import get_playback_event
+    except Exception:
+        return None
+
+    event = get_playback_event(uid)
+    if not event:
+        return None
+    if event.get("echo_risk") not in _ECHO_RISKY_OUTPUTS:
+        return None
+    recorded_at = event.get("recorded_at")
+    if isinstance(recorded_at, (int, float)) and time.time() - recorded_at > GUARDIAN_ECHO_SUPPRESSION_SECONDS:
+        return None
+    return event
+
+
+def should_suppress_guardian_echo(
+    uid: str, scanner_segments: List[dict], playback_event: Optional[dict] = None
+) -> bool:
+    """Return True when the scanner input is likely Guardian audio re-captured by the mic."""
+    text = " ".join(str(segment.get("text") or "") for segment in scanner_segments).strip()
+    if not _looks_like_guardian_echo_text(text):
+        return False
+
+    event = playback_event if playback_event is not None else _recent_risky_playback_event(uid)
+    if not event:
+        return False
+    return event.get("echo_risk") in _ECHO_RISKY_OUTPUTS
 
 
 def _trace_id_for(conversation_id: str) -> str:
@@ -51,11 +119,7 @@ def _log_trace_event(
 
 
 def send_to_scanner(
-    uid: str,
-    conversation_id: str,
-    segments: List[dict],
-    device_type: str = "omi",
-    timeout: Optional[float] = None
+    uid: str, conversation_id: str, segments: List[dict], device_type: str = "omi", timeout: Optional[float] = None
 ) -> Optional[int]:
     """
     Send transcript segments to Ella scanner agent.
@@ -97,6 +161,26 @@ def send_to_scanner(
     if not scanner_segments:
         return None
 
+    if should_suppress_guardian_echo(uid, scanner_segments):
+        _log_trace_event(
+            trace_id=trace_id,
+            uid=uid,
+            stage="scanner_dispatch_suppressed",
+            status="skipped",
+            metadata={
+                "conversation_id": str(conversation_id),
+                "device_type": device_type,
+                "segment_count": len(scanner_segments),
+                "reason": "guardian_playback_echo",
+            },
+        )
+        preview = " ".join(segment["text"] for segment in scanner_segments)[:120]
+        print(
+            f"📡 Scanner suppressed guardian playback echo trace={trace_id} preview={preview!r}",
+            flush=True,
+        )
+        return None
+
     payload = {
         "uid": uid,
         "conversation_id": str(conversation_id),
@@ -113,11 +197,7 @@ def send_to_scanner(
 
     try:
         start = time.time()
-        resp = requests.post(
-            ELLA_CONFIG.scanner_url,
-            json=payload,
-            timeout=timeout
-        )
+        resp = requests.post(ELLA_CONFIG.scanner_url, json=payload, timeout=timeout)
         latency_ms = int((time.time() - start) * 1000)
         _log_trace_event(
             trace_id=trace_id,


### PR DESCRIPTION
## Summary
- suppress scanner dispatch when recent high-risk Guardian playback is re-captured as transcript
- reject wake-word fallback queue inserts that contain the Guardian assistant's own generic acknowledgement
- treat wake_word_* rows as wake rows for queue consolidation/supersede logic

## Validation
- python3 -m pytest backend/tests/unit/test_ella_scanner_echo_suppression.py backend/tests/unit/test_ella_guardian_delivery.py -q
- live VPS deploy: py_compile passed, omi-backend restarted, /v1/health OK
- live smoke: synthetic wake_word_fallback echo enqueue returned {"ok":false,"rejected":true,"reason":"guardian_playback_echo"}

## Live note
Surgically deployed to VPS because the loop was active in production. Drained one pending self-echo queue row for Plato.