### PR TITLE
Implement correction Honcho fact contract

### DIFF
--- a/backend/ella/services/correction_honcho_contract.py
+++ b/backend/ella/services/correction_honcho_contract.py
@@ -1,0 +1,438 @@
+"""Durable Honcho contract for OMI correction-derived facts.
+
+OMI owns correction evidence, proposals, audit trails, and rollback pointers.
+Hermes/Honcho owns durable facts. This module defines the boundary between the
+two systems without adding an OMI fact/entity store.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+import httpx
+from pydantic import BaseModel, Field
+
+from ella.services import proposal_ingest
+
+HONCHO_FACT_TOOL_NAME = "omi_correction_honcho_fact_propose"
+HONCHO_FACT_WRITE_TOOL_NAME = "omi_correction_honcho_fact_write"
+HONCHO_FACT_PROPOSALS_ENABLED = os.getenv("ELLA_CORRECTION_HONCHO_FACT_PROPOSALS_ENABLED", "true").lower() not in {
+    "0",
+    "false",
+    "no",
+}
+HONCHO_FACT_WRITE_ENABLED = os.getenv("ELLA_CORRECTION_HONCHO_FACT_WRITE_ENABLED", "false").lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+HONCHO_FACT_MIN_CONFIDENCE = float(os.getenv("ELLA_CORRECTION_HONCHO_FACT_MIN_CONFIDENCE", "0.9"))
+HERMES_GATEWAY_URL = os.getenv("HERMES_GATEWAY_URL", "http://100.76.138.56:8642").rstrip("/")
+HERMES_MODEL = os.getenv("HERMES_MODEL", "plato-eval")
+HERMES_TIMEOUT_SECONDS = float(os.getenv("ELLA_CORRECTION_HONCHO_FACT_TIMEOUT_SECONDS", "20"))
+
+TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9'_-]{2,}", re.I)
+PERSON_MARKERS = re.compile(
+    r"(?i)(?:is|was|named|called|a\\.k\\.a\\.|aka|person is|speaker is)\\s+([A-Z][A-Za-z0-9 .'-]{1,80})"
+)
+PLACE_MARKERS = re.compile(r"(?i)(?:at|in|near|from|place is|location is)\\s+([A-Z][A-Za-z0-9 .'-]{1,80})")
+
+
+class HonchoFactCandidate(BaseModel):
+    uid: str
+    correction_id: str
+    trace_id: str
+    source_conversation_id: str
+    related_conversation_id: str = ""
+    correction_type: str
+    fact_text: str
+    fact_type: str = "correction_fact"
+    entity_type: str = ""
+    entity_name: str = ""
+    person: str = ""
+    place: str = ""
+    environment: str = ""
+    confidence: float
+    fingerprint: str
+    idempotency_key: str
+    active_summary_version_id: str = ""
+    rollback_ref: dict[str, Any] = Field(default_factory=dict)
+    evidence: list[dict[str, Any]] = Field(default_factory=list)
+    session_key: str
+    write_policy: str = "proposal_first"
+    durable_owner: str = "honcho/hermes"
+
+
+class HonchoFactWriteDecision(BaseModel):
+    action: str
+    reason: str = ""
+    uid: str
+    correction_id: str
+    fingerprint: str
+    idempotency_key: str
+    confidence: float = 0.0
+    session_key: str = ""
+    status_code: int = 0
+    latency_ms: int = 0
+    response_ref: dict[str, Any] = Field(default_factory=dict)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value or {}, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _stable_hash(value: Any) -> str:
+    return hashlib.sha256(_stable_json(value).encode("utf-8")).hexdigest()[:20]
+
+
+def _safe_session_component(value: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9_.:-]+", "-", value).strip("-")[:160] or "unknown"
+
+
+def honcho_session_key(uid: str) -> str:
+    return f"ella:omi:{_safe_session_component(uid.lower())}:canonical"
+
+
+def _conversation_id(conversation: dict[str, Any]) -> str:
+    return str(conversation.get("id") or conversation.get("conversation_id") or "")
+
+
+def _conversation_uid(conversation: dict[str, Any], fallback_uid: str) -> str:
+    return str(conversation.get("uid") or conversation.get("profile_uid") or fallback_uid)
+
+
+def _summary_text(conversation: dict[str, Any]) -> str:
+    structured = conversation.get("structured") if isinstance(conversation.get("structured"), dict) else {}
+    return " ".join(
+        str(value or "")
+        for value in (
+            conversation.get("title"),
+            conversation.get("overview"),
+            structured.get("title"),
+            structured.get("overview"),
+            structured.get("category"),
+            conversation.get("category"),
+        )
+    )[:2500]
+
+
+def _active_summary_version(conversation: dict[str, Any]) -> str:
+    return str(conversation.get("active_summary_version_id") or "")
+
+
+def _is_active_version_current(conversation: dict[str, Any], expected_active_summary_version_id: str) -> bool:
+    expected = str(expected_active_summary_version_id or "")
+    if not expected:
+        return True
+    return _active_summary_version(conversation) == expected
+
+
+def _clean_fact_text(text: str) -> str:
+    return re.sub(r"\s+", " ", str(text or "").replace("\x00", " ")).strip()[:1200]
+
+
+def _entity_fields(correction_text: str, correction_type: str) -> dict[str, str]:
+    text = _clean_fact_text(correction_text)
+    fields = {"entity_type": "", "entity_name": "", "person": "", "place": "", "environment": ""}
+    person_match = PERSON_MARKERS.search(text)
+    place_match = PLACE_MARKERS.search(text)
+    if correction_type == "identity" or person_match:
+        person = (person_match.group(1) if person_match else "").strip(" .'-")
+        fields.update({"entity_type": "person", "entity_name": person, "person": person})
+    elif correction_type in {"media", "topic", "title"}:
+        fields.update({"entity_type": correction_type, "entity_name": ""})
+    if place_match:
+        fields.update({"place": place_match.group(1).strip(" .'-")})
+    if any(word in text.lower() for word in ("glasses", "keys", "backpack", "charger", "wallet")):
+        fields["environment"] = "item_location"
+    return fields
+
+
+def build_honcho_fact_candidate(
+    *,
+    uid: str,
+    correction_id: str,
+    trace_id: str,
+    correction_text: str,
+    correction_type: str,
+    source_conversation: dict[str, Any],
+    related_conversation: dict[str, Any] | None = None,
+    confidence: float,
+) -> HonchoFactCandidate | None:
+    if confidence < HONCHO_FACT_MIN_CONFIDENCE:
+        return None
+    if correction_type not in {"identity", "media", "topic", "title", "other"}:
+        return None
+    if _conversation_uid(source_conversation, uid) != uid:
+        return None
+    related = related_conversation or source_conversation
+    if _conversation_uid(related, uid) != uid:
+        return None
+
+    fact_text = _clean_fact_text(correction_text)
+    if not fact_text:
+        return None
+    entity = _entity_fields(fact_text, correction_type)
+    source_id = _conversation_id(source_conversation)
+    related_id = _conversation_id(related)
+    active_summary_version_id = _active_summary_version(related)
+    fingerprint_payload = {
+        "uid": uid,
+        "correction_type": correction_type,
+        "fact_text": fact_text.lower(),
+        "entity": entity,
+    }
+    fingerprint = _stable_hash(fingerprint_payload)
+    idempotency_key = f"omi-correction-honcho-fact:{uid}:{correction_id}:{fingerprint}"
+    return HonchoFactCandidate(
+        uid=uid,
+        correction_id=correction_id,
+        trace_id=trace_id,
+        source_conversation_id=source_id,
+        related_conversation_id=related_id,
+        correction_type=correction_type,
+        fact_text=fact_text,
+        confidence=round(float(confidence), 3),
+        fingerprint=fingerprint,
+        idempotency_key=idempotency_key,
+        active_summary_version_id=active_summary_version_id,
+        rollback_ref={
+            "conversation_id": related_id,
+            "active_summary_version_id": active_summary_version_id,
+            "summary_before": _summary_text(related),
+        },
+        evidence=[
+            {
+                "kind": "source_correction",
+                "conversation_id": source_id,
+                "correction_id": correction_id,
+                "trace_id": trace_id,
+                "correction_text": fact_text,
+                "correction_type": correction_type,
+            },
+            {
+                "kind": "related_conversation_summary",
+                "conversation_id": related_id,
+                "content": _summary_text(related),
+            },
+        ],
+        session_key=honcho_session_key(uid),
+        **entity,
+    )
+
+
+def _claims(candidate: HonchoFactCandidate) -> dict[str, Any]:
+    return {
+        "sub": "ella-correction-observer",
+        "profile_uid": candidate.uid,
+        "role": "system_observer",
+        "external_provider": "omi_backend",
+        "grant_id": "omi-correction-honcho-fact",
+        "trace_id": candidate.trace_id,
+        "scopes": ["proposals:write"],
+        "allowed_tools": [HONCHO_FACT_TOOL_NAME],
+    }
+
+
+def _proposal_payload(candidate: HonchoFactCandidate) -> dict[str, Any]:
+    return {
+        "title": f"Honcho fact candidate from correction {candidate.correction_id}",
+        "description": candidate.fact_text,
+        "target": {
+            "kind": "honcho_fact_candidate",
+            "durable_owner": candidate.durable_owner,
+            "session_key": candidate.session_key,
+            "fingerprint": candidate.fingerprint,
+            "active_summary_version_id": candidate.active_summary_version_id,
+        },
+        "requested_change": {
+            "fact_text": candidate.fact_text,
+            "fact_type": candidate.fact_type,
+            "correction_type": candidate.correction_type,
+            "entity_type": candidate.entity_type,
+            "entity_name": candidate.entity_name,
+            "person": candidate.person,
+            "place": candidate.place,
+            "environment": candidate.environment,
+            "confidence": candidate.confidence,
+            "write_policy": candidate.write_policy,
+            "durable_write_enabled": HONCHO_FACT_WRITE_ENABLED,
+        },
+        "evidence": candidate.evidence,
+        "rollback_ref": candidate.rollback_ref,
+        "source": "omi_correction_observer",
+        "write_policy": "proposal_only" if not HONCHO_FACT_WRITE_ENABLED else "proposal_then_honcho_optional",
+        "confidence": candidate.confidence,
+        "durable_owner": candidate.durable_owner,
+    }
+
+
+def create_honcho_fact_candidate_proposal(
+    candidate: HonchoFactCandidate,
+    *,
+    create_proposal: Callable[..., dict[str, Any]] = proposal_ingest.create_proposal,
+) -> dict[str, Any]:
+    if not HONCHO_FACT_PROPOSALS_ENABLED:
+        return {"created": False, "skipped": True, "reason": "honcho_fact_proposals_disabled", "proposal": {}}
+    return create_proposal(
+        session_claims=_claims(candidate),
+        tool_name=HONCHO_FACT_TOOL_NAME,
+        proposal_type="memory_note",
+        payload=_proposal_payload(candidate),
+        idempotency_key=candidate.idempotency_key,
+    )
+
+
+def _write_prompt(candidate: HonchoFactCandidate) -> str:
+    return (
+        "Persist the following correction-derived durable fact only if it is appropriate for the "
+        "active Ella/Honcho memory policy. Return compact JSON with keys: status, memory_id, reason. "
+        "Do not modify OMI summaries, raw transcripts, caregiver routing, scanner rules, or reminders.\n\n"
+        f"Fact candidate:\n{candidate.model_dump_json(indent=2)}"
+    )
+
+
+async def write_honcho_fact_candidate(
+    candidate: HonchoFactCandidate,
+    *,
+    current_conversation: dict[str, Any] | None = None,
+    token: str | None = None,
+    gateway_url: str | None = None,
+    model: str | None = None,
+    http_client_factory: Callable[..., Any] = httpx.AsyncClient,
+) -> HonchoFactWriteDecision:
+    if not HONCHO_FACT_WRITE_ENABLED:
+        return HonchoFactWriteDecision(
+            action="skip",
+            reason="durable_write_disabled",
+            uid=candidate.uid,
+            correction_id=candidate.correction_id,
+            fingerprint=candidate.fingerprint,
+            idempotency_key=candidate.idempotency_key,
+            confidence=candidate.confidence,
+            session_key=candidate.session_key,
+        )
+    if current_conversation is not None and _conversation_uid(current_conversation, candidate.uid) != candidate.uid:
+        return HonchoFactWriteDecision(
+            action="skip",
+            reason="cross_user_current_conversation",
+            uid=candidate.uid,
+            correction_id=candidate.correction_id,
+            fingerprint=candidate.fingerprint,
+            idempotency_key=candidate.idempotency_key,
+            confidence=candidate.confidence,
+            session_key=candidate.session_key,
+        )
+    if current_conversation is not None and not _is_active_version_current(
+        current_conversation, candidate.active_summary_version_id
+    ):
+        return HonchoFactWriteDecision(
+            action="skip",
+            reason="stale_active_summary_version",
+            uid=candidate.uid,
+            correction_id=candidate.correction_id,
+            fingerprint=candidate.fingerprint,
+            idempotency_key=candidate.idempotency_key,
+            confidence=candidate.confidence,
+            session_key=candidate.session_key,
+        )
+
+    api_token = token if token is not None else os.getenv("HERMES_API_SERVER_KEY", os.getenv("API_SERVER_KEY", ""))
+    if not api_token:
+        return HonchoFactWriteDecision(
+            action="skip",
+            reason="missing_hermes_token",
+            uid=candidate.uid,
+            correction_id=candidate.correction_id,
+            fingerprint=candidate.fingerprint,
+            idempotency_key=candidate.idempotency_key,
+            confidence=candidate.confidence,
+            session_key=candidate.session_key,
+        )
+
+    url = (gateway_url or HERMES_GATEWAY_URL).rstrip()
+    started = time.monotonic()
+    session_id = (
+        f"honcho-fact:{_safe_session_component(candidate.uid)}:{candidate.correction_id}:{candidate.fingerprint}"
+    )
+    try:
+        async with http_client_factory(timeout=HERMES_TIMEOUT_SECONDS) as client:
+            response = await client.post(
+                f"{url}/v1/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {api_token}",
+                    "Content-Type": "application/json",
+                    "X-Hermes-Session-Id": session_id,
+                    "X-Hermes-Session-Key": candidate.session_key,
+                    "X-Idempotency-Key": candidate.idempotency_key,
+                    "X-Trace-Id": candidate.trace_id,
+                },
+                json={
+                    "model": model or HERMES_MODEL,
+                    "messages": [
+                        {
+                            "role": "system",
+                            "content": (
+                                "You are the Hermes/Honcho durable memory writer for Ella. "
+                                "Use the supplied session key as the durable memory scope."
+                            ),
+                        },
+                        {"role": "user", "content": _write_prompt(candidate)},
+                    ],
+                    "temperature": 0,
+                    "max_tokens": 300,
+                    "stream": False,
+                },
+            )
+        latency_ms = int((time.monotonic() - started) * 1000)
+        if response.status_code >= 400:
+            return HonchoFactWriteDecision(
+                action="error",
+                reason=f"hermes_http_{response.status_code}",
+                uid=candidate.uid,
+                correction_id=candidate.correction_id,
+                fingerprint=candidate.fingerprint,
+                idempotency_key=candidate.idempotency_key,
+                confidence=candidate.confidence,
+                session_key=candidate.session_key,
+                status_code=response.status_code,
+                latency_ms=latency_ms,
+                response_ref={"body": getattr(response, "text", "")[:500]},
+            )
+        return HonchoFactWriteDecision(
+            action="written",
+            reason="hermes_honcho_write_accepted",
+            uid=candidate.uid,
+            correction_id=candidate.correction_id,
+            fingerprint=candidate.fingerprint,
+            idempotency_key=candidate.idempotency_key,
+            confidence=candidate.confidence,
+            session_key=candidate.session_key,
+            status_code=response.status_code,
+            latency_ms=latency_ms,
+            response_ref={"transport": "hermes_chat_completions", "at": _now_iso()},
+        )
+    except Exception as exc:
+        return HonchoFactWriteDecision(
+            action="error",
+            reason=type(exc).__name__,
+            uid=candidate.uid,
+            correction_id=candidate.correction_id,
+            fingerprint=candidate.fingerprint,
+            idempotency_key=candidate.idempotency_key,
+            confidence=candidate.confidence,
+            session_key=candidate.session_key,
+            latency_ms=int((time.monotonic() - started) * 1000),
+            response_ref={"error": str(exc)[:500]},
+        )

--- a/backend/ella/services/correction_propagation.py
+++ b/backend/ella/services/correction_propagation.py
@@ -19,6 +19,11 @@ from pydantic import BaseModel, Field
 
 from database._client import db
 from ella.services import proposal_ingest
+from ella.services.correction_honcho_contract import (
+    HONCHO_FACT_PROPOSALS_ENABLED,
+    build_honcho_fact_candidate,
+    create_honcho_fact_candidate_proposal,
+)
 
 PROPAGATION_TOOL_NAME = "omi_correction_propagation_propose"
 STOPWORDS = {
@@ -81,6 +86,8 @@ class CorrectionPropagationRun(BaseModel):
     latency_ms: int = 0
     candidate_count: int = 0
     proposal_count: int = 0
+    honcho_fact_candidate_count: int = 0
+    honcho_fact_proposal_count: int = 0
     skipped_count: int = 0
     auto_applied_count: int = 0
     decisions: list[CorrectionPropagationDecision] = Field(default_factory=list)
@@ -350,6 +357,8 @@ def run_correction_propagation(
     source_terms = _terms(correction_text, _summary_text(source_conversation), _transcript_text(source_conversation))
     decisions: list[CorrectionPropagationDecision] = []
     proposal_count = 0
+    honcho_fact_candidate_count = 0
+    honcho_fact_proposal_count = 0
 
     for candidate in candidates:
         candidate_id = _conversation_id(candidate)
@@ -403,6 +412,18 @@ def run_correction_propagation(
             overlap_terms=overlap,
         )
         idempotency_key = f"omi-correction-propagation:{uid}:{correction_id}:{candidate_id}:{_stable_hash(payload)}"
+        fact_candidate = build_honcho_fact_candidate(
+            uid=uid,
+            source_conversation=source_conversation,
+            related_conversation=candidate,
+            correction_id=correction_id,
+            trace_id=trace_id,
+            correction_text=correction_text,
+            correction_type=correction_type,
+            confidence=confidence,
+        )
+        if fact_candidate is not None:
+            honcho_fact_candidate_count += 1
         if dry_run:
             decisions.append(
                 CorrectionPropagationDecision(
@@ -416,6 +437,20 @@ def run_correction_propagation(
                     rollback_ref=_source_ref(candidate),
                 )
             )
+            if fact_candidate is not None and HONCHO_FACT_PROPOSALS_ENABLED:
+                decisions.append(
+                    CorrectionPropagationDecision(
+                        conversation_id=candidate_id,
+                        action="would_create_honcho_fact_proposal",
+                        reason="high_confidence_correction_fact_candidate",
+                        confidence=confidence,
+                        overlap_terms=overlap,
+                        idempotency_key=fact_candidate.idempotency_key,
+                        active_summary_version_id=_active_summary_version(candidate),
+                        rollback_ref=_source_ref(candidate),
+                    )
+                )
+                honcho_fact_proposal_count += 1
             proposal_count += 1
             continue
 
@@ -443,6 +478,32 @@ def run_correction_propagation(
                 )
             )
             proposal_count += 1
+            if fact_candidate is not None:
+                fact_result = create_honcho_fact_candidate_proposal(fact_candidate, create_proposal=create_proposal)
+                fact_proposal = fact_result.get("proposal") or {}
+                fact_proposal_id = str(fact_proposal.get("proposal_id") or "")
+                if fact_result.get("skipped"):
+                    action = "honcho_fact_proposal_skipped"
+                    reason = str(fact_result.get("reason") or "honcho_fact_proposal_skipped")
+                else:
+                    action = (
+                        "created_honcho_fact_proposal" if fact_result.get("created") else "deduped_honcho_fact_proposal"
+                    )
+                    reason = "high_confidence_correction_fact_candidate"
+                    honcho_fact_proposal_count += 1
+                decisions.append(
+                    CorrectionPropagationDecision(
+                        conversation_id=candidate_id,
+                        action=action,
+                        reason=reason,
+                        confidence=confidence,
+                        overlap_terms=overlap,
+                        idempotency_key=fact_candidate.idempotency_key,
+                        proposal_id=fact_proposal_id,
+                        active_summary_version_id=_active_summary_version(candidate),
+                        rollback_ref=_source_ref(candidate),
+                    )
+                )
         except Exception as exc:
             decisions.append(
                 CorrectionPropagationDecision(
@@ -475,6 +536,8 @@ def run_correction_propagation(
         latency_ms=int((time.monotonic() - monotonic_start) * 1000),
         candidate_count=len(candidates),
         proposal_count=proposal_count,
+        honcho_fact_candidate_count=honcho_fact_candidate_count,
+        honcho_fact_proposal_count=honcho_fact_proposal_count,
         skipped_count=skipped_count,
         auto_applied_count=0,
         decisions=decisions,
@@ -487,6 +550,11 @@ def run_correction_propagation(
             },
             "durable_owner": "honcho/hermes",
             "write_policy": "proposal_only",
+            "honcho_fact_contract": {
+                "enabled": HONCHO_FACT_PROPOSALS_ENABLED,
+                "proposal_type": "memory_note",
+                "write_default": "disabled",
+            },
         },
     )
 

--- a/backend/tests/unit/test_ella_correction_honcho_contract.py
+++ b/backend/tests/unit/test_ella_correction_honcho_contract.py
@@ -1,0 +1,154 @@
+import asyncio
+from datetime import datetime, timezone
+import sys
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("database._client", MagicMock(db=MagicMock()))
+
+from ella.services import correction_honcho_contract as contract
+
+
+def _conversation(conversation_id="conv-1", uid="user-123", version="v1"):
+    return {
+        "id": conversation_id,
+        "uid": uid,
+        "created_at": datetime(2026, 5, 29, 9, 30, tzinfo=timezone.utc),
+        "active_summary_version_id": version,
+        "structured": {
+            "title": "Teacher conversation",
+            "overview": "[Ella] The summary called Mei Xin a teen.",
+            "category": "education",
+        },
+    }
+
+
+def _candidate(**overrides):
+    candidate = contract.build_honcho_fact_candidate(
+        uid="user-123",
+        correction_id="corr-123",
+        trace_id="trace-123",
+        correction_text="Actually the speaker is Mei Xin, also called Rain.",
+        correction_type="identity",
+        source_conversation=_conversation("source"),
+        related_conversation=_conversation("related"),
+        confidence=0.96,
+    )
+    assert candidate is not None
+    return (
+        candidate.model_copy(update=overrides) if hasattr(candidate, "model_copy") else candidate.copy(update=overrides)
+    )
+
+
+def test_build_honcho_fact_candidate_uses_stable_session_key_and_idempotency():
+    candidate = _candidate()
+
+    assert candidate.uid == "user-123"
+    assert candidate.source_conversation_id == "source"
+    assert candidate.related_conversation_id == "related"
+    assert candidate.entity_type == "person"
+    assert candidate.session_key == "ella:omi:user-123:canonical"
+    assert candidate.idempotency_key.startswith("omi-correction-honcho-fact:user-123:corr-123:")
+    assert candidate.durable_owner == "honcho/hermes"
+
+
+def test_build_honcho_fact_candidate_rejects_cross_user_related_conversation():
+    candidate = contract.build_honcho_fact_candidate(
+        uid="user-123",
+        correction_id="corr-123",
+        trace_id="trace-123",
+        correction_text="Actually the speaker is Mei Xin.",
+        correction_type="identity",
+        source_conversation=_conversation("source", uid="user-123"),
+        related_conversation=_conversation("related", uid="user-999"),
+        confidence=0.96,
+    )
+
+    assert candidate is None
+
+
+def test_create_honcho_fact_candidate_proposal_is_idempotent_memory_note():
+    calls = []
+    candidate = _candidate()
+
+    def fake_create_proposal(**kwargs):
+        calls.append(kwargs)
+        return {"created": True, "deduped": False, "proposal": {"proposal_id": "proposal-1"}}
+
+    result = contract.create_honcho_fact_candidate_proposal(candidate, create_proposal=fake_create_proposal)
+
+    assert result["proposal"]["proposal_id"] == "proposal-1"
+    assert calls[0]["tool_name"] == contract.HONCHO_FACT_TOOL_NAME
+    assert calls[0]["proposal_type"] == "memory_note"
+    assert calls[0]["idempotency_key"] == candidate.idempotency_key
+    assert calls[0]["session_claims"]["profile_uid"] == "user-123"
+    assert calls[0]["payload"]["target"]["kind"] == "honcho_fact_candidate"
+    assert calls[0]["payload"]["target"]["durable_owner"] == "honcho/hermes"
+    assert calls[0]["payload"]["write_policy"] == "proposal_only"
+
+
+def test_write_honcho_fact_candidate_defaults_to_no_durable_write(monkeypatch):
+    candidate = _candidate()
+
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", False)
+    decision = asyncio.run(contract.write_honcho_fact_candidate(candidate))
+
+    assert decision.action == "skip"
+    assert decision.reason == "durable_write_disabled"
+    assert decision.session_key == "ella:omi:user-123:canonical"
+
+
+def test_write_honcho_fact_candidate_rechecks_active_summary_version(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
+
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
+    decision = asyncio.run(
+        contract.write_honcho_fact_candidate(
+            candidate,
+            current_conversation=_conversation("related", uid="user-123", version="v2"),
+            token="hermes-token",
+        )
+    )
+
+    assert decision.action == "skip"
+    assert decision.reason == "stale_active_summary_version"
+
+
+def test_write_honcho_fact_candidate_uses_hermes_session_key(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
+    calls = []
+
+    class FakeResponse:
+        status_code = 200
+        text = "{}"
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, **kwargs):
+            calls.append({"url": url, **kwargs})
+            return FakeResponse()
+
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
+    decision = asyncio.run(
+        contract.write_honcho_fact_candidate(
+            candidate,
+            current_conversation=_conversation("related", uid="user-123", version="v1"),
+            token="hermes-token",
+            gateway_url="https://hermes.test",
+            model="test-model",
+            http_client_factory=FakeClient,
+        )
+    )
+
+    assert decision.action == "written"
+    assert calls[0]["url"] == "https://hermes.test/v1/chat/completions"
+    assert calls[0]["headers"]["X-Hermes-Session-Key"] == "ella:omi:user-123:canonical"
+    assert calls[0]["headers"]["X-Idempotency-Key"] == candidate.idempotency_key
+    assert calls[0]["json"]["model"] == "test-model"

--- a/backend/tests/unit/test_ella_correction_propagation.py
+++ b/backend/tests/unit/test_ella_correction_propagation.py
@@ -95,8 +95,11 @@ def test_correction_propagation_creates_idempotent_same_user_candidate_proposal(
 
     assert run1.run_id == "omi-correction-propagation:user-123:conv-source:corr-123"
     assert run1.proposal_count == 1
+    assert run1.honcho_fact_candidate_count == 1
+    assert run1.honcho_fact_proposal_count == 1
     assert run1.auto_applied_count == 0
     assert [d.action for d in run1.decisions].count("created_proposal") == 1
+    assert [d.action for d in run1.decisions].count("created_honcho_fact_proposal") == 1
     assert any(d.reason == "cross_user_candidate" for d in run1.decisions)
     assert any(d.conversation_id == "conv-unrelated" and d.action == "skip" for d in run1.decisions)
     created = next(d for d in run1.decisions if d.action == "created_proposal")
@@ -104,7 +107,8 @@ def test_correction_propagation_creates_idempotent_same_user_candidate_proposal(
     assert "teacher" in created.overlap_terms
     assert run2.proposal_count == 1
     assert any(d.action == "deduped_proposal" for d in run2.decisions)
-    assert len(seen) == 1
+    assert any(d.action == "deduped_honcho_fact_proposal" for d in run2.decisions)
+    assert len(seen) == 2
 
 
 def test_correction_propagation_skips_active_version_incompatible_candidate():


### PR DESCRIPTION
## Summary
- Adds a dedicated correction-derived Honcho fact contract boundary without creating an OMI-owned fact/entity store.
- Adds idempotent `honcho_fact_candidate` proposal creation using `memory_note` proposals and `uid + correction_id + fact fingerprint` idempotency.
- Adds an explicitly feature-flagged durable write hook through Hermes chat completions with stable `X-Hermes-Session-Key=ella:omi:{uid}:canonical`; durable writes remain off by default.
- Extends correction propagation audit/run output with Honcho fact candidate/proposal counts and decision records.

## Safety
- Same uid/profile only.
- Raw transcripts are never mutated.
- Durable writes default off via `ELLA_CORRECTION_HONCHO_FACT_WRITE_ENABLED=false`.
- Version freshness is rechecked before the optional durable write function can finalize a fact.
- OMI stores proposals/audit/evidence/rollback refs only; durable fact ownership remains Hermes/Honcho.

## Validation
- `python3 -m py_compile ella/services/correction_honcho_contract.py ella/services/correction_propagation.py tests/unit/test_ella_correction_honcho_contract.py tests/unit/test_ella_correction_propagation.py tests/unit/test_ella_conversation_corrections.py`
- `pytest tests/unit/test_ella_correction_honcho_contract.py tests/unit/test_ella_correction_propagation.py tests/unit/test_ella_conversation_corrections.py tests/unit/test_ella_canonical_omi.py -q` -> 29 passed
- `git diff --check`

Closes/refs ellaaicare/ella-ai#1015.
