### PR TITLE
Route iOS summary corrections through Hermes

### DIFF
--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -33,6 +33,15 @@ DIRECT_CORRECTION_APPLY_ENABLED = os.getenv("ELLA_CORRECTION_DIRECT_APPLY", "tru
     "false",
     "no",
 }
+CORRECTION_PROVIDER = os.getenv("ELLA_CORRECTION_PROVIDER", "hermes-api").strip().lower() or "hermes-api"
+HERMES_CORRECTION_API_URL = os.getenv(
+    "ELLA_CORRECTION_HERMES_CHAT_URL",
+    os.getenv("HERMES_CHAT_COMPLETIONS_URL", "http://100.76.138.56:8642/v1/chat/completions"),
+)
+HERMES_CORRECTION_MODEL = os.getenv(
+    "ELLA_CORRECTION_HERMES_MODEL",
+    os.getenv("HERMES_CORRECTION_MODEL", "ella-plato-hermes-eval"),
+)
 DIRECT_CORRECTION_API_URL = os.getenv("ELLA_CORRECTION_API_URL", "https://api.x.ai/v1/chat/completions")
 DIRECT_CORRECTION_MODEL = os.getenv("ELLA_CORRECTION_MODEL", "grok-4.3")
 DIRECT_CORRECTION_INTERNAL_BASE_URL = os.getenv("ELLA_INTERNAL_BASE_URL", "http://127.0.0.1:8000")
@@ -149,8 +158,29 @@ def _extract_json_object(content: str) -> dict[str, Any]:
     return parsed
 
 
-def _correction_api_key() -> str:
+def _legacy_correction_api_key() -> str:
     return os.getenv("ELLA_CORRECTION_API_KEY") or os.getenv("XAI_API_KEY") or os.getenv("HERMES_API_KEY") or ""
