### PR TITLE
Fix Hermes session-key scoping for memory

### DIFF
--- a/backend/ella/routers/chat.py
+++ b/backend/ella/routers/chat.py
@@ -82,26 +82,44 @@ ELLA_SYSTEM_PROMPT = (
 )
 
 
+def _safe_session_component(value: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9_.:-]+", "-", value).strip("-")[:160] or "unknown"
+
+
+def _hermes_chat_memory_key(uid: str) -> str:
+    """Stable Hermes/Honcho long-term memory scope for this authenticated user."""
+
+    return f"ella:omi:{_safe_session_component(uid.lower())}:canonical"
+
+
 def _hermes_chat_session_key(uid: str) -> str:
+    safe_uid = _safe_session_component(uid.lower())
     if HERMES_CHAT_SESSION_SCOPE in {"canonical", "shared", "cross_channel", "cross-channel"}:
-        return f"ella:omi:{uid.lower()}:canonical"
+        return _hermes_chat_memory_key(uid)
     if HERMES_CHAT_SESSION_EPOCH:
         epoch = HERMES_CHAT_SESSION_EPOCH
     else:
         epoch = datetime.now(timezone.utc).astimezone(ZoneInfo(CHAT_USER_TIMEZONE)).strftime("daily-%Y%m%d")
