### PR TITLE
Add Hermes-first agent config API

### DIFF
--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -365,6 +365,15 @@ def _register_routers(app) -> None:
     except ImportError as e:
         print(f"  ⚠️ Ella settings not available: {e}", flush=True)
 
+    # Hermes-first agent/provider/model settings used by Developer Settings
+    try:
+        from ella.routers.agent_config import router as agent_config_router
+
+        app.include_router(agent_config_router, tags=["Ella Agent Config"])
+        print("  🌐 /v1/ella/agent-config - Hermes agent model config", flush=True)
+    except ImportError as e:
+        print(f"  ⚠️ Ella agent config not available: {e}", flush=True)
+
     # Voice session management (token issuance for Ella Voice)
     if ELLA_VOICE_V2_ENABLED:
         try:

--- a/backend/ella/routers/agent_config.py
+++ b/backend/ella/routers/agent_config.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, ConfigDict
+
+from ella.services.agent_config import get_agent_config, patch_agent_config
+from utils.other import endpoints as auth
+
+router = APIRouter(prefix="/v1/ella", tags=["Ella Agent Config"])
+
+
+class AgentConfigPatch(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str
+    model: str
+
+
+@router.get("/agent-config")
+async def get_current_agent_config(uid: str = Depends(auth.get_current_user_uid)) -> dict[str, Any]:
+    """Return the authenticated user's active Hermes agent model config."""
+    return await get_agent_config(uid)
+
+
+@router.patch("/agent-config")
+async def patch_current_agent_config(
+    payload: AgentConfigPatch,
+    uid: str = Depends(auth.get_current_user_uid),
+) -> dict[str, Any]:
+    """Update only provider/model for the authenticated user's active Hermes profile."""
+    return await patch_agent_config(uid, payload.provider, payload.model)

--- a/backend/ella/services/agent_config.py
+++ b/backend/ella/services/agent_config.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+from fastapi import HTTPException
+
+from ella.routers import resolve as resolve_router
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODELS_BY_PROVIDER: dict[str, list[str]] = {
+    "openai-codex": ["gpt-5.5", "gpt-5.5-mini", "gpt-5.4", "gpt-5.4-mini"],
+    "openai": ["gpt-5.5", "gpt-5.5-mini", "gpt-5.4", "gpt-5.4-mini", "gpt-4.1", "gpt-4.1-mini"],
+    "anthropic": ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"],
+    "openrouter": ["x-ai/grok-4.1-fast", "anthropic/claude-sonnet-4-6", "openai/gpt-5.5"],
+    "ollama-cloud": ["kimi-k2.6", "gpt-oss:120b", "qwen3-coder"],
+}
+
+DEFAULT_HERMES_PROVIDER = os.getenv("ELLA_AGENT_CONFIG_DEFAULT_PROVIDER", "openai-codex").strip()
+DEFAULT_HERMES_MODEL = os.getenv("ELLA_AGENT_CONFIG_DEFAULT_MODEL", "gpt-5.5").strip()
+HERMES_PROVISION_URL = os.getenv("HERMES_PROVISION_API_URL", "http://100.76.138.56:8210").rstrip("/")
+HERMES_PROVISION_TOKEN = os.getenv(
+    "HERMES_PROVISION_API_TOKEN",
+    os.getenv("ELLA_PROVISION_API_TOKEN", os.getenv("ELLA_PROVISION_API_KEY", "")),
+).strip()
+HERMES_AGENT_ID = os.getenv("HERMES_AGENT_ID", "hermes").strip() or "hermes"
+
+
+@dataclass(frozen=True)
+class AgentRouting:
+    platform: str
+    agent_id: str
+    provision_url: str
+    provision_token: str
+    profile: str | None = None
+
+
+def models_by_provider() -> dict[str, list[str]]:
+    raw = os.getenv("ELLA_AGENT_CONFIG_MODELS_BY_PROVIDER_JSON", "").strip()
+    if not raw:
+        return {key: list(value) for key, value in DEFAULT_MODELS_BY_PROVIDER.items()}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning("Invalid ELLA_AGENT_CONFIG_MODELS_BY_PROVIDER_JSON: %s", exc)
+        return {key: list(value) for key, value in DEFAULT_MODELS_BY_PROVIDER.items()}
+    if not isinstance(parsed, dict):
+        return {key: list(value) for key, value in DEFAULT_MODELS_BY_PROVIDER.items()}
+    normalized: dict[str, list[str]] = {}
+    for provider, models in parsed.items():
+        if not isinstance(provider, str) or not isinstance(models, list):
+            continue
+        clean_models = [str(model).strip() for model in models if str(model).strip()]
+        if provider.strip() and clean_models:
+            normalized[provider.strip()] = clean_models
+    return normalized or {key: list(value) for key, value in DEFAULT_MODELS_BY_PROVIDER.items()}
+
+
+def options_payload() -> dict[str, Any]:
+    options = models_by_provider()
+    return {
+        "providers": list(options.keys()),
+        "modelsByProvider": options,
+    }
+
+
+def validate_provider_model(provider: str, model: str) -> tuple[str, str]:
+    provider = str(provider or "").strip()
+    model = str(model or "").strip()
+    if not provider:
+        raise HTTPException(status_code=422, detail={"error": "provider_required"})
+    if not model:
+        raise HTTPException(status_code=422, detail={"error": "model_required"})
+    options = models_by_provider()
+    if provider not in options:
+        raise HTTPException(
+            status_code=422,
+            detail={"error": "provider_not_allowed", "provider": provider, "allowed_providers": list(options.keys())},
+        )
+    if model not in options[provider]:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "model_not_allowed_for_provider",
+                "provider": provider,
+                "model": model,
+                "allowed_models": options[provider],
+            },
+        )
+    return provider, model
+
+
+async def resolve_agent_routing(uid: str) -> AgentRouting:
+    resolved = await resolve_router.resolve_user_routing(uid)
+    routing = (resolved or {}).get("routing") or {}
+    platform = str(routing.get("platform") or resolve_router.CHAT_PLATFORM or "openclaw").strip().lower()
+    if platform != "hermes":
+        return AgentRouting(
+            platform=platform,
+            agent_id=str(routing.get("agentId") or HERMES_AGENT_ID),
+            provision_url=str(routing.get("provisionUrl") or HERMES_PROVISION_URL).rstrip("/"),
+            provision_token=str(routing.get("provisionToken") or HERMES_PROVISION_TOKEN),
+        )
+    return AgentRouting(
+        platform="hermes",
+        agent_id=str(routing.get("agentId") or HERMES_AGENT_ID),
+        provision_url=str(routing.get("provisionUrl") or HERMES_PROVISION_URL).rstrip("/"),
+        provision_token=str(routing.get("provisionToken") or HERMES_PROVISION_TOKEN),
+        profile=str(routing.get("profile") or "") or None,
+    )
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _base_response(
+    *,
+    uid: str,
+    routing: AgentRouting,
+    provider: str,
+    model: str,
+    source: dict[str, Any],
+    cache: dict[str, Any] | None = None,
+    reload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "uid": uid,
+        "platform": routing.platform,
+        "provider": provider,
+        "model": model,
+        "editable": {
+            "platform": False,
+            "provider": routing.platform == "hermes",
+            "model": routing.platform == "hermes",
+        },
+        "options": options_payload(),
+        "source": source,
+        "cache": cache or {"invalidated": False},
+        "reload": reload or {"status": "not_requested"},
+        "updated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+
+
+async def get_agent_config(uid: str) -> dict[str, Any]:
+    routing = await resolve_agent_routing(uid)
+    if routing.platform != "hermes":
+        return _base_response(
+            uid=uid,
+            routing=routing,
+            provider=DEFAULT_HERMES_PROVIDER,
+            model=DEFAULT_HERMES_MODEL,
+            source={
+                "runtime": "openclaw",
+                "profile": routing.profile,
+                "override": "legacy_openclaw_fallback",
+                "agent_id": routing.agent_id,
+                "read_only_reason": "active chat routing is not Hermes",
+            },
+        )
+
+    url = f"{routing.provision_url}/agent-config"
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(
+                url,
+                params={"uid": uid, "agent_id": routing.agent_id},
+                headers=_auth_headers(routing.provision_token),
+            )
+        if response.status_code == 404:
+            raise RuntimeError("Hermes provision shim does not expose /agent-config")
+        if response.status_code >= 400:
+            raise RuntimeError(f"Hermes provision shim returned {response.status_code}: {response.text[:300]}")
+        payload = response.json()
+        provider = str(payload.get("provider") or DEFAULT_HERMES_PROVIDER)
+        model = str(payload.get("model") or DEFAULT_HERMES_MODEL)
+        return _base_response(
+            uid=uid,
+            routing=routing,
+            provider=provider,
+            model=model,
+            source={
+                "runtime": "hermes",
+                "profile": payload.get("profile"),
+                "override": payload.get("override") or "profile",
+                "agent_id": routing.agent_id,
+                "config_path": payload.get("config_path"),
+            },
+            cache=payload.get("cache") if isinstance(payload.get("cache"), dict) else None,
+            reload=payload.get("reload") if isinstance(payload.get("reload"), dict) else None,
+        )
+    except Exception as exc:  # noqa: BLE001 - API must stay readable while Hermes shim is rolling out.
+        logger.warning("Hermes agent config read failed for uid=%s agent=%s: %s", uid, routing.agent_id, exc)
+        return _base_response(
+            uid=uid,
+            routing=routing,
+            provider=DEFAULT_HERMES_PROVIDER,
+            model=DEFAULT_HERMES_MODEL,
+            source={
+                "runtime": "hermes",
+                "profile": routing.profile,
+                "override": "hermes_unavailable_default",
+                "agent_id": routing.agent_id,
+                "warning": str(exc),
+            },
+        )
+
+
+async def invalidate_model_cache(uid: str, agent_id: str) -> dict[str, Any]:
+    try:
+        pool = await resolve_router._get_pool()
+        updated = await pool.execute(
+            """
+            UPDATE agent_configs
+               SET is_stale = TRUE, updated_at = NOW()
+             WHERE agent_id = $1
+                OR user_id IN (SELECT id FROM users WHERE omi_uid = $2)
+            """,
+            agent_id,
+            uid,
+        )
+        return {"invalidated": True, "store": "postgres.agent_configs", "result": updated}
+    except Exception as exc:  # noqa: BLE001 - cache table is optional during rollout.
+        logger.info("Agent config cache invalidation skipped uid=%s agent=%s: %s", uid, agent_id, exc)
+        return {
+            "invalidated": False,
+            "store": "postgres.agent_configs",
+            "reason": "cache_unavailable_or_schema_absent",
+        }
+
+
+async def patch_agent_config(uid: str, provider: str, model: str) -> dict[str, Any]:
+    provider, model = validate_provider_model(provider, model)
+    routing = await resolve_agent_routing(uid)
+    if routing.platform != "hermes":
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "active_platform_not_editable",
+                "platform": routing.platform,
+                "message": "Agent config writes are only enabled for active Hermes routing.",
+            },
+        )
+
+    url = f"{routing.provision_url}/agent-config"
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.patch(
+                url,
+                params={"uid": uid, "agent_id": routing.agent_id},
+                headers=_auth_headers(routing.provision_token),
+                json={"provider": provider, "model": model},
+            )
+        if response.status_code >= 400:
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "error": "hermes_agent_config_patch_failed",
+                    "status_code": response.status_code,
+                    "body": response.text[:500],
+                },
+            )
+        payload = response.json()
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(
+            status_code=502,
+            detail={"error": "hermes_agent_config_unreachable", "message": str(exc)},
+        ) from exc
+
+    cache = await invalidate_model_cache(uid, routing.agent_id)
+    return _base_response(
+        uid=uid,
+        routing=routing,
+        provider=str(payload.get("provider") or provider),
+        model=str(payload.get("model") or model),
+        source={
+            "runtime": "hermes",
+            "profile": payload.get("profile"),
+            "override": payload.get("override") or "profile",
+            "agent_id": routing.agent_id,
+            "config_path": payload.get("config_path"),
+        },
+        cache=cache,
+        reload=payload.get("reload") if isinstance(payload.get("reload"), dict) else {"status": "unknown"},
+    )

