### PR TITLE
Rank broad temporal OMI results by signal quality

### DIFF
--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -1759,6 +1759,39 @@ def _canonical_event_timestamp(event: dict, user_timezone: str = "America/Los_An
         return str(raw)[:16]
 
 
+def _canonical_omi_quality_score(metadata: dict) -> int:
+    signal = metadata.get("ella_signal") if isinstance(metadata.get("ella_signal"), dict) else {}
+    tags = metadata.get("ella_tags") if isinstance(metadata.get("ella_tags"), list) else []
+    tags = {str(tag).lower() for tag in tags}
+
+    score = 0
+    salience = str(signal.get("salience") or "").lower()
+    if salience == "high":
+        score += 30
+    elif salience == "medium":
+        score += 18
+
+    noise = str(signal.get("noise_level") or "").lower()
+    if noise == "none":
+        score += 4
+    elif noise == "low":
+        score += 2
+    elif noise == "medium":
+        score -= 6
+    elif noise == "high":
+        score -= 14
+
+    if "low_signal" in tags:
+        score -= 12
+    if "background" in tags:
+        score -= 8
+    if "media" in tags:
+        score -= 4
+    if signal.get("contains_user_speech") is False:
+        score -= 10
+    return score
+
+
 async def _search_canonical_omi_events(uid: str, query: str, limit: int, full_access: bool) -> list:
     """Search OMI canonical summary events via GET /v1/ella/timeline first."""
     results = []
@@ -1799,13 +1832,16 @@ async def _search_canonical_omi_events(uid: str, query: str, limit: int, full_ac
         score = _keyword_score(searchable, query_terms) if query_terms else 1
         if score <= 0:
             continue
+        rank_score = score
+        if window_start and not query_terms:
+            rank_score += _canonical_omi_quality_score(metadata)
 
         started_sort = started_sort or datetime.min
 
         content = text
         if not full_access:
             content = content[:300] + ("..." if len(content) > 300 else "")
-        matches.append((score, started_sort, event, title, content))
+        matches.append((rank_score, started_sort, event, title, content))
 
     matches.sort(key=lambda item: (item[0], item[1]), reverse=True)
     for score, _started_sort, event, title, content in matches[:limit]:

--- a/backend/tests/unit/test_voice_search_canonical_omi.py
+++ b/backend/tests/unit/test_voice_search_canonical_omi.py
@@ -108,6 +108,43 @@ def test_voice_memory_fast_path_skips_temporal_or_omi_queries():
     assert module._should_use_voice_memory_fast_path("what was that restaurant name") is True
 
 
+def test_search_canonical_omi_events_prefers_salient_events_for_broad_time_window():
+    low_signal_late = {
+        **_cafe_event(),
+        "event_id": "omi:brief-late:summary",
+        "source_identity": "omi:brief-late",
+        "text": "Brief Okay\n\nA quick one-word exchange.",
+        "started_at": "2026-05-07T18:58:00+00:00",
+        "metadata": {
+            "ella_tags": ["omi", "low_signal"],
+            "ella_signal": {"salience": "low", "noise_level": "high", "contains_user_speech": True},
+            "structured": {"title": "Brief Okay"},
+        },
+    }
+    salient_early = {
+        **_cafe_event(),
+        "event_id": "omi:salient-early:summary",
+        "source_identity": "omi:salient-early",
+        "text": "Morning school support\n\nHelped Meisheng with school anxiety and decided to email the teacher.",
+        "started_at": "2026-05-07T16:20:00+00:00",
+        "metadata": {
+            "ella_tags": ["omi", "family", "health"],
+            "ella_signal": {"salience": "medium", "noise_level": "low", "contains_user_speech": True},
+            "structured": {"title": "Morning school support"},
+        },
+    }
+
+    async def fake_fetch(_uid, **_kwargs):
+        return [low_signal_late, salient_early]
+
+    module = _load_voice_omi_helpers(fake_fetch)
+    module._pacific_now = lambda: datetime(2026, 5, 7, 15, 0, tzinfo=ZoneInfo("America/Los_Angeles"))
+
+    results = asyncio.run(module._search_canonical_omi_events("uid-1", "what happened this morning", 5, True))
+
+    assert [item["title"] for item in results] == ["Morning school support", "Brief Okay"]
+
+
 def test_search_canonical_omi_events_returns_empty_when_no_useful_match():
     async def fake_fetch(_uid, **_kwargs):
         return [_cafe_event()]


### PR DESCRIPTION
## Summary
- rank broad temporal OMI search results by canonical signal quality instead of pure recency
- boost medium/high salience and low/no-noise conversations
- demote `low_signal`, background/media, high-noise, and non-user-speech summaries
- add regression coverage so a salient morning event outranks a later low-signal fragment

## Validation
- `pytest -q backend/tests/unit/test_voice_search_canonical_omi.py backend/tests/unit/test_ella_chat_temporal_context.py`

## Live context
Grok voice now calls `search_all`, and `/v1/voice/search` returns canonical OMI. The remaining bad UX was that broad queries like `what happened this morning in OMI conversations` returned the latest low-signal fragments first because every in-window event had the same score. This patch makes broad time-window recall favor useful conversations before fragments/noise.