### PR TITLE
Complete MCP OAuth auto-discovery (PKCE, WWW-Authenticate, client_id)

### DIFF
--- a/backend/ella/routers/mcp_onboarding.py
+++ b/backend/ella/routers/mcp_onboarding.py
@@ -127,7 +127,9 @@ def _authenticate_connector_session(
         if token in tokens:
             return resolve_static_connector_session(_fingerprint(token), selected_profile_uid)
         if not tokens and "not configured" in str(session_error):
-            raise HTTPException(status_code=503, detail="MCP bearer authentication is not configured") from session_error
+            raise HTTPException(
+                status_code=503, detail="MCP bearer authentication is not configured"
+            ) from session_error
         raise HTTPException(status_code=401, detail="Invalid or expired MCP bearer token") from session_error
 
 
@@ -246,21 +248,47 @@ def _issue_oauth_token_response(resolution: MCPIdentityResolution, *, ttl_second
     }
 
 
-def _store_authorization_code(resolution: MCPIdentityResolution) -> str:
+def _store_authorization_code(
+    resolution: MCPIdentityResolution,
+    code_challenge: str = "",
+    code_challenge_method: str = "",
+) -> str:
     code = uuid.uuid4().hex
     _auth_codes[code] = {
         "resolution": resolution,
         "expires_at": time.time() + _oauth_code_ttl_seconds(),
+        "code_challenge": code_challenge,
+        "code_challenge_method": code_challenge_method,
     }
     return code
 
 
-def _consume_authorization_code(code: str) -> MCPIdentityResolution:
+def _verify_pkce(code_verifier: str, code_challenge: str, method: str) -> bool:
+    """Verify PKCE code_verifier against stored code_challenge."""
+    if method == "S256":
+        digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+        import base64 as _b64
+
+        computed = _b64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+        return computed == code_challenge
+    if method == "plain":
+        return code_verifier == code_challenge
+    return False
+
+
+def _consume_authorization_code(code: str, code_verifier: str = "") -> MCPIdentityResolution:
     item = _auth_codes.pop(code, None)
     if not item:
         raise HTTPException(status_code=400, detail="Invalid authorization code")
     if time.time() > float(item.get("expires_at") or 0):
         raise HTTPException(status_code=400, detail="Expired authorization code")
+    stored_challenge = item.get("code_challenge") or ""
+    stored_method = item.get("code_challenge_method") or ""
+    if stored_challenge:
+        if not code_verifier:
+            raise HTTPException(status_code=400, detail="code_verifier is required (PKCE)")
+        if not _verify_pkce(code_verifier, stored_challenge, stored_method):
+            raise HTTPException(status_code=400, detail="Invalid code_verifier (PKCE)")
     return item["resolution"]
 
 
@@ -290,6 +318,8 @@ def _render_mcp_oauth_page(
     redirect_uri: str,
     state: str = "",
     scope: str = "",
+    code_challenge: str = "",
+    code_challenge_method: str = "",
 ) -> Response:
     if not _firebase_web_configured():
         return Response(
@@ -308,6 +338,8 @@ def _render_mcp_oauth_page(
         "redirectUri": redirect_uri,
         "state": state,
         "scope": scope,
+        "codeChallenge": code_challenge,
+        "codeChallengeMethod": code_challenge_method,
         "authorizeUrl": "/v1/ella/mcp/authorize",
         "onboardingUrl": "/v1/ella/mcp/onboarding/oauth",
         "firebaseConfig": _firebase_web_config(),
@@ -368,6 +400,8 @@ def _render_mcp_oauth_page(
       }});
       if (page.state) params.set("state", page.state);
       if (page.scope) params.set("scope", page.scope);
+      if (page.codeChallenge) params.set("code_challenge", page.codeChallenge);
+      if (page.codeChallengeMethod) params.set("code_challenge_method", page.codeChallengeMethod);
       if (selectedProfileUid) params.set("selected_profile_uid", selectedProfileUid);
       window.location.href = page.authorizeUrl + "?" + params.toString();
     }}
