### PR TITLE
Reduce iOS Guardian wake ack poll latency

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -757,9 +757,26 @@ extension AppDelegate: WCSessionDelegate {
             let args = call.arguments as? [String: Any]
             GuardianModeManager.shared.requestWakeAckPoll(
                 reason: args?["reason"] as? String ?? "wake_candidate",
-                transcript: args?["transcript"] as? String
+                transcript: args?["transcript"] as? String,
+                clientRequestedAtMs: args?["client_requested_at_ms"] as? Int
             )
             result(["status": "queued"])
+
+        case "recordLatencyBreadcrumb":
+            guard let args = call.arguments as? [String: Any],
+                  let eventName = args["event_name"] as? String else {
+                result(FlutterError(
+                    code: "INVALID_ARGS",
+                    message: "Missing event_name parameter",
+                    details: nil
+                ))
+                return
+            }
+            GuardianModeManager.shared.recordWakeLatencyBreadcrumb(
+                eventName: eventName,
+                metadata: args["metadata"] as? [String: Any] ?? [:]
+            )
+            result(["status": "recorded"])
 
         case "injectRemoteAudioClip":
             guard let args = call.arguments as? [String: Any],

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -753,6 +753,14 @@ extension AppDelegate: WCSessionDelegate {
                 "poller": GuardianModePollingService.shared.statusSnapshot()
             ])
 
+        case "requestWakeAckPoll":
+            let args = call.arguments as? [String: Any]
+            GuardianModeManager.shared.requestWakeAckPoll(
+                reason: args?["reason"] as? String ?? "wake_candidate",
+                transcript: args?["transcript"] as? String
+            )
+            result(["status": "queued"])
+
         case "injectRemoteAudioClip":
             guard let args = call.arguments as? [String: Any],
                   let audioURLString = args["audioURL"] as? String,

--- a/app/ios/Runner/GuardianMode/GuardianModeManager.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModeManager.swift
@@ -126,6 +126,31 @@ class GuardianModeManager: NSObject, AVSpeechSynthesizerDelegate {
         }
     }
 
+    /// Called when the app-side transcript stream sees a likely wake phrase.
+    /// This does not synthesize or route audio locally; it only interrupts the
+    /// active Guardian poll timer so a backend-created wake ack can be consumed
+    /// without waiting for the normal idle poll cadence.
+    func requestWakeAckPoll(reason: String, transcript: String?) {
+        queue.async { [weak self] in
+            guard let self = self, self.isActive else {
+                NSLog("GuardianMode: Ignoring wake ack poll request because Guardian is inactive")
+                return
+            }
+
+            let preview = transcript.map { String($0.prefix(80)) } ?? ""
+            DebugEventBuffer.shared.add(
+                id: "wake-ack-poll-\(Int(Date().timeIntervalSince1970 * 1000))",
+                triggerType: "guardian_wake_ack_poll_request",
+                message: "Wake candidate requested immediate Guardian next-audio poll",
+                metadata: [
+                    "reason": reason,
+                    "transcript_preview": preview
+                ]
+            )
+            GuardianModePollingService.shared.requestWakeAckPollBurst(reason: reason)
+        }
+    }
+
     // MARK: - Health Monitor
 
     /// Periodic check to detect queue stalls and recover

