### PR TITLE
Promote MCP observations into memory proposals

### DIFF
--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -114,6 +114,13 @@ class MCPSession:
     sse_queue: asyncio.Queue[dict[str, Any] | None] = field(default_factory=asyncio.Queue)
 
 
+@dataclass(frozen=True)
+class MCPAuthContext:
+    token_fingerprint: str
+    trusted_static_token: bool
+    session_claims: dict[str, Any]
+
+
 class ToolExecutionError(Exception):
     def __init__(self, message: str, code: int = -32000):
         super().__init__(message)
@@ -186,7 +193,7 @@ _WWW_AUTHENTICATE = (
 )
 
 
-def _authenticate(authorization: Optional[str]) -> str:
+def _authenticate(authorization: Optional[str]) -> MCPAuthContext:
     token = _token_from_authorization(authorization)
     if not token:
         raise HTTPException(
@@ -198,7 +205,11 @@ def _authenticate(authorization: Optional[str]) -> str:
     tokens = _allowed_tokens()
     if token in tokens:
         _check_rate_limit(token)
-        return _fingerprint(token)
+        return MCPAuthContext(
+            token_fingerprint=_fingerprint(token),
+            trusted_static_token=True,
+            session_claims=_legacy_plato_onboarding()["session_claims"],
+        )
 
     try:
         claims = validate_mcp_session_token(token)
@@ -224,7 +235,11 @@ def _authenticate(authorization: Optional[str]) -> str:
             },
         )
     _check_rate_limit(token)
-    return _fingerprint(token)
+    return MCPAuthContext(
+        token_fingerprint=_fingerprint(token),
+        trusted_static_token=False,
+        session_claims=dict(claims),
+    )
 
 
 def _check_rate_limit(token: str) -> None:
@@ -1074,13 +1089,25 @@ async def _companion_propose_change(arguments: dict[str, Any]) -> dict[str, Any]
         raise ToolExecutionError(str(exc), code=-32004) from exc
 
 
-def _observation_proposal_claims() -> dict[str, Any]:
+def _can_write_observations(auth_context: MCPAuthContext | None) -> bool:
+    if auth_context is None:
+        return False
+    if auth_context.trusted_static_token:
+        return True
+    scopes = {str(scope) for scope in auth_context.session_claims.get("scopes") or [] if str(scope)}
+    allowed_tools = {str(tool) for tool in auth_context.session_claims.get("allowed_tools") or [] if str(tool)}
+    return "observations:write" in scopes and "companion_submit_observation" in allowed_tools
+
+
+def _observation_proposal_claims(auth_context: MCPAuthContext | None) -> dict[str, Any]:
     """Internal trusted claims for turning observation writes into memory proposals.
 
     `companion_submit_observation` is the public write surface exposed to hosted
     companion clients. The legacy proposal tool can stay hidden while this
     trusted internal bridge still uses the existing proposal/apply safety path.
     """
+    if not _can_write_observations(auth_context):
+        raise ToolExecutionError("MCP bearer token is missing observations:write scope", code=-32003)
     claims = dict(_legacy_plato_onboarding()["session_claims"])
     scopes = {str(scope) for scope in claims.get("scopes") or [] if str(scope)}
     scopes.add("proposals:write")
@@ -1129,7 +1156,11 @@ def _observation_memory_payload(
     }
 
 
-async def _companion_submit_observation(arguments: dict[str, Any]) -> dict[str, Any]:
+async def _companion_submit_observation(
+    arguments: dict[str, Any],
+    *,
+    auth_context: MCPAuthContext | None = None,
+) -> dict[str, Any]:
     text = _compact_text(arguments.get("text"), MAX_OBSERVATION_CHARS)
     if not text or len(text.strip()) < 10:
         raise ToolExecutionError("text is required (minimum 10 characters)", code=-32602)
