### PR TITLE
Fix Ella voice TTS playback audio session

### DIFF
--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -13,7 +13,6 @@ import 'package:speech_to_text/speech_to_text.dart';
 
 import 'package:uuid/uuid.dart';
 
-import 'package:omi/backend/http/api/messages.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/services/ella_chat_service.dart';
 import 'package:omi/backend/schema/message.dart';
@@ -37,8 +36,7 @@ class EllaVoiceChatPage extends StatefulWidget {
   State<EllaVoiceChatPage> createState() => _EllaVoiceChatPageState();
 }
 
-class _EllaVoiceChatPageState extends State<EllaVoiceChatPage>
-    with AutomaticKeepAliveClientMixin {
+class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKeepAliveClientMixin {
   VoiceOrbState _orbState = VoiceOrbState.idle;
   double _audioLevel = 0.0;
   String _statusText = 'Tap to Pause';
@@ -53,7 +51,6 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage>
   StreamSubscription? _playerSub;
   final SpeechToText _speech = SpeechToText();
   bool _speechAvailable = false;
-  bool _didPauseCaptureRecording = false;
   String _currentWords = '';
 
   /// Guard against concurrent _startListening() calls
@@ -94,8 +91,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage>
   );
 
   /// Check if current TTS provider is a V2V provider.
-  static bool _isV2VProvider(String provider) =>
-      provider == 'grok-voice' || provider == 'gemini-live';
+  static bool _isV2VProvider(String provider) => provider == 'grok-voice' || provider == 'gemini-live';
 
   @override
   bool get wantKeepAlive => true;
@@ -105,8 +101,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage>
     super.initState();
     // Voice mode auto-starts when the Voice tab becomes active (see didChangeDependencies)
     _playerSub = _audioPlayer.playerStateStream.listen((state) {
-      if (state.processingState == ProcessingState.completed &&
-          _orbState == VoiceOrbState.speaking) {
+      if (state.processingState == ProcessingState.completed && _orbState == VoiceOrbState.speaking) {
         // Immediately transition out of speaking to prevent duplicate triggers
         _orbState = VoiceOrbState.idle;
         if (_voiceModeActive) {
@@ -159,8 +154,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage>
     _speechAvailable = await _speech.initialize(
       onError: (error) {
         debugPrint('[VoiceChat] Speech error: ${error.errorMsg}');
-        if (error.errorMsg == 'error_no_match' &&
-            _orbState == VoiceOrbState.listening) {
+        if (error.errorMsg == 'error_no_match' && _orbState == VoiceOrbState.listening) {
           if (_currentWords.isNotEmpty) {
             _processTranscript(_currentWords);
           } else if (_voiceModeActive) {
@@ -385,7 +379,6 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage>
       if (captureProvider.recordingState == RecordingState.record) {
         debugPrint('[VoiceChat] Pausing capture recording to free mic');
         await captureProvider.stopStreamRecording();
-        _didPauseCaptureRecording = true;
       }
     }
 
@@ -481,7 +474,6 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage>
       if (captureProvider.recordingState == RecordingState.record) {
         debugPrint('[VoiceChat] Pausing capture recording for V2V');
         await captureProvider.stopStreamRecording();
-        _didPauseCaptureRecording = true;
       }
     }
 
@@ -563,9 +555,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage>
         break;
       case 'audio_done':
         // Inject into chat history once per turn (using final transcript)
-        if (!_v2vTurnInjected &&
-            _lastUserText.isNotEmpty &&
-            _lastEllaText.isNotEmpty) {
+        if (!_v2vTurnInjected && _lastUserText.isNotEmpty && _lastEllaText.isNotEmpty) {
           _injectVoiceMessages(_lastUserText, _lastEllaText);
           _v2vTurnInjected = true;
         }
@@ -671,8 +661,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage>
       await for (var chunk in sendEllaChatStream(transcript)) {
         if (chunk.type == MessageChunkType.data) {
           replyBuffer.write(chunk.text);
-        } else if (chunk.type == MessageChunkType.done &&
-            chunk.message != null) {
+        } else if (chunk.type == MessageChunkType.done && chunk.message != null) {
           if (chunk.message!.text.isNotEmpty) {
             replyBuffer.clear();
             replyBuffer.write(chunk.message!.text);
@@ -769,14 +758,12 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage>
     await session.configure(
       AudioSessionConfiguration(
         avAudioSessionCategory: AVAudioSessionCategory.playAndRecord,
-        avAudioSessionCategoryOptions:
-            AVAudioSessionCategoryOptions.defaultToSpeaker |
+        avAudioSessionCategoryOptions: AVAudioSessionCategoryOptions.defaultToSpeaker |
             AVAudioSessionCategoryOptions.allowBluetooth |
             AVAudioSessionCategoryOptions.allowBluetoothA2dp |
             AVAudioSessionCategoryOptions.allowAirPlay,
         avAudioSessionMode: AVAudioSessionMode.defaultMode,
-        avAudioSessionRouteSharingPolicy:
-            AVAudioSessionRouteSharingPolicy.defaultPolicy,
+        avAudioSessionRouteSharingPolicy: AVAudioSessionRouteSharingPolicy.defaultPolicy,
         avAudioSessionSetActiveOptions: AVAudioSessionSetActiveOptions.none,
       ),
     );
@@ -786,10 +773,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage>
 
   /// Strip emojis from text so TTS doesn't read them aloud.
   String _stripEmojis(String text) {
-    return text
-        .replaceAll(_emojiRegex, '')
-        .replaceAll(RegExp(r'  +'), ' ')
-        .trim();
+    return text.replaceAll(_emojiRegex, '').replaceAll(RegExp(r'  +'), ' ').trim();
   }
 
   /// Inject voice exchange into MessageProvider so Chat tab shows it.

--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:audio_session/audio_session.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -36,7 +37,8 @@ class EllaVoiceChatPage extends StatefulWidget {
   State<EllaVoiceChatPage> createState() => _EllaVoiceChatPageState();
 }
 
-class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKeepAliveClientMixin {
+class _EllaVoiceChatPageState extends State<EllaVoiceChatPage>
+    with AutomaticKeepAliveClientMixin {
   VoiceOrbState _orbState = VoiceOrbState.idle;
   double _audioLevel = 0.0;
   String _statusText = 'Tap to Pause';
@@ -92,7 +94,8 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   );
 
   /// Check if current TTS provider is a V2V provider.
-  static bool _isV2VProvider(String provider) => provider == 'grok-voice' || provider == 'gemini-live';
+  static bool _isV2VProvider(String provider) =>
+      provider == 'grok-voice' || provider == 'gemini-live';
 
   @override
   bool get wantKeepAlive => true;
@@ -102,7 +105,8 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     super.initState();
     // Voice mode auto-starts when the Voice tab becomes active (see didChangeDependencies)
     _playerSub = _audioPlayer.playerStateStream.listen((state) {
-      if (state.processingState == ProcessingState.completed && _orbState == VoiceOrbState.speaking) {
+      if (state.processingState == ProcessingState.completed &&
+          _orbState == VoiceOrbState.speaking) {
         // Immediately transition out of speaking to prevent duplicate triggers
         _orbState = VoiceOrbState.idle;
         if (_voiceModeActive) {
@@ -155,7 +159,8 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     _speechAvailable = await _speech.initialize(
       onError: (error) {
         debugPrint('[VoiceChat] Speech error: ${error.errorMsg}');
-        if (error.errorMsg == 'error_no_match' && _orbState == VoiceOrbState.listening) {
+        if (error.errorMsg == 'error_no_match' &&
+            _orbState == VoiceOrbState.listening) {
           if (_currentWords.isNotEmpty) {
             _processTranscript(_currentWords);
           } else if (_voiceModeActive) {
@@ -211,7 +216,9 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   }
 
   Future<void> _onOrbTap() async {
-    debugPrint('[VoiceChat] Orb tapped, state: $_orbState, voiceMode: $_voiceModeActive, v2v: $_isV2VMode');
+    debugPrint(
+      '[VoiceChat] Orb tapped, state: $_orbState, voiceMode: $_voiceModeActive, v2v: $_isV2VMode',
+    );
     HapticFeedback.mediumImpact();
 
     if (!_voiceModeActive) {
@@ -296,10 +303,16 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
           context: context,
           builder: (ctx) => AlertDialog(
             backgroundColor: EllaColors.bgSecondary,
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(EllaSizes.radiusLarge)),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(EllaSizes.radiusLarge),
+            ),
             title: const Text(
               'Microphone Access',
-              style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold, color: EllaColors.textPrimary),
+              style: TextStyle(
+                fontSize: 22,
+                fontWeight: FontWeight.bold,
+                color: EllaColors.textPrimary,
+              ),
             ),
             content: const Text(
               'Ella needs microphone access for voice chat. Please enable it in Settings.',
@@ -308,21 +321,32 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
             actions: [
               TextButton(
                 onPressed: () => Navigator.of(ctx).pop(),
-                child: const Text('Cancel', style: TextStyle(fontSize: 18, color: EllaColors.textTertiary)),
+                child: const Text(
+                  'Cancel',
+                  style: TextStyle(
+                    fontSize: 18,
+                    color: EllaColors.textTertiary,
+                  ),
+                ),
               ),
               TextButton(
                 onPressed: () {
                   Navigator.of(ctx).pop();
                   openAppSettings();
                 },
-                child: const Text('Open Settings', style: TextStyle(fontSize: 18, color: EllaColors.primary)),
+                child: const Text(
+                  'Open Settings',
+                  style: TextStyle(fontSize: 18, color: EllaColors.primary),
+                ),
               ),
             ],
           ),
         );
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Microphone permission is required for voice chat')),
+          const SnackBar(
+            content: Text('Microphone permission is required for voice chat'),
+          ),
         );
       }
       return;
@@ -332,7 +356,9 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     if (!speechStatus.isGranted) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Speech recognition permission is required')),
+        const SnackBar(
+          content: Text('Speech recognition permission is required'),
+        ),
       );
       return;
     }
@@ -342,7 +368,9 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       if (!_speechAvailable) {
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Speech recognition is not available on this device')),
+          const SnackBar(
+            content: Text('Speech recognition is not available on this device'),
+          ),
         );
         return;
       }
@@ -350,7 +378,10 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
     // Stop any existing mic recording from CaptureProvider
     if (mounted) {
-      final captureProvider = Provider.of<CaptureProvider>(context, listen: false);
+      final captureProvider = Provider.of<CaptureProvider>(
+        context,
+        listen: false,
+      );
       if (captureProvider.recordingState == RecordingState.record) {
         debugPrint('[VoiceChat] Pausing capture recording to free mic');
         await captureProvider.stopStreamRecording();
@@ -443,7 +474,10 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
     // Stop any existing mic recording from CaptureProvider
     if (mounted) {
-      final captureProvider = Provider.of<CaptureProvider>(context, listen: false);
+      final captureProvider = Provider.of<CaptureProvider>(
+        context,
+        listen: false,
+      );
       if (captureProvider.recordingState == RecordingState.record) {
         debugPrint('[VoiceChat] Pausing capture recording for V2V');
         await captureProvider.stopStreamRecording();
@@ -529,7 +563,9 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
         break;
       case 'audio_done':
         // Inject into chat history once per turn (using final transcript)
-        if (!_v2vTurnInjected && _lastUserText.isNotEmpty && _lastEllaText.isNotEmpty) {
+        if (!_v2vTurnInjected &&
+            _lastUserText.isNotEmpty &&
+            _lastEllaText.isNotEmpty) {
           _injectVoiceMessages(_lastUserText, _lastEllaText);
           _v2vTurnInjected = true;
         }
@@ -591,7 +627,9 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
   void _onSpeechResult(SpeechRecognitionResult result) {
     if (!mounted) return;
-    debugPrint('[VoiceChat] Speech result: final=${result.finalResult}, text="${result.recognizedWords}"');
+    debugPrint(
+      '[VoiceChat] Speech result: final=${result.finalResult}, text="${result.recognizedWords}"',
+    );
 
     _currentWords = result.recognizedWords;
 
@@ -618,13 +656,23 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     });
 
     try {
+      if (_speech.isListening) {
+        debugPrint(
+          '[VoiceChat] Stopping speech recognizer before response playback',
+        );
+        await _speech.stop();
+        // Let iOS release the recording session before we synthesize/play audio.
+        await Future.delayed(const Duration(milliseconds: 150));
+      }
+
       // Send via Ella's chat endpoint
       debugPrint('[VoiceChat] Sending to Ella chat...');
       final replyBuffer = StringBuffer();
       await for (var chunk in sendEllaChatStream(transcript)) {
         if (chunk.type == MessageChunkType.data) {
           replyBuffer.write(chunk.text);
-        } else if (chunk.type == MessageChunkType.done && chunk.message != null) {
+        } else if (chunk.type == MessageChunkType.done &&
+            chunk.message != null) {
           if (chunk.message!.text.isNotEmpty) {
             replyBuffer.clear();
             replyBuffer.write(chunk.message!.text);
@@ -634,7 +682,8 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
       final fullReply = replyBuffer.toString().trim();
       debugPrint(
-          '[VoiceChat] Ella reply (${fullReply.length} chars): "${fullReply.substring(0, math.min(100, fullReply.length))}"');
+        '[VoiceChat] Ella reply (${fullReply.length} chars): "${fullReply.substring(0, math.min(100, fullReply.length))}"',
+      );
       if (!mounted) return;
       if (fullReply.isEmpty) {
         if (_voiceModeActive) {
@@ -658,7 +707,9 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       });
 
       // Strip emojis before TTS — prevents the TTS engine from reading emoji names aloud
-      final ttsText = _stripEmojis(fullReply.length > 500 ? fullReply.substring(0, 500) : fullReply);
+      final ttsText = _stripEmojis(
+        fullReply.length > 500 ? fullReply.substring(0, 500) : fullReply,
+      );
       debugPrint('[VoiceChat] Synthesizing TTS (${ttsText.length} chars)...');
       final audioPath = await ElevenLabsTts.synthesize(ttsText);
       debugPrint('[VoiceChat] TTS result: $audioPath');
@@ -679,8 +730,23 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
       // Play audio
       debugPrint('[VoiceChat] Playing audio: $audioPath');
-      await _audioPlayer.setFilePath(audioPath);
-      await _audioPlayer.play();
+      try {
+        await _prepareTtsPlaybackSession();
+        await _audioPlayer.setVolume(1.0);
+        await _audioPlayer.setFilePath(audioPath);
+        await _audioPlayer.play();
+      } catch (playbackError, playbackStack) {
+        debugPrint(
+          '[VoiceChat] File playback failed, using on-device TTS: $playbackError\n$playbackStack',
+        );
+        await ElevenLabsTts.speakOnDevice(ttsText);
+        if (!mounted) return;
+        if (_voiceModeActive) {
+          _startListening();
+        } else {
+          _returnToIdle();
+        }
+      }
       // playerStateStream listener handles return to idle on completion
     } catch (e, st) {
       debugPrint('[VoiceChat] Error in voice flow: $e\n$st');
@@ -698,9 +764,32 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     }
   }
 
+  Future<void> _prepareTtsPlaybackSession() async {
+    final session = await AudioSession.instance;
+    await session.configure(
+      AudioSessionConfiguration(
+        avAudioSessionCategory: AVAudioSessionCategory.playAndRecord,
+        avAudioSessionCategoryOptions:
+            AVAudioSessionCategoryOptions.defaultToSpeaker |
+            AVAudioSessionCategoryOptions.allowBluetooth |
+            AVAudioSessionCategoryOptions.allowBluetoothA2dp |
+            AVAudioSessionCategoryOptions.allowAirPlay,
+        avAudioSessionMode: AVAudioSessionMode.defaultMode,
+        avAudioSessionRouteSharingPolicy:
+            AVAudioSessionRouteSharingPolicy.defaultPolicy,
+        avAudioSessionSetActiveOptions: AVAudioSessionSetActiveOptions.none,
+      ),
+    );
+    await session.setActive(true);
+    debugPrint('[VoiceChat] Audio session prepared for TTS playback');
+  }
+
   /// Strip emojis from text so TTS doesn't read them aloud.
   String _stripEmojis(String text) {
-    return text.replaceAll(_emojiRegex, '').replaceAll(RegExp(r'  +'), ' ').trim();
+    return text
+        .replaceAll(_emojiRegex, '')
+        .replaceAll(RegExp(r'  +'), ' ')
+        .trim();
   }
 
   /// Inject voice exchange into MessageProvider so Chat tab shows it.
@@ -749,7 +838,9 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     _typewriterTimer?.cancel();
     _ellaDisplayText = '';
     int charIndex = 0;
-    _typewriterTimer = Timer.periodic(const Duration(milliseconds: 50), (timer) {
+    _typewriterTimer = Timer.periodic(const Duration(milliseconds: 50), (
+      timer,
+    ) {
       if (!mounted || charIndex >= fullText.length) {
         timer.cancel();
         if (mounted) {
@@ -807,7 +898,11 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
         backgroundColor: EllaColors.bgPrimary,
         title: const Text(
           'Voice Chat',
-          style: TextStyle(fontSize: 22, fontWeight: FontWeight.w600, color: EllaColors.textPrimary),
+          style: TextStyle(
+            fontSize: 22,
+            fontWeight: FontWeight.w600,
+            color: EllaColors.textPrimary,
+          ),
         ),
         elevation: 0,
         centerTitle: true,
@@ -827,11 +922,17 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
             const SizedBox(height: 24),
             Center(
               child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 10,
+                ),
                 decoration: BoxDecoration(
                   color: EllaColors.bgSecondary,
                   borderRadius: BorderRadius.circular(EllaSizes.radiusCircular),
-                  border: Border.all(color: EllaColors.primary.withOpacity(0.22), width: 1),
+                  border: Border.all(
+                    color: EllaColors.primary.withOpacity(0.22),
+                    width: 1,
+                  ),
                 ),
                 child: Text(
                   _statusText,
@@ -856,7 +957,10 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
                         controller: _transcriptScrollController,
                         child: Text(
                           _transcriptContent,
-                          style: TextStyle(fontSize: 16, color: _transcriptColor),
+                          style: TextStyle(
+                            fontSize: 16,
+                            color: _transcriptColor,
+                          ),
                           textAlign: TextAlign.center,
                         ),
                       ),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.522+784
+version: 1.0.522+785
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- stop the iOS speech recognizer before standard voice TTS playback
- prepare an explicit play-and-record audio session with speaker/Bluetooth routing before playing synthesized audio
- fall back to on-device TTS if file playback throws, so text-only voice responses degrade audibly instead of silently

## Evidence
- Backend `/v1/voice/tts` is returning valid `audio/mpeg` Kokoro bytes.
- Recent live logs show the failing test used standard `X-TTS-Provider: kokoro`, not `/v1/voice/session` Grok/Gemini V2V.

## Validation
- `flutter test test/utils/app_localizations_helper_test.dart`
- `flutter analyze lib/ella/pages/ella_voice_chat_page.dart` only reports pre-existing warnings/deprecations in this file; no new type errors.

## TestFlight request
Please build/upload this branch so Greg can validate that standard voice mode no longer shows text without audio.