### PR TITLE
Add Hermes workspace search to Plato MCP

### DIFF
--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -51,6 +51,7 @@ DEFAULT_PROVISION_API_URL = "http://100.76.138.56:8200"
 MAX_CONTEXT_LIMIT = 50
 MAX_WINDOW_CONTEXT_LIMIT = 500
 MAX_SEARCH_RESULTS = 20
+MAX_WORKSPACE_SEARCH_RESULTS = 10
 MAX_PROMPT_CHARS = 4000
 MAX_OBSERVATION_CHARS = 8000
 MAX_CONSULT_CONTEXT_CHARS = 7000
@@ -730,6 +731,56 @@ def _score_item(query_tokens: set[str], item: dict[str, Any]) -> int:
     return len(query_tokens & _tokens(haystack))
 
 
+def _workspace_search_result_to_event(result: dict[str, Any]) -> dict[str, Any]:
+    file_name = str(result.get("file") or "")
+    line = result.get("line")
+    event = {
+        "event_id": f"hermes-workspace:{file_name}:{line}",
+        "channel": "hermes_workspace",
+        "provider": "hermes-provision-search",
+        "role": "memory",
+        "started_at": result.get("started_at") or "",
+        "title": result.get("title") or "Hermes workspace match",
+        "text": _compact_text(result.get("excerpt"), 1800),
+        "source_ref": {
+            "source": "hermes_workspace",
+            "file": file_name,
+            "line": line,
+        },
+        "score": result.get("score"),
+        "matched_terms": result.get("matched_terms") or [],
+    }
+    return annotate_event_time(event, tz_name=_plato_timezone())
+
+
+async def _fetch_workspace_search(query: str, max_results: int) -> list[dict[str, Any]]:
+    provision_token = _env("ELLA_PROVISION_API_TOKEN")
+    if not provision_token:
+        logger.warning("plato_mcp workspace search skipped: ELLA_PROVISION_API_TOKEN is not configured")
+        return []
+    provision_url = _env("ELLA_PROVISION_API_URL", DEFAULT_PROVISION_API_URL).rstrip("/")
+    limit = max(1, min(max_results, MAX_WORKSPACE_SEARCH_RESULTS))
+    try:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            response = await client.post(
+                f"{provision_url}/workspace/{_plato_agent_id()}/search",
+                headers={"Authorization": f"Bearer {provision_token}"},
+                json={"query": query, "limit": limit, "excerpt_chars": 1400},
+            )
+        if response.status_code != 200:
+            logger.warning("plato_mcp workspace search HTTP %s: %s", response.status_code, response.text[:300])
+            return []
+        payload = response.json()
+        return [
+            _workspace_search_result_to_event(item)
+            for item in (payload.get("results") or [])
+            if isinstance(item, dict)
+        ]
+    except Exception as exc:
+        logger.warning("plato_mcp workspace search failed: %s", exc)
+        return []
+
+
 def _format_consult_context(context: dict[str, Any], limit: int) -> str:
     lines = [
         f"source={context.get('source') or 'unknown'}",
@@ -776,9 +827,17 @@ async def _search_memory(arguments: dict[str, Any]) -> dict[str, Any]:
     if inferred_since is not None and not results:
         meaningful_events = [item for item in events if not _is_temporal_low_value_fragment(item)]
         results = (meaningful_events or list(events))[-max_results:]
+    workspace_results = await _fetch_workspace_search(query, max_results)
+    if workspace_results:
+        seen = {_event_identity(item) for item in workspace_results}
+        results = (workspace_results + [item for item in results if _event_identity(item) not in seen])[:max_results]
     return {
         "query": query,
-        "source": context.get("source"),
+        "source": (
+            f"{context.get('source')}_with_hermes_workspace_search"
+            if workspace_results
+            else context.get("source")
+        ),
         "inferred_time_window": inferred_label or None,
         "time_context": context.get("time_context") or build_time_context(_plato_timezone()),
         "results": results,
@@ -824,6 +883,13 @@ async def _consult_plato(arguments: dict[str, Any]) -> dict[str, Any]:
     context_limit = _clamp_int(arguments.get("context_limit"), 15, 1, MAX_CONTEXT_LIMIT)
     context = await _recent_context({"limit": context_limit})
     context_block = _format_consult_context(context, context_limit)
+    workspace_results = await _fetch_workspace_search(prompt, min(5, context_limit))
+    if workspace_results:
+        workspace_context = _format_consult_context(
+            {"source": "hermes_workspace_search", "uid": _plato_uid(), "events": workspace_results},
+            len(workspace_results),
+        )
+        context_block = f"{context_block}\n\nDeep Hermes workspace search:\n{workspace_context}"
     token = _env("HERMES_API_SERVER_KEY", _env("API_SERVER_KEY", ""))
     if not token:
         raise ToolExecutionError("HERMES_API_SERVER_KEY is not configured", code=-32003)
@@ -868,8 +934,12 @@ async def _consult_plato(arguments: dict[str, Any]) -> dict[str, Any]:
         "mode": mode,
         "agent_id": agent_id,
         "session": session_key,
-        "context_source": context.get("source"),
-        "context_events": len(context.get("events") or []),
+        "context_source": (
+            f"{context.get('source')}_with_hermes_workspace_search"
+            if workspace_results
+            else context.get("source")
+        ),
+        "context_events": len(context.get("events") or []) + len(workspace_results),
     }
 
 

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -621,6 +621,66 @@ def test_plato_search_memory_uses_merged_omi_fallback(monkeypatch):
     assert result["results"][0]["event_id"] == "cafe-1"
 
 
+def test_plato_search_memory_prefers_deep_hermes_workspace_matches(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    async def recent_meta_chat(arguments):
+        return {
+            "uid": module._plato_uid(),
+            "source": "canonical_timeline",
+            "events": [
+                {
+                    "event_id": "today-meta-chat",
+                    "channel": "imessage",
+                    "role": "assistant",
+                    "title": "Follow-Up on Meisheng 504 Plan Meeting",
+                    "text": "I do not have the full kickoff meeting transcript.",
+                    "started_at": "2026-05-27T20:33:47Z",
+                }
+            ],
+        }
+
+    async def workspace_search(query, max_results):
+        assert "504" in query
+        return [
+            {
+                "event_id": "hermes-workspace:TIMELINE.md:121",
+                "channel": "hermes_workspace",
+                "provider": "hermes-provision-search",
+                "role": "memory",
+                "title": "2026-04-24 15:00 — Initial 504 meeting for Meisheng",
+                "text": "The school team walked through the first Section 504 meeting with Plato, Meisheng, and staff.",
+                "source_ref": {"source": "hermes_workspace", "file": "TIMELINE.md", "line": 121},
+            }
+        ]
+
+    monkeypatch.setattr(module, "_recent_context", recent_meta_chat)
+    monkeypatch.setattr(module, "_fetch_workspace_search", workspace_search)
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc(
+            "tools/call",
+            params={
+                "name": "plato_search_memory",
+                "arguments": {
+                    "query": "Meisheng 504 plan administrators kickoff meeting last month",
+                    "max_results": 5,
+                },
+            },
+        ),
+    )
+
+    assert response.status_code == 200
+    result = _tool_result(response)
+    assert result["source"] == "canonical_timeline_with_hermes_workspace_search"
+    assert result["results"][0]["channel"] == "hermes_workspace"
+    assert result["results"][0]["source_ref"]["file"] == "TIMELINE.md"
+    assert result["results"][1]["event_id"] == "today-meta-chat"
+
+
 def test_plato_search_memory_temporal_query_returns_morning_window_without_keyword_match(monkeypatch):
     module = _load_module(monkeypatch)
     client = _client(module)
@@ -730,6 +790,7 @@ def test_plato_consult_includes_fresh_mcp_context(monkeypatch):
             return FakeResponse()
 
     monkeypatch.setattr(module, "_recent_context", fake_recent_context)
+    monkeypatch.setattr(module, "_fetch_workspace_search", lambda prompt, max_results: asyncio.sleep(0, result=[]))
     monkeypatch.setattr(module.httpx, "AsyncClient", FakeAsyncClient)
 
     result = asyncio.run(module._consult_plato({"prompt": "Did I order at a cafe today?", "mode": "normal"}))
@@ -740,6 +801,60 @@ def test_plato_consult_includes_fresh_mcp_context(monkeypatch):
     assert "Ordered a noah drink and a waffle" in user_message
     assert "freshest available evidence" in captured["json"]["messages"][0]["content"]
     assert result["context_source"] == "canonical_timeline_empty_omi_firestore_fallback"
+    assert result["context_events"] == 1
+
+
+def test_plato_consult_includes_deep_workspace_search(monkeypatch):
+    module = _load_module(monkeypatch)
+    monkeypatch.setenv("HERMES_API_SERVER_KEY", "hermes-test-token")
+    captured = {}
+
+    async def fake_recent_context(arguments):
+        return {"uid": "test-uid", "source": "canonical_timeline", "events": []}
+
+    async def workspace_search(prompt, max_results):
+        return [
+            {
+                "event_id": "hermes-workspace:TIMELINE.md:121",
+                "channel": "hermes_workspace",
+                "provider": "hermes-provision-search",
+                "role": "memory",
+                "title": "2026-04-24 15:00 — Initial 504 meeting for Meisheng",
+                "text": "The school team walked through the first Section 504 meeting with Plato, Meisheng, and staff.",
+                "source_ref": {"source": "hermes_workspace", "file": "TIMELINE.md", "line": 121},
+            }
+        ]
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"choices": [{"message": {"content": "The 504 meeting is in the deep workspace context."}}]}
+
+    class FakeAsyncClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, headers, json):
+            captured["json"] = json
+            return FakeResponse()
+
+    monkeypatch.setattr(module, "_recent_context", fake_recent_context)
+    monkeypatch.setattr(module, "_fetch_workspace_search", workspace_search)
+    monkeypatch.setattr(module.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = asyncio.run(module._consult_plato({"prompt": "What happened in Meisheng's 504 meeting?", "mode": "deep"}))
+
+    user_message = captured["json"]["messages"][1]["content"]
+    assert "Deep Hermes workspace search" in user_message
+    assert "Initial 504 meeting for Meisheng" in user_message
+    assert result["context_source"] == "canonical_timeline_with_hermes_workspace_search"
     assert result["context_events"] == 1
 
 


### PR DESCRIPTION
## Summary
- Add Hermes workspace deep search to `plato_search_memory`, using the Mac Mini provision shim `/workspace/{agent_id}/search` endpoint.
- Prepend primary Hermes workspace matches ahead of recent canonical-window hits so older but relevant files like `TIMELINE.md` surface correctly.
- Include deep workspace matches in `plato_consult` context for longer recall questions.

## Live validation
The live path was patched and tested before this PR so the Grok MCP connector can retry immediately. Query:

`Mei Xin Meisheng 504 plan administrators kickoff meeting last month school accommodations`

Live `plato_search_memory` now returns:

- `source`: `canonical_timeline_with_omi_firestore_fallback_with_hermes_workspace_search`
- top result: `TIMELINE.md | 2026-04-24 15:00 — Initial 504 meeting for Meisheng`
- channel: `hermes_workspace`

## Tests
- `/opt/homebrew/bin/python3 -m py_compile backend/ella/routers/plato_mcp.py`
- `/opt/homebrew/bin/python3 -m pytest backend/tests/unit/test_ella_plato_mcp.py -q -k 'workspace or merged_omi_fallback or consult_includes_fresh'` -> 4 passed

Note: the full `backend/tests/unit/test_ella_plato_mcp.py` file still has pre-existing proposal/tool-list expectation drift unrelated to this MCP search patch.
