### PR TITLE
Issue fresh MCP dynamic client ids

### DIFF
--- a/backend/ella/routers/mcp_onboarding.py
+++ b/backend/ella/routers/mcp_onboarding.py
@@ -553,13 +553,15 @@ async def post_mcp_register(request: Request):
     client_name = body.get("client_name", "")
     application_type = body.get("application_type", "web")
 
-    # Generate a stable client_id from redirect_uris so re-registration
-    # returns the same ID (idempotent).
-    uri_key = "|".join(sorted(redirect_uris))
-    client_id = "dcr-" + hashlib.sha256(uri_key.encode()).hexdigest()[:24]
+    # Issue a fresh client id for each registration. Some hosted MCP clients
+    # cache DCR state aggressively; returning the same id after a deleted
+    # connector can leave the client stuck on stale auth metadata.
+    client_id = f"dcr-{uuid.uuid4().hex[:24]}"
 
     registration = {
         "client_id": client_id,
+        "client_id_issued_at": int(time.time()),
+        "client_secret_expires_at": 0,
         "redirect_uris": redirect_uris,
         "grant_types": grant_types,
         "response_types": response_types,

--- a/backend/tests/unit/test_ella_mcp_onboarding.py
+++ b/backend/tests/unit/test_ella_mcp_onboarding.py
@@ -110,6 +110,32 @@ def test_mcp_onboarding_without_default_profile_returns_invite_state(monkeypatch
     assert "session_claims" not in payload
 
 
+def test_dynamic_client_registration_issues_fresh_client_ids(monkeypatch):
+    module = _load_module(monkeypatch)
+    client = _client(module)
+    body = {
+        "redirect_uris": ["https://grok.com/connectors-oauth-exchange-code/"],
+        "grant_types": ["authorization_code"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+        "client_name": "Grok",
+    }
+
+    first = client.post("/v1/ella/mcp/register", json=body)
+    second = client.post("/v1/ella/mcp/register", json=body)
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    first_payload = first.json()
+    second_payload = second.json()
+    assert first_payload["client_id"].startswith("dcr-")
+    assert second_payload["client_id"].startswith("dcr-")
+    assert first_payload["client_id"] != second_payload["client_id"]
+    assert first_payload["client_id_issued_at"] > 0
+    assert first_payload["client_secret_expires_at"] == 0
+    assert first_payload["token_endpoint_auth_method"] == "none"
+
+
 def test_oauth_onboarding_maps_verified_google_identity_to_grant(monkeypatch):
     module = _load_module(monkeypatch)
     _install_firebase_stub(monkeypatch)
@@ -284,7 +310,9 @@ def test_oauth_token_exchange_selected_profile_issues_scoped_session(monkeypatch
     assert claims["role"] == "caregiver"
     assert claims["grant_id"] == "grant-mom-1"
 
-    session_response = client.get("/v1/ella/mcp/onboarding", headers={"Authorization": f"Bearer {payload['access_token']}"})
+    session_response = client.get(
+        "/v1/ella/mcp/onboarding", headers={"Authorization": f"Bearer {payload['access_token']}"}
+    )
     assert session_response.status_code == 200
     assert session_response.json()["session_claims"]["profile_uid"] == "mom-1"
 


### PR DESCRIPTION
## Summary
- changes MCP Dynamic Client Registration to issue a fresh `client_id` per registration instead of reusing a deterministic redirect-based id
- returns standard DCR metadata (`client_id_issued_at`, `client_secret_expires_at`)
- adds regression coverage for repeated Grok-style registrations

## Validation
- `python3 -m pytest tests/unit/test_ella_mcp_onboarding.py tests/unit/test_ella_plato_mcp.py -q` -> 49 passed

Follow-up for ellaaicare/ella-ai#1031: Grok can get stuck after deleting/recreating a connector if the authorization server reuses stale DCR client ids.