### PR TITLE
Implement OMI correction Observer propagation skeleton

### DIFF
--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -21,6 +21,8 @@ from pydantic import AliasChoices, BaseModel, Field, field_validator
 import database.conversations as conversations_db
 from database._client import db
 from ella.config import ELLA_CONFIG
+from ella.routers.canonical_events import CanonicalEventIn, PostgresCanonicalEventStore
+from ella.services.correction_propagation import propagation_run_to_dict, run_correction_propagation
 from ella.services import proposal_ingest
 from utils.other import endpoints as auth
 
@@ -57,7 +59,18 @@ N8N_CORRECTION_FALLBACK_ENABLED = os.getenv("ELLA_CORRECTION_N8N_FALLBACK_ENABLE
     "yes",
     "on",
 }
+CORRECTION_CANONICAL_EVENT_ENABLED = os.getenv("ELLA_CORRECTION_CANONICAL_EVENT_ENABLED", "true").lower() not in {
+    "0",
+    "false",
+    "no",
+}
+CORRECTION_PROPAGATION_ENABLED = os.getenv("ELLA_CORRECTION_PROPAGATION_ENABLED", "true").lower() not in {
+    "0",
+    "false",
+    "no",
+}
 JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+_canonical_event_store = PostgresCanonicalEventStore()
 
 
 class SummaryContext(BaseModel):