-    return f"ella:omi:{uid.lower()}:ios-chat:{epoch}"
+    return f"ella:omi:{safe_uid}:ios-chat:{epoch}"
 
 
-async def _hermes_nonstream_completion(messages: list[dict], session_key: str) -> str:
+def _hermes_chat_headers(session_id: str, session_key: str | None = None) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {HERMES_GATEWAY_TOKEN}",
+        "Content-Type": "application/json",
+        "X-Hermes-Session-Id": session_id,
+    }
+    if session_key:
+        headers["X-Hermes-Session-Key"] = session_key
+    return headers
+
+
+async def _hermes_nonstream_completion(messages: list[dict], session_key: str, memory_key: str | None = None) -> str:
     recovery_session = f"{session_key}:empty-recovery"
     async with httpx.AsyncClient(timeout=60.0) as client:
         response = await client.post(
             f"{HERMES_GATEWAY_URL}/v1/chat/completions",
-            headers={
-                "Authorization": f"Bearer {HERMES_GATEWAY_TOKEN}",
-                "Content-Type": "application/json",
-                "X-Hermes-Session-Id": recovery_session,
-            },
+            headers=_hermes_chat_headers(recovery_session, memory_key or session_key),
             json={
                 "model": HERMES_MODEL,
                 "messages": messages,
@@ -743,8 +761,9 @@ async def _stream_hermes_chat(
         )
     )
     messages.append({"role": "user", "content": user_message})
+    memory_key = _hermes_chat_memory_key(uid)
     print(
-        f"[FLOW:CHAT-HERMES] uid={uid} gateway={HERMES_GATEWAY_URL} session={session_key} session_strategy={HERMES_CHAT_SESSION_SCOPE} turn_id={turn_id} canonical_events={len(canonical_events)} temporal_events={len(temporal_events)}",
+        f"[FLOW:CHAT-HERMES] uid={uid} gateway={HERMES_GATEWAY_URL} session={session_key} memory_key={memory_key} session_strategy={HERMES_CHAT_SESSION_SCOPE} turn_id={turn_id} canonical_events={len(canonical_events)} temporal_events={len(temporal_events)}",
         flush=True,
     )
 
@@ -753,11 +772,7 @@ async def _stream_hermes_chat(
             async with client.stream(
                 "POST",
                 f"{HERMES_GATEWAY_URL}/v1/chat/completions",
-                headers={
-                    "Authorization": f"Bearer {HERMES_GATEWAY_TOKEN}",
-                    "Content-Type": "application/json",
-                    "X-Hermes-Session-Id": session_key,
-                },
+                headers=_hermes_chat_headers(session_key, memory_key),
                 json={
                     "model": HERMES_MODEL,
                     "messages": messages,
@@ -795,7 +810,7 @@ async def _stream_hermes_chat(
 
         full_text = "".join(text).strip()
         if not full_text:
-            recovery_text = await _hermes_nonstream_completion(messages, session_key)
+            recovery_text = await _hermes_nonstream_completion(messages, session_key, memory_key)
             if recovery_text:
                 text.append(recovery_text)
                 full_text = recovery_text

--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -188,6 +188,12 @@ def _correction_session_id(uid: str, conversation_id: str, correction_id: str) -
     )
 
 
+def _correction_session_key(uid: str) -> str:
+    """Stable Hermes long-term memory scope for correction/enrichment calls."""
+
+    return f"ella:omi:{_safe_session_component(uid.lower())}:canonical"
+
+
 def _build_direct_correction_prompt(
     *,
     request: ConversationCorrectionRequest,
@@ -316,6 +322,7 @@ async def _generate_corrected_summary(
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
             "X-Hermes-Session-Id": _correction_session_id(uid, conversation_id, correction_id),
+            "X-Hermes-Session-Key": _correction_session_key(uid),
             "X-Trace-Id": trace_id,
         }
         async with httpx.AsyncClient(timeout=DIRECT_CORRECTION_TIMEOUT_SECONDS) as client:

--- a/backend/tests/unit/test_ella_chat_temporal_context.py
+++ b/backend/tests/unit/test_ella_chat_temporal_context.py
@@ -92,3 +92,13 @@ def test_hermes_session_defaults_to_canonical(monkeypatch):
     monkeypatch.setattr(chat, "HERMES_CHAT_SESSION_SCOPE", "canonical")
 
     assert chat._hermes_chat_session_key("ABC123") == "ella:omi:abc123:canonical"
+    assert chat._hermes_chat_session_key("User/123") == "ella:omi:user-123:canonical"
+    assert chat._hermes_chat_memory_key("User/123") == "ella:omi:user-123:canonical"
+
+
+def test_hermes_chat_headers_include_stable_session_key():
+    headers = chat._hermes_chat_headers("ella:omi:abc123:ios-chat:daily-20260530", "ella:omi:abc123:canonical")
+
+    assert headers["X-Hermes-Session-Id"] == "ella:omi:abc123:ios-chat:daily-20260530"
+    assert headers["X-Hermes-Session-Key"] == "ella:omi:abc123:canonical"
+    assert headers["Content-Type"] == "application/json"

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -545,9 +545,29 @@ def test_generate_corrected_summary_uses_hermes_api_with_scoped_session(monkeypa
     assert calls[0]["url"] == "https://hermes.test/v1/chat/completions"
     assert calls[0]["headers"]["Authorization"] == "Bearer hermes-secret"
     assert calls[0]["headers"]["X-Hermes-Session-Id"] == "correction:user-123:conv-123:corr-123"
+    assert calls[0]["headers"]["X-Hermes-Session-Key"] == "ella:omi:user-123:canonical"
     assert calls[0]["headers"]["X-Trace-Id"] == "trace-123"
     assert calls[0]["json"]["model"] == "profile-model"
     assert "Speaker 5" in calls[0]["json"]["messages"][0]["content"]
+
+
+def test_correction_session_key_is_stable_per_user():
+    assert corrections._correction_session_key("User/123") == "ella:omi:user-123:canonical"
+    assert corrections._correction_session_key("User/123") == corrections._correction_session_key("user/123")
+    assert corrections._correction_session_key("Other User") == "ella:omi:other-user:canonical"
+    assert corrections._correction_session_key("User/123") != corrections._correction_session_key("Other User")
+
+
+def test_correction_session_key_matches_chat_memory_scope(monkeypatch):
+    from ella.routers import chat
+
+    monkeypatch.setattr(chat, "HERMES_CHAT_SESSION_SCOPE", "canonical")
+    assert corrections._correction_session_key("abc123") == chat._hermes_chat_session_key("abc123")
+    assert corrections._correction_session_key("abc123") == chat._hermes_chat_memory_key("abc123")
+
+    monkeypatch.setattr(chat, "HERMES_CHAT_SESSION_SCOPE", "daily")
+    assert chat._hermes_chat_session_key("abc123").startswith("ella:omi:abc123:ios-chat:")
+    assert corrections._correction_session_key("abc123") == chat._hermes_chat_memory_key("abc123")
 
 
 def test_generate_corrected_summary_can_use_legacy_provider(monkeypatch):


### PR DESCRIPTION
## Summary
- Adds stable `X-Hermes-Session-Key` to Hermes correction summary calls so correction-derived memory attaches to the durable user/profile scope.
- Adds the same stable session key to iOS chat Hermes calls, while preserving existing `X-Hermes-Session-Id` for short-term transcript/session behavior.
- Adds tests for per-user correction session key isolation and chat headers.

## Why
Linda's review on ellaaicare/ella-ai#1010 found that Hermes/Honcho long-term memory is scoped by `X-Hermes-Session-Key`, not just `X-Hermes-Session-Id`. Without this, correction/enrichment work can appear successful but fail to persist into the correct durable Honcho context.

## Validation
- `python3 -m pytest backend/tests/unit/test_ella_conversation_corrections.py -q` -> 16 passed
- `python3 -m pytest backend/tests/unit/test_ella_chat_temporal_context.py -q` -> 5 passed
- `python3 -m py_compile backend/ella/routers/corrections.py backend/ella/routers/chat.py`

Closes ellaaicare/ella-ai#1011
