### PR TITLE
Fix temporal OMI recall windows

### DIFF
--- a/backend/ella/routers/chat.py
+++ b/backend/ella/routers/chat.py
@@ -22,8 +22,9 @@ import json
 import logging
 import os
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
+from zoneinfo import ZoneInfo
 
 import httpx
 from fastapi import APIRouter, Header, Request
@@ -39,6 +40,7 @@ from utils.ella.canonical_context import (
     fetch_canonical_timeline,
     format_canonical_context,
 )
+from utils.ella.time_context import timezone_name
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +59,9 @@ HERMES_AGENT_ID = os.getenv("HERMES_AGENT_ID", "hermes")
 HERMES_MODEL = os.getenv("HERMES_MODEL", "plato-eval")
 CHAT_CONTEXT_LIMIT = int(os.getenv("ELLA_CHAT_CANONICAL_CONTEXT_LIMIT", "25"))
 CHAT_CONTEXT_MAX_CHARS = int(os.getenv("ELLA_CHAT_CANONICAL_CONTEXT_MAX_CHARS", "6000"))
+CHAT_TEMPORAL_CONTEXT_LIMIT = int(os.getenv("ELLA_CHAT_TEMPORAL_CONTEXT_LIMIT", "250"))
+CHAT_TEMPORAL_CONTEXT_MAX_CHARS = int(os.getenv("ELLA_CHAT_TEMPORAL_CONTEXT_MAX_CHARS", "9000"))
+CHAT_USER_TIMEZONE = timezone_name(os.getenv("ELLA_USER_TIMEZONE", os.getenv("ELLA_PLATO_TIMEZONE", "")))
 CHAT_CONTEXT_CHANNELS = [
     channel.strip()
     for channel in os.getenv("ELLA_CHAT_CANONICAL_CHANNELS", ",".join(DEFAULT_CONTEXT_CHANNELS)).split(",")
@@ -91,13 +96,23 @@ def _resolve_debug_level(header_value: str = None) -> int:
     return ELLA_CONFIG.debug_level
 
 
-async def _fetch_chat_canonical_events(uid: str, *, limit: int, before: str = None) -> list[dict]:
+async def _fetch_chat_canonical_events(
+    uid: str,
+    *,
+    limit: int,
+    before: str = None,
+    channels: list[str] | None = None,
+    since: str = None,
+    user_timezone: str = None,
+) -> list[dict]:
     try:
         events = await fetch_canonical_timeline(
             uid,
             limit=limit,
-            channels=CHAT_CONTEXT_CHANNELS,
+            channels=channels or CHAT_CONTEXT_CHANNELS,
+            since=since,
             before=before,
+            user_timezone=user_timezone,
         )
         logger.info("[FLOW:CANONICAL-CONTEXT] uid=%s events=%s source=timeline", uid, len(events))
         return events
@@ -108,6 +123,89 @@ async def _fetch_chat_canonical_events(uid: str, *, limit: int, before: str = No
             e,
         )
         return []
+
+
+def _chat_temporal_window(user_message: str) -> tuple[str | None, datetime | None, datetime | None]:
+    """Detect user-local recall windows that shallow recent context often misses."""
+    text = user_message.lower()
+    temporal_terms = (
+        "this morning",
+        "morning",
+        "today",
+        "earlier",
+        "latest omi",
+        "last omi",
+        "omi conversation",
+        "necklace",
+        "captured",
+    )
+    if not any(term in text for term in temporal_terms):
+        return None, None, None
+    tz = ZoneInfo(CHAT_USER_TIMEZONE)
+    now_local = datetime.now(timezone.utc).astimezone(tz)
+    start_of_day = datetime(now_local.year, now_local.month, now_local.day, tzinfo=tz)
+    if "morning" in text:
+        return (
+            "same-day morning OMI context",
+            (start_of_day + timedelta(hours=5)).astimezone(timezone.utc),
+            (start_of_day + timedelta(hours=12)).astimezone(timezone.utc),
+        )
+    return "same-day OMI context", start_of_day.astimezone(timezone.utc), now_local.astimezone(timezone.utc)
+
+
+def _event_datetime(event: dict, key: str = "started_at") -> datetime | None:
+    raw = event.get(key) or event.get("created_at") or event.get("timestamp")
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _filter_events_window(events: list[dict], since: datetime, until: datetime) -> list[dict]:
+    filtered = []
+    for event in events:
+        started = _event_datetime(event, "started_at")
+        ended = _event_datetime(event, "ended_at") or started
+        if started is None or ended is None:
+            continue
+        if ended >= since and started <= until:
+            filtered.append(event)
+    return filtered
+
+
+def _is_low_value_omi_event(event: dict) -> bool:
+    title = str(event.get("title") or "").lower()
+    text = str(event.get("text") or event.get("overview") or event.get("summary") or "").strip()
+    metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+    tags = metadata.get("ella_tags") if isinstance(metadata.get("ella_tags"), list) else []
+    if "low_signal" in tags:
+        return True
+    if "brief" in title or "fragment" in title or "utterance" in title:
+        return True
+    if len(text) <= 180:
+        return True
+    return False
+
+
+async def _fetch_temporal_chat_context(uid: str, user_message: str) -> tuple[str, list[dict]]:
+    label, since, until = _chat_temporal_window(user_message)
+    if not label or since is None or until is None:
+        return "", []
+    events = await _fetch_chat_canonical_events(
+        uid,
+        limit=CHAT_TEMPORAL_CONTEXT_LIMIT,
+        channels=["omi"],
+        since=(since - timedelta(hours=2)).isoformat().replace("+00:00", "Z"),
+        user_timezone=CHAT_USER_TIMEZONE,
+    )
+    window_events = _filter_events_window(events, since, until)
+    meaningful_events = [event for event in window_events if not _is_low_value_omi_event(event)]
+    return label, meaningful_events or window_events
 
 
 async def _stream_level_1_ack(user_message: str):
@@ -311,6 +409,12 @@ async def _stream_level_4_openclaw(user_message: str, uid: str, client_info: dic
 
     canonical_events = await _fetch_chat_canonical_events(uid, limit=CHAT_CONTEXT_LIMIT)
     canonical_context = format_canonical_context(canonical_events, max_chars=CHAT_CONTEXT_MAX_CHARS)
+    temporal_label, temporal_events = await _fetch_temporal_chat_context(uid, user_message)
+    temporal_context = format_canonical_context(
+        temporal_events,
+        max_chars=CHAT_TEMPORAL_CONTEXT_MAX_CHARS,
+        user_timezone=CHAT_USER_TIMEZONE,
+    )
     messages = []
     if canonical_context:
         messages.append(
@@ -328,6 +432,17 @@ async def _stream_level_4_openclaw(user_message: str, uid: str, client_info: dic
         print(
             f"[FLOW:CHAT-L4] uid={uid} canonical_context=empty fallback=openclaw_session_history_migration",
             flush=True,
+        )
+    if temporal_context:
+        messages.append(
+            {
+                "role": "system",
+                "content": (
+                    f"Additional {temporal_label}. Use this when the user asks about today, this morning, "
+                    "or OMI/necklace captures; do not claim the window is empty if events are listed here.\n\n"
+                    f"{temporal_context}"
+                ),
+            }
         )
     messages.append({"role": "user", "content": user_message})
 
@@ -441,6 +556,12 @@ async def _stream_hermes_chat(user_message: str, uid: str, client_info: dict = N
     text = []
     canonical_events = await _fetch_chat_canonical_events(uid, limit=CHAT_CONTEXT_LIMIT)
     canonical_context = format_canonical_context(canonical_events, max_chars=CHAT_CONTEXT_MAX_CHARS)
+    temporal_label, temporal_events = await _fetch_temporal_chat_context(uid, user_message)
+    temporal_context = format_canonical_context(
+        temporal_events,
+        max_chars=CHAT_TEMPORAL_CONTEXT_MAX_CHARS,
+        user_timezone=CHAT_USER_TIMEZONE,
+    )
     messages = []
     if canonical_context:
         messages.append(
@@ -459,9 +580,20 @@ async def _stream_hermes_chat(user_message: str, uid: str, client_info: dict = N
             f"[FLOW:CHAT-HERMES] uid={uid} canonical_context=empty fallback=hermes_session_history_migration",
             flush=True,
         )
+    if temporal_context:
+        messages.append(
+            {
+                "role": "system",
+                "content": (
+                    f"Additional {temporal_label}. Use this when the user asks about today, this morning, "
+                    "or OMI/necklace captures; do not claim the window is empty if events are listed here.\n\n"
+                    f"{temporal_context}"
+                ),
+            }
+        )
     messages.append({"role": "user", "content": user_message})
     print(
-        f"[FLOW:CHAT-HERMES] uid={uid} gateway={HERMES_GATEWAY_URL} session={session_key} canonical_events={len(canonical_events)}",
+        f"[FLOW:CHAT-HERMES] uid={uid} gateway={HERMES_GATEWAY_URL} session={session_key} canonical_events={len(canonical_events)} temporal_events={len(temporal_events)}",
         flush=True,
     )
 
@@ -784,12 +916,22 @@ async def ella_chat_history(
             return result
         elif response.status_code == 404:
             logger.warning(f"[FLOW:HISTORY] uid={uid} agent={agent_id} no_sessions latency={_elapsed}ms")
-            return {"messages": [], "hasMore": False, "source": "provision_openclaw_history_migration", "fallback": True}
+            return {
+                "messages": [],
+                "hasMore": False,
+                "source": "provision_openclaw_history_migration",
+                "fallback": True,
+            }
         else:
             logger.error(
                 f"[FLOW:HISTORY] uid={uid} agent={agent_id} status={response.status_code} latency={_elapsed}ms"
             )
-            return {"messages": [], "hasMore": False, "source": "provision_openclaw_history_migration", "fallback": True}
+            return {
+                "messages": [],
+                "hasMore": False,
+                "source": "provision_openclaw_history_migration",
+                "fallback": True,
+            }
 
     except httpx.TimeoutException:
         _elapsed = int((_time.time() - _start) * 1000)

--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -48,11 +48,39 @@ DEFAULT_HERMES_AGENT_ID = "hermes"
 DEFAULT_PROVISION_API_URL = "http://100.76.138.56:8200"
 
 MAX_CONTEXT_LIMIT = 50
+MAX_WINDOW_CONTEXT_LIMIT = 500
 MAX_SEARCH_RESULTS = 20
 MAX_PROMPT_CHARS = 4000
 MAX_CONSULT_CONTEXT_CHARS = 7000
 RATE_LIMIT_WINDOW_SECONDS = 60
 SALIENCE_RANKS = {"none": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
+SEARCH_STOPWORDS = {
+    "about",
+    "after",
+    "before",
+    "capture",
+    "captured",
+    "conversation",
+    "conversations",
+    "did",
+    "earlier",
+    "evening",
+    "happen",
+    "happened",
+    "happens",
+    "latest",
+    "last",
+    "morning",
+    "necklace",
+    "omi",
+    "that",
+    "this",
+    "today",
+    "what",
+    "when",
+    "where",
+    "with",
+}
 COMPANION_PROPOSAL_TYPES = {
     "scanner_rule_change",
     "reminder_request",
@@ -256,6 +284,70 @@ def _parse_duration_seconds(value: Any, default_seconds: int = 30 * 60) -> int:
     raise ToolExecutionError(f"Invalid time_range: {value}", code=-32602)
 
 
+def _parse_local_date_window(arguments: dict[str, Any], tz_name: str) -> tuple[Optional[datetime], Optional[datetime]]:
+    """Parse explicit local-date / part-of-day arguments into UTC bounds."""
+    local_date = str(arguments.get("local_date") or arguments.get("date") or "").strip()
+    if not local_date:
+        return None, None
+    try:
+        date_value = datetime.fromisoformat(local_date).date()
+    except ValueError as exc:
+        raise ToolExecutionError(f"Invalid local_date: {local_date}", code=-32602) from exc
+
+    tz = ZoneInfo(tz_name)
+    part = str(arguments.get("part_of_day") or arguments.get("day_part") or "day").strip().lower()
+    ranges = {
+        "day": (0, 24),
+        "today": (0, 24),
+        "morning": (5, 12),
+        "afternoon": (12, 17),
+        "evening": (17, 22),
+        "night": (22, 24),
+    }
+    if part in {"overnight", "early_morning"}:
+        start_hour, end_hour = 0, 5
+    elif part in ranges:
+        start_hour, end_hour = ranges[part]
+    else:
+        raise ToolExecutionError(f"Invalid part_of_day: {part}", code=-32602)
+    since_local = datetime(date_value.year, date_value.month, date_value.day, start_hour, tzinfo=tz)
+    until_local = (
+        datetime(date_value.year, date_value.month, date_value.day, 0, tzinfo=tz) + timedelta(days=1)
+        if end_hour == 24
+        else datetime(date_value.year, date_value.month, date_value.day, end_hour, tzinfo=tz)
+    )
+    return since_local.astimezone(timezone.utc), until_local.astimezone(timezone.utc)
+
+
+def _infer_query_time_window(query: str, tz_name: str) -> tuple[Optional[datetime], Optional[datetime], str]:
+    """Infer a broad local time window for natural-language temporal recall queries."""
+    text = query.lower()
+    tz = ZoneInfo(tz_name)
+    now_local = datetime.now(timezone.utc).astimezone(tz)
+    start_of_day = datetime(now_local.year, now_local.month, now_local.day, tzinfo=tz)
+    if "this morning" in text or re.search(r"\bmorning\b", text):
+        return (
+            (start_of_day + timedelta(hours=5)).astimezone(timezone.utc),
+            (start_of_day + timedelta(hours=12)).astimezone(timezone.utc),
+            "morning",
+        )
+    if "this afternoon" in text or re.search(r"\bafternoon\b", text):
+        return (
+            (start_of_day + timedelta(hours=12)).astimezone(timezone.utc),
+            (start_of_day + timedelta(hours=17)).astimezone(timezone.utc),
+            "afternoon",
+        )
+    if "this evening" in text or re.search(r"\bevening\b", text):
+        return (
+            (start_of_day + timedelta(hours=17)).astimezone(timezone.utc),
+            (start_of_day + timedelta(hours=22)).astimezone(timezone.utc),
+            "evening",
+        )
+    if re.search(r"\btoday\b", text) or "latest omi" in text or "omi conversation" in text:
+        return start_of_day.astimezone(timezone.utc), now_local.astimezone(timezone.utc), "today"
+    return None, None, ""
+
+
 def _event_datetime(item: dict[str, Any], *keys: str) -> Optional[datetime]:
     for key in keys:
         try:
@@ -310,6 +402,23 @@ def _is_low_salience_fragment(item: dict[str, Any]) -> bool:
     if len(text) <= 240:
         return True
     if isinstance(segment_count, int) and segment_count <= 2 and "brief" in title:
+        return True
+    return False
+
+
+def _is_temporal_low_value_fragment(item: dict[str, Any]) -> bool:
+    """More aggressive fragment filter for broad 'what happened this morning' recall."""
+    if _is_low_salience_fragment(item):
+        return True
+    title = str(item.get("title") or "").lower()
+    text = _compact_text(item.get("text") or item.get("overview") or item.get("summary") or "", 500)
+    metadata = item.get("metadata") or {}
+    tags = metadata.get("ella_tags") if isinstance(metadata, dict) else []
+    if isinstance(tags, list) and "low_signal" in tags:
+        return True
+    if "brief" in title or "fragment" in title or "utterance" in title:
+        return True
+    if len(text) <= 180:
         return True
     return False
 
@@ -467,7 +576,8 @@ def _fallback_recent_context(limit: int, channels: list[str], since: Optional[st
 
 
 async def _recent_context(arguments: dict[str, Any]) -> dict[str, Any]:
-    limit = _clamp_int(arguments.get("limit"), 10, 1, MAX_CONTEXT_LIMIT)
+    max_limit = MAX_WINDOW_CONTEXT_LIMIT if arguments.get("_allow_large_window") else MAX_CONTEXT_LIMIT
+    limit = _clamp_int(arguments.get("limit"), 10, 1, max_limit)
     raw_channels = arguments.get("channels") or []
     channels = (
         [str(item).strip() for item in raw_channels if str(item).strip()] if isinstance(raw_channels, list) else []
@@ -525,15 +635,27 @@ async def _omi_activity_window(arguments: dict[str, Any]) -> dict[str, Any]:
     until = _parse_iso_datetime(arguments.get("until")) or datetime.now(timezone.utc)
     since = _parse_iso_datetime(arguments.get("since"))
     duration_seconds = None
-    if since is None:
+    local_since, local_until = _parse_local_date_window(arguments, tz_name)
+    if local_since is not None and local_until is not None:
+        since = local_since
+        until = local_until
+    elif since is None:
         duration_seconds = _parse_duration_seconds(arguments.get("time_range"), default_seconds=30 * 60)
         since = until - timedelta(seconds=duration_seconds)
-    limit = _clamp_int(arguments.get("limit"), MAX_CONTEXT_LIMIT, 1, MAX_CONTEXT_LIMIT)
+    limit = _clamp_int(arguments.get("limit"), MAX_CONTEXT_LIMIT, 1, MAX_WINDOW_CONTEXT_LIMIT)
 
-    # Pull a recent OMI window without relying on model-side filtering. We do
-    # not pass since here because a multi-minute conversation can start before
-    # the window but end inside it.
-    context = await _recent_context({"limit": limit, "channels": ["omi"]})
+    # Pull enough source rows for the requested local-time window instead of
+    # only the last few fragments. Include a small lookback buffer so a
+    # multi-minute conversation that began before the window can still overlap.
+    fetch_since = since - timedelta(hours=2)
+    context = await _recent_context(
+        {
+            "limit": max(limit, 200),
+            "channels": ["omi"],
+            "since": fetch_since.isoformat().replace("+00:00", "Z"),
+            "_allow_large_window": True,
+        }
+    )
     events = [
         annotate_event_time(dict(event), tz_name=tz_name)
         for event in context.get("events", [])
@@ -587,7 +709,9 @@ async def _omi_activity_window(arguments: dict[str, Any]) -> dict[str, Any]:
 
 
 def _tokens(text: str) -> set[str]:
-    return {token for token in re.findall(r"[a-zA-Z0-9][a-zA-Z0-9_-]{2,}", text.lower())}
+    return {
+        token for token in re.findall(r"[a-zA-Z0-9][a-zA-Z0-9_-]{2,}", text.lower()) if token not in SEARCH_STOPWORDS
+    }
 
 
 def _score_item(query_tokens: set[str], item: dict[str, Any]) -> int:
@@ -618,25 +742,35 @@ async def _search_memory(arguments: dict[str, Any]) -> dict[str, Any]:
     if not query:
         raise ToolExecutionError("query is required", code=-32602)
     max_results = _clamp_int(arguments.get("max_results"), 5, 1, MAX_SEARCH_RESULTS)
+    tz_name = _plato_timezone()
+    inferred_since, inferred_until, inferred_label = _infer_query_time_window(query, tz_name)
+    since = arguments.get("since") or (
+        inferred_since.isoformat().replace("+00:00", "Z") if inferred_since is not None else None
+    )
     context = await _recent_context(
         {
-            "limit": max(max_results * 5, 25),
+            "limit": max(max_results * 12, 80) if inferred_since else max(max_results * 5, 25),
             "channels": arguments.get("channels") or [],
-            "since": arguments.get("since"),
+            "since": since,
+            "_allow_large_window": bool(inferred_since),
         }
     )
+    events = context.get("events", [])
+    if inferred_since is not None and inferred_until is not None:
+        events = [event for event in events if _event_overlaps_window(event, inferred_since, inferred_until)]
     query_tokens = _tokens(query)
-    ranked = [
-        (score, idx, item)
-        for idx, item in enumerate(context.get("events", []))
-        if (score := _score_item(query_tokens, item)) > 0
-    ]
+    ranked = [(score, idx, item) for idx, item in enumerate(events) if (score := _score_item(query_tokens, item)) > 0]
     ranked.sort(key=lambda row: (row[0], -row[1]), reverse=True)
+    results = [item for _score, _idx, item in ranked[:max_results]]
+    if inferred_since is not None and not results:
+        meaningful_events = [item for item in events if not _is_temporal_low_value_fragment(item)]
+        results = (meaningful_events or list(events))[-max_results:]
     return {
         "query": query,
         "source": context.get("source"),
+        "inferred_time_window": inferred_label or None,
         "time_context": context.get("time_context") or build_time_context(_plato_timezone()),
-        "results": [item for _score, _idx, item in ranked[:max_results]],
+        "results": results,
     }
 
 
@@ -958,7 +1092,8 @@ MCP_TOOLS: list[dict[str, Any]] = [
         "name": "plato_omi_activity_window",
         "description": (
             "Return OMI/necklace conversations in a local-time activity window, split into meaningful moments "
-            "and low-salience fragments. Use this for questions like 'what happened in OMI in the last 30 minutes'."
+            "and low-salience fragments. Use this for questions like 'what happened in OMI in the last 30 minutes', "
+            "'what happened this morning', or 'what did OMI capture today'."
         ),
         "inputSchema": {
             "type": "object",
@@ -970,9 +1105,23 @@ MCP_TOOLS: list[dict[str, Any]] = [
                 },
                 "since": {"type": "string", "description": "Optional ISO timestamp lower bound."},
                 "until": {"type": "string", "description": "Optional ISO timestamp upper bound; defaults to now."},
+                "local_date": {
+                    "type": "string",
+                    "description": "Optional YYYY-MM-DD in the user's local timezone for day/part-of-day windows.",
+                },
+                "part_of_day": {
+                    "type": "string",
+                    "enum": ["day", "morning", "afternoon", "evening", "night", "overnight"],
+                    "description": "Optional local day segment; requires local_date.",
+                },
                 "timezone": {"type": "string", "default": "America/Los_Angeles"},
                 "local_time_zone": {"type": "string", "description": "Alias accepted for timezone, e.g. PDT."},
-                "limit": {"type": "integer", "default": MAX_CONTEXT_LIMIT, "minimum": 1, "maximum": MAX_CONTEXT_LIMIT},
+                "limit": {
+                    "type": "integer",
+                    "default": MAX_CONTEXT_LIMIT,
+                    "minimum": 1,
+                    "maximum": MAX_WINDOW_CONTEXT_LIMIT,
+                },
                 "include_fragments": {"type": "boolean", "default": True},
             },
         },

--- a/backend/tests/unit/test_ella_chat_temporal_context.py
+++ b/backend/tests/unit/test_ella_chat_temporal_context.py
@@ -1,0 +1,49 @@
+import asyncio
+from datetime import datetime, timezone
+
+from ella.routers import chat
+
+
+def test_temporal_chat_context_filters_morning_omi_fragments(monkeypatch):
+    async def fake_fetch(uid, *, limit, before=None, channels=None, since=None, user_timezone=None):
+        assert uid == "uid-1"
+        assert channels == ["omi"]
+        assert since
+        return [
+            {
+                "event_id": "cafe",
+                "channel": "omi",
+                "title": "Cafe Visit - Ordering Food and Drinks",
+                "text": (
+                    "A full morning cafe visit with food and drink orders, including several specific items, "
+                    "a longer exchange about the cafe, and enough surrounding detail to count as a meaningful "
+                    "conversation rather than a one-word fragment."
+                ),
+                "started_at": "2026-05-11T17:49:30Z",
+                "ended_at": "2026-05-11T18:05:00Z",
+            },
+            {
+                "event_id": "brief",
+                "channel": "omi",
+                "title": "Brief Utterance",
+                "text": "Okay.",
+                "started_at": "2026-05-11T18:56:15Z",
+                "ended_at": "2026-05-11T18:56:16Z",
+                "metadata": {"ella_tags": ["omi", "low_signal"]},
+            },
+        ]
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return (
+                datetime(2026, 5, 11, 20, 0, tzinfo=timezone.utc).astimezone(tz) if tz else datetime(2026, 5, 11, 20, 0)
+            )
+
+    monkeypatch.setattr(chat, "_fetch_chat_canonical_events", fake_fetch)
+    monkeypatch.setattr(chat, "datetime", FixedDateTime)
+
+    label, events = asyncio.run(chat._fetch_temporal_chat_context("uid-1", "what happened this morning?"))
+
+    assert label == "same-day morning OMI context"
+    assert [event["event_id"] for event in events] == ["cafe"]

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -463,6 +463,67 @@ def test_plato_omi_activity_window_splits_meaningful_from_fragments(monkeypatch)
     assert result["low_salience_fragments"][0]["event_id"] == "brief-color"
 
 
+def test_plato_omi_activity_window_supports_local_morning_window(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+    captured = {}
+
+    async def fake_recent_context(arguments):
+        captured.update(arguments)
+        return {
+            "uid": module._plato_uid(),
+            "source": "canonical_timeline",
+            "events": [
+                {
+                    "event_id": "morning-cafe",
+                    "channel": "omi",
+                    "title": "Cafe Visit - Ordering Food and Drinks",
+                    "text": "Ordered food and drinks during the cafe visit.",
+                    "started_at": "2026-05-11T17:49:30Z",
+                    "ended_at": "2026-05-11T18:05:00Z",
+                    "metadata": {"ella_signal": {"salience": "medium"}},
+                },
+                {
+                    "event_id": "noon-fragment",
+                    "channel": "omi",
+                    "title": "Caffeine Fragment",
+                    "text": "Caffeine.",
+                    "started_at": "2026-05-11T19:01:05Z",
+                    "ended_at": "2026-05-11T19:01:08Z",
+                    "metadata": {"ella_signal": {"salience": "low"}, "segment_count": 1},
+                },
+            ],
+        }
+
+    monkeypatch.setattr(module, "_recent_context", fake_recent_context)
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc(
+            "tools/call",
+            params={
+                "name": "plato_omi_activity_window",
+                "arguments": {
+                    "local_date": "2026-05-11",
+                    "part_of_day": "morning",
+                    "timezone": "America/Los_Angeles",
+                },
+            },
+        ),
+    )
+
+    assert response.status_code == 200
+    result = _tool_result(response)
+    assert captured["_allow_large_window"] is True
+    assert captured["limit"] == 200
+    assert captured["since"].startswith("2026-05-11T10:00:00Z")
+    assert result["counts"]["window_events"] == 1
+    assert result["meaningful_moments"][0]["event_id"] == "morning-cafe"
+    assert result["window"]["since_local"].startswith("2026-05-11T05:00:00")
+    assert result["window"]["until_local"].startswith("2026-05-11T12:00:00")
+
+
 def test_plato_recent_context_merges_omi_fallback_when_canonical_has_other_channels(monkeypatch):
     module = _load_module(monkeypatch)
     client = _client(module)
@@ -558,6 +619,57 @@ def test_plato_search_memory_uses_merged_omi_fallback(monkeypatch):
     result = _tool_result(response)
     assert result["source"] == "canonical_timeline_with_omi_firestore_fallback"
     assert result["results"][0]["event_id"] == "cafe-1"
+
+
+def test_plato_search_memory_temporal_query_returns_morning_window_without_keyword_match(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    async def fake_recent_context(arguments):
+        assert arguments["_allow_large_window"] is True
+        assert arguments["since"]
+        return {
+            "uid": module._plato_uid(),
+            "source": "canonical_timeline",
+            "events": [
+                {
+                    "event_id": "morning-cafe",
+                    "channel": "omi",
+                    "title": "Cafe Visit - Ordering Food and Drinks",
+                    "text": "Ordered food and drinks during the cafe visit.",
+                    "started_at": "2026-05-11T17:49:30Z",
+                    "ended_at": "2026-05-11T18:05:00Z",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(module, "_recent_context", fake_recent_context)
+    monkeypatch.setattr(
+        module,
+        "_infer_query_time_window",
+        lambda query, tz_name: (
+            module.datetime(2026, 5, 11, 12, 0, tzinfo=module.timezone.utc),
+            module.datetime(2026, 5, 11, 19, 0, tzinfo=module.timezone.utc),
+            "morning",
+        ),
+    )
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc(
+            "tools/call",
+            params={
+                "name": "plato_search_memory",
+                "arguments": {"query": "what happened this morning", "max_results": 5, "channels": ["omi"]},
+            },
+        ),
+    )
+
+    assert response.status_code == 200
+    result = _tool_result(response)
+    assert result["inferred_time_window"] == "morning"
+    assert result["results"][0]["event_id"] == "morning-cafe"
 
 
 def test_plato_search_memory_rejects_missing_query(monkeypatch):


### PR DESCRIPTION
## Summary\n- add local day/part-of-day support to Plato MCP OMI activity windows\n- widen internal window retrieval beyond the last 50 fragments for temporal recall\n- inject same-day/morning OMI context into Hermes/iOS chat when the user asks temporal OMI questions\n- filter low-signal fragments from broad temporal recall results\n\n## Validation\n- pytest tests/unit/test_ella_plato_mcp.py tests/unit/test_ella_chat_temporal_context.py -q\n- python3 -m py_compile ella/routers/chat.py ella/routers/plato_mcp.py\n- ad-hoc patched live-data smoke: 'what happened this morning' returns the 10:49 cafe visit and other morning OMI moments instead of noon-only fragments\n\n## Deployment note\nBackend-only. Rollback by reverting this PR or redeploying previous backend commit.