### PR TITLE
Harden OMI search indexing and vector coverage

### DIFF
--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -1,13 +1,16 @@
 import json
+import logging
 import os
 from collections import defaultdict
 from datetime import datetime, timezone, timedelta
-from typing import List
+from typing import List, Optional
 
 from pinecone import Pinecone
 
 from models.conversation import Conversation
 from utils.llm.clients import embeddings
+
+logger = logging.getLogger(__name__)
 
 if os.getenv('PINECONE_API_KEY') is not None:
     pc = Pinecone(api_key=os.getenv('PINECONE_API_KEY', ''))
@@ -15,10 +18,16 @@ if os.getenv('PINECONE_API_KEY') is not None:
 else:
     index = None
 
+CONVERSATIONS_NAMESPACE = "ns1"
+
+
+def build_conversation_vector_id(uid: str, conversation_id: str) -> str:
+    return f'{uid}-{conversation_id}'
+
 
 def _get_data(uid: str, conversation_id: str, vector: List[float]):
     return {
-        "id": f'{uid}-{conversation_id}',
+        "id": build_conversation_vector_id(uid, conversation_id),
         "values": vector,
         'metadata': {
             'uid': uid,
@@ -29,37 +38,128 @@ def _get_data(uid: str, conversation_id: str, vector: List[float]):
 
 
 def upsert_vector(uid: str, conversation: Conversation, vector: List[float]):
-    res = index.upsert(vectors=[_get_data(uid, conversation.id, vector)], namespace="ns1")
-    print('upsert_vector', res)
+    if index is None:
+        logger.warning(
+            "pinecone_index_unavailable action=upsert_vector uid=%s conversation_id=%s", uid, conversation.id
+        )
+        return None
+    try:
+        res = index.upsert(vectors=[_get_data(uid, conversation.id, vector)], namespace=CONVERSATIONS_NAMESPACE)
+        logger.info("conversation_vector_upserted uid=%s conversation_id=%s result=%s", uid, conversation.id, res)
+        return res
+    except Exception:
+        logger.exception("conversation_vector_upsert_failed uid=%s conversation_id=%s", uid, conversation.id)
+        raise
 
 
 def upsert_vector2(uid: str, conversation: Conversation, vector: List[float], metadata: dict):
-    data = _get_data(uid, conversation.id, vector)
-    data['metadata'].update(metadata)
-    res = index.upsert(vectors=[data], namespace="ns1")
-    print('upsert_vector', res)
+    return upsert_conversation_vector(uid, conversation.id, vector, metadata)
+
+
+def upsert_conversation_vector(uid: str, conversation_id: str, vector: List[float], metadata: Optional[dict] = None):
+    if index is None:
+        logger.warning(
+            "pinecone_index_unavailable action=upsert_conversation_vector uid=%s conversation_id=%s",
+            uid,
+            conversation_id,
+        )
+        return None
+    data = _get_data(uid, conversation_id, vector)
+    if metadata:
+        data['metadata'].update(metadata)
+    try:
+        res = index.upsert(vectors=[data], namespace=CONVERSATIONS_NAMESPACE)
+        logger.info(
+            "conversation_vector_upserted uid=%s conversation_id=%s metadata_keys=%s result=%s",
+            uid,
+            conversation_id,
+            sorted((metadata or {}).keys()),
+            res,
+        )
+        return res
+    except Exception:
+        logger.exception("conversation_vector_upsert_failed uid=%s conversation_id=%s", uid, conversation_id)
+        raise
 
 
 def update_vector_metadata(uid: str, conversation_id: str, metadata: dict):
+    if index is None:
+        logger.warning(
+            "pinecone_index_unavailable action=update_vector_metadata uid=%s conversation_id=%s",
+            uid,
+            conversation_id,
+        )
+        return None
     metadata['uid'] = uid
     metadata['memory_id'] = conversation_id
-    return index.update(f'{uid}-{conversation_id}', set_metadata=metadata, namespace="ns1")
+    try:
+        return index.update(
+            build_conversation_vector_id(uid, conversation_id),
+            set_metadata=metadata,
+            namespace=CONVERSATIONS_NAMESPACE,
+        )
+    except Exception:
+        logger.exception("conversation_vector_metadata_update_failed uid=%s conversation_id=%s", uid, conversation_id)
+        raise
 
 
 def upsert_vectors(uid: str, vectors: List[List[float]], conversations: List[Conversation]):
+    if index is None:
+        logger.warning("pinecone_index_unavailable action=upsert_vectors uid=%s count=%s", uid, len(conversations))
+        return None
     data = [_get_data(uid, conversation.id, vector) for conversation, vector in zip(conversations, vectors)]
-    res = index.upsert(vectors=data, namespace="ns1")
-    print('upsert_vectors', res)
+    try:
+        res = index.upsert(vectors=data, namespace=CONVERSATIONS_NAMESPACE)
+        logger.info("conversation_vectors_upserted uid=%s count=%s result=%s", uid, len(data), res)
+        return res
+    except Exception:
+        logger.exception("conversation_vectors_upsert_failed uid=%s count=%s", uid, len(data))
+        raise
 
 
 def query_vectors(query: str, uid: str, starts_at: int = None, ends_at: int = None, k: int = 5) -> List[str]:
+    if index is None:
+        logger.warning("pinecone_index_unavailable action=query_vectors uid=%s", uid)
+        return []
     filter_data = {'uid': uid}
     if starts_at is not None:
         filter_data['created_at'] = {'$gte': starts_at, '$lte': ends_at}
 
-    xq = embeddings.embed_query(query)
-    xc = index.query(vector=xq, top_k=k, include_metadata=False, filter=filter_data, namespace="ns1")
-    return [item['id'].replace(f'{uid}-', '') for item in xc['matches']]
+    try:
+        xq = embeddings.embed_query(query)
+        xc = index.query(
+            vector=xq,
+            top_k=k,
+            include_metadata=False,
+            filter=filter_data,
+            namespace=CONVERSATIONS_NAMESPACE,
+        )
+        return [item['id'].replace(f'{uid}-', '') for item in xc['matches']]
+    except Exception:
+        logger.exception(
+            "conversation_vector_query_failed uid=%s starts_at=%s ends_at=%s k=%s", uid, starts_at, ends_at, k
+        )
+        raise
+
+
+def fetch_existing_conversation_vector_ids(uid: str, conversation_ids: List[str]) -> set[str]:
+    """Return conversation ids that currently have Pinecone vectors."""
+    if index is None or not conversation_ids:
+        return set()
+    vector_ids = [build_conversation_vector_id(uid, conversation_id) for conversation_id in conversation_ids]
+    try:
+        fetched = index.fetch(ids=vector_ids, namespace=CONVERSATIONS_NAMESPACE)
+        vectors = getattr(fetched, "vectors", None)
+        if vectors is None and isinstance(fetched, dict):
+            vectors = fetched.get("vectors") or {}
+        return {
+            str(vector_id).replace(f'{uid}-', '')
+            for vector_id in (vectors or {}).keys()
+            if str(vector_id).startswith(f'{uid}-')
+        }
+    except Exception:
+        logger.exception("conversation_vector_fetch_failed uid=%s count=%s", uid, len(conversation_ids))
+        raise
 
 
 def query_vectors_by_metadata(
@@ -72,6 +172,9 @@ def query_vectors_by_metadata(
     dates: List[str],
     limit: int = 5,
 ):
+    if index is None:
+        logger.warning("pinecone_index_unavailable action=query_vectors_by_metadata uid=%s", uid)
+        return []
     filter_data = {
         '$and': [
             {'uid': {'$eq': uid}},
@@ -94,21 +197,34 @@ def query_vectors_by_metadata(
             {'created_at': {'$gte': int(dates_filter[0].timestamp()), '$lte': int(dates_filter[1].timestamp())}}
         )
 
-    xc = index.query(
-        vector=vector, filter=filter_data, namespace="ns1", include_values=False, include_metadata=True, top_k=1000
-    )
+    try:
+        xc = index.query(
+            vector=vector,
+            filter=filter_data,
+            namespace=CONVERSATIONS_NAMESPACE,
+            include_values=False,
+            include_metadata=True,
+            top_k=1000,
+        )
+    except Exception:
+        logger.exception("conversation_vector_metadata_query_failed uid=%s", uid)
+        raise
     if not xc['matches']:
         if len(filter_data['$and']) == 3:
             filter_data['$and'].pop(1)
-            print('query_vectors_by_metadata retrying without structured filters:', json.dumps(filter_data))
-            xc = index.query(
-                vector=vector,
-                filter=filter_data,
-                namespace="ns1",
-                include_values=False,
-                include_metadata=True,
-                top_k=20,
-            )
+            logger.info("conversation_vector_metadata_query_retry uid=%s filter=%s", uid, json.dumps(filter_data))
+            try:
+                xc = index.query(
+                    vector=vector,
+                    filter=filter_data,
+                    namespace=CONVERSATIONS_NAMESPACE,
+                    include_values=False,
+                    include_metadata=True,
+                    top_k=20,
+                )
+            except Exception:
+                logger.exception("conversation_vector_metadata_query_retry_failed uid=%s", uid)
+                raise
         else:
             return []
 
@@ -137,9 +253,19 @@ def delete_vector(uid: str, conversation_id: str):
 
     Note: Vectors are stored with ID format '{uid}-{conversation_id}'
     """
-    vector_id = f'{uid}-{conversation_id}'
-    result = index.delete(ids=[vector_id], namespace="ns1")
-    print('delete_vector', vector_id, result)
+    if index is None:
+        logger.warning(
+            "pinecone_index_unavailable action=delete_vector uid=%s conversation_id=%s", uid, conversation_id
+        )
+        return None
+    vector_id = build_conversation_vector_id(uid, conversation_id)
+    try:
+        result = index.delete(ids=[vector_id], namespace=CONVERSATIONS_NAMESPACE)
+        logger.info("conversation_vector_deleted uid=%s conversation_id=%s result=%s", uid, conversation_id, result)
+        return result
+    except Exception:
+        logger.exception("conversation_vector_delete_failed uid=%s conversation_id=%s", uid, conversation_id)
+        raise
 
 
 # ==========================================

--- a/backend/ella/docs/OMI_SEARCH_INDEXING.md
+++ b/backend/ella/docs/OMI_SEARCH_INDEXING.md
@@ -1,0 +1,98 @@
+# OMI Search Indexing Contract
+
+OMI recall must not depend only on Pinecone semantic search. Production search
+paths should resolve in this order:
+
+1. Canonical timeline / exact-date lookup for recent OMI events.
+2. Firestore exact/date lookup over `users/{uid}/conversations`.
+3. Pinecone semantic search as a helper for fuzzy concepts.
+4. Legacy workspace mirrors only as explicit fallback.
+
+## Required Firestore Index
+
+The conversation exact/date pass queries:
+
+```text
+users/{uid}/conversations
+  WHERE discarded == false
+  WHERE created_at >= <optional start>
+  WHERE created_at <= <optional end>
+  ORDER BY created_at DESC
+```
+
+Deploy the repo-managed index from the repository root:
+
+```bash
+firebase deploy --only firestore:indexes
+```
+
+Index definition lives in [`firestore.indexes.json`](../../../firestore.indexes.json).
+
+## Vector Coverage Backfill
+
+Pinecone conversation vectors live in namespace `ns1` with stable ids:
+
+```text
+{uid}-{conversation_id}
+```
+
+Reruns are idempotent because upserts replace the same vector id.
+
+Dry-run a user/date window:
+
+```bash
+cd backend
+python scripts/backfill_conversation_vectors.py \
+  --uid <uid> \
+  --start-date 2026-05-01T00:00:00Z \
+  --end-date 2026-05-28T00:00:00Z \
+  --dry-run
+```
+
+Backfill only missing vectors and fail if coverage remains below 95%:
+
+```bash
+cd backend
+python scripts/backfill_conversation_vectors.py \
+  --uid <uid> \
+  --start-date 2026-05-01T00:00:00Z \
+  --only-missing \
+  --min-coverage 0.95
+```
+
+Coverage-only audit:
+
+```bash
+cd backend
+python scripts/backfill_conversation_vectors.py \
+  --uid <uid> \
+  --start-date 2026-05-01T00:00:00Z \
+  --coverage-only \
+  --min-coverage 0.95
+```
+
+The script logs:
+
+- `conversation_vector_coverage`
+- `conversation_vector_backfill_failed`
+- `conversation_vector_coverage_below_threshold`
+- `conversation_vector_backfill_summary`
+
+These log lines are intended for runtime alerting. A nonzero exit code means
+backfill errors occurred or the requested `--min-coverage` threshold was not
+met.
+
+## Search Path Audit
+
+Known production consumers:
+
+- `/v1/voice/search`: OMI-scoped searches call canonical timeline first, then
+  Firestore legacy OMI fallback. Results include provenance metadata such as
+  `canonical_event`, `firestore_legacy_omi`, and `hermes_voice_memory`.
+- MCP Plato-Hermes tools: recent context and memory search use canonical
+  timeline first, then OMI Firestore fallback, then workspace search fallback.
+- LangChain retrieval `search_conversations_tool`: now performs Firestore
+  exact/date lookup first and merges Pinecone vector results after it.
+
+New consumers should expose provenance in responses and should not treat an
+empty Pinecone result as proof that no OMI conversation exists.

--- a/backend/scripts/backfill_conversation_vectors.py
+++ b/backend/scripts/backfill_conversation_vectors.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Backfill OMI conversation vectors into Pinecone.
+
+The script is intentionally idempotent: every upsert uses the stable
+`{uid}-{conversation_id}` Pinecone id in namespace `ns1`, so reruns replace the
+same vector instead of creating duplicates.
+
+Examples:
+    python backend/scripts/backfill_conversation_vectors.py --uid USER_ID --start-date 2026-05-01T00:00:00Z --dry-run
+    python backend/scripts/backfill_conversation_vectors.py --uid USER_ID --start-date 2026-05-01T00:00:00Z --only-missing --min-coverage 0.95
+    python backend/scripts/backfill_conversation_vectors.py --uid USER_ID --coverage-only --start-date 2026-05-01T00:00:00Z
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import logging
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+logger = logging.getLogger("backfill_conversation_vectors")
+firestore = None
+FieldFilter = None
+vector_db = None
+_decrypt_conversation_data = None
+generate_embedding = None
+
+
+def _load_backend_dependencies() -> None:
+    global vector_db, _decrypt_conversation_data, generate_embedding
+    from database import vector_db as vector_db_module
+    from database.conversations import _decrypt_conversation_data as decrypt_conversation_data
+    from utils.llm.clients import generate_embedding as generate_embedding_func
+
+    vector_db = vector_db_module
+    _decrypt_conversation_data = decrypt_conversation_data
+    generate_embedding = generate_embedding_func
+
+
+def _init_firebase() -> Any:
+    global firestore, FieldFilter
+    import firebase_admin
+    from firebase_admin import credentials, firestore as firestore_module
+    from google.cloud.firestore_v1 import FieldFilter as field_filter
+
+    firestore = firestore_module
+    FieldFilter = field_filter
+    try:
+        firebase_admin.initialize_app(credentials.ApplicationDefault())
+    except ValueError:
+        pass
+    return firestore_module.client()
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _created_at_epoch(value: Any) -> int:
+    if isinstance(value, datetime):
+        parsed = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        return int(parsed.timestamp())
+    if value:
+        try:
+            return int(_parse_datetime(str(value)).timestamp())
+        except Exception:
+            return int(time.time())
+    return int(time.time())
+
+
+def _iter_user_ids(db: Any, limit: int | None = None) -> list[str]:
+    query = db.collection("users")
+    if limit:
+        query = query.limit(limit)
+    return [doc.id for doc in query.stream()]
+
+
+def _fetch_conversations(
+    db: Any,
+    uid: str,
+    *,
+    start_date: datetime | None,
+    end_date: datetime | None,
+    include_discarded: bool,
+    limit: int | None,
+) -> list[dict[str, Any]]:
+    query = db.collection("users").document(uid).collection("conversations")
+    if not include_discarded:
+        query = query.where(filter=FieldFilter("discarded", "==", False))
+    if start_date:
+        query = query.where(filter=FieldFilter("created_at", ">=", start_date))
+    if end_date:
+        query = query.where(filter=FieldFilter("created_at", "<=", end_date))
+    query = query.order_by("created_at", direction=firestore.Query.DESCENDING)
+    if limit:
+        query = query.limit(limit)
+
+    conversations = []
+    for doc in query.stream():
+        data = doc.to_dict() or {}
+        data["id"] = data.get("id") or doc.id
+        conversations.append(data)
+    return conversations
+
+
+def _conversation_embedding_text(uid: str, conversation: dict[str, Any], max_chars: int) -> str:
+    try:
+        conversation = _decrypt_conversation_data(conversation, uid)
+    except Exception as exc:
+        logger.warning(
+            "conversation_decrypt_failed uid=%s conversation_id=%s error=%s",
+            uid,
+            conversation.get("id"),
+            exc,
+        )
+
+    structured = conversation.get("structured") or {}
+    parts = [
+        structured.get("title", ""),
+        structured.get("overview", ""),
+        structured.get("category", ""),
+    ]
+    for segment in conversation.get("transcript_segments") or []:
+        if isinstance(segment, dict):
+            text = segment.get("text") or segment.get("transcript") or ""
+        else:
+            text = getattr(segment, "text", "") or getattr(segment, "transcript", "")
+        if text:
+            parts.append(str(text))
+        if sum(len(part) for part in parts) >= max_chars:
+            break
+    return "\n".join(str(part).strip() for part in parts if str(part or "").strip())[:max_chars]
+
+
+def _metadata(conversation: dict[str, Any], content: str) -> dict[str, Any]:
+    structured = conversation.get("structured") or {}
+    created_at = conversation.get("created_at")
+    return {
+        "memory_id": conversation.get("id", ""),
+        "conversation_id": conversation.get("id", ""),
+        "created_at": _created_at_epoch(created_at),
+        "source": conversation.get("source", ""),
+        "status": conversation.get("status", ""),
+        "category": structured.get("category", ""),
+        "title": str(structured.get("title") or "")[:200],
+        "vector_schema": "conversation_summary_transcript_v1",
+        "content_sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+        "backfilled_at": int(time.time()),
+    }
+
+
+def _existing_ids(uid: str, conversation_ids: list[str], chunk_size: int = 100) -> set[str]:
+    existing = set()
+    for i in range(0, len(conversation_ids), chunk_size):
+        chunk = conversation_ids[i : i + chunk_size]
+        existing.update(vector_db.fetch_existing_conversation_vector_ids(uid, chunk))
+    return existing
+
+
+def _process_user(db: Any, uid: str, args: argparse.Namespace) -> dict[str, Any]:
+    conversations = _fetch_conversations(
+        db,
+        uid,
+        start_date=args.start_date,
+        end_date=args.end_date,
+        include_discarded=args.include_discarded,
+        limit=args.limit,
+    )
+    conversation_ids = [str(c.get("id")) for c in conversations if c.get("id")]
+    existing = _existing_ids(uid, conversation_ids) if conversation_ids else set()
+    missing = [conversation_id for conversation_id in conversation_ids if conversation_id not in existing]
+    before_coverage = (len(existing) / len(conversation_ids)) if conversation_ids else 1.0
+
+    logger.info(
+        "conversation_vector_coverage uid=%s total=%s existing=%s missing=%s coverage=%.4f namespace=%s",
+        uid,
+        len(conversation_ids),
+        len(existing),
+        len(missing),
+        before_coverage,
+        vector_db.CONVERSATIONS_NAMESPACE,
+    )
+
+    stats = {
+        "uid": uid,
+        "total": len(conversation_ids),
+        "existing": len(existing),
+        "missing": len(missing),
+        "processed": 0,
+        "skipped_existing": 0,
+        "skipped_empty": 0,
+        "errors": 0,
+        "coverage_before": before_coverage,
+        "coverage_after": before_coverage,
+    }
+    if args.coverage_only:
+        return stats
+
+    existing_after = set(existing)
+    for index, conversation in enumerate(conversations, start=1):
+        conversation_id = str(conversation.get("id") or "")
+        if not conversation_id:
+            continue
+        if args.only_missing and conversation_id in existing:
+            stats["skipped_existing"] += 1
+            continue
+
+        content = _conversation_embedding_text(uid, conversation, args.max_chars)
+        if not content.strip():
+            stats["skipped_empty"] += 1
+            logger.warning("conversation_vector_skipped_empty uid=%s conversation_id=%s", uid, conversation_id)
+            continue
+
+        if args.dry_run:
+            stats["processed"] += 1
+            existing_after.add(conversation_id)
+            continue
+
+        try:
+            vector = generate_embedding(content)
+            vector_db.upsert_conversation_vector(uid, conversation_id, vector, _metadata(conversation, content))
+            stats["processed"] += 1
+            existing_after.add(conversation_id)
+        except Exception as exc:
+            stats["errors"] += 1
+            logger.exception(
+                "conversation_vector_backfill_failed uid=%s conversation_id=%s error=%s",
+                uid,
+                conversation_id,
+                exc,
+            )
+
+        if index % args.batch_size == 0:
+            logger.info("conversation_vector_backfill_progress uid=%s processed=%s/%s", uid, index, len(conversations))
+            if args.sleep_seconds:
+                time.sleep(args.sleep_seconds)
+
+    stats["coverage_after"] = (len(existing_after) / len(conversation_ids)) if conversation_ids else 1.0
+    if args.min_coverage and stats["coverage_after"] < args.min_coverage:
+        logger.warning(
+            "conversation_vector_coverage_below_threshold uid=%s coverage=%.4f threshold=%.4f",
+            uid,
+            stats["coverage_after"],
+            args.min_coverage,
+        )
+    return stats
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Backfill OMI conversation vectors to Pinecone")
+    parser.add_argument("--uid", help="Process a single OMI user id")
+    parser.add_argument("--all-users", action="store_true", help="Process all users")
+    parser.add_argument("--user-limit", type=int, help="Limit users when --all-users is set")
+    parser.add_argument("--start-date", type=_parse_datetime, help="Inclusive ISO start datetime")
+    parser.add_argument("--end-date", type=_parse_datetime, help="Inclusive ISO end datetime")
+    parser.add_argument("--limit", type=int, help="Limit conversations per user")
+    parser.add_argument("--batch-size", type=int, default=25)
+    parser.add_argument("--sleep-seconds", type=float, default=0.0)
+    parser.add_argument("--max-chars", type=int, default=12000)
+    parser.add_argument("--include-discarded", action="store_true")
+    parser.add_argument("--only-missing", action="store_true")
+    parser.add_argument("--coverage-only", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--min-coverage", type=float, default=0.0)
+    parser.add_argument("--log-level", default="INFO")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO), format="%(levelname)s %(message)s"
+    )
+
+    if not args.uid and not args.all_users:
+        parser.error("Provide --uid or --all-users")
+    if args.uid and args.all_users:
+        parser.error("Use either --uid or --all-users, not both")
+
+    _load_backend_dependencies()
+    db = _init_firebase()
+    user_ids = [args.uid] if args.uid else _iter_user_ids(db, args.user_limit)
+
+    all_stats = []
+    for uid in user_ids:
+        all_stats.append(_process_user(db, uid, args))
+
+    total = sum(item["total"] for item in all_stats)
+    existing = sum(item["existing"] for item in all_stats)
+    processed = sum(item["processed"] for item in all_stats)
+    errors = sum(item["errors"] for item in all_stats)
+    coverage_after = sum(item["coverage_after"] * item["total"] for item in all_stats) / total if total else 1.0
+    logger.info(
+        "conversation_vector_backfill_summary users=%s total=%s existing=%s processed=%s errors=%s coverage_after=%.4f dry_run=%s coverage_only=%s",
+        len(all_stats),
+        total,
+        existing,
+        processed,
+        errors,
+        coverage_after,
+        args.dry_run,
+        args.coverage_only,
+    )
+    if args.min_coverage and coverage_after < args.min_coverage:
+        return 2
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/unit/test_conversation_search_exact_first.py
+++ b/backend/tests/unit/test_conversation_search_exact_first.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+import types
+
+
+def _load_search_helpers():
+    path = Path(__file__).resolve().parents[2] / "utils" / "retrieval" / "tools" / "conversation_tools.py"
+    source = path.read_text()
+    start = source.index("_SEARCH_STOPWORDS =")
+    end = source.index("\n\n@tool", start)
+    module = types.ModuleType("conversation_search_helpers")
+    module.datetime = datetime
+    module.timezone = timezone
+    module.re = re
+    exec(source[start:end], module.__dict__)
+    return module
+
+
+def test_exact_conversation_search_finds_summary_without_vector():
+    module = _load_search_helpers()
+    conversations = [
+        {
+            "id": "older",
+            "created_at": datetime(2026, 5, 7, 16, 0, tzinfo=timezone.utc),
+            "structured": {"title": "Morning errand", "overview": "Stopped for groceries."},
+            "transcript_segments": [],
+        },
+        {
+            "id": "cafe",
+            "created_at": datetime(2026, 5, 7, 18, 56, tzinfo=timezone.utc),
+            "structured": {
+                "title": "Cafe Coffee and Waffle Stop",
+                "overview": "Ordered a noah drink and a waffle with oat.",
+            },
+            "transcript_segments": [],
+        },
+    ]
+
+    assert module._rank_exact_conversation_ids(conversations, "Cafe Coffee and Waffle Stop", 5) == ["cafe"]
+
+
+def test_exact_conversation_search_checks_transcript_terms():
+    module = _load_search_helpers()
+    conversations = [
+        {
+            "id": "keys",
+            "created_at": datetime(2026, 5, 8, 18, 56, tzinfo=timezone.utc),
+            "structured": {"title": "Home conversation", "overview": ""},
+            "transcript_segments": [{"text": "I put the keys in the backpack near the door."}],
+        }
+    ]
+
+    assert module._rank_exact_conversation_ids(conversations, "keys backpack", 5) == ["keys"]
+
+
+def test_merge_ranked_ids_prefers_exact_then_vector_without_duplicates():
+    module = _load_search_helpers()
+
+    assert module._merge_ranked_ids(["exact-a", "shared"], ["shared", "vector-b"], 3) == [
+        "exact-a",
+        "shared",
+        "vector-b",
+    ]
+
+
+def test_date_only_exact_search_returns_window_conversations():
+    module = _load_search_helpers()
+    conversations = [
+        {
+            "id": "morning-a",
+            "created_at": datetime(2026, 5, 8, 15, 0, tzinfo=timezone.utc),
+            "structured": {"title": "Quick check-in", "overview": "No special keywords."},
+            "transcript_segments": [],
+        }
+    ]
+
+    assert module._rank_exact_conversation_ids(
+        conversations,
+        "what happened",
+        5,
+        allow_date_only=True,
+    ) == ["morning-a"]
+    assert module._rank_exact_conversation_ids(conversations, "what happened", 5) == []

--- a/backend/utils/retrieval/tools/conversation_tools.py
+++ b/backend/utils/retrieval/tools/conversation_tools.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from typing import List, Optional
 from zoneinfo import ZoneInfo
 import contextvars
+import re
 
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
@@ -23,6 +24,158 @@ try:
 except ImportError:
     # Fallback if import fails
     agent_config_context = contextvars.ContextVar('agent_config', default=None)
+
+
+_SEARCH_STOPWORDS = {
+    "the",
+    "a",
+    "an",
+    "and",
+    "or",
+    "to",
+    "in",
+    "on",
+    "of",
+    "for",
+    "with",
+    "what",
+    "where",
+    "when",
+    "who",
+    "why",
+    "how",
+    "did",
+    "do",
+    "does",
+    "i",
+    "me",
+    "my",
+    "you",
+    "tell",
+    "check",
+    "latest",
+    "recent",
+    "memory",
+    "memories",
+    "omi",
+    "conversation",
+    "conversations",
+    "transcript",
+    "transcripts",
+    "summary",
+    "summaries",
+    "happened",
+    "happen",
+    "find",
+    "pull",
+    "about",
+}
+
+
+def _keyword_score(text: str, terms: list[str]) -> int:
+    text_lower = text.lower()
+    score = 0
+    for term in terms:
+        term = (term or "").strip().lower()
+        if not term:
+            continue
+        if re.search(rf"(?<![a-z0-9]){re.escape(term)}(?![a-z0-9])", text_lower):
+            score += 1
+    return score
+
+
+def _normalized_query_terms(query: str) -> list[str]:
+    terms = [term.strip(".,?!:;()[]{}\"'’‘“”").lower() for term in str(query or "").split()]
+    filtered = [term for term in terms if len(term) > 2 and term not in _SEARCH_STOPWORDS]
+    return filtered or [term for term in terms if len(term) > 2]
+
+
+def _significant_query_terms(query: str) -> list[str]:
+    terms = [term.strip(".,?!:;()[]{}\"'’‘“”").lower() for term in str(query or "").split()]
+    return [term for term in terms if len(term) > 2 and term not in _SEARCH_STOPWORDS]
+
+
+def _expand_query_terms(terms: list[str]) -> list[str]:
+    expanded = list(terms)
+    aliases = {
+        "meisheng": ["mei", "sheng", "may", "shing"],
+        "meishengs": ["mei", "sheng", "may", "shing"],
+    }
+    for term in terms:
+        expanded.extend(aliases.get(term, []))
+    return list(dict.fromkeys(expanded))
+
+
+def _conversation_search_blob(conv_data: dict, *, include_transcript: bool = True) -> str:
+    structured = conv_data.get("structured") or {}
+    fields = [
+        structured.get("title", ""),
+        structured.get("overview", ""),
+        structured.get("category", ""),
+        structured.get("emoji", ""),
+    ]
+    created = conv_data.get("created_at")
+    if created and hasattr(created, "strftime"):
+        fields.append(created.strftime("%B %d %Y %b %A %I:%M %p"))
+    elif created:
+        fields.append(str(created))
+
+    if include_transcript:
+        transcript_parts = []
+        for segment in conv_data.get("transcript_segments") or []:
+            if isinstance(segment, dict):
+                transcript_parts.append(str(segment.get("text") or segment.get("transcript") or ""))
+            else:
+                transcript_parts.append(str(getattr(segment, "text", "") or getattr(segment, "transcript", "")))
+        fields.append(" ".join(part for part in transcript_parts if part))
+
+    return " ".join(str(field or "") for field in fields).lower()
+
+
+def _rank_exact_conversation_ids(
+    conversations_data: list[dict],
+    query: str,
+    limit: int,
+    *,
+    allow_date_only: bool = False,
+) -> list[str]:
+    significant_terms = _significant_query_terms(query)
+    query_terms = _expand_query_terms(significant_terms or ([] if allow_date_only else _normalized_query_terms(query)))
+    query_phrase = " ".join(str(query or "").lower().split())
+    ranked = []
+
+    for conv_data in conversations_data:
+        conversation_id = conv_data.get("id")
+        if not conversation_id:
+            continue
+        searchable = _conversation_search_blob(conv_data, include_transcript=True)
+        score = _keyword_score(searchable, query_terms) if query_terms else (1 if allow_date_only else 0)
+        if query_phrase and query_phrase in searchable:
+            score += max(2, len(query_terms))
+        if score <= 0:
+            continue
+        created = conv_data.get("created_at")
+        if isinstance(created, datetime):
+            created_sort = created if created.tzinfo else created.replace(tzinfo=timezone.utc)
+        else:
+            created_sort = datetime.min.replace(tzinfo=timezone.utc)
+        ranked.append((score, created_sort, str(conversation_id)))
+
+    ranked.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    return [conversation_id for _score, _created, conversation_id in ranked[:limit]]
+
+
+def _merge_ranked_ids(primary: list[str], secondary: list[str], limit: int) -> list[str]:
+    merged = []
+    seen = set()
+    for conversation_id in list(primary or []) + list(secondary or []):
+        if not conversation_id or conversation_id in seen:
+            continue
+        seen.add(conversation_id)
+        merged.append(conversation_id)
+        if len(merged) >= limit:
+            break
+    return merged
 
 
 @tool
@@ -350,27 +503,31 @@ def search_conversations_tool(
         max_transcript_segments = min(max_transcript_segments, 1000)
         print(f"📊 max_transcript_segments capped at: {max_transcript_segments}")
 
-    # Parse dates to timestamps if provided
+    # Parse dates for Firestore exact/date retrieval and Pinecone metadata filters.
+    # Firestore is the source of truth for exact/date lookups; Pinecone is a
+    # semantic helper and may lag if vector coverage is incomplete.
+    start_dt = None
+    end_dt = None
     starts_at = None
     ends_at = None
 
     if start_date:
         try:
-            dt = datetime.fromisoformat(start_date.replace('Z', '+00:00'))
-            if dt.tzinfo is None:
+            start_dt = datetime.fromisoformat(start_date.replace('Z', '+00:00'))
+            if start_dt.tzinfo is None:
                 return f"Error: start_date must include timezone in user's timezone format YYYY-MM-DDTHH:MM:SS+HH:MM (e.g., '2024-01-19T15:00:00-08:00'): {start_date}"
-            print(f"📅 Parsed start_date '{start_date}' as {dt.strftime('%Y-%m-%d %H:%M:%S %Z')}")
-            starts_at = int(dt.timestamp())
+            print(f"📅 Parsed start_date '{start_date}' as {start_dt.strftime('%Y-%m-%d %H:%M:%S %Z')}")
+            starts_at = int(start_dt.timestamp())
         except ValueError as e:
             return f"Error: Invalid start_date format. Expected YYYY-MM-DDTHH:MM:SS+HH:MM in user's timezone: {start_date} - {str(e)}"
 
     if end_date:
         try:
-            dt = datetime.fromisoformat(end_date.replace('Z', '+00:00'))
-            if dt.tzinfo is None:
+            end_dt = datetime.fromisoformat(end_date.replace('Z', '+00:00'))
+            if end_dt.tzinfo is None:
                 return f"Error: end_date must include timezone in user's timezone format YYYY-MM-DDTHH:MM:SS+HH:MM (e.g., '2024-01-19T23:59:59-08:00'): {end_date}"
-            print(f"📅 Parsed end_date '{end_date}' as {dt.strftime('%Y-%m-%d %H:%M:%S %Z')}")
-            ends_at = int(dt.timestamp())
+            print(f"📅 Parsed end_date '{end_date}' as {end_dt.strftime('%Y-%m-%d %H:%M:%S %Z')}")
+            ends_at = int(end_dt.timestamp())
         except ValueError as e:
             return f"Error: Invalid end_date format. Expected YYYY-MM-DDTHH:MM:SS+HH:MM in user's timezone: {end_date} - {str(e)}"
 
@@ -378,18 +535,46 @@ def search_conversations_tool(
     limit = min(limit, 20)
 
     try:
-        # Perform vector search
-        conversation_ids = vector_db.query_vectors(query=query, uid=uid, starts_at=starts_at, ends_at=ends_at, k=limit)
+        # First-class exact/date retrieval from Firestore. This catches newly
+        # indexed conversations even when Pinecone vectors have not been
+        # backfilled yet.
+        exact_candidates = conversations_db.get_conversations_without_photos(
+            uid,
+            limit=max(50, limit * 10),
+            offset=0,
+            start_date=start_dt,
+            end_date=end_dt,
+            include_discarded=False,
+        )
+        exact_ids = _rank_exact_conversation_ids(
+            exact_candidates, query, limit, allow_date_only=bool(start_dt or end_dt)
+        )
+        print(f"📊 search_conversations_tool - exact/date Firestore results: {len(exact_ids)}")
 
-        print(f"📊 search_conversations_tool - found {len(conversation_ids)} results for query: '{query}'")
+        # Semantic vector search is still useful for fuzzy concepts, but it is
+        # not the only retrieval path.
+        vector_ids = []
+        try:
+            vector_ids = vector_db.query_vectors(query=query, uid=uid, starts_at=starts_at, ends_at=ends_at, k=limit)
+        except Exception as vector_error:
+            print(
+                f"⚠️ search_conversations_tool - vector helper failed, using Firestore exact/date results: {vector_error}"
+            )
+
+        conversation_ids = _merge_ranked_ids(exact_ids, vector_ids, limit)
+
+        print(
+            f"📊 search_conversations_tool - merged results exact={len(exact_ids)} "
+            f"vector={len(vector_ids)} total={len(conversation_ids)} for query: '{query}'"
+        )
 
         if not conversation_ids:
             date_info = ""
-            if starts_at and ends_at:
+            if start_dt and end_dt:
                 date_info = f" in the specified date range"
-            elif starts_at:
+            elif start_dt:
                 date_info = f" after the specified start date"
-            elif ends_at:
+            elif end_dt:
                 date_info = f" before the specified end date"
 
             msg = f"No conversations found matching the concept '{query}'{date_info}. The user may not have discussed this topic yet, or it may not be in their recorded conversation history."
@@ -458,7 +643,7 @@ def search_conversations_tool(
         )
 
         # Return formatted string
-        result = f"Found {len(conversations)} conversations semantically matching '{query}':\n\n"
+        result = f"Found {len(conversations)} conversations matching '{query}' via exact/date and semantic search:\n\n"
         result += Conversation.conversations_to_string(
             conversations, use_transcript=include_transcript, include_timestamps=include_timestamps, people=people
         )

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,19 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "conversations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "discarded",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "DESCENDING"
+        }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
## Summary
- add repo-managed Firestore composite index docs for discarded + created_at conversation queries
- add idempotent conversation vector coverage/backfill CLI with coverage threshold logging
- add vector DB warning/error logs for Pinecone unavailable/query/upsert/fetch/delete failures
- make LangChain conversation search exact/date Firestore-first, with Pinecone semantic search merged as a helper

## Validation
- python3 -m py_compile database/vector_db.py utils/retrieval/tools/conversation_tools.py scripts/backfill_conversation_vectors.py tests/unit/test_conversation_search_exact_first.py
- python3 scripts/backfill_conversation_vectors.py --help
- pytest tests/unit/test_conversation_search_exact_first.py tests/unit/test_voice_search_canonical_omi.py -q

## Follow-up
- deploy Firestore indexes with firebase deploy --only firestore:indexes
- after deploy, run coverage-only/backfill from backend runtime with Firebase/Pinecone/OpenAI credentials