### PR TITLE
[codex] Add iOS Developer Settings agent config selector

### DIFF
--- a/app/lib/ella/services/agent_config_service.dart
+++ b/app/lib/ella/services/agent_config_service.dart
@@ -1,0 +1,228 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:omi/backend/http/shared.dart';
+import 'package:omi/env/env.dart';
+
+class AgentConfigResponse {
+  const AgentConfigResponse({required this.statusCode, required this.body});
+
+  final int statusCode;
+  final Map<String, dynamic> body;
+
+  bool get isSuccess => statusCode >= 200 && statusCode < 300;
+}
+
+abstract class AgentConfigTransport {
+  Future<AgentConfigResponse?> get(String path);
+
+  Future<AgentConfigResponse?> patch(String path, Map<String, dynamic> payload);
+}
+
+class _AgentConfigHttpTransport implements AgentConfigTransport {
+  @override
+  Future<AgentConfigResponse?> get(String path) async {
+    final response = await makeApiCall(
+      url: '${Env.apiBaseUrl}$path',
+      headers: const {'Content-Type': 'application/json'},
+      method: 'GET',
+      body: '',
+      timeout: const Duration(seconds: 10),
+      retries: 0,
+    );
+    if (response == null) return null;
+    return AgentConfigResponse(statusCode: response.statusCode, body: _decodeBody(response.body));
+  }
+
+  @override
+  Future<AgentConfigResponse?> patch(String path, Map<String, dynamic> payload) async {
+    final response = await makeApiCall(
+      url: '${Env.apiBaseUrl}$path',
+      headers: const {'Content-Type': 'application/json'},
+      method: 'PATCH',
+      body: jsonEncode(payload),
+      timeout: const Duration(seconds: 10),
+      retries: 0,
+    );
+    if (response == null) return null;
+    return AgentConfigResponse(statusCode: response.statusCode, body: _decodeBody(response.body));
+  }
+
+  static Map<String, dynamic> _decodeBody(String raw) {
+    if (raw.trim().isEmpty) return {};
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic>) return decoded;
+    } catch (_) {}
+    return {};
+  }
+}
+
+class AgentConfig {
+  const AgentConfig({
+    required this.platform,
+    required this.provider,
+    required this.model,
+    required this.editable,
+    required this.options,
+    required this.source,
+  });
+
+  final String platform;
+  final String provider;
+  final String model;
+  final AgentConfigEditable editable;
+  final AgentConfigOptions options;
+  final AgentConfigSource source;
+
+  factory AgentConfig.fromJson(Map<String, dynamic> json) {
+    return AgentConfig(
+      platform: _readString(json['platform']),
+      provider: _readString(json['provider']),
+      model: _readString(json['model']),
+      editable: AgentConfigEditable.fromJson(_readMap(json['editable'])),
+      options: AgentConfigOptions.fromJson(_readMap(json['options'])),
+      source: AgentConfigSource.fromJson(_readMap(json['source'])),
+    );
+  }
+
+  AgentConfig copyWith({
+    String? platform,
+    String? provider,
+    String? model,
+    AgentConfigEditable? editable,
+    AgentConfigOptions? options,
+    AgentConfigSource? source,
+  }) {
+    return AgentConfig(
+      platform: platform ?? this.platform,
+      provider: provider ?? this.provider,
+      model: model ?? this.model,
+      editable: editable ?? this.editable,
+      options: options ?? this.options,
+      source: source ?? this.source,
+    );
+  }
+}
+
+class AgentConfigEditable {
+  const AgentConfigEditable({
+    required this.platform,
+    required this.provider,
+    required this.model,
+  });
+
+  final bool platform;
+  final bool provider;
+  final bool model;
+
+  factory AgentConfigEditable.fromJson(Map<String, dynamic> json) {
+    return AgentConfigEditable(
+      platform: json['platform'] == true,
+      provider: json['provider'] == true,
+      model: json['model'] == true,
+    );
+  }
+}
+
+class AgentConfigOptions {
+  const AgentConfigOptions({
+    required this.providers,
+    required this.modelsByProvider,
+  });
+
+  final List<String> providers;
+  final Map<String, List<String>> modelsByProvider;
+
+  factory AgentConfigOptions.fromJson(Map<String, dynamic> json) {
+    final providers = _readStringList(json['providers']);
+    final modelsByProvider = <String, List<String>>{};
+    final rawModelsByProvider = json['modelsByProvider'];
+
+    if (rawModelsByProvider is Map<String, dynamic>) {
+      for (final entry in rawModelsByProvider.entries) {
+        modelsByProvider[entry.key] = _readStringList(entry.value);
+      }
+    }
+
+    return AgentConfigOptions(
+      providers: providers,
+      modelsByProvider: modelsByProvider,
+    );
+  }
+
+  List<String> modelsForProvider(String provider) => modelsByProvider[provider] ?? const [];
+}
+
+class AgentConfigSource {
+  const AgentConfigSource({
+    required this.runtime,
+    required this.profile,
+    required this.override,
+  });
+
+  final String runtime;
+  final String profile;
+  final String override;
+
+  factory AgentConfigSource.fromJson(Map<String, dynamic> json) {
+    return AgentConfigSource(
+      runtime: _readString(json['runtime']),
+      profile: _readString(json['profile']),
+      override: _readString(json['override']),
+    );
+  }
+}
+
+class AgentConfigService {
+  AgentConfigService._();
+
+  static const path = 'v1/ella/agent-config';
+
+  @visibleForTesting
+  static AgentConfigTransport transport = _AgentConfigHttpTransport();
+
+  static Future<AgentConfig?> fetch() async {
+    final response = await transport.get(path);
+    if (response == null || !response.isSuccess) return null;
+    return AgentConfig.fromJson(response.body);
+  }
+
+  static Future<AgentConfig?> update({
+    required String provider,
+    required String model,
+    AgentConfig? previous,
+  }) async {
+    final response = await transport.patch(path, buildPatchPayload(provider: provider, model: model));
+    if (response == null || !response.isSuccess) return null;
+    if (response.body.isNotEmpty) return AgentConfig.fromJson(response.body);
+    return previous?.copyWith(provider: provider, model: model);
+  }
+
+  @visibleForTesting
+  static Map<String, dynamic> buildPatchPayload({
+    required String provider,
+    required String model,
+  }) {
+    return {
+      'provider': provider,
+      'model': model,
+    };
+  }
+}
+
+String _readString(dynamic value) {
+  if (value is String) return value.trim();
+  return '';
+}
+
+Map<String, dynamic> _readMap(dynamic value) {
+  if (value is Map<String, dynamic>) return value;
+  return {};
+}
+
+List<String> _readStringList(dynamic value) {
+  if (value is! List) return const [];
+  return value.whereType<String>().map((item) => item.trim()).where((item) => item.isNotEmpty).toList(growable: false);
+}

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10136,5 +10136,13 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "chatModelSettings": "Chat Model",
+  "chatModelSettingsSubtitle": "Backend chat routing for Ella responses",
+  "platform": "Platform",
+  "agentConfigRefresh": "Refresh",
+  "agentConfigSaving": "Saving chat model...",
+  "agentConfigUnavailable": "Chat model config is unavailable until the backend agent-config endpoint is live.",
+  "agentConfigUpdateFailed": "Could not update chat model config. Try again after backend support is live.",
+  "notAvailable": "Not available"
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -15896,6 +15896,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Guardian ON: Audio monitoring and care features active.'**
   String get ellaGuardianOnTooltip;