--- a/backend/tests/unit/test_ella_agent_config.py
+++ b/backend/tests/unit/test_ella_agent_config.py
@@ -1,0 +1,173 @@
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ella.routers import agent_config as router_module
+from ella.services import agent_config as service
+from utils.other import endpoints as auth
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+def _client():
+    app = FastAPI()
+    app.include_router(router_module.router)
+    app.dependency_overrides[auth.get_current_user_uid] = lambda: "uid-1"
+    return TestClient(app)
+
+
+def test_get_agent_config_reads_hermes_runtime_first(monkeypatch):
+    calls = []
+
+    async def fake_resolve(uid):
+        assert uid == "uid-1"
+        return service.AgentRouting(
+            platform="hermes",
+            agent_id="hermes",
+            provision_url="http://hermes-provision",
+            provision_token="secret",
+        )
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, **kwargs):
+            calls.append((url, kwargs))
+            return _FakeResponse(
+                payload={
+                    "provider": "openai-codex",
+                    "model": "gpt-5.5",
+                    "profile": "plato-eval",
+                    "override": "profile",
+                    "config_path": "/Users/ellaai/.hermes/profiles/plato-eval/config.yaml",
+                }
+            )
+
+    monkeypatch.setattr(service, "resolve_agent_routing", fake_resolve)
+    monkeypatch.setattr(service.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = asyncio.run(service.get_agent_config("uid-1"))
+
+    assert result["platform"] == "hermes"
+    assert result["provider"] == "openai-codex"
+    assert result["model"] == "gpt-5.5"
+    assert result["editable"] == {"platform": False, "provider": True, "model": True}
+    assert result["source"]["runtime"] == "hermes"
+    assert calls[0][0] == "http://hermes-provision/agent-config"
+    assert calls[0][1]["headers"]["Authorization"] == "Bearer secret"
+
+
+def test_patch_agent_config_rejects_read_only_platform_field(monkeypatch):
+    client = _client()
+
+    response = client.patch(
+        "/v1/ella/agent-config",
+        json={"platform": "openclaw", "provider": "openai-codex", "model": "gpt-5.5"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_patch_agent_config_validates_provider_model_allowlist(monkeypatch):
+    async def fake_resolve(uid):
+        return service.AgentRouting(
+            platform="hermes",
+            agent_id="hermes",
+            provision_url="http://hermes-provision",
+            provision_token="secret",
+        )
+
+    monkeypatch.setattr(service, "resolve_agent_routing", fake_resolve)
+
+    with pytest.raises(Exception) as exc:
+        asyncio.run(service.patch_agent_config("uid-1", "openai-codex", "not-real"))
+
+    assert getattr(exc.value, "status_code", None) == 422
+    assert exc.value.detail["error"] == "model_not_allowed_for_provider"
+
+
+def test_patch_agent_config_scopes_to_hermes_profile_and_invalidates_cache(monkeypatch):
+    calls = []
+
+    async def fake_resolve(uid):
+        assert uid == "uid-1"
+        return service.AgentRouting(
+            platform="hermes",
+            agent_id="hermes",
+            provision_url="http://hermes-provision",
+            provision_token="secret",
+        )
+
+    async def fake_invalidate(uid, agent_id):
+        return {"invalidated": True, "store": "postgres.agent_configs", "agent_id": agent_id}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def patch(self, url, **kwargs):
+            calls.append((url, kwargs))
+            return _FakeResponse(
+                payload={
+                    "provider": "openai-codex",
+                    "model": "gpt-5.5-mini",
+                    "profile": "plato-eval",
+                    "override": "profile",
+                    "config_path": "/Users/ellaai/.hermes/profiles/plato-eval/config.yaml",
+                    "reload": {"status": "requested", "scope": "profile"},
+                }
+            )
+
+    monkeypatch.setattr(service, "resolve_agent_routing", fake_resolve)
+    monkeypatch.setattr(service, "invalidate_model_cache", fake_invalidate)
+    monkeypatch.setattr(service.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = asyncio.run(service.patch_agent_config("uid-1", "openai-codex", "gpt-5.5-mini"))
+
+    assert result["provider"] == "openai-codex"
+    assert result["model"] == "gpt-5.5-mini"
+    assert result["cache"]["invalidated"] is True
+    assert result["reload"]["scope"] == "profile"
+    assert calls[0][1]["params"] == {"uid": "uid-1", "agent_id": "hermes"}
+    assert calls[0][1]["json"] == {"provider": "openai-codex", "model": "gpt-5.5-mini"}
+
+
+def test_patch_agent_config_blocks_non_hermes_platform(monkeypatch):
+    async def fake_resolve(uid):
+        return service.AgentRouting(
+            platform="openclaw",
+            agent_id="openclaw-agent",
+            provision_url="http://openclaw-provision",
+            provision_token="secret",
+        )
+
+    monkeypatch.setattr(service, "resolve_agent_routing", fake_resolve)
+
+    with pytest.raises(Exception) as exc:
+        asyncio.run(service.patch_agent_config("uid-1", "openai-codex", "gpt-5.5"))
+
+    assert getattr(exc.value, "status_code", None) == 409
+    assert exc.value.detail["error"] == "active_platform_not_editable"


### PR DESCRIPTION
Implements the backend API slice for ellaaicare/ella-ai#902.

Summary:
- Adds authenticated GET/PATCH /v1/ella/agent-config.
- Resolves active routing first and keeps platform read-only.
- Validates provider/model against a server allowlist.
- Calls the Hermes provision shim for profile config reads/writes.
- Marks model-dependent cache stale on PATCH best-effort.
- Returns OpenClaw only as read-only legacy fallback metadata.

Validation:
- python3 -m pytest backend/tests/unit/test_ella_agent_config.py -q

Deployment notes:
- Requires Hermes provision shim endpoint from ellaaicare/ella-ai branch codex/agent-config-backend-902 deployed on the Mac Mini before PATCH is fully live.
- Static/default GET response remains readable if the shim is temporarily unavailable.