### PR TITLE
Allow user-facing MCP and API summary topics

### DIFF
--- a/backend/ella/services/summary_sanitizer.py
+++ b/backend/ella/services/summary_sanitizer.py
@@ -6,7 +6,6 @@ import re
 from dataclasses import dataclass, field
 from typing import Optional
 
-
 ELLA_PREFIX = "[Ella] "
 MIN_OVERVIEW_CHARS = 40
 
@@ -20,8 +19,9 @@ _RAW_SCANNER_CATEGORY_RE = re.compile(
     re.IGNORECASE,
 )
 _INTERNAL_JARGON_RE = re.compile(
-    r"\b(?:qmd|write-?back|routing|model[_ -]?runner|tool\s+(?:call|error|trace)|"
-    r"metadata/conversations|scanner[_ -]?logs?|observer[_ -]?logs?|openclaw\s+workspace|mcp|n8n)\b",
+    r"\b(?:qmd|write-?back|(?:internal|agent|model|tool|n8n|openclaw)\s+routing|"
+    r"model[_ -]?runner|tool\s+(?:call|error|trace)|"
+    r"metadata/conversations|scanner[_ -]?logs?|observer[_ -]?logs?|openclaw\s+workspace|n8n)\b",
     re.IGNORECASE,
 )
 _WHITESPACE_RE = re.compile(r"\s+")

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -148,6 +148,33 @@ def test_update_conversation_summary_rejects_internal_debug_jargon(monkeypatch):
     callbacks.conversations_db.update_conversation.assert_not_called()
 
 
+def test_update_conversation_summary_allows_user_facing_mcp_api_topic(monkeypatch):
+    captured = {}
+
+    def fake_update(uid, conversation_id, update_data):
+        captured["update_data"] = update_data
+
+    monkeypatch.setattr(callbacks.conversations_db, "update_conversation", fake_update)
+
+    result = asyncio.run(
+        callbacks.update_conversation_summary(
+            "conv-123",
+            callbacks.ConversationSummaryUpdate(
+                overview=(
+                    "[Ella] You and Greg discussed using an MCP connector and direct QuickBooks API access "
+                    "to make accounting work faster than the browser-based workflow."
+                ),
+                category="technology",
+            ),
+            uid="user-123",
+        )
+    )
+
+    assert result["status"] == "ok"
+    assert captured["update_data"]["structured.overview"].startswith("[Ella] ")
+    assert captured["update_data"]["structured.category"] == "technology"
+
+
 def test_update_conversation_summary_rejects_invalid_category():
     with pytest.raises(HTTPException) as excinfo:
         asyncio.run(
@@ -313,6 +340,7 @@ def test_update_conversation_summary_persists_internal_assessment_when_available
         "update_conversation",
         lambda uid, conversation_id, update_data: captured.setdefault("update_data", update_data),
     )
+
     async def fake_fetch_internal_assessment(uid, conversation_id):
         return {
             "media_likelihood": 0.92,


### PR DESCRIPTION
## Summary
- keep blocking internal routing/debug jargon in summary writeback
- allow legitimate user-facing MCP/API topics such as QuickBooks MCP connector and direct API access
- add regression coverage for the QuickBooks/MCP case

## Tests
- python3 -m pytest backend/tests/unit/test_ella_callbacks_summary_update.py backend/tests/unit/test_mcp_summary_sanitizer.py -q
- python3 -m py_compile backend/ella/services/summary_sanitizer.py
- git diff --check