### PR TITLE
Return MCP DCR client secrets

### DIFF
--- a/backend/ella/routers/mcp_onboarding.py
+++ b/backend/ella/routers/mcp_onboarding.py
@@ -557,9 +557,11 @@ async def post_mcp_register(request: Request):
     # cache DCR state aggressively; returning the same id after a deleted
     # connector can leave the client stuck on stale auth metadata.
     client_id = f"dcr-{uuid.uuid4().hex[:24]}"
+    client_secret = f"dcr-secret-{uuid.uuid4().hex}"
 
     registration = {
         "client_id": client_id,
+        "client_secret": client_secret,
         "client_id_issued_at": int(time.time()),
         "client_secret_expires_at": 0,
         "redirect_uris": redirect_uris,

--- a/backend/tests/unit/test_ella_mcp_onboarding.py
+++ b/backend/tests/unit/test_ella_mcp_onboarding.py
@@ -131,6 +131,9 @@ def test_dynamic_client_registration_issues_fresh_client_ids(monkeypatch):
     assert first_payload["client_id"].startswith("dcr-")
     assert second_payload["client_id"].startswith("dcr-")
     assert first_payload["client_id"] != second_payload["client_id"]
+    assert first_payload["client_secret"].startswith("dcr-secret-")
+    assert second_payload["client_secret"].startswith("dcr-secret-")
+    assert first_payload["client_secret"] != second_payload["client_secret"]
     assert first_payload["client_id_issued_at"] > 0
     assert first_payload["client_secret_expires_at"] == 0
     assert first_payload["token_endpoint_auth_method"] == "none"


### PR DESCRIPTION
## Summary
- returns a `client_secret` from MCP Dynamic Client Registration for hosted connector compatibility
- keeps fresh `client_id` issuance from #275
- updates DCR regression coverage for unique secrets

## Validation
- `python3 -m pytest tests/unit/test_ella_mcp_onboarding.py tests/unit/test_ella_plato_mcp.py -q` -> 49 passed

Follow-up for ellaaicare/ella-ai#1031: Grok still stops after DCR, so return a confidential-client-compatible response even when clients request `token_endpoint_auth_method=none`.