### PR TITLE
Parse markdown scanner tuning keyterm sections

### DIFF
--- a/backend/tests/unit/test_scanner_keyterms.py
+++ b/backend/tests/unit/test_scanner_keyterms.py
@@ -5,32 +5,39 @@ from utils.ella import scanner_keyterms
 
 
 SCANNER_TUNING = """
-@runtime: current-state [ACTIVE]
+## @runtime: current-state
+[ACTIVE]
 - guardian_mode: EMERGENCY_ONLY
 
-@wakeword: defaults [ACTIVE]
+## @wakeword: defaults
+[ACTIVE]
 - Hey Ella
 - Ella
 - "Hey Dina"
 
-@wakeword: personal-learned [ACTIVE]
-- where did I put my glasses
-- keys location lookup
+## @wakeword: personal-learned
+[ACTIVE]
+- where did I put my glasses → response_template: item_location_lookup[glasses]
+- keys location lookup | response_template: item_location_lookup[keys]
 
-@prefilter: media-baseline [ACTIVE]
+## @prefilter: media-baseline
+[ACTIVE]
 - suppress: podcast audio
 - ignore: "normal TV audio"
 
-@scanner: health-context [ACTIVE]
+## @scanner: health-context
+[ACTIVE]
 - medications: metformin, rescue inhaler
 - providers: Dr. Pu, Claudia
 - conditions: type 2 diabetes, hypertension
 
-@fastpath: old-temp-rule [ACTIVE]
+## @fastpath: old-temp-rule
+[ACTIVE]
 - expires: 2020-01-01
 - obsolete phrase
 
-@wakeword: inactive-test [INACTIVE]
+## @wakeword: inactive-test
+[INACTIVE]
 - Should Not Appear
 """
 

--- a/backend/utils/ella/scanner_keyterms.py
+++ b/backend/utils/ella/scanner_keyterms.py
@@ -174,23 +174,28 @@ def _section_is_active(header_state: Optional[str], lines: list[str]) -> bool:
 
 def _split_sections(content: str) -> list[tuple[str, str, Optional[str], list[str]]]:
     sections: list[tuple[str, str, Optional[str], list[str]]] = []
-    current: Optional[tuple[str, str, Optional[str], list[str]]] = None
+    current: Optional[list] = None
     for line in content.splitlines():
-        match = _SECTION_RE.match(line)
+        header_line = re.sub(r"^\s*#+\s*", "", line)
+        match = _SECTION_RE.match(header_line)
         if match:
             if current:
-                sections.append(current)
-            current = (
+                sections.append((current[0], current[1], current[2], current[3]))
+            current = [
                 match.group("kind").strip().lower(),
                 match.group("name").strip().lower(),
                 match.group("state"),
                 [],
-            )
+            ]
             continue
         if current:
+            state_match = re.match(r"^\s*\[(?P<state>[A-Z_ -]+)\]\s*$", line)
+            if state_match and not current[3] and current[2] is None:
+                current[2] = state_match.group("state")
+                continue
             current[3].append(line)
     if current:
-        sections.append(current)
+        sections.append((current[0], current[1], current[2], current[3]))
     return sections
 
 
@@ -262,6 +267,7 @@ def _extract_line_terms(line: str, *, include_plain_bullets: bool) -> list[str]:
 
     terms = _extract_inline_terms(stripped)
     without_inline = _INLINE_TERM_RE.sub("", stripped)
+    without_inline = re.split(r"\s*(?:→|=>|\|)\s*", without_inline, maxsplit=1)[0]
     cleaned = _clean_candidate(without_inline)
     if not cleaned:
         return terms


### PR DESCRIPTION
## Summary
- handle Hermes scanner-tuning.md markdown section headers like `## @wakeword: defaults` with `[ACTIVE]` on the next line
- strip response-template metadata from wake/fast-path phrase keyterms before sending them to Deepgram
- update scanner keyterm tests to match the live scanner-tuning.md format

## Tests
- `pytest tests/unit/test_scanner_keyterms.py tests/unit/test_stt_provider_routing.py`
- `python3 -m py_compile utils/ella/scanner_keyterms.py routers/transcribe.py`

Follow-up to ellaaicare/ella-ai#1000 / ellaaicare/omi#218.