### PR TITLE
Confirm Honcho writes before marking durable

### DIFF
--- a/backend/ella/routers/chat.py
+++ b/backend/ella/routers/chat.py
@@ -36,6 +36,7 @@ from ella.config import ELLA_CONFIG
 from ella.routers.canonical_events import CanonicalEventIn, PostgresCanonicalEventStore
 from ella.routers.resolve import resolve_user_routing
 from ella.routers.trace import RouteTrace, record_trace
+from ella.services.hermes_session import canonical_omi_session_key, safe_session_component
 from utils.ella.canonical_context import (
     DEFAULT_CONTEXT_CHANNELS,
     canonical_events_to_server_messages,
@@ -82,18 +83,14 @@ ELLA_SYSTEM_PROMPT = (
 )
 
 
-def _safe_session_component(value: str) -> str:
-    return re.sub(r"[^a-zA-Z0-9_.:-]+", "-", value).strip("-")[:160] or "unknown"
-
-
 def _hermes_chat_memory_key(uid: str) -> str:
     """Stable Hermes/Honcho long-term memory scope for this authenticated user."""
 
-    return f"ella:omi:{_safe_session_component(uid.lower())}:canonical"
+    return canonical_omi_session_key(uid)
 
 
 def _hermes_chat_session_key(uid: str) -> str:
-    safe_uid = _safe_session_component(uid.lower())
+    safe_uid = safe_session_component(uid.lower())
     if HERMES_CHAT_SESSION_SCOPE in {"canonical", "shared", "cross_channel", "cross-channel"}:
         return _hermes_chat_memory_key(uid)
     if HERMES_CHAT_SESSION_EPOCH:

--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -23,6 +23,7 @@ from database._client import db
 from ella.config import ELLA_CONFIG
 from ella.routers.canonical_events import CanonicalEventIn, PostgresCanonicalEventStore
 from ella.services.correction_propagation import propagation_run_to_dict, run_correction_propagation
+from ella.services.hermes_session import canonical_omi_session_key, safe_session_component
 from ella.services import proposal_ingest
 from utils.other import endpoints as auth
 
@@ -195,17 +196,13 @@ def _hermes_correction_api_key() -> str:
     )
 
 
-def _safe_session_component(value: str) -> str:
-    return re.sub(r"[^a-zA-Z0-9_.:-]+", "-", value).strip("-")[:160] or "unknown"
-
-
 def _correction_session_id(uid: str, conversation_id: str, correction_id: str) -> str:
     return ":".join(
         [
             "correction",
-            _safe_session_component(uid),
-            _safe_session_component(conversation_id),
-            _safe_session_component(correction_id),
+            safe_session_component(uid),
+            safe_session_component(conversation_id),
+            safe_session_component(correction_id),
         ]
     )
 
@@ -213,7 +210,7 @@ def _correction_session_id(uid: str, conversation_id: str, correction_id: str) -
 def _correction_session_key(uid: str) -> str:
     """Stable Hermes long-term memory scope for correction/enrichment calls."""
 
-    return f"ella:omi:{_safe_session_component(uid.lower())}:canonical"
+    return canonical_omi_session_key(uid)
 
 
 def _build_direct_correction_prompt(

--- a/backend/ella/services/correction_honcho_contract.py
+++ b/backend/ella/services/correction_honcho_contract.py
@@ -19,6 +19,7 @@ import httpx
 from pydantic import BaseModel, Field
 
 from ella.services import proposal_ingest
+from ella.services.hermes_session import canonical_omi_session_key, safe_session_component
 
 HONCHO_FACT_TOOL_NAME = "omi_correction_honcho_fact_propose"
 HONCHO_FACT_WRITE_TOOL_NAME = "omi_correction_honcho_fact_write"
@@ -39,6 +40,7 @@ HERMES_MODEL = os.getenv("HERMES_MODEL", "plato-eval")
 HERMES_TIMEOUT_SECONDS = float(os.getenv("ELLA_CORRECTION_HONCHO_FACT_TIMEOUT_SECONDS", "20"))
 
 TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9'_-]{2,}", re.I)
+JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
 PERSON_MARKERS = re.compile(
     r"(?i)(?:is|was|named|called|a\\.k\\.a\\.|aka|person is|speaker is)\\s+([A-Z][A-Za-z0-9 .'-]{1,80})"
 )
@@ -96,12 +98,8 @@ def _stable_hash(value: Any) -> str:
     return hashlib.sha256(_stable_json(value).encode("utf-8")).hexdigest()[:20]
 
 
-def _safe_session_component(value: str) -> str:
-    return re.sub(r"[^a-zA-Z0-9_.:-]+", "-", value).strip("-")[:160] or "unknown"
-
-
 def honcho_session_key(uid: str) -> str:
-    return f"ella:omi:{_safe_session_component(uid.lower())}:canonical"
+    return canonical_omi_session_key(uid)
 
 
 def _conversation_id(conversation: dict[str, Any]) -> str:
@@ -303,6 +301,91 @@ def _write_prompt(candidate: HonchoFactCandidate) -> str:
     )
 
 
