### PR TITLE
Fix temporal OMI recall in voice search

### DIFF
--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -1191,7 +1191,11 @@ async def search_omi_conversations(request: Request):
             created = c.get("created_at")
             ts = ""
             if created:
-                if hasattr(created, "strftime"):
+                created_utc = _parse_event_datetime_utc(created)
+                if created_utc:
+                    created_local = created_utc.replace(tzinfo=timezone.utc).astimezone(ZoneInfo("America/Los_Angeles"))
+                    ts = created_local.strftime("%Y-%m-%d %I:%M %p %Z")
+                elif hasattr(created, "strftime"):
                     ts = created.strftime("%Y-%m-%d %I:%M %p")
                 else:
                     ts = str(created)[:16]
@@ -1349,7 +1353,9 @@ def _normalized_query_terms(query: str) -> list[str]:
         "me", "my", "you", "greg", "plato", "tell", "check", "latest", "recent",
         "memory", "memories", "after", "before", "else", "went", "go", "this",
         "omi", "conversation", "conversations", "transcript", "transcripts",
-        "summary", "summaries", "morning", "today", "yesterday", "raw",
+        "summary", "summaries", "morning", "afternoon", "evening", "today",
+        "yesterday", "raw", "happened", "happen", "heard", "hear", "catch",
+        "caught", "find", "pull", "about",
     }
     terms = [t.strip(".,?!:;()[]{}\"'’‘“”").lower() for t in query.split()]
     filtered = [t for t in terms if len(t) > 2 and t not in stop]
@@ -1365,7 +1371,9 @@ def _significant_query_terms(query: str) -> list[str]:
         "me", "my", "you", "greg", "plato", "tell", "check", "latest", "recent",
         "memory", "memories", "after", "before", "else", "went", "go", "this",
         "omi", "conversation", "conversations", "transcript", "transcripts",
-        "summary", "summaries", "morning", "today", "yesterday", "raw",
+        "summary", "summaries", "morning", "afternoon", "evening", "today",
+        "yesterday", "raw", "happened", "happen", "heard", "hear", "catch",
+        "caught", "find", "pull", "about",
     }
     terms = [t.strip(".,?!:;()[]{}\"'’‘“”").lower() for t in query.split()]
     return [t for t in terms if len(t) > 2 and t not in stop]
@@ -1391,6 +1399,58 @@ def _local_window_to_utc(start_local: datetime, end_local: datetime) -> tuple[da
         start_local.astimezone(timezone.utc).replace(tzinfo=None),
         end_local.astimezone(timezone.utc).replace(tzinfo=None),
     )
+
+
+def _parse_relative_time_window(query: str) -> tuple[Optional[datetime], Optional[datetime], str]:
+    """Parse common relative-time phrases into a naive UTC window."""
+    query_lower = query.lower().strip()
+    now_local = _pacific_now()
+    start_local = None
+    end_local = None
+    remaining = query_lower
+
+    if "this morning" in query_lower:
+        start_local = now_local.replace(hour=5, minute=0, second=0, microsecond=0)
+        end_local = min(now_local, now_local.replace(hour=12, minute=0, second=0, microsecond=0))
+        remaining = remaining.replace("this morning", " ")
+    elif "this afternoon" in query_lower:
+        start_local = now_local.replace(hour=12, minute=0, second=0, microsecond=0)
+        end_local = min(now_local, now_local.replace(hour=17, minute=0, second=0, microsecond=0))
+        remaining = remaining.replace("this afternoon", " ")
+    elif "this evening" in query_lower:
+        start_local = now_local.replace(hour=17, minute=0, second=0, microsecond=0)
+        end_local = now_local
+        remaining = remaining.replace("this evening", " ")
+    elif "yesterday" in query_lower:
+        day = now_local - timedelta(days=1)
+        start_local = day.replace(hour=0, minute=0, second=0, microsecond=0)
+        end_local = day.replace(hour=23, minute=59, second=59, microsecond=999999)
+        remaining = remaining.replace("yesterday", " ")
+    elif "today" in query_lower:
+        start_local = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+        end_local = now_local
+        remaining = remaining.replace("today", " ")
+
+    if not start_local or not end_local:
+        return None, None, query
+
+    start_utc, end_utc = _local_window_to_utc(start_local, end_local)
+    return start_utc, end_utc, " ".join(remaining.split())
+
+
+def _parse_event_datetime_utc(raw: object) -> Optional[datetime]:
+    if not raw:
+        return None
+    if isinstance(raw, datetime):
+        parsed = raw
+    else:
+        try:
+            parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except Exception:
+            return None
+    if parsed.tzinfo is None:
+        return parsed
+    return parsed.astimezone(timezone.utc).replace(tzinfo=None)
 
 
 async def _search_canonical_timeline(uid: str, query: str, limit: int) -> list:
@@ -1664,13 +1724,16 @@ def _canonical_event_title(event: dict) -> str:
     return str(event.get("title") or structured.get("title") or "OMI conversation")
 
 
-def _canonical_event_timestamp(event: dict) -> str:
+def _canonical_event_timestamp(event: dict, user_timezone: str = "America/Los_Angeles") -> str:
     raw = event.get("started_at") or event.get("created_at") or event.get("timestamp") or ""
     if not raw:
         return ""
     try:
         parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
-        return parsed.strftime("%Y-%m-%d %I:%M %p")
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        local = parsed.astimezone(ZoneInfo(user_timezone))
+        return local.strftime("%Y-%m-%d %I:%M %p %Z")
     except Exception:
         return str(raw)[:16]
 
@@ -1678,19 +1741,28 @@ def _canonical_event_timestamp(event: dict) -> str:
 async def _search_canonical_omi_events(uid: str, query: str, limit: int, full_access: bool) -> list:
     """Search OMI canonical summary events via GET /v1/ella/timeline first."""
     results = []
+    window_start, window_end, query_without_time = _parse_relative_time_window(query)
+    timeline_limit = 300 if window_start and window_end else 120
     try:
-        events = await fetch_canonical_timeline(uid, limit=120, channels=["omi"])
+        events = await fetch_canonical_timeline(uid, limit=timeline_limit, channels=["omi"])
     except Exception as e:
         logger.warning(f"[FLOW:UNIFIED-SEARCH] Canonical OMI timeline fetch error: {e}")
         return results
 
