### PR TITLE
Accept MCP info POST probes

### DIFF
--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -1794,9 +1794,11 @@ async def plato_mcp_token(request: Request):
 
 
 @router.get("/mcp/info")
+@router.post("/mcp/info")
 async def plato_mcp_info(request: Request):
     base_url = str(request.base_url).rstrip("/")
     endpoint = f"{base_url}/v1/ella/plato/mcp"
+    visible_tools = [tool["name"] for tool in _visible_tools()]
     return {
         "endpoint": endpoint,
         "transport": "streamable-http",
@@ -1810,10 +1812,18 @@ async def plato_mcp_info(request: Request):
                 "client_id": _env("ELLA_MCP_OAUTH_CLIENT_ID", "ella-mcp"),
                 "authorization_endpoint": f"{base_url}/v1/ella/mcp/authorize",
                 "token_endpoint": f"{base_url}/v1/ella/mcp/token",
-                "scopes": ["tools:read", "startup:read", "timeline:read", "memory:read"],
+                "scopes": [
+                    "tools:read",
+                    "startup:read",
+                    "timeline:read",
+                    "memory:read",
+                    "context:read",
+                    "profile:read",
+                    "observations:write",
+                ],
             },
         },
-        "tools": [tool["name"] for tool in MCP_TOOLS],
-        "write_tools_enabled": False,
+        "tools": visible_tools,
+        "write_tools_enabled": "companion_submit_observation" in visible_tools,
         "rollback": "remove or rotate ELLA_PLATO_MCP_TOKEN / ELLA_PLATO_MCP_TOKENS",
     }

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -102,6 +102,22 @@ def test_plato_mcp_lists_default_safe_tools(monkeypatch):
     assert "companion_get_proposal_status" not in tool_names
 
 
+def test_plato_mcp_info_accepts_post_and_lists_visible_tools(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+
+    response = client.post("/v1/ella/plato/mcp/info")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["transport"] == "streamable-http"
+    assert payload["write_tools_enabled"] is True
+    assert "observations:write" in payload["authentication"]["oauth"]["scopes"]
+    assert "companion_submit_observation" in payload["tools"]
+    assert "companion_propose_change" not in payload["tools"]
+    assert "companion_get_proposal_status" not in payload["tools"]
+
+
 def test_companion_surface_prompt_returns_no_secret_bootstrap(monkeypatch):
     module = _load_module(monkeypatch)
     client = _client(module)


### PR DESCRIPTION
## Summary
- accepts both GET and POST on `/v1/ella/plato/mcp/info` for hosted connector probes
- makes the info payload list only visible MCP tools
- includes `observations:write` in the OAuth scope hint for companion observation writes

## Validation
- `python3 -m pytest tests/unit/test_ella_plato_mcp.py tests/unit/test_ella_mcp_identity.py -q` -> 37 passed

Follow-up for ellaaicare/ella-ai#1031 after Grok marked the connector unavailable while POST-probing `/mcp/info`.