### PR TITLE
Include MCP observations in canonical context

### DIFF
--- a/backend/ella/docs/UNIFIED_MEMORY_CONTEXT.md
+++ b/backend/ella/docs/UNIFIED_MEMORY_CONTEXT.md
@@ -66,7 +66,11 @@ Parameters:
   window sorted chronologically ascending inside that window.
 - `since`: optional ISO timestamp lower bound.
 - `channels`: optional comma-separated filter, for example
-  `omi,ios_chat,ios_voice,imessage,telegram,memory`.
+  `omi,ios_chat,ios_voice,imessage,telegram,memory,observer_memory,companion_observation,grok_conversation`.
+  Default hot-context callers include OMI, app chat, voice, iMessage,
+  Telegram, Guardian, memory, observer memory, and external companion
+  observation channels so MCP/Grok writes can appear in normal startup context
+  without a deep search.
 
 Response shape:
 
@@ -236,4 +240,3 @@ For new context features:
 4. Keep downstream stores behind owner APIs or workers.
 5. Add tests that prove the user-visible path reads canonical data, not a
    private source-specific fallback.
-

--- a/backend/tests/unit/test_ella_canonical_context.py
+++ b/backend/tests/unit/test_ella_canonical_context.py
@@ -7,6 +7,7 @@ sys.modules.setdefault("python_multipart", types.SimpleNamespace(__version__="0.
 from ella.routers import chat as ella_chat
 from ella.routers import guardian
 from utils.ella.canonical_context import (
+    DEFAULT_CONTEXT_CHANNELS,
     canonical_events_to_server_messages,
     canonical_events_to_chat_turns,
     format_canonical_context,
@@ -37,6 +38,13 @@ def test_format_canonical_context_includes_latest_omi_summary():
     assert "2026-05-07T11:56:59" in context
     assert "Cafe Coffee and Waffle Stop" in context
     assert "waffle with oat" in context
+
+
+def test_default_context_channels_include_external_continuity_sources():
+    assert "observer_memory" in DEFAULT_CONTEXT_CHANNELS
+    assert "companion_observation" in DEFAULT_CONTEXT_CHANNELS
+    assert "grok_conversation" in DEFAULT_CONTEXT_CHANNELS
+    assert "companion_note" in DEFAULT_CONTEXT_CHANNELS
 
 
 def test_canonical_events_to_server_messages_maps_ios_history_shape():

--- a/backend/utils/ella/canonical_context.py
+++ b/backend/utils/ella/canonical_context.py
@@ -19,6 +19,12 @@ DEFAULT_CONTEXT_CHANNELS = [
     "telegram",
     "guardian",
     "memory",
+    "observer_memory",
+    "companion_observation",
+    "grok_conversation",
+    "companion_note",
+    "companion_summary",
+    "companion_idea",
 ]
 
 


### PR DESCRIPTION
## Summary
- Add observer_memory, companion_observation, grok_conversation, and companion note/summary/idea channels to the shared canonical context defaults.
- This makes Grok/MCP saved observations eligible for the normal startup/chat/Guardian context pack instead of requiring explicit deep search.
- Add a regression test so the external continuity channels are not silently dropped.

## Tests
- GOOGLE_CLOUD_PROJECT=test-project FIRESTORE_EMULATOR_HOST=127.0.0.1:9999 python3 -m pytest backend/tests/unit/test_ella_canonical_context.py backend/tests/unit/test_ella_mcp_onboarding.py -q

## Live deploy plan
- Patch backend/utils/ella/canonical_context.py on prod VPS.
- Restart omi-backend.service.
- Verify companion_start_here includes the MCP sentinel in default context.