### PR TITLE
Read Honcho profile map from provision API

### DIFF
--- a/backend/ella/services/correction_honcho_contract.py
+++ b/backend/ella/services/correction_honcho_contract.py
@@ -14,6 +14,8 @@ import re
 import time
 from datetime import datetime, timezone
 from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 import httpx
 from pydantic import BaseModel, Field
@@ -53,12 +55,16 @@ HONCHO_OBSERVED_PEER_ID = (
 )
 HONCHO_PROFILE_MAP_JSON = os.getenv("ELLA_CORRECTION_HONCHO_PROFILE_MAP_JSON", "")
 HONCHO_PROFILE_MAP_PATH = os.getenv("ELLA_CORRECTION_HONCHO_PROFILE_MAP_PATH", "")
+HONCHO_PROFILE_MAP_URL = os.getenv("ELLA_CORRECTION_HONCHO_PROFILE_MAP_URL", "")
+HONCHO_PROFILE_MAP_URL_TOKEN = os.getenv("ELLA_CORRECTION_HONCHO_PROFILE_MAP_TOKEN", "")
+HONCHO_PROFILE_MAP_URL_TTL_SECONDS = float(os.getenv("ELLA_CORRECTION_HONCHO_PROFILE_MAP_URL_TTL_SECONDS", "30"))
 HONCHO_PROFILE_CONFIG_PATH = os.getenv("ELLA_CORRECTION_HONCHO_PROFILE_CONFIG_PATH", "")
 HONCHO_PROFILE_UID = os.getenv("ELLA_CORRECTION_HONCHO_PROFILE_UID", "")
 
 TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9'_-]{2,}", re.I)
 JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
 HONCHO_RESOURCE_RE = re.compile(r"[^a-zA-Z0-9_-]+")
+_PROFILE_MAP_URL_CACHE: dict[str, Any] = {"url": "", "fetched_at": 0.0, "data": None}
 PERSON_MARKERS = re.compile(
     r"(?i)(?:is|was|named|called|a\\.k\\.a\\.|aka|person is|speaker is)\\s+([A-Z][A-Za-z0-9 .'-]{1,80})"
 )
@@ -161,6 +167,30 @@ def _safe_json_file(path: str) -> Any:
         return None
 
 
+def _safe_json_url(url: str) -> Any:
+    if not str(url or "").strip():
+        return None
+    now = time.monotonic()
+    if (
+        _PROFILE_MAP_URL_CACHE.get("url") == url
+        and _PROFILE_MAP_URL_CACHE.get("data") is not None
+        and now - float(_PROFILE_MAP_URL_CACHE.get("fetched_at") or 0) < HONCHO_PROFILE_MAP_URL_TTL_SECONDS
+    ):
+        return _PROFILE_MAP_URL_CACHE["data"]
+    headers = {"Accept": "application/json"}
+    if HONCHO_PROFILE_MAP_URL_TOKEN:
+        headers["Authorization"] = f"Bearer {HONCHO_PROFILE_MAP_URL_TOKEN}"
+    try:
+        with urlopen(Request(url, headers=headers), timeout=5) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except (HTTPError, URLError, OSError, json.JSONDecodeError, TimeoutError):
+        return None
+    if isinstance(data, dict) and isinstance(data.get("entries"), dict):
+        data = data["entries"]
+    _PROFILE_MAP_URL_CACHE.update({"url": url, "fetched_at": now, "data": data})
+    return data
+
+
 def _profile_target_from_entry(entry: Any) -> dict[str, str] | None:
     if not isinstance(entry, dict):
         return None
@@ -199,6 +229,9 @@ def _target_from_profile_map(uid: str) -> dict[str, str] | None:
     inline = _safe_json_loads(HONCHO_PROFILE_MAP_JSON)
     if inline is not None:
         candidates.append(inline)
+    url_data = _safe_json_url(HONCHO_PROFILE_MAP_URL)
+    if url_data is not None:
+        candidates.append(url_data)
     file_data = _safe_json_file(HONCHO_PROFILE_MAP_PATH)
     if file_data is not None:
         candidates.append(file_data)