@@ -450,13 +484,19 @@ async def get_mcp_authorize(
     redirect_uri: str,
     state: Optional[str] = None,
     scope: Optional[str] = None,
+    code_challenge: Optional[str] = Query(None, description="PKCE code challenge (RFC 7636)."),
+    code_challenge_method: Optional[str] = Query(None, description="PKCE method, must be S256."),
+    resource: Optional[str] = Query(None, description="RFC 8707 resource indicator."),
     firebase_id_token: str = Query("", description="Verified Firebase ID token supplied by the auth handoff page."),
     selected_profile_uid: str = Query("", description="Selected Ella profile UID for multi-profile identities."),
 ):
     if response_type != "code":
         raise HTTPException(status_code=400, detail="response_type must be code")
-    if client_id != _oauth_client_id():
+    # Accept our static client_id OR any HTTPS URL (Client ID Metadata Document per MCP spec)
+    if client_id != _oauth_client_id() and not client_id.startswith("https://"):
         raise HTTPException(status_code=400, detail="Invalid client_id")
+    if code_challenge_method and code_challenge_method != "S256":
+        raise HTTPException(status_code=400, detail="code_challenge_method must be S256")
     if not firebase_id_token:
         return _render_mcp_oauth_page(
             response_type=response_type,
@@ -464,6 +504,8 @@ async def get_mcp_authorize(
             redirect_uri=redirect_uri,
             state=state or "",
             scope=scope or "",
+            code_challenge=code_challenge or "",
+            code_challenge_method=code_challenge_method or "",
         )
 
     resolution = resolve_oauth_connector_resolution(
@@ -481,7 +523,11 @@ async def get_mcp_authorize(
                 "state": state,
             },
         )
-    code = _store_authorization_code(resolution)
+    code = _store_authorization_code(
+        resolution,
+        code_challenge=code_challenge or "",
+        code_challenge_method=code_challenge_method or "S256" if code_challenge else "",
+    )
     return _redirect_with_params(redirect_uri, {"code": code, "state": state})
 
 
@@ -489,13 +535,14 @@ async def get_mcp_authorize(
 async def post_mcp_token(request: Request):
     data = await _parse_token_request(request)
     client_id = str(data.get("client_id") or "")
-    if client_id and client_id != _oauth_client_id():
+    if client_id and client_id != _oauth_client_id() and not client_id.startswith("https://"):
         raise HTTPException(status_code=400, detail="Invalid client_id")
 
     ttl_seconds = _mcp_session_ttl_seconds(data.get("ttl_seconds") or data.get("expires_in"))
     grant_type = str(data.get("grant_type") or "").strip()
     if grant_type in {"authorization_code", ""} and data.get("code"):
-        resolution = _consume_authorization_code(str(data.get("code") or ""))
+        code_verifier = str(data.get("code_verifier") or "").strip()
+        resolution = _consume_authorization_code(str(data.get("code") or ""), code_verifier=code_verifier)
         return _issue_oauth_token_response(resolution, ttl_seconds=ttl_seconds)
 
     if grant_type in {

--- a/backend/ella/routers/mcp_well_known.py
+++ b/backend/ella/routers/mcp_well_known.py
@@ -28,6 +28,18 @@ def _base_url() -> str:
     return _BASE_URL.rstrip("/")
 
 
+@router.get("/.well-known/oauth-protected-resource/v1/ella/plato/mcp")
+async def get_oauth_protected_resource_subpath():
+    """RFC 9728 — Path-specific Protected Resource Metadata.
+
+    MCP clients try the path-specific URI first (the MCP endpoint path
+    appended to /.well-known/oauth-protected-resource), then fall back
+    to the root. This endpoint ensures immediate discovery for clients
+    following the spec strictly.
+    """
+    return await get_oauth_protected_resource()
+
+
 @router.get("/.well-known/oauth-protected-resource")
 async def get_oauth_protected_resource():
     """RFC 9728 — OAuth 2.0 Protected Resource Metadata.
@@ -73,6 +85,7 @@ async def get_oauth_authorization_server():
             "grant_types_supported": [
                 "authorization_code",
             ],
+            "code_challenge_methods_supported": ["S256"],
             "scopes_supported": [
                 "context:read",
                 "memory:read",
@@ -84,6 +97,7 @@ async def get_oauth_authorization_server():
                 "proposals:write",
             ],
             "token_endpoint_auth_methods_supported": ["none"],
+            "client_id_metadata_document_supported": True,
             "service_documentation": f"{base}/v1/ella/mcp/info",
         },
         headers={"Cache-Control": "public, max-age=3600"},

--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -140,10 +140,20 @@ def _fingerprint(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
 
 
+_WWW_AUTHENTICATE = (
+    'Bearer resource_metadata="https://api.ella-ai-care.com/.well-known/oauth-protected-resource",'
+    ' scope="context:read memory:read profile:read startup:read timeline:read tools:read"'
+)
+
+
 def _authenticate(authorization: Optional[str]) -> str:
     token = _token_from_authorization(authorization)
     if not token:
-        raise HTTPException(status_code=401, detail="Invalid or missing Plato MCP bearer token")
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid or missing Plato MCP bearer token",
+            headers={"WWW-Authenticate": _WWW_AUTHENTICATE},
+        )
 
     tokens = _allowed_tokens()
     if token in tokens:
@@ -155,10 +165,24 @@ def _authenticate(authorization: Optional[str]) -> str:
     except ValueError as exc:
         if not tokens and "not configured" in str(exc):
             raise HTTPException(status_code=503, detail="Plato MCP token is not configured") from exc
-        raise HTTPException(status_code=401, detail="Invalid or missing Plato MCP bearer token") from exc
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid or missing Plato MCP bearer token",
+            headers={"WWW-Authenticate": _WWW_AUTHENTICATE},
+        ) from exc
 
     if "tools:read" not in set(claims.get("scopes") or []):
-        raise HTTPException(status_code=403, detail="MCP bearer token is missing tools:read scope")
+        raise HTTPException(
+            status_code=403,
+            detail="MCP bearer token is missing tools:read scope",
+            headers={
+                "WWW-Authenticate": (
+                    'Bearer error="insufficient_scope",'
+                    ' scope="tools:read",'
+                    ' resource_metadata="https://api.ella-ai-care.com/.well-known/oauth-protected-resource"'
+                )
+            },
+        )
     _check_rate_limit(token)
     return _fingerprint(token)
 


### PR DESCRIPTION
## Summary
- Adds `WWW-Authenticate: Bearer resource_metadata=...` header to all 401 responses from the Plato MCP endpoint — this is the **primary** discovery mechanism per MCP auth spec
- Adds PKCE (S256) support to `/v1/ella/mcp/authorize` and `/v1/ella/mcp/token` endpoints — **required** by MCP spec, clients MUST refuse to proceed without it
- Adds `code_challenge_methods_supported: ["S256"]` and `client_id_metadata_document_supported: true` to `/.well-known/oauth-authorization-server` metadata
- Adds path-specific `/.well-known/oauth-protected-resource/v1/ella/plato/mcp` — clients try this before the root endpoint per RFC 9728
- Relaxes `client_id` validation to accept HTTPS URL-formatted IDs (Client ID Metadata Documents per MCP spec, needed for Grok and other connectors)
- Forwards PKCE parameters through the OAuth consent page JavaScript

## Context
Follow-up to ellaaicare/omi#210 which added the basic well-known endpoints. That got the form pre-filled but didn't trigger the auto-discovery OAuth flow. This PR adds the missing pieces that MCP clients need for full automatic OAuth.

## Test plan
- [ ] `curl -s https://api.ella-ai-care.com/v1/ella/plato/mcp -D-` shows `WWW-Authenticate` header in 401 response
- [ ] `curl -s https://api.ella-ai-care.com/.well-known/oauth-authorization-server` includes `code_challenge_methods_supported`
- [ ] `curl -s https://api.ella-ai-care.com/.well-known/oauth-protected-resource/v1/ella/plato/mcp` returns same data as root
- [ ] Grok Custom Connector can auto-discover OAuth from SSE endpoint URL

Refs ellaaicare/ella-ai#999

🤖 Generated with [Claude Code](https://claude.com/claude-code)