+
+  /// No description provided for @chatModelSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Chat Model'**
+  String get chatModelSettings;
+
+  /// No description provided for @chatModelSettingsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Backend chat routing for Ella responses'**
+  String get chatModelSettingsSubtitle;
+
+  /// No description provided for @platform.
+  ///
+  /// In en, this message translates to:
+  /// **'Platform'**
+  String get platform;
+
+  /// No description provided for @agentConfigRefresh.
+  ///
+  /// In en, this message translates to:
+  /// **'Refresh'**
+  String get agentConfigRefresh;
+
+  /// No description provided for @agentConfigSaving.
+  ///
+  /// In en, this message translates to:
+  /// **'Saving chat model...'**
+  String get agentConfigSaving;
+
+  /// No description provided for @agentConfigUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Chat model config is unavailable until the backend agent-config endpoint is live.'**
+  String get agentConfigUnavailable;
+
+  /// No description provided for @agentConfigUpdateFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not update chat model config. Try again after backend support is live.'**
+  String get agentConfigUpdateFailed;
+
+  /// No description provided for @notAvailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Not available'**
+  String get notAvailable;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8461,4 +8461,29 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8549,4 +8549,29 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8565,4 +8565,29 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8512,4 +8512,29 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8501,4 +8501,29 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8583,4 +8583,29 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8574,4 +8574,29 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8514,4 +8514,29 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8531,4 +8531,29 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8516,4 +8516,29 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8515,4 +8515,29 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8590,4 +8590,29 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8497,4 +8497,29 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8554,4 +8554,29 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8529,4 +8529,29 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8566,4 +8566,29 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8383,4 +8383,29 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8385,4 +8385,29 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8522,4 +8522,29 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8534,4 +8534,29 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8540,4 +8540,29 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8542,4 +8542,29 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8512,4 +8512,29 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8535,4 +8535,29 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8517,4 +8517,29 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8555,4 +8555,29 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8542,4 +8542,29 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8507,4 +8507,29 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8522,4 +8522,29 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8479,4 +8479,29 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8530,4 +8530,29 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8529,4 +8529,29 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8519,4 +8519,29 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8373,4 +8373,29 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get chatModelSettings => 'Chat Model';
+
+  @override
+  String get chatModelSettingsSubtitle => 'Backend chat routing for Ella responses';
+
+  @override
+  String get platform => 'Platform';
+
+  @override
+  String get agentConfigRefresh => 'Refresh';
+
+  @override
+  String get agentConfigSaving => 'Saving chat model...';
+
+  @override
+  String get agentConfigUnavailable =>
+      'Chat model config is unavailable until the backend agent-config endpoint is live.';
+
+  @override
+  String get agentConfigUpdateFailed => 'Could not update chat model config. Try again after backend support is live.';
+
+  @override
+  String get notAvailable => 'Not available';
 }

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -14,6 +15,7 @@ import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/http/api/knowledge_graph_api.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/ella/services/agent_config_service.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/models/stt_provider.dart';
 import 'package:omi/pages/persona/persona_profile.dart';
