### PR TITLE
Mark Grok xAI TTS as matched Guardian one-shot

### DIFF
--- a/backend/ella/services/app_settings.py
+++ b/backend/ella/services/app_settings.py
@@ -148,14 +148,16 @@ def build_settings_response(uid: str, voice: dict[str, Any] | None = None) -> di
 def build_effective_voice_settings(uid: str, voice: dict[str, Any] | None = None) -> dict[str, Any]:
     resolved_voice = _json_safe(extract_voice_settings({"settings": {"voice": voice or {}}}))
     voice_mode = resolved_voice["voice_mode"]
-    fallback_used = voice_mode in V2V_PROVIDERS
+    one_shot_provider = one_shot_tts_provider(voice_mode)
+    provider_matched_one_shot = voice_mode == "grok-voice" and one_shot_provider == "xai-tts"
+    fallback_used = voice_mode in V2V_PROVIDERS and not provider_matched_one_shot
     fallback_reason = None
     if fallback_used:
         fallback_reason = f"{voice_mode} is a V2V mode; Guardian one-shots require a TTS provider"
 
     effective = {
         **resolved_voice,
-        "one_shot_tts_provider": one_shot_tts_provider(voice_mode),
+        "one_shot_tts_provider": one_shot_provider,
         "one_shot_tts_candidates": one_shot_tts_candidates(voice_mode),
         "provider_type": "v2v" if is_v2v_voice_mode(voice_mode) else "tts",
         "fallback_used": fallback_used,

--- a/backend/tests/unit/test_ella_app_settings.py
+++ b/backend/tests/unit/test_ella_app_settings.py
@@ -43,8 +43,8 @@ def test_effective_settings_maps_v2v_to_explicit_one_shot_fallback():
     assert effective["one_shot_tts_provider"] == "xai-tts"
     assert effective["effective_voice_settings"]["one_shot_tts_candidates"] == ["xai-tts", "kokoro", "elevenlabs"]
     assert effective["effective_voice_settings"]["provider_type"] == "v2v"
-    assert effective["effective_voice_settings"]["fallback_used"] is True
-    assert "Guardian one-shots" in effective["effective_voice_settings"]["fallback_reason"]
+    assert effective["effective_voice_settings"]["fallback_used"] is False
+    assert effective["effective_voice_settings"]["fallback_reason"] is None
 
 
 def test_effective_settings_maps_tts_mode_to_closest_guardian_candidates():


### PR DESCRIPTION
## Summary
- treat `grok-voice` -> `xai-tts` as a matched Guardian one-shot path instead of a generic fallback
- keeps fallback headers meaningful: fallback only means Kokoro/ElevenLabs or another alternate provider was needed

## Tests
- python3 -m pytest backend/tests/unit/test_ella_app_settings.py -q
- python3 -m pytest backend/tests/unit/test_ella_guardian_delivery.py -q
- python3 -m py_compile backend/ella/services/app_settings.py backend/ella/routers/voice.py backend/ella/routers/guardian.py