### PR TITLE
Add native Honcho correction fact write gate

### DIFF
--- a/backend/ella/services/correction_honcho_contract.py
+++ b/backend/ella/services/correction_honcho_contract.py
@@ -48,6 +48,13 @@ HONCHO_WORKSPACE_PREFIX = os.getenv("ELLA_CORRECTION_HONCHO_WORKSPACE_PREFIX", "
 HONCHO_OBSERVER_PEER_ID = (
     os.getenv("ELLA_CORRECTION_HONCHO_OBSERVER_PEER_ID") or os.getenv("HONCHO_OBSERVER_PEER_ID") or ""
 )
+HONCHO_OBSERVED_PEER_ID = (
+    os.getenv("ELLA_CORRECTION_HONCHO_OBSERVED_PEER_ID") or os.getenv("HONCHO_OBSERVED_PEER_ID") or ""
+)
+HONCHO_PROFILE_MAP_JSON = os.getenv("ELLA_CORRECTION_HONCHO_PROFILE_MAP_JSON", "")
+HONCHO_PROFILE_MAP_PATH = os.getenv("ELLA_CORRECTION_HONCHO_PROFILE_MAP_PATH", "")
+HONCHO_PROFILE_CONFIG_PATH = os.getenv("ELLA_CORRECTION_HONCHO_PROFILE_CONFIG_PATH", "")
+HONCHO_PROFILE_UID = os.getenv("ELLA_CORRECTION_HONCHO_PROFILE_UID", "")
 
 TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9'_-]{2,}", re.I)
 JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
@@ -133,6 +140,140 @@ def _honcho_workspace_id(candidate: HonchoFactCandidate, explicit_workspace: str
     uid_hash = hashlib.sha256(candidate.uid.encode("utf-8")).hexdigest()[:12]
     uid_component = _honcho_resource_id(candidate.uid, max_len=48)
     return _honcho_resource_id(f"{HONCHO_WORKSPACE_PREFIX}-{uid_component}-{uid_hash}")
+
+
+def _safe_json_loads(value: str) -> Any:
+    if not str(value or "").strip():
+        return None
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return None
+
+
+def _safe_json_file(path: str) -> Any:
+    if not str(path or "").strip():
+        return None
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _profile_target_from_entry(entry: Any) -> dict[str, str] | None:
+    if not isinstance(entry, dict):
+        return None
+    hosts = entry.get("hosts") if isinstance(entry.get("hosts"), dict) else {}
+    host_entry = hosts.get(f"hermes.{HERMES_MODEL}") if isinstance(hosts.get(f"hermes.{HERMES_MODEL}"), dict) else {}
+    if host_entry:
+        entry = {**entry, **host_entry}
+    workspace = str(entry.get("workspace") or entry.get("honcho_workspace") or "").strip()
+    observed_peer_id = str(
+        entry.get("observed_peer_id")
+        or entry.get("observedPeerId")
+        or entry.get("peerName")
+        or entry.get("peer_name")
+        or ""
+    ).strip()
+    if not workspace or not observed_peer_id:
+        return None
+    observer_peer_id = str(
+        entry.get("observer_peer_id")
+        or entry.get("observerPeerId")
+        or entry.get("aiPeer")
+        or entry.get("ai_peer")
+        or ""
+    ).strip()
+    return {
+        "workspace": _honcho_resource_id(workspace),
+        "observed_peer_id": _honcho_resource_id(observed_peer_id),
+        "observer_peer_id": _honcho_resource_id(observer_peer_id) if observer_peer_id else "",
+        "source": str(entry.get("source") or "profile_mapping"),
+    }
+
+
+def _target_from_profile_map(uid: str) -> dict[str, str] | None:
+    uid_norm = str(uid or "").strip().lower()
+    candidates = []
+    inline = _safe_json_loads(HONCHO_PROFILE_MAP_JSON)
+    if inline is not None:
+        candidates.append(inline)
+    file_data = _safe_json_file(HONCHO_PROFILE_MAP_PATH)
+    if file_data is not None:
+        candidates.append(file_data)
+
+    for data in candidates:
+        if isinstance(data, dict):
+            for key in (uid, uid_norm):
+                if key in data:
+                    target = _profile_target_from_entry(data[key])
+                    if target:
+                        return {**target, "source": "profile_map"}
+            profiles = data.get("profiles") or data.get("users")
+            if isinstance(profiles, list):
+                data = profiles
+        if isinstance(data, list):
+            for entry in data:
+                if not isinstance(entry, dict):
+                    continue
+                entry_uid = str(entry.get("uid") or entry.get("profile_uid") or entry.get("profileUid") or "").lower()
+                if entry_uid != uid_norm:
+                    continue
+                target = _profile_target_from_entry(entry)
+                if target:
+                    return {**target, "source": "profile_map"}
+    return None
+
+
+def _target_from_profile_config(candidate: HonchoFactCandidate) -> dict[str, str] | None:
+    if HONCHO_PROFILE_UID and HONCHO_PROFILE_UID.lower() != candidate.uid.lower():
+        return None
+    data = _safe_json_file(HONCHO_PROFILE_CONFIG_PATH)
+    target = _profile_target_from_entry(data)
+    if target:
+        return {**target, "source": "profile_config"}
+    return None
+
+
+def _resolve_native_honcho_target(
+    candidate: HonchoFactCandidate,
+    *,
+    honcho_workspace: str | None = None,
+    honcho_observer_peer_id: str | None = None,
+    honcho_observed_peer_id: str | None = None,
+) -> tuple[dict[str, str] | None, str]:
+    explicit_workspace = honcho_workspace if honcho_workspace is not None else HONCHO_WORKSPACE
+    explicit_observed = honcho_observed_peer_id if honcho_observed_peer_id is not None else HONCHO_OBSERVED_PEER_ID
+    explicit_observer = honcho_observer_peer_id if honcho_observer_peer_id is not None else HONCHO_OBSERVER_PEER_ID
+
+    if explicit_workspace:
+        return (
+            {
+                "workspace": _honcho_workspace_id(candidate, explicit_workspace),
+                "observer_peer_id": _honcho_resource_id(explicit_observer or "ella-correction-observer"),
+                "observed_peer_id": _honcho_resource_id(
+                    explicit_observed or candidate.uid, prefix="" if explicit_observed else "omi-uid-"
+                ),
+                "source": "explicit_override",
+            },
+            "",
+        )
+
+    target = _target_from_profile_map(candidate.uid) or _target_from_profile_config(candidate)
+    if target:
+        observer_peer_id = explicit_observer or target.get("observer_peer_id") or "ella-correction-observer"
+        return (
+            {
+                "workspace": target["workspace"],
+                "observer_peer_id": _honcho_resource_id(observer_peer_id),
+                "observed_peer_id": target["observed_peer_id"],
+                "source": target.get("source") or "companion_profile",
+            },
+            "",
+        )
+
+    return None, "missing_companion_honcho_target"
 
 
 def _conversation_id(conversation: dict[str, Any]) -> str:
@@ -484,14 +625,31 @@ async def _write_honcho_fact_candidate_via_native_honcho(
     honcho_api_key: str | None = None,
     honcho_workspace: str | None = None,
     honcho_observer_peer_id: str | None = None,
+    honcho_observed_peer_id: str | None = None,
     http_client_factory: Callable[..., Any] = httpx.AsyncClient,
 ) -> HonchoFactWriteDecision:
     api_key = honcho_api_key if honcho_api_key is not None else HONCHO_API_KEY
-    workspace = _honcho_workspace_id(candidate, honcho_workspace)
-    observer_peer_id = _honcho_resource_id(
-        honcho_observer_peer_id or HONCHO_OBSERVER_PEER_ID or "ella-correction-observer"
+    target, target_error = _resolve_native_honcho_target(
+        candidate,
+        honcho_workspace=honcho_workspace,
+        honcho_observer_peer_id=honcho_observer_peer_id,
+        honcho_observed_peer_id=honcho_observed_peer_id,
     )
-    observed_peer_id = _honcho_resource_id(candidate.uid, prefix="omi-uid-")
+    if target is None:
+        return HonchoFactWriteDecision(
+            action="skip",
+            reason=target_error,
+            uid=candidate.uid,
+            correction_id=candidate.correction_id,
+            fingerprint=candidate.fingerprint,
+            idempotency_key=candidate.idempotency_key,
+            confidence=candidate.confidence,
+            session_key=candidate.session_key,
+            response_ref={"transport": "honcho_conclusions"},
+        )
+    workspace = target["workspace"]
+    observer_peer_id = target["observer_peer_id"]
+    observed_peer_id = target["observed_peer_id"]
     session_id = _honcho_resource_id(candidate.session_key)
     base_url = (honcho_base_url or HONCHO_BASE_URL).rstrip("/")
     started = time.monotonic()
@@ -545,6 +703,7 @@ async def _write_honcho_fact_candidate_via_native_honcho(
                         response_ref={
                             "transport": "honcho_conclusions",
                             "workspace": workspace,
+                            "target_source": target.get("source"),
                             "body": getattr(response, "text", "")[:500],
                         },
                     )
@@ -569,6 +728,7 @@ async def _write_honcho_fact_candidate_via_native_honcho(
                     response_ref={
                         "transport": "honcho_conclusions",
                         "workspace": workspace,
+                        "target_source": target.get("source"),
                         "body": getattr(idempotency_response, "text", "")[:500],
                     },
                 )
@@ -604,6 +764,7 @@ async def _write_honcho_fact_candidate_via_native_honcho(
                     response_ref={
                         "transport": "honcho_conclusions",
                         "workspace": workspace,
+                        "target_source": target.get("source"),
                         "observer_peer_id": observer_peer_id,
                         "observed_peer_id": observed_peer_id,
                         "session_id": session_id,
@@ -643,6 +804,7 @@ async def _write_honcho_fact_candidate_via_native_honcho(
                 response_ref={
                     "transport": "honcho_conclusions",
                     "workspace": workspace,
+                    "target_source": target.get("source"),
                     "body": getattr(response, "text", "")[:500],
                 },
             )
@@ -694,6 +856,7 @@ async def _write_honcho_fact_candidate_via_native_honcho(
             response_ref={
                 "transport": "honcho_conclusions",
                 "workspace": workspace,
+                "target_source": target.get("source"),
                 "observer_peer_id": observer_peer_id,
                 "observed_peer_id": observed_peer_id,
                 "session_id": session_id,
@@ -728,6 +891,7 @@ async def write_honcho_fact_candidate(
     honcho_api_key: str | None = None,
     honcho_workspace: str | None = None,
     honcho_observer_peer_id: str | None = None,
+    honcho_observed_peer_id: str | None = None,
     http_client_factory: Callable[..., Any] = httpx.AsyncClient,
 ) -> HonchoFactWriteDecision:
     if not HONCHO_FACT_WRITE_ENABLED:
@@ -774,6 +938,7 @@ async def write_honcho_fact_candidate(
             honcho_api_key=honcho_api_key,
             honcho_workspace=honcho_workspace,
             honcho_observer_peer_id=honcho_observer_peer_id,
+            honcho_observed_peer_id=honcho_observed_peer_id,
             http_client_factory=http_client_factory,
         )
     if selected_transport not in {"hermes", "hermes_chat", "hermes_chat_completions"}:

--- a/backend/ella/services/correction_honcho_contract.py
+++ b/backend/ella/services/correction_honcho_contract.py
@@ -38,9 +38,20 @@ HONCHO_FACT_MIN_CONFIDENCE = float(os.getenv("ELLA_CORRECTION_HONCHO_FACT_MIN_CO
 HERMES_GATEWAY_URL = os.getenv("HERMES_GATEWAY_URL", "http://100.76.138.56:8642").rstrip("/")
 HERMES_MODEL = os.getenv("HERMES_MODEL", "plato-eval")
 HERMES_TIMEOUT_SECONDS = float(os.getenv("ELLA_CORRECTION_HONCHO_FACT_TIMEOUT_SECONDS", "20"))
+HONCHO_FACT_WRITE_TRANSPORT = os.getenv("ELLA_CORRECTION_HONCHO_FACT_WRITE_TRANSPORT", "hermes").strip().lower()
+HONCHO_BASE_URL = (
+    os.getenv("ELLA_CORRECTION_HONCHO_BASE_URL") or os.getenv("HONCHO_BASE_URL") or "http://127.0.0.1:8320"
+).rstrip("/")
+HONCHO_API_KEY = os.getenv("ELLA_CORRECTION_HONCHO_API_KEY") or os.getenv("HONCHO_API_KEY") or ""
+HONCHO_WORKSPACE = os.getenv("ELLA_CORRECTION_HONCHO_WORKSPACE") or os.getenv("HONCHO_WORKSPACE") or ""
+HONCHO_WORKSPACE_PREFIX = os.getenv("ELLA_CORRECTION_HONCHO_WORKSPACE_PREFIX", "ella-correction-facts")
+HONCHO_OBSERVER_PEER_ID = (
+    os.getenv("ELLA_CORRECTION_HONCHO_OBSERVER_PEER_ID") or os.getenv("HONCHO_OBSERVER_PEER_ID") or ""
+)
 
 TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9'_-]{2,}", re.I)
 JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+HONCHO_RESOURCE_RE = re.compile(r"[^a-zA-Z0-9_-]+")
 PERSON_MARKERS = re.compile(
     r"(?i)(?:is|was|named|called|a\\.k\\.a\\.|aka|person is|speaker is)\\s+([A-Z][A-Za-z0-9 .'-]{1,80})"
 )
@@ -100,6 +111,28 @@ def _stable_hash(value: Any) -> str:
 
 def honcho_session_key(uid: str) -> str:
     return canonical_omi_session_key(uid)
+
+
+def _honcho_resource_id(value: str, *, prefix: str = "", max_len: int = 100) -> str:
+    raw = f"{prefix}{value}".strip()
+    sanitized = HONCHO_RESOURCE_RE.sub("-", raw).strip("-")
+    if not sanitized:
+        sanitized = "unknown"
+    if len(sanitized) <= max_len and sanitized == raw:
+        return sanitized
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:10]
+    room = max_len - len(digest) - 1
+    return f"{sanitized[:room].rstrip('-')}-{digest}"
+
+
+def _honcho_workspace_id(candidate: HonchoFactCandidate, explicit_workspace: str | None = None) -> str:
+    if explicit_workspace:
+        return _honcho_resource_id(explicit_workspace)
+    if HONCHO_WORKSPACE:
+        return _honcho_resource_id(HONCHO_WORKSPACE)
+    uid_hash = hashlib.sha256(candidate.uid.encode("utf-8")).hexdigest()[:12]
+    uid_component = _honcho_resource_id(candidate.uid, max_len=48)
+    return _honcho_resource_id(f"{HONCHO_WORKSPACE_PREFIX}-{uid_component}-{uid_hash}")
 
 
 def _conversation_id(conversation: dict[str, Any]) -> str:
@@ -386,6 +419,303 @@ def _confirmation_from_response(response: Any) -> tuple[str, str, dict[str, Any]
     )
 
 
+def _honcho_headers(api_key: str) -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def _honcho_success_ref(body: Any) -> dict[str, Any] | None:
+    if not isinstance(body, list) or not body or not isinstance(body[0], dict):
+        return None
+    first = body[0]
+    durable_ref = first.get("id") or first.get("memory_id") or first.get("durable_ref")
+    if not durable_ref:
+        return None
+    return {
+        "memory_id": str(durable_ref),
+        "durable_ref": str(durable_ref),
+        "honcho_conclusion": {
+            key: first.get(key)
+            for key in ("id", "observer_id", "observer", "observed_id", "observed", "session_id", "session_name")
+            if first.get(key) is not None
+        },
+    }
+
+
+def _honcho_existing_ref(body: Any, *, fact_text: str, session_id: str) -> dict[str, Any] | None:
+    if not isinstance(body, dict) or not isinstance(body.get("items"), list):
+        return None
+    for item in body["items"]:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("content") or "").strip() != fact_text.strip():
+            continue
+        item_session_id = str(item.get("session_id") or item.get("session_name") or "")
+        if item_session_id and item_session_id != session_id:
+            continue
+        durable_ref = item.get("id") or item.get("memory_id") or item.get("durable_ref")
+        if durable_ref:
+            return {
+                "memory_id": str(durable_ref),
+                "durable_ref": str(durable_ref),
+                "honcho_conclusion": {
+                    key: item.get(key)
+                    for key in (
+                        "id",
+                        "observer_id",
+                        "observer",
+                        "observed_id",
+                        "observed",
+                        "session_id",
+                        "session_name",
+                    )
+                    if item.get(key) is not None
+                },
+            }
+    return None
+
+
+async def _write_honcho_fact_candidate_via_native_honcho(
+    candidate: HonchoFactCandidate,
+    *,
+    honcho_base_url: str | None = None,
+    honcho_api_key: str | None = None,
+    honcho_workspace: str | None = None,
+    honcho_observer_peer_id: str | None = None,
+    http_client_factory: Callable[..., Any] = httpx.AsyncClient,
+) -> HonchoFactWriteDecision:
+    api_key = honcho_api_key if honcho_api_key is not None else HONCHO_API_KEY
+    workspace = _honcho_workspace_id(candidate, honcho_workspace)
+    observer_peer_id = _honcho_resource_id(
+        honcho_observer_peer_id or HONCHO_OBSERVER_PEER_ID or "ella-correction-observer"
+    )
+    observed_peer_id = _honcho_resource_id(candidate.uid, prefix="omi-uid-")
+    session_id = _honcho_resource_id(candidate.session_key)
+    base_url = (honcho_base_url or HONCHO_BASE_URL).rstrip("/")
+    started = time.monotonic()
+
+    try:
+        async with http_client_factory(timeout=HERMES_TIMEOUT_SECONDS) as client:
+            headers = _honcho_headers(api_key)
+            setup_calls = [
+                (
+                    f"{base_url}/v3/workspaces",
+                    {"id": workspace, "metadata": {"source": "omi_correction_observer"}},
+                ),
+                (
+                    f"{base_url}/v3/workspaces/{workspace}/peers",
+                    {"id": observer_peer_id, "metadata": {"role": "observer", "source": "omi_correction_observer"}},
+                ),
+                (
+                    f"{base_url}/v3/workspaces/{workspace}/peers",
+                    {"id": observed_peer_id, "metadata": {"profile_uid": candidate.uid, "source": "omi_correction"}},
+                ),
+                (
+                    f"{base_url}/v3/workspaces/{workspace}/sessions",
+                    {
+                        "id": session_id,
+                        "metadata": {
+                            "profile_uid": candidate.uid,
+                            "source": "omi_correction_observer",
+                            "session_key": candidate.session_key,
+                        },
+                        "peers": {
+                            observer_peer_id: {"observe_me": True, "observe_others": True},
+                            observed_peer_id: {"observe_me": True, "observe_others": True},
+                        },
+                    },
+                ),
+            ]
+            for setup_url, payload in setup_calls:
+                response = await client.post(setup_url, headers=headers, json=payload)
+                if response.status_code >= 400:
+                    return HonchoFactWriteDecision(
+                        action="error",
+                        reason=f"honcho_setup_http_{response.status_code}",
+                        uid=candidate.uid,
+                        correction_id=candidate.correction_id,
+                        fingerprint=candidate.fingerprint,
+                        idempotency_key=candidate.idempotency_key,
+                        confidence=candidate.confidence,
+                        session_key=candidate.session_key,
+                        status_code=response.status_code,
+                        latency_ms=int((time.monotonic() - started) * 1000),
+                        response_ref={
+                            "transport": "honcho_conclusions",
+                            "workspace": workspace,
+                            "body": getattr(response, "text", "")[:500],
+                        },
+                    )
+
+            idempotency_response = await client.post(
+                f"{base_url}/v3/workspaces/{workspace}/conclusions/list",
+                headers=headers,
+                json={"filters": {"observer_id": observer_peer_id, "observed_id": observed_peer_id}},
+            )
+            if idempotency_response.status_code >= 400:
+                return HonchoFactWriteDecision(
+                    action="error",
+                    reason=f"honcho_idempotency_http_{idempotency_response.status_code}",
+                    uid=candidate.uid,
+                    correction_id=candidate.correction_id,
+                    fingerprint=candidate.fingerprint,
+                    idempotency_key=candidate.idempotency_key,
+                    confidence=candidate.confidence,
+                    session_key=candidate.session_key,
+                    status_code=idempotency_response.status_code,
+                    latency_ms=int((time.monotonic() - started) * 1000),
+                    response_ref={
+                        "transport": "honcho_conclusions",
+                        "workspace": workspace,
+                        "body": getattr(idempotency_response, "text", "")[:500],
+                    },
+                )
+            try:
+                existing_body = idempotency_response.json()
+            except Exception as exc:
+                return HonchoFactWriteDecision(
+                    action="uncertain",
+                    reason="malformed_honcho_idempotency_response",
+                    uid=candidate.uid,
+                    correction_id=candidate.correction_id,
+                    fingerprint=candidate.fingerprint,
+                    idempotency_key=candidate.idempotency_key,
+                    confidence=candidate.confidence,
+                    session_key=candidate.session_key,
+                    status_code=idempotency_response.status_code,
+                    latency_ms=int((time.monotonic() - started) * 1000),
+                    response_ref={"transport": "honcho_conclusions", "workspace": workspace, "error": str(exc)[:240]},
+                )
+            existing_ref = _honcho_existing_ref(existing_body, fact_text=candidate.fact_text, session_id=session_id)
+            if existing_ref:
+                return HonchoFactWriteDecision(
+                    action="written",
+                    reason="honcho_conclusion_already_exists",
+                    uid=candidate.uid,
+                    correction_id=candidate.correction_id,
+                    fingerprint=candidate.fingerprint,
+                    idempotency_key=candidate.idempotency_key,
+                    confidence=candidate.confidence,
+                    session_key=candidate.session_key,
+                    status_code=idempotency_response.status_code,
+                    latency_ms=int((time.monotonic() - started) * 1000),
+                    response_ref={
+                        "transport": "honcho_conclusions",
+                        "workspace": workspace,
+                        "observer_peer_id": observer_peer_id,
+                        "observed_peer_id": observed_peer_id,
+                        "session_id": session_id,
+                        "idempotency": "backend_exact_match",
+                        "at": _now_iso(),
+                        **existing_ref,
+                    },
+                )
+
+            response = await client.post(
+                f"{base_url}/v3/workspaces/{workspace}/conclusions",
+                headers={**headers, "X-Idempotency-Key": candidate.idempotency_key, "X-Trace-Id": candidate.trace_id},
+                json={
+                    "conclusions": [
+                        {
+                            "observer_id": observer_peer_id,
+                            "observed_id": observed_peer_id,
+                            "content": candidate.fact_text,
+                            "session_id": session_id,
+                        }
+                    ]
+                },
+            )
+        latency_ms = int((time.monotonic() - started) * 1000)
+        if response.status_code >= 400:
+            return HonchoFactWriteDecision(
+                action="error",
+                reason=f"honcho_http_{response.status_code}",
+                uid=candidate.uid,
+                correction_id=candidate.correction_id,
+                fingerprint=candidate.fingerprint,
+                idempotency_key=candidate.idempotency_key,
+                confidence=candidate.confidence,
+                session_key=candidate.session_key,
+                status_code=response.status_code,
+                latency_ms=latency_ms,
+                response_ref={
+                    "transport": "honcho_conclusions",
+                    "workspace": workspace,
+                    "body": getattr(response, "text", "")[:500],
+                },
+            )
+
+        try:
+            body = response.json()
+        except Exception as exc:
+            return HonchoFactWriteDecision(
+                action="uncertain",
+                reason="malformed_honcho_response",
+                uid=candidate.uid,
+                correction_id=candidate.correction_id,
+                fingerprint=candidate.fingerprint,
+                idempotency_key=candidate.idempotency_key,
+                confidence=candidate.confidence,
+                session_key=candidate.session_key,
+                status_code=response.status_code,
+                latency_ms=latency_ms,
+                response_ref={"transport": "honcho_conclusions", "workspace": workspace, "error": str(exc)[:240]},
+            )
+
+        success_ref = _honcho_success_ref(body)
+        if not success_ref:
+            return HonchoFactWriteDecision(
+                action="uncertain",
+                reason="missing_honcho_durable_ref",
+                uid=candidate.uid,
+                correction_id=candidate.correction_id,
+                fingerprint=candidate.fingerprint,
+                idempotency_key=candidate.idempotency_key,
+                confidence=candidate.confidence,
+                session_key=candidate.session_key,
+                status_code=response.status_code,
+                latency_ms=latency_ms,
+                response_ref={"transport": "honcho_conclusions", "workspace": workspace, "body": body},
+            )
+
+        return HonchoFactWriteDecision(
+            action="written",
+            reason="honcho_conclusion_written",
+            uid=candidate.uid,
+            correction_id=candidate.correction_id,
+            fingerprint=candidate.fingerprint,
+            idempotency_key=candidate.idempotency_key,
+            confidence=candidate.confidence,
+            session_key=candidate.session_key,
+            status_code=response.status_code,
+            latency_ms=latency_ms,
+            response_ref={
+                "transport": "honcho_conclusions",
+                "workspace": workspace,
+                "observer_peer_id": observer_peer_id,
+                "observed_peer_id": observed_peer_id,
+                "session_id": session_id,
+                "at": _now_iso(),
+                **success_ref,
+            },
+        )
+    except Exception as exc:
+        return HonchoFactWriteDecision(
+            action="error",
+            reason=type(exc).__name__,
+            uid=candidate.uid,
+            correction_id=candidate.correction_id,
+            fingerprint=candidate.fingerprint,
+            idempotency_key=candidate.idempotency_key,
+            confidence=candidate.confidence,
+            session_key=candidate.session_key,
+            latency_ms=int((time.monotonic() - started) * 1000),
+            response_ref={"transport": "honcho_conclusions", "error": str(exc)[:500]},
+        )
+
+
 async def write_honcho_fact_candidate(
     candidate: HonchoFactCandidate,
     *,
@@ -393,6 +723,11 @@ async def write_honcho_fact_candidate(
     token: str | None = None,
     gateway_url: str | None = None,
     model: str | None = None,
+    transport: str | None = None,
+    honcho_base_url: str | None = None,
+    honcho_api_key: str | None = None,
+    honcho_workspace: str | None = None,
+    honcho_observer_peer_id: str | None = None,
     http_client_factory: Callable[..., Any] = httpx.AsyncClient,
 ) -> HonchoFactWriteDecision:
     if not HONCHO_FACT_WRITE_ENABLED:
@@ -423,6 +758,28 @@ async def write_honcho_fact_candidate(
         return HonchoFactWriteDecision(
             action="skip",
             reason="stale_active_summary_version",
+            uid=candidate.uid,
+            correction_id=candidate.correction_id,
+            fingerprint=candidate.fingerprint,
+            idempotency_key=candidate.idempotency_key,
+            confidence=candidate.confidence,
+            session_key=candidate.session_key,
+        )
+
+    selected_transport = (transport or HONCHO_FACT_WRITE_TRANSPORT or "hermes").strip().lower()
+    if selected_transport in {"honcho", "honcho_conclusions", "native_honcho"}:
+        return await _write_honcho_fact_candidate_via_native_honcho(
+            candidate,
+            honcho_base_url=honcho_base_url,
+            honcho_api_key=honcho_api_key,
+            honcho_workspace=honcho_workspace,
+            honcho_observer_peer_id=honcho_observer_peer_id,
+            http_client_factory=http_client_factory,
+        )
+    if selected_transport not in {"hermes", "hermes_chat", "hermes_chat_completions"}:
+        return HonchoFactWriteDecision(
+            action="skip",
+            reason=f"unsupported_transport:{selected_transport}",
             uid=candidate.uid,
             correction_id=candidate.correction_id,
             fingerprint=candidate.fingerprint,

--- a/backend/tests/unit/test_ella_correction_honcho_contract.py
+++ b/backend/tests/unit/test_ella_correction_honcho_contract.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from datetime import datetime, timezone
 import sys
 from unittest.mock import MagicMock
@@ -366,6 +367,7 @@ def test_write_honcho_fact_candidate_native_honcho_chatty_200_is_uncertain(monke
             candidate,
             current_conversation=_conversation("related", uid="user-123", version="v1"),
             transport="honcho",
+            honcho_workspace="ella-staging",
             http_client_factory=fake_client,
         )
     )
@@ -393,6 +395,7 @@ def test_write_honcho_fact_candidate_native_honcho_http_error(monkeypatch):
             candidate,
             current_conversation=_conversation("related", uid="user-123", version="v1"),
             transport="native_honcho",
+            honcho_workspace="ella-staging",
             http_client_factory=fake_client,
         )
     )
@@ -411,6 +414,7 @@ def test_write_honcho_fact_candidate_native_honcho_setup_error(monkeypatch):
             candidate,
             current_conversation=_conversation("related", uid="user-123", version="v1"),
             transport="honcho",
+            honcho_workspace="ella-staging",
             http_client_factory=fake_client,
         )
     )
@@ -419,13 +423,150 @@ def test_write_honcho_fact_candidate_native_honcho_setup_error(monkeypatch):
     assert decision.reason == "honcho_setup_http_401"
 
 
-def test_write_honcho_fact_candidate_native_honcho_default_workspace_is_per_uid(monkeypatch):
-    first = _candidate(uid="user-123", active_summary_version_id="v1")
-    second = _candidate(uid="user-456", active_summary_version_id="v1")
+def test_write_honcho_fact_candidate_native_honcho_fails_closed_without_companion_target(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
 
-    assert contract._honcho_workspace_id(first) != contract._honcho_workspace_id(second)
-    assert contract._honcho_workspace_id(first).startswith("ella-correction-facts-")
-    assert contract._honcho_workspace_id(second).startswith("ella-correction-facts-")
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
+    monkeypatch.setattr(contract, "HONCHO_WORKSPACE", "")
+    monkeypatch.setattr(contract, "HONCHO_OBSERVED_PEER_ID", "")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_JSON", "")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_PATH", "")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_CONFIG_PATH", "")
+    decision = asyncio.run(
+        contract.write_honcho_fact_candidate(
+            candidate,
+            current_conversation=_conversation("related", uid="user-123", version="v1"),
+            transport="honcho",
+        )
+    )
+
+    assert decision.action == "skip"
+    assert decision.reason == "missing_companion_honcho_target"
+
+
+def test_write_honcho_fact_candidate_native_honcho_profile_map_targets_companion_scope(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
+    fake_client, calls = _fake_sequence_client_factory(
+        [
+            FakeJsonResponse(body={"id": "workspace"}),
+            FakeJsonResponse(body={"id": "observer"}),
+            FakeJsonResponse(body={"id": "observed"}),
+            FakeJsonResponse(body={"id": "session"}),
+            FakeJsonResponse(body={"items": []}),
+            FakeJsonResponse(
+                status_code=201,
+                body=[
+                    {
+                        "id": "conclusion-456",
+                        "observer_id": "ella",
+                        "observed_id": "plato",
+                        "session_id": "ella-omi-user-123-canonical",
+                    }
+                ],
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
+    monkeypatch.setattr(contract, "HONCHO_WORKSPACE", "")
+    monkeypatch.setattr(contract, "HONCHO_OBSERVED_PEER_ID", "")
+    monkeypatch.setattr(
+        contract,
+        "HONCHO_PROFILE_MAP_JSON",
+        json.dumps({"user-123": {"workspace": "ella-plato-canonical", "peerName": "plato", "aiPeer": "ella"}}),
+    )
+    decision = asyncio.run(
+        contract.write_honcho_fact_candidate(
+            candidate,
+            current_conversation=_conversation("related", uid="user-123", version="v1"),
+            transport="honcho",
+            honcho_base_url="http://honcho.test",
+            http_client_factory=fake_client,
+        )
+    )
+
+    assert decision.action == "written"
+    assert decision.reason == "honcho_conclusion_written"
+    assert decision.response_ref["workspace"] == "ella-plato-canonical"
+    assert decision.response_ref["observer_peer_id"] == "ella"
+    assert decision.response_ref["observed_peer_id"] == "plato"
+    assert decision.response_ref["target_source"] == "profile_map"
+    assert calls[1]["url"] == "http://honcho.test/v3/workspaces/ella-plato-canonical/peers"
+    assert calls[2]["json"]["id"] == "plato"
+    assert calls[4]["json"]["filters"] == {"observer_id": "ella", "observed_id": "plato"}
+
+
+def test_write_honcho_fact_candidate_native_honcho_profile_config_prefers_host_ai_peer(monkeypatch, tmp_path):
+    candidate = _candidate(active_summary_version_id="v1")
+    config = tmp_path / "honcho.json"
+    config.write_text(
+        json.dumps(
+            {
+                "workspace": "ella-plato-canonical",
+                "peerName": "plato",
+                "aiPeer": "ella",
+                "hosts": {
+                    "hermes.plato-eval": {
+                        "workspace": "ella-plato-canonical",
+                        "peerName": "plato",
+                        "aiPeer": "plato-eval",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(contract, "HONCHO_WORKSPACE", "")
+    monkeypatch.setattr(contract, "HONCHO_OBSERVED_PEER_ID", "")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_JSON", "")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_PATH", "")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_CONFIG_PATH", str(config))
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_UID", "user-123")
+    target, reason = contract._resolve_native_honcho_target(candidate)
+
+    assert reason == ""
+    assert target == {
+        "workspace": "ella-plato-canonical",
+        "observer_peer_id": "plato-eval",
+        "observed_peer_id": "plato",
+        "source": "profile_config",
+    }
+
+
+def test_write_honcho_fact_candidate_native_honcho_explicit_workspace_can_set_observed_peer(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
+    fake_client, calls = _fake_sequence_client_factory(
+        [
+            FakeJsonResponse(body={"id": "workspace"}),
+            FakeJsonResponse(body={"id": "observer"}),
+            FakeJsonResponse(body={"id": "observed"}),
+            FakeJsonResponse(body={"id": "session"}),
+            FakeJsonResponse(body={"items": []}),
+            FakeJsonResponse(status_code=201, body=[{"id": "conclusion-789"}]),
+        ]
+    )
+
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
+    decision = asyncio.run(
+        contract.write_honcho_fact_candidate(
+            candidate,
+            current_conversation=_conversation("related", uid="user-123", version="v1"),
+            transport="honcho",
+            honcho_base_url="http://honcho.test",
+            honcho_workspace="ella-plato-canonical",
+            honcho_observer_peer_id="ella",
+            honcho_observed_peer_id="plato",
+            http_client_factory=fake_client,
+        )
+    )
+
+    assert decision.action == "written"
+    assert decision.response_ref["workspace"] == "ella-plato-canonical"
+    assert decision.response_ref["observer_peer_id"] == "ella"
+    assert decision.response_ref["observed_peer_id"] == "plato"
+    assert decision.response_ref["target_source"] == "explicit_override"
+    assert calls[2]["json"]["id"] == "plato"
 
 
 def test_write_honcho_fact_candidate_native_honcho_existing_fact_is_idempotent(monkeypatch):

--- a/backend/tests/unit/test_ella_correction_honcho_contract.py
+++ b/backend/tests/unit/test_ella_correction_honcho_contract.py
@@ -133,6 +133,27 @@ def _fake_client_factory(response):
     return FakeClient, calls
 
 
+def _fake_sequence_client_factory(responses):
+    calls = []
+    remaining = list(responses)
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, **kwargs):
+            calls.append({"url": url, **kwargs})
+            return remaining.pop(0)
+
+    return FakeClient, calls
+
+
 class FakeResponse:
     def __init__(self, *, status_code=200, content='{"status":"written","memory_id":"mem-123"}', text=None):
         self.status_code = status_code
@@ -141,6 +162,19 @@ class FakeResponse:
 
     def json(self):
         return {"choices": [{"message": {"content": self._content}}]}
+
+
+class FakeJsonResponse:
+    def __init__(self, *, status_code=200, body=None, text=None, raises=False):
+        self.status_code = status_code
+        self._body = [] if body is None else body
+        self.text = text if text is not None else str(self._body)
+        self.raises = raises
+
+    def json(self):
+        if self.raises:
+            raise ValueError("bad json")
+        return self._body
 
 
 def test_write_honcho_fact_candidate_uses_hermes_session_key_and_requires_confirmation(monkeypatch):
@@ -258,3 +292,181 @@ def test_write_honcho_fact_candidate_http_error_remains_error(monkeypatch):
 
     assert decision.action == "error"
     assert decision.reason == "hermes_http_502"
+
+
+def test_write_honcho_fact_candidate_native_honcho_requires_durable_ref(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
+    fake_client, calls = _fake_sequence_client_factory(
+        [
+            FakeJsonResponse(body={"id": "workspace"}),
+            FakeJsonResponse(body={"id": "observer"}),
+            FakeJsonResponse(body={"id": "observed"}),
+            FakeJsonResponse(body={"id": "session"}),
+            FakeJsonResponse(body={"items": []}),
+            FakeJsonResponse(
+                status_code=201,
+                body=[
+                    {
+                        "id": "conclusion-123",
+                        "observer_id": "ella-observer",
+                        "observed_id": "omi-uid-user-123",
+                        "session_id": "ella-omi-user-123-canonical",
+                    }
+                ],
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
+    decision = asyncio.run(
+        contract.write_honcho_fact_candidate(
+            candidate,
+            current_conversation=_conversation("related", uid="user-123", version="v1"),
+            transport="honcho_conclusions",
+            honcho_base_url="http://honcho.test",
+            honcho_api_key="honcho-token",
+            honcho_workspace="ella-staging",
+            honcho_observer_peer_id="ella-observer",
+            http_client_factory=fake_client,
+        )
+    )
+
+    assert decision.action == "written"
+    assert decision.reason == "honcho_conclusion_written"
+    assert decision.response_ref["memory_id"] == "conclusion-123"
+    assert decision.response_ref["workspace"] == "ella-staging"
+    assert decision.response_ref["observer_peer_id"] == "ella-observer"
+    assert decision.response_ref["observed_peer_id"] == "omi-uid-user-123"
+    assert calls[0]["url"] == "http://honcho.test/v3/workspaces"
+    assert calls[0]["headers"]["Authorization"] == "Bearer honcho-token"
+    assert calls[3]["url"] == "http://honcho.test/v3/workspaces/ella-staging/sessions"
+    assert calls[3]["json"]["peers"]["ella-observer"]["observe_others"] is True
+    assert calls[4]["url"] == "http://honcho.test/v3/workspaces/ella-staging/conclusions/list"
+    assert calls[5]["url"] == "http://honcho.test/v3/workspaces/ella-staging/conclusions"
+    assert calls[5]["headers"]["X-Idempotency-Key"] == candidate.idempotency_key
+    assert calls[5]["json"]["conclusions"][0]["content"] == candidate.fact_text
+
+
+def test_write_honcho_fact_candidate_native_honcho_chatty_200_is_uncertain(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
+    fake_client, _ = _fake_sequence_client_factory(
+        [
+            FakeJsonResponse(body={"id": "workspace"}),
+            FakeJsonResponse(body={"id": "observer"}),
+            FakeJsonResponse(body={"id": "observed"}),
+            FakeJsonResponse(body={"id": "session"}),
+            FakeJsonResponse(body={"items": []}),
+            FakeJsonResponse(status_code=201, body={"ok": True}),
+        ]
+    )
+
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
+    decision = asyncio.run(
+        contract.write_honcho_fact_candidate(
+            candidate,
+            current_conversation=_conversation("related", uid="user-123", version="v1"),
+            transport="honcho",
+            http_client_factory=fake_client,
+        )
+    )
+
+    assert decision.action == "uncertain"
+    assert decision.reason == "missing_honcho_durable_ref"
+
+
+def test_write_honcho_fact_candidate_native_honcho_http_error(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
+    fake_client, _ = _fake_sequence_client_factory(
+        [
+            FakeJsonResponse(body={"id": "workspace"}),
+            FakeJsonResponse(body={"id": "observer"}),
+            FakeJsonResponse(body={"id": "observed"}),
+            FakeJsonResponse(body={"id": "session"}),
+            FakeJsonResponse(body={"items": []}),
+            FakeJsonResponse(status_code=503, body={"detail": "unavailable"}, text="unavailable"),
+        ]
+    )
+
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
+    decision = asyncio.run(
+        contract.write_honcho_fact_candidate(
+            candidate,
+            current_conversation=_conversation("related", uid="user-123", version="v1"),
+            transport="native_honcho",
+            http_client_factory=fake_client,
+        )
+    )
+
+    assert decision.action == "error"
+    assert decision.reason == "honcho_http_503"
+
+
+def test_write_honcho_fact_candidate_native_honcho_setup_error(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
+    fake_client, _ = _fake_sequence_client_factory([FakeJsonResponse(status_code=401, text="unauthorized")])
+
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
+    decision = asyncio.run(
+        contract.write_honcho_fact_candidate(
+            candidate,
+            current_conversation=_conversation("related", uid="user-123", version="v1"),
+            transport="honcho",
+            http_client_factory=fake_client,
+        )
+    )
+
+    assert decision.action == "error"
+    assert decision.reason == "honcho_setup_http_401"
+
+
+def test_write_honcho_fact_candidate_native_honcho_default_workspace_is_per_uid(monkeypatch):
+    first = _candidate(uid="user-123", active_summary_version_id="v1")
+    second = _candidate(uid="user-456", active_summary_version_id="v1")
+
+    assert contract._honcho_workspace_id(first) != contract._honcho_workspace_id(second)
+    assert contract._honcho_workspace_id(first).startswith("ella-correction-facts-")
+    assert contract._honcho_workspace_id(second).startswith("ella-correction-facts-")
+
+
+def test_write_honcho_fact_candidate_native_honcho_existing_fact_is_idempotent(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
+    fake_client, calls = _fake_sequence_client_factory(
+        [
+            FakeJsonResponse(body={"id": "workspace"}),
+            FakeJsonResponse(body={"id": "observer"}),
+            FakeJsonResponse(body={"id": "observed"}),
+            FakeJsonResponse(body={"id": "session"}),
+            FakeJsonResponse(
+                body={
+                    "items": [
+                        {
+                            "id": "existing-123",
+                            "content": candidate.fact_text,
+                            "observer_id": "ella-observer",
+                            "observed_id": "omi-uid-user-123",
+                        }
+                    ]
+                }
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
+    decision = asyncio.run(
+        contract.write_honcho_fact_candidate(
+            candidate,
+            current_conversation=_conversation("related", uid="user-123", version="v1"),
+            transport="honcho",
+            honcho_base_url="http://honcho.test",
+            honcho_workspace="ella-staging",
+            honcho_observer_peer_id="ella-observer",
+            http_client_factory=fake_client,
+        )
+    )
+
+    assert decision.action == "written"
+    assert decision.reason == "honcho_conclusion_already_exists"
+    assert decision.response_ref["memory_id"] == "existing-123"
+    assert decision.response_ref["idempotency"] == "backend_exact_match"
+    assert len(calls) == 5
+    assert calls[-1]["url"] == "http://honcho.test/v3/workspaces/ella-staging/conclusions/list"


### PR DESCRIPTION
## Summary
- add an opt-in native Honcho conclusions transport for correction-derived durable fact writes
- keep durable writes default-off and preserve existing Hermes chat-completions transport
- only return written after Honcho returns a concrete conclusion id/durable ref
- create scoped workspace/observer/observed/session resources before writing the conclusion

## Validation
- pytest backend/tests/unit/test_ella_correction_honcho_contract.py
- live staging gate against local Honcho workspace ella-honcho-gate-265 returned durable ref qG1RuhUoeIEA_c6qhgSgM
- separate-process Honcho conclusions query retrieved the Cobalt Lantern fact for the staging peer and returned [] for a different peer

## Safety
- prod flag remains default/off: ELLA_CORRECTION_HONCHO_FACT_WRITE_ENABLED=false
- no OMI shadow fact store added
- no caregiver/scanner paths touched

Closes ellaaicare/ella-ai#1017