### PR TITLE
Surface MCP observation write audits

### DIFF
--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -1540,9 +1540,17 @@ def _mcp_error(msg_id: Any, code: int, message: str) -> dict[str, Any]:
 
 
 def _argument_summary(arguments: dict[str, Any]) -> dict[str, Any]:
+    safe_scalar_keys = {
+        "channel",
+        "mode",
+        "proposal_id",
+        "proposal_type",
+        "surface",
+        "tool",
+    }
     summary: dict[str, Any] = {}
     for key, value in arguments.items():
-        if key in {"prompt", "query", "correction_text", "fact"}:
+        if isinstance(value, str) and key not in safe_scalar_keys:
             summary[key] = {"chars": len(str(value or ""))}
         elif isinstance(value, (str, int, float, bool)) or value is None:
             summary[key] = value
@@ -1563,7 +1571,8 @@ def _audit_tool_call(
     status: str,
     error: str = "",
 ) -> None:
-    logger.info(
+    log = logger.warning if status != "ok" or tool_name == "companion_submit_observation" else logger.info
+    log(
         "plato_mcp_tool_call %s",
         json.dumps(
             {

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -1095,3 +1095,21 @@ def test_oauth_authorize_redirects_with_code_and_state(monkeypatch):
 
     assert response.status_code == 302
     assert response.headers["location"] == "https://grok.example/callback?code=plato_mcp&state=abc"
+
+
+def test_argument_summary_redacts_observation_text(monkeypatch):
+    module = _load_module(monkeypatch)
+
+    summary = module._argument_summary(
+        {
+            "channel": "companion_observation",
+            "title": "Private title",
+            "text": "Private memory text that should not appear in logs.",
+            "idempotency_key": "private-key",
+        }
+    )
+
+    assert summary["channel"] == "companion_observation"
+    assert summary["title"] == {"chars": len("Private title")}
+    assert summary["text"] == {"chars": len("Private memory text that should not appear in logs.")}
+    assert summary["idempotency_key"] == {"chars": len("private-key")}


### PR DESCRIPTION
## Summary
- Make `companion_submit_observation` MCP tool-call audits visible at warning level.
- Keep normal read-tool audits at info level.
- Error tool calls remain warning-level.

This is to debug cases where a hosted MCP client claims it saved an observation but no canonical row appears. The audit payload is redacted/shape-only: tool name, trace id, token fingerprint, argument key lengths/types, status, and short error. It does not log bearer tokens or full observation text.

## Tests
- GOOGLE_CLOUD_PROJECT=test-project FIRESTORE_EMULATOR_HOST=127.0.0.1:9999 python3 -m pytest backend/tests/unit/test_ella_plato_mcp.py -q

## Live intent
Patch prod so the next Grok write attempt leaves a visible `plato_mcp_tool_call` trace.