+def _chat_completion_content(body: dict[str, Any]) -> str:
+    choices = body.get("choices") if isinstance(body.get("choices"), list) else []
+    if not choices:
+        return ""
+    message = choices[0].get("message") if isinstance(choices[0], dict) else {}
+    return str((message or {}).get("content") or "")
+
+
+def _extract_json_object(content: str) -> dict[str, Any] | None:
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        match = JSON_OBJECT_RE.search(content)
+        if not match:
+            return None
+        try:
+            parsed = json.loads(match.group(0))
+        except json.JSONDecodeError:
+            return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _confirmation_from_response(response: Any) -> tuple[str, str, dict[str, Any]]:
+    try:
+        body = response.json()
+    except Exception as exc:
+        return (
+            "uncertain",
+            "malformed_hermes_response",
+            {"error": str(exc)[:240], "body": getattr(response, "text", "")[:500]},
+        )
+    if not isinstance(body, dict):
+        return "uncertain", "malformed_hermes_response", {"body_type": type(body).__name__}
+
+    content = _chat_completion_content(body)
+    parsed = _extract_json_object(content)
+    if parsed is None:
+        return "uncertain", "malformed_confirmation_json", {"content": content[:500]}
+
+    status_value = str(parsed.get("status") or parsed.get("action") or "").strip().lower()
+    durable_ref = (
+        parsed.get("memory_id")
+        or parsed.get("fact_id")
+        or parsed.get("durable_ref")
+        or parsed.get("durable_id")
+        or parsed.get("id")
+    )
+    refused = status_value in {"refused", "rejected", "declined", "denied"} or bool(parsed.get("refusal"))
+    if refused:
+        return (
+            "uncertain",
+            "honcho_write_refused",
+            {"status": status_value, "reason": str(parsed.get("reason") or "")[:500], "confirmation": parsed},
+        )
+    if status_value in {"error", "failed", "failure"}:
+        return (
+            "error",
+            "honcho_write_failed",
+            {"status": status_value, "reason": str(parsed.get("reason") or "")[:500], "confirmation": parsed},
+        )
+    if status_value in {"written", "persisted", "applied", "saved", "success", "ok"} and durable_ref:
+        memory_id = str(parsed.get("memory_id") or durable_ref)
+        return (
+            "written",
+            "hermes_honcho_write_confirmed",
+            {
+                "status": status_value,
+                "memory_id": memory_id,
+                "durable_ref": str(durable_ref),
+                "confirmation": parsed,
+            },
+        )
+    if not durable_ref:
+        return (
+            "uncertain",
+            "missing_durable_ref",
+            {"status": status_value, "reason": str(parsed.get("reason") or "")[:500], "confirmation": parsed},
+        )
+    return (
+        "uncertain",
+        "unconfirmed_honcho_write_status",
+        {"status": status_value, "durable_ref": str(durable_ref), "confirmation": parsed},
+    )
+
+
 async def write_honcho_fact_candidate(
     candidate: HonchoFactCandidate,
     *,
@@ -361,10 +444,10 @@ async def write_honcho_fact_candidate(
             session_key=candidate.session_key,
         )
 
-    url = (gateway_url or HERMES_GATEWAY_URL).rstrip()
+    url = (gateway_url or HERMES_GATEWAY_URL).rstrip("/")
     started = time.monotonic()
     session_id = (
-        f"honcho-fact:{_safe_session_component(candidate.uid)}:{candidate.correction_id}:{candidate.fingerprint}"
+        f"honcho-fact:{safe_session_component(candidate.uid)}:{candidate.correction_id}:{candidate.fingerprint}"
     )
     try:
         async with http_client_factory(timeout=HERMES_TIMEOUT_SECONDS) as client:
@@ -410,9 +493,11 @@ async def write_honcho_fact_candidate(
                 latency_ms=latency_ms,
                 response_ref={"body": getattr(response, "text", "")[:500]},
             )
+        action, reason, response_ref = _confirmation_from_response(response)
+        response_ref = {"transport": "hermes_chat_completions", "at": _now_iso(), **response_ref}
         return HonchoFactWriteDecision(
-            action="written",
-            reason="hermes_honcho_write_accepted",
+            action=action,
+            reason=reason,
             uid=candidate.uid,
             correction_id=candidate.correction_id,
             fingerprint=candidate.fingerprint,
@@ -421,7 +506,7 @@ async def write_honcho_fact_candidate(
             session_key=candidate.session_key,
             status_code=response.status_code,
             latency_ms=latency_ms,
-            response_ref={"transport": "hermes_chat_completions", "at": _now_iso()},
+            response_ref=response_ref,
         )
     except Exception as exc:
         return HonchoFactWriteDecision(

--- a/backend/ella/services/hermes_session.py
+++ b/backend/ella/services/hermes_session.py
@@ -1,0 +1,15 @@
+"""Shared Hermes/Honcho session key helpers."""
+
+from __future__ import annotations
+
+import re
+
+
+def safe_session_component(value: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9_.:-]+", "-", str(value or "")).strip("-")[:160] or "unknown"
+
+
+def canonical_omi_session_key(uid: str) -> str:
+    """Stable Hermes/Honcho long-term memory scope for one Ella profile."""
+
+    return f"ella:omi:{safe_session_component(uid.lower())}:canonical"

--- a/backend/tests/unit/test_ella_correction_honcho_contract.py
+++ b/backend/tests/unit/test_ella_correction_honcho_contract.py
@@ -113,13 +113,8 @@ def test_write_honcho_fact_candidate_rechecks_active_summary_version(monkeypatch
     assert decision.reason == "stale_active_summary_version"
 
 
-def test_write_honcho_fact_candidate_uses_hermes_session_key(monkeypatch):
-    candidate = _candidate(active_summary_version_id="v1")
+def _fake_client_factory(response):
     calls = []
-
-    class FakeResponse:
-        status_code = 200
-        text = "{}"
 
     class FakeClient:
         def __init__(self, **kwargs):
@@ -133,7 +128,26 @@ def test_write_honcho_fact_candidate_uses_hermes_session_key(monkeypatch):
 
         async def post(self, url, **kwargs):
             calls.append({"url": url, **kwargs})
-            return FakeResponse()
+            return response
+
+    return FakeClient, calls
+
+
+class FakeResponse:
+    def __init__(self, *, status_code=200, content='{"status":"written","memory_id":"mem-123"}', text=None):
+        self.status_code = status_code
+        self._content = content
+        self.text = text if text is not None else content
+
+    def json(self):
+        return {"choices": [{"message": {"content": self._content}}]}
+
+
+def test_write_honcho_fact_candidate_uses_hermes_session_key_and_requires_confirmation(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
+    fake_client, calls = _fake_client_factory(
+        FakeResponse(content='{"status":"written","memory_id":"honcho-memory-123","reason":"stored"}')
+    )
 
     monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
     decision = asyncio.run(
@@ -143,12 +157,104 @@ def test_write_honcho_fact_candidate_uses_hermes_session_key(monkeypatch):
             token="hermes-token",
             gateway_url="https://hermes.test",
             model="test-model",
-            http_client_factory=FakeClient,
+            http_client_factory=fake_client,
         )
     )
 
     assert decision.action == "written"
+    assert decision.reason == "hermes_honcho_write_confirmed"
+    assert decision.response_ref["memory_id"] == "honcho-memory-123"
     assert calls[0]["url"] == "https://hermes.test/v1/chat/completions"
     assert calls[0]["headers"]["X-Hermes-Session-Key"] == "ella:omi:user-123:canonical"
     assert calls[0]["headers"]["X-Idempotency-Key"] == candidate.idempotency_key
     assert calls[0]["json"]["model"] == "test-model"
+
+
+def test_write_honcho_fact_candidate_treats_chatty_200_as_uncertain(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
+    fake_client, _ = _fake_client_factory(FakeResponse(content="Okay, I saved it."))
+
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
+    decision = asyncio.run(
+        contract.write_honcho_fact_candidate(
+            candidate,
+            current_conversation=_conversation("related", uid="user-123", version="v1"),
+            token="hermes-token",
+            http_client_factory=fake_client,
+        )
+    )
+
+    assert decision.action == "uncertain"
+    assert decision.reason == "malformed_confirmation_json"
+
+
+def test_write_honcho_fact_candidate_treats_malformed_json_as_uncertain(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
+    fake_client, _ = _fake_client_factory(FakeResponse(content='{"status":"written",'))
+
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
+    decision = asyncio.run(
+        contract.write_honcho_fact_candidate(
+            candidate,
+            current_conversation=_conversation("related", uid="user-123", version="v1"),
+            token="hermes-token",
+            http_client_factory=fake_client,
+        )
+    )
+
+    assert decision.action == "uncertain"
+    assert decision.reason == "malformed_confirmation_json"
+
+
+def test_write_honcho_fact_candidate_requires_durable_ref(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
+    fake_client, _ = _fake_client_factory(FakeResponse(content='{"status":"written","reason":"ok"}'))
+
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
+    decision = asyncio.run(
+        contract.write_honcho_fact_candidate(
+            candidate,
+            current_conversation=_conversation("related", uid="user-123", version="v1"),
+            token="hermes-token",
+            http_client_factory=fake_client,
+        )
+    )
+
+    assert decision.action == "uncertain"
+    assert decision.reason == "missing_durable_ref"
+
+
+def test_write_honcho_fact_candidate_treats_refusal_as_uncertain(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
+    fake_client, _ = _fake_client_factory(FakeResponse(content='{"status":"refused","reason":"policy"}'))
+
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
+    decision = asyncio.run(
+        contract.write_honcho_fact_candidate(
+            candidate,
+            current_conversation=_conversation("related", uid="user-123", version="v1"),
+            token="hermes-token",
+            http_client_factory=fake_client,
+        )
+    )
+
+    assert decision.action == "uncertain"
+    assert decision.reason == "honcho_write_refused"
+
+
+def test_write_honcho_fact_candidate_http_error_remains_error(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
+    fake_client, _ = _fake_client_factory(FakeResponse(status_code=502, content='{"error":"bad gateway"}'))
+
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
+    decision = asyncio.run(
+        contract.write_honcho_fact_candidate(
+            candidate,
+            current_conversation=_conversation("related", uid="user-123", version="v1"),
+            token="hermes-token",
+            http_client_factory=fake_client,
+        )
+    )
+
+    assert decision.action == "error"
+    assert decision.reason == "hermes_http_502"


### PR DESCRIPTION
## Summary
- Parses Hermes chat-completions content in the optional Honcho fact write hook.
- Returns `written` only when the response confirms a durable write and includes a durable ref such as `memory_id`, `fact_id`, `durable_ref`, `durable_id`, or `id`.
- Returns `uncertain` for chatty/non-JSON 200s, malformed confirmation JSON, refusal, and missing durable refs.
- Keeps HTTP failures as `error`.
- Captures confirmed `memory_id`/durable ref in `response_ref` for audit/rollback.
- Keeps `ELLA_CORRECTION_HONCHO_FACT_WRITE_ENABLED=false` by default.
- Folds duplicated stable Hermes/Honcho session-key derivation into `ella.services.hermes_session` and updates chat/corrections/Honcho contract to use it.

## Validation
- `python3 -m py_compile ella/services/hermes_session.py ella/services/correction_honcho_contract.py ella/routers/chat.py ella/routers/corrections.py tests/unit/test_ella_correction_honcho_contract.py tests/unit/test_ella_chat_temporal_context.py tests/unit/test_ella_conversation_corrections.py`
- `pytest tests/unit/test_ella_correction_honcho_contract.py tests/unit/test_ella_correction_propagation.py tests/unit/test_ella_conversation_corrections.py tests/unit/test_ella_canonical_omi.py tests/unit/test_ella_chat_temporal_context.py -q` -> 39 passed
- `git diff --check`

Refs ellaaicare/ella-ai#1016.
