### PR TITLE
Omit voice memory for temporal OMI fanout

### DIFF
--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -2384,7 +2384,10 @@ async def unified_search(request: Request):
     tasks = []
     task_source_names = []
 
-    if agent_role in {"voice", "user"} and (not requested_sources or "voice_memory" in requested_sources):
+    include_voice_memory = bool(requested_sources and "voice_memory" in requested_sources) or (
+        not requested_sources and _should_use_voice_memory_fast_path(query)
+    )
+    if agent_role in {"voice", "user"} and include_voice_memory:
         tasks.append(_search_voice_memory_pack(uid, query, limit))
         task_source_names.append("voice_memory")
 


### PR DESCRIPTION
## Summary
- omit Hermes `voice_memory` from default fan-out for temporal or OMI/transcript-specific voice searches
- keep `voice_memory` available when explicitly requested
- prevents stale high-confidence Hermes memory results from outranking canonical OMI on generic Grok `search_all` calls

## Validation
- `pytest -q backend/tests/unit/test_voice_search_canonical_omi.py backend/tests/unit/test_ella_chat_temporal_context.py`

## Live context
PR #222 stopped the early fast-path return, but default fan-out still included `voice_memory`, whose score could rank stale results ahead of the canonical OMI morning window. This keeps temporal/OMI detail queries canonical-first in the merged result set.