### PR TITLE
Route temporal voice search to canonical OMI

### DIFF
--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -1453,6 +1453,27 @@ def _parse_event_datetime_utc(raw: object) -> Optional[datetime]:
     return parsed.astimezone(timezone.utc).replace(tzinfo=None)
 
 
+def _should_use_voice_memory_fast_path(query: str) -> bool:
+    query_lower = query.lower()
+    window_start, _window_end, _remaining = _parse_relative_time_window(query)
+    if window_start:
+        return False
+    detail_terms = (
+        "omi",
+        "necklace",
+        "transcript",
+        "transcripts",
+        "conversation",
+        "conversations",
+        "this morning",
+        "this afternoon",
+        "this evening",
+        "today",
+        "yesterday",
+    )
+    return not any(term in query_lower for term in detail_terms)
+
+
 async def _search_canonical_timeline(uid: str, query: str, limit: int) -> list:
     """Search the canonical cross-channel event ledger.
 
@@ -2313,7 +2334,7 @@ async def unified_search(request: Request):
     # Realtime voice needs a bounded fast path. If the compact Hermes memory
     # pack has a high-confidence answer, return it immediately and avoid
     # waiting on slower Firestore/workspace/Honcho fallback searches.
-    if agent_role == "voice" and not requested_sources:
+    if agent_role == "voice" and not requested_sources and _should_use_voice_memory_fast_path(query):
         fast_results = await _search_voice_memory_pack(uid, query, limit)
         if fast_results and fast_results[0].get("score", 0) >= 120:
             _elapsed = int((time.time() - _start) * 1000)

--- a/backend/tests/unit/test_voice_search_canonical_omi.py
+++ b/backend/tests/unit/test_voice_search_canonical_omi.py
@@ -96,6 +96,18 @@ def test_search_canonical_omi_events_applies_this_morning_window():
     assert results[0]["metadata"]["time_window_applied"] is True
 
 
+def test_voice_memory_fast_path_skips_temporal_or_omi_queries():
+    async def fake_fetch(_uid, **_kwargs):
+        return []
+
+    module = _load_voice_omi_helpers(fake_fetch)
+    module._pacific_now = lambda: datetime(2026, 5, 7, 15, 0, tzinfo=ZoneInfo("America/Los_Angeles"))
+
+    assert module._should_use_voice_memory_fast_path("what happened this morning in my OMI conversations") is False
+    assert module._should_use_voice_memory_fast_path("find my latest OMI transcript") is False
+    assert module._should_use_voice_memory_fast_path("what was that restaurant name") is True
+
+
 def test_search_canonical_omi_events_returns_empty_when_no_useful_match():
     async def fake_fetch(_uid, **_kwargs):
         return [_cafe_event()]


### PR DESCRIPTION
## Summary
- skip the Hermes voice-memory fast path for temporal or OMI/transcript-specific voice searches
- let generic Grok `search_all` calls fan out to canonical OMI for queries like `what happened this morning in my OMI conversations`
- add regression coverage for fast-path bypass behavior

## Validation
- `pytest -q backend/tests/unit/test_voice_search_canonical_omi.py backend/tests/unit/test_ella_chat_temporal_context.py`

## Live context
After #221, `sources=["omi"]` worked, but Grok voice normally calls `search_all` without explicit sources. That still returned a stale high-confidence Hermes voice-memory fast-path result and never reached canonical OMI. This patch keeps the low-latency fast path for generic lookup queries while routing temporal/OMI detail queries through the canonical fan-out.