--- a/app/ios/Runner/GuardianMode/GuardianModeManager.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModeManager.swift
@@ -130,7 +130,7 @@ class GuardianModeManager: NSObject, AVSpeechSynthesizerDelegate {
     /// This does not synthesize or route audio locally; it only interrupts the
     /// active Guardian poll timer so a backend-created wake ack can be consumed
     /// without waiting for the normal idle poll cadence.
-    func requestWakeAckPoll(reason: String, transcript: String?) {
+    func requestWakeAckPoll(reason: String, transcript: String?, clientRequestedAtMs: Int?) {
         queue.async { [weak self] in
             guard let self = self, self.isActive else {
                 NSLog("GuardianMode: Ignoring wake ack poll request because Guardian is inactive")
@@ -138,16 +138,40 @@ class GuardianModeManager: NSObject, AVSpeechSynthesizerDelegate {
             }
 
             let preview = transcript.map { String($0.prefix(80)) } ?? ""
+            var metadata: [String: Any] = [
+                "reason": reason,
+                "transcript_preview": preview,
+                "client_received_at_ms": Int(Date().timeIntervalSince1970 * 1000)
+            ]
+            if let clientRequestedAtMs = clientRequestedAtMs {
+                metadata["client_requested_at_ms"] = clientRequestedAtMs
+            }
             DebugEventBuffer.shared.add(
                 id: "wake-ack-poll-\(Int(Date().timeIntervalSince1970 * 1000))",
                 triggerType: "guardian_wake_ack_poll_request",
                 message: "Wake candidate requested immediate Guardian next-audio poll",
-                metadata: [
-                    "reason": reason,
-                    "transcript_preview": preview
-                ]
+                metadata: metadata
             )
             GuardianModePollingService.shared.requestWakeAckPollBurst(reason: reason)
+        }
+    }
+
+    func recordWakeLatencyBreadcrumb(eventName: String, metadata: [String: Any]) {
+        queue.async { [weak self] in
+            guard let self = self, self.isActive else { return }
+
+            let normalizedName = eventName
+                .lowercased()
+                .replacingOccurrences(of: " ", with: "_")
+                .replacingOccurrences(of: "-", with: "_")
+            var eventMetadata = metadata
+            eventMetadata["client_native_received_at_ms"] = Int(Date().timeIntervalSince1970 * 1000)
+            DebugEventBuffer.shared.add(
+                id: "wake-latency-\(normalizedName)-\(Int(Date().timeIntervalSince1970 * 1000))",
+                triggerType: "guardian_\(normalizedName)",
+                message: "Guardian wake latency breadcrumb: \(normalizedName)",
+                metadata: eventMetadata
+            )
         }
     }
 
@@ -239,7 +263,8 @@ class GuardianModeManager: NSObject, AVSpeechSynthesizerDelegate {
             "port_type": portType,
             "port_name": portName,
             "device_uid": deviceUID,
-            "duration_ms": durationMs
+            "duration_ms": durationMs,
+            "client_ts_ms": Int(Date().timeIntervalSince1970 * 1000)
         ]
         body["queue_item_id"] = queueItemId
         if let traceId = traceId {

--- a/app/ios/Runner/GuardianMode/GuardianModePollingService.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModePollingService.swift
@@ -27,6 +27,8 @@ class GuardianModePollingService {
     private var isPollInFlight = false
     private var pollGeneration: UInt = 0
     private var lastScheduledDelay: TimeInterval = 0
+    private var lastImmediatePollRequestedAt: Date?
+    private let immediatePollThrottle: TimeInterval = 0.5
 
     struct PollResponse: Codable {
         let url: String?
@@ -155,6 +157,40 @@ class GuardianModePollingService {
         isPollInFlight = false
         consecutiveErrors = 0
         scheduleNextPollLocked(after: 0, reason: reason)
+    }
+
+    /// Wake acknowledgements are created immediately after the backend sees a
+    /// wake phrase, but the normal idle poll can still be several seconds away.
+    /// This interrupts the timer only while Guardian polling is active.
+    func requestWakeAckPollBurst(reason: String) {
+        let burstDelays: [TimeInterval] = [0.0, 1.0, 2.5]
+
+        for (index, delay) in burstDelays.enumerated() {
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.requestImmediatePoll(reason: "\(reason)_burst_\(index)")
+            }
+        }
+    }
+
+    private func requestImmediatePoll(reason: String) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        guard isPolling else {
+            NSLog("GuardianPolling: Ignoring immediate poll reason=\(reason) because polling is inactive")
+            return
+        }
+
+        let now = Date()
+        if let lastRequested = lastImmediatePollRequestedAt,
+           now.timeIntervalSince(lastRequested) < immediatePollThrottle {
+            NSLog("GuardianPolling: Throttled immediate poll reason=\(reason)")
+            return
+        }
+        lastImmediatePollRequestedAt = now
+
+        let delay = isPollInFlight ? 0.35 : 0.0
+        scheduleNextPollLocked(after: delay, reason: reason)
     }
 
     func statusSnapshot() -> [String: Any] {

--- a/app/ios/Runner/GuardianMode/GuardianModePollingService.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModePollingService.swift
@@ -190,6 +190,17 @@ class GuardianModePollingService {
         lastImmediatePollRequestedAt = now
 
         let delay = isPollInFlight ? 0.35 : 0.0
+        DebugEventBuffer.shared.add(
+            id: "next-audio-poll-request-\(Int(now.timeIntervalSince1970 * 1000))",
+            triggerType: "guardian_next_audio_poll_requested",
+            message: "Immediate Guardian next-audio poll requested",
+            metadata: [
+                "reason": reason,
+                "scheduled_delay_ms": Int(delay * 1000),
+                "is_poll_in_flight": isPollInFlight,
+                "client_native_requested_at_ms": Int(now.timeIntervalSince1970 * 1000)
+            ]
+        )
         scheduleNextPollLocked(after: delay, reason: reason)
     }
 

--- a/app/lib/ella/services/guardian_mode_service.dart
+++ b/app/lib/ella/services/guardian_mode_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 enum GuardianModeState {
@@ -79,6 +80,19 @@ class GuardianModeService {
     } catch (e) {
       print('GuardianMode: Error stopping: $e');
       _updateState(GuardianModeState.error);
+    }
+  }
+
+  /// Ask native iOS to interrupt the active Guardian poll timer after a likely
+  /// wake phrase. Native side still verifies Guardian is active.
+  Future<void> requestWakeAckPoll({String reason = 'wake_candidate', String? transcript}) async {
+    try {
+      await _channel.invokeMethod('requestWakeAckPoll', {
+        'reason': reason,
+        if (transcript != null) 'transcript': transcript,
+      });
+    } catch (e) {
+      debugPrint('GuardianMode: Error requesting wake ack poll: $e');
     }
   }
 

--- a/app/lib/ella/services/guardian_mode_service.dart
+++ b/app/lib/ella/services/guardian_mode_service.dart
@@ -89,11 +89,46 @@ class GuardianModeService {
     try {
       await _channel.invokeMethod('requestWakeAckPoll', {
         'reason': reason,
+        'client_requested_at_ms': DateTime.now().toUtc().millisecondsSinceEpoch,
         if (transcript != null) 'transcript': transcript,
       });
     } catch (e) {
       debugPrint('GuardianMode: Error requesting wake ack poll: $e');
     }
+  }
+
+  /// Records a Guardian latency breadcrumb through native iOS. Native side
+  /// drops it unless Guardian Mode is active, which avoids idle battery/network
+  /// work when the feature is off.
+  Future<void> recordLatencyBreadcrumb(String eventName, Map<String, Object?> fields) async {
+    try {
+      final now = DateTime.now().toUtc();
+      await _channel.invokeMethod('recordLatencyBreadcrumb', {
+        'event_name': eventName,
+        'metadata': _sanitizeMetadata({
+          ...fields,
+          'client_ts_ms': now.millisecondsSinceEpoch,
+          'client_ts_iso': now.toIso8601String(),
+        }),
+      });
+    } catch (e) {
+      debugPrint('GuardianMode: Error recording latency breadcrumb: $e');
+    }
+  }
+
+  Map<String, Object> _sanitizeMetadata(Map<String, Object?> fields) {
+    final sanitized = <String, Object>{};
+    fields.forEach((key, value) {
+      if (value == null) return;
+      if (value is String || value is num || value is bool) {
+        sanitized[key] = value;
+      } else if (value is Iterable) {
+        sanitized[key] = value.map((item) => item?.toString() ?? '').toList();
+      } else {
+        sanitized[key] = value.toString();
+      }
+    });
+    return sanitized;
   }
 
   /// Start timer to inject test audio clips

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -114,6 +114,7 @@ class CaptureProvider extends ChangeNotifier
   Timer? _recordingTimer;
   int _recordingDuration = 0; // in seconds
   DateTime? _lastGuardianWakeAckPollAt;
+  final Map<String, DateTime> _guardianLatencyBreadcrumbLastAt = {};
 
   int _getRecordingDuration() => _recordingDuration;
 
@@ -191,7 +192,61 @@ class CaptureProvider extends ChangeNotifier
     DebugLogManager.logEvent('guardian_wake_candidate_poll_requested', {
       'transcript_preview': preview.length > 120 ? preview.substring(0, 120) : preview,
     });
+    _recordGuardianLatencyBreadcrumb('wake_candidate_detected', {
+      'segment_count': newSegments.length,
+      'transcript_preview': preview.length > 120 ? preview.substring(0, 120) : preview,
+    });
+    _recordGuardianLatencyBreadcrumb('next_audio_poll_requested', {
+      'reason': 'transcript_wake_candidate',
+    });
     unawaited(GuardianModeService().requestWakeAckPoll(reason: 'transcript_wake_candidate', transcript: preview));
+  }
+
+  void _recordTranscriptReceiptBreadcrumb(List<TranscriptSegment> newSegments) {
+    if (!PlatformService.isIOS || newSegments.isEmpty) return;
+
+    final existingSegmentIds = segments.map((segment) => segment.id).toSet();
+    final hasExistingSegmentUpdate = newSegments.any((segment) => existingSegmentIds.contains(segment.id));
+    final hasNewSegment = newSegments.any((segment) => !existingSegmentIds.contains(segment.id));
+    final metadata = {
+      'segment_count': newSegments.length,
+      'segment_ids': newSegments.map((segment) => segment.id).take(5).toList(),
+      'text_lengths': newSegments.map((segment) => segment.text.length).take(5).toList(),
+      'speaker_ids': newSegments.map((segment) => segment.speakerId).take(5).toList(),
+      'speech_profile_processed': newSegments.map((segment) => segment.speechProfileProcessed).take(5).toList(),
+      'stt_providers': newSegments.map((segment) => segment.sttProvider ?? '').take(5).toList(),
+    };
+
+    if (hasExistingSegmentUpdate) {
+      _recordGuardianLatencyBreadcrumb('interim_transcript_received', metadata);
+    }
+    if (hasNewSegment) {
+      _recordGuardianLatencyBreadcrumb('final_transcript_received', metadata);
+    }
+  }
+
+  void _recordGuardianLatencyBreadcrumb(
+    String eventName,
+    Map<String, Object?> fields, {
+    Duration? throttle,
+  }) {
+    if (!PlatformService.isIOS) return;
+
+    if (throttle != null) {
+      final now = DateTime.now();
+      final lastAt = _guardianLatencyBreadcrumbLastAt[eventName];
+      if (lastAt != null && now.difference(lastAt) < throttle) return;
+      _guardianLatencyBreadcrumbLastAt[eventName] = now;
+    }
+
+    unawaited(GuardianModeService().recordLatencyBreadcrumb(eventName, {
+      ...fields,
+      'recording_state': recordingState.name,
+      'socket_connected': _socket?.state == SocketServiceState.connected,
+      'has_recording_device': _recordingDevice != null,
+      'recording_device_type': _recordingDevice?.type.name,
+      'recording_device_id': _recordingDevice?.id,
+    }));
   }
 
   CaptureProvider() {
@@ -696,6 +751,15 @@ class CaptureProvider extends ChangeNotifier
         _commandBytes.add(snapshot.sublist(3));
       }
 
+      _recordGuardianLatencyBreadcrumb(
+          'audio_frame_available',
+          {
+            'source': 'ble_device',
+            'bytes': snapshot.length,
+            'codec': codec.name,
+          },
+          throttle: const Duration(seconds: 2));
+
       // Local storage syncs
       var checkWalSupported =
           (_recordingDevice?.type == DeviceType.omi || _recordingDevice?.type == DeviceType.openglass) &&
@@ -714,6 +778,14 @@ class CaptureProvider extends ChangeNotifier
             (_recordingDevice?.type == DeviceType.omi || _recordingDevice?.type == DeviceType.openglass) ? 3 : 0;
         final trimmedValue = paddingLeft > 0 ? value.sublist(paddingLeft) : value;
         _socket?.send(trimmedValue);
+        _recordGuardianLatencyBreadcrumb(
+            'audio_chunk_sent_to_ws',
+            {
+              'source': 'ble_device',
+              'bytes': trimmedValue.length,
+              'codec': codec.name,
+            },
+            throttle: const Duration(seconds: 2));
 
         // Track bytes sent to websocket
         _wsSocketBytesSent += trimmedValue.length;
@@ -1028,8 +1100,24 @@ class CaptureProvider extends ChangeNotifier
 
     // record
     await ServiceManager.instance().mic.start(onByteReceived: (bytes) {
+      _recordGuardianLatencyBreadcrumb(
+          'audio_frame_available',
+          {
+            'source': 'phone_mic',
+            'bytes': bytes.length,
+            'codec': BleAudioCodec.pcm16.name,
+          },
+          throttle: const Duration(seconds: 2));
       if (_socket?.state == SocketServiceState.connected) {
         _socket?.send(bytes);
+        _recordGuardianLatencyBreadcrumb(
+            'audio_chunk_sent_to_ws',
+            {
+              'source': 'phone_mic',
+              'bytes': bytes.length,
+              'codec': BleAudioCodec.pcm16.name,
+            },
+            throttle: const Duration(seconds: 2));
       }
     }, onRecording: () {
       updateRecordingState(RecordingState.record);
@@ -1756,6 +1844,10 @@ class CaptureProvider extends ChangeNotifier
   void _processNewSegmentReceived(List<TranscriptSegment> newSegments) async {
     if (newSegments.isEmpty) return;
 
+    _recordGuardianLatencyBreadcrumb('scanner_transcript_dispatch_start', {
+      'segment_count': newSegments.length,
+    });
+    _recordTranscriptReceiptBreadcrumb(newSegments);
     _maybeRequestGuardianWakeAckPoll(newSegments);
 
     if (segments.isEmpty && !_isLoadingInProgressConversation) {
@@ -1784,6 +1876,10 @@ class CaptureProvider extends ChangeNotifier
     _segmentsPhotosVersion++; // Bump version so Selector rebuilds
     hasTranscripts = true;
     notifyListeners();
+    _recordGuardianLatencyBreadcrumb('scanner_transcript_dispatch_done', {
+      'segment_count': newSegments.length,
+      'remaining_new_segments': remainSegments.length,
+    });
   }
 
   void onConnectionStateChanged(bool isConnected) {

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -21,6 +21,7 @@ import 'package:omi/backend/schema/message.dart';
 import 'package:omi/backend/schema/person.dart';
 import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/ella/services/guardian_mode_service.dart';
 import 'package:omi/models/custom_stt_config.dart';
 import 'package:omi/providers/calendar_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
@@ -112,6 +113,7 @@ class CaptureProvider extends ChangeNotifier
 
   Timer? _recordingTimer;
   int _recordingDuration = 0; // in seconds
+  DateTime? _lastGuardianWakeAckPollAt;
 
   int _getRecordingDuration() => _recordingDuration;
 
@@ -162,6 +164,34 @@ class CaptureProvider extends ChangeNotifier
     final cachedIds = SharedPreferencesUtil().cachedPeople.map((p) => p.id).toSet();
     final segmentPersonIds = segments.map((s) => s.personId).whereType<String>().toSet();
     return segmentPersonIds.difference(cachedIds).isNotEmpty;
+  }
+
+  @visibleForTesting
+  static bool hasGuardianWakePhraseText(String text) {
+    final normalized = text.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), ' ').trim();
+    return RegExp(r'\b(hey|hi|hello|ok|okay)\s+ella\b').hasMatch(normalized);
+  }
+
+  bool _hasGuardianWakePhrase(List<TranscriptSegment> segments) =>
+      segments.any((segment) => hasGuardianWakePhraseText(segment.text));
+
+  String _guardianWakeTranscriptPreview(List<TranscriptSegment> segments) {
+    return segments.map((segment) => segment.text.trim()).where((text) => text.isNotEmpty).join(' ').trim();
+  }
+
+  void _maybeRequestGuardianWakeAckPoll(List<TranscriptSegment> newSegments) {
+    if (!PlatformService.isIOS || !_hasGuardianWakePhrase(newSegments)) return;
+
+    final now = DateTime.now();
+    final lastPollAt = _lastGuardianWakeAckPollAt;
+    if (lastPollAt != null && now.difference(lastPollAt) < const Duration(seconds: 6)) return;
+    _lastGuardianWakeAckPollAt = now;
+
+    final preview = _guardianWakeTranscriptPreview(newSegments);
+    DebugLogManager.logEvent('guardian_wake_candidate_poll_requested', {
+      'transcript_preview': preview.length > 120 ? preview.substring(0, 120) : preview,
+    });
+    unawaited(GuardianModeService().requestWakeAckPoll(reason: 'transcript_wake_candidate', transcript: preview));
   }
 
   CaptureProvider() {
@@ -1725,6 +1755,8 @@ class CaptureProvider extends ChangeNotifier
 
   void _processNewSegmentReceived(List<TranscriptSegment> newSegments) async {
     if (newSegments.isEmpty) return;
+
+    _maybeRequestGuardianWakeAckPoll(newSegments);
 
     if (segments.isEmpty && !_isLoadingInProgressConversation) {
       _isLoadingInProgressConversation = true;

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+781
+version: 1.0.524+782
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.524+780
+version: 1.0.524+781
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -283,6 +283,18 @@ void main() {
     });
   });
 
+  group('Guardian wake phrase detection', () {
+    test('detects common wake phrases with punctuation', () {
+      expect(CaptureProvider.hasGuardianWakePhraseText('Hey, Ella.'), true);
+      expect(CaptureProvider.hasGuardianWakePhraseText('Okay Ella can you help?'), true);
+    });
+
+    test('does not trigger on unrelated mentions', () {
+      expect(CaptureProvider.hasGuardianWakePhraseText('I talked to Ella yesterday'), false);
+      expect(CaptureProvider.hasGuardianWakePhraseText('hello there'), false);
+    });
+  });
+
   group('SpeakerLabelSuggestionEvent', () {
     test('ignores event when personId is empty', () {
       final provider = CaptureProvider();


### PR DESCRIPTION
## Summary
- Detect conservative iOS transcript wake candidates like `Hey, Ella` from the capture stream.
- Request a native Guardian next-audio poll burst immediately after wake detection while Guardian is active.
- Keep idle poll cadence unchanged and add wake phrase matcher tests.

## Validation
- `flutter test test/providers/capture_provider_test.dart`
- `./test.sh`

## Notes
- This is scoped to the iOS active Guardian/TestFlight line and intentionally does not change backend, caregiver, n8n, Firebase, auth, or signing config.
- Local thinking pulse was evaluated but deferred: first patch consumes backend ack faster without adding a new UI/audio state that could become stale while full response is pending.