@@ -39,12 +41,54 @@ class DeveloperSettingsPage extends StatefulWidget {
 }
 
 class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
+  AgentConfig? _agentConfig;
+  bool _agentConfigLoading = false;
+  bool _agentConfigSaving = false;
+  String? _agentConfigError;
+
   @override
   void initState() {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       context.read<McpProvider>().fetchKeys();
+      unawaited(_loadAgentConfig());
     });
     super.initState();
+  }
+
+  Future<void> _loadAgentConfig() async {
+    if (_agentConfigLoading) return;
+    setState(() {
+      _agentConfigLoading = true;
+      _agentConfigError = null;
+    });
+
+    final config = await AgentConfigService.fetch();
+    if (!mounted) return;
+
+    setState(() {
+      _agentConfig = config;
+      _agentConfigLoading = false;
+      _agentConfigError = config == null ? context.l10n.agentConfigUnavailable : null;
+    });
+  }
+
+  Future<void> _updateAgentConfig({required String provider, required String model}) async {
+    final previous = _agentConfig;
+    if (previous == null || _agentConfigSaving) return;
+
+    setState(() {
+      _agentConfigSaving = true;
+      _agentConfigError = null;
+    });
+
+    final updated = await AgentConfigService.update(provider: provider, model: model, previous: previous);
+    if (!mounted) return;
+
+    setState(() {
+      _agentConfig = updated ?? previous;
+      _agentConfigSaving = false;
+      _agentConfigError = updated == null ? context.l10n.agentConfigUpdateFailed : null;
+    });
   }
 
   Widget _buildSectionContainer({required List<Widget> children}) {
@@ -90,6 +134,162 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
             ),
           ],
         ],