@@ -1138,6 +1169,7 @@ async def _companion_submit_observation(arguments: dict[str, Any]) -> dict[str, 
     if channel not in OBSERVATION_CHANNELS:
         allowed = ", ".join(sorted(OBSERVATION_CHANNELS))
         raise ToolExecutionError(f"channel must be one of: {allowed}", code=-32602)
+    proposal_claims = _observation_proposal_claims(auth_context)
     title = _compact_text(arguments.get("title") or "", 240) or None
     event_id = str(arguments.get("idempotency_key") or uuid.uuid4())
     now = datetime.now(timezone.utc)
@@ -1159,7 +1191,7 @@ async def _companion_submit_observation(arguments: dict[str, Any]) -> dict[str, 
     result = await _canonical_store.write_batch([event])
     try:
         proposal_result = proposal_ingest.create_proposal(
-            session_claims=_observation_proposal_claims(),
+            session_claims=proposal_claims,
             tool_name="companion_propose_change",
             proposal_type="memory_note",
             payload=_observation_memory_payload(
@@ -1459,10 +1491,11 @@ def _audit_tool_call(
 
 
 async def _handle_mcp_message(
-    token_fingerprint: str,
+    auth_context: MCPAuthContext,
     message: dict[str, Any],
     session: Optional[MCPSession] = None,
 ) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+    token_fingerprint = auth_context.token_fingerprint
     msg_id = message.get("id")
     method = message.get("method")
     params = message.get("params") or {}
@@ -1504,7 +1537,10 @@ async def _handle_mcp_message(
         if tool_name not in _TOOL_HANDLERS or tool_name not in visible_tool_names:
             return _mcp_error(msg_id, -32601, f"Unknown tool: {tool_name}"), None
         try:
-            result = await _TOOL_HANDLERS[tool_name](arguments)
+            if tool_name == "companion_submit_observation":
+                result = await _companion_submit_observation(arguments, auth_context=auth_context)
+            else:
+                result = await _TOOL_HANDLERS[tool_name](arguments)
             _audit_tool_call(
                 trace_id=trace_id,
                 token_fingerprint=token_fingerprint,
@@ -1552,7 +1588,8 @@ async def plato_mcp_streamable_http(
     mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id"),
     accept: Optional[str] = Header(None, alias="Accept"),
 ):
-    token_fingerprint = _authenticate(authorization)
+    auth_context = _authenticate(authorization)
+    token_fingerprint = auth_context.token_fingerprint
     try:
         body = await request.json()
     except Exception as exc:
@@ -1572,13 +1609,13 @@ async def plato_mcp_streamable_http(
 
     if all(message.get("id") is None for message in messages):
         for message in messages:
-            await _handle_mcp_message(token_fingerprint, message, session)
+            await _handle_mcp_message(auth_context, message, session)
         return Response(status_code=202)
 
     responses = []
     new_session_id = None
     for message in messages:
-        response, session_id = await _handle_mcp_message(token_fingerprint, message, session)
+        response, session_id = await _handle_mcp_message(auth_context, message, session)
         if session_id:
             new_session_id = session_id
         if response:
@@ -1610,7 +1647,8 @@ async def plato_mcp_sse_keepalive(
     request: Request,
     authorization: Optional[str] = Header(None, alias="Authorization"),
 ):
-    token_fingerprint = _authenticate(authorization)
+    auth_context = _authenticate(authorization)
+    token_fingerprint = auth_context.token_fingerprint
     session_id = str(uuid.uuid4())
     session = MCPSession(
         session_id=session_id,
@@ -1652,7 +1690,8 @@ async def plato_mcp_sse_message(
     session_id: str,
     authorization: Optional[str] = Header(None, alias="Authorization"),
 ):
-    token_fingerprint = _authenticate(authorization)
+    auth_context = _authenticate(authorization)
+    token_fingerprint = auth_context.token_fingerprint
     session = _active_sessions.get(session_id)
     if not session:
         raise HTTPException(status_code=404, detail="MCP session not found")
@@ -1668,7 +1707,7 @@ async def plato_mcp_sse_message(
         raise HTTPException(status_code=400, detail="MCP body must be a JSON-RPC object or array")
 
     for message in messages:
-        response, _ = await _handle_mcp_message(token_fingerprint, message, session)
+        response, _ = await _handle_mcp_message(auth_context, message, session)
         if response:
             await session.sse_queue.put(response)
     return Response(status_code=202)
@@ -1679,7 +1718,8 @@ async def plato_mcp_delete_session(
     authorization: Optional[str] = Header(None, alias="Authorization"),
     mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id"),
 ):
-    token_fingerprint = _authenticate(authorization)
+    auth_context = _authenticate(authorization)
+    token_fingerprint = auth_context.token_fingerprint
     if not mcp_session_id:
         raise HTTPException(status_code=400, detail="Mcp-Session-Id header required")
     session = _active_sessions.get(mcp_session_id)

--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -772,9 +772,7 @@ async def _fetch_workspace_search(query: str, max_results: int) -> list[dict[str
             return []
         payload = response.json()
         return [
-            _workspace_search_result_to_event(item)
-            for item in (payload.get("results") or [])
-            if isinstance(item, dict)
+            _workspace_search_result_to_event(item) for item in (payload.get("results") or []) if isinstance(item, dict)
         ]
     except Exception as exc:
         logger.warning("plato_mcp workspace search failed: %s", exc)
@@ -834,9 +832,7 @@ async def _search_memory(arguments: dict[str, Any]) -> dict[str, Any]:
     return {
         "query": query,
         "source": (
-            f"{context.get('source')}_with_hermes_workspace_search"
-            if workspace_results
-            else context.get("source")
+            f"{context.get('source')}_with_hermes_workspace_search" if workspace_results else context.get("source")
         ),
         "inferred_time_window": inferred_label or None,
         "time_context": context.get("time_context") or build_time_context(_plato_timezone()),
@@ -935,9 +931,7 @@ async def _consult_plato(arguments: dict[str, Any]) -> dict[str, Any]:
         "agent_id": agent_id,
         "session": session_key,
         "context_source": (
-            f"{context.get('source')}_with_hermes_workspace_search"
-            if workspace_results
-            else context.get("source")
+            f"{context.get('source')}_with_hermes_workspace_search" if workspace_results else context.get("source")
         ),
         "context_events": len(context.get("events") or []) + len(workspace_results),
     }
@@ -1080,6 +1074,61 @@ async def _companion_propose_change(arguments: dict[str, Any]) -> dict[str, Any]
         raise ToolExecutionError(str(exc), code=-32004) from exc
 
 
+def _observation_proposal_claims() -> dict[str, Any]:
+    """Internal trusted claims for turning observation writes into memory proposals.
+
+    `companion_submit_observation` is the public write surface exposed to hosted
+    companion clients. The legacy proposal tool can stay hidden while this
+    trusted internal bridge still uses the existing proposal/apply safety path.
+    """
+    claims = dict(_legacy_plato_onboarding()["session_claims"])
+    scopes = {str(scope) for scope in claims.get("scopes") or [] if str(scope)}
+    scopes.add("proposals:write")
+    allowed_tools = {str(tool) for tool in claims.get("allowed_tools") or [] if str(tool)}
+    allowed_tools.add("companion_propose_change")
+    claims["scopes"] = sorted(scopes)
+    claims["allowed_tools"] = sorted(allowed_tools)
+    claims["trace_id"] = str(claims.get("trace_id") or f"mcp-observation:{uuid.uuid4()}")
+    return claims
+
+
+def _observation_memory_payload(
+    *,
+    event_id: str,
+    channel: str,
+    title: str | None,
+    text: str,
+) -> dict[str, Any]:
+    display_title = title or f"MCP observation from {channel}"
+    return {
+        "title": display_title[:240],
+        "description": f"Trusted companion observation submitted through MCP channel `{channel}`.",
+        "target": {
+            "canonical_identity": _plato_canonical_identity(),
+            "uid": _plato_uid(),
+            "durable_owner": "observer_memory",
+        },
+        "evidence": [
+            {
+                "event_id": event_id,
+                "channel": channel,
+                "provider": "mcp_companion",
+                "mcp_tool": "companion_submit_observation",
+            }
+        ],
+        "requested_change": {
+            "memory": text,
+            "source_text": text,
+            "source_channel": channel,
+            "source_title": title or "",
+            "category": "mcp_companion_observation",
+        },
+        "source": "plato_mcp",
+        "write_policy": "proposal_only",
+        "confidence": 0.92,
+    }
+
+
 async def _companion_submit_observation(arguments: dict[str, Any]) -> dict[str, Any]:
     text = _compact_text(arguments.get("text"), MAX_OBSERVATION_CHARS)
     if not text or len(text.strip()) < 10:
@@ -1108,12 +1157,31 @@ async def _companion_submit_observation(arguments: dict[str, Any]) -> dict[str, 
         metadata={"title": title} if title else {},
     )
     result = await _canonical_store.write_batch([event])
+    try:
+        proposal_result = proposal_ingest.create_proposal(
+            session_claims=_observation_proposal_claims(),
+            tool_name="companion_propose_change",
+            proposal_type="memory_note",
+            payload=_observation_memory_payload(
+                event_id=event_id,
+                channel=channel,
+                title=title,
+                text=text,
+            ),
+            idempotency_key=f"mcp-observation:{event_id}:memory_note",
+        )
+    except proposal_ingest.ProposalIngestError as exc:
+        raise ToolExecutionError(f"Observation recorded but memory proposal failed: {exc}", code=-32004) from exc
     return {
         "accepted": True,
         "event_id": event_id,
         "channel": channel,
         "inserted": result.get("inserted", 0) > 0,
-        "note": "Observation recorded. Hermes will process it during the next Observer run.",
+        "memory_proposal": proposal_result,
+        "note": (
+            "Observation recorded and submitted as a durable memory proposal. "
+            "Observer apply will promote it into recallable memory if accepted."
+        ),
     }
 
 

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -72,7 +72,7 @@ def test_plato_mcp_rejects_missing_and_invalid_token(monkeypatch):
     assert invalid.status_code == 401
 
 
-def test_plato_mcp_lists_only_read_only_tools(monkeypatch):
+def test_plato_mcp_lists_default_safe_tools(monkeypatch):
     module = _load_module(monkeypatch)
     client = _client(module)
 
@@ -87,7 +87,7 @@ def test_plato_mcp_lists_only_read_only_tools(monkeypatch):
     assert tool_names == {
         "companion_start_here",
         "companion_surface_prompt",
-        "companion_get_proposal_status",
+        "companion_submit_observation",
         "plato_recent_context",
         "plato_search_memory",
         "plato_latest_omi",
@@ -99,6 +99,7 @@ def test_plato_mcp_lists_only_read_only_tools(monkeypatch):
     assert "delete_memory" not in tool_names
     assert "update_conversation_summary" not in tool_names
     assert "companion_propose_change" not in tool_names
+    assert "companion_get_proposal_status" not in tool_names
 
 
 def test_companion_surface_prompt_returns_no_secret_bootstrap(monkeypatch):
@@ -123,7 +124,7 @@ def test_companion_surface_prompt_returns_no_secret_bootstrap(monkeypatch):
     assert "test-token" not in payload["prompt"]
 
 
-def test_plato_mcp_lists_proposal_tool_only_when_enabled(monkeypatch):
+def test_plato_mcp_keeps_deprecated_proposal_tools_hidden_when_enabled(monkeypatch):
     monkeypatch.setenv("ELLA_PLATO_MCP_ENABLE_PROPOSALS", "true")
     module = _load_module(monkeypatch)
     client = _client(module)
@@ -136,7 +137,9 @@ def test_plato_mcp_lists_proposal_tool_only_when_enabled(monkeypatch):
 
     assert response.status_code == 200
     tool_names = {tool["name"] for tool in response.json()["result"]["tools"]}
-    assert "companion_propose_change" in tool_names
+    assert "companion_submit_observation" in tool_names
+    assert "companion_propose_change" not in tool_names
+    assert "companion_get_proposal_status" not in tool_names
 
 
 def test_streamable_http_prefers_json_when_client_accepts_json_and_sse(monkeypatch):
@@ -194,16 +197,9 @@ def test_companion_start_here_tool_returns_generic_startup_packet(monkeypatch):
     assert result["account"]["role"] == "self"
 
 
-def test_companion_get_proposal_status_tool_is_read_only(monkeypatch):
+def test_companion_get_proposal_status_tool_is_hidden(monkeypatch):
     module = _load_module(monkeypatch)
     client = _client(module)
-
-    def fake_status(*, session_claims, proposal_id):
-        assert session_claims["profile_uid"] == module._plato_uid()
-        assert proposal_id == "proposal-1"
-        return {"proposal_id": "proposal-1", "status": "submitted", "profile_uid": module._plato_uid()}
-
-    monkeypatch.setattr(module.proposal_ingest, "get_proposal_status", fake_status)
 
     response = client.post(
         "/v1/ella/plato/mcp",
@@ -215,30 +211,14 @@ def test_companion_get_proposal_status_tool_is_read_only(monkeypatch):
     )
 
     assert response.status_code == 200
-    result = _tool_result(response)
-    assert result["proposal_id"] == "proposal-1"
-    assert result["status"] == "submitted"
+    payload = response.json()
+    assert payload["error"]["code"] == -32601
 
 
-def test_companion_propose_change_creates_proposal_when_enabled(monkeypatch):
+def test_companion_propose_change_is_hidden_when_enabled(monkeypatch):
     monkeypatch.setenv("ELLA_PLATO_MCP_ENABLE_PROPOSALS", "true")
     module = _load_module(monkeypatch)
     client = _client(module)
-    captured = {}
-
-    def fake_create(*, session_claims, tool_name, proposal_type, payload, idempotency_key):
-        captured["session_claims"] = session_claims
-        captured["tool_name"] = tool_name
-        captured["proposal_type"] = proposal_type
-        captured["payload"] = payload
-        captured["idempotency_key"] = idempotency_key
-        return {
-            "created": True,
-            "deduped": False,
-            "proposal": {"proposal_id": "proposal-1", "status": "submitted"},
-        }
-
-    monkeypatch.setattr(module.proposal_ingest, "create_proposal", fake_create)
 
     response = client.post(
         "/v1/ella/plato/mcp",
@@ -260,15 +240,8 @@ def test_companion_propose_change_creates_proposal_when_enabled(monkeypatch):
     )
 
     assert response.status_code == 200
-    result = _tool_result(response)
-    assert result["created"] is True
-    assert result["proposal"]["proposal_id"] == "proposal-1"
-    assert captured["tool_name"] == "companion_propose_change"
-    assert captured["proposal_type"] == "scanner_rule_change"
-    assert "proposals:write" in captured["session_claims"]["scopes"]
-    assert "companion_propose_change" in captured["session_claims"]["allowed_tools"]
-    assert captured["payload"]["write_policy"] == "proposal_only"
-    assert captured["idempotency_key"] == "glasses-1"
+    payload = response.json()
+    assert payload["error"]["code"] == -32601
 
 
 def test_companion_propose_change_is_unknown_when_disabled(monkeypatch):
@@ -319,8 +292,78 @@ def test_companion_propose_change_rejects_unsupported_type(monkeypatch):
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["error"]["code"] == -32602
-    assert "proposal_type must be one of" in payload["error"]["message"]
+    assert payload["error"]["code"] == -32601
+
+
+def test_companion_submit_observation_creates_memory_proposal(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+    captured = {"events": [], "proposal": {}}
+
+    class FakeCanonicalStore:
+        async def write_batch(self, events):
+            captured["events"].extend(events)
+            return {"ok": True, "inserted": len(events), "duplicates": 0}
+
+    def fake_create(*, session_claims, tool_name, proposal_type, payload, idempotency_key):
+        captured["proposal"] = {
+            "session_claims": session_claims,
+            "tool_name": tool_name,
+            "proposal_type": proposal_type,
+            "payload": payload,
+            "idempotency_key": idempotency_key,
+        }
+        return {
+            "created": True,
+            "deduped": False,
+            "proposal": {"proposal_id": "proposal-memory-1", "status": "submitted"},
+        }
+
+    monkeypatch.setattr(module, "_canonical_store", FakeCanonicalStore())
+    monkeypatch.setattr(module.proposal_ingest, "create_proposal", fake_create)
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer test-token"},
+        json=_rpc(
+            "tools/call",
+            params={
+                "name": "companion_submit_observation",
+                "arguments": {
+                    "channel": "grok_conversation",
+                    "title": "Grok MCP sentinel",
+                    "text": "Live Grok MCP test phrase is copper sailboat.",
+                    "idempotency_key": "MCP-WRITE-PROBE-4417",
+                },
+            },
+        ),
+    )
+
+    assert response.status_code == 200
+    result = _tool_result(response)
+    assert result["accepted"] is True
+    assert result["event_id"] == "MCP-WRITE-PROBE-4417"
+    assert result["channel"] == "grok_conversation"
+    assert result["memory_proposal"]["proposal"]["proposal_id"] == "proposal-memory-1"
+
+    assert len(captured["events"]) == 1
+    raw_event = captured["events"][0]
+    assert raw_event.channel == "grok_conversation"
+    assert raw_event.provider == "mcp_companion"
+    assert raw_event.role == "companion"
+    assert raw_event.text == "Live Grok MCP test phrase is copper sailboat."
+    assert raw_event.source_ref == {"mcp_tool": "companion_submit_observation"}
+
+    proposal = captured["proposal"]
+    assert proposal["tool_name"] == "companion_propose_change"
+    assert proposal["proposal_type"] == "memory_note"
+    assert proposal["idempotency_key"] == "mcp-observation:MCP-WRITE-PROBE-4417:memory_note"
+    assert "proposals:write" in proposal["session_claims"]["scopes"]
+    assert "companion_propose_change" in proposal["session_claims"]["allowed_tools"]
+    assert proposal["payload"]["source"] == "plato_mcp"
+    assert proposal["payload"]["target"]["canonical_identity"] == module._plato_canonical_identity()
+    assert proposal["payload"]["requested_change"]["memory"] == "Live Grok MCP test phrase is copper sailboat."
+    assert proposal["payload"]["evidence"][0]["event_id"] == "MCP-WRITE-PROBE-4417"
 
 
 def test_plato_recent_context_uses_canonical_timeline(monkeypatch):

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -366,6 +366,60 @@ def test_companion_submit_observation_creates_memory_proposal(monkeypatch):
     assert proposal["payload"]["evidence"][0]["event_id"] == "MCP-WRITE-PROBE-4417"
 
 
+def test_companion_submit_observation_rejects_read_only_session_token(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+    captured = {"write_called": False, "proposal_called": False}
+
+    class FakeCanonicalStore:
+        async def write_batch(self, events):
+            captured["write_called"] = True
+            return {"ok": True, "inserted": len(events), "duplicates": 0}
+
+    def fake_validate(token):
+        assert token == "read-only-session-token"
+        return {
+            "profile_uid": module._plato_uid(),
+            "role": "self",
+            "scopes": ["tools:read", "startup:read", "timeline:read", "memory:read"],
+            "allowed_tools": ["companion_start_here", "plato_search_memory", "companion_submit_observation"],
+            "grant_id": "read-only-grant",
+            "external_provider": "grok",
+        }
+
+    def fake_create(**kwargs):
+        captured["proposal_called"] = True
+        return {}
+
+    monkeypatch.setattr(module, "validate_mcp_session_token", fake_validate)
+    monkeypatch.setattr(module, "_canonical_store", FakeCanonicalStore())
+    monkeypatch.setattr(module.proposal_ingest, "create_proposal", fake_create)
+
+    response = client.post(
+        "/v1/ella/plato/mcp",
+        headers={"Authorization": "Bearer read-only-session-token"},
+        json=_rpc(
+            "tools/call",
+            params={
+                "name": "companion_submit_observation",
+                "arguments": {
+                    "channel": "grok_conversation",
+                    "title": "Read-only probe",
+                    "text": "This read-only MCP session must not write a durable memory proposal.",
+                    "idempotency_key": "READ-ONLY-MCP-WRITE-PROBE",
+                },
+            },
+        ),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["error"]["code"] == -32003
+    assert "observations:write" in payload["error"]["message"]
+    assert captured["write_called"] is False
+    assert captured["proposal_called"] is False
+
+
 def test_plato_recent_context_uses_canonical_timeline(monkeypatch):
     module = _load_module(monkeypatch)
     client = _client(module)


### PR DESCRIPTION
## Summary
- Keep `companion_submit_observation` as the visible hosted-companion write tool.
- Preserve the raw canonical audit event for MCP observations.
- Also create a trusted `memory_note` proposal using the existing `plato_mcp` -> Observer apply path, so Grok/MCP observations can become `observer_memory` instead of getting stranded in `grok_conversation-events`.
- Update MCP tool-surface tests to match the current deprecated-proposal-tool design: direct proposal tools stay hidden; `companion_submit_observation` is the supported write surface.

## Why
Related to ellaaicare/ella-ai#1031.

The live investigation showed Grok MCP observations were written as raw canonical events but never promoted to recallable memory. This patch keeps the audit trail while routing durable memory through the existing proposal/apply safety boundary.

## Validation
- `cd backend && python3 -m pytest tests/unit/test_ella_plato_mcp.py tests/unit/test_ella_observer.py -q`
- Result: `40 passed`
