### PR TITLE
Allow MCP observation write grants

### DIFF
--- a/backend/ella/services/mcp_identity.py
+++ b/backend/ella/services/mcp_identity.py
@@ -41,6 +41,15 @@ READ_ONLY_SCOPES = {
     "tools:read",
 }
 
+OBSERVATION_WRITE_SCOPES = {
+    # Narrow write scope for companion clients to submit observations into the
+    # audited proposal/Observer pipeline. Proposal and direct mutation scopes
+    # remain filtered out below.
+    "observations:write",
+}
+
+PROFILE_GRANT_SCOPES = READ_ONLY_SCOPES | OBSERVATION_WRITE_SCOPES
+
 PROPOSAL_SCOPES = {
     "proposals:read",
     "proposals:write",
@@ -72,11 +81,11 @@ def _normalized_role(role: Any) -> str:
     return ROLE_SELF
 
 
-def _read_only_scopes(scopes: Iterable[Any], role: str) -> list[str]:
+def _profile_grant_scopes(scopes: Iterable[Any], role: str) -> list[str]:
     requested = [_clean_string(scope) for scope in scopes if _clean_string(scope)]
     if not requested:
         requested = DEFAULT_ROLE_SCOPES.get(role, DEFAULT_ROLE_SCOPES[ROLE_SELF])
-    return sorted(scope for scope in set(requested) if scope in READ_ONLY_SCOPES)
+    return sorted(scope for scope in set(requested) if scope in PROFILE_GRANT_SCOPES)
 
 
 @dataclass(frozen=True)
@@ -140,7 +149,7 @@ class MCPProfileGrant:
             role=role,
             profile_label=_clean_string(data.get("profile_label") or data.get("display_name") or data.get("label")),
             status=_clean_string(data.get("status") or "active").lower(),
-            scopes=_read_only_scopes(scopes, role),
+            scopes=_profile_grant_scopes(scopes, role),
             allowed_tools=sorted({_clean_string(tool) for tool in allowed_tools if _clean_string(tool)}),
             metadata=dict(data.get("metadata") or {}),
         )
@@ -251,8 +260,9 @@ def grant_to_firestore_data(
 ) -> dict[str, Any]:
     """Build the durable grant record stored in `mcp_identity_grants`.
 
-    Proposal/write scopes are intentionally filtered out by `MCPProfileGrant`.
-    A later writeback PR must explicitly add role-scoped proposal permissions.
+    Proposal/direct mutation scopes are intentionally filtered out by
+    `MCPProfileGrant`. `observations:write` is the only narrow write scope
+    currently allowed; it feeds the audited proposal/Observer pipeline.
     """
     normalized_role = _normalized_role(role)
     grant = MCPProfileGrant.from_mapping(
@@ -426,7 +436,9 @@ def mcp_session_secret() -> str:
     return os.getenv("ELLA_MCP_SESSION_SECRET") or os.getenv("ELLA_SESSION_SECRET", "")
 
 
-def issue_mcp_session_token(resolution: MCPIdentityResolution, *, ttl_seconds: int = 3600) -> tuple[str, dict[str, Any]]:
+def issue_mcp_session_token(
+    resolution: MCPIdentityResolution, *, ttl_seconds: int = 3600
+) -> tuple[str, dict[str, Any]]:
     secret = mcp_session_secret()
     if not secret:
         raise RuntimeError("ELLA_MCP_SESSION_SECRET or ELLA_SESSION_SECRET must be configured")

--- a/backend/tests/unit/test_ella_mcp_identity.py
+++ b/backend/tests/unit/test_ella_mcp_identity.py
@@ -56,8 +56,8 @@ def test_resolve_authenticated_unknown_identity_needs_invite():
     assert resolution.available_grants == []
 
 
-def test_single_grant_maps_and_builds_read_only_claims():
-    grant = _grant(scopes=["context:read", "startup:read", "memory:write", "delete:memory"])
+def test_single_grant_maps_and_builds_limited_claims():
+    grant = _grant(scopes=["context:read", "startup:read", "observations:write", "memory:write", "delete:memory"])
     resolution = resolve_mcp_identity(_identity(), grants=[grant], trace_id="trace-1")
 
     assert resolution.state == STATE_AUTHENTICATED_MAPPED
@@ -68,7 +68,7 @@ def test_single_grant_maps_and_builds_read_only_claims():
     assert claims["profile_uid"] == "user-1"
     assert claims["role"] == "self"
     assert claims["trace_id"] == "trace-1"
-    assert claims["scopes"] == ["context:read", "startup:read"]
+    assert claims["scopes"] == ["context:read", "observations:write", "startup:read"]
     assert "memory:write" not in claims["scopes"]
     assert "delete:memory" not in claims["scopes"]
 
@@ -118,12 +118,12 @@ def test_cannot_build_claims_for_unmapped_identity():
         build_session_claims(resolution)
 
 
-def test_grant_to_firestore_data_filters_write_scopes():
+def test_grant_to_firestore_data_allows_observation_write_but_filters_proposal_scopes():
     data = grant_to_firestore_data(
         identity=_identity(),
         profile_uid="user-1",
         role="self",
-        scopes=["context:read", "proposals:write", "rules:propose"],
+        scopes=["context:read", "observations:write", "proposals:write", "rules:propose"],
         allowed_tools=["companion_start_here", "companion_submit_note"],
         profile_label="Test User",
         created_by="unit-test",
@@ -133,8 +133,9 @@ def test_grant_to_firestore_data_filters_write_scopes():
     assert data["email_norm"] == "person@example.com"
     assert data["profile_uid"] == "user-1"
     assert data["role"] == "self"
-    assert data["scopes"] == ["context:read"]
+    assert data["scopes"] == ["context:read", "observations:write"]
     assert "proposals:write" not in data["scopes"]
+    assert "rules:propose" not in data["scopes"]
     assert data["allowed_tools"] == ["companion_start_here", "companion_submit_note"]
     assert data["created_by"] == "unit-test"
 
@@ -172,12 +173,12 @@ def test_provision_identity_grant_writes_durable_record(monkeypatch):
         identity=_identity(),
         profile_uid="user-1",
         role="self",
-        scopes=["startup:read", "proposals:write"],
+        scopes=["startup:read", "observations:write", "proposals:write"],
         allowed_tools=["companion_start_here"],
     )
 
     assert grant.profile_uid == "user-1"
-    assert grant.scopes == ["startup:read"]
+    assert grant.scopes == ["observations:write", "startup:read"]
     assert len(writes) == 1
     write = next(iter(writes.values()))
     assert write["merge"] is True


### PR DESCRIPTION
## Summary
- preserves `observations:write` in MCP profile grants while continuing to filter proposal/direct mutation scopes
- keeps `proposals:write` and `rules:propose` out of generic MCP session claims
- updates identity tests so hosted MCP clients can legitimately call `companion_submit_observation` when granted

## Validation
- `python3 -m pytest tests/unit/test_ella_mcp_identity.py tests/unit/test_ella_mcp_onboarding.py tests/unit/test_ella_plato_mcp.py -q` -> 56 passed

Fixes the live #1031 follow-up where Grok OAuth/session tokens had `companion_submit_observation` exposed but could not retain `observations:write`.