-    query_terms = _expand_query_terms(_significant_query_terms(query))
+    query_terms = _expand_query_terms(_significant_query_terms(query_without_time if window_start else query))
     matches = []
     for event in events:
         title = _canonical_event_title(event)
         text = str(event.get("text") or "")
         metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
         structured = metadata.get("structured") if isinstance(metadata.get("structured"), dict) else {}
+        started_sort = _parse_event_datetime_utc(
+            event.get("started_at") or event.get("created_at") or event.get("timestamp")
+        )
+        if window_start and window_end:
+            if not started_sort or started_sort < window_start or started_sort > window_end:
+                continue
+
         searchable = " ".join(
             str(part or "")
             for part in (
@@ -1707,11 +1779,7 @@ async def _search_canonical_omi_events(uid: str, query: str, limit: int, full_ac
         if score <= 0:
             continue
 
-        started_raw = event.get("started_at") or ""
-        try:
-            started_sort = datetime.fromisoformat(str(started_raw).replace("Z", "+00:00"))
-        except Exception:
-            started_sort = datetime.min.replace(tzinfo=timezone.utc)
+        started_sort = started_sort or datetime.min
 
         content = text
         if not full_access:
@@ -1727,7 +1795,7 @@ async def _search_canonical_omi_events(uid: str, query: str, limit: int, full_ac
             "title": title,
             "content": content[:1400],
             "timestamp": _canonical_event_timestamp(event),
-            "score": score + 45,
+            "score": score + (55 if window_start else 45),
             "metadata": {
                 "provenance": "canonical_event",
                 "fallback": False,
@@ -1737,6 +1805,10 @@ async def _search_canonical_omi_events(uid: str, query: str, limit: int, full_ac
                 "provider": event.get("provider"),
                 "emoji": structured.get("emoji", ""),
                 "category": structured.get("category", ""),
+                "time_window_applied": bool(window_start and window_end),
+                "time_window_start_utc": window_start.isoformat() if window_start else "",
+                "time_window_end_utc": window_end.isoformat() if window_end else "",
+                "timestamp_timezone": "America/Los_Angeles",
             },
         })
     return results
@@ -1864,6 +1936,8 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
 
         if not date_parsed:
             keyword_terms = query_lower.split()
+        else:
+            keyword_terms = _expand_query_terms(_significant_query_terms(" ".join(keyword_terms)))
 
         # --- Firestore query ---
         if date_filter_start and date_filter_end:
@@ -1924,7 +1998,11 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             created = c.get("created_at")
             ts = ""
             if created:
-                if hasattr(created, "strftime"):
+                created_utc = _parse_event_datetime_utc(created)
+                if created_utc:
+                    created_local = created_utc.replace(tzinfo=timezone.utc).astimezone(ZoneInfo("America/Los_Angeles"))
+                    ts = created_local.strftime("%Y-%m-%d %I:%M %p %Z")
+                elif hasattr(created, "strftime"):
                     ts = created.strftime("%Y-%m-%d %I:%M %p")
                 else:
                     ts = str(created)[:16]
@@ -1953,6 +2031,7 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
                     "emoji": structured.get("emoji", ""),
                     "category": structured.get("category", ""),
                     "has_transcript_detail": bool(transcript_text and full_access),
+                    "timestamp_timezone": "America/Los_Angeles",
                 },
             })
 

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -430,9 +430,7 @@ async def create_voice_session(
     user_display_name = None
     try:
         pool = await _get_pool()
-        row = await pool.fetchrow(
-            "SELECT name FROM users WHERE omi_uid = $1", uid
-        )
+        row = await pool.fetchrow("SELECT name FROM users WHERE omi_uid = $1", uid)
         if row:
             user_display_name = row["name"]
     except Exception as e:
@@ -544,7 +542,10 @@ async def synthesize_speech(
                 )
             _elapsed = int((time.time() - _start) * 1000)
             if response.status_code != 200:
-                print(f"[FLOW:VOICE-TTS] ERROR provider={provider} status={response.status_code} latency={_elapsed}ms", flush=True)
+                print(
+                    f"[FLOW:VOICE-TTS] ERROR provider={provider} status={response.status_code} latency={_elapsed}ms",
+                    flush=True,
+                )
                 raise HTTPException(status_code=502, detail=f"ella-tts error: {response.status_code}")
             audio_size = len(response.content)
             print(f"[FLOW:VOICE-TTS] OK provider={provider} audio_bytes={audio_size} latency={_elapsed}ms", flush=True)
@@ -566,7 +567,10 @@ async def synthesize_speech(
             print(f"[FLOW:VOICE-TTS] ERROR provider=xai-tts key_missing=true", flush=True)
             raise HTTPException(status_code=500, detail="XAI_API_KEY not configured")
         voice_id = request.voice_id if request.voice_id != DEFAULT_ELEVENLABS_VOICE_ID else XAI_TTS_VOICE_ID
-        print(f"[FLOW:VOICE-TTS] provider=xai-tts voice={voice_id} language={XAI_TTS_LANGUAGE} text_len={text_len}", flush=True)
+        print(
+            f"[FLOW:VOICE-TTS] provider=xai-tts voice={voice_id} language={XAI_TTS_LANGUAGE} text_len={text_len}",
+            flush=True,
+        )
         try:
             async with httpx.AsyncClient() as client:
                 response = await client.post(
@@ -629,7 +633,10 @@ async def synthesize_speech(
     # --- Reject unknown providers (no silent fallbacks) ---
     if provider != "elevenlabs":
         print(f"[FLOW:VOICE-TTS] ERROR unknown provider={provider!r}", flush=True)
-        raise HTTPException(status_code=400, detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, xai-tts, grok-voice, gemini-live")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, xai-tts, grok-voice, gemini-live",
+        )
 
     # --- ElevenLabs ---
     if not ELEVENLABS_API_KEY:
@@ -658,11 +665,17 @@ async def synthesize_speech(
         _elapsed = int((time.time() - _start) * 1000)
 
         if response.status_code != 200:
-            print(f"[FLOW:VOICE-TTS] ERROR provider=elevenlabs status={response.status_code} latency={_elapsed}ms body={response.text[:200]}", flush=True)
+            print(
+                f"[FLOW:VOICE-TTS] ERROR provider=elevenlabs status={response.status_code} latency={_elapsed}ms body={response.text[:200]}",
+                flush=True,
+            )
             raise HTTPException(status_code=502, detail=f"ElevenLabs error: {response.status_code}")
 
         audio_size = len(response.content)
-        print(f"[FLOW:VOICE-TTS] OK provider=elevenlabs voice={request.voice_id} audio_bytes={audio_size} latency={_elapsed}ms", flush=True)
+        print(
+            f"[FLOW:VOICE-TTS] OK provider=elevenlabs voice={request.voice_id} audio_bytes={audio_size} latency={_elapsed}ms",
+            flush=True,
+        )
 
         return Response(content=response.content, media_type="audio/mpeg")
 
@@ -707,8 +720,6 @@ async def voice_health():
 # ============================================================================
 
 
-
-
 async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
     """Fetch recent OMI conversation summaries from Firestore for voice context.
     Returns formatted string of recent conversations (title + overview)."""
@@ -716,17 +727,20 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
         # Direct Firestore query — simpler than get_conversations() to avoid
         # composite index requirements (discarded + created_at needs index)
         from google.cloud import firestore
+
         db = firestore.Client()
         convos_ref = (
-            db.collection("users").document(uid).collection("conversations")
+            db.collection("users")
+            .document(uid)
+            .collection("conversations")
             .order_by("created_at", direction=firestore.Query.DESCENDING)
             .limit(limit)
         )
         convos = [doc.to_dict() for doc in convos_ref.stream()]
-        
+
         if not convos:
             return ""
-        
+
         parts = []
         for c in convos:
             structured = c.get("structured", {})
@@ -734,7 +748,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
             overview = structured.get("overview", "")
             emoji = structured.get("emoji", "")
             created = c.get("created_at")
-            
+
             # Format timestamp
             ts = ""
             if created:
@@ -742,7 +756,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
                     ts = created.strftime("%b %d %I:%M %p")
                 else:
                     ts = str(created)[:16]
-            
+
             entry = f"- {emoji} {title}"
             if overview:
                 # Truncate long overviews
@@ -751,7 +765,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
             if ts:
                 entry += f" ({ts})"
             parts.append(entry)
-        
+
         return "\n".join(parts)
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Conversation fetch failed: {e}")
@@ -768,15 +782,15 @@ async def _fetch_memory_context(
     Returns formatted string of relevant memory snippets."""
     if not gateway_token:
         return ""
-    
+
     headers = {
         "Authorization": f"Bearer {gateway_token}",
         "Content-Type": "application/json",
     }
-    
+
     results_all = []
     queries = [f"{user_name} recent activity today schedule important"]
-    
+
     try:
         async with httpx.AsyncClient(timeout=timeout_seconds) as client:
             for query in queries:
@@ -790,6 +804,7 @@ async def _fetch_memory_context(
                         data = resp.json()
                         if data.get("ok"):
                             import json as json_mod
+
                             results_text = data["result"]["content"][0]["text"]
                             results = json_mod.loads(results_text).get("results", [])
                             for r in results[:3]:
@@ -803,10 +818,10 @@ async def _fetch_memory_context(
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Memory context fetch failed: {e}")
         return ""
-    
+
     if not results_all:
         return ""
-    
+
     # Sort by score, deduplicate, take top 5
     results_all.sort(key=lambda x: x[1], reverse=True)
     seen = set()
@@ -818,8 +833,9 @@ async def _fetch_memory_context(
             unique.append(snippet)
         if len(unique) >= 5:
             break
-    
+
     return "\n---\n".join(unique)
+
 
 def _extract_caregiver_section(user_profile: str) -> str:
     """Extract caregiver-relevant notes from USER.md content."""
@@ -900,18 +916,11 @@ async def get_voice_context(request: Request):
                 )
                 if resp.status_code == 200:
                     file_list = resp.json().get("files", [])
-                    files = {
-                        f.get("name", f.get("filename", "")): f.get("content", "")
-                        for f in file_list
-                    }
-                    logger.info(
-                        f"[FLOW:VOICE-CONTEXT] Loaded {len(files)} workspace files "
-                        f"for agent={agent_id}"
-                    )
+                    files = {f.get("name", f.get("filename", "")): f.get("content", "") for f in file_list}
+                    logger.info(f"[FLOW:VOICE-CONTEXT] Loaded {len(files)} workspace files " f"for agent={agent_id}")
                 else:
                     logger.warning(
-                        f"[FLOW:VOICE-CONTEXT] Provision API returned "
-                        f"{resp.status_code} for agent={agent_id}"
+                        f"[FLOW:VOICE-CONTEXT] Provision API returned " f"{resp.status_code} for agent={agent_id}"
                     )
         except Exception as e:
             logger.warning(f"[FLOW:VOICE-CONTEXT] Provision API error: {e}")
@@ -940,6 +949,7 @@ async def get_voice_context(request: Request):
     memory_context = ""
     try:
         import asyncio as _aio
+
         conv_task = _aio.create_task(_fetch_recent_conversations(uid, limit=8))
         timeline_task = _aio.create_task(_fetch_recent_canonical_timeline(uid, limit=40, max_chars=9000))
         mem_task = _aio.create_task(
@@ -986,7 +996,7 @@ async def get_voice_context(request: Request):
         except Exception as _ve:
             logger.warning(f"[FLOW:VOICE-CONTEXT] Voice daily log read error: {_ve}")
     memory = files.get("MEMORY.md", "")[:500]
-    
+
     # Additional workspace files for richer context
     tools_md = files.get("TOOLS.md", "")[:500]  # Agent capabilities awareness
     shared_reports = ""
@@ -1035,33 +1045,34 @@ async def search_omi_conversations(request: Request):
     """
     Search OMI conversations for a user. Called by Grok voice proxy during live calls
     when the user asks to look up specific past conversations.
-    
+
     Body:
         uid (str): Firebase UID of the user
         query (str): Search terms (matched against title and overview)
         limit (int, optional): Max results (default: 5, max: 10)
-    
+
     Returns list of matching conversations with title, overview, and timestamp.
     """
     body = await request.json()
     uid = body.get("uid", "")
     query = body.get("query", "")
     limit = min(body.get("limit", 5), 10)
-    
+
     if not uid:
         raise HTTPException(status_code=400, detail="uid required")
     if not query:
         raise HTTPException(status_code=400, detail="query required")
-    
+
     logger.info(f"[FLOW:VOICE-SEARCH] uid={uid} query=\"{query}\" limit={limit}")
-    
+
     try:
         from google.cloud import firestore
+
         db = firestore.Client()
-        
+
         from datetime import datetime, timedelta
         import re as re_mod
-        
+
         # Parse date hints from query for date-range filtering
         now_local = _pacific_now()
         now_local = _pacific_now()
@@ -1069,12 +1080,12 @@ async def search_omi_conversations(request: Request):
         date_filter_start = None
         date_filter_end = None
         keyword_terms = []
-        
+
         query_lower = query.lower().strip()
-        
+
         # Date patterns: "march 8", "march 8th", "3/8", "yesterday", "last week", "today"
         date_parsed = False
-        
+
         if "yesterday" in query_lower:
             d = now - timedelta(days=1)
             date_filter_start = d.replace(hour=0, minute=0, second=0)
@@ -1099,15 +1110,34 @@ async def search_omi_conversations(request: Request):
         else:
             # Try "month day" pattern: "march 8", "march 8th", "mar 8"
             month_names = {
-                "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
-                "apr": 4, "april": 4, "may": 5, "jun": 6, "june": 6, "jul": 7, "july": 7,
-                "aug": 8, "august": 8, "sep": 9, "september": 9, "oct": 10, "october": 10,
-                "nov": 11, "november": 11, "dec": 12, "december": 12,
+                "jan": 1,
+                "january": 1,
+                "feb": 2,
+                "february": 2,
+                "mar": 3,
+                "march": 3,
+                "apr": 4,
+                "april": 4,
+                "may": 5,
+                "jun": 6,
+                "june": 6,
+                "jul": 7,
+                "july": 7,
+                "aug": 8,
+                "august": 8,
+                "sep": 9,
+                "september": 9,
+                "oct": 10,
+                "october": 10,
+                "nov": 11,
+                "november": 11,
+                "dec": 12,
+                "december": 12,
             }
             date_match = re_mod.search(
                 r"(january|february|march|april|may|june|july|august|september|october|november|december|"
                 r"jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)\s+(\d{1,2})(?:st|nd|rd|th)?",
-                query_lower
+                query_lower,
             )
             if date_match:
                 month_str = date_match.group(1)
@@ -1124,24 +1154,26 @@ async def search_omi_conversations(request: Request):
                         date_filter_end = target.replace(hour=23, minute=59, second=59)
                         date_parsed = True
                         # Remove date part from query for keyword matching
-                        remaining = query_lower[:date_match.start()] + query_lower[date_match.end():]
+                        remaining = query_lower[: date_match.start()] + query_lower[date_match.end() :]
                         keyword_terms = [t for t in remaining.split() if t]
                     except ValueError:
                         pass
-        
+
         if not date_parsed:
             keyword_terms = query_lower.split()
 
         keyword_terms = _expand_query_terms(_significant_query_terms(" ".join(keyword_terms)))
         keyword_terms = _normalized_query_terms(" ".join(keyword_terms))
-        
+
         logger.info(f"[FLOW:VOICE-SEARCH] date_filter={date_filter_start}->{date_filter_end}, keywords={keyword_terms}")
-        
+
         # Fetch conversations — use date filter if we have one, otherwise get last 100
         if date_filter_start and date_filter_end:
             # Firestore query with date range
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .where("created_at", ">=", date_filter_start)
                 .where("created_at", "<=", date_filter_end)
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
@@ -1149,29 +1181,31 @@ async def search_omi_conversations(request: Request):
             )
         else:
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
                 .limit(100)
             )
         convos = [doc.to_dict() for doc in convos_ref.stream()]
-        
+
         # Client-side keyword match (skip if only date search with no keywords)
         matches = []
-        
+
         for c in convos:
             structured = c.get("structured", {})
             title = (structured.get("title", "") or "").lower()
             overview = (structured.get("overview", "") or "").lower()
             category = (structured.get("category", "") or "").lower()
-            
+
             # Include formatted date in searchable text
             created = c.get("created_at")
             date_str = ""
             if created and hasattr(created, "strftime"):
                 date_str = created.strftime("%B %d %Y %b %A").lower()  # "march 18 2026 mar monday"
-            
+
             searchable = f"{title} {overview} {category} {date_str}"
-            
+
             if keyword_terms:
                 # Score: how many keyword terms match
                 score = _keyword_score(searchable, keyword_terms)
@@ -1180,11 +1214,11 @@ async def search_omi_conversations(request: Request):
             else:
                 # Date-only search — return all conversations from that date
                 matches.append((1, c))
-        
+
         # Sort by score (desc), then by recency
         matches.sort(key=lambda x: x[0], reverse=True)
         matches = matches[:limit]
-        
+
         results = []
         for score, c in matches:
             structured = c.get("structured", {})
@@ -1199,19 +1233,21 @@ async def search_omi_conversations(request: Request):
                     ts = created.strftime("%Y-%m-%d %I:%M %p")
                 else:
                     ts = str(created)[:16]
-            
-            results.append({
-                "title": structured.get("title", "Untitled"),
-                "overview": structured.get("overview", ""),
-                "emoji": structured.get("emoji", ""),
-                "category": structured.get("category", ""),
-                "timestamp": ts,
-                "score": score,
-            })
-        
+
+            results.append(
+                {
+                    "title": structured.get("title", "Untitled"),
+                    "overview": structured.get("overview", ""),
+                    "emoji": structured.get("emoji", ""),
+                    "category": structured.get("category", ""),
+                    "timestamp": ts,
+                    "score": score,
+                }
+            )
+
         logger.info(f"[FLOW:VOICE-SEARCH] Found {len(results)} matches for \"{query}\"")
         return {"results": results, "total_searched": len(convos), "query": query}
-    
+
     except Exception as e:
         logger.error(f"[FLOW:VOICE-SEARCH] Error: {e}")
         return {"results": [], "error": str(e), "query": query}
@@ -1226,21 +1262,53 @@ async def search_omi_conversations(request: Request):
 # Privacy policy: maps agent_role -> source -> access level
 # True = full access, False = no access, "own" = own data only, "full" = full
 SEARCH_POLICY = {
-    "user":      {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": "own"},
-    "caregiver": {"timeline": True, "workspace": True, "omi_full": False, "omi_meta": True, "memories": False, "voice": False, "scanner": "full"},
-    "scanner":   {"timeline": False, "workspace": False, "omi_full": False, "omi_meta": False, "memories": False, "voice": False, "scanner": False},
-    "voice":     {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": False},
+    "user": {
+        "timeline": True,
+        "workspace": True,
+        "omi_full": True,
+        "omi_meta": True,
+        "memories": True,
+        "voice": True,
+        "scanner": "own",
+    },
+    "caregiver": {
+        "timeline": True,
+        "workspace": True,
+        "omi_full": False,
+        "omi_meta": True,
+        "memories": False,
+        "voice": False,
+        "scanner": "full",
+    },
+    "scanner": {
+        "timeline": False,
+        "workspace": False,
+        "omi_full": False,
+        "omi_meta": False,
+        "memories": False,
+        "voice": False,
+        "scanner": False,
+    },
+    "voice": {
+        "timeline": True,
+        "workspace": True,
+        "omi_full": True,
+        "omi_meta": True,
+        "memories": True,
+        "voice": True,
+        "scanner": False,
+    },
 }
 
 # Which source keys map to which request-level source names
 _SOURCE_TO_POLICY_KEYS = {
-    "timeline":  ["timeline"],
-    "channel":   ["timeline"],
+    "timeline": ["timeline"],
+    "channel": ["timeline"],
     "workspace": ["workspace"],
-    "omi":       ["omi_full", "omi_meta"],
-    "memories":  ["memories"],
-    "voice":     ["voice"],
-    "scanner":   ["scanner"],
+    "omi": ["omi_full", "omi_meta"],
+    "memories": ["memories"],
+    "voice": ["voice"],
+    "scanner": ["scanner"],
 }
 
 
@@ -1348,14 +1416,66 @@ def _snippet_around_terms(text: str, terms: list, max_chars: int = 900) -> str:
 
 def _normalized_query_terms(query: str) -> list[str]:
     stop = {
-        "the", "a", "an", "and", "or", "to", "in", "on", "of", "for", "with",
-        "what", "where", "when", "who", "why", "how", "did", "do", "does", "i",
-        "me", "my", "you", "greg", "plato", "tell", "check", "latest", "recent",
-        "memory", "memories", "after", "before", "else", "went", "go", "this",
-        "omi", "conversation", "conversations", "transcript", "transcripts",
-        "summary", "summaries", "morning", "afternoon", "evening", "today",
-        "yesterday", "raw", "happened", "happen", "heard", "hear", "catch",
-        "caught", "find", "pull", "about",
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "to",
+        "in",
+        "on",
+        "of",
+        "for",
+        "with",
+        "what",
+        "where",
+        "when",
+        "who",
+        "why",
+        "how",
+        "did",
+        "do",
+        "does",
+        "i",
+        "me",
+        "my",
+        "you",
+        "greg",
+        "plato",
+        "tell",
+        "check",
+        "latest",
+        "recent",
+        "memory",
+        "memories",
+        "after",
+        "before",
+        "else",
+        "went",
+        "go",
+        "this",
+        "omi",
+        "conversation",
+        "conversations",
+        "transcript",
+        "transcripts",
+        "summary",
+        "summaries",
+        "morning",
+        "afternoon",
+        "evening",
+        "today",
+        "yesterday",
+        "raw",
+        "happened",
+        "happen",
+        "heard",
+        "hear",
+        "catch",
+        "caught",
+        "find",
+        "pull",
+        "about",
     }
     terms = [t.strip(".,?!:;()[]{}\"'’‘“”").lower() for t in query.split()]
     filtered = [t for t in terms if len(t) > 2 and t not in stop]
@@ -1366,14 +1486,66 @@ def _significant_query_terms(query: str) -> list[str]:
     """Return only evidence-bearing terms; unlike _normalized_query_terms,
     this may return an empty list for broad temporal questions."""
     stop = {
-        "the", "a", "an", "and", "or", "to", "in", "on", "of", "for", "with",
-        "what", "where", "when", "who", "why", "how", "did", "do", "does", "i",
-        "me", "my", "you", "greg", "plato", "tell", "check", "latest", "recent",
-        "memory", "memories", "after", "before", "else", "went", "go", "this",
-        "omi", "conversation", "conversations", "transcript", "transcripts",
-        "summary", "summaries", "morning", "afternoon", "evening", "today",
-        "yesterday", "raw", "happened", "happen", "heard", "hear", "catch",
-        "caught", "find", "pull", "about",
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "to",
+        "in",
+        "on",
+        "of",
+        "for",
+        "with",
+        "what",
+        "where",
+        "when",
+        "who",
+        "why",
+        "how",
+        "did",
+        "do",
+        "does",
+        "i",
+        "me",
+        "my",
+        "you",
+        "greg",
+        "plato",
+        "tell",
+        "check",
+        "latest",
+        "recent",
+        "memory",
+        "memories",
+        "after",
+        "before",
+        "else",
+        "went",
+        "go",
+        "this",
+        "omi",
+        "conversation",
+        "conversations",
+        "transcript",
+        "transcripts",
+        "summary",
+        "summaries",
+        "morning",
+        "afternoon",
+        "evening",
+        "today",
+        "yesterday",
+        "raw",
+        "happened",
+        "happen",
+        "heard",
+        "hear",
+        "catch",
+        "caught",
+        "find",
+        "pull",
+        "about",
     }
     terms = [t.strip(".,?!:;()[]{}\"'’‘“”").lower() for t in query.split()]
     return [t for t in terms if len(t) > 2 and t not in stop]
@@ -1453,6 +1625,49 @@ def _parse_event_datetime_utc(raw: object) -> Optional[datetime]:
     return parsed.astimezone(timezone.utc).replace(tzinfo=None)
 
 
+def _voice_query_requires_source_fanout(query: str) -> bool:
+    """Return True when the compact voice-memory fast path is too lossy.
+
+    Realtime voice can usually answer from the hot memory pack, but explicit
+    source or time-window questions need the canonical ledger fan-out so "latest
+    OMI", "this morning", and transcript searches cannot be answered from a
+    stale compact pack.
+    """
+    query_lower = f" {query.lower()} "
+    source_terms = (
+        " omi ",
+        " necklace ",
+        " transcript",
+        " conversation",
+        " summary",
+        " summaries",
+        " imessage",
+        " chat ",
+        " voice call",
+        " scanner",
+        " guardian",
+    )
+    if any(term in query_lower for term in source_terms):
+        return True
+
+    temporal_terms = (
+        " this morning",
+        " this afternoon",
+        " this evening",
+        " today",
+        " yesterday",
+        " latest",
+        " recent",
+        " last night",
+        " last hour",
+        " last few",
+    )
+    if any(term in query_lower for term in temporal_terms):
+        return True
+
+    return False
+
+
 async def _search_canonical_timeline(uid: str, query: str, limit: int) -> list:
     """Search the canonical cross-channel event ledger.
 
@@ -1508,20 +1723,26 @@ async def _search_canonical_timeline(uid: str, query: str, limit: int) -> list:
             ts = row["started_at"]
             ts_text = ts.strftime("%Y-%m-%d %I:%M %p") if ts else ""
             role_boost = 15 if role == "user" else 3
-            matches.append((score, ts or datetime.min, {
-                "source": "timeline",
-                "title": f"{channel} {role}".strip(),
-                "content": text[:700],
-                "timestamp": ts_text,
-                "score": score + role_boost,
-                "metadata": {
-                    "provenance": "canonical_event",
-                    "channel": channel,
-                    "provider": provider,
-                    "role": role,
-                    "session_id": row["session_id"] or "",
-                },
-            }))
+            matches.append(
+                (
+                    score,
+                    ts or datetime.min,
+                    {
+                        "source": "timeline",
+                        "title": f"{channel} {role}".strip(),
+                        "content": text[:700],
+                        "timestamp": ts_text,
+                        "score": score + role_boost,
+                        "metadata": {
+                            "provenance": "canonical_event",
+                            "channel": channel,
+                            "provider": provider,
+                            "role": role,
+                            "session_id": row["session_id"] or "",
+                        },
+                    },
+                )
+            )
         matches.sort(key=lambda x: (x[0], x[1]), reverse=True)
         return [m[2] for m in matches[:limit]]
     except Exception as e:
@@ -1562,21 +1783,23 @@ async def _search_voice_memory_pack(uid: str, query: str, limit: int) -> list:
         top = sources[0] if sources else {}
         confidence = data.get("confidence") or "medium"
         score = 120 if confidence == "high" else 70
-        return [{
-            "source": "voice_memory",
-            "title": top.get("title") or "Hermes Voice Memory",
-            "content": answer[:900],
-            "timestamp": top.get("timestamp") or "",
-            "score": score,
-            "metadata": {
-                "provenance": "hermes_voice_memory",
-                "path": data.get("path"),
-                "confidence": confidence,
-                "latency_ms": data.get("latency_ms"),
-                "source_ref": top.get("source_ref"),
-                "channel": top.get("channel"),
-            },
-        }]
+        return [
+            {
+                "source": "voice_memory",
+                "title": top.get("title") or "Hermes Voice Memory",
+                "content": answer[:900],
+                "timestamp": top.get("timestamp") or "",
+                "score": score,
+                "metadata": {
+                    "provenance": "hermes_voice_memory",
+                    "path": data.get("path"),
+                    "confidence": confidence,
+                    "latency_ms": data.get("latency_ms"),
+                    "source_ref": top.get("source_ref"),
+                    "channel": top.get("channel"),
+                },
+            }
+        ]
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-MEMORY] lookup error: {e}")
         return []
@@ -1654,21 +1877,21 @@ async def _search_workspace(uid: str, agent_id: str, query: str, limit: int) -> 
             if resp.status_code == 200:
                 data = resp.json()
                 for item in data.get("results", [])[:limit]:
-                    results.append({
-                        "source": "workspace",
-                        "title": item.get("file", ""),
-                        "content": (item.get("snippet", "") or item.get("content", ""))[:500],
-                        "timestamp": "",
-                        "score": item.get("score", 1),
-                        "metadata": {"provenance": "hermes_workspace_mirror", "file": item.get("file", "")},
-                    })
+                    results.append(
+                        {
+                            "source": "workspace",
+                            "title": item.get("file", ""),
+                            "content": (item.get("snippet", "") or item.get("content", ""))[:500],
+                            "timestamp": "",
+                            "score": item.get("score", 1),
+                            "metadata": {"provenance": "hermes_workspace_mirror", "file": item.get("file", "")},
+                        }
+                    )
                 return results
 
             # 404 = no search endpoint; fall back to reading key files
             if resp.status_code != 404:
-                logger.warning(
-                    f"[FLOW:UNIFIED-SEARCH] Provision search returned {resp.status_code}"
-                )
+                logger.warning(f"[FLOW:UNIFIED-SEARCH] Provision search returned {resp.status_code}")
                 return results
 
             # Fallback: read files list and grep
@@ -1700,14 +1923,16 @@ async def _search_workspace(uid: str, agent_id: str, query: str, limit: int) -> 
                     if not snippet:
                         snippet = content[:200]
 
-                    results.append({
-                        "source": "workspace",
-                        "title": fname,
-                        "content": snippet,
-                        "timestamp": "",
-                        "score": score,
-                        "metadata": {"provenance": "hermes_workspace_mirror", "file": fname},
-                    })
+                    results.append(
+                        {
+                            "source": "workspace",
+                            "title": fname,
+                            "content": snippet,
+                            "timestamp": "",
+                            "score": score,
+                            "metadata": {"provenance": "hermes_workspace_mirror", "file": fname},
+                        }
+                    )
 
             # Sort by score desc, limit
             results.sort(key=lambda x: x["score"], reverse=True)
@@ -1790,36 +2015,36 @@ async def _search_canonical_omi_events(uid: str, query: str, limit: int, full_ac
     for score, _started_sort, event, title, content in matches[:limit]:
         metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
         structured = metadata.get("structured") if isinstance(metadata.get("structured"), dict) else {}
-        results.append({
-            "source": "omi",
-            "title": title,
-            "content": content[:1400],
-            "timestamp": _canonical_event_timestamp(event),
-            "score": score + (55 if window_start else 45),
-            "metadata": {
-                "provenance": "canonical_event",
-                "fallback": False,
-                "event_id": event.get("event_id"),
-                "source_identity": event.get("source_identity"),
-                "channel": event.get("channel"),
-                "provider": event.get("provider"),
-                "emoji": structured.get("emoji", ""),
-                "category": structured.get("category", ""),
-                "time_window_applied": bool(window_start and window_end),
-                "time_window_start_utc": window_start.isoformat() if window_start else "",
-                "time_window_end_utc": window_end.isoformat() if window_end else "",
-                "timestamp_timezone": "America/Los_Angeles",
-            },
-        })
+        results.append(
+            {
+                "source": "omi",
+                "title": title,
+                "content": content[:1400],
+                "timestamp": _canonical_event_timestamp(event),
+                "score": score + (55 if window_start else 45),
+                "metadata": {
+                    "provenance": "canonical_event",
+                    "fallback": False,
+                    "event_id": event.get("event_id"),
+                    "source_identity": event.get("source_identity"),
+                    "channel": event.get("channel"),
+                    "provider": event.get("provider"),
+                    "emoji": structured.get("emoji", ""),
+                    "category": structured.get("category", ""),
+                    "time_window_applied": bool(window_start and window_end),
+                    "time_window_start_utc": window_start.isoformat() if window_start else "",
+                    "time_window_end_utc": window_end.isoformat() if window_end else "",
+                    "timestamp_timezone": "America/Los_Angeles",
+                },
+            }
+        )
     return results
 
 
 async def _search_omi_canonical_first(uid: str, query: str, limit: int, full_access: bool) -> list:
     canonical_results = await _search_canonical_omi_events(uid, query, limit, full_access)
     if canonical_results:
-        logger.info(
-            f"[FLOW:UNIFIED-SEARCH] uid={uid} omi_source=canonical_event results={len(canonical_results)}"
-        )
+        logger.info(f"[FLOW:UNIFIED-SEARCH] uid={uid} omi_source=canonical_event results={len(canonical_results)}")
         return canonical_results
 
     logger.warning(
@@ -1905,10 +2130,29 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             keyword_terms = [t for t in query_lower.replace("last month", "").split() if t]
         else:
             month_names = {
-                "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
-                "apr": 4, "april": 4, "may": 5, "jun": 6, "june": 6, "jul": 7, "july": 7,
-                "aug": 8, "august": 8, "sep": 9, "september": 9, "oct": 10, "october": 10,
-                "nov": 11, "november": 11, "dec": 12, "december": 12,
+                "jan": 1,
+                "january": 1,
+                "feb": 2,
+                "february": 2,
+                "mar": 3,
+                "march": 3,
+                "apr": 4,
+                "april": 4,
+                "may": 5,
+                "jun": 6,
+                "june": 6,
+                "jul": 7,
+                "july": 7,
+                "aug": 8,
+                "august": 8,
+                "sep": 9,
+                "september": 9,
+                "oct": 10,
+                "october": 10,
+                "nov": 11,
+                "november": 11,
+                "dec": 12,
+                "december": 12,
             }
             date_match = _re.search(
                 r"(january|february|march|april|may|june|july|august|september|october|"
@@ -1942,7 +2186,9 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
         # --- Firestore query ---
         if date_filter_start and date_filter_end:
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .where("created_at", ">=", date_filter_start)
                 .where("created_at", "<=", date_filter_end)
                 .order_by("created_at", direction=_fs.Query.DESCENDING)
@@ -1950,7 +2196,9 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             )
         else:
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .order_by("created_at", direction=_fs.Query.DESCENDING)
                 .limit(100)
             )
@@ -2019,21 +2267,23 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
                         + snippet
                     )[:1400]
 
-            results.append({
-                "source": "omi",
-                "title": structured.get("title", "Untitled"),
-                "content": overview_text,
-                "timestamp": ts,
-                "score": score + 18,
-                "metadata": {
-                    "provenance": "firestore_legacy_omi",
-                    "fallback": True,
-                    "emoji": structured.get("emoji", ""),
-                    "category": structured.get("category", ""),
-                    "has_transcript_detail": bool(transcript_text and full_access),
-                    "timestamp_timezone": "America/Los_Angeles",
-                },
-            })
+            results.append(
+                {
+                    "source": "omi",
+                    "title": structured.get("title", "Untitled"),
+                    "content": overview_text,
+                    "timestamp": ts,
+                    "score": score + 18,
+                    "metadata": {
+                        "provenance": "firestore_legacy_omi",
+                        "fallback": True,
+                        "emoji": structured.get("emoji", ""),
+                        "category": structured.get("category", ""),
+                        "has_transcript_detail": bool(transcript_text and full_access),
+                        "timestamp_timezone": "America/Los_Angeles",
+                    },
+                }
+            )
 
         return results
 
@@ -2056,7 +2306,9 @@ async def _search_memories(uid: str, query: str, limit: int) -> list:
 
         # Fetch recent memories sorted by scoring (same pattern as database/memories.py)
         memories_ref = (
-            db.collection("users").document(uid).collection("memories")
+            db.collection("users")
+            .document(uid)
+            .collection("memories")
             .order_by("scoring", direction=_fs.Query.DESCENDING)
             .order_by("created_at", direction=_fs.Query.DESCENDING)
             .limit(100)
@@ -2091,17 +2343,19 @@ async def _search_memories(uid: str, query: str, limit: int) -> list:
                     ts = str(created)[:16]
 
             display_content = mem.get("structured_memory", "") or mem.get("content", "")
-            results.append({
-                "source": "memories",
-                "title": (mem.get("category", "") or "Memory").title(),
-                "content": (display_content or "")[:500],
-                "timestamp": ts,
-                "score": score,
-                "metadata": {
-                    "category": mem.get("category", ""),
-                    "id": mem.get("id", ""),
-                },
-            })
+            results.append(
+                {
+                    "source": "memories",
+                    "title": (mem.get("category", "") or "Memory").title(),
+                    "content": (display_content or "")[:500],
+                    "timestamp": ts,
+                    "score": score,
+                    "metadata": {
+                        "category": mem.get("category", ""),
+                        "id": mem.get("id", ""),
+                    },
+                }
+            )
 
         return results
 
@@ -2171,14 +2425,16 @@ async def _search_voice_logs(uid: str, agent_id: str, query: str, limit: int) ->
                     if not snippet:
                         snippet = content[:200]
 
-                    results.append({
-                        "source": "voice",
-                        "title": fname,
-                        "content": snippet,
-                        "timestamp": fname.replace("voice/", "").replace(".md", ""),
-                        "score": score,
-                        "metadata": {"file": fname},
-                    })
+                    results.append(
+                        {
+                            "source": "voice",
+                            "title": fname,
+                            "content": snippet,
+                            "timestamp": fname.replace("voice/", "").replace(".md", ""),
+                            "score": score,
+                            "metadata": {"file": fname},
+                        }
+                    )
 
             results.sort(key=lambda x: x["score"], reverse=True)
             return results[:limit]
@@ -2248,19 +2504,24 @@ async def _search_scanner_logs(uid: str, query: str, limit: int, access_level: s
                     ts = row["created_at"].strftime("%Y-%m-%d %I:%M %p")
 
                 display_content = result_data.get("summary", row["transcript_preview"] or "")
-                matches.append((score, {
-                    "source": "scanner",
-                    "title": f"[{(row['urgency'] or 'info').upper()}] {row['category'] or 'alert'}",
-                    "content": (display_content or "")[:500],
-                    "timestamp": ts,
-                    "score": score,
-                    "metadata": {
-                        "category": row["category"] or "",
-                        "urgency": row["urgency"] or "",
-                        "escalated": row["escalated"],
-                        "id": str(row["id"]),
-                    },
-                }))
+                matches.append(
+                    (
+                        score,
+                        {
+                            "source": "scanner",
+                            "title": f"[{(row['urgency'] or 'info').upper()}] {row['category'] or 'alert'}",
+                            "content": (display_content or "")[:500],
+                            "timestamp": ts,
+                            "score": score,
+                            "metadata": {
+                                "category": row["category"] or "",
+                                "urgency": row["urgency"] or "",
+                                "escalated": row["escalated"],
+                                "id": str(row["id"]),
+                            },
+                        },
+                    )
+                )
 
         matches.sort(key=lambda x: x[0], reverse=True)
         return [m[1] for m in matches[:limit]]
@@ -2302,7 +2563,9 @@ async def unified_search(request: Request):
     if not query:
         raise HTTPException(status_code=400, detail="query required")
     if agent_role not in SEARCH_POLICY:
-        raise HTTPException(status_code=400, detail=f"Invalid agent_role: {agent_role}. Must be one of: {list(SEARCH_POLICY.keys())}")
+        raise HTTPException(
+            status_code=400, detail=f"Invalid agent_role: {agent_role}. Must be one of: {list(SEARCH_POLICY.keys())}"
+        )
 
     # Validate agent-uid association
     if not _validate_agent_uid(agent_id, uid):
@@ -2312,8 +2575,10 @@ async def unified_search(request: Request):
 
     # Realtime voice needs a bounded fast path. If the compact Hermes memory
     # pack has a high-confidence answer, return it immediately and avoid
-    # waiting on slower Firestore/workspace/Honcho fallback searches.
-    if agent_role == "voice" and not requested_sources:
+    # waiting on slower Firestore/workspace/Honcho fallback searches. Explicit
+    # source/time-window queries still need canonical fan-out so the voice agent
+    # does not answer "latest OMI" from a stale compact pack.
+    if agent_role == "voice" and not requested_sources and not _voice_query_requires_source_fanout(query):
         fast_results = await _search_voice_memory_pack(uid, query, limit)
         if fast_results and fast_results[0].get("score", 0) >= 120:
             _elapsed = int((time.time() - _start) * 1000)

--- a/backend/tests/unit/test_voice_search_canonical_omi.py
+++ b/backend/tests/unit/test_voice_search_canonical_omi.py
@@ -1,7 +1,9 @@
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import types
+from typing import Optional
+from zoneinfo import ZoneInfo
 
 
 def _load_voice_omi_helpers(fetch_canonical_timeline):
@@ -11,7 +13,10 @@ def _load_voice_omi_helpers(fetch_canonical_timeline):
     end = source.index("\n\nasync def _search_omi_conversations(", start)
     module = types.ModuleType("voice_omi_canonical_test")
     module.datetime = datetime
+    module.timedelta = timedelta
     module.timezone = timezone
+    module.ZoneInfo = ZoneInfo
+    module.Optional = Optional
     module.fetch_canonical_timeline = fetch_canonical_timeline
     module.logger = types.SimpleNamespace(warning=lambda *_args, **_kwargs: None, info=lambda *_args, **_kwargs: None)
     exec(source[start:end], module.__dict__)
@@ -64,6 +69,33 @@ def test_search_canonical_omi_events_uses_timeline_channel_omi_first():
     assert results[0]["metadata"]["event_id"] == "omi:cafe-123:summary"
 
 
+def test_search_canonical_omi_events_applies_this_morning_window():
+    calls = []
+    afternoon_event = {
+        **_cafe_event(),
+        "event_id": "omi:afternoon:summary",
+        "source_identity": "omi:afternoon",
+        "text": "Afternoon drive\n\nTalked about traffic after lunch.",
+        "started_at": "2026-05-07T21:30:00+00:00",
+        "metadata": {"structured": {"title": "Afternoon drive"}},
+    }
+
+    async def fake_fetch(uid, **kwargs):
+        calls.append((uid, kwargs))
+        return [afternoon_event, _cafe_event()]
+
+    module = _load_voice_omi_helpers(fake_fetch)
+    module._pacific_now = lambda: datetime(2026, 5, 7, 15, 0, tzinfo=ZoneInfo("America/Los_Angeles"))
+
+    results = asyncio.run(module._search_canonical_omi_events("uid-1", "what happened this morning", 5, True))
+
+    assert calls == [("uid-1", {"limit": 300, "channels": ["omi"]})]
+    assert len(results) == 1
+    assert results[0]["title"] == "Cafe Coffee and Waffle Stop"
+    assert results[0]["timestamp"] == "2026-05-07 11:56 AM PDT"
+    assert results[0]["metadata"]["time_window_applied"] is True
+
+
 def test_search_canonical_omi_events_returns_empty_when_no_useful_match():
     async def fake_fetch(_uid, **_kwargs):
         return [_cafe_event()]
@@ -73,4 +105,3 @@ def test_search_canonical_omi_events_returns_empty_when_no_useful_match():
     results = asyncio.run(module._search_canonical_omi_events("uid-1", "dentist appointment", 5, True))
 
     assert results == []
-

--- a/backend/tests/unit/test_voice_search_canonical_omi.py
+++ b/backend/tests/unit/test_voice_search_canonical_omi.py
@@ -105,3 +105,15 @@ def test_search_canonical_omi_events_returns_empty_when_no_useful_match():
     results = asyncio.run(module._search_canonical_omi_events("uid-1", "dentist appointment", 5, True))
 
     assert results == []
+
+
+def test_voice_query_requires_fanout_for_explicit_omi_and_time_queries():
+    async def fake_fetch(_uid, **_kwargs):
+        return []
+
+    module = _load_voice_omi_helpers(fake_fetch)
+
+    assert module._voice_query_requires_source_fanout("latest OMI conversation") is True
+    assert module._voice_query_requires_source_fanout("what OMI conversations happened this morning") is True
+    assert module._voice_query_requires_source_fanout("what did I do today") is True
+    assert module._voice_query_requires_source_fanout("where did I put my glasses") is False


### PR DESCRIPTION
## Summary\n- route explicit OMI/source/time-window voice queries through canonical fan-out instead of returning the compact voice-memory fast path\n- keep the fast Hermes memory pack for ordinary voice recall queries\n- add focused coverage for temporal/source fan-out behavior\n\n## Test\n- pytest backend/tests/unit/test_voice_search_canonical_omi.py -q\n\nContext: fixes Grok/Gemini voice missing recent OMI even though canonical OMI search is healthy.