### PR TITLE
Unify iOS chat with canonical Hermes session

### DIFF
--- a/app/lib/backend/http/api/messages.dart
+++ b/app/lib/backend/http/api/messages.dart
@@ -60,29 +60,49 @@ Future<List<ServerMessage>> clearChatServer({String? appId}) async {
 
 ServerMessageChunk? parseMessageChunk(String line, String messageId) {
   if (line.startsWith('think: ')) {
-    return ServerMessageChunk(messageId, line.substring(7).replaceAll("__CRLF__", "\n"), MessageChunkType.think);
+    return ServerMessageChunk(
+      messageId,
+      line.substring(7).replaceAll("__CRLF__", "\n"),
+      MessageChunkType.think,
+    );
   }
 
   if (line.startsWith('data: ')) {
-    return ServerMessageChunk(messageId, line.substring(6).replaceAll("__CRLF__", "\n"), MessageChunkType.data);
+    return ServerMessageChunk(
+      messageId,
+      line.substring(6).replaceAll("__CRLF__", "\n"),
+      MessageChunkType.data,
+    );
   }
 
   if (line.startsWith('done: ')) {
     var text = decodeBase64(line.substring(6));
-    return ServerMessageChunk(messageId, text, MessageChunkType.done,
-        message: ServerMessage.fromJson(json.decode(text)));
+    return ServerMessageChunk(
+      messageId,
+      text,
+      MessageChunkType.done,
+      message: ServerMessage.fromJson(json.decode(text)),
+    );
   }
 
   if (line.startsWith('message: ')) {
     var text = decodeBase64(line.substring(9));
-    return ServerMessageChunk(messageId, text, MessageChunkType.message,
-        message: ServerMessage.fromJson(json.decode(text)));
+    return ServerMessageChunk(
+      messageId,
+      text,
+      MessageChunkType.message,
+      message: ServerMessage.fromJson(json.decode(text)),
+    );
   }
 
   return null;
 }
 
-Stream<ServerMessageChunk> sendMessageStreamServer(String text, {String? appId, List<String>? filesId}) async* {
+Stream<ServerMessageChunk> sendMessageStreamServer(
+  String text, {
+  String? appId,
+  List<String>? filesId,
+}) async* {
   var url = '${Env.apiBaseUrl}v2/messages?app_id=$appId';
   if (appId == null || appId.isEmpty || appId == 'null' || appId == 'no_selected') {
     url = '${Env.apiBaseUrl}v2/messages';
@@ -107,15 +127,28 @@ Stream<ServerMessageChunk> sendMessageStreamServer(String text, {String? appId, 
 /// Send a chat message via the Ella endpoint (/v1/ella/chat/stream).
 /// Backend emits OMI-compatible format (data:/done:), so we reuse parseMessageChunk.
 /// SSE comment lines (starting with ':') are used as keep-alives and are skipped.
-Stream<ServerMessageChunk> sendEllaMessageStream(String text, {Map<String, String> headers = const {}}) async* {
+Stream<ServerMessageChunk> sendEllaMessageStream(
+  String text, {
+  Map<String, String> headers = const {},
+  String? clientMessageId,
+  DateTime? clientSentAt,
+}) async* {
   var url = '${Env.apiBaseUrl}v1/ella/chat/stream';
   var uid = SharedPreferencesUtil().uid;
   var messageId = "1000";
+  final requestClientMessageId = clientMessageId ?? '';
+  final requestClientSentAt = clientSentAt?.toUtc().toIso8601String() ?? '';
 
   await for (var line in makeStreamingApiCall(
     url: url,
     headers: headers,
-    body: jsonEncode({'uid': uid, 'message': text, 'conversation_id': ''}),
+    body: jsonEncode({
+      'uid': uid,
+      'message': text,
+      'conversation_id': '',
+      'client_message_id': requestClientMessageId,
+      'client_sent_at': requestClientSentAt,
+    }),
   )) {
     // Skip SSE comment lines (keep-alives from backend while waiting for LLM)
     if (line.startsWith(':')) continue;
@@ -146,7 +179,10 @@ Future<ServerMessage> getInitialAppMessage(String? appId) {
   });
 }
 
-Stream<ServerMessageChunk> sendVoiceMessageStreamServer(List<File> files, {String? language}) async* {
+Stream<ServerMessageChunk> sendVoiceMessageStreamServer(
+  List<File> files, {
+  String? language,
+}) async* {
   var messageId = "1000"; // Default new message
 
   await for (var line in makeMultipartStreamingApiCall(
@@ -164,24 +200,30 @@ Stream<ServerMessageChunk> sendVoiceMessageStreamServer(List<File> files, {Strin
   }
 }
 
-Future<List<MessageFile>?> uploadFilesServer(List<File> files, {String? appId}) async {
+Future<List<MessageFile>?> uploadFilesServer(
+  List<File> files, {
+  String? appId,
+}) async {
   var url = '${Env.apiBaseUrl}v2/files?app_id=$appId';
   if (appId == null || appId.isEmpty || appId == 'null' || appId == 'no_selected') {
     url = '${Env.apiBaseUrl}v2/files';
   }
 
   try {
-    var response = await makeMultipartApiCall(
-      url: url,
-      files: files,
-    );
+    var response = await makeMultipartApiCall(url: url, files: files);
 
     if (response.statusCode == 200) {
-      Logger.debug('uploadFileServer response body: ${jsonDecode(response.body)}');
+      Logger.debug(
+        'uploadFileServer response body: ${jsonDecode(response.body)}',
+      );
       return MessageFile.fromJsonList(jsonDecode(response.body));
     } else {
-      Logger.debug('Failed to upload file. Status code: ${response.statusCode} ${response.body}');
-      throw Exception('Failed to upload file. Status code: ${response.statusCode}');
+      Logger.debug(
+        'Failed to upload file. Status code: ${response.statusCode} ${response.body}',
+      );
+      throw Exception(
+        'Failed to upload file. Status code: ${response.statusCode}',
+      );
     }
   } catch (e) {
     Logger.debug('An error occurred uploadFileServer: $e');
@@ -202,7 +244,10 @@ Future reportMessageServer(String messageId) async {
   }
 }
 
-Future<String> transcribeVoiceMessage(File audioFile, {String? language}) async {
+Future<String> transcribeVoiceMessage(
+  File audioFile, {
+  String? language,
+}) async {
   try {
     var response = await makeMultipartApiCall(
       url: '${Env.apiBaseUrl}v2/voice-message/transcribe',
@@ -214,7 +259,9 @@ Future<String> transcribeVoiceMessage(File audioFile, {String? language}) async 
       final data = jsonDecode(response.body);
       return data['transcript'] ?? '';
     } else {
-      Logger.debug('Failed to transcribe voice message: ${response.statusCode} ${response.body}');
+      Logger.debug(
+        'Failed to transcribe voice message: ${response.statusCode} ${response.body}',
+      );
       throw Exception('Failed to transcribe voice message');
     }
   } catch (e) {

--- a/app/lib/ella/services/ella_chat_service.dart
+++ b/app/lib/ella/services/ella_chat_service.dart
@@ -11,8 +11,10 @@ import 'package:omi/env/env.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 
-/// Feature flag — set to false to disable direct chat and use proxy fallback.
-const bool _useDirectChat = true;
+/// Feature flag — direct gateway chat bypasses backend canonical writeback.
+/// Keep disabled so iOS chat routes through /v1/ella/chat/stream, hydrates from
+/// the shared canonical timeline, and writes ios_chat turns to /v1/ella/events.
+const bool _useDirectChat = false;
 
 /// Build Ella-specific debug headers for routing observability (Issue #216).
 /// Backend trace.py captures these to correlate client requests with server routing decisions.
@@ -69,7 +71,7 @@ class _ResolvedEndpoint {
 /// In-memory cache (fast path).
 _ResolvedEndpoint? _cachedEndpoint;
 
-/// Resolve the user's OpenClaw endpoint. Returns null on any failure.
+/// Resolve the user's active Ella endpoint. Returns null on any failure.
 Future<_ResolvedEndpoint?> _resolveEndpoint() async {
   final uid = SharedPreferencesUtil().uid;
   if (uid.isEmpty) return null;
@@ -133,7 +135,10 @@ Future<_ResolvedEndpoint?> _resolveEndpoint() async {
 
     // Cache it
     _cachedEndpoint = endpoint;
-    SharedPreferencesUtil().saveString('ellaResolvedEndpoint', jsonEncode(endpoint.toJson()));
+    SharedPreferencesUtil().saveString(
+      'ellaResolvedEndpoint',
+      jsonEncode(endpoint.toJson()),
+    );
 
     return endpoint;
   } catch (e) {
@@ -180,12 +185,16 @@ ServerMessageChunk? _parseOpenAiSseChunk(String line, String messageId) {
 Future<List<ServerMessage>> fetchEllaChatHistory({int limit = 50}) async {
   final endpoint = await _resolveEndpoint();
   if (endpoint == null || endpoint.historyUrl.isEmpty) {
-    Logger.debug('[EllaChat] Cannot fetch history: no resolved endpoint or historyUrl');
+    Logger.debug(
+      '[EllaChat] Cannot fetch history: no resolved endpoint or historyUrl',
+    );
     return [];
   }
 
   try {
-    final url = '${Env.apiBaseUrl}${endpoint.historyUrl.replaceFirst(RegExp(r'^/'), '')}?limit=$limit';
+    final uid = SharedPreferencesUtil().uid;
+    final url =
+        '${Env.apiBaseUrl}${endpoint.historyUrl.replaceFirst(RegExp(r'^/'), '')}?uid=${Uri.encodeComponent(uid)}&limit=$limit';
     final response = await makeApiCall(
       url: url,
       headers: _ellaDebugHeaders(routeSource: 'chat-history'),
@@ -209,21 +218,25 @@ Future<List<ServerMessage>> fetchEllaChatHistory({int limit = 50}) async {
       final ts = m['timestamp'] as String?;
       final id = m['id'] as String? ?? const Uuid().v4();
       if (content.isEmpty) continue;
-      if (content.startsWith('[SYSTEM:')) continue; // Filter scanner notifications from chat UI
+      if (content.startsWith('[SYSTEM:')) {
+        continue; // Filter scanner notifications from chat UI
+      }
 
-      result.add(ServerMessage(
-        id,
-        ts != null ? DateTime.parse(ts).toLocal() : DateTime.now(),
-        content,
-        role == 'user' ? MessageSender.human : MessageSender.ai,
-        MessageType.text,
-        null,
-        false,
-        [],
-        [],
-        [],
-        askForNps: false,
-      ));
+      result.add(
+        ServerMessage(
+          id,
+          ts != null ? DateTime.parse(ts).toLocal() : DateTime.now(),
+          content,
+          role == 'user' ? MessageSender.human : MessageSender.ai,
+          MessageType.text,
+          null,
+          false,
+          [],
+          [],
+          [],
+          askForNps: false,
+        ),
+      );
     }
 
     // API returns newest first; reverse for chronological UI order
@@ -236,28 +249,38 @@ Future<List<ServerMessage>> fetchEllaChatHistory({int limit = 50}) async {
   }
 }
 
-/// Main entry point: resolve then stream directly, or fall back to proxy.
+/// Main entry point for Ella chat streaming.
 ///
 /// Yields the same [ServerMessageChunk] types as [sendEllaMessageStream],
 /// so callers (MessageProvider, EllaVoiceChatPage) need no logic changes.
 Stream<ServerMessageChunk> sendEllaChatStream(String text) async* {
   // Feature flag — delegate to existing proxy path if disabled
   if (!_useDirectChat) {
-    yield* sendEllaMessageStream(text, headers: _ellaDebugHeaders(routeSource: 'proxy-flag-off'));
+    yield* sendEllaMessageStream(
+      text,
+      headers: _ellaDebugHeaders(routeSource: 'proxy-canonical'),
+      clientMessageId: const Uuid().v4(),
+      clientSentAt: DateTime.now().toUtc(),
+    );
     return;
   }
 
-  // Attempt to resolve the user's agent endpoint
+  // Attempt to resolve the user's agent endpoint when direct mode is enabled.
   final endpoint = await _resolveEndpoint();
   if (endpoint == null) {
     Logger.debug('[EllaChat] Resolve unavailable, using proxy fallback');
-    yield* sendEllaMessageStream(text, headers: _ellaDebugHeaders(routeSource: 'proxy-resolve-fail'));
+    yield* sendEllaMessageStream(
+      text,
+      headers: _ellaDebugHeaders(routeSource: 'proxy-resolve-fail'),
+      clientMessageId: const Uuid().v4(),
+      clientSentAt: DateTime.now().toUtc(),
+    );
     return;
   }
 
-  // Stream directly from OpenClaw gateway
-  final messageId = '1000';
-  final uid = SharedPreferencesUtil().uid;
+  // Legacy direct gateway path. Production keeps this disabled so canonical
+  // writeback remains centralized in the backend.
+  const messageId = '1000';
   final accumulatedText = StringBuffer();
 
   try {
@@ -294,7 +317,12 @@ Stream<ServerMessageChunk> sendEllaChatStream(String text) async* {
     // No text accumulated — invalidate cache and retry via proxy
     if (accumulatedText.isEmpty) {
       _invalidateResolveCache();
-      yield* sendEllaMessageStream(text, headers: _ellaDebugHeaders(routeSource: 'proxy-gateway-error'));
+      yield* sendEllaMessageStream(
+        text,
+        headers: _ellaDebugHeaders(routeSource: 'proxy-gateway-error'),
+        clientMessageId: const Uuid().v4(),
+        clientSentAt: DateTime.now().toUtc(),
+      );
       return;
     }
     // Partial text accumulated — fall through to synthesize done chunk below
@@ -316,8 +344,12 @@ Stream<ServerMessageChunk> sendEllaChatStream(String text) async* {
       [],
       askForNps: false,
     );
-    yield ServerMessageChunk(messageId, jsonEncode(serverMessage.toJson()), MessageChunkType.done,
-        message: serverMessage);
+    yield ServerMessageChunk(
+      messageId,
+      jsonEncode(serverMessage.toJson()),
+      MessageChunkType.done,
+      message: serverMessage,
+    );
   } else {
     yield ServerMessageChunk.failedMessage();
   }

--- a/backend/ella/docs/IOS_CHAT_CANONICAL_SESSION.md
+++ b/backend/ella/docs/IOS_CHAT_CANONICAL_SESSION.md
@@ -1,0 +1,72 @@
+# iOS Chat Canonical Session Contract
+
+iOS Chat must share the same memory lane as iMessage, voice postbacks, Guardian,
+and MCP reads. The backend enforces this by routing iOS Chat through
+`/v1/ella/chat/stream` and writing both sides of each turn to the canonical
+ledger.
+
+## Runtime Flow
+
+1. iOS sends chat text to `/v1/ella/chat/stream`.
+2. Backend fetches `/v1/ella/timeline` context before answering.
+3. Backend writes the user turn to `/v1/ella/events` storage internally as:
+   - `channel=ios_chat`
+   - `provider=omi-ios-chat`
+   - `role=user`
+   - `scan_policy=immediate`
+4. Backend sends the prompt to Hermes with the canonical timeline injected as
+   the freshest shared context.
+5. Backend writes the assistant turn as:
+   - `channel=ios_chat`
+   - `provider=omi-ios-chat`
+   - `role=assistant`
+   - `scan_policy=none`
+6. iOS history reads `/v1/ella/chat/history`, which is canonical timeline first.
+
+## Session Strategy
+
+Default Hermes session key:
+
+```text
+ella:omi:{uid}:canonical
+```
+
+This is intentionally not an `ios-chat:daily-*` lane. Source-specific lanes can
+still exist, but they must inject canonical timeline context and write canonical
+turns. If lane isolation is needed for migration testing, set:
+
+```text
+ELLA_CHAT_HERMES_SESSION_SCOPE=lane
+ELLA_CHAT_HERMES_SESSION_EPOCH=<explicit epoch>
+```
+
+The production default should remain `canonical` to avoid split-brain behavior
+between iOS Chat and iMessage.
+
+## Stable Event IDs
+
+iOS passes `client_message_id` and `client_sent_at`. Backend creates stable ids:
+
+```text
+source_identity = ios_chat:{uid}:{client_message_id}
+event_id        = ios_chat:{uid}:{client_message_id}:{role}
+```
+
+If old clients omit `client_message_id`, backend derives a server id from
+`uid`, message text, and timestamp as migration fallback.
+
+## Smoke Test
+
+Use a test user/contact only:
+
+1. Send iOS Chat: "Remember the demo banana is on the blue shelf."
+2. Confirm `/v1/ella/timeline?uid=<uid>&channels=ios_chat` contains user and
+   assistant turns in chronological order.
+3. Ask iMessage: "Where is the demo banana?"
+4. Confirm answer uses the iOS Chat fact.
+5. Send iMessage: "The demo mug is in the garage."
+6. Ask iOS Chat: "Where is the demo mug?"
+7. Confirm answer uses canonical iMessage context.
+
+Do not rely on Hermes private session history as proof of success; canonical
+timeline is the source of truth.

--- a/backend/ella/routers/chat.py
+++ b/backend/ella/routers/chat.py
@@ -22,6 +22,7 @@ import json
 import logging
 import os
 import re
+import hashlib
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 from zoneinfo import ZoneInfo
@@ -32,6 +33,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from ella.config import ELLA_CONFIG
+from ella.routers.canonical_events import CanonicalEventIn, PostgresCanonicalEventStore
 from ella.routers.resolve import resolve_user_routing
 from ella.routers.trace import RouteTrace, record_trace
 from utils.ella.canonical_context import (
@@ -58,6 +60,7 @@ HERMES_GATEWAY_TOKEN = os.getenv("HERMES_API_SERVER_KEY", os.getenv("API_SERVER_
 HERMES_AGENT_ID = os.getenv("HERMES_AGENT_ID", "hermes")
 HERMES_MODEL = os.getenv("HERMES_MODEL", "plato-eval")
 HERMES_CHAT_SESSION_EPOCH = os.getenv("ELLA_CHAT_HERMES_SESSION_EPOCH", "").strip()
+HERMES_CHAT_SESSION_SCOPE = os.getenv("ELLA_CHAT_HERMES_SESSION_SCOPE", "canonical").strip().lower()
 CHAT_CONTEXT_LIMIT = int(os.getenv("ELLA_CHAT_CANONICAL_CONTEXT_LIMIT", "25"))
 CHAT_CONTEXT_MAX_CHARS = int(os.getenv("ELLA_CHAT_CANONICAL_CONTEXT_MAX_CHARS", "6000"))
 CHAT_TEMPORAL_CONTEXT_LIMIT = int(os.getenv("ELLA_CHAT_TEMPORAL_CONTEXT_LIMIT", "250"))
@@ -68,6 +71,7 @@ CHAT_CONTEXT_CHANNELS = [
     for channel in os.getenv("ELLA_CHAT_CANONICAL_CHANNELS", ",".join(DEFAULT_CONTEXT_CHANNELS)).split(",")
     if channel.strip()
 ]
+_canonical_event_store = PostgresCanonicalEventStore()
 
 ELLA_SYSTEM_PROMPT = (
     "You are Ella, a warm and caring AI companion for elderly users. "
@@ -79,6 +83,8 @@ ELLA_SYSTEM_PROMPT = (
 
 
 def _hermes_chat_session_key(uid: str) -> str:
+    if HERMES_CHAT_SESSION_SCOPE in {"canonical", "shared", "cross_channel", "cross-channel"}:
+        return f"ella:omi:{uid.lower()}:canonical"
     if HERMES_CHAT_SESSION_EPOCH:
         epoch = HERMES_CHAT_SESSION_EPOCH
     else:
@@ -122,6 +128,90 @@ class EllaChatRequest(BaseModel):
     uid: str
     message: str
     conversation_id: str = ""
+    client_message_id: str = ""
+    client_sent_at: str = ""
+
+
+def _parse_client_sent_at(value: str = "") -> datetime:
+    if value:
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.astimezone(timezone.utc)
+        except ValueError:
+            pass
+    return datetime.now(timezone.utc)
+
+
+def _canonical_turn_id(uid: str, request: EllaChatRequest, started_at: datetime) -> str:
+    if request.client_message_id:
+        return request.client_message_id
+    if request.conversation_id:
+        return request.conversation_id
+    digest = hashlib.sha256(f"{uid}|{request.message}|{started_at.isoformat()}".encode("utf-8")).hexdigest()[:16]
+    return f"server-{digest}"
+
+
+def _ios_chat_event(
+    *,
+    uid: str,
+    turn_id: str,
+    role: str,
+    text: str,
+    session_key: str,
+    started_at: datetime,
+    ended_at: datetime = None,
+    client_info: dict = None,
+) -> CanonicalEventIn:
+    source_identity = f"ios_chat:{uid}:{turn_id}"
+    return CanonicalEventIn(
+        uid=uid,
+        canonical_identity=uid,
+        event_id=f"{source_identity}:{role}",
+        session_id=session_key,
+        channel="ios_chat",
+        provider="omi-ios-chat",
+        role=role,
+        text=text,
+        started_at=started_at,
+        ended_at=ended_at,
+        privacy_scope="user_private",
+        scan_policy="immediate" if role == "user" else "none",
+        source_ref={
+            "source_identity": source_identity,
+            "client_message_id": turn_id,
+            "message_id": f"{turn_id}:{role}",
+            "source": "ios_chat",
+        },
+        metadata={
+            "adapter": "ios-chat",
+            "client": client_info or {},
+            "session_strategy": HERMES_CHAT_SESSION_SCOPE,
+            "hermes_session_key": session_key,
+        },
+    )
+
+
+async def _write_ios_chat_canonical_event(event: CanonicalEventIn) -> None:
+    try:
+        result = await _canonical_event_store.write_batch([event])
+        logger.info(
+            "[FLOW:CHAT-CANONICAL-WRITE] uid=%s role=%s event_id=%s inserted=%s duplicates=%s",
+            event.uid,
+            event.role,
+            event.event_id,
+            result.get("inserted"),
+            result.get("duplicates"),
+        )
+    except Exception as exc:
+        logger.warning(
+            "[FLOW:CHAT-CANONICAL-WRITE] uid=%s role=%s event_id=%s error=%s",
+            event.uid,
+            event.role,
+            event.event_id,
+            exc,
+        )
 
 
 def _resolve_debug_level(header_value: str = None) -> int:
@@ -582,7 +672,14 @@ async def _stream_level_4_openclaw(user_message: str, uid: str, client_info: dic
         yield f"data: Error: {str(e)}\n\n"
 
 
-async def _stream_hermes_chat(user_message: str, uid: str, client_info: dict = None):
+async def _stream_hermes_chat(
+    user_message: str,
+    uid: str,
+    client_info: dict = None,
+    *,
+    turn_id: str = "",
+    client_sent_at: datetime = None,
+):
     """Stream iOS chat through Hermes while preserving OMI chat SSE format."""
     import time as _time
 
@@ -594,6 +691,8 @@ async def _stream_hermes_chat(user_message: str, uid: str, client_info: dict = N
         return
 
     session_key = _hermes_chat_session_key(uid)
+    user_started_at = client_sent_at or datetime.now(timezone.utc)
+    turn_id = turn_id or f"server-{uuid4()}"
     text = []
     canonical_events = await _fetch_chat_canonical_events(uid, limit=CHAT_CONTEXT_LIMIT)
     canonical_context = format_canonical_context(canonical_events, max_chars=CHAT_CONTEXT_MAX_CHARS)
@@ -632,9 +731,20 @@ async def _stream_hermes_chat(user_message: str, uid: str, client_info: dict = N
                 ),
             }
         )
+    await _write_ios_chat_canonical_event(
+        _ios_chat_event(
+            uid=uid,
+            turn_id=turn_id,
+            role="user",
+            text=user_message,
+            session_key=session_key,
+            started_at=user_started_at,
+            client_info=client_info,
+        )
+    )
     messages.append({"role": "user", "content": user_message})
     print(
-        f"[FLOW:CHAT-HERMES] uid={uid} gateway={HERMES_GATEWAY_URL} session={session_key} canonical_events={len(canonical_events)} temporal_events={len(temporal_events)}",
+        f"[FLOW:CHAT-HERMES] uid={uid} gateway={HERMES_GATEWAY_URL} session={session_key} session_strategy={HERMES_CHAT_SESSION_SCOPE} turn_id={turn_id} canonical_events={len(canonical_events)} temporal_events={len(temporal_events)}",
         flush=True,
     )
 
@@ -700,6 +810,19 @@ async def _stream_hermes_chat(user_message: str, uid: str, client_info: dict = N
                     flush=True,
                 )
         if full_text:
+            assistant_started_at = datetime.now(timezone.utc)
+            await _write_ios_chat_canonical_event(
+                _ios_chat_event(
+                    uid=uid,
+                    turn_id=turn_id,
+                    role="assistant",
+                    text=full_text,
+                    session_key=session_key,
+                    started_at=assistant_started_at,
+                    ended_at=assistant_started_at,
+                    client_info=client_info,
+                )
+            )
             msg = {
                 "id": str(uuid4()),
                 "created_at": datetime.now(timezone.utc).isoformat(),
@@ -715,7 +838,10 @@ async def _stream_hermes_chat(user_message: str, uid: str, client_info: dict = N
             yield f"done: {base64.b64encode(json.dumps(msg).encode()).decode()}\n\n"
 
         _elapsed = int((_time.time() - _start) * 1000)
-        print(f"[FLOW:CHAT-HERMES] OK uid={uid} chars={len(full_text)} latency={_elapsed}ms", flush=True)
+        print(
+            f"[FLOW:CHAT-HERMES] OK uid={uid} turn_id={turn_id} chars={len(full_text)} latency={_elapsed}ms",
+            flush=True,
+        )
 
     except httpx.TimeoutException:
         _elapsed = int((_time.time() - _start) * 1000)
@@ -773,6 +899,9 @@ async def ella_chat_stream(
     trace.uid = request.uid
     trace.debug_level = debug_level
     trace.notes.append(f"message_length={len(request.message)}")
+    client_sent_at = _parse_client_sent_at(request.client_sent_at)
+    turn_id = _canonical_turn_id(request.uid, request, client_sent_at)
+    trace.notes.append(f"canonical_turn_id={turn_id}")
     # Capture all X-Ella-* headers for debugging
     trace.client_headers = {k: v for k, v in raw_request.headers.items() if k.lower().startswith("x-ella-")}
 
@@ -792,6 +921,8 @@ async def ella_chat_stream(
                     "route": x_ella_route or "",
                     "headers": trace.client_headers,
                 },
+                turn_id=turn_id,
+                client_sent_at=client_sent_at,
             ),
             media_type="text/event-stream",
         )

--- a/backend/ella/routers/resolve.py
+++ b/backend/ella/routers/resolve.py
@@ -1,8 +1,9 @@
 """
-Ella Resolve Router - User identity to OpenClaw agent resolution.
+Ella Resolve Router - User identity to active Ella agent resolution.
 
 Resolves any user identifier (Firebase UID, email, phone) to the correct
-OpenClaw agent routing info (agentId, sessionKey, gatewayUrl, token).
+Hermes or legacy OpenClaw agent routing info (agentId, sessionKey, gatewayUrl,
+token).
 
 Endpoints:
 - GET  /v1/ella/resolve?uid={firebase_uid}
@@ -10,9 +11,11 @@ Endpoints:
 - GET  /v1/ella/resolve?phone={phone}
 
 Used by:
-- iOS Flutter app (Pattern C: resolve + direct SSE)
+- iOS Flutter app for history/config discovery. Production chat should use
+  /v1/ella/chat/stream so the backend can hydrate from and write to the
+  canonical timeline.
 - E2E Flow Debugger
-- Any client that needs to discover the correct agent before calling OpenClaw
+- Any client that needs to discover the active agent runtime
 """
 
 import json
@@ -60,7 +63,7 @@ async def _get_pool() -> asyncpg.Pool:
 
 
 async def resolve_user_routing(uid: str) -> Optional[dict]:
-    """Resolve a Firebase UID to OpenClaw routing info.
+    """Resolve a Firebase UID to active agent routing info.
 
     Shared helper used by both /resolve endpoint and chat.py dynamic routing.
     Returns None if user not found.
@@ -90,7 +93,11 @@ async def resolve_user_routing(uid: str) -> Optional[dict]:
             "caregiverAgentId": agents.get("caregiverAgentId"),
             "scannerAgentId": agents.get("scannerAgentId"),
             "summarizerAgentId": agents.get("summarizerAgentId"),
-            "sessionKey": f"agent:{agents.get('userAgentId')}:direct:ella:omi-{row['omi_uid'].lower()}" if row["omi_uid"] and agents.get("userAgentId") else None,
+            "sessionKey": (
+                f"agent:{agents.get('userAgentId')}:direct:ella:omi-{row['omi_uid'].lower()}"
+                if row["omi_uid"] and agents.get("userAgentId")
+                else None
+            ),
             "gatewayUrl": PUBLIC_GATEWAY_URL,
             "scannerGatewayUrl": agents.get("scannerGatewayUrl", gateway_url),
             "token": agents.get("gatewayToken") or OPENCLAW_GATEWAY_TOKEN,
@@ -106,7 +113,7 @@ async def resolve_user_routing(uid: str) -> Optional[dict]:
             routing.update(
                 {
                     "agentId": HERMES_AGENT_ID,
-                    "sessionKey": f"ella:omi:{row['omi_uid'].lower()}:ios-chat",
+                    "sessionKey": f"ella:omi:{row['omi_uid'].lower()}:canonical",
                     "gatewayUrl": HERMES_GATEWAY_URL.rstrip("/"),
                     "scannerGatewayUrl": HERMES_GATEWAY_URL.rstrip("/"),
                     "token": HERMES_GATEWAY_TOKEN,
@@ -139,7 +146,7 @@ async def resolve_endpoint(
     email: Optional[str] = Query(None, description="User email"),
     phone: Optional[str] = Query(None, description="User phone (E.164)"),
 ):
-    """Resolve a user identifier to OpenClaw agent routing info.
+    """Resolve a user identifier to active agent routing info.
 
     Accepts one of: uid, email, phone. Returns the user's agent cluster
     routing information including agentId, sessionKey, gatewayUrl, and token.
@@ -208,7 +215,11 @@ async def resolve_endpoint(
             "caregiverAgentId": agents.get("caregiverAgentId"),
             "scannerAgentId": agents.get("scannerAgentId"),
             "summarizerAgentId": agents.get("summarizerAgentId"),
-            "sessionKey": f"agent:{agents.get('userAgentId')}:direct:ella:omi-{row['omi_uid'].lower()}" if row["omi_uid"] and agents.get("userAgentId") else None,
+            "sessionKey": (
+                f"agent:{agents.get('userAgentId')}:direct:ella:omi-{row['omi_uid'].lower()}"
+                if row["omi_uid"] and agents.get("userAgentId")
+                else None
+            ),
             "gatewayUrl": PUBLIC_GATEWAY_URL,
             "scannerGatewayUrl": agents.get("scannerGatewayUrl", gateway_url),
             "token": agents.get("gatewayToken") or OPENCLAW_GATEWAY_TOKEN,
@@ -222,7 +233,7 @@ async def resolve_endpoint(
             routing.update(
                 {
                     "agentId": HERMES_AGENT_ID,
-                    "sessionKey": f"ella:omi:{row['omi_uid'].lower()}:ios-chat",
+                    "sessionKey": f"ella:omi:{row['omi_uid'].lower()}:canonical",
                     "gatewayUrl": HERMES_GATEWAY_URL.rstrip("/"),
                     "scannerGatewayUrl": HERMES_GATEWAY_URL.rstrip("/"),
                     "token": HERMES_GATEWAY_TOKEN,
@@ -263,6 +274,7 @@ async def proxy_chat_history(agent_id: str, limit: int = 50, session_key: Option
     params = f"limit={limit}"
     if session_key:
         from urllib.parse import quote
+
         params += f"&session_key={quote(session_key)}"
     url = f"{provision_base}/chat/history/{agent_id}?{params}"
 
@@ -271,9 +283,11 @@ async def proxy_chat_history(agent_id: str, limit: int = 50, session_key: Option
             resp = await client.get(url, headers={"x-api-key": PROVISION_API_KEY})
             if resp.status_code != 200:
                 from fastapi.responses import JSONResponse
+
                 return JSONResponse(status_code=resp.status_code, content={"error": "upstream_error"})
             return resp.json()
     except Exception as e:
         logger.error(f"Chat history proxy error: {e}")
         from fastapi.responses import JSONResponse
+
         return JSONResponse(status_code=502, content={"error": "provision_unreachable"})

--- a/backend/tests/unit/test_ella_chat_temporal_context.py
+++ b/backend/tests/unit/test_ella_chat_temporal_context.py
@@ -47,3 +47,48 @@ def test_temporal_chat_context_filters_morning_omi_fragments(monkeypatch):
 
     assert label == "same-day morning OMI context"
     assert [event["event_id"] for event in events] == ["cafe"]
+
+
+def test_ios_chat_event_uses_stable_turn_identity():
+    started_at = datetime(2026, 5, 27, 18, 30, tzinfo=timezone.utc)
+
+    event = chat._ios_chat_event(
+        uid="uid-1",
+        turn_id="client-123",
+        role="user",
+        text="Remember the demo banana is on the blue shelf.",
+        session_key="ella:omi:uid-1:canonical",
+        started_at=started_at,
+        client_info={"type": "ios-app"},
+    )
+    normalized = event.normalized()
+
+    assert event.channel == "ios_chat"
+    assert event.provider == "omi-ios-chat"
+    assert event.role == "user"
+    assert event.scan_policy == "immediate"
+    assert event.event_id == "ios_chat:uid-1:client-123:user"
+    assert normalized["source_identity"] == "ios_chat:uid-1:client-123"
+    assert event.session_id == "ella:omi:uid-1:canonical"
+
+
+def test_ios_chat_assistant_event_disables_scan_policy():
+    started_at = datetime(2026, 5, 27, 18, 31, tzinfo=timezone.utc)
+
+    event = chat._ios_chat_event(
+        uid="uid-1",
+        turn_id="client-123",
+        role="assistant",
+        text="I will remember that.",
+        session_key="ella:omi:uid-1:canonical",
+        started_at=started_at,
+    )
+
+    assert event.scan_policy == "none"
+    assert event.event_id == "ios_chat:uid-1:client-123:assistant"
+
+
+def test_hermes_session_defaults_to_canonical(monkeypatch):
+    monkeypatch.setattr(chat, "HERMES_CHAT_SESSION_SCOPE", "canonical")
+
+    assert chat._hermes_chat_session_key("ABC123") == "ella:omi:abc123:canonical"


### PR DESCRIPTION
## Summary
- route iOS Ella chat through the backend canonical proxy instead of the direct gateway path
- write iOS chat user and assistant turns into the canonical ledger with stable turn ids and scan policies
- switch Hermes chat session identity to the shared canonical lane and update resolve docs/log labels away from OpenClaw-primary wording
- document the iOS chat canonical session contract and smoke test

## Validation
- `python3 -m py_compile ella/routers/chat.py ella/routers/resolve.py tests/unit/test_ella_chat_temporal_context.py`
- `pytest tests/unit/test_ella_chat_temporal_context.py -q`
- `git diff --check`
- `flutter analyze lib/ella/services/ella_chat_service.dart lib/backend/http/api/messages.dart`

Fixes ellaaicare/ella-ai#1007