### PR TITLE
Use OpenRouter for primary generic OMI summaries

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -18,6 +18,15 @@ DEEPGRAM_API_KEY=
 ADMIN_KEY=
 OPENAI_API_KEY=
 
+# Generic OMI summary provider chain. OpenRouter remains inside the stock OMI
+# processing path; Hermes enrichment runs asynchronously after the summary is saved.
+OPENROUTER_API_KEY=
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+OPENROUTER_SITE_URL=https://ella-ai-care.com
+OPENROUTER_APP_NAME=Ella AI OMI Summary
+OMI_OPENROUTER_MODEL=google/gemini-3.1-flash-lite
+OMI_LLM_PROVIDER_ORDER=openrouter,gemini,groq,ollama_cloud
+
 GITHUB_TOKEN=
 
 WORKFLOW_API_KEY=

--- a/backend/tests/unit/test_llm_openrouter_provider.py
+++ b/backend/tests/unit/test_llm_openrouter_provider.py
@@ -1,0 +1,110 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+
+def _load_clients(monkeypatch):
+    class FakeMessage:
+        def __init__(self, content=None):
+            self.content = content
+
+    class FakeChatOpenAI:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.model_name = kwargs.get("model")
+
+        def _generate(self, *args, **kwargs):
+            return None
+
+        def _stream(self, *args, **kwargs):
+            return None
+
+        def with_fallbacks(self, fallbacks):
+            return self, fallbacks
+
+    class FakeOpenAIEmbeddings:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def embed_documents(self, documents):
+            return [[0.0] for _ in documents]
+
+    class FakeParser:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeEncoding:
+        def encode(self, value):
+            return value.split()
+
+    langchain_core = types.ModuleType("langchain_core")
+    output_parsers = types.ModuleType("langchain_core.output_parsers")
+    output_parsers.PydanticOutputParser = FakeParser
+    messages = types.ModuleType("langchain_core.messages")
+    messages.HumanMessage = FakeMessage
+    messages.SystemMessage = FakeMessage
+    langchain_openai = types.ModuleType("langchain_openai")
+    langchain_openai.ChatOpenAI = FakeChatOpenAI
+    langchain_openai.OpenAIEmbeddings = FakeOpenAIEmbeddings
+    tiktoken = types.ModuleType("tiktoken")
+    tiktoken.encoding_for_model = lambda model: FakeEncoding()
+    conversation = types.ModuleType("models.conversation")
+    conversation.Structured = type("Structured", (), {})
+
+    for name, module in {
+        "langchain_core": langchain_core,
+        "langchain_core.output_parsers": output_parsers,
+        "langchain_core.messages": messages,
+        "langchain_openai": langchain_openai,
+        "tiktoken": tiktoken,
+        "models.conversation": conversation,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+    monkeypatch.setenv("OMI_LLM_PROVIDER_ORDER", "openrouter")
+
+    module_path = Path(__file__).resolve().parents[2] / "utils" / "llm" / "clients.py"
+    spec = importlib.util.spec_from_file_location("test_llm_openrouter_clients", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_openrouter_client_uses_compatible_endpoint_and_attribution(monkeypatch):
+    clients = _load_clients(monkeypatch)
+    clients._openrouter_base_url = "https://openrouter.example/v1"
+    clients._openrouter_site_url = "https://ella.example"
+    clients._openrouter_app_name = "Ella Summary Test"
+
+    result = clients._make_openrouter(temperature=0.2)
+
+    assert result.kwargs["api_key"] == "test-openrouter-key"
+    assert result.kwargs["base_url"] == "https://openrouter.example/v1"
+    assert result.kwargs["model"] == "google/gemini-3.1-flash-lite"
+    assert result.kwargs["temperature"] == 0.2
+    assert result.kwargs["default_headers"] == {
+        "HTTP-Referer": "https://ella.example",
+        "X-Title": "Ella Summary Test",
+    }
+
+
+def test_openrouter_provider_is_skipped_without_key(monkeypatch):
+    clients = _load_clients(monkeypatch)
+    clients._openrouter_api_key = None
+
+    assert clients._provider_instance("openrouter") is None
+
+
+def test_provider_chain_keeps_openrouter_primary(monkeypatch):
+    clients = _load_clients(monkeypatch)
+    clients._provider_order = ["openrouter", "groq"]
+    clients._groq_api_key = "test-groq-key"
+
+    primary, fallbacks = clients._build_chain(openrouter_model="google/gemini-3.1-flash-lite")
+
+    assert primary.kwargs["base_url"] == "https://openrouter.ai/api/v1"
+    assert primary.kwargs["model"] == "google/gemini-3.1-flash-lite"
+    assert len(fallbacks) == 1
+    assert fallbacks[0].kwargs["base_url"] == "https://api.groq.com/openai/v1"

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -81,9 +81,12 @@ _apply_ella_llm_patch()
 # All exported llm_* variables are RunnableWithFallbacks (or plain ChatOpenAI if only 1 provider).
 # Callers use .invoke(), .ainvoke(), pipe (|), .stream() — all work transparently.
 #
-# Dead providers (out of credits): OpenRouter, xAI — NOT included in the default chain.
+# xAI is intentionally excluded from this generic-summary chain. OpenRouter is
+# supported as an OpenAI-compatible provider and can be placed first without
+# enabling direct OpenAI API billing.
 
 _openai_api_key = os.getenv('OPENAI_API_KEY')
+_openrouter_api_key = os.getenv('OPENROUTER_API_KEY')
 _ollama_api_key = os.getenv('OLLAMA_API_KEY')
 _groq_api_key = os.getenv('GROQ_API_KEY')
 _gemini_api_key = os.getenv('GEMINI_API_KEY')
@@ -97,6 +100,9 @@ _direct_openai_llm_enabled = os.getenv('OMI_ALLOW_DIRECT_OPENAI_LLM', 'false').l
     'yes',
     'on',
 )
+_openrouter_base_url = os.getenv('OPENROUTER_BASE_URL', 'https://openrouter.ai/api/v1')
+_openrouter_site_url = os.getenv('OPENROUTER_SITE_URL', 'https://ella-ai-care.com')
+_openrouter_app_name = os.getenv('OPENROUTER_APP_NAME', 'Ella AI OMI Summary')
 
 # Ollama Cloud endpoint (direct to ollama.com — local proxy had auth issues)
 _ollama_cloud_base_url = "https://ollama.com/v1"
@@ -104,13 +110,14 @@ _ollama_cloud_base_url = "https://ollama.com/v1"
 # Model selections per provider
 _openai_mini = os.getenv('OMI_OPENAI_MINI', 'gpt-4.1-mini')
 _openai_medium = os.getenv('OMI_OPENAI_MEDIUM', 'gpt-4.1-mini')
+_openrouter_model = os.getenv('OMI_OPENROUTER_MODEL', 'google/gemini-3.1-flash-lite')
 _ollama_model = os.getenv('OMI_OLLAMA_MODEL', 'nemotron-3-super')
 _ollama_fallback_model = os.getenv('OMI_OLLAMA_FALLBACK', 'gemma3:27b')
 _groq_model = os.getenv('OMI_GROQ_MODEL', 'llama-3.1-8b-instant')
 _gemini_model = os.getenv('OMI_GEMINI_MODEL', 'gemini-2.5-flash')
 _provider_order = [
     provider.strip()
-    for provider in os.getenv('OMI_LLM_PROVIDER_ORDER', 'gemini,groq,ollama_cloud').split(',')
+    for provider in os.getenv('OMI_LLM_PROVIDER_ORDER', 'openrouter,gemini,groq,ollama_cloud').split(',')
     if provider.strip()
 ]
 
@@ -118,6 +125,23 @@ _provider_order = [
 def _make_openai(model=None, **kwargs):
     """Create a ChatOpenAI instance using OpenAI direct."""
     return ChatOpenAI(api_key=_openai_api_key, model=model or _openai_medium, **kwargs)
+
+
+def _make_openrouter(model=None, **kwargs):
+    """Create a ChatOpenAI instance using OpenRouter's compatible endpoint."""
+    supplied_headers = kwargs.pop('default_headers', None) or {}
+    default_headers = {
+        'HTTP-Referer': _openrouter_site_url,
+        'X-Title': _openrouter_app_name,
+        **supplied_headers,
+    }
+    return ChatOpenAI(
+        api_key=_openrouter_api_key,
+        base_url=_openrouter_base_url,
+        model=model or _openrouter_model,
+        default_headers=default_headers,
+        **kwargs,
+    )
 
 
 def _make_ella_proxy(**kwargs):
@@ -165,12 +189,20 @@ def _with_fallbacks(primary, fallbacks):
 
 
 def _provider_instance(
-    provider: str, openai_model=None, ollama_model=None, groq_model=None, gemini_model=None, **kwargs
+    provider: str,
+    openai_model=None,
+    openrouter_model=None,
+    ollama_model=None,
+    groq_model=None,
+    gemini_model=None,
+    **kwargs,
 ):
     if provider == 'ella_proxy':
         return _make_ella_proxy(**kwargs) if (_ella_proxy_enabled and _ella_base_url) else None
     if provider == 'openai':
         return _make_openai(model=openai_model, **kwargs) if (_direct_openai_llm_enabled and _openai_api_key) else None
+    if provider == 'openrouter':
+        return _make_openrouter(model=openrouter_model, **kwargs) if _openrouter_api_key else None
     if provider == 'ollama_cloud':
         return _make_ollama_cloud(model=ollama_model, **kwargs) if _ollama_api_key else None
     if provider == 'groq':
@@ -185,9 +217,17 @@ _providers_available = [provider for provider in _provider_order if _provider_in
 print(f"[FLOW:LLM-INIT] providers_available={_providers_available} mode=runtime_fallback", flush=True)
 
 
-def _build_chain(openai_model=None, ollama_model=None, groq_model=None, gemini_model=None, **kwargs):
+def _build_chain(
+    openai_model=None,
+    openrouter_model=None,
+    ollama_model=None,
+    groq_model=None,
+    gemini_model=None,
+    **kwargs,
+):
     """Build a primary→fallback chain from all available providers."""
     openai_model = openai_model or _openai_medium
+    openrouter_model = openrouter_model or _openrouter_model
     ollama_model = ollama_model or _ollama_model
     groq_model = groq_model or _groq_model
     gemini_model = gemini_model or _gemini_model
@@ -199,6 +239,7 @@ def _build_chain(openai_model=None, ollama_model=None, groq_model=None, gemini_m
         inst = _provider_instance(
             provider,
             openai_model=openai_model,
+            openrouter_model=openrouter_model,
             ollama_model=ollama_model,
             groq_model=groq_model,
             gemini_model=gemini_model,


### PR DESCRIPTION
## Summary
- add OpenRouter as an OpenAI-compatible provider in the existing OMI LLM chain
- default the OpenRouter model to `google/gemini-3.1-flash-lite`
- document secret-free provider configuration and preserve provider fallbacks

## Architecture
This keeps the established sequence intact:

1. OMI backend generates and persists the generic summary as the primary processing path.
2. Existing conversation-ready/n8n processing invokes Hermes enrichment asynchronously.
3. Hermes writes the enriched summary back to OMI for iOS/canonical consumers.

This PR does **not** send transcripts directly to n8n, replace generic summaries with Hermes, or add a historical repair generator.

## Validation
- `python3 -m pytest tests/unit/test_llm_openrouter_provider.py tests/unit/test_conversation_processing_failures.py tests/unit/test_long_discarded_inventory.py -q` -> 14 passed
- `./test.sh` -> 116 passed
- production LangChain 0.3.35 constructor compatibility checked for `base_url` and `default_headers`
- live OpenRouter completion probe for the selected model succeeded; no transcript data used

Related: ellaaicare/ella-ai#1049, ellaaicare/ella-ai#1050, ellaaicare/ella-ai#1051