### PR TITLE
Queue iOS summary corrections asynchronously

### DIFF
--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from pydantic import AliasChoices, BaseModel, Field, field_validator
 
 import database.conversations as conversations_db
@@ -29,6 +29,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["conversation-corrections"])
 
 DIRECT_CORRECTION_APPLY_ENABLED = os.getenv("ELLA_CORRECTION_DIRECT_APPLY", "true").lower() not in {
+    "0",
+    "false",
+    "no",
+}
+DIRECT_CORRECTION_BACKGROUND_ENABLED = os.getenv("ELLA_CORRECTION_BACKGROUND_APPLY", "true").lower() not in {
     "0",
     "false",
     "no",
@@ -541,9 +546,131 @@ async def _submit_correction_to_n8n(
     }
 
 
+async def _run_direct_correction_apply(
+    *,
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+    trace_id: str,
+    request: ConversationCorrectionRequest,
+    structured: dict[str, Any],
+    transcript: str,
+    segment_count: int,
+    submitted_at: str,
+    active_summary_version_id: Optional[str],
+    proposal_id: Optional[str],
+) -> ConversationCorrectionResponse:
+    try:
+        corrected_summary = await _generate_corrected_summary(
+            uid=uid,
+            conversation_id=conversation_id,
+            correction_id=correction_id,
+            trace_id=trace_id,
+            request=request,
+            structured=structured,
+            transcript=transcript,
+            segment_count=segment_count,
+        )
+        apply_result = await _apply_corrected_summary(
+            uid=uid,
+            conversation_id=conversation_id,
+            correction_id=correction_id,
+            trace_id=trace_id,
+            active_summary_version_id=active_summary_version_id,
+            corrected=corrected_summary,
+        )
+        applied_at = _now_iso()
+        _persist_correction_audit(
+            uid,
+            conversation_id,
+            correction_id,
+            {
+                "status": "applied",
+                "updated_at": applied_at,
+                "direct_apply_result": apply_result,
+                "direct_apply_summary": corrected_summary,
+            },
+        )
+        _append_correction_event(
+            uid,
+            conversation_id,
+            correction_id,
+            {
+                "stage": "direct_apply_succeeded",
+                "status": "ok",
+                "at": applied_at,
+                "trace_id": trace_id,
+                "apply_result": apply_result,
+            },
+        )
+        return ConversationCorrectionResponse(
+            correction_id=correction_id,
+            conversation_id=conversation_id,
+            trace_id=trace_id,
+            status="applied",
+            queued=False,
+            proposal_id=proposal_id,
+        )
+    except Exception as exc:
+        logger.exception(
+            "Direct conversation correction apply failed",
+            extra={"uid": uid, "conversation_id": conversation_id, "correction_id": correction_id},
+        )
+        failed_at = _now_iso()
+        _append_correction_event(
+            uid,
+            conversation_id,
+            correction_id,
+            {
+                "stage": "direct_apply_failed",
+                "status": "error",
+                "at": failed_at,
+                "trace_id": trace_id,
+                "error": str(exc),
+                "n8n_fallback_enabled": N8N_CORRECTION_FALLBACK_ENABLED,
+            },
+        )
+        if not N8N_CORRECTION_FALLBACK_ENABLED:
+            _persist_correction_audit(
+                uid,
+                conversation_id,
+                correction_id,
+                {
+                    "status": "direct_apply_failed",
+                    "updated_at": failed_at,
+                    "direct_apply_error": str(exc),
+                },
+            )
+            _update_conversation_correction_state(
+                uid,
+                conversation_id,
+                {
+                    "correction_state": {
+                        "status": "direct_apply_failed",
+                        "pending": False,
+                        "correction_id": correction_id,
+                        "trace_id": trace_id,
+                        "submitted_at": submitted_at,
+                        "updated_at": failed_at,
+                        "error": str(exc),
+                    }
+                },
+            )
+            return ConversationCorrectionResponse(
+                correction_id=correction_id,
+                conversation_id=conversation_id,
+                trace_id=trace_id,
+                status="direct_apply_failed",
+                queued=False,
+                proposal_id=proposal_id,
+            )
+        raise
+
+
 async def _submit_conversation_correction(
     conversation_id: str,
     request: ConversationCorrectionRequest,
+    background_tasks: Optional[BackgroundTasks] = None,
     uid: str = Depends(auth.get_current_user_uid),
 ) -> ConversationCorrectionResponse:
     conversation = conversations_db.get_conversation(uid, conversation_id)
@@ -648,35 +775,38 @@ async def _submit_conversation_correction(
         )
 
     if DIRECT_CORRECTION_APPLY_ENABLED:
-        try:
-            corrected_summary = await _generate_corrected_summary(
-                uid=uid,
-                conversation_id=conversation_id,
-                correction_id=correction_id,
-                trace_id=trace_id,
-                request=request,
-                structured=structured,
-                transcript=transcript,
-                segment_count=segment_count,
-            )
-            apply_result = await _apply_corrected_summary(
-                uid=uid,
-                conversation_id=conversation_id,
-                correction_id=correction_id,
-                trace_id=trace_id,
-                active_summary_version_id=submitted_state.get("active_summary_version_id"),
-                corrected=corrected_summary,
-            )
-            applied_at = _now_iso()
+        direct_apply_kwargs = {
+            "uid": uid,
+            "conversation_id": conversation_id,
+            "correction_id": correction_id,
+            "trace_id": trace_id,
+            "request": request,
+            "structured": structured,
+            "transcript": transcript,
+            "segment_count": segment_count,
+            "submitted_at": submitted_at,
+            "active_summary_version_id": submitted_state.get("active_summary_version_id"),
+            "proposal_id": proposal_id,
+        }
+        if DIRECT_CORRECTION_BACKGROUND_ENABLED and background_tasks is not None:
+            queued_at = _now_iso()
+            queued_state = {
+                "correction_id": correction_id,
+                "status": "queued",
+                "pending": True,
+                "source": request.source,
+                "submitted_at": submitted_at,
+                "updated_at": queued_at,
+                "active_summary_version_id": submitted_state.get("active_summary_version_id"),
+            }
             _persist_correction_audit(
                 uid,
                 conversation_id,
                 correction_id,
                 {
-                    "status": "applied",
-                    "updated_at": applied_at,
-                    "direct_apply_result": apply_result,
-                    "direct_apply_summary": corrected_summary,
+                    "status": "queued",
+                    "updated_at": queued_at,
+                    "queue_result": {"mode": "background_direct_apply"},
                 },
             )
             _append_correction_event(
@@ -684,66 +814,27 @@ async def _submit_conversation_correction(
                 conversation_id,
                 correction_id,
                 {
-                    "stage": "direct_apply_succeeded",
+                    "stage": "direct_apply_queued",
                     "status": "ok",
-                    "at": applied_at,
+                    "at": queued_at,
                     "trace_id": trace_id,
-                    "apply_result": apply_result,
+                    "queue_result": {"mode": "background_direct_apply"},
                 },
             )
+            _update_conversation_correction_state(uid, conversation_id, {"correction_state": queued_state})
+            background_tasks.add_task(_run_direct_correction_apply, **direct_apply_kwargs)
             return ConversationCorrectionResponse(
                 correction_id=correction_id,
                 conversation_id=conversation_id,
                 trace_id=trace_id,
-                status="applied",
-                queued=False,
+                status="queued",
+                queued=True,
                 proposal_id=proposal_id,
             )
+        try:
+            return await _run_direct_correction_apply(**direct_apply_kwargs)
         except Exception as exc:
-            logger.exception(
-                "Direct conversation correction apply failed",
-                extra={"uid": uid, "conversation_id": conversation_id, "correction_id": correction_id},
-            )
-            failed_at = _now_iso()
-            _append_correction_event(
-                uid,
-                conversation_id,
-                correction_id,
-                {
-                    "stage": "direct_apply_failed",
-                    "status": "error",
-                    "at": failed_at,
-                    "trace_id": trace_id,
-                    "error": str(exc),
-                    "n8n_fallback_enabled": N8N_CORRECTION_FALLBACK_ENABLED,
-                },
-            )
             if not N8N_CORRECTION_FALLBACK_ENABLED:
-                _persist_correction_audit(
-                    uid,
-                    conversation_id,
-                    correction_id,
-                    {
-                        "status": "direct_apply_failed",
-                        "updated_at": failed_at,
-                        "direct_apply_error": str(exc),
-                    },
-                )
-                _update_conversation_correction_state(
-                    uid,
-                    conversation_id,
-                    {
-                        "correction_state": {
-                            "status": "direct_apply_failed",
-                            "pending": False,
-                            "correction_id": correction_id,
-                            "trace_id": trace_id,
-                            "submitted_at": submitted_at,
-                            "updated_at": failed_at,
-                            "error": str(exc),
-                        }
-                    },
-                )
                 return ConversationCorrectionResponse(
                     correction_id=correction_id,
                     conversation_id=conversation_id,
@@ -901,9 +992,10 @@ async def _submit_conversation_correction(
 async def submit_conversation_correction_ella(
     conversation_id: str,
     request: ConversationCorrectionRequest,
+    background_tasks: BackgroundTasks,
     uid: str = Depends(auth.get_current_user_uid),
 ) -> ConversationCorrectionResponse:
-    return await _submit_conversation_correction(conversation_id, request, uid)
+    return await _submit_conversation_correction(conversation_id, request, background_tasks, uid)
 
 
 @router.post(
@@ -914,6 +1006,7 @@ async def submit_conversation_correction_ella(
 async def submit_conversation_correction(
     conversation_id: str,
     request: ConversationCorrectionRequest,
+    background_tasks: BackgroundTasks,
     uid: str = Depends(auth.get_current_user_uid),
 ) -> ConversationCorrectionResponse:
-    return await _submit_conversation_correction(conversation_id, request, uid)
+    return await _submit_conversation_correction(conversation_id, request, background_tasks, uid)

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -101,6 +101,7 @@ def test_submit_correction_accepts_ios_payload_and_queues(monkeypatch):
                     "app_summary": "The app summary was too clinical.",
                 },
             ),
+            background_tasks=None,
             uid="user-123",
         )
     )
@@ -142,6 +143,7 @@ def test_submit_correction_uses_authenticated_uid_for_ownership(monkeypatch):
             corrections.submit_conversation_correction(
                 "conv-123",
                 corrections.ConversationCorrectionRequest(correction_text="Wrong person."),
+                background_tasks=None,
                 uid="authenticated-user",
             )
         )
@@ -162,6 +164,7 @@ def test_submit_correction_rejects_locked_conversation(monkeypatch):
             corrections.submit_conversation_correction(
                 "conv-locked",
                 corrections.ConversationCorrectionRequest(correction_text="Please fix this."),
+                background_tasks=None,
                 uid="user-123",
             )
         )
