### PR TITLE
[codex] Add iOS Guardian Alerts history view

### DIFF
--- a/app/lib/ella/models/guardian_alert.dart
+++ b/app/lib/ella/models/guardian_alert.dart
@@ -1,0 +1,205 @@
+class GuardianAlertRecord {
+  const GuardianAlertRecord({
+    required this.id,
+    required this.alertText,
+    required this.triggerType,
+    required this.deliveryTarget,
+    required this.playbackStatus,
+    required this.createdAt,
+    this.sourceConversationId,
+    this.sourceTranscriptId,
+    this.escalation = false,
+    this.escalationStatus,
+    this.traceId,
+    this.queueItemId,
+    this.ttsProvider,
+    this.isTest = false,
+    this.fromLocalDebugLog = false,
+  });
+
+  final String id;
+  final String alertText;
+  final String triggerType;
+  final String deliveryTarget;
+  final String playbackStatus;
+  final DateTime? createdAt;
+  final String? sourceConversationId;
+  final String? sourceTranscriptId;
+  final bool escalation;
+  final String? escalationStatus;
+  final String? traceId;
+  final String? queueItemId;
+  final String? ttsProvider;
+  final bool isTest;
+  final bool fromLocalDebugLog;
+
+  factory GuardianAlertRecord.fromJson(Map<String, dynamic> json) {
+    final id = _firstString(json, const [
+      'id',
+      'alert_id',
+      'queue_item_id',
+      'guardian_queue_item_id',
+      'trace_id',
+      'event_id',
+    ]);
+    final alertText = _firstString(json, const [
+      'alert_text',
+      'summary',
+      'text',
+      'message',
+      'tts_text',
+      'user_facing_text',
+      'spoken_text',
+    ]);
+    final triggerType = _firstString(json, const [
+      'trigger_type',
+      'trigger',
+      'reason',
+      'guardian_mode',
+      'mode',
+    ]);
+    final deliveryTarget = _firstString(json, const [
+      'delivery_target',
+      'target',
+      'audience',
+      'recipient_type',
+    ]);
+    final playbackStatus = _firstString(json, const [
+      'playback_status',
+      'status',
+      'item_status',
+      'audio_status',
+    ]);
+
+    return GuardianAlertRecord(
+      id: id.isNotEmpty ? id : 'guardian-alert-${DateTime.now().microsecondsSinceEpoch}',
+      alertText: alertText.isNotEmpty ? alertText : 'Guardian alert',
+      triggerType: triggerType.isNotEmpty ? triggerType : 'unknown',
+      deliveryTarget: deliveryTarget.isNotEmpty ? deliveryTarget : 'user',
+      playbackStatus: playbackStatus.isNotEmpty ? playbackStatus : 'unknown',
+      createdAt: _firstDate(json, const [
+        'created_at',
+        'createdAt',
+        'queued_at',
+        'started_at',
+        'timestamp',
+        'ts',
+      ]),
+      sourceConversationId: _nullableFirstString(json, const [
+        'source_conversation_id',
+        'conversation_id',
+        'conversationId',
+      ]),
+      sourceTranscriptId: _nullableFirstString(json, const [
+        'source_transcript_id',
+        'transcript_id',
+        'transcriptId',
+      ]),
+      escalation: json['escalation'] == true || json['caregiver_escalation'] == true || json['escalated'] == true,
+      escalationStatus: _nullableFirstString(json, const ['escalation_status', 'caregiver_status']),
+      traceId: _nullableFirstString(json, const ['trace_id', 'traceId']),
+      queueItemId: _nullableFirstString(json, const ['queue_item_id', 'guardian_queue_item_id']),
+      ttsProvider: _nullableFirstString(json, const ['tts_provider', 'provider']),
+      isTest: json['is_test'] == true ||
+          json['dry_run'] == true ||
+          _isTestTarget(_firstString(json, const ['delivery_target', 'target'])),
+    );
+  }
+
+  factory GuardianAlertRecord.fromDebugLog(Map<String, dynamic> json) {
+    final extra = json['extra'];
+    final fields = <String, dynamic>{...json};
+    if (extra is Map<String, dynamic>) fields.addAll(extra);
+
+    final type = _firstString(fields, const ['type', 'event_type']);
+    final message = _firstString(fields, const ['message']);
+    final status = _statusFromDebugEvent(type, fields);
+    final trigger = _firstString(fields, const ['trigger_type', 'trigger', 'guardian_mode', 'mode']);
+    final target = _firstString(fields, const ['delivery_target', 'target', 'audience']);
+    final text = _firstString(fields, const ['alert_text', 'summary', 'tts_text', 'text']);
+
+    return GuardianAlertRecord(
+      id: _firstString(fields, const ['id', 'event_id', 'queue_item_id', 'trace_id']).ifEmpty(
+        'local-${_firstString(fields, const ['timestamp', 'ts'])}',
+      ),
+      alertText: text.isNotEmpty ? text : message.ifEmpty(type.ifEmpty('Guardian debug event')),
+      triggerType: trigger.isNotEmpty ? trigger : type.ifEmpty('guardian'),
+      deliveryTarget: target.isNotEmpty ? target : 'local-debug',
+      playbackStatus: status,
+      createdAt: _firstDate(fields, const ['timestamp', 'ts', 'created_at']),
+      sourceConversationId: _nullableFirstString(fields, const ['source_conversation_id', 'conversation_id']),
+      sourceTranscriptId: _nullableFirstString(fields, const ['source_transcript_id', 'transcript_id']),
+      escalation: fields['escalation'] == true || fields['caregiver_escalation'] == true || fields['escalated'] == true,
+      escalationStatus: _nullableFirstString(fields, const ['escalation_status', 'caregiver_status']),
+      traceId: _nullableFirstString(fields, const ['trace_id', 'traceId']),
+      queueItemId: _nullableFirstString(fields, const ['queue_item_id', 'guardian_queue_item_id']),
+      ttsProvider: _nullableFirstString(fields, const ['tts_provider', 'provider']),
+      isTest: fields['is_test'] == true || fields['dry_run'] == true || _isTestTarget(target),
+      fromLocalDebugLog: true,
+    );
+  }
+
+  static bool isGuardianDebugLog(Map<String, dynamic> json) {
+    final extra = json['extra'];
+    final fields = <String, dynamic>{...json};
+    if (extra is Map<String, dynamic>) fields.addAll(extra);
+    final haystack = [
+      fields['type'],
+      fields['message'],
+      fields['trigger_type'],
+      fields['queue_item_id'],
+      fields['trace_id'],
+      fields['playback_source'],
+    ].whereType<Object>().join(' ').toLowerCase();
+    return haystack.contains('guardian') || haystack.contains('wake_word') || haystack.contains('playback');
+  }
+}
+
+extension on String {
+  String ifEmpty(String fallback) => isEmpty ? fallback : this;
+}
+
+String _firstString(Map<String, dynamic> json, List<String> keys) {
+  for (final key in keys) {
+    final value = json[key];
+    if (value is String && value.trim().isNotEmpty) return value.trim();
+    if (value is num || value is bool) return value.toString();
+  }
+  return '';
+}
+
+String? _nullableFirstString(Map<String, dynamic> json, List<String> keys) {
+  final value = _firstString(json, keys);
+  return value.isEmpty ? null : value;
+}
+
+DateTime? _firstDate(Map<String, dynamic> json, List<String> keys) {
+  for (final key in keys) {
+    final value = json[key];
+    if (value is String && value.trim().isNotEmpty) {
+      final parsed = DateTime.tryParse(value.trim());
+      if (parsed != null) return parsed;
+    }
+    if (value is int) {
+      final millis = value > 1000000000000 ? value : value * 1000;
+      return DateTime.fromMillisecondsSinceEpoch(millis, isUtc: true);
+    }
+  }
+  return null;
+}
+
+String _statusFromDebugEvent(String type, Map<String, dynamic> fields) {
+  final explicit = _firstString(fields, const ['playback_status', 'status', 'item_status']);
+  if (explicit.isNotEmpty) return explicit;
+  final normalized = type.toLowerCase();
+  if (normalized.contains('failed')) return 'failed';
+  if (normalized.contains('completed') || normalized.contains('played')) return 'played';
+  if (normalized.contains('start')) return 'playing';
+  if (normalized.contains('queued')) return 'queued';
+  return 'debug';
+}
+
+bool _isTestTarget(String value) {
+  final normalized = value.toLowerCase();
+  return normalized.contains('test') || normalized.contains('dry-run') || normalized.contains('dry_run');
+}

