### PR TITLE
[codex] Document Ella iOS source of truth

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -4,6 +4,8 @@ The Omi App is a Flutter-based mobile application that serves as the companion a
 
 ## 📚 **[View Full App setup instructions in the documentation](https://docs.omi.me/doc/developer/AppSetup)**
 
+Ella iOS fork/source-of-truth notes: [app/docs/ella-ios-source-of-truth.md](docs/ella-ios-source-of-truth.md)
+
 ### Quick Setup
 
 Before getting started, make sure your device is connected and unlocked. If you're using an iPhone, ensure that Developer Mode is enabled — you can toggle this in the iPhone settings. For Android devices, make sure the device is connected and USB debugging is enabled in Developer Options

--- a/app/docs/ella-ios-source-of-truth.md
+++ b/app/docs/ella-ios-source-of-truth.md
@@ -1,0 +1,144 @@
+# Ella iOS Source Of Truth
+
+Last verified: 2026-07-19
+
+## Where The App Lives
+
+The current Ella iOS app lives in the Ella fork of OMI:
+
+```bash
+https://github.com/ellaaicare/omi.git
+```
+
+The Flutter app is under:
+
+```bash
+app/
+```
+
+Use `main` as the latest shared baseline unless a specific active PR says otherwise. The Mac Mini worktree is only a checkout of this repository, not the source of truth:
+
+```bash
+/Users/ellaai/worktrees/omi-ios-agent/app
+```
+
+The upstream BasedHardware repository is retained as `upstream` for comparison/cherry-picks only:
+
+```bash
+https://github.com/BasedHardware/omi.git
+```
+
+Do not use upstream directly for Ella iOS app work unless the task is explicitly an upstream comparison or cherry-pick.
+
+## Current Shared Baseline
+
+As of 2026-07-19, `ellaaicare/omi` `main` includes the recent iOS screenshot/simulator work:
+
+- PR #270: iOS Simulator Soloud linker fix.
+- PR #271: Demo Mode curated screenshot fixtures.
+- PR #271 feature branch `feature/demo-mode-fixtures` was merged and then deleted remotely. Do not try to pull that branch for current work.
+
+Current verified remote head at the time this document was written:
+
+```bash
+origin/main = 3bc091aea9ffa050ad7fb12edac4e2d3be189239
+```
+
+Because `main` moves, always fetch before starting work.
+
+## Clone Or Update From Another Machine
+
+Fresh clone:
+
+```bash
+git clone https://github.com/ellaaicare/omi.git
+cd omi
+git remote add upstream https://github.com/BasedHardware/omi.git
+git fetch origin --prune
+git switch main
+git pull --ff-only origin main
+cd app
+```
+
+Existing clone:
+
+```bash
+cd /path/to/omi
+git fetch origin --prune
+git switch main
+git pull --ff-only origin main
+cd app
+```
+
+Start a new iOS feature branch from the shared baseline:
+
+```bash
+cd /path/to/omi
+git fetch origin --prune
+git switch -c codex/<short-ios-task-name> origin/main
+cd app
+```
+
+Do not base new iOS work on old stacked branches unless the GitHub issue or PR explicitly names that branch.
+
+## Setup And Validation
+
+From `app/`:
+
+```bash
+flutter pub get
+./test.sh
+```
+
+Simulator smoke build:
+
+```bash
+flutter build ios --simulator --flavor prod --debug
+```
+
+If you need a specific simulator:
+
+```bash
+xcrun simctl list devices available
+flutter build ios --simulator --flavor prod --debug -d <SIMULATOR_UDID>
+xcrun simctl boot <SIMULATOR_UDID>
+xcrun simctl install <SIMULATOR_UDID> "build/ios/iphonesimulator/Ella Care.app"
+xcrun simctl launch <SIMULATOR_UDID> com.ellaaicare.ella
+```
+
+Focused analyzer example for app-side changes:
+
+```bash
+flutter analyze --no-fatal-infos <changed-dart-files>
+```
+
+## TestFlight And Signing
+
+TestFlight builds must preserve the Ella app identity:
+
+```text
+Bundle ID: com.ellaaicare.ella
+Firebase project: omi-dev-ca005
+```
+
+Do not change Firebase, auth, bundle ID, signing, provisioning, or App Store Connect configuration just to make a local build pass. If TestFlight is required, use the repo deploy scripts and the Mac Mini App Store Connect environment documented in the agent runbooks.
+
+## Branch Hygiene
+
+Use this rule of thumb:
+
+- `main`: current shared Ella iOS baseline.
+- `codex/<task>` or `feature/<task>`: active work intended for PR.
+- Deleted merged branches: historical only; do not use as a baseline.
+- Local Mac Mini worktrees: temporary working copies; never assume changes are durable until committed and pushed to GitHub.
+
+Before handing work to another laptop/server, confirm:
+
+```bash
+git status --short --branch
+git fetch origin --prune
+git log --oneline --decorate --max-count=10 origin/main
+gh pr status --repo ellaaicare/omi
+```
+
+If a needed change exists only locally, push a branch and open a draft PR before handing it off.


### PR DESCRIPTION
## Summary

Documents the current Ella iOS source of truth for laptop/server handoff work.

## Details

- States that `ellaaicare/omi` `main` is the current shared Ella iOS baseline.
- Records that PR #270 and PR #271 are merged into `main`, and that `feature/demo-mode-fixtures` was deleted after merge.
- Adds clone/update/branch setup commands for other machines.
- Calls out the Mac Mini worktree as a checkout only, not durable source of truth.
- Links the runbook from `app/README.md`.

## Validation

- `git diff --check`
- Documentation-only change; app tests not run.
