### PR TITLE
Add xAI TTS for Guardian one-shot audio

### DIFF
--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -54,6 +54,10 @@ ELLA_SESSION_SECRET = os.getenv("ELLA_SESSION_SECRET", "")
 ELLA_API_BASE = os.getenv("ELLA_API_BASE", "https://api.ella-ai-care.com")
 SESSION_EXPIRY_HOURS = int(os.getenv("ELLA_SESSION_EXPIRY_HOURS", "1"))
 ELEVENLABS_API_KEY = os.getenv("ELEVENLABS_API_KEY", "")
+XAI_API_KEY = os.getenv("XAI_API_KEY", "")
+XAI_TTS_VOICE_ID = os.getenv("XAI_TTS_VOICE_ID", "eve")
+XAI_TTS_LANGUAGE = os.getenv("XAI_TTS_LANGUAGE", "en")
+XAI_TTS_OPTIMIZE_STREAMING_LATENCY = int(os.getenv("XAI_TTS_OPTIMIZE_STREAMING_LATENCY", "1"))
 INWORLD_API_KEY = os.getenv("INWORLD_API_KEY", "")
 ELLA_TTS_URL = os.getenv("ELLA_TTS_URL", "http://100.76.138.56:8930")
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
@@ -162,11 +166,14 @@ class VoiceConfigResponse(BaseModel):
     byte_order: str = "little_endian"
 
 
+DEFAULT_ELEVENLABS_VOICE_ID = "pFZP5JQG7iQjIQuC4Bku"
+
+
 class TtsRequest(BaseModel):
     """Request for text-to-speech synthesis."""
 
     text: str
-    voice_id: str = "pFZP5JQG7iQjIQuC4Bku"  # Lily voice
+    voice_id: str = DEFAULT_ELEVENLABS_VOICE_ID  # Lily voice
 
 
 # ============================================================================
@@ -309,6 +316,13 @@ async def get_voice_providers():
             "type": "tts",
             "description": "Inworld TTS WebSocket, ~120-200ms, $5-10/1M chars",
             "available": bool(INWORLD_API_KEY),