--- a/app/lib/ella/pages/ella_settings_page.dart
+++ b/app/lib/ella/pages/ella_settings_page.dart
@@ -16,6 +16,7 @@ import 'package:omi/ella/pages/ella_emergency_contact_page.dart';
 import 'package:omi/ella/pages/ella_profile_page.dart';
 import 'package:omi/ella/models/guardian_mode.dart';
 import 'package:omi/ella/pages/debug_event_log_page.dart';
+import 'package:omi/ella/pages/guardian_alert_history_page.dart';
 import 'package:omi/ella/pages/guardian_mode_page.dart';
 import 'package:omi/ella/services/caregiver_api.dart' as caregiver_api;
 import 'package:omi/ella/services/guardian_mode_api.dart' as guardian_api;
@@ -256,6 +257,15 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
               subtitle: context.l10n.ellaAlertChannelsSubtitle,
               onTap: () {
                 Navigator.push(context, MaterialPageRoute(builder: (context) => const AlertChannelsPage()));
+              },
+            ),
+            const SizedBox(height: 8),
+            EllaSettingsRow(
+              icon: Icons.history,
+              title: context.l10n.guardianAlertsHistoryTitle,
+              subtitle: context.l10n.guardianAlertsHistorySubtitle,
+              onTap: () {
+                Navigator.push(context, MaterialPageRoute(builder: (context) => const GuardianAlertHistoryPage()));
               },
             ),
 