@@ -435,6 +448,224 @@ def _append_correction_event(
     ref.set({"events": events, "updated_at": event.get("at") or _now_iso()}, merge=True)
 
 
+async def _emit_canonical_correction_event(
+    *,
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+    trace_id: str,
+    request: ConversationCorrectionRequest,
+    structured: dict[str, Any],
+    submitted_at: str,
+    active_summary_version_id: Optional[str],
+    proposal_id: Optional[str],
+) -> None:
+    if not CORRECTION_CANONICAL_EVENT_ENABLED:
+        return
+    event = CanonicalEventIn(
+        uid=uid,
+        canonical_identity=uid,
+        event_id=f"omi_correction:{uid}:{conversation_id}:{correction_id}:summary_correction_submitted",
+        session_id=f"omi:{uid}:{conversation_id}",
+        channel="omi_correction",
+        provider="omi-backend",
+        role="user",
+        text=request.correction_text,
+        started_at=submitted_at,
+        privacy_scope="user_private",
+        scan_policy="none",
+        source_ref={
+            "source_identity": f"omi_correction:{uid}:{conversation_id}:{correction_id}",
+            "conversation_id": conversation_id,
+            "correction_id": correction_id,
+            "trace_id": trace_id,
+        },
+        metadata={
+            "event_type": "summary_correction_submitted",
+            "source": request.source,
+            "correction_type": _correction_category(request.correction_text, request.summary_context),
+            "summary_context": request.summary_context.model_dump(),
+            "before": {
+                "active_summary_version_id": active_summary_version_id,
+                "current_summary": structured,
+            },
+            "after": {
+                "correction_text": request.correction_text,
+                "proposal_id": proposal_id,
+                "write_policy": "proposal_then_observer",
+            },
+            "local_timestamps": {
+                "submitted_at": submitted_at,
+            },
+            "durable_owner": "honcho/hermes",
+        },
+    )
+    try:
+        result = await _canonical_event_store.write_batch([event])
+        _append_correction_event(
+            uid,
+            conversation_id,
+            correction_id,
+            {
+                "stage": "canonical_event_emitted",
+                "status": "ok",
+                "at": _now_iso(),
+                "trace_id": trace_id,
+                "event_id": event.event_id,
+                "write_result": result,
+            },
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to emit canonical correction event",
+            extra={"uid": uid, "conversation_id": conversation_id, "correction_id": correction_id, "error": str(exc)},
+        )
+        _append_correction_event(
+            uid,
+            conversation_id,
+            correction_id,
+            {
+                "stage": "canonical_event_failed",
+                "status": "error",
+                "at": _now_iso(),
+                "trace_id": trace_id,
+                "error": str(exc),
+            },
+        )
+
+
+def _persist_correction_propagation_run(
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+    run_payload: dict[str, Any],
+) -> None:
+    _audit_ref(uid, conversation_id, correction_id).collection("propagation_runs").document(run_payload["run_id"]).set(
+        run_payload, merge=True
+    )
+
+
+async def _run_correction_propagation_for_submission(
+    *,
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+    trace_id: str,
+    request: ConversationCorrectionRequest,
+    source_conversation: dict[str, Any],
+) -> None:
+    if not CORRECTION_PROPAGATION_ENABLED:
+        return
+    try:
+        run = run_correction_propagation(
+            uid=uid,
+            source_conversation={**source_conversation, "id": conversation_id},
+            correction_id=correction_id,
+            trace_id=trace_id,
+            correction_text=request.correction_text,
+            correction_type=_correction_category(request.correction_text, request.summary_context),
+        )
+        payload = propagation_run_to_dict(run)
+        _persist_correction_propagation_run(uid, conversation_id, correction_id, payload)
+        _append_correction_event(
+            uid,
+            conversation_id,
+            correction_id,
+            {
+                "stage": "propagation_run_completed",
+                "status": run.status,
+                "at": _now_iso(),
+                "trace_id": trace_id,
+                "run_id": run.run_id,
+                "candidate_count": run.candidate_count,
+                "proposal_count": run.proposal_count,
+                "skipped_count": run.skipped_count,
+            },
+        )
+        _persist_correction_audit(
+            uid,
+            conversation_id,
+            correction_id,
+            {
+                "propagation_run_id": run.run_id,
+                "propagation_status": run.status,
+                "propagation_candidate_count": run.candidate_count,
+                "propagation_proposal_count": run.proposal_count,
+                "updated_at": _now_iso(),
+            },
+        )
+    except Exception as exc:
+        logger.exception(
+            "Correction propagation run failed",
+            extra={"uid": uid, "conversation_id": conversation_id, "correction_id": correction_id},
+        )
+        _append_correction_event(
+            uid,
+            conversation_id,
+            correction_id,
+            {
+                "stage": "propagation_run_failed",
+                "status": "error",
+                "at": _now_iso(),
+                "trace_id": trace_id,
+                "error": str(exc),
+            },
+        )
+
+
+async def _queue_correction_observer_work(
+    *,
+    background_tasks: Optional[BackgroundTasks],
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+    trace_id: str,
+    request: ConversationCorrectionRequest,
+    source_conversation: dict[str, Any],
+    structured: dict[str, Any],
+    submitted_at: str,
+    active_summary_version_id: Optional[str],
+    proposal_id: Optional[str],
+) -> None:
+    await _emit_canonical_correction_event(
+        uid=uid,
+        conversation_id=conversation_id,
+        correction_id=correction_id,
+        trace_id=trace_id,
+        request=request,
+        structured=structured,
+        submitted_at=submitted_at,
+        active_summary_version_id=active_summary_version_id,
+        proposal_id=proposal_id,
+    )
+    if not CORRECTION_PROPAGATION_ENABLED:
+        return
+    propagation_kwargs = {
+        "uid": uid,
+        "conversation_id": conversation_id,
+        "correction_id": correction_id,
+        "trace_id": trace_id,
+        "request": request,
+        "source_conversation": source_conversation,
+    }
+    if background_tasks is not None:
+        background_tasks.add_task(_run_correction_propagation_for_submission, **propagation_kwargs)
+        _append_correction_event(
+            uid,
+            conversation_id,
+            correction_id,
+            {
+                "stage": "propagation_run_queued",
+                "status": "ok",
+                "at": _now_iso(),
+                "trace_id": trace_id,
+                "queue_result": {"mode": "background_correction_observer"},
+            },
+        )
+        return
+    await _run_correction_propagation_for_submission(**propagation_kwargs)
+
+
 def _summary_correction_claims(*, uid: str, trace_id: str) -> dict[str, Any]:
     return {
         "sub": f"omi-user:{uid}",
@@ -780,6 +1011,20 @@ async def _submit_conversation_correction(
             correction_id,
             {"stage": "proposal_failed", "status": "error", "at": _now_iso(), "trace_id": trace_id, "error": str(exc)},
         )
+
+    await _queue_correction_observer_work(
+        background_tasks=background_tasks,
+        uid=uid,
+        conversation_id=conversation_id,
+        correction_id=correction_id,
+        trace_id=trace_id,
+        request=request,
+        source_conversation=conversation,
+        structured=structured,
+        submitted_at=submitted_at,
+        active_summary_version_id=submitted_state.get("active_summary_version_id"),
+        proposal_id=proposal_id,
+    )
 
     if DIRECT_CORRECTION_APPLY_ENABLED:
         direct_apply_kwargs = {

--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -64,7 +64,16 @@ CORRECTION_CANONICAL_EVENT_ENABLED = os.getenv("ELLA_CORRECTION_CANONICAL_EVENT_
     "false",
     "no",
 }
-CORRECTION_PROPAGATION_ENABLED = os.getenv("ELLA_CORRECTION_PROPAGATION_ENABLED", "true").lower() not in {
+CORRECTION_PROPAGATION_ENABLED = os.getenv("ELLA_CORRECTION_PROPAGATION_ENABLED", "false").lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+CORRECTION_OBSERVER_WORK_ENABLED = CORRECTION_CANONICAL_EVENT_ENABLED or CORRECTION_PROPAGATION_ENABLED
+CORRECTION_OBSERVER_WORK_INLINE_WITHOUT_BACKGROUND = os.getenv(
+    "ELLA_CORRECTION_OBSERVER_WORK_INLINE_WITHOUT_BACKGROUND", "true"
+).lower() not in {
     "0",
     "false",
     "no",
@@ -613,9 +622,8 @@ async def _run_correction_propagation_for_submission(
         )
 
 
-async def _queue_correction_observer_work(
+async def _run_correction_observer_work(
     *,
-    background_tasks: Optional[BackgroundTasks],
     uid: str,
     conversation_id: str,
     correction_id: str,
@@ -638,24 +646,52 @@ async def _queue_correction_observer_work(
         active_summary_version_id=active_summary_version_id,
         proposal_id=proposal_id,
     )
-    if not CORRECTION_PROPAGATION_ENABLED:
+    await _run_correction_propagation_for_submission(
+        uid=uid,
+        conversation_id=conversation_id,
+        correction_id=correction_id,
+        trace_id=trace_id,
+        request=request,
+        source_conversation=source_conversation,
+    )
+
+
+async def _queue_correction_observer_work(
+    *,
+    background_tasks: Optional[BackgroundTasks],
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+    trace_id: str,
+    request: ConversationCorrectionRequest,
+    source_conversation: dict[str, Any],
+    structured: dict[str, Any],
+    submitted_at: str,
+    active_summary_version_id: Optional[str],
+    proposal_id: Optional[str],
+) -> None:
+    if not CORRECTION_OBSERVER_WORK_ENABLED:
         return
-    propagation_kwargs = {
+    observer_kwargs = {
         "uid": uid,
         "conversation_id": conversation_id,
         "correction_id": correction_id,
         "trace_id": trace_id,
         "request": request,
         "source_conversation": source_conversation,
+        "structured": structured,
+        "submitted_at": submitted_at,
+        "active_summary_version_id": active_summary_version_id,
+        "proposal_id": proposal_id,
     }
     if background_tasks is not None:
-        background_tasks.add_task(_run_correction_propagation_for_submission, **propagation_kwargs)
+        background_tasks.add_task(_run_correction_observer_work, **observer_kwargs)
         _append_correction_event(
             uid,
             conversation_id,
             correction_id,
             {
-                "stage": "propagation_run_queued",
+                "stage": "observer_work_queued",
                 "status": "ok",
                 "at": _now_iso(),
                 "trace_id": trace_id,
@@ -663,7 +699,8 @@ async def _queue_correction_observer_work(
             },
         )
         return
-    await _run_correction_propagation_for_submission(**propagation_kwargs)
+    if CORRECTION_OBSERVER_WORK_INLINE_WITHOUT_BACKGROUND:
+        await _run_correction_observer_work(**observer_kwargs)
 
 
 def _summary_correction_claims(*, uid: str, trace_id: str) -> dict[str, Any]:

--- a/backend/ella/services/correction_propagation.py
+++ b/backend/ella/services/correction_propagation.py
@@ -1,0 +1,495 @@
+"""Conservative OMI correction propagation worker.
+
+OMI keeps evidence, audit records, candidate decisions, and rollback pointers.
+Durable user facts remain owned by Hermes/Honcho and are represented here as
+proposal records until that write contract is explicit.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+from pydantic import BaseModel, Field
+
+from database._client import db
+from ella.services import proposal_ingest
+
+PROPAGATION_TOOL_NAME = "omi_correction_propagation_propose"
+STOPWORDS = {
+    "about",
+    "actually",
+    "after",
+    "also",
+    "and",
+    "are",
+    "audio",
+    "before",
+    "conversation",
+    "correct",
+    "correction",
+    "did",
+    "for",
+    "from",
+    "had",
+    "has",
+    "have",
+    "not",
+    "omi",
+    "please",
+    "said",
+    "summary",
+    "that",
+    "the",
+    "this",
+    "was",
+    "were",
+    "with",
+}
+TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9'_-]{2,}", re.I)
+
+
+class CorrectionPropagationDecision(BaseModel):
+    conversation_id: str = ""
+    action: str
+    reason: str = ""
+    confidence: float = 0.0
+    skipped_reasons: list[str] = Field(default_factory=list)
+    overlap_terms: list[str] = Field(default_factory=list)
+    idempotency_key: str = ""
+    proposal_id: str = ""
+    active_summary_version_id: str = ""
+    rollback_ref: dict[str, Any] = Field(default_factory=dict)
+
+
+class CorrectionPropagationRun(BaseModel):
+    run_id: str
+    uid: str
+    source_conversation_id: str
+    correction_id: str
+    trace_id: str
+    correction_type: str
+    status: str = "success"
+    dry_run: bool = False
+    started_at: datetime
+    completed_at: datetime
+    latency_ms: int = 0
+    candidate_count: int = 0
+    proposal_count: int = 0
+    skipped_count: int = 0
+    auto_applied_count: int = 0
+    decisions: list[CorrectionPropagationDecision] = Field(default_factory=list)
+    model_metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value or {}, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _stable_hash(value: Any) -> str:
+    return hashlib.sha256(_stable_json(value).encode("utf-8")).hexdigest()[:16]
+
+
+def _as_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+    elif hasattr(value, "timestamp"):
+        try:
+            parsed = datetime.fromtimestamp(value.timestamp(), timezone.utc)
+        except Exception:
+            return None
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _conversation_time(conversation: dict[str, Any]) -> datetime:
+    for key in ("started_at", "created_at", "finished_at", "updated_at"):
+        parsed = _as_datetime(conversation.get(key))
+        if parsed:
+            return parsed
+    return _now()
+
+
+def _summary_text(conversation: dict[str, Any]) -> str:
+    structured = conversation.get("structured") if isinstance(conversation.get("structured"), dict) else {}
+    return " ".join(
+        str(value or "")
+        for value in (
+            conversation.get("title"),
+            conversation.get("overview"),
+            structured.get("title"),
+            structured.get("overview"),
+            structured.get("category"),
+            conversation.get("category"),
+        )
+    )
+
+
+def _transcript_text(conversation: dict[str, Any], max_segments: int = 30) -> str:
+    segments = conversation.get("transcript_segments") or []
+    if not isinstance(segments, list):
+        return ""
+    return " ".join(str(segment.get("text") or "") for segment in segments[:max_segments] if isinstance(segment, dict))
+
+
+def _terms(*values: str) -> set[str]:
+    raw = " ".join(values).lower()
+    return {token for token in TOKEN_RE.findall(raw) if token not in STOPWORDS and len(token) >= 3}
+
+
+def _active_summary_version(conversation: dict[str, Any]) -> str:
+    return str(conversation.get("active_summary_version_id") or "")
+
+
+def _active_version_compatible(conversation: dict[str, Any]) -> bool:
+    active = _active_summary_version(conversation)
+    if not active:
+        return True
+    versions = conversation.get("summary_versions") or []
+    if not versions:
+        return True
+    for version in versions:
+        if not isinstance(version, dict):
+            continue
+        if str(version.get("id") or "") == active:
+            return bool(version.get("is_active", True))
+    return False
+
+
+def _conversation_id(conversation: dict[str, Any]) -> str:
+    return str(conversation.get("id") or conversation.get("conversation_id") or "")
+
+
+def _source_ref(conversation: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "conversation_id": _conversation_id(conversation),
+        "active_summary_version_id": _active_summary_version(conversation),
+        "created_at": _conversation_time(conversation).isoformat(),
+    }
+
+
+def _load_related_conversations(uid: str, source_conversation: dict[str, Any], *, limit: int) -> list[dict[str, Any]]:
+    """Best-effort Firestore bounded same-user loader.
+
+    Unit tests can inject a candidate_loader; production keeps this narrow and
+    returns [] if Firestore cannot satisfy the local query.
+    """
+    source_at = _conversation_time(source_conversation)
+    window_hours = max(1, min(int(os.getenv("ELLA_CORRECTION_PROPAGATION_WINDOW_HOURS", "12")), 48))
+    start = source_at - timedelta(hours=window_hours)
+    end = source_at + timedelta(hours=window_hours)
+    try:
+        query = (
+            db.collection("users")
+            .document(uid)
+            .collection("conversations")
+            .where("created_at", ">=", start)
+            .where("created_at", "<=", end)
+            .limit(limit)
+        )
+        conversations: list[dict[str, Any]] = []
+        for snapshot in query.stream():
+            data = snapshot.to_dict() or {}
+            data.setdefault("id", getattr(snapshot, "id", ""))
+            conversations.append(data)
+        return conversations
+    except Exception:
+        return []
+
+
+def _score_candidate(
+    *,
+    source_terms: set[str],
+    source_time: datetime,
+    correction_type: str,
+    candidate: dict[str, Any],
+) -> tuple[float, list[str], list[str]]:
+    skipped: list[str] = []
+    candidate_time = _conversation_time(candidate)
+    delta_seconds = abs((candidate_time - source_time).total_seconds())
+    window_hours = max(1, min(int(os.getenv("ELLA_CORRECTION_PROPAGATION_WINDOW_HOURS", "12")), 48))
+    if delta_seconds > window_hours * 3600:
+        skipped.append("outside_local_window")
+    if not _active_version_compatible(candidate):
+        skipped.append("active_summary_version_incompatible")
+
+    candidate_terms = _terms(_summary_text(candidate), _transcript_text(candidate, max_segments=20))
+    overlap = sorted(source_terms & candidate_terms)
+    if not overlap:
+        skipped.append("no_keyword_entity_overlap")
+
+    overlap_score = min(1.0, len(overlap) / max(3, min(len(source_terms), 10)))
+    same_day_score = 1.0 if source_time.date() == candidate_time.date() else 0.0
+    source_score = (
+        1.0 if str(candidate.get("source") or candidate.get("channel") or "omi").lower() in {"omi", "necklace"} else 0.5
+    )
+    correction_score = 0.1 if correction_type in {"identity", "media", "topic", "title"} else 0.0
+    confidence = min(1.0, 0.42 * overlap_score + 0.28 * same_day_score + 0.2 * source_score + correction_score)
+    return round(confidence, 3), skipped, overlap[:20]
+
+
+def _claims(uid: str, trace_id: str) -> dict[str, Any]:
+    return {
+        "sub": "ella-correction-observer",
+        "profile_uid": uid,
+        "role": "system_observer",
+        "external_provider": "omi_backend",
+        "grant_id": "omi-correction-propagation",
+        "trace_id": trace_id,
+        "scopes": ["proposals:write"],
+        "allowed_tools": [PROPAGATION_TOOL_NAME],
+    }
+
+
+def _proposal_payload(
+    *,
+    uid: str,
+    source_conversation: dict[str, Any],
+    candidate: dict[str, Any],
+    correction_id: str,
+    correction_text: str,
+    correction_type: str,
+    trace_id: str,
+    confidence: float,
+    overlap_terms: list[str],
+) -> dict[str, Any]:
+    candidate_id = _conversation_id(candidate)
+    source_id = _conversation_id(source_conversation)
+    return {
+        "title": f"Propagate OMI correction to related conversation {candidate_id}",
+        "description": correction_text,
+        "target": {
+            "kind": "omi_conversation_summary",
+            "conversation_id": candidate_id,
+            "active_summary_version_id": _active_summary_version(candidate),
+            "correction_id": correction_id,
+        },
+        "evidence": [
+            {
+                "kind": "source_correction",
+                "uid": uid,
+                "conversation_id": source_id,
+                "correction_id": correction_id,
+                "trace_id": trace_id,
+                "correction_text": correction_text,
+                "correction_type": correction_type,
+            },
+            {"kind": "source_conversation_summary", "content": _summary_text(source_conversation)[:2000]},
+            {"kind": "candidate_conversation_summary", "content": _summary_text(candidate)[:2000]},
+            {"kind": "candidate_transcript_excerpt", "content": _transcript_text(candidate, max_segments=12)[:3000]},
+            {"kind": "overlap_terms", "terms": overlap_terms},
+        ],
+        "requested_change": {
+            "correction_text": correction_text,
+            "correction_type": correction_type,
+            "source_conversation_id": source_id,
+            "related_conversation_id": candidate_id,
+            "confidence": confidence,
+            "durable_owner": "honcho/hermes",
+            "honcho_write_contract": "pending",
+        },
+        "source": "omi_correction_observer",
+        "write_policy": "proposal_only",
+        "reason": "Bounded same-user OMI correction propagation candidate.",
+        "confidence": confidence,
+    }
+
+
+def _dump_run(run: CorrectionPropagationRun) -> dict[str, Any]:
+    if hasattr(run, "model_dump"):
+        return run.model_dump(mode="json")
+    return run.dict()
+
+
+def run_correction_propagation(
+    *,
+    uid: str,
+    source_conversation: dict[str, Any],
+    correction_id: str,
+    trace_id: str,
+    correction_text: str,
+    correction_type: str,
+    candidate_loader: Callable[..., list[dict[str, Any]]] | None = None,
+    create_proposal: Callable[..., dict[str, Any]] = proposal_ingest.create_proposal,
+    dry_run: bool = False,
+    limit: int = 25,
+    min_confidence: float | None = None,
+) -> CorrectionPropagationRun:
+    started = _now()
+    monotonic_start = time.monotonic()
+    source_id = _conversation_id(source_conversation)
+    run_id = f"omi-correction-propagation:{uid}:{source_id}:{correction_id}"
+    confidence_threshold = (
+        min_confidence
+        if min_confidence is not None
+        else float(os.getenv("ELLA_CORRECTION_PROPAGATION_MIN_CONFIDENCE", "0.82"))
+    )
+    candidate_limit = max(1, min(int(limit or 25), 100))
+    loader = candidate_loader or _load_related_conversations
+    candidates = loader(uid, source_conversation, limit=candidate_limit)
+    source_time = _conversation_time(source_conversation)
+    source_terms = _terms(correction_text, _summary_text(source_conversation), _transcript_text(source_conversation))
+    decisions: list[CorrectionPropagationDecision] = []
+    proposal_count = 0
+
+    for candidate in candidates:
+        candidate_id = _conversation_id(candidate)
+        if candidate_id == source_id:
+            decisions.append(
+                CorrectionPropagationDecision(conversation_id=candidate_id, action="skip", reason="source_conversation")
+            )
+            continue
+        candidate_uid = str(candidate.get("uid") or candidate.get("profile_uid") or uid)
+        if candidate_uid != uid:
+            decisions.append(
+                CorrectionPropagationDecision(
+                    conversation_id=candidate_id,
+                    action="skip",
+                    reason="cross_user_candidate",
+                    skipped_reasons=["cross_user_candidate"],
+                )
+            )
+            continue
+
+        confidence, skipped, overlap = _score_candidate(
+            source_terms=source_terms,
+            source_time=source_time,
+            correction_type=correction_type,
+            candidate=candidate,
+        )
+        if skipped or confidence < confidence_threshold:
+            decisions.append(
+                CorrectionPropagationDecision(
+                    conversation_id=candidate_id,
+                    action="skip",
+                    reason="candidate_below_threshold" if confidence < confidence_threshold else skipped[0],
+                    confidence=confidence,
+                    skipped_reasons=skipped,
+                    overlap_terms=overlap,
+                    active_summary_version_id=_active_summary_version(candidate),
+                    rollback_ref=_source_ref(candidate),
+                )
+            )
+            continue
+
+        payload = _proposal_payload(
+            uid=uid,
+            source_conversation=source_conversation,
+            candidate=candidate,
+            correction_id=correction_id,
+            correction_text=correction_text,
+            correction_type=correction_type,
+            trace_id=trace_id,
+            confidence=confidence,
+            overlap_terms=overlap,
+        )
+        idempotency_key = f"omi-correction-propagation:{uid}:{correction_id}:{candidate_id}:{_stable_hash(payload)}"
+        if dry_run:
+            decisions.append(
+                CorrectionPropagationDecision(
+                    conversation_id=candidate_id,
+                    action="would_create_proposal",
+                    reason="high_confidence_same_user_candidate",
+                    confidence=confidence,
+                    overlap_terms=overlap,
+                    idempotency_key=idempotency_key,
+                    active_summary_version_id=_active_summary_version(candidate),
+                    rollback_ref=_source_ref(candidate),
+                )
+            )
+            proposal_count += 1
+            continue
+
+        try:
+            result = create_proposal(
+                session_claims=_claims(uid, trace_id),
+                tool_name=PROPAGATION_TOOL_NAME,
+                proposal_type="summary_correction",
+                payload=payload,
+                idempotency_key=idempotency_key,
+            )
+            proposal = result.get("proposal") or {}
+            proposal_id = str(proposal.get("proposal_id") or "")
+            decisions.append(
+                CorrectionPropagationDecision(
+                    conversation_id=candidate_id,
+                    action="created_proposal" if result.get("created") else "deduped_proposal",
+                    reason="high_confidence_same_user_candidate",
+                    confidence=confidence,
+                    overlap_terms=overlap,
+                    idempotency_key=idempotency_key,
+                    proposal_id=proposal_id,
+                    active_summary_version_id=_active_summary_version(candidate),
+                    rollback_ref=_source_ref(candidate),
+                )
+            )
+            proposal_count += 1
+        except Exception as exc:
+            decisions.append(
+                CorrectionPropagationDecision(
+                    conversation_id=candidate_id,
+                    action="error",
+                    reason="proposal_create_failed",
+                    confidence=confidence,
+                    skipped_reasons=[str(exc)],
+                    overlap_terms=overlap,
+                    idempotency_key=idempotency_key,
+                    active_summary_version_id=_active_summary_version(candidate),
+                    rollback_ref=_source_ref(candidate),
+                )
+            )
+
+    completed = _now()
+    skipped_count = sum(1 for decision in decisions if decision.action == "skip")
+    error_count = sum(1 for decision in decisions if decision.action == "error")
+    return CorrectionPropagationRun(
+        run_id=run_id,
+        uid=uid,
+        source_conversation_id=source_id,
+        correction_id=correction_id,
+        trace_id=trace_id,
+        correction_type=correction_type,
+        status="error" if error_count else "success",
+        dry_run=dry_run,
+        started_at=started,
+        completed_at=completed,
+        latency_ms=int((time.monotonic() - monotonic_start) * 1000),
+        candidate_count=len(candidates),
+        proposal_count=proposal_count,
+        skipped_count=skipped_count,
+        auto_applied_count=0,
+        decisions=decisions,
+        model_metadata={
+            "candidate_bounds": {
+                "same_uid_only": True,
+                "window_hours": int(os.getenv("ELLA_CORRECTION_PROPAGATION_WINDOW_HOURS", "12")),
+                "min_confidence": confidence_threshold,
+                "source_preference": "omi/necklace",
+            },
+            "durable_owner": "honcho/hermes",
+            "write_policy": "proposal_only",
+        },
+    )
+
+
+def propagation_run_to_dict(run: CorrectionPropagationRun) -> dict[str, Any]:
+    return _dump_run(run)

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -446,8 +446,8 @@ def test_submit_correction_queues_background_direct_apply_without_waiting(monkey
     assert events[-1]["stage"] == "direct_apply_queued"
     assert conversation_updates[-1]["correction_state"]["status"] == "queued"
 
-    propagation_func, _, _ = background_tasks.tasks[0]
-    assert propagation_func is corrections._run_correction_propagation_for_submission
+    observer_func, _, _ = background_tasks.tasks[0]
+    assert observer_func is corrections._run_correction_observer_work
 
     func, args, kwargs = background_tasks.tasks[1]
     assert func is corrections._run_direct_correction_apply
@@ -459,7 +459,7 @@ def test_submit_correction_queues_background_direct_apply_without_waiting(monkey
     assert events[-1]["stage"] == "direct_apply_succeeded"
 
 
-def test_submit_correction_emits_canonical_event_and_queues_observer_propagation(monkeypatch):
+def test_submit_correction_queues_observer_work_without_blocking_on_canonical_event(monkeypatch):
     emitted = {}
     events = []
     conversation_updates = []
@@ -476,6 +476,8 @@ def test_submit_correction_emits_canonical_event_and_queues_observer_propagation
 
     monkeypatch.setattr(corrections, "DIRECT_CORRECTION_APPLY_ENABLED", False)
     monkeypatch.setattr(corrections, "N8N_CORRECTION_FALLBACK_ENABLED", False)
+    monkeypatch.setattr(corrections, "CORRECTION_PROPAGATION_ENABLED", True)
+    monkeypatch.setattr(corrections, "CORRECTION_OBSERVER_WORK_ENABLED", True)
     monkeypatch.setattr(corrections.conversations_db, "get_conversation", lambda uid, conversation_id: _conversation())
     monkeypatch.setattr(corrections.conversations_db, "bootstrap_summary_versioning_update", lambda conversation: {})
     monkeypatch.setattr(
@@ -499,18 +501,26 @@ def test_submit_correction_emits_canonical_event_and_queues_observer_propagation
     )
 
     assert result.status == "direct_apply_disabled"
+    assert emitted == {}
+    assert len(background_tasks.tasks) == 1
+    func, args, kwargs = background_tasks.tasks[0]
+    assert func is corrections._run_correction_observer_work
+    assert kwargs["uid"] == "user-123"
+    assert kwargs["conversation_id"] == "conv-123"
+    assert kwargs["correction_id"] == result.correction_id
+    assert any(event["stage"] == "observer_work_queued" for event in events)
+
+    asyncio.run(func(*args, **kwargs))
+
     assert emitted["uid"] == "user-123"
     assert emitted["conversation_id"] == "conv-123"
     assert emitted["correction_id"] == result.correction_id
     assert emitted["proposal_id"] == "proposal-123"
     assert emitted["request"].correction_text == "Actually this was background TV audio."
-    assert len(background_tasks.tasks) == 1
-    func, args, kwargs = background_tasks.tasks[0]
-    assert func is corrections._run_correction_propagation_for_submission
-    assert kwargs["uid"] == "user-123"
-    assert kwargs["conversation_id"] == "conv-123"
-    assert kwargs["correction_id"] == result.correction_id
-    assert any(event["stage"] == "propagation_run_queued" for event in events)
+
+
+def test_correction_propagation_feature_flag_defaults_off():
+    assert corrections.CORRECTION_PROPAGATION_ENABLED is False
 
 
 def test_router_uses_custom_ella_namespace_only():

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -26,6 +26,18 @@ _corrections_spec.loader.exec_module(corrections)
 corrections.ELLA_CONFIG = SimpleNamespace(n8n_base_url="https://n8n.test")
 
 
+@pytest.fixture(autouse=True)
+def _disable_external_observer_side_effects(monkeypatch):
+    async def noop_emit(**kwargs):
+        return None
+
+    async def noop_propagate(**kwargs):
+        return None
+
+    monkeypatch.setattr(corrections, "_emit_canonical_correction_event", noop_emit)
+    monkeypatch.setattr(corrections, "_run_correction_propagation_for_submission", noop_propagate)
+
+
 def _conversation():
     return {
         "transcript_segments": [
@@ -427,14 +439,17 @@ def test_submit_correction_queues_background_direct_apply_without_waiting(monkey
     assert result.status == "queued"
     assert result.queued is True
     assert result.proposal_id == "proposal-123"
-    assert len(background_tasks.tasks) == 1
+    assert len(background_tasks.tasks) == 2
     assert generated == []
     assert audits[-1]["status"] == "queued"
     assert audits[-1]["queue_result"] == {"mode": "background_direct_apply"}
     assert events[-1]["stage"] == "direct_apply_queued"
     assert conversation_updates[-1]["correction_state"]["status"] == "queued"
 
-    func, args, kwargs = background_tasks.tasks[0]
+    propagation_func, _, _ = background_tasks.tasks[0]
+    assert propagation_func is corrections._run_correction_propagation_for_submission
+
+    func, args, kwargs = background_tasks.tasks[1]
     assert func is corrections._run_direct_correction_apply
     asyncio.run(func(*args, **kwargs))
 
@@ -442,6 +457,60 @@ def test_submit_correction_queues_background_direct_apply_without_waiting(monkey
     assert generated[0]["conversation_id"] == "conv-123"
     assert audits[-1]["status"] == "applied"
     assert events[-1]["stage"] == "direct_apply_succeeded"
+
+
+def test_submit_correction_emits_canonical_event_and_queues_observer_propagation(monkeypatch):
+    emitted = {}
+    events = []
+    conversation_updates = []
+
+    class FakeBackgroundTasks:
+        def __init__(self):
+            self.tasks = []
+
+        def add_task(self, func, *args, **kwargs):
+            self.tasks.append((func, args, kwargs))
+
+    async def capture_emit(**kwargs):
+        emitted.update(kwargs)
+
+    monkeypatch.setattr(corrections, "DIRECT_CORRECTION_APPLY_ENABLED", False)
+    monkeypatch.setattr(corrections, "N8N_CORRECTION_FALLBACK_ENABLED", False)
+    monkeypatch.setattr(corrections.conversations_db, "get_conversation", lambda uid, conversation_id: _conversation())
+    monkeypatch.setattr(corrections.conversations_db, "bootstrap_summary_versioning_update", lambda conversation: {})
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "update_conversation",
+        lambda uid, conversation_id, update_data: conversation_updates.append(update_data),
+    )
+    monkeypatch.setattr(corrections, "_persist_correction_audit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(corrections, "_append_correction_event", lambda uid, cid, corr_id, event: events.append(event))
+    monkeypatch.setattr(corrections, "_create_summary_correction_proposal", lambda **kwargs: "proposal-123")
+    monkeypatch.setattr(corrections, "_emit_canonical_correction_event", capture_emit)
+
+    background_tasks = FakeBackgroundTasks()
+    result = asyncio.run(
+        corrections.submit_conversation_correction(
+            "conv-123",
+            corrections.ConversationCorrectionRequest(correction_text="Actually this was background TV audio."),
+            background_tasks=background_tasks,
+            uid="user-123",
+        )
+    )
+
+    assert result.status == "direct_apply_disabled"
+    assert emitted["uid"] == "user-123"
+    assert emitted["conversation_id"] == "conv-123"
+    assert emitted["correction_id"] == result.correction_id
+    assert emitted["proposal_id"] == "proposal-123"
+    assert emitted["request"].correction_text == "Actually this was background TV audio."
+    assert len(background_tasks.tasks) == 1
+    func, args, kwargs = background_tasks.tasks[0]
+    assert func is corrections._run_correction_propagation_for_submission
+    assert kwargs["uid"] == "user-123"
+    assert kwargs["conversation_id"] == "conv-123"
+    assert kwargs["correction_id"] == result.correction_id
+    assert any(event["stage"] == "propagation_run_queued" for event in events)
 
 
 def test_router_uses_custom_ella_namespace_only():

--- a/backend/tests/unit/test_ella_correction_propagation.py
+++ b/backend/tests/unit/test_ella_correction_propagation.py
@@ -1,0 +1,129 @@
+from datetime import datetime, timezone
+import sys
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("database._client", MagicMock(db=MagicMock()))
+from ella.services.correction_propagation import run_correction_propagation
+
+
+def _conversation(conversation_id: str, uid: str, title: str, overview: str, text: str, hour: int = 9):
+    return {
+        "id": conversation_id,
+        "uid": uid,
+        "created_at": datetime(2026, 5, 29, hour, 30, tzinfo=timezone.utc),
+        "source": "omi",
+        "structured": {
+            "title": title,
+            "overview": overview,
+            "category": "education",
+        },
+        "active_summary_version_id": f"{conversation_id}-v1",
+        "summary_versions": [{"id": f"{conversation_id}-v1", "is_active": True}],
+        "transcript_segments": [{"speaker": "Speaker", "text": text}],
+    }
+
+
+def test_correction_propagation_creates_idempotent_same_user_candidate_proposal():
+    source = _conversation(
+        "conv-source",
+        "user-123",
+        "Mei Xin teacher meeting",
+        "[Ella] The summary called Mei Xin a teen.",
+        "Mei Xin wanted to email her teacher instead of meeting in person.",
+    )
+    related = _conversation(
+        "conv-related",
+        "user-123",
+        "Teacher email follow-up",
+        "[Ella] Mei Xin discussed emailing her teacher.",
+        "Mei Xin and Greg talked about the teacher email plan.",
+    )
+    other_user = _conversation(
+        "conv-other-user",
+        "user-999",
+        "Teacher email follow-up",
+        "[Ella] Mei Xin discussed emailing her teacher.",
+        "Mei Xin and Greg talked about the teacher email plan.",
+    )
+    unrelated = _conversation(
+        "conv-unrelated",
+        "user-123",
+        "Grocery list",
+        "[Ella] Plato bought apples.",
+        "Apples and bread were on the list.",
+    )
+    seen = {}
+
+    def load_candidates(uid, source_conversation, limit):
+        assert uid == "user-123"
+        return [source_conversation, related, other_user, unrelated]
+
+    def create_proposal(**kwargs):
+        key = kwargs["idempotency_key"]
+        if key in seen:
+            return {"created": False, "deduped": True, "proposal": seen[key]}
+        proposal = {
+            "proposal_id": "proposal-related",
+            "idempotency_key": key,
+            "payload": kwargs["payload"],
+        }
+        seen[key] = proposal
+        return {"created": True, "deduped": False, "proposal": proposal}
+
+    run1 = run_correction_propagation(
+        uid="user-123",
+        source_conversation=source,
+        correction_id="corr-123",
+        trace_id="trace-123",
+        correction_text="Actually Mei Xin, also called Rain, was the student emailing the teacher.",
+        correction_type="identity",
+        candidate_loader=load_candidates,
+        create_proposal=create_proposal,
+        min_confidence=0.7,
+    )
+    run2 = run_correction_propagation(
+        uid="user-123",
+        source_conversation=source,
+        correction_id="corr-123",
+        trace_id="trace-123",
+        correction_text="Actually Mei Xin, also called Rain, was the student emailing the teacher.",
+        correction_type="identity",
+        candidate_loader=load_candidates,
+        create_proposal=create_proposal,
+        min_confidence=0.7,
+    )
+
+    assert run1.run_id == "omi-correction-propagation:user-123:conv-source:corr-123"
+    assert run1.proposal_count == 1
+    assert run1.auto_applied_count == 0
+    assert [d.action for d in run1.decisions].count("created_proposal") == 1
+    assert any(d.reason == "cross_user_candidate" for d in run1.decisions)
+    assert any(d.conversation_id == "conv-unrelated" and d.action == "skip" for d in run1.decisions)
+    created = next(d for d in run1.decisions if d.action == "created_proposal")
+    assert created.conversation_id == "conv-related"
+    assert "teacher" in created.overlap_terms
+    assert run2.proposal_count == 1
+    assert any(d.action == "deduped_proposal" for d in run2.decisions)
+    assert len(seen) == 1
+
+
+def test_correction_propagation_skips_active_version_incompatible_candidate():
+    source = _conversation("conv-source", "user-123", "Cafe order", "[Ella] Cafe order.", "Cafe Coffee Waffle Stop.")
+    stale = _conversation("conv-stale", "user-123", "Cafe order", "[Ella] Cafe order.", "Cafe Coffee Waffle Stop.")
+    stale["active_summary_version_id"] = "missing-active-version"
+
+    run = run_correction_propagation(
+        uid="user-123",
+        source_conversation=source,
+        correction_id="corr-123",
+        trace_id="trace-123",
+        correction_text="Actually the cafe was Cafe Coffee and Waffle Stop.",
+        correction_type="title",
+        candidate_loader=lambda uid, source_conversation, limit: [stale],
+        create_proposal=lambda **kwargs: {"created": True, "proposal": {"proposal_id": "should-not-create"}},
+        min_confidence=0.1,
+    )
+
+    assert run.proposal_count == 0
+    assert run.decisions[0].action == "skip"
+    assert "active_summary_version_incompatible" in run.decisions[0].skipped_reasons


### PR DESCRIPTION
## Summary
- emit a canonical `omi_correction` / `summary_correction_submitted` event when a summary correction is submitted
- queue a backend correction Observer propagation run from correction submit
- add a conservative same-user bounded propagation worker that records candidate decisions and creates idempotent summary-correction proposals instead of writing durable facts directly
- persist propagation run records under the correction audit path with candidate/proposal/skipped counts and rollback refs

## Safety
- no broad all-history rewrite: candidates are same uid, bounded by local time window, source preference, keyword/entity overlap, and active summary version compatibility
- no cross-user propagation
- Honcho/Hermes remains durable owner; this PR only creates auditable proposals and does not mutate caregiver/scanner state
- auto-apply count stays zero until the Honcho/session write contract is explicit

## Validation
- `python3 -m py_compile ella/routers/corrections.py ella/services/correction_propagation.py tests/unit/test_ella_conversation_corrections.py tests/unit/test_ella_correction_propagation.py`
- `pytest tests/unit/test_ella_correction_propagation.py tests/unit/test_ella_conversation_corrections.py tests/unit/test_ella_canonical_omi.py -q` -> 20 passed
- `git diff --check`

## Notes
- Attempted `npx gitnexus analyze`; it hung for over 4 minutes after the initial large-file skip notice, so I stopped it rather than leave a runaway process.
- `tests/unit/test_ella_observer.py` still cannot be collected in this local Python 3.14 environment due an existing FastAPI/Starlette `TestClient` metaclass conflict before project code runs.

Fixes ellaaicare/ella-ai#1012