@@ -203,6 +206,7 @@ def test_submit_correction_persists_n8n_failure_trace_and_still_returns_202(monk
         corrections.submit_conversation_correction(
             "conv-123",
             corrections.ConversationCorrectionRequest(correction_text="Please correct the summary."),
+            background_tasks=None,
             uid="user-123",
         )
     )
@@ -257,6 +261,7 @@ def test_submit_correction_skips_n8n_fallback_by_default_when_direct_apply_fails
         corrections.submit_conversation_correction(
             "conv-123",
             corrections.ConversationCorrectionRequest(correction_text="Please correct the summary."),
+            background_tasks=None,
             uid="user-123",
         )
     )
@@ -327,6 +332,7 @@ def test_submit_correction_directly_applies_when_model_path_succeeds(monkeypatch
                 correction_text="This was background TV audio, not a real memory concern.",
                 source="ios",
             ),
+            background_tasks=None,
             uid="user-123",
         )
     )
@@ -342,6 +348,100 @@ def test_submit_correction_directly_applies_when_model_path_succeeds(monkeypatch
     assert audits[-1]["direct_apply_result"]["active_summary_version_id"] == "corrected-v1"
     assert events[-1]["stage"] == "direct_apply_succeeded"
     assert conversation_updates[0]["correction_state"]["status"] == "submitted"
+
+
+def test_submit_correction_queues_background_direct_apply_without_waiting(monkeypatch):
+    audits = []
+    events = []
+    conversation_updates = []
+    proposals = []
+    generated = []
+
+    class FakeBackgroundTasks:
+        def __init__(self):
+            self.tasks = []
+
+        def add_task(self, func, *args, **kwargs):
+            self.tasks.append((func, args, kwargs))
+
+    monkeypatch.setattr(corrections, "DIRECT_CORRECTION_APPLY_ENABLED", True)
+    monkeypatch.setattr(corrections, "DIRECT_CORRECTION_BACKGROUND_ENABLED", True)
+    monkeypatch.setattr(corrections, "N8N_CORRECTION_FALLBACK_ENABLED", False)
+    monkeypatch.setattr(corrections.conversations_db, "get_conversation", lambda uid, conversation_id: _conversation())
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "bootstrap_summary_versioning_update",
+        lambda conversation: {"summary_versions": [{"id": "legacy-v1"}], "active_summary_version_id": "legacy-v1"},
+    )
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "update_conversation",
+        lambda uid, conversation_id, update_data: conversation_updates.append(update_data),
+    )
+    monkeypatch.setattr(
+        corrections,
+        "_persist_correction_audit",
+        lambda uid, conversation_id, correction_id, payload: audits.append(payload),
+    )
+    monkeypatch.setattr(
+        corrections,
+        "_append_correction_event",
+        lambda uid, conversation_id, correction_id, event: events.append(event),
+    )
+    monkeypatch.setattr(
+        corrections,
+        "_create_summary_correction_proposal",
+        lambda **kwargs: proposals.append(kwargs) or "proposal-123",
+    )
+
+    async def fake_generate(**kwargs):
+        generated.append(kwargs)
+        return {
+            "title": "Corrected",
+            "overview": "[Ella] Corrected in background.",
+            "emoji": "🪽",
+            "category": "other",
+            "ella_tags": ["omi", "correction"],
+            "ella_signal": {},
+        }
+
+    async def fake_apply(**kwargs):
+        return {"status": "ok", "active_summary_version_id": "corrected-v1"}
+
+    monkeypatch.setattr(corrections, "_generate_corrected_summary", fake_generate)
+    monkeypatch.setattr(corrections, "_apply_corrected_summary", fake_apply)
+
+    background_tasks = FakeBackgroundTasks()
+    result = asyncio.run(
+        corrections.submit_conversation_correction(
+            "conv-123",
+            corrections.ConversationCorrectionRequest(
+                correction_text="This was Mei Xin speaking.",
+                source="ios",
+            ),
+            background_tasks=background_tasks,
+            uid="user-123",
+        )
+    )
+
+    assert result.status == "queued"
+    assert result.queued is True
+    assert result.proposal_id == "proposal-123"
+    assert len(background_tasks.tasks) == 1
+    assert generated == []
+    assert audits[-1]["status"] == "queued"
+    assert audits[-1]["queue_result"] == {"mode": "background_direct_apply"}
+    assert events[-1]["stage"] == "direct_apply_queued"
+    assert conversation_updates[-1]["correction_state"]["status"] == "queued"
+
+    func, args, kwargs = background_tasks.tasks[0]
+    assert func is corrections._run_direct_correction_apply
+    asyncio.run(func(*args, **kwargs))
+
+    assert generated[0]["uid"] == "user-123"
+    assert generated[0]["conversation_id"] == "conv-123"
+    assert audits[-1]["status"] == "applied"
+    assert events[-1]["stage"] == "direct_apply_succeeded"
 
 
 def test_router_uses_custom_ella_namespace_only():


### PR DESCRIPTION
## Summary
- changes iOS correction submit to return queued immediately when FastAPI background tasks are available
- runs Hermes regenerate/apply in a background task while preserving correction audit events and state transitions
- keeps synchronous path for direct internal/test calls and legacy n8n fallback behavior

## Tests
- python3 -m pytest backend/tests/unit/test_ella_conversation_corrections.py -q
- python3 -m py_compile backend/ella/routers/corrections.py

Refs ellaaicare/ella-ai#1009