### PR TITLE
Cap Deepgram scanner keyterm payload

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -857,11 +857,15 @@ async def _stream_handler(
         nonlocal first_stt_result_at
         if segments and first_stt_result_at is None:
             first_stt_result_at = time.time()
+            first_segment = segments[0] if isinstance(segments[0], dict) else {}
+            result_provider = (
+                first_segment.get("stt_provider") if isinstance(first_segment, dict) else None
+            ) or _stt_service_value(stt_service)
             _latency_log(
                 "first_final_result",
                 segment_count=len(segments),
-                first_text=(segments[0].get("text", "")[:80] if isinstance(segments[0], dict) else None),
-                provider=_stt_service_value(stt_service),
+                first_text=(first_segment.get("text", "")[:80] if isinstance(first_segment, dict) else None),
+                provider=result_provider,
                 since_stt_ready_ms=_elapsed_ms(stt_connect_ready_at, first_stt_result_at),
                 since_stt_connect_start_ms=_elapsed_ms(stt_connect_started_at, first_stt_result_at),
             )

--- a/backend/tests/unit/test_scanner_keyterms.py
+++ b/backend/tests/unit/test_scanner_keyterms.py
@@ -72,8 +72,19 @@ def test_combine_deepgram_keyterms_gives_scanner_terms_priority():
     combined = scanner_keyterms.combine_deepgram_keyterms(vocabulary, scanner_terms)
 
     assert combined[:3] == ["Hey Ella", "metformin", "Dr. Pu"]
-    assert len(combined) == 100
+    assert len(combined) == scanner_keyterms.DEFAULT_DEEPGRAM_MAX_TERMS
     assert combined.count("Hey Ella") == 1
+
+
+def test_combine_deepgram_keyterms_uses_provider_specific_budget(monkeypatch):
+    monkeypatch.setenv("ELLA_DEEPGRAM_KEYTERMS_MAX_TERMS", "3")
+
+    combined = scanner_keyterms.combine_deepgram_keyterms(
+        ["generic"],
+        ["Hey Ella", "where did I put my glasses", "Dr. Pu", "metformin"],
+    )
+
+    assert combined == ["Hey Ella", "where did I put my glasses", "Dr. Pu"]
 
 
 def test_limit_keyterms_enforces_token_budget():

--- a/backend/utils/ella/scanner_keyterms.py
+++ b/backend/utils/ella/scanner_keyterms.py
@@ -17,6 +17,8 @@ DEFAULT_TTL_SECONDS = 120.0
 DEFAULT_TIMEOUT_SECONDS = 1.5
 DEFAULT_MAX_TERMS = 100
 DEFAULT_MAX_TOKENS = 500
+DEFAULT_DEEPGRAM_MAX_TERMS = 50
+DEFAULT_DEEPGRAM_MAX_TOKENS = 250
 
 _cache: dict[str, "KeytermCacheEntry"] = {}
 _uid_agent_ids: dict[str, str] = {}
@@ -90,6 +92,14 @@ def _max_terms() -> int:
 
 def _max_tokens() -> int:
     return _env_int("ELLA_SCANNER_KEYTERMS_MAX_TOKENS", DEFAULT_MAX_TOKENS)
+
+
+def _deepgram_max_terms() -> int:
+    return _env_int("ELLA_DEEPGRAM_KEYTERMS_MAX_TERMS", DEFAULT_DEEPGRAM_MAX_TERMS)
+
+
+def _deepgram_max_tokens() -> int:
+    return _env_int("ELLA_DEEPGRAM_KEYTERMS_MAX_TOKENS", DEFAULT_DEEPGRAM_MAX_TOKENS)
 
 
 def _enabled() -> bool:
@@ -338,8 +348,18 @@ def limit_keyterms(terms: list[str], *, max_terms: Optional[int] = None, max_tok
 
 
 def combine_deepgram_keyterms(vocabulary: list[str], scanner_terms: list[str]) -> list[str]:
-    """Merge scanner terms before generic user vocabulary within Deepgram limits."""
-    return limit_keyterms([*(scanner_terms or []), *(vocabulary or [])])
+    """Merge scanner terms before generic user vocabulary within safe Deepgram limits.
+
+    Deepgram documents a hard 500-token keyterm limit, but recommends keeping
+    requests focused on the most important 20-50 terms. Live websocket opens
+    can reject larger practical payloads with HTTP 400, so keep the provider
+    payload conservative while preserving the full scanner cache separately.
+    """
+    return limit_keyterms(
+        [*(scanner_terms or []), *(vocabulary or [])],
+        max_terms=_deepgram_max_terms(),
+        max_tokens=_deepgram_max_tokens(),
+    )
 
 
 async def _fetch_scanner_tuning(agent_id: str) -> str:


### PR DESCRIPTION
## Summary
- cap Deepgram-specific scanner keyterm payload to a conservative 50 terms / 250 estimated tokens
- preserve the full scanner keyterm cache, but avoid sending oversized provider payloads that reject live Deepgram websockets
- add unit coverage for provider-specific keyterm budget

## Validation
- PASS: cd backend && /opt/homebrew/bin/python3 -m pytest tests/unit/test_scanner_keyterms.py tests/unit/test_stt_provider_routing.py
- LIVE: VPS Deepgram probe with Plato scanner keyterms now opens via SDK and raw websocket after cap; previous 85-term payload returned HTTP 400

## Live deploy note
Patched live VPS file with backup and restarted omi-backend.service so Deepgram capture can resume immediately. Backport this PR through normal deploy to prevent overwrite.