--- a/backend/tests/unit/test_ella_correction_honcho_contract.py
+++ b/backend/tests/unit/test_ella_correction_honcho_contract.py
@@ -431,6 +431,7 @@ def test_write_honcho_fact_candidate_native_honcho_fails_closed_without_companio
     monkeypatch.setattr(contract, "HONCHO_OBSERVED_PEER_ID", "")
     monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_JSON", "")
     monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_PATH", "")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_URL", "")
     monkeypatch.setattr(contract, "HONCHO_PROFILE_CONFIG_PATH", "")
     decision = asyncio.run(
         contract.write_honcho_fact_candidate(
@@ -494,6 +495,70 @@ def test_write_honcho_fact_candidate_native_honcho_profile_map_targets_companion
     assert calls[1]["url"] == "http://honcho.test/v3/workspaces/ella-plato-canonical/peers"
     assert calls[2]["json"]["id"] == "plato"
     assert calls[4]["json"]["filters"] == {"observer_id": "ella", "observed_id": "plato"}
+
+
+def test_write_honcho_fact_candidate_native_honcho_profile_map_url_targets_companion_scope(monkeypatch):
+    candidate = _candidate(active_summary_version_id="v1")
+    fake_client, calls = _fake_sequence_client_factory(
+        [
+            FakeJsonResponse(body={"id": "workspace"}),
+            FakeJsonResponse(body={"id": "observer"}),
+            FakeJsonResponse(body={"id": "observed"}),
+            FakeJsonResponse(body={"id": "session"}),
+            FakeJsonResponse(body={"items": []}),
+            FakeJsonResponse(
+                status_code=201,
+                body=[
+                    {
+                        "id": "conclusion-url",
+                        "observer_id": "ella-FirebaseUID-A",
+                        "observed_id": "user-FirebaseUID-A",
+                        "session_id": "ella-omi-user-123-canonical",
+                    }
+                ],
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(contract, "HONCHO_FACT_WRITE_ENABLED", True)
+    monkeypatch.setattr(contract, "HONCHO_WORKSPACE", "")
+    monkeypatch.setattr(contract, "HONCHO_OBSERVED_PEER_ID", "")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_JSON", "")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_PATH", "")
+    monkeypatch.setattr(
+        contract, "HONCHO_PROFILE_MAP_URL", "http://provision.test/honcho/profile-map?includeEntries=true"
+    )
+    monkeypatch.setattr(
+        contract,
+        "_safe_json_url",
+        lambda url: {
+            "user-123": {
+                "workspace": "ella-omi-firebaseuid-a-canonical",
+                "observed_peer_id": "user-FirebaseUID-A",
+                "observer_peer_id": "ella-FirebaseUID-A",
+            }
+        },
+    )
+
+    decision = asyncio.run(
+        contract.write_honcho_fact_candidate(
+            candidate,
+            current_conversation=_conversation("related", uid="user-123", version="v1"),
+            transport="honcho",
+            honcho_base_url="http://honcho.test",
+            http_client_factory=fake_client,
+        )
+    )
+
+    assert decision.action == "written"
+    assert decision.response_ref["workspace"] == "ella-omi-firebaseuid-a-canonical"
+    assert decision.response_ref["observer_peer_id"] == "ella-FirebaseUID-A"
+    assert decision.response_ref["observed_peer_id"] == "user-FirebaseUID-A"
+    assert decision.response_ref["target_source"] == "profile_map"
+    assert calls[4]["json"]["filters"] == {
+        "observer_id": "ella-FirebaseUID-A",
+        "observed_id": "user-FirebaseUID-A",
+    }
 
 
 def test_write_honcho_fact_candidate_native_honcho_profile_config_prefers_host_ai_peer(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add optional ELLA_CORRECTION_HONCHO_PROFILE_MAP_URL support so the OMI correction writer can read the provisioning-owned uid -> Hermes/Honcho map directly from the Hermes provision API
- support bearer auth via ELLA_CORRECTION_HONCHO_PROFILE_MAP_TOKEN and a short TTL cache
- keep inline/file map fallbacks and fail-closed behavior for unmapped users

## Validation
- python3 -m pytest backend/tests/unit/test_ella_correction_honcho_contract.py -q
- python3 -m py_compile backend/ella/services/correction_honcho_contract.py
- git diff --check HEAD

## Pairing
Complements ellaaicare/ella-ai#931 for ella-ai#916. Configure URL to the provision shim endpoint, for example /honcho/profile-map?includeEntries=true.