### PR TITLE
Make Guardian scanner resilient to reconnects

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -151,6 +151,7 @@ async def _stream_handler(
 
     # Set Ella context for LLM proxy
     from utils.llm.clients import set_ella_context
+
     set_ella_context(uid=uid, task='transcription')
 
     # Helper to gate person_id based on client capability (backward compatibility)
@@ -1461,9 +1462,15 @@ async def _stream_handler(
 
             # DEBUG: Log received transcript segments
             if segments_to_process:
-                print(f"[TRANSCRIPT-RECV] Processing {len(segments_to_process)} buffered segments for uid={uid} session={session_id}  conv={current_conversation_id}")
+                print(
+                    f"[TRANSCRIPT-RECV] Processing {len(segments_to_process)} buffered segments for uid={uid} session={session_id}  conv={current_conversation_id}"
+                )
                 if len(segments_to_process) > 0:
-                    first_text = segments_to_process[0].get("text", "")[:80] if isinstance(segments_to_process[0], dict) else str(segments_to_process[0])[:80]
+                    first_text = (
+                        segments_to_process[0].get("text", "")[:80]
+                        if isinstance(segments_to_process[0], dict)
+                        else str(segments_to_process[0])[:80]
+                    )
                     print(f"[TRANSCRIPT-RECV] First segment: {first_text}")
 
             realtime_segment_buffers = []
@@ -1537,11 +1544,10 @@ async def _stream_handler(
                 _send_message_event(SegmentsDeletedEvent(segment_ids=removed_ids))
 
             if transcript_segments:
-                await websocket.send_json([segment.dict() for segment in updated_segments])
-
                 # ====== ELLA INTEGRATION: Send chunks to scanner ======
                 try:
                     from utils.ella import send_to_scanner
+
                     send_to_scanner(
                         uid=uid,
                         conversation_id=str(current_conversation_id),
@@ -1549,6 +1555,11 @@ async def _stream_handler(
                     )
                 except ImportError:
                     pass
+
+                try:
+                    await websocket.send_json([segment.dict() for segment in updated_segments])
+                except Exception as e:
+                    print(f"Error sending transcript segments to websocket: {e}", uid, session_id)
 
                 if transcript_send is not None and user_has_credits:
                     transcript_send([segment.dict() for segment in transcript_segments])
@@ -2130,6 +2141,7 @@ async def listen_handler(
             ensure_firestore_user_document,
             get_agent_cluster,
         )
+
         await ensure_firestore_user_document(uid)
         cluster = await get_agent_cluster(uid)
         if not cluster:

--- a/backend/tests/unit/test_ella_scanner_echo_suppression.py
+++ b/backend/tests/unit/test_ella_scanner_echo_suppression.py
@@ -1,4 +1,4 @@
-from utils.ella.scanner import should_suppress_guardian_echo
+from utils.ella.scanner import prepare_scanner_segments_for_dispatch, should_suppress_guardian_echo
 
 
 def test_suppresses_recent_high_risk_guardian_playback_echo():
@@ -30,3 +30,34 @@ def test_does_not_suppress_echo_like_text_without_risky_playback_event():
     segments = [{"speaker": "SPEAKER_1", "text": "Why did it say hi Greg I heard my name?"}]
 
     assert not should_suppress_guardian_echo("uid-1", segments, playback_event={})
+
+
+def test_short_wake_prefix_dispatches_immediately():
+    segments = [{"speaker": "SPEAKER_1", "text": "Hey, Ella."}]
+
+    dispatch_segments, pending_segments, pending_since, metadata = prepare_scanner_segments_for_dispatch(
+        segments,
+        now=100.0,
+    )
+
+    assert dispatch_segments == segments
+    assert pending_segments == []
+    assert pending_since is None
+    assert metadata["action"] == "direct_wake_prefix_dispatch"
+
+
+def test_existing_pending_wake_prefix_still_prepends_to_followup():
+    pending = [{"speaker": "SPEAKER_1", "text": "Hey, Ella."}]
+    current = [{"speaker": "SPEAKER_1", "text": "What did you hear last?"}]
+
+    dispatch_segments, pending_segments, pending_since, metadata = prepare_scanner_segments_for_dispatch(
+        current,
+        pending_wake_prefix_segments=pending,
+        pending_wake_prefix_since=100.0,
+        now=101.0,
+    )
+
+    assert dispatch_segments == pending + current
+    assert pending_segments == []
+    assert pending_since is None
+    assert metadata["action"] == "prepend_pending_wake_prefix"

--- a/backend/utils/ella/scanner.py
+++ b/backend/utils/ella/scanner.py
@@ -222,10 +222,11 @@ def prepare_scanner_segments_for_dispatch(
     max_pending_window_s: float = WAKE_WORD_PENDING_WINDOW_S,
 ):
     """
-    Hold very short wake-word-only batches briefly and prepend them to the next batch.
+    Prepare transcript batches for scanner dispatch.
 
-    This preserves "Hey Ella" / "Ela" prefixes when diarization or STT flushes the
-    prefix separately from the actual question.
+    Short wake-word-only batches are dispatched immediately so a reconnect between
+    "Hey Ella" and the follow-up question cannot lose the wake event. Older
+    pending-prefix state is still honored for workers that already carry one.
     """
     now = now if now is not None else time.time()
     pending_wake_prefix_segments = list(pending_wake_prefix_segments or [])
@@ -248,11 +249,11 @@ def prepare_scanner_segments_for_dispatch(
 
     if is_short_wake_prefix_only(current_segments):
         return (
-            [],
             list(current_segments),
-            now,
+            [],
+            None,
             {
-                "action": "hold_wake_prefix",
+                "action": "direct_wake_prefix_dispatch",
                 "prepended_count": 0,
             },
         )


### PR DESCRIPTION
## Summary
- dispatch scanner batches before websocket fanout so a closed/reconnected websocket cannot abort Guardian scanner delivery
- dispatch short wake-prefix-only batches immediately instead of holding them in websocket-local memory
- add regression tests for direct wake-prefix dispatch and existing pending-prefix prepend behavior

## Live deploy note
This patch is already deployed on the VPS as a hotfix. The live VPS transcribe file has extra scanner-context code, so it was patched surgically to preserve those live-only helpers. n8n guardian-audio-pipeline was also updated to use backend /v1/ella/guardian/synthesize so local Kokoro/free TTS is the fallback when paid TTS quota is exhausted.

## Tests
- python3 -m pytest backend/tests/unit/test_ella_scanner_echo_suppression.py backend/tests/unit/test_ella_guardian_delivery.py -q
- python3 -m py_compile backend/utils/ella/scanner.py backend/routers/transcribe.py

## Smoke
- Direct backend synth returned x-guardian-tts-provider: kokoro with fallback_used=true
- n8n guardian-audio-pipeline smoke enqueued a fresh generated MP3 URL and the test row was drained before playback