+        },
+        {
+            "id": "xai-tts",
+            "name": "xAI TTS",
+            "type": "tts",
+            "description": "Grok/xAI one-shot TTS for queued Guardian playback",
+            "available": bool(XAI_API_KEY),
         },
         {
             "id": "grok-voice",
@@ -493,6 +507,7 @@ async def synthesize_speech(
       fish-audio-s1      — Fish Audio S1 (alias)
       fish-audio-s2      — Fish Audio S2 (alias)
       kokoro             — Kokoro-82M via local ella-tts server (Mac Mini :8930)
+      xai-tts            — xAI TTS REST API, useful for Grok-matched Guardian one-shots
       inworld            — Inworld TTS WebSocket (~120-200ms, $5-10/1M chars)
 
     V2V providers (grok-voice, gemini-live) return 422 directing iOS to use
@@ -545,6 +560,56 @@ async def synthesize_speech(
             print(f"[FLOW:VOICE-TTS] ERROR provider={provider} error={e} latency={_elapsed}ms", flush=True)
             raise HTTPException(status_code=500, detail=str(e))
 
+    # --- xAI TTS (Grok one-shot audio, REST) ---
+    if provider == "xai-tts":
+        if not XAI_API_KEY:
+            print(f"[FLOW:VOICE-TTS] ERROR provider=xai-tts key_missing=true", flush=True)
+            raise HTTPException(status_code=500, detail="XAI_API_KEY not configured")
+        voice_id = request.voice_id if request.voice_id != DEFAULT_ELEVENLABS_VOICE_ID else XAI_TTS_VOICE_ID
+        print(f"[FLOW:VOICE-TTS] provider=xai-tts voice={voice_id} language={XAI_TTS_LANGUAGE} text_len={text_len}", flush=True)
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    "https://api.x.ai/v1/tts",
+                    headers={
+                        "Authorization": f"Bearer {XAI_API_KEY}",
+                        "Content-Type": "application/json",
+                        "Accept": "audio/mpeg",
+                    },
+                    json={
+                        "text": text,
+                        "voice_id": voice_id,
+                        "language": XAI_TTS_LANGUAGE,
+                        "codec": "mp3",
+                        "optimize_streaming_latency": XAI_TTS_OPTIMIZE_STREAMING_LATENCY,
+                        "text_normalization": True,
+                    },
+                    timeout=30.0,
+                )
+            _elapsed = int((time.time() - _start) * 1000)
+            if response.status_code != 200:
+                print(
+                    f"[FLOW:VOICE-TTS] ERROR provider=xai-tts status={response.status_code} "
+                    f"latency={_elapsed}ms body={response.text[:200]}",
+                    flush=True,
+                )
+                raise HTTPException(status_code=502, detail=f"xAI TTS error: {response.status_code}")
+            print(
+                f"[FLOW:VOICE-TTS] OK provider=xai-tts voice={voice_id} audio_bytes={len(response.content)} latency={_elapsed}ms",
+                flush=True,
+            )
+            return Response(content=response.content, media_type=response.headers.get("content-type", "audio/mpeg"))
+        except httpx.TimeoutException:
+            _elapsed = int((time.time() - _start) * 1000)
+            print(f"[FLOW:VOICE-TTS] TIMEOUT provider=xai-tts latency={_elapsed}ms", flush=True)
+            raise HTTPException(status_code=504, detail="xAI TTS timed out")
+        except HTTPException:
+            raise
+        except Exception as e:
+            _elapsed = int((time.time() - _start) * 1000)
+            print(f"[FLOW:VOICE-TTS] ERROR provider=xai-tts error={e} latency={_elapsed}ms", flush=True)
+            raise HTTPException(status_code=500, detail=str(e))
+
     # --- Inworld TTS (WebSocket, ~120-200ms) ---
     if provider == "inworld":
         if not INWORLD_API_KEY:
@@ -564,7 +629,7 @@ async def synthesize_speech(
     # --- Reject unknown providers (no silent fallbacks) ---
     if provider != "elevenlabs":
         print(f"[FLOW:VOICE-TTS] ERROR unknown provider={provider!r}", flush=True)
-        raise HTTPException(status_code=400, detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, grok-voice, gemini-live")
+        raise HTTPException(status_code=400, detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, xai-tts, grok-voice, gemini-live")
 
     # --- ElevenLabs ---
     if not ELEVENLABS_API_KEY:
@@ -629,8 +694,9 @@ async def voice_health():
         "service": "ella-voice",
         "voice_endpoint": ELLA_VOICE_ENDPOINT,
         "session_secret_configured": bool(ELLA_SESSION_SECRET),
-        "tts_providers": ["elevenlabs", "fish-audio", "kokoro", "inworld"],
+        "tts_providers": ["elevenlabs", "fish-audio", "kokoro", "inworld", "xai-tts"],
         "tts_elevenlabs_configured": bool(ELEVENLABS_API_KEY),
+        "tts_xai_configured": bool(XAI_API_KEY),
         "tts_local_url": ELLA_TTS_URL,
         "v2v_providers": v2v_status,
     }

--- a/backend/ella/services/app_settings.py
+++ b/backend/ella/services/app_settings.py
@@ -7,7 +7,7 @@ from typing import Any
 from google.cloud.firestore_v1.transforms import Sentinel
 
 
-TTS_PROVIDERS = {"elevenlabs", "fish-audio", "fish-audio-s1", "fish-audio-s2", "kokoro", "inworld"}
+TTS_PROVIDERS = {"elevenlabs", "fish-audio", "fish-audio-s1", "fish-audio-s2", "kokoro", "inworld", "xai-tts"}
 V2V_PROVIDERS = {"openclaw-direct", "grok-voice", "gemini-native-live", "openai-native-realtime"}
 VOICE_MODE_ALIASES = {
     "gemini-live": "gemini-native-live",
@@ -33,10 +33,11 @@ _ONE_SHOT_CANDIDATES_BY_VOICE_MODE = {
     "fish-audio-s2": ["fish-audio-s2", "fish-audio", "kokoro", "elevenlabs"],
     "kokoro": ["kokoro", "fish-audio-s2", "elevenlabs"],
     "inworld": ["inworld", "kokoro", "elevenlabs"],
+    "xai-tts": ["xai-tts", "kokoro", "elevenlabs"],
     # V2V modes keep conversation routing intact, but Guardian one-shots need
-    # explicit TTS routing until provider-native one-shot adapters are wired in.
+    # explicit TTS routing because queued Guardian playback is file-based.
     "openclaw-direct": [os.getenv("ELLA_OPENCLAW_ONE_SHOT_TTS_PROVIDER", _DEFAULT_ONE_SHOT_TTS_PROVIDER)],
-    "grok-voice": [os.getenv("ELLA_GROK_VOICE_ONE_SHOT_TTS_PROVIDER", _DEFAULT_ONE_SHOT_TTS_PROVIDER)],
+    "grok-voice": [os.getenv("ELLA_GROK_VOICE_ONE_SHOT_TTS_PROVIDER", "xai-tts")],
     "gemini-native-live": [os.getenv("ELLA_GEMINI_LIVE_ONE_SHOT_TTS_PROVIDER", _DEFAULT_ONE_SHOT_TTS_PROVIDER)],
     "openai-native-realtime": [os.getenv("ELLA_OPENAI_REALTIME_ONE_SHOT_TTS_PROVIDER", _DEFAULT_ONE_SHOT_TTS_PROVIDER)],
 }

--- a/backend/tests/unit/test_ella_app_settings.py
+++ b/backend/tests/unit/test_ella_app_settings.py
@@ -40,8 +40,8 @@ def test_effective_settings_maps_v2v_to_explicit_one_shot_fallback():
     effective = service.build_effective_voice_settings("uid-1", {"voice_mode": "grok-voice"})
 
     assert effective["voice_mode"] == "grok-voice"
-    assert effective["one_shot_tts_provider"] == "kokoro"
-    assert effective["effective_voice_settings"]["one_shot_tts_candidates"] == ["kokoro", "elevenlabs"]
+    assert effective["one_shot_tts_provider"] == "xai-tts"
+    assert effective["effective_voice_settings"]["one_shot_tts_candidates"] == ["xai-tts", "kokoro", "elevenlabs"]
     assert effective["effective_voice_settings"]["provider_type"] == "v2v"
     assert effective["effective_voice_settings"]["fallback_used"] is True
     assert "Guardian one-shots" in effective["effective_voice_settings"]["fallback_reason"]

--- a/backend/tests/unit/test_ella_guardian_delivery.py
+++ b/backend/tests/unit/test_ella_guardian_delivery.py
@@ -21,17 +21,17 @@ sys.modules["ella.services.escalation_policy"] = policy
 _POLICY_SPEC.loader.exec_module(policy)
 
 ella_app_settings_module = types.ModuleType("ella.services.app_settings")
-ella_app_settings_module.TTS_PROVIDERS = {"kokoro", "elevenlabs", "fish-audio", "fish-audio-s2"}
+ella_app_settings_module.TTS_PROVIDERS = {"kokoro", "elevenlabs", "fish-audio", "fish-audio-s2", "xai-tts"}
 ella_app_settings_module.build_effective_voice_settings = lambda _uid, voice: {
     "effective_voice_settings": {
         "voice_mode": voice.get("voice_mode", "elevenlabs") if isinstance(voice, dict) else "elevenlabs",
         "one_shot_tts_provider": {
             "fish-audio-s2": "fish-audio-s2",
-            "grok-voice": "kokoro",
+            "grok-voice": "xai-tts",
         }.get(voice.get("voice_mode") if isinstance(voice, dict) else None, "kokoro"),
         "one_shot_tts_candidates": {
             "fish-audio-s2": ["fish-audio-s2", "fish-audio", "kokoro", "elevenlabs"],
-            "grok-voice": ["kokoro", "elevenlabs"],
+            "grok-voice": ["xai-tts", "kokoro", "elevenlabs"],
         }.get(voice.get("voice_mode") if isinstance(voice, dict) else None, ["kokoro", "elevenlabs"]),
     }
 }
@@ -227,11 +227,11 @@ def test_synthesize_audio_resolves_server_voice_settings(monkeypatch):
     assert response.body == b"mp3-bytes"
     url, kwargs = _FakeAsyncClient.posts[0]
     assert url == guardian.ELLA_INTERNAL_VOICE_TTS_URL
-    assert kwargs["headers"]["X-TTS-Provider"] == "kokoro"
+    assert kwargs["headers"]["X-TTS-Provider"] == "xai-tts"
     assert kwargs["json"]["text"] == "Hello"
-    assert response.headers["x-guardian-tts-provider"] == "kokoro"
+    assert response.headers["x-guardian-tts-provider"] == "xai-tts"
     assert response.headers["x-guardian-voice-mode"] == "grok-voice"
-    assert response.headers["x-guardian-tts-candidates"] == "kokoro,elevenlabs"
+    assert response.headers["x-guardian-tts-candidates"] == "xai-tts,kokoro,elevenlabs"
 
 
 def test_synthesize_audio_uses_matching_tts_provider(monkeypatch):


### PR DESCRIPTION
## Summary
- add `xai-tts` as a first-class backend TTS provider using `POST https://api.x.ai/v1/tts`
- map `grok-voice` Guardian one-shot playback to `xai-tts`, with `kokoro` and `elevenlabs` fallbacks
- expose xAI TTS availability in voice provider/health responses

## Notes
- This keeps Grok V2V chat/calls separate from queued Guardian MP3 playback. Guardian now has a Grok/xAI one-shot path for wake-word responses and alerts.
- Defaults: voice `eve`, language `en`, mp3 codec, streaming-latency optimization enabled. Override with `XAI_TTS_VOICE_ID`, `XAI_TTS_LANGUAGE`, `XAI_TTS_OPTIMIZE_STREAMING_LATENCY`, or `ELLA_GROK_VOICE_ONE_SHOT_TTS_PROVIDER`.

## Tests
- python3 -m pytest backend/tests/unit/test_ella_app_settings.py -q
- python3 -m pytest backend/tests/unit/test_ella_guardian_delivery.py -q
- python3 -m py_compile backend/ella/services/app_settings.py backend/ella/routers/voice.py backend/ella/routers/guardian.py

Sources: xAI docs confirm `POST /v1/tts`, built-in voices, MP3 output, and streaming TTS support.