### PR TITLE
[codex] Bump iOS canonical chat TestFlight build 784

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.522+727
+version: 1.0.522+784
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- Bumps the iOS/TestFlight build number to `1.0.522+784` so current `main` including ellaaicare/omi#245 can be uploaded after existing valid build `783`.

## Scope
- No functional code changes beyond merged `main`.
- Includes canonical iOS chat routing from ellaaicare/omi#245 because this branch is based on current `main` at `bbf5d347`.

## Validation
- Pending local TestFlight build/upload from this branch.

Links ellaaicare/ella-ai#1007
