### PR TITLE
Add fast Guardian wake ack tracing

### DIFF
--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -581,6 +581,14 @@ def _enqueue_rejects_guardian_echo(uid: str, req: "EnqueueRequest") -> tuple[boo
     return False, None
 
 
+def _is_wake_ack_request(req: "EnqueueRequest") -> bool:
+    metadata = _coerce_metadata_dict(req.metadata)
+    trigger = str(
+        req.trigger or metadata.get("trigger_type") or metadata.get("event_type") or metadata.get("category") or ""
+    ).lower()
+    return trigger == "wake_word_ack" or metadata.get("ack_only") is True
+
+
 def _is_wake_word_row(row: dict[str, Any]) -> bool:
     metadata = _coerce_metadata_dict(row.get("metadata"))
     trigger = str(row.get("trigger_type") or metadata.get("trigger_type") or metadata.get("category") or "").lower()
@@ -1185,6 +1193,42 @@ async def enqueue(
                 "rejected": True,
                 "reason": reject_reason,
                 "suggestion": "Route critical alerts to iMessage instead",
+            }
+
+    if _is_wake_ack_request(req):
+        duplicate_ack_id = await pool.fetchval(
+            """
+            SELECT id
+            FROM guardian_queue
+            WHERE uid = $1
+              AND trigger_type = 'wake_word_ack'
+              AND metadata->>'trace_id' = $2
+              AND created_at > NOW() - INTERVAL '15 seconds'
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            uid,
+            trace_id,
+        )
+        if duplicate_ack_id:
+            _elapsed = int((time.time() - _start) * 1000)
+            await _log_pipeline_event(
+                trace_id=trace_id,
+                uid=uid,
+                stage="ack_deduped",
+                status="skipped",
+                latency_ms=_elapsed,
+                metadata={
+                    "queue_item_id": item_id,
+                    "duplicate_queue_item_id": duplicate_ack_id,
+                    "trigger_type": req.trigger,
+                },
+            )
+            return {
+                "ok": True,
+                "deduped": True,
+                "id": duplicate_ack_id,
+                "trace_id": trace_id,
             }
 
     # Serialize metadata to JSON string for the JSONB column

--- a/backend/tests/unit/test_ella_guardian_delivery.py
+++ b/backend/tests/unit/test_ella_guardian_delivery.py
@@ -326,6 +326,30 @@ def test_enqueue_does_not_reject_real_wake_word_question():
     assert reason is None
 
 
+def test_wake_ack_request_detects_trigger_and_metadata_flag():
+    assert guardian._is_wake_ack_request(
+        guardian.EnqueueRequest(
+            uid="uid-1",
+            url="https://example.test/wake.mp3",
+            trigger="wake_word_ack",
+        )
+    )
+    assert guardian._is_wake_ack_request(
+        guardian.EnqueueRequest(
+            uid="uid-1",
+            url="https://example.test/wake.mp3",
+            metadata={"ack_only": True},
+        )
+    )
+    assert not guardian._is_wake_ack_request(
+        guardian.EnqueueRequest(
+            uid="uid-1",
+            url="https://example.test/full.mp3",
+            trigger="wake_word_user_support",
+        )
+    )
+
+
 def test_wake_word_row_matches_fallback_variants():
     assert guardian._is_wake_word_row({"trigger_type": "wake_word_fallback", "metadata": {}})
 

--- a/backend/tests/unit/test_ella_scanner_echo_suppression.py
+++ b/backend/tests/unit/test_ella_scanner_echo_suppression.py
@@ -1,4 +1,8 @@
-from utils.ella.scanner import prepare_scanner_segments_for_dispatch, should_suppress_guardian_echo
+from utils.ella.scanner import (
+    _build_wake_ack_payload,
+    prepare_scanner_segments_for_dispatch,
+    should_suppress_guardian_echo,
+)
 
 
 def test_suppresses_recent_high_risk_guardian_playback_echo():
@@ -61,3 +65,22 @@ def test_existing_pending_wake_prefix_still_prepends_to_followup():
     assert pending_segments == []
     assert pending_since is None
     assert metadata["action"] == "prepend_pending_wake_prefix"
+
+
+def test_wake_ack_payload_is_built_for_wake_question():
+    segments = [{"speaker": "SPEAKER_1", "text": "Hey Ella, are cats clean animals?"}]
+
+    payload = _build_wake_ack_payload("uid-1", "conv-1", "trace-1", segments)
+
+    assert payload is not None
+    assert payload["id"].startswith("wake_ack_trace-1_wake_")
+    assert payload["trigger"] == "wake_word_ack"
+    assert payload["metadata"]["ack_only"] is True
+    assert payload["metadata"]["parent_conversation_id"] == "conv-1"
+    assert payload["metadata"]["segments_preview"][0]["text"] == "Hey Ella, are cats clean animals?"
+
+
+def test_wake_ack_payload_ignores_non_wake_ambient_text():
+    segments = [{"speaker": "SPEAKER_1", "text": "The cats on the video are clean animals."}]
+
+    assert _build_wake_ack_payload("uid-1", "conv-1", "trace-1", segments) is None

--- a/backend/utils/ella/scanner.py
+++ b/backend/utils/ella/scanner.py
@@ -3,8 +3,10 @@
 # Sends real-time transcript segments to n8n scanner for urgency detection.
 # Fire-and-forget with short timeout - doesn't block transcription flow.
 
+import hashlib
 import os
 import re
+import threading
 import time
 from typing import List, Optional
 
@@ -16,6 +18,16 @@ GUARDIAN_TRACE_LOG_URL = os.getenv(
     "ELLA_GUARDIAN_TRACE_LOG_URL",
     "http://127.0.0.1:8000/v1/ella/guardian/trace/log",
 )
+GUARDIAN_ENQUEUE_URL = os.getenv(
+    "ELLA_GUARDIAN_ENQUEUE_URL",
+    "http://127.0.0.1:8000/v1/ella/guardian/enqueue",
+)
+GUARDIAN_WEBHOOK_KEY = os.getenv("GUARDIAN_WEBHOOK_KEY", "4f13699d8462adf71e35d2098e6a791f")
+GUARDIAN_WAKE_ACK_AUDIO_URL = os.getenv(
+    "ELLA_GUARDIAN_WAKE_ACK_AUDIO_URL",
+    "https://ella-ai-care.com/audio/system/wake_ack_pulse.mp3",
+)
+GUARDIAN_WAKE_ACK_TIMEOUT_S = float(os.getenv("ELLA_GUARDIAN_WAKE_ACK_TIMEOUT_S", "2.0"))
 WAKE_WORD_PREFIX_MAX_WORDS = 4
 WAKE_WORD_PENDING_WINDOW_S = float(os.getenv("ELLA_WAKE_WORD_PENDING_WINDOW_S", "12.0"))
 SCANNER_CONTEXT_WINDOW_S = float(os.getenv("ELLA_SCANNER_CONTEXT_WINDOW_S", "12.0"))
@@ -356,6 +368,97 @@ def _log_trace_event(
         pass
 
 
+def _wake_turn_id(trace_id: str, text: str) -> str:
+    digest = hashlib.sha1(f"{trace_id}:{_normalize_text(text)}".encode("utf-8")).hexdigest()[:12]
+    return f"wake_{digest}"
+
+
+def _build_wake_ack_payload(uid: str, conversation_id: str, trace_id: str, scanner_segments: List[dict]) -> dict | None:
+    text = _combined_segment_text(scanner_segments)
+    if not contains_wake_phrase(text):
+        return None
+
+    wake_turn_id = _wake_turn_id(trace_id, text)
+    return {
+        "uid": uid,
+        "userID": uid,
+        "id": f"wake_ack_{trace_id}_{wake_turn_id}",
+        "url": GUARDIAN_WAKE_ACK_AUDIO_URL,
+        "priority": "normal",
+        "message": "wake_ack",
+        "trigger": "wake_word_ack",
+        "metadata": {
+            "trace_id": trace_id,
+            "parent_conversation_id": str(conversation_id),
+            "wake_turn_id": wake_turn_id,
+            "matched_pattern": "wake_phrase",
+            "ack_only": True,
+            "source": "omi_backend_fast_wake_ack",
+            "detected_at": time.time(),
+            "segments_preview": scanner_payload_preview(scanner_segments, limit=2),
+        },
+    }
+
+
+def _enqueue_wake_ack(uid: str, conversation_id: str, trace_id: str, scanner_segments: List[dict]) -> None:
+    """Fire-and-forget audible wake acknowledgement before slower scanner work."""
+    payload = _build_wake_ack_payload(uid, conversation_id, trace_id, scanner_segments)
+    if payload is None:
+        return
+
+    wake_turn_id = str(payload["metadata"]["wake_turn_id"])
+
+    _log_trace_event(
+        trace_id=trace_id,
+        uid=uid,
+        stage="wake_detected",
+        status="success",
+        metadata={
+            "conversation_id": str(conversation_id),
+            "wake_turn_id": wake_turn_id,
+            "segments_preview": scanner_payload_preview(scanner_segments, limit=2),
+        },
+    )
+
+    def _post() -> None:
+        start = time.time()
+        try:
+            response = requests.post(
+                GUARDIAN_ENQUEUE_URL,
+                json=payload,
+                headers={"X-Guardian-Key": GUARDIAN_WEBHOOK_KEY},
+                timeout=GUARDIAN_WAKE_ACK_TIMEOUT_S,
+            )
+            _log_trace_event(
+                trace_id=trace_id,
+                uid=uid,
+                stage="ack_enqueued",
+                status="success" if 200 <= response.status_code < 300 else "error",
+                latency_ms=int((time.time() - start) * 1000),
+                metadata={
+                    "wake_turn_id": wake_turn_id,
+                    "queue_item_id": payload["id"],
+                    "status_code": response.status_code,
+                    "response": response.text[:200],
+                },
+            )
+        except Exception as e:
+            _log_trace_event(
+                trace_id=trace_id,
+                uid=uid,
+                stage="ack_enqueued",
+                status="error",
+                latency_ms=int((time.time() - start) * 1000),
+                metadata={
+                    "wake_turn_id": wake_turn_id,
+                    "queue_item_id": payload["id"],
+                    "error": str(e)[:200],
+                },
+            )
+
+    threading.Thread(target=_post, name="guardian-wake-ack", daemon=True).start()
+
+
 def send_to_scanner(
     uid: str,
     conversation_id: str,
@@ -426,6 +529,8 @@ def send_to_scanner(
             flush=True,
         )
         return None
+
+    _enqueue_wake_ack(uid, str(conversation_id), trace_id, scanner_segments)
 
     payload = {
         "uid": uid,


### PR DESCRIPTION
## Summary
- enqueue an audible Guardian wake ack from OMI backend scanner as soon as a wake phrase is detected
- add wake/ack trace stages with stable `wake_turn_id` metadata
- dedupe wake ack queue inserts by trace for 15 seconds so the existing n8n ack branch cannot double-ring
- add unit coverage for wake ack payload construction and ack request detection

## Validation
- `pytest backend/tests/unit/test_ella_scanner_echo_suppression.py backend/tests/unit/test_ella_guardian_delivery.py -q`
- `python3 -m py_compile backend/utils/ella/scanner.py backend/ella/routers/guardian.py`

Tracking: ellaaicare/ella-ai#866
Parent: ellaaicare/ella-ai#865