+
+
+def _hermes_correction_api_key() -> str:
+    return (
+        os.getenv("ELLA_CORRECTION_HERMES_API_KEY") or os.getenv("API_SERVER_KEY") or os.getenv("HERMES_API_KEY") or ""
+    )
+
+
+def _safe_session_component(value: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9_.:-]+", "-", value).strip("-")[:160] or "unknown"
+
+
+def _correction_session_id(uid: str, conversation_id: str, correction_id: str) -> str:
+    return ":".join(
+        [
+            "correction",
+            _safe_session_component(uid),
+            _safe_session_component(conversation_id),
+            _safe_session_component(correction_id),
+        ]
+    )
 
 
 def _build_direct_correction_prompt(
@@ -169,6 +199,11 @@ Rules:
 - overview must start with "[Ella] ".
 - Keep the overview warm, specific, and useful for Plato to reread later.
 - Use the correction as authoritative when it resolves identity, topic, title, or media attribution.
+- Re-read the entire transcript and current summary, then produce one coherent corrected summary. Do not append or splice the correction text verbatim.
+- Correction text may contain dictation errors, rough phrasing, homophones, or ASR artifacts. Infer the intended correction only when strongly supported by the transcript, current summary, or durable companion context. For example, in a transcript context, "Trang script" likely means "transcript"; when discussing a young person, "team" may mean "teen".
+- When the correction resolves a person's identity, propagate that identity through all relevant references in the title and overview. Do not leave stale generic labels such as "the teen" where the resolved name should be used.
+- Avoid raw speaker labels such as "Speaker 5" in user-facing summaries when a name, role, or natural description can be inferred. If a speaker is still unknown, describe the action without the raw label.
+- Use durable companion context when available to identify Plato/Greg and close family members, but preserve uncertainty instead of inventing.
 - Preserve useful details from the transcript and current summary when they do not conflict with the correction.
 - Do not invent unsupported details.
 - title must be short and contain no markdown.
@@ -252,21 +287,51 @@ def _normalize_direct_summary(result: dict[str, Any], fallback: dict[str, Any]) 
 
 async def _generate_corrected_summary(
     *,
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+    trace_id: str,
     request: ConversationCorrectionRequest,
     structured: dict[str, Any],
     transcript: str,
     segment_count: int,
 ) -> dict[str, Any]:
-    api_key = _correction_api_key()
-    if not api_key:
-        raise RuntimeError("No correction model API key configured")
-
     prompt = _build_direct_correction_prompt(
         request=request,
         structured=structured,
         transcript=transcript,
         segment_count=segment_count,
     )
+    provider = CORRECTION_PROVIDER
+    if provider == "hermes-api":
+        api_key = _hermes_correction_api_key()
+        if not api_key:
+            raise RuntimeError("No Hermes correction API key configured")
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "X-Hermes-Session-Id": _correction_session_id(uid, conversation_id, correction_id),
+            "X-Trace-Id": trace_id,
+        }
+        async with httpx.AsyncClient(timeout=DIRECT_CORRECTION_TIMEOUT_SECONDS) as client:
+            response = await client.post(
+                HERMES_CORRECTION_API_URL,
+                headers=headers,
+                json={
+                    "model": HERMES_CORRECTION_MODEL,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "temperature": 0.1,
+                    "max_tokens": 900,
+                },
+            )
+        response.raise_for_status()
+        body = response.json()
+        content = body["choices"][0]["message"]["content"]
+        return _normalize_direct_summary(_extract_json_object(content), structured)
+
+    api_key = _legacy_correction_api_key()
+    if not api_key:
+        raise RuntimeError("No legacy correction model API key configured")
     async with httpx.AsyncClient(timeout=DIRECT_CORRECTION_TIMEOUT_SECONDS) as client:
         response = await client.post(
             DIRECT_CORRECTION_API_URL,
@@ -585,6 +650,10 @@ async def _submit_conversation_correction(
     if DIRECT_CORRECTION_APPLY_ENABLED:
         try:
             corrected_summary = await _generate_corrected_summary(
+                uid=uid,
+                conversation_id=conversation_id,
+                correction_id=correction_id,
+                trace_id=trace_id,
                 request=request,
                 structured=structured,
                 transcript=transcript,

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -357,6 +357,159 @@ def test_submit_correction_accepts_text_alias():
     assert request.correction_text == "Please fix the doctor name."
 
 
+def test_build_correction_prompt_guides_identity_reprocessing():
+    prompt = corrections._build_direct_correction_prompt(
+        request=corrections.ConversationCorrectionRequest(
+            correction_text="the team in this Trang script is Mei Xin a.k.a. Rain",
+            source="ios",
+        ),
+        structured={
+            "title": "Teen avoids meeting",
+            "overview": "[Ella] Speaker 5 discussed a teen avoiding an in-person meeting.",
+            "emoji": "🏫",
+            "category": "education",
+        },
+        transcript="Speaker 5: She wants to email the teacher instead of meeting in person.",
+        segment_count=1,
+    )
+
+    assert "Do not append or splice the correction text verbatim" in prompt
+    assert '"Trang script" likely means "transcript"' in prompt
+    assert '"team" may mean "teen"' in prompt
+    assert "propagate that identity through all relevant references" in prompt
+    assert "Avoid raw speaker labels such as \"Speaker 5\"" in prompt
+
+
+def test_generate_corrected_summary_uses_hermes_api_with_scoped_session(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(corrections, "CORRECTION_PROVIDER", "hermes-api")
+    monkeypatch.setattr(corrections, "HERMES_CORRECTION_API_URL", "https://hermes.test/v1/chat/completions")
+    monkeypatch.setattr(corrections, "HERMES_CORRECTION_MODEL", "profile-model")
+    monkeypatch.setenv("ELLA_CORRECTION_HERMES_API_KEY", "hermes-secret")
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "content": (
+                                '{"title":"Mei Xin Emails Teacher",'
+                                '"overview":"[Ella] Mei Xin, also called Rain, preferred emailing her teacher instead of an in-person meeting.",'
+                                '"emoji":"🏫","category":"education"}'
+                            )
+                        }
+                    }
+                ]
+            }
+
+    class FakeAsyncClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, headers, json):
+            calls.append({"url": url, "headers": headers, "json": json, "timeout": self.timeout})
+            return FakeResponse()
+
+    monkeypatch.setattr(corrections.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = asyncio.run(
+        corrections._generate_corrected_summary(
+            uid="user/123",
+            conversation_id="conv 123",
+            correction_id="corr 123",
+            trace_id="trace-123",
+            request=corrections.ConversationCorrectionRequest(
+                correction_text="the team in this Trang script is Mei Xin a.k.a. Rain",
+                source="ios",
+            ),
+            structured={"title": "Teen meeting", "overview": "[Ella] Speaker 5 talked about the teen."},
+            transcript="Speaker 5: She wants to email Miss Boyd.",
+            segment_count=1,
+        )
+    )
+
+    assert result["title"] == "Mei Xin Emails Teacher"
+    assert "Mei Xin" in result["overview"]
+    assert result["ella_tags"] == ["omi", "correction"]
+    assert calls[0]["url"] == "https://hermes.test/v1/chat/completions"
+    assert calls[0]["headers"]["Authorization"] == "Bearer hermes-secret"
+    assert calls[0]["headers"]["X-Hermes-Session-Id"] == "correction:user-123:conv-123:corr-123"
+    assert calls[0]["headers"]["X-Trace-Id"] == "trace-123"
+    assert calls[0]["json"]["model"] == "profile-model"
+    assert "Speaker 5" in calls[0]["json"]["messages"][0]["content"]
+
+
+def test_generate_corrected_summary_can_use_legacy_provider(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(corrections, "CORRECTION_PROVIDER", "legacy")
+    monkeypatch.setattr(corrections, "DIRECT_CORRECTION_API_URL", "https://legacy.test/v1/chat/completions")
+    monkeypatch.setattr(corrections, "DIRECT_CORRECTION_MODEL", "grok-4.3")
+    monkeypatch.setenv("ELLA_CORRECTION_API_KEY", "legacy-secret")
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "content": (
+                                '{"title":"Corrected","overview":"[Ella] Corrected summary.",'
+                                '"emoji":"🪽","category":"other"}'
+                            )
+                        }
+                    }
+                ]
+            }
+
+    class FakeAsyncClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, headers, json):
+            calls.append({"url": url, "headers": headers, "json": json})
+            return FakeResponse()
+
+    monkeypatch.setattr(corrections.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = asyncio.run(
+        corrections._generate_corrected_summary(
+            uid="user-123",
+            conversation_id="conv-123",
+            correction_id="corr-123",
+            trace_id="trace-123",
+            request=corrections.ConversationCorrectionRequest(correction_text="Fix this."),
+            structured={"title": "Old", "overview": "[Ella] Old."},
+            transcript="Speaker: transcript",
+            segment_count=1,
+        )
+    )
+
+    assert result["title"] == "Corrected"
+    assert calls[0]["url"] == "https://legacy.test/v1/chat/completions"
+    assert calls[0]["headers"]["Authorization"] == "Bearer legacy-secret"
+
+
 def test_create_summary_correction_proposal_uses_proposal_only_policy(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Summary
- routes direct iOS summary correction generation through the Hermes API-server by default
- scopes correction sessions by uid/conversation/correction id for traceable context without using the old direct xAI path
- strengthens correction instructions so identity fixes are propagated across the whole rewritten summary instead of copied verbatim

## Tests
- python3 -m pytest backend/tests/unit/test_ella_conversation_corrections.py -q
- python3 -m py_compile backend/ella/routers/corrections.py

Closes ellaaicare/ella-ai#1008