--- a/app/lib/ella/pages/guardian_alert_history_page.dart
+++ b/app/lib/ella/pages/guardian_alert_history_page.dart
@@ -1,0 +1,324 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/ella/models/guardian_alert.dart';
+import 'package:omi/ella/services/guardian_alert_history_api.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+
+class GuardianAlertHistoryPage extends StatefulWidget {
+  const GuardianAlertHistoryPage({super.key});
+
+  @override
+  State<GuardianAlertHistoryPage> createState() => _GuardianAlertHistoryPageState();
+}
+
+class _GuardianAlertHistoryPageState extends State<GuardianAlertHistoryPage> {
+  late Future<GuardianAlertHistoryResult> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = GuardianAlertHistoryApi.fetch();
+  }
+
+  Future<void> _refresh() async {
+    setState(() {
+      _future = GuardianAlertHistoryApi.fetch();
+    });
+    await _future;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: EllaColors.bgPrimary,
+      appBar: AppBar(
+        backgroundColor: EllaColors.bgPrimary,
+        elevation: 0,
+        foregroundColor: EllaColors.textPrimary,
+        title: Text(
+          context.l10n.guardianAlertsHistoryTitle,
+          style: const TextStyle(fontSize: 22, fontWeight: FontWeight.w700, color: EllaColors.textPrimary),
+        ),
+      ),
+      body: FutureBuilder<GuardianAlertHistoryResult>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator(color: EllaColors.primary));
+          }
+
+          final result = snapshot.data;
+          if (snapshot.hasError || result == null) {
+            return _EmptyState(
+              title: context.l10n.guardianAlertsLoadFailed,
+              subtitle: context.l10n.guardianAlertsPullToRetry,
+              onRefresh: _refresh,
+            );
+          }
+
+          return RefreshIndicator(
+            onRefresh: _refresh,
+            color: EllaColors.primary,
+            child: ListView(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+              children: [
+                if (result.isLocalFallback) _FallbackBanner(message: context.l10n.guardianAlertsLocalFallback),
+                if (result.records.isEmpty)
+                  _EmptyState(
+                    title: context.l10n.guardianAlertsEmptyTitle,
+                    subtitle: context.l10n.guardianAlertsEmptySubtitle,
+                    onRefresh: _refresh,
+                  )
+                else
+                  ...result.records.map((record) => _GuardianAlertCard(record: record)),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _FallbackBanner extends StatelessWidget {
+  const _FallbackBanner({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: EllaColors.warning.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+        border: Border.all(color: EllaColors.warning.withValues(alpha: 0.35)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(Icons.info_outline, color: EllaColors.warning, size: 22),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              message,
+              style: const TextStyle(fontSize: 16, color: EllaColors.textSecondary, height: 1.35),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GuardianAlertCard extends StatelessWidget {
+  const _GuardianAlertCard({required this.record});
+
+  final GuardianAlertRecord record;
+
+  @override
+  Widget build(BuildContext context) {
+    final status = _displayStatus(context, record.playbackStatus);
+    final details = _details(context);
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: EllaColors.bgSecondary,
+        borderRadius: BorderRadius.circular(EllaSizes.radiusLarge),
+        border: Border.all(color: EllaColors.bgTertiary),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 42,
+                height: 42,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: _statusColor(record.playbackStatus).withValues(alpha: 0.14),
+                ),
+                child: Icon(_statusIcon(record.playbackStatus), color: _statusColor(record.playbackStatus), size: 22),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      record.alertText,
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w600,
+                        color: EllaColors.textPrimary,
+                        height: 1.25,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      _formatTime(context, record.createdAt),
+                      style: const TextStyle(fontSize: 15, color: EllaColors.textTertiary),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _Chip(label: status, color: _statusColor(record.playbackStatus)),
+              _Chip(
+                  label: _pretty(record.triggerType, unknownLabel: context.l10n.guardianAlertsUnknown),
+                  color: EllaColors.primary),
+              _Chip(
+                label: _pretty(record.deliveryTarget, unknownLabel: context.l10n.guardianAlertsUnknown),
+                color: EllaColors.textTertiary,
+              ),
+              if (record.isTest) _Chip(label: context.l10n.guardianAlertsTestTag, color: EllaColors.warning),
+              if (record.escalation) _Chip(label: context.l10n.guardianAlertsEscalatedTag, color: EllaColors.error),
+            ],
+          ),
+          if (details.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            Text(
+              details,
+              style: const TextStyle(fontSize: 14, color: EllaColors.textTertiary, height: 1.35),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _details(BuildContext context) {
+    final parts = <String>[];
+    if (record.sourceConversationId != null) {
+      parts.add(context.l10n.guardianAlertsConversationDetail(record.sourceConversationId!));
+    }
+    if (record.escalationStatus != null) {
+      parts.add(context.l10n.guardianAlertsEscalationDetail(
+        _pretty(record.escalationStatus!, unknownLabel: context.l10n.guardianAlertsUnknown),
+      ));
+    }
+    if (record.traceId != null) parts.add(context.l10n.guardianAlertsTraceDetail(record.traceId!));
+    if (record.fromLocalDebugLog) parts.add(context.l10n.guardianAlertsLocalDebugDetail);
+    return parts.join('  |  ');
+  }
+
+  static String _formatTime(BuildContext context, DateTime? value) {
+    if (value == null) return context.l10n.guardianAlertsTimeUnavailable;
+    return DateFormat('MMM d, h:mm a').format(value.toLocal());
+  }
+
+  static String _displayStatus(BuildContext context, String value) {
+    final normalized = value.toLowerCase();
+    if (normalized.contains('fail')) return context.l10n.guardianAlertsStatusFailed;
+    if (normalized.contains('miss')) return context.l10n.guardianAlertsStatusMissed;
+    if (normalized.contains('play') || normalized.contains('complete')) return context.l10n.guardianAlertsStatusPlayed;
+    if (normalized.contains('queue')) return context.l10n.guardianAlertsStatusQueued;
+    return _pretty(value, unknownLabel: context.l10n.guardianAlertsUnknown);
+  }
+
+  static String _pretty(String value, {required String unknownLabel}) {
+    if (value.trim().isEmpty) return unknownLabel;
+    return value
+        .replaceAll('_', ' ')
+        .replaceAll('-', ' ')
+        .split(' ')
+        .where((word) => word.isNotEmpty)
+        .map((word) => word[0].toUpperCase() + word.substring(1))
+        .join(' ');
+  }
+
+  static Color _statusColor(String value) {
+    final normalized = value.toLowerCase();
+    if (normalized.contains('fail') || normalized.contains('miss')) return EllaColors.error;
+    if (normalized.contains('play') || normalized.contains('complete')) return EllaColors.success;
+    if (normalized.contains('queue')) return EllaColors.warning;
+    return EllaColors.primary;
+  }
+
+  static IconData _statusIcon(String value) {
+    final normalized = value.toLowerCase();
+    if (normalized.contains('fail') || normalized.contains('miss')) return Icons.error_outline;
+    if (normalized.contains('play') || normalized.contains('complete')) return Icons.volume_up;
+    if (normalized.contains('queue')) return Icons.schedule;
+    return Icons.notifications_active;
+  }
+}
+
+class _Chip extends StatelessWidget {
+  const _Chip({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(EllaSizes.radiusCircular),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600, color: color),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({
+    required this.title,
+    required this.subtitle,
+    required this.onRefresh,
+  });
+
+  final String title;
+  final String subtitle;
+  final Future<void> Function() onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: MediaQuery.of(context).size.height * 0.62,
+      child: RefreshIndicator(
+        onRefresh: onRefresh,
+        color: EllaColors.primary,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: [
+            const SizedBox(height: 96),
+            const Icon(Icons.notifications_none, size: 56, color: EllaColors.textDisabled),
+            const SizedBox(height: 18),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w700, color: EllaColors.textPrimary),
+            ),
+            const SizedBox(height: 8),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Text(
+                subtitle,
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontSize: 16, color: EllaColors.textSecondary, height: 1.4),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/ella/services/guardian_alert_history_api.dart
+++ b/app/lib/ella/services/guardian_alert_history_api.dart
@@ -1,0 +1,115 @@
+import 'dart:convert';
+
+import 'package:omi/backend/http/shared.dart';
+import 'package:omi/ella/models/guardian_alert.dart';
+import 'package:omi/env/env.dart';
+import 'package:omi/utils/debug_log_manager.dart';
+import 'package:omi/utils/logger.dart';
+
+class GuardianAlertHistoryResult {
+  const GuardianAlertHistoryResult({
+    required this.records,
+    required this.source,
+    this.error,
+  });
+
+  final List<GuardianAlertRecord> records;
+  final GuardianAlertHistorySource source;
+  final String? error;
+
+  bool get isLocalFallback => source == GuardianAlertHistorySource.localDebugLog;
+}
+
+enum GuardianAlertHistorySource { backend, localDebugLog }
+
+class GuardianAlertHistoryApi {
+  GuardianAlertHistoryApi._();
+
+  static Future<GuardianAlertHistoryResult> fetch({int limit = 50}) async {
+    final backend = await _fetchBackend(limit: limit);
+    if (backend != null) return backend;
+
+    final fallback = await _fetchLocalDebugLogs(limit: limit);
+    return GuardianAlertHistoryResult(
+      records: fallback,
+      source: GuardianAlertHistorySource.localDebugLog,
+      error: 'Backend Guardian alert history is unavailable. Showing local debug fallback.',
+    );
+  }
+
+  static Future<GuardianAlertHistoryResult?> _fetchBackend({required int limit}) async {
+    final baseUrl = Env.apiBaseUrl;
+    if (baseUrl == null || baseUrl.isEmpty) return null;
+
+    try {
+      final response = await makeApiCall(
+        url: '${baseUrl}v1/ella/guardian-alerts?limit=$limit',
+        headers: const {'Content-Type': 'application/json'},
+        body: '',
+        method: 'GET',
+        timeout: const Duration(seconds: 10),
+        retries: 0,
+      );
+      if (response == null || response.statusCode == 404 || response.statusCode == 501) return null;
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        Logger.debug('Guardian alert history fetch failed: ${response.statusCode} ${response.body}');
+        return null;
+      }
+
+      final decoded = jsonDecode(response.body);
+      final records = parseBackendRecords(decoded).take(limit).toList(growable: false);
+      return GuardianAlertHistoryResult(records: records, source: GuardianAlertHistorySource.backend);
+    } catch (e) {
+      Logger.debug('Guardian alert history fetch error: $e');
+      return null;
+    }
+  }
+
+  static List<GuardianAlertRecord> parseBackendRecords(dynamic decoded) {
+    final items = _extractRecordList(decoded);
+    final records = items.map(GuardianAlertRecord.fromJson).toList();
+    records.sort(_newestFirst);
+    return records;
+  }
+
+  static Future<List<GuardianAlertRecord>> _fetchLocalDebugLogs({required int limit}) async {
+    final records = <GuardianAlertRecord>[];
+    try {
+      final files = await DebugLogManager.listLogFiles();
+      for (final file in files) {
+        final lines = await file.readAsLines();
+        for (final line in lines.reversed) {
+          if (records.length >= limit) break;
+          final trimmed = line.trim();
+          if (trimmed.isEmpty) continue;
+          final decoded = jsonDecode(trimmed);
+          if (decoded is! Map<String, dynamic>) continue;
+          if (!GuardianAlertRecord.isGuardianDebugLog(decoded)) continue;
+          records.add(GuardianAlertRecord.fromDebugLog(decoded));
+        }
+        if (records.length >= limit) break;
+      }
+    } catch (e) {
+      Logger.debug('Guardian alert local fallback error: $e');
+    }
+    records.sort(_newestFirst);
+    return records.take(limit).toList(growable: false);
+  }
+
+  static List<Map<String, dynamic>> _extractRecordList(dynamic decoded) {
+    if (decoded is List) return decoded.whereType<Map<String, dynamic>>().toList(growable: false);
+    if (decoded is! Map<String, dynamic>) return const [];
+
+    for (final key in const ['alerts', 'records', 'items', 'data', 'history']) {
+      final value = decoded[key];
+      if (value is List) return value.whereType<Map<String, dynamic>>().toList(growable: false);
+    }
+    return const [];
+  }
+
+  static int _newestFirst(GuardianAlertRecord a, GuardianAlertRecord b) {
+    final left = a.createdAt ?? DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+    final right = b.createdAt ?? DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+    return right.compareTo(left);
+  }
+}

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10136,5 +10136,45 @@
   "ellaAlertChannelsEnabled": "Enabled",
   "ellaAlertChannelsDisabled": "Disabled",
   "ellaGuardianOffTooltip": "Guardian OFF: Audio and non-critical check-ins disabled. Emergency alerts to your contact remain active.",
-  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active."
+  "ellaGuardianOnTooltip": "Guardian ON: Audio monitoring and care features active.",
+  "guardianAlertsHistoryTitle": "Guardian Alerts",
+  "guardianAlertsHistorySubtitle": "Recent Guardian alerts and playback status",
+  "guardianAlertsLoadFailed": "Could not load Guardian alerts",
+  "guardianAlertsPullToRetry": "Pull down to retry.",
+  "guardianAlertsLocalFallback": "Backend Guardian history is unavailable. Showing local debug events from this device only.",
+  "guardianAlertsEmptyTitle": "No Guardian alerts yet",
+  "guardianAlertsEmptySubtitle": "Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.",
+  "guardianAlertsTestTag": "Test",
+  "guardianAlertsEscalatedTag": "Escalated",
+  "guardianAlertsUnknown": "Unknown",
+  "guardianAlertsStatusFailed": "Failed",
+  "guardianAlertsStatusMissed": "Missed",
+  "guardianAlertsStatusPlayed": "Played",
+  "guardianAlertsStatusQueued": "Queued",
+  "guardianAlertsTimeUnavailable": "Time unavailable",
+  "guardianAlertsLocalDebugDetail": "Local debug fallback",
+  "guardianAlertsConversationDetail": "Conversation: {conversationId}",
+  "@guardianAlertsConversationDetail": {
+    "placeholders": {
+      "conversationId": {
+        "type": "String"
+      }
+    }
+  },
+  "guardianAlertsEscalationDetail": "Escalation: {status}",
+  "@guardianAlertsEscalationDetail": {
+    "placeholders": {
+      "status": {
+        "type": "String"
+      }
+    }
+  },
+  "guardianAlertsTraceDetail": "Trace: {traceId}",
+  "@guardianAlertsTraceDetail": {
+    "placeholders": {
+      "traceId": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -15896,6 +15896,120 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Guardian ON: Audio monitoring and care features active.'**
   String get ellaGuardianOnTooltip;
+
+  /// No description provided for @guardianAlertsHistoryTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Guardian Alerts'**
+  String get guardianAlertsHistoryTitle;
+
+  /// No description provided for @guardianAlertsHistorySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Recent Guardian alerts and playback status'**
+  String get guardianAlertsHistorySubtitle;
+
+  /// No description provided for @guardianAlertsLoadFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load Guardian alerts'**
+  String get guardianAlertsLoadFailed;
+
+  /// No description provided for @guardianAlertsPullToRetry.
+  ///
+  /// In en, this message translates to:
+  /// **'Pull down to retry.'**
+  String get guardianAlertsPullToRetry;
+
+  /// No description provided for @guardianAlertsLocalFallback.
+  ///
+  /// In en, this message translates to:
+  /// **'Backend Guardian history is unavailable. Showing local debug events from this device only.'**
+  String get guardianAlertsLocalFallback;
+
+  /// No description provided for @guardianAlertsEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No Guardian alerts yet'**
+  String get guardianAlertsEmptyTitle;
+
+  /// No description provided for @guardianAlertsEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.'**
+  String get guardianAlertsEmptySubtitle;
+
+  /// No description provided for @guardianAlertsTestTag.
+  ///
+  /// In en, this message translates to:
+  /// **'Test'**
+  String get guardianAlertsTestTag;
+
+  /// No description provided for @guardianAlertsEscalatedTag.
+  ///
+  /// In en, this message translates to:
+  /// **'Escalated'**
+  String get guardianAlertsEscalatedTag;
+
+  /// No description provided for @guardianAlertsUnknown.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown'**
+  String get guardianAlertsUnknown;
+
+  /// No description provided for @guardianAlertsStatusFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed'**
+  String get guardianAlertsStatusFailed;
+
+  /// No description provided for @guardianAlertsStatusMissed.
+  ///
+  /// In en, this message translates to:
+  /// **'Missed'**
+  String get guardianAlertsStatusMissed;
+
+  /// No description provided for @guardianAlertsStatusPlayed.
+  ///
+  /// In en, this message translates to:
+  /// **'Played'**
+  String get guardianAlertsStatusPlayed;
+
+  /// No description provided for @guardianAlertsStatusQueued.
+  ///
+  /// In en, this message translates to:
+  /// **'Queued'**
+  String get guardianAlertsStatusQueued;
+
+  /// No description provided for @guardianAlertsTimeUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Time unavailable'**
+  String get guardianAlertsTimeUnavailable;
+
+  /// No description provided for @guardianAlertsLocalDebugDetail.
+  ///
+  /// In en, this message translates to:
+  /// **'Local debug fallback'**
+  String get guardianAlertsLocalDebugDetail;
+
+  /// No description provided for @guardianAlertsConversationDetail.
+  ///
+  /// In en, this message translates to:
+  /// **'Conversation: {conversationId}'**
+  String guardianAlertsConversationDetail(String conversationId);
+
+  /// No description provided for @guardianAlertsEscalationDetail.
+  ///
+  /// In en, this message translates to:
+  /// **'Escalation: {status}'**
+  String guardianAlertsEscalationDetail(String status);
+
+  /// No description provided for @guardianAlertsTraceDetail.
+  ///
+  /// In en, this message translates to:
+  /// **'Trace: {traceId}'**
+  String guardianAlertsTraceDetail(String traceId);
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8461,4 +8461,69 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8549,4 +8549,69 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8565,4 +8565,69 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8512,4 +8512,69 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8501,4 +8501,69 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8583,4 +8583,69 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8574,4 +8574,69 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8514,4 +8514,69 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8531,4 +8531,69 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8516,4 +8516,69 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8515,4 +8515,69 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8590,4 +8590,69 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8497,4 +8497,69 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8554,4 +8554,69 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8529,4 +8529,69 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8566,4 +8566,69 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8383,4 +8383,69 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8385,4 +8385,69 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8522,4 +8522,69 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8534,4 +8534,69 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8540,4 +8540,69 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8542,4 +8542,69 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8512,4 +8512,69 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8535,4 +8535,69 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8517,4 +8517,69 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8555,4 +8555,69 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8542,4 +8542,69 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8507,4 +8507,69 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8522,4 +8522,69 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8479,4 +8479,69 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8530,4 +8530,69 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8529,4 +8529,69 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8519,4 +8519,69 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8373,4 +8373,69 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get ellaGuardianOnTooltip => 'Guardian ON: Audio monitoring and care features active.';
+
+  @override
+  String get guardianAlertsHistoryTitle => 'Guardian Alerts';
+
+  @override
+  String get guardianAlertsHistorySubtitle => 'Recent Guardian alerts and playback status';
+
+  @override
+  String get guardianAlertsLoadFailed => 'Could not load Guardian alerts';
+
+  @override
+  String get guardianAlertsPullToRetry => 'Pull down to retry.';
+
+  @override
+  String get guardianAlertsLocalFallback =>
+      'Backend Guardian history is unavailable. Showing local debug events from this device only.';
+
+  @override
+  String get guardianAlertsEmptyTitle => 'No Guardian alerts yet';
+
+  @override
+  String get guardianAlertsEmptySubtitle =>
+      'Wake-word, support, test, and playback-failure alerts will appear here after they are recorded.';
+
+  @override
+  String get guardianAlertsTestTag => 'Test';
+
+  @override
+  String get guardianAlertsEscalatedTag => 'Escalated';
+
+  @override
+  String get guardianAlertsUnknown => 'Unknown';
+
+  @override
+  String get guardianAlertsStatusFailed => 'Failed';
+
+  @override
+  String get guardianAlertsStatusMissed => 'Missed';
+
+  @override
+  String get guardianAlertsStatusPlayed => 'Played';
+
+  @override
+  String get guardianAlertsStatusQueued => 'Queued';
+
+  @override
+  String get guardianAlertsTimeUnavailable => 'Time unavailable';
+
+  @override
+  String get guardianAlertsLocalDebugDetail => 'Local debug fallback';
+
+  @override
+  String guardianAlertsConversationDetail(String conversationId) {
+    return 'Conversation: $conversationId';
+  }
+
+  @override
+  String guardianAlertsEscalationDetail(String status) {
+    return 'Escalation: $status';
+  }
+
+  @override
+  String guardianAlertsTraceDetail(String traceId) {
+    return 'Trace: $traceId';
+  }
 }

--- a/app/test/ella/services/guardian_alert_history_api_test.dart
+++ b/app/test/ella/services/guardian_alert_history_api_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/ella/models/guardian_alert.dart';
+import 'package:omi/ella/services/guardian_alert_history_api.dart';
+
+void main() {
+  group('GuardianAlertHistoryApi', () {
+    test('parses backend alert records from suggested response shape newest-first', () {
+      final records = GuardianAlertHistoryApi.parseBackendRecords({
+        'alerts': [
+          {
+            'id': 'older',
+            'alert_text': 'Older alert',
+            'trigger_type': 'memory_support',
+            'delivery_target': 'user',
+            'playback_status': 'played',
+            'created_at': '2026-05-15T20:00:00Z',
+          },
+          {
+            'id': 'newer',
+            'summary': 'Wake word response',
+            'trigger': 'wake_word',
+            'target': 'dry-run',
+            'status': 'failed',
+            'created_at': '2026-05-15T20:05:00Z',
+            'trace_id': 'trace-123',
+            'queue_item_id': 'guardian_123',
+            'caregiver_escalation': true,
+            'escalation_status': 'not_sent',
+          },
+        ],
+      });
+
+      expect(records.map((record) => record.id), ['newer', 'older']);
+      expect(records.first.alertText, 'Wake word response');
+      expect(records.first.triggerType, 'wake_word');
+      expect(records.first.deliveryTarget, 'dry-run');
+      expect(records.first.playbackStatus, 'failed');
+      expect(records.first.traceId, 'trace-123');
+      expect(records.first.queueItemId, 'guardian_123');
+      expect(records.first.escalation, isTrue);
+      expect(records.first.isTest, isTrue);
+    });
+
+    test('recognizes and normalizes local Guardian debug log fallback records', () {
+      final log = {
+        'timestamp': '2026-05-15T20:05:00.000Z',
+        'level': 'EVENT',
+        'type': 'guardian_playback_failed',
+        'queue_item_id': 'guardian_456',
+        'trigger_type': 'wake_word_user_support',
+        'message': 'Guardian playback failed',
+        'trace_id': 'trace-456',
+      };
+
+      expect(GuardianAlertRecord.isGuardianDebugLog(log), isTrue);
+
+      final record = GuardianAlertRecord.fromDebugLog(log);
+
+      expect(record.id, 'guardian_456');
+      expect(record.alertText, 'Guardian playback failed');
+      expect(record.triggerType, 'wake_word_user_support');
+      expect(record.playbackStatus, 'failed');
+      expect(record.fromLocalDebugLog, isTrue);
+      expect(record.createdAt, DateTime.parse('2026-05-15T20:05:00.000Z'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a Guardian Alerts history row under Ella settings.
- Adds a readable Guardian Alerts history screen with chronological cards, status chips, trace/conversation details, and no raw debug JSON by default.
- Adds an auth-backed client for `GET /v1/ella/guardian-alerts?limit=50` with a local debug-log fallback while the backend contract is not yet live.
- Adds parser coverage for the suggested backend response shape and local Guardian playback/debug events.

## Backend contract used
Primary source: `GET /v1/ella/guardian-alerts?limit=50` on `Env.apiBaseUrl`, authenticated through existing `makeApiCall` headers.

The parser accepts flexible top-level list keys (`alerts`, `records`, `items`, `data`, `history`) and fields discussed in ella-ai#904: alert text, trigger, target, playback status, trace/queue IDs, escalation/test markers, and timestamps.

## Validation
- `flutter gen-l10n`
- `flutter test test/ella/services/guardian_alert_history_api_test.dart`
- `flutter analyze lib/ella/models/guardian_alert.dart lib/ella/services/guardian_alert_history_api.dart lib/ella/pages/guardian_alert_history_page.dart lib/ella/pages/ella_settings_page.dart test/ella/services/guardian_alert_history_api_test.dart`
- `./test.sh`

## Notes
- Draft until Jack finalizes or stubs the Guardian alert history API.
- No Firebase/auth/signing/TestFlight changes in this PR.

Links ellaaicare/ella-ai#904
Closes ellaaicare/ella-ai#1002
