### PR TITLE
Add Demo Mode with curated fixture content for screenshots

### DIFF
--- a/app/lib/backend/http/api/users.dart
+++ b/app/lib/backend/http/api/users.dart
@@ -8,6 +8,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/daily_summary.dart';
 import 'package:omi/backend/schema/geolocation.dart';
 import 'package:omi/backend/schema/person.dart';
+import 'package:omi/ella/demo/demo_fixtures.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/models/subscription.dart';
 import 'package:omi/models/user_usage.dart';
@@ -565,6 +566,10 @@ Future<bool> setDailySummarySettings({bool? enabled, int? hour}) async {
 // Daily Summaries API
 
 Future<List<DailySummary>> getDailySummaries({int limit = 30, int offset = 0}) async {
+  if (SharedPreferencesUtil().demoMode) {
+    return offset == 0 ? DemoFixtures.dailySummaries() : [];
+  }
+
   var response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/users/daily-summaries?limit=$limit&offset=$offset',
     headers: {},
@@ -584,6 +589,10 @@ Future<List<DailySummary>> getDailySummaries({int limit = 30, int offset = 0}) a
 }
 
 Future<DailySummary?> getDailySummary(String summaryId) async {
+  if (SharedPreferencesUtil().demoMode) {
+    return DemoFixtures.dailySummary();
+  }
+
   var response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/users/daily-summaries/$summaryId',
     headers: {},

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -69,7 +69,7 @@ class SharedPreferencesUtil {
   }
 
   BtDevice get btDevice {
-    final String device = getString('btDevice') ?? '';
+    final String device = getString('btDevice');
     if (device.isEmpty) return BtDevice(id: '', name: '', type: DeviceType.omi, rssi: 0);
     return BtDevice.fromJson(jsonDecode(device));
   }
@@ -180,6 +180,10 @@ class SharedPreferencesUtil {
   set dailyReflectionEnabled(bool value) => saveBool('dailyReflectionEnabled', value);
 
   bool get dailyReflectionEnabled => getBool('dailyReflectionEnabled', defaultValue: true);
+
+  set demoMode(bool value) => saveBool('demoMode', value);
+
+  bool get demoMode => getBool('demoMode', defaultValue: false);
 
   // Notification frequency (0-5): 0 = off, 5 = most frequent. Default is 0 (disabled)
   set notificationFrequency(int value) => saveInt('notificationFrequency', value);

--- a/app/lib/ella/demo/demo_fixtures.dart
+++ b/app/lib/ella/demo/demo_fixtures.dart
@@ -1,0 +1,157 @@
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/daily_summary.dart';
+import 'package:omi/backend/schema/message.dart';
+import 'package:omi/backend/schema/structured.dart';
+
+class DemoFixtures {
+  static const gardenConversationId = 'demo-garden-chat-with-margaret';
+  static const dailySummaryId = 'demo-daily-recap';
+
+  static const dailyRecap =
+      "Mom had a good day. She did her crossword with coffee, found the scissors (kitchen drawer, as usual), and spent the afternoon in the garden with Margaret — the tomatoes are coming in early. She's looking forward to dinner with David on Tuesday and asked about it twice, because she's excited.";
+
+  static List<ServerConversation> conversations({DateTime? now}) {
+    final base = now ?? DateTime.now();
+    final day = DateTime(base.year, base.month, base.day);
+
+    return [
+      _conversation(
+        id: 'demo-planning-tuesday-dinner-with-david',
+        title: '🪽 Planning Tuesday Dinner with David',
+        startedAt: day.add(const Duration(hours: 17, minutes: 40)),
+        duration: const Duration(minutes: 3, seconds: 12),
+        overview: 'Mom and David talked through a simple Tuesday dinner plan.',
+      ),
+      _conversation(
+        id: gardenConversationId,
+        title: '🪽 Garden Chat with Margaret',
+        startedAt: day.add(const Duration(hours: 14, minutes: 15)),
+        duration: const Duration(minutes: 12, seconds: 4),
+        overview:
+            "A long, easy visit with Margaret out by the garden. They talked about the tomatoes coming in early this year and Margaret's granddaughter starting college in the fall. Mom told the story about the county-fair ribbon again, and it got a good laugh. She mentioned wanting to pick up more potting soil next time anyone drives to the hardware store.",
+      ),
+      _conversation(
+        id: 'demo-where-did-the-scissors-go',
+        title: '🪽 Where Did the Scissors Go',
+        startedAt: day.add(const Duration(hours: 11, minutes: 32)),
+        duration: const Duration(minutes: 1, seconds: 8),
+        overview: 'Mom found the scissors in the kitchen drawer.',
+      ),
+      _conversation(
+        id: 'demo-morning-crossword-and-coffee',
+        title: '🪽 Morning Crossword & Coffee',
+        startedAt: day.add(const Duration(hours: 8, minutes: 10)),
+        duration: const Duration(minutes: 4, seconds: 21),
+        overview: 'Mom started the morning with coffee and her crossword.',
+      ),
+    ];
+  }
+
+  static ServerConversation? conversationById(String id) {
+    return conversations().where((conversation) => conversation.id == id).firstOrNull;
+  }
+
+  static List<ServerMessage> chatMessages({DateTime? now}) {
+    final base = now ?? DateTime.now();
+    return [
+      _message(
+        id: 'demo-chat-1',
+        createdAt: base.subtract(const Duration(minutes: 4)),
+        text: "What's the word for the appointment where they take your fingerprints?",
+        sender: MessageSender.human,
+      ),
+      _message(
+        id: 'demo-chat-2',
+        createdAt: base.subtract(const Duration(minutes: 3)),
+        text:
+            "That's the biometrics appointment — it's on Thursday at 10 in the morning. Want me to remind you Thursday after breakfast?",
+        sender: MessageSender.ai,
+      ),
+      _message(
+        id: 'demo-chat-3',
+        createdAt: base.subtract(const Duration(minutes: 2)),
+        text: 'Yes please. And where did I put my glasses?',
+        sender: MessageSender.human,
+      ),
+      _message(
+        id: 'demo-chat-4',
+        createdAt: base.subtract(const Duration(minutes: 1)),
+        text: 'Last night you set them in the front pocket of your blue backpack, by the door. 🪽',
+        sender: MessageSender.ai,
+      ),
+    ];
+  }
+
+  static DailySummary dailySummary({DateTime? now}) {
+    final base = now ?? DateTime.now();
+    final day = DateTime(base.year, base.month, base.day);
+    return DailySummary(
+      id: dailySummaryId,
+      date: _dateString(day),
+      createdAt: day.add(const Duration(hours: 19)),
+      headline: '🪽 Today with Mom',
+      overview: dailyRecap,
+      dayEmoji: '🪽',
+      stats: DayStats(totalConversations: 4, totalDurationMinutes: 21),
+      highlights: [
+        TopicHighlight(
+          topic: 'Garden with Margaret',
+          emoji: '🪽',
+          summary: 'Mom spent the afternoon in the garden with Margaret and talked about the tomatoes.',
+          conversationIds: [gardenConversationId],
+        ),
+      ],
+    );
+  }
+
+  static List<DailySummary> dailySummaries({DateTime? now}) => [dailySummary(now: now)];
+
+  static ServerConversation _conversation({
+    required String id,
+    required String title,
+    required DateTime startedAt,
+    required Duration duration,
+    required String overview,
+  }) {
+    return ServerConversation(
+      id: id,
+      createdAt: startedAt,
+      startedAt: startedAt,
+      finishedAt: startedAt.add(duration),
+      structured: Structured(title, overview, emoji: '🪽', category: ''),
+      transcriptSegments: const [],
+      status: ConversationStatus.completed,
+    );
+  }
+
+  static ServerMessage _message({
+    required String id,
+    required DateTime createdAt,
+    required String text,
+    required MessageSender sender,
+  }) {
+    return ServerMessage(
+      id,
+      createdAt,
+      text,
+      sender,
+      MessageType.text,
+      null,
+      false,
+      [],
+      [],
+      [],
+      askForNps: false,
+    );
+  }
+
+  static String _dateString(DateTime date) {
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    return '${date.year}-$month-$day';
+  }
+}
+
+extension _FirstOrNull<T> on Iterable<T> {
+  T? get firstOrNull => isEmpty ? null : first;
+}

--- a/app/lib/ella/pages/ella_settings_page.dart
+++ b/app/lib/ella/pages/ella_settings_page.dart
@@ -156,7 +156,9 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
     final userName = SharedPreferencesUtil().givenName.isNotEmpty
         ? SharedPreferencesUtil().givenName
         : SharedPreferencesUtil().fullName;
-    final deviceName = context.watch<DeviceProvider>().connectedDevice?.name ?? 'Not connected';
+    final deviceProvider = context.watch<DeviceProvider>();
+    final deviceName =
+        deviceProvider.presentationConnectedDevice?.name ?? deviceProvider.connectedDevice?.name ?? 'Not connected';
     final userProvider = context.watch<UserProvider>();
 
     return Scaffold(

--- a/app/lib/ella/services/ella_chat_service.dart
+++ b/app/lib/ella/services/ella_chat_service.dart
@@ -7,6 +7,7 @@ import 'package:omi/backend/http/api/messages.dart';
 import 'package:omi/backend/http/shared.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/message.dart';
+import 'package:omi/ella/demo/demo_fixtures.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
@@ -183,6 +184,10 @@ ServerMessageChunk? _parseOpenAiSseChunk(String line, String messageId) {
 /// Fetch chat history from the VPS proxy endpoint.
 /// Returns messages in chronological order (oldest first), or empty list on failure.
 Future<List<ServerMessage>> fetchEllaChatHistory({int limit = 50}) async {
+  if (SharedPreferencesUtil().demoMode) {
+    return DemoFixtures.chatMessages();
+  }
+
   final endpoint = await _resolveEndpoint();
   if (endpoint == null || endpoint.historyUrl.isEmpty) {
     Logger.debug(
@@ -254,6 +259,12 @@ Future<List<ServerMessage>> fetchEllaChatHistory({int limit = 50}) async {
 /// Yields the same [ServerMessageChunk] types as [sendEllaMessageStream],
 /// so callers (MessageProvider, EllaVoiceChatPage) need no logic changes.
 Stream<ServerMessageChunk> sendEllaChatStream(String text) async* {
+  if (SharedPreferencesUtil().demoMode) {
+    final message = DemoFixtures.chatMessages().last;
+    yield ServerMessageChunk(message.id, message.text, MessageChunkType.done, message: message);
+    return;
+  }
+
   // Feature flag — delegate to existing proxy path if disabled
   if (!_useDirectChat) {
     yield* sendEllaMessageStream(

--- a/app/lib/pages/conversation_detail/conversation_detail_provider.dart
+++ b/app/lib/pages/conversation_detail/conversation_detail_provider.dart
@@ -14,6 +14,7 @@ import 'package:omi/backend/schema/app.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/ella/demo/demo_fixtures.dart';
 import 'package:omi/providers/app_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/utils/analytics/mixpanel.dart';
@@ -225,11 +226,19 @@ class ConversationDetailProvider extends ChangeNotifier with MessageNotifierMixi
       print('titleFocusNode focus changed');
       if (!titleFocusNode!.hasFocus) {
         conversation.structured.title = titleController!.text;
-        updateConversationTitle(conversation.id, titleController!.text);
+        if (!SharedPreferencesUtil().demoMode) {
+          updateConversationTitle(conversation.id, titleController!.text);
+        }
       }
     });
 
     canDisplaySeconds = TranscriptSegment.canDisplaySeconds(conversation.transcriptSegments);
+
+    if (SharedPreferencesUtil().demoMode) {
+      hasAudioRecording = false;
+      notifyListeners();
+      return;
+    }
 
     loadPreferredSummarizationApp();
 
@@ -493,6 +502,15 @@ class ConversationDetailProvider extends ChangeNotifier with MessageNotifierMixi
   }
 
   Future<void> refreshConversation() async {
+    if (SharedPreferencesUtil().demoMode) {
+      final fixture = DemoFixtures.conversationById(conversation.id);
+      if (fixture != null) {
+        _cachedConversation = fixture;
+        conversationProvider?.updateConversation(fixture);
+        notifyListeners();
+      }
+      return;
+    }
     try {
       final updatedConversation = await getConversationById(conversation.id);
       if (_isDisposed) return;

--- a/app/lib/pages/conversation_detail/page.dart
+++ b/app/lib/pages/conversation_detail/page.dart
@@ -11,6 +11,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:tuple/tuple.dart';
 
 import 'package:omi/backend/http/api/conversations.dart';
+import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/person.dart';
 import 'package:omi/backend/schema/structured.dart';
@@ -39,8 +40,6 @@ import 'widgets/internal_assessment_debug_sheet.dart';
 import 'widgets/name_speaker_sheet.dart';
 import 'widgets/share_to_contacts_sheet.dart';
 import 'package:omi/ella/ella_theme.dart';
-
-// import 'package:omi/backend/preferences.dart';
 
 // import 'share.dart';
 // import 'package:omi/pages/settings/developer.dart';
@@ -190,11 +189,14 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
 
       final provider = Provider.of<ConversationDetailProvider>(context, listen: false);
       final conversationProvider = Provider.of<ConversationProvider>(context, listen: false);
+      final demoMode = SharedPreferencesUtil().demoMode;
 
       // Ensure the provider has the conversation data from the widget parameter
       provider.setCachedConversation(widget.conversation);
       // Fire-and-forget refresh so enriched [Ella] titles are always shown (#508)
-      provider.refreshConversation();
+      if (!demoMode) {
+        provider.refreshConversation();
+      }
 
       conversationProvider.groupConversationsByDate();
 
@@ -209,7 +211,7 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
       }
 
       await provider.initConversation();
-      if (provider.conversation.appResults.isEmpty) {
+      if (!demoMode && provider.conversation.appResults.isEmpty) {
         final date = provider.selectedDate;
         final idx = conversationProvider.getConversationIndexById(provider.conversation.id, date);
         if (idx != -1) {
@@ -219,7 +221,7 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
       }
 
       // Check if this is the first conversation and show app review prompt
-      if (await _appReviewService.isFirstConversation()) {
+      if (!demoMode && await _appReviewService.isFirstConversation()) {
         if (mounted) {
           await _appReviewService.showReviewPromptIfNeeded(context, isProcessingFirstConversation: true);
         }
@@ -752,7 +754,8 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
                                       });
                                       return;
                                     }
-                                    String content = 'https://ella-ai-care.com/conversations/${provider.conversation.id}';
+                                    String content =
+                                        'https://ella-ai-care.com/conversations/${provider.conversation.id}';
                                     // Track share event
                                     MixpanelManager().conversationShared(
                                       conversation: provider.conversation,

--- a/app/lib/pages/conversation_detail/page.dart
+++ b/app/lib/pages/conversation_detail/page.dart
@@ -1330,8 +1330,8 @@ class _SummaryTabState extends State<SummaryTab> with AutomaticKeepAliveClientMi
 
   void _maybeShowInternalAssessment(BuildContext context) {
     final conversation = context.read<ConversationDetailProvider>().conversation;
-    if (!DebugInternalAssessmentSheet.isSupported(
-      conversation,
+    if (!shouldShowInternalAssessmentDebugUi(
+      conversation: conversation,
       isDebugMode: kDebugMode,
       isIOS: PlatformService.isIOS,
     )) {

--- a/app/lib/pages/home/device.dart
+++ b/app/lib/pages/home/device.dart
@@ -178,6 +178,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
   }
 
   Widget _buildBatterySection(DeviceProvider provider) {
+    final batteryLevel = provider.presentationBatteryLevel;
     return Container(
       decoration: BoxDecoration(
         color: EllaColors.bgSecondary,
@@ -193,8 +194,8 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
               child: Padding(
                 padding: const EdgeInsets.only(left: 2, top: 1),
                 child: FaIcon(
-                  _getBatteryIcon(provider.batteryLevel),
-                  color: _getBatteryColor(provider.batteryLevel),
+                  _getBatteryIcon(batteryLevel),
+                  color: _getBatteryColor(batteryLevel),
                   size: 20,
                 ),
               ),
@@ -217,7 +218,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
                 borderRadius: BorderRadius.circular(100),
               ),
               child: Text(
-                '${provider.batteryLevel}%',
+                '$batteryLevel%',
                 style: const TextStyle(
                   color: EllaColors.textPrimary,
                   fontSize: 13,
@@ -232,6 +233,10 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
   }
 
   Widget _buildActionsSection(DeviceProvider provider) {
+    if (SharedPreferencesUtil().demoMode) {
+      return const SizedBox.shrink();
+    }
+
     final syncProvider = context.watch<SyncProvider>();
     final pendingSeconds = syncProvider.missingWalsInSeconds;
 
@@ -253,14 +258,15 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
                     : null,
             onTap: provider.connectedDevice != null
                 ? () {
+                    final connectedDevice = provider.connectedDevice!;
                     // Route to OmiGlass OTA page for openglass devices
-                    final deviceName = provider.connectedDevice?.name?.toLowerCase() ?? '';
-                    final isOpenGlass = provider.connectedDevice?.type == DeviceType.openglass ||
+                    final deviceName = connectedDevice.name.toLowerCase();
+                    final isOpenGlass = connectedDevice.type == DeviceType.openglass ||
                         deviceName.contains('openglass') ||
                         deviceName.contains('omiglass') ||
                         deviceName.contains('glass');
-                    debugPrint('ProductUpdate: connectedDevice type: ${provider.connectedDevice?.type}');
-                    debugPrint('ProductUpdate: connectedDevice name: "${provider.connectedDevice?.name}"');
+                    debugPrint('ProductUpdate: connectedDevice type: ${connectedDevice.type}');
+                    debugPrint('ProductUpdate: connectedDevice name: "${connectedDevice.name}"');
                     debugPrint('ProductUpdate: deviceName lowercase: "$deviceName"');
                     debugPrint('ProductUpdate: isOpenGlass: $isOpenGlass');
                     if (isOpenGlass) {
@@ -468,13 +474,14 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
   }
 
   Widget _buildDeviceInfoSection(DeviceProvider provider) {
-    final deviceName = provider.pairedDevice?.name ?? context.l10n.unknownDevice;
-    final modelNumber = provider.pairedDevice?.modelNumber ?? context.l10n.unknown;
-    final manufacturer = provider.pairedDevice?.manufacturerName ?? context.l10n.unknown;
-    final firmware = provider.pairedDevice?.firmwareRevision ?? context.l10n.unknown;
-    final deviceId = provider.pairedDevice?.id ?? context.l10n.unknown;
-    final serialNumber = provider.pairedDevice?.serialNumber ??
-        provider.pairedDevice?.id.replaceAll(':', '').replaceAll('-', '').toUpperCase() ??
+    final pairedDevice = provider.presentationPairedDevice;
+    final deviceName = pairedDevice?.name ?? context.l10n.unknownDevice;
+    final modelNumber = pairedDevice?.modelNumber ?? context.l10n.unknown;
+    final manufacturer = pairedDevice?.manufacturerName ?? context.l10n.unknown;
+    final firmware = pairedDevice?.firmwareRevision ?? context.l10n.unknown;
+    final deviceId = pairedDevice?.id ?? context.l10n.unknown;
+    final serialNumber = pairedDevice?.serialNumber ??
+        pairedDevice?.id.replaceAll(':', '').replaceAll('-', '').toUpperCase() ??
         context.l10n.unknown;
 
     String truncateValue(String value) {
@@ -546,6 +553,11 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
   @override
   Widget build(BuildContext context) {
     return Consumer2<DeviceProvider, CaptureProvider>(builder: (context, provider, captureProvider, child) {
+      final connectedDevice = provider.presentationConnectedDevice;
+      final pairedDevice = provider.presentationPairedDevice;
+      final isConnected = provider.presentationIsConnected;
+      final batteryLevel = provider.presentationBatteryLevel;
+
       return Scaffold(
         backgroundColor: EllaColors.bgPrimary,
         appBar: AppBar(
@@ -565,7 +577,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
               Column(
                 children: [
                   Text(
-                    provider.pairedDevice?.name ?? context.l10n.unknownDevice,
+                    pairedDevice?.name ?? context.l10n.unknownDevice,
                     style: const TextStyle(
                       color: EllaColors.textPrimary,
                       fontSize: 32,
@@ -577,9 +589,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
                   Container(
                     padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                     decoration: BoxDecoration(
-                      color: provider.connectedDevice != null
-                          ? Colors.green.withValues(alpha: 0.2)
-                          : Colors.grey.withValues(alpha: 0.2),
+                      color: isConnected ? Colors.green.withValues(alpha: 0.2) : Colors.grey.withValues(alpha: 0.2),
                       borderRadius: BorderRadius.circular(20),
                     ),
                     child: Row(
@@ -589,15 +599,15 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
                           width: 6,
                           height: 6,
                           decoration: BoxDecoration(
-                            color: provider.connectedDevice != null ? Colors.green : Colors.grey,
+                            color: isConnected ? Colors.green : Colors.grey,
                             shape: BoxShape.circle,
                           ),
                         ),
                         const SizedBox(width: 6),
                         Text(
-                          provider.connectedDevice != null ? context.l10n.connected : context.l10n.offline,
+                          isConnected ? context.l10n.connected : context.l10n.offline,
                           style: TextStyle(
-                            color: provider.connectedDevice != null ? Colors.green : Colors.grey,
+                            color: isConnected ? Colors.green : Colors.grey,
                             fontSize: 14,
                             fontWeight: FontWeight.w500,
                           ),
@@ -609,17 +619,17 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
               ),
               const SizedBox(height: 32),
               DeviceAnimationWidget(
-                deviceType: provider.connectedDevice?.type,
-                modelNumber: provider.connectedDevice?.modelNumber,
-                isConnected: provider.connectedDevice != null,
-                deviceName: provider.connectedDevice?.name ?? provider.pairedDevice?.name,
-                animatedBackground: provider.connectedDevice != null,
+                deviceType: connectedDevice?.type,
+                modelNumber: connectedDevice?.modelNumber,
+                isConnected: isConnected,
+                deviceName: connectedDevice?.name ?? pairedDevice?.name,
+                animatedBackground: isConnected,
               ),
 
               const SizedBox(height: 24),
 
               // Battery Level Section
-              if (provider.connectedDevice != null && provider.batteryLevel > 0) ...[
+              if (isConnected && batteryLevel > 0) ...[
                 _buildBatterySection(provider),
                 const SizedBox(height: 16),
               ],
@@ -632,7 +642,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
               _buildDeviceInfoSection(provider),
 
               // Streaming Metrics Section - Bottom
-              if (provider.connectedDevice != null && captureProvider.havingRecordingDevice) ...[
+              if (isConnected && captureProvider.havingRecordingDevice) ...[
                 const SizedBox(height: 32),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.center,

--- a/app/lib/pages/home/widgets/battery_info_widget.dart
+++ b/app/lib/pages/home/widgets/battery_info_widget.dart
@@ -26,7 +26,8 @@ class BatteryInfoWidget extends StatelessWidget {
         // Use Selector to only rebuild when battery level, connected device, or connecting state changes
         // This reduces battery drain by avoiding unnecessary rebuilds during other provider updates
         return Selector<DeviceProvider, (int, BtDevice?, bool)>(
-          selector: (_, provider) => (provider.batteryLevel, provider.connectedDevice, provider.isConnecting),
+          selector: (_, provider) =>
+              (provider.presentationBatteryLevel, provider.presentationConnectedDevice, provider.isConnecting),
           builder: (context, data, child) {
             final (batteryLevel, connectedDevice, isConnecting) = data;
             if (connectedDevice != null) {

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -769,6 +769,23 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                   ),
                   const SizedBox(height: 32),
 
+                  _buildSectionHeader('Demo'),
+                  Container(
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: const Color(0xFF1C1C1E),
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                    child: _buildExperimentalItem(
+                      title: 'Demo Mode',
+                      description: 'Use curated local content for screenshots',
+                      icon: FontAwesomeIcons.images,
+                      value: provider.demoMode,
+                      onChanged: provider.onDemoModeChanged,
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+
                   // TTS Provider Section
                   _buildSectionHeader('Voice (TTS)', subtitle: 'Text-to-speech engine for Ella voice responses'),
                   Container(

--- a/app/lib/pages/settings/settings_drawer.dart
+++ b/app/lib/pages/settings/settings_drawer.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:omi/backend/preferences.dart';
 import 'package:omi/core/app_shell.dart';
 import 'package:omi/pages/persona/persona_provider.dart';
 import 'package:omi/utils/auth_utils.dart';
@@ -398,7 +397,7 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
               ),
               Consumer<DeviceProvider>(
                 builder: (context, deviceProvider, child) {
-                  if (!deviceProvider.isConnected) {
+                  if (!deviceProvider.presentationIsConnected) {
                     return const SizedBox.shrink();
                   }
                   return Column(

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -7,6 +7,7 @@ import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/ella/demo/demo_fixtures.dart';
 import 'package:omi/services/app_review_service.dart';
 import 'package:omi/services/notifications/merge_notification_handler.dart';
 import 'package:omi/utils/analytics/mixpanel.dart';
@@ -94,6 +95,13 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   Future updateSearchedConvoDetails(String id, DateTime date, int idx) async {
+    if (SharedPreferencesUtil().demoMode) {
+      final convo = DemoFixtures.conversationById(id);
+      if (convo != null) {
+        updateSpecificGroupedConvo(convo, date, idx);
+      }
+      return;
+    }
     var convo = await getConversationById(id);
     if (convo != null) {
       updateSpecificGroupedConvo(convo, date, idx);
@@ -107,6 +115,23 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   Future<void> searchConversations(String query, {bool showShimmer = false}) async {
+    if (SharedPreferencesUtil().demoMode) {
+      previousQuery = query;
+      currentSearchPage = 0;
+      totalSearchPages = 0;
+      searchedConversations = query.isEmpty
+          ? []
+          : DemoFixtures.conversations()
+              .where((conversation) => conversation.structured.title.toLowerCase().contains(query.toLowerCase()))
+              .toList();
+      if (query.isEmpty) {
+        groupConversationsByDate();
+      } else {
+        groupSearchConvosByDate();
+      }
+      return;
+    }
+
     if (query.isEmpty) {
       previousQuery = "";
       currentSearchPage = 0;
@@ -263,6 +288,11 @@ class ConversationProvider extends ChangeNotifier {
 
   /// Check if user has any daily summaries
   Future<void> checkHasDailySummaries() async {
+    if (SharedPreferencesUtil().demoMode) {
+      hasDailySummaries = true;
+      notifyListeners();
+      return;
+    }
     final summaries = await getDailySummaries(limit: 1, offset: 0);
     hasDailySummaries = summaries.isNotEmpty;
     notifyListeners();
@@ -320,6 +350,10 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   Future _fetchNewConversations() async {
+    if (SharedPreferencesUtil().demoMode) {
+      await fetchConversations();
+      return;
+    }
     setLoadingConversations(true);
     List<ServerConversation> newConversations = await _getConversationsFromServer();
     setLoadingConversations(false);
@@ -363,7 +397,8 @@ class ConversationProvider extends ChangeNotifier {
     searchedConversations = [];
 
     setLoadingConversations(true);
-    conversations = await _getConversationsFromServer();
+    conversations =
+        SharedPreferencesUtil().demoMode ? DemoFixtures.conversations() : await _getConversationsFromServer();
     setLoadingConversations(false);
 
     // processing convos
@@ -542,6 +577,7 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   Future getMoreConversationsFromServer() async {
+    if (SharedPreferencesUtil().demoMode) return;
     if (conversations.length % 50 != 0) return;
     if (isLoadingConversations) return;
     setLoadingConversations(true);

--- a/app/lib/providers/developer_mode_provider.dart
+++ b/app/lib/providers/developer_mode_provider.dart
@@ -34,6 +34,7 @@ class DeveloperModeProvider extends BaseProvider {
   bool autoCreateSpeakersEnabled = false;
   bool showGoalTrackerEnabled = true; // Default to true
   bool dailyReflectionEnabled = true;
+  bool demoMode = false;
 
   void onConversationEventsToggled(bool value) {
     conversationEventsToggled = value;
@@ -106,6 +107,7 @@ class DeveloperModeProvider extends BaseProvider {
     autoCreateSpeakersEnabled = SharedPreferencesUtil().autoCreateSpeakersEnabled;
     showGoalTrackerEnabled = SharedPreferencesUtil().showGoalTrackerEnabled;
     dailyReflectionEnabled = SharedPreferencesUtil().dailyReflectionEnabled;
+    demoMode = SharedPreferencesUtil().demoMode;
     conversationEventsToggled = SharedPreferencesUtil().conversationEventsToggled;
     transcriptsToggled = SharedPreferencesUtil().transcriptsToggled;
     audioBytesToggled = SharedPreferencesUtil().audioBytesToggled;
@@ -211,6 +213,7 @@ class DeveloperModeProvider extends BaseProvider {
     prefs.transcriptionDiagnosticEnabled = transcriptionDiagnosticEnabled;
     prefs.autoCreateSpeakersEnabled = autoCreateSpeakersEnabled;
     prefs.showGoalTrackerEnabled = showGoalTrackerEnabled;
+    prefs.demoMode = demoMode;
 
     MixpanelManager().settingsSaved(
       hasWebhookConversationCreated: conversationEventsToggled,
@@ -260,6 +263,12 @@ class DeveloperModeProvider extends BaseProvider {
       DailyReflectionNotification.cancelNotification();
     }
 
+    notifyListeners();
+  }
+
+  void onDemoModeChanged(bool value) {
+    demoMode = value;
+    SharedPreferencesUtil().demoMode = value;
     notifyListeners();
   }
 }

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -41,6 +41,23 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   bool _havingNewFirmware = false;
   bool get havingNewFirmware => _havingNewFirmware && pairedDevice != null && isConnected;
 
+  BtDevice? get presentationConnectedDevice => SharedPreferencesUtil().demoMode ? _demoDevice : connectedDevice;
+
+  BtDevice? get presentationPairedDevice => SharedPreferencesUtil().demoMode ? _demoDevice : pairedDevice;
+
+  bool get presentationIsConnected => SharedPreferencesUtil().demoMode ? true : isConnected;
+
+  int get presentationBatteryLevel => SharedPreferencesUtil().demoMode ? 96 : batteryLevel;
+
+  static final BtDevice _demoDevice = BtDevice(
+    name: 'Ella',
+    id: 'demo-device',
+    type: DeviceType.omi,
+    rssi: 0,
+    modelNumber: 'Demo',
+    firmwareRevision: 'Demo',
+  );
+
   // Track firmware update state to prevent showing dialog during updates
   bool _isFirmwareUpdateInProgress = false;
   bool get isFirmwareUpdateInProgress => _isFirmwareUpdateInProgress;
@@ -580,8 +597,6 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
           _disconnectDebouncer.run(onDeviceDisconnected);
         }
         break;
-      default:
-        Logger.debug("Device connection state is not supported $state");
     }
   }
 

--- a/app/lib/providers/message_provider.dart
+++ b/app/lib/providers/message_provider.dart
@@ -19,6 +19,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/app.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/message.dart';
+import 'package:omi/ella/demo/demo_fixtures.dart';
 import 'package:omi/providers/app_provider.dart';
 import 'package:omi/main.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
@@ -27,6 +28,8 @@ import 'package:omi/utils/analytics/mixpanel.dart';
 import 'package:omi/utils/file.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_service.dart';
+
+bool get _isEllaApp => true;
 
 class MessageProvider extends ChangeNotifier {
   static late MethodChannel _askAIChannel;
@@ -389,12 +392,19 @@ class MessageProvider extends ChangeNotifier {
 
   Future refreshMessages({bool dropdownSelected = false}) async {
     setLoadingMessages(true);
+    if (SharedPreferencesUtil().demoMode) {
+      messages = DemoFixtures.chatMessages();
+      setHasCachedMessages(true);
+      setLoadingMessages(false);
+      notifyListeners();
+      return;
+    }
     if (SharedPreferencesUtil().cachedMessages.isNotEmpty) {
       setHasCachedMessages(true);
     }
 
     // Ella mode: use local cache first, fall back to server history API.
-    const isEllaApp = true; // TODO: replace with flavor check
+    final isEllaApp = _isEllaApp; // TODO: replace with flavor check
     if (isEllaApp) {
       final cached = SharedPreferencesUtil().cachedMessages;
       if (cached.isNotEmpty) {
@@ -601,6 +611,13 @@ class MessageProvider extends ChangeNotifier {
   }
 
   Future sendMessageStreamToServer(String text) async {
+    if (SharedPreferencesUtil().demoMode) {
+      messages = DemoFixtures.chatMessages();
+      setSendingMessage(false);
+      setShowTypingIndicator(false);
+      notifyListeners();
+      return;
+    }
     aiStreamProgress = 0.0;
     setShowTypingIndicator(true);
     var currentAppId = appProvider?.selectedChatAppId;
@@ -644,7 +661,7 @@ class MessageProvider extends ChangeNotifier {
 
     try {
       // Ella uses its own simple chat endpoint; OMI uses the graph chat
-      const isEllaApp = true; // TODO: replace with flavor check
+      final isEllaApp = _isEllaApp; // TODO: replace with flavor check
       var stream =
           isEllaApp ? sendEllaChatStream(text) : sendMessageStreamServer(text, appId: currentAppId, filesId: fileIds);
       await for (var chunk in stream) {


### PR DESCRIPTION
## Summary
- Adds a persisted Developer Settings toggle for demo mode, off by default.
- Adds local Ella fixture content for conversations, conversation detail, chat, device display state, and daily recap surfaces.
- Gates presentation data providers/services so demo mode avoids backend calls for swapped surfaces while leaving normal data paths unchanged when off.

## Verification
- ../flutter/bin/flutter analyze --no-fatal-infos lib/ella/demo/demo_fixtures.dart lib/backend/preferences.dart lib/providers/developer_mode_provider.dart lib/pages/settings/developer.dart lib/providers/conversation_provider.dart lib/pages/conversation_detail/conversation_detail_provider.dart lib/pages/conversation_detail/page.dart lib/providers/message_provider.dart lib/ella/services/ella_chat_service.dart lib/backend/http/api/users.dart lib/providers/device_provider.dart lib/pages/home/widgets/battery_info_widget.dart lib/pages/settings/settings_drawer.dart lib/pages/home/device.dart lib/ella/pages/ella_settings_page.dart