+      ),
+    );
+  }
+
+  Widget _buildChatModelSection(BuildContext context) {
+    final config = _agentConfig;
+    final providers = config?.options.providers ?? const <String>[];
+    final selectedProvider = config != null && providers.contains(config.provider) ? config.provider : null;
+    final models = config == null ? const <String>[] : config.options.modelsForProvider(config.provider);
+    final selectedModel = config != null && models.contains(config.model) ? config.model : null;
+    final canEditProvider = config?.editable.provider == true && providers.isNotEmpty && !_agentConfigSaving;
+    final canEditModel = config?.editable.model == true && models.isNotEmpty && !_agentConfigSaving;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSectionHeader(
+          context.l10n.chatModelSettings,
+          subtitle: context.l10n.chatModelSettingsSubtitle,
+          trailing: _agentConfigLoading
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                )
+              : TextButton(
+                  onPressed: _loadAgentConfig,
+                  child: Text(context.l10n.agentConfigRefresh),
+                ),
+        ),
+        Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: const Color(0xFF1C1C1E),
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: Column(
+            children: [
+              _buildAgentConfigValueRow(
+                icon: FontAwesomeIcons.layerGroup,
+                label: context.l10n.platform,
+                child: _buildReadOnlyPill(config?.platform ?? context.l10n.notAvailable),
+              ),
+              const SizedBox(height: 14),
+              _buildAgentConfigValueRow(
+                icon: FontAwesomeIcons.plug,
+                label: context.l10n.provider,
+                child: DropdownButton<String>(
+                  value: selectedProvider,
+                  hint: Text(context.l10n.notAvailable),
+                  dropdownColor: const Color(0xFF2A2A2E),
+                  underline: const SizedBox.shrink(),
+                  isExpanded: true,
+                  style: const TextStyle(color: Colors.white, fontSize: 14),
+                  items: providers.map((provider) => DropdownMenuItem(value: provider, child: Text(provider))).toList(),
+                  onChanged: canEditProvider
+                      ? (provider) {
+                          if (provider == null || config == null) return;
+                          final providerModels = config.options.modelsForProvider(provider);
+                          final model = providerModels.contains(config.model)
+                              ? config.model
+                              : providerModels.isNotEmpty
+                                  ? providerModels.first
+                                  : config.model;
+                          unawaited(_updateAgentConfig(provider: provider, model: model));
+                        }
+                      : null,
+                ),
+              ),
+              const SizedBox(height: 14),
+              _buildAgentConfigValueRow(
+                icon: FontAwesomeIcons.microchip,
+                label: context.l10n.model,
+                child: DropdownButton<String>(
+                  value: selectedModel,
+                  hint: Text(context.l10n.notAvailable),
+                  dropdownColor: const Color(0xFF2A2A2E),
+                  underline: const SizedBox.shrink(),
+                  isExpanded: true,
+                  style: const TextStyle(color: Colors.white, fontSize: 14),
+                  items: models.map((model) => DropdownMenuItem(value: model, child: Text(model))).toList(),
+                  onChanged: canEditModel
+                      ? (model) {
+                          if (model == null || config == null) return;
+                          unawaited(_updateAgentConfig(provider: config.provider, model: model));
+                        }
+                      : null,
+                ),
+              ),
+              if (_agentConfigSaving) ...[
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                    ),
+                    const SizedBox(width: 8),
+                    Text(context.l10n.agentConfigSaving, style: TextStyle(color: Colors.grey.shade400, fontSize: 12)),
+                  ],
+                ),
+              ],
+              if (_agentConfigError != null) ...[
+                const SizedBox(height: 12),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(_agentConfigError!, style: const TextStyle(color: Color(0xFFFCA5A5), fontSize: 12)),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildAgentConfigValueRow({
+    required IconData icon,
+    required String label,
+    required Widget child,
+  }) {
+    return Row(
+      children: [
+        Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: const Color(0xFF2A2A2E),
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Center(child: FaIcon(icon, color: Colors.grey.shade400, size: 16)),
+        ),
+        const SizedBox(width: 14),
+        SizedBox(
+          width: 82,
+          child: Text(label, style: const TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w500)),
+        ),
+        const SizedBox(width: 12),
+        Expanded(child: child),
+      ],
+    );
+  }
+
+  Widget _buildReadOnlyPill(String value) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+      decoration: BoxDecoration(
+        color: const Color(0xFF2A2A2E),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        value,
+        overflow: TextOverflow.ellipsis,
+        style: TextStyle(color: Colors.grey.shade300, fontSize: 14),
       ),
     );
   }
@@ -767,6 +967,10 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                       ),
                     ),
                   ),
+                  const SizedBox(height: 32),
+
+                  // Chat Model Section
+                  _buildChatModelSection(context),
                   const SizedBox(height: 32),
 
                   // TTS Provider Section

--- a/app/test/ella/services/agent_config_service_test.dart
+++ b/app/test/ella/services/agent_config_service_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/ella/services/agent_config_service.dart';
+
+class _FakeAgentConfigTransport implements AgentConfigTransport {
+  final List<String> getPaths = [];
+  final List<String> patchPaths = [];
+  final List<Map<String, dynamic>> patchPayloads = [];
+  AgentConfigResponse? getResponse;
+  AgentConfigResponse? patchResponse;
+
+  @override
+  Future<AgentConfigResponse?> get(String path) async {
+    getPaths.add(path);
+    return getResponse;
+  }
+
+  @override
+  Future<AgentConfigResponse?> patch(String path, Map<String, dynamic> payload) async {
+    patchPaths.add(path);
+    patchPayloads.add(payload);
+    return patchResponse;
+  }
+}
+
+void main() {
+  group('AgentConfigService', () {
+    late _FakeAgentConfigTransport transport;
+
+    setUp(() {
+      transport = _FakeAgentConfigTransport();
+      AgentConfigService.transport = transport;
+    });
+
+    test('parses platform/provider/model and backend allowlists', () async {
+      transport.getResponse = const AgentConfigResponse(
+        statusCode: 200,
+        body: {
+          'platform': 'hermes',
+          'provider': 'openai-codex',
+          'model': 'gpt-5.5',
+          'editable': {'platform': false, 'provider': true, 'model': true},
+          'options': {
+            'providers': ['openai-codex', 'anthropic'],
+            'modelsByProvider': {
+              'openai-codex': ['gpt-5.5', 'gpt-5.5-mini'],
+              'anthropic': ['claude-opus-4-7'],
+            },
+          },
+          'source': {'runtime': 'hermes', 'profile': 'plato', 'override': 'profile'},
+        },
+      );
+
+      final config = await AgentConfigService.fetch();
+
+      expect(transport.getPaths, [AgentConfigService.path]);
+      expect(config, isNotNull);
+      expect(config!.platform, 'hermes');
+      expect(config.provider, 'openai-codex');
+      expect(config.model, 'gpt-5.5');
+      expect(config.editable.platform, isFalse);
+      expect(config.editable.provider, isTrue);
+      expect(config.options.providers, ['openai-codex', 'anthropic']);
+      expect(config.options.modelsForProvider('openai-codex'), ['gpt-5.5', 'gpt-5.5-mini']);
+      expect(config.source.runtime, 'hermes');
+    });
+
+    test('builds provider/model patch and preserves platform from previous config on empty success body', () async {
+      const previous = AgentConfig(
+        platform: 'hermes',
+        provider: 'openai-codex',
+        model: 'gpt-5.5',
+        editable: AgentConfigEditable(platform: false, provider: true, model: true),
+        options: AgentConfigOptions(
+          providers: ['openai-codex'],
+          modelsByProvider: {
+            'openai-codex': ['gpt-5.5', 'gpt-5.5-mini'],
+          },
+        ),
+        source: AgentConfigSource(runtime: 'hermes', profile: 'plato', override: 'profile'),
+      );
+      transport.patchResponse = const AgentConfigResponse(statusCode: 204, body: {});
+
+      final updated = await AgentConfigService.update(
+        provider: 'openai-codex',
+        model: 'gpt-5.5-mini',
+        previous: previous,
+      );
+
+      expect(transport.patchPaths, [AgentConfigService.path]);
+      expect(transport.patchPayloads.single, {'provider': 'openai-codex', 'model': 'gpt-5.5-mini'});
+      expect(updated, isNotNull);
+      expect(updated!.platform, 'hermes');
+      expect(updated.provider, 'openai-codex');
+      expect(updated.model, 'gpt-5.5-mini');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the iOS Developer Settings slice for ellaaicare/ella-ai#902 and links OMI tracking issue ellaaicare/ella-ai#1001.

- Adds an `AgentConfigService` for `GET/PATCH v1/ella/agent-config`.
- Adds a Developer Settings **Chat Model** section showing platform/provider/model.
- Keeps platform read-only.
- Enables provider/model dropdowns only when backend returns editable flags and allowlisted options.
- Uses backend-provided options only; does not hard-code OpenClaw or any provider as primary.
- Adds focused parser/payload tests.

## Backend dependency

Live TestFlight validation is blocked until Jack lands or stubs the backend schema from ellaaicare/ella-ai#902. Until then, the UI degrades safely with an unavailable message.

## Validation

- `flutter gen-l10n`
- `dart format --line-length 120 lib/ella/services/agent_config_service.dart lib/pages/settings/developer.dart test/ella/services/agent_config_service_test.dart`
- `flutter test test/ella/services/agent_config_service_test.dart`
- `flutter analyze lib/ella/services/agent_config_service.dart test/ella/services/agent_config_service_test.dart`
- `./test.sh`

Note: targeted `flutter analyze lib/pages/settings/developer.dart` still reports pre-existing info-level warnings in that file unrelated to this change (deprecated switch/share APIs and existing async-context lint sites).
