### PR TITLE
Show failed summaries with Retry with Ella on iOS

### DIFF
--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -70,16 +70,51 @@ Future<List<ServerConversation>> getConversations({
 
 enum ConversationProcessingRetryOutcome { processing, completed, failed }
 
+enum ConversationProcessingRecoveryMode { none, full, enrichmentOnly }
+
 class ConversationProcessingRetryResult {
   final ConversationProcessingRetryOutcome outcome;
+  final ConversationProcessingRecoveryMode recoveryMode;
+  final String? phase;
+  final String? genericStatus;
+  final String? genericVectorStatus;
+  final String? enrichmentStatus;
+  final String? vectorStatus;
+  final DateTime? leaseExpiresAt;
+  final int attemptCount;
   final ServerConversation conversation;
 
-  const ConversationProcessingRetryResult({required this.outcome, required this.conversation});
+  const ConversationProcessingRetryResult({
+    required this.outcome,
+    this.recoveryMode = ConversationProcessingRecoveryMode.none,
+    this.phase,
+    this.genericStatus,
+    this.genericVectorStatus,
+    this.enrichmentStatus,
+    this.vectorStatus,
+    this.leaseExpiresAt,
+    this.attemptCount = 0,
+    required this.conversation,
+  });
+
+  bool get isTerminal =>
+      outcome == ConversationProcessingRetryOutcome.completed || outcome == ConversationProcessingRetryOutcome.failed;
 
   factory ConversationProcessingRetryResult.fromJson(Map<String, dynamic> json) {
     return ConversationProcessingRetryResult(
       outcome: ConversationProcessingRetryOutcome.values.asNameMap()[json['outcome']] ??
           ConversationProcessingRetryOutcome.failed,
+      recoveryMode: json['recovery_mode'] == 'enrichment_only'
+          ? ConversationProcessingRecoveryMode.enrichmentOnly
+          : ConversationProcessingRecoveryMode.values.asNameMap()[json['recovery_mode']] ??
+              ConversationProcessingRecoveryMode.none,
+      phase: json['phase'],
+      genericStatus: json['generic_status'],
+      genericVectorStatus: json['generic_vector_status'],
+      enrichmentStatus: json['enrichment_status'],
+      vectorStatus: json['vector_status'],
+      leaseExpiresAt: json['lease_expires_at'] != null ? DateTime.tryParse(json['lease_expires_at'])?.toLocal() : null,
+      attemptCount: (json['attempt_count'] as num?)?.toInt() ?? 0,
       conversation: ServerConversation.fromJson(json['conversation']),
     );
   }

--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -68,6 +68,46 @@ Future<List<ServerConversation>> getConversations({
   return [];
 }
 
+enum ConversationProcessingRetryOutcome { processing, completed, failed }
+
+class ConversationProcessingRetryResult {
+  final ConversationProcessingRetryOutcome outcome;
+  final ServerConversation conversation;
+
+  const ConversationProcessingRetryResult({required this.outcome, required this.conversation});
+
+  factory ConversationProcessingRetryResult.fromJson(Map<String, dynamic> json) {
+    return ConversationProcessingRetryResult(
+      outcome: ConversationProcessingRetryOutcome.values.asNameMap()[json['outcome']] ??
+          ConversationProcessingRetryOutcome.failed,
+      conversation: ServerConversation.fromJson(json['conversation']),
+    );
+  }
+}
+
+Future<ConversationProcessingRetryResult?> retryConversationProcessing(
+  String conversationId,
+  String requestId, {
+  String? correctionText,
+}) async {
+  final normalizedCorrection = correctionText?.trim();
+  final response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/conversations/$conversationId/processing-retries',
+    headers: {},
+    method: 'POST',
+    body: jsonEncode({
+      'request_id': requestId,
+      if (normalizedCorrection != null && normalizedCorrection.isNotEmpty) 'correction_text': normalizedCorrection,
+    }),
+  );
+  if (response == null) return null;
+  Logger.debug('retryConversationProcessing: ${response.statusCode}');
+  if (response.statusCode == 200 || response.statusCode == 202) {
+    return ConversationProcessingRetryResult.fromJson(jsonDecode(response.body));
+  }
+  return null;
+}
+
 Future<ServerConversation?> reProcessConversationServer(String conversationId, {String? appId}) async {
   var response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/conversations/$conversationId/reprocess${appId != null ? '?app_id=$appId' : ''}',

--- a/app/lib/backend/schema/conversation.dart
+++ b/app/lib/backend/schema/conversation.dart
@@ -192,6 +192,8 @@ class ServerConversation {
   final Object? internalAssessment;
   final List<String> ellaTags;
   final Map<String, dynamic>? ellaSignal;
+  final String? processingError;
+  final DateTime? processingErrorAt;
 
   ConversationStatus status;
   bool discarded;
@@ -223,6 +225,8 @@ class ServerConversation {
     this.internalAssessment,
     this.ellaTags = const [],
     this.ellaSignal,
+    this.processingError,
+    this.processingErrorAt,
     this.status = ConversationStatus.completed,
     this.isLocked = false,
     this.starred = false,
@@ -257,6 +261,9 @@ class ServerConversation {
       internalAssessment: json['internal_assessment'],
       ellaTags: ((json['ella_tags'] ?? []) as List<dynamic>).map((tag) => tag.toString()).toList(),
       ellaSignal: json['ella_signal'] is Map ? Map<String, dynamic>.from(json['ella_signal']) : null,
+      processingError: json['processing_error'],
+      processingErrorAt:
+          json['processing_error_at'] != null ? DateTime.parse(json['processing_error_at']).toLocal() : null,
       status: json['status'] != null
           ? ConversationStatus.values.asNameMap()[json['status']] ?? ConversationStatus.completed
           : ConversationStatus.completed,
@@ -286,6 +293,8 @@ class ServerConversation {
       'internal_assessment': internalAssessment,
       'ella_tags': ellaTags,
       'ella_signal': ellaSignal,
+      'processing_error': processingError,
+      'processing_error_at': processingErrorAt?.toUtc().toIso8601String(),
       'status': status.toString().split('.').last,
       'is_locked': isLocked,
       'starred': starred,

--- a/app/lib/backend/schema/conversation.dart
+++ b/app/lib/backend/schema/conversation.dart
@@ -192,6 +192,8 @@ class ServerConversation {
   final Object? internalAssessment;
   final List<String> ellaTags;
   final Map<String, dynamic>? ellaSignal;
+  final Map<String, dynamic>? enrichmentState;
+  final String? processingRetryEnrichmentVectorStatus;
   final String? processingError;
   final DateTime? processingErrorAt;
 
@@ -204,6 +206,12 @@ class ServerConversation {
   bool get isRetryableSummaryFailure =>
       status == ConversationStatus.failed &&
       (processingError == 'conversation_summary_failed' || processingError == 'conversation_summary_recovery_failed');
+
+  bool get isRetryableEnrichmentFailure =>
+      status == ConversationStatus.completed &&
+      (enrichmentState?['status'] == 'failed' ||
+          enrichmentState?['canonical_status'] == 'failed' ||
+          processingRetryEnrichmentVectorStatus == 'failed');
 
   String? folderId;
 
@@ -230,6 +238,8 @@ class ServerConversation {
     this.internalAssessment,
     this.ellaTags = const [],
     this.ellaSignal,
+    this.enrichmentState,
+    this.processingRetryEnrichmentVectorStatus,
     this.processingError,
     this.processingErrorAt,
     this.status = ConversationStatus.completed,
@@ -266,6 +276,8 @@ class ServerConversation {
       internalAssessment: json['internal_assessment'],
       ellaTags: ((json['ella_tags'] ?? []) as List<dynamic>).map((tag) => tag.toString()).toList(),
       ellaSignal: json['ella_signal'] is Map ? Map<String, dynamic>.from(json['ella_signal']) : null,
+      enrichmentState: json['enrichment_state'] is Map ? Map<String, dynamic>.from(json['enrichment_state']) : null,
+      processingRetryEnrichmentVectorStatus: json['processing_retry_enrichment_vector_status'],
       processingError: json['processing_error'],
       processingErrorAt:
           json['processing_error_at'] != null ? DateTime.parse(json['processing_error_at']).toLocal() : null,
@@ -298,6 +310,8 @@ class ServerConversation {
       'internal_assessment': internalAssessment,
       'ella_tags': ellaTags,
       'ella_signal': ellaSignal,
+      'enrichment_state': enrichmentState,
+      'processing_retry_enrichment_vector_status': processingRetryEnrichmentVectorStatus,
       'processing_error': processingError,
       'processing_error_at': processingErrorAt?.toUtc().toIso8601String(),
       'status': status.toString().split('.').last,

--- a/app/lib/backend/schema/conversation.dart
+++ b/app/lib/backend/schema/conversation.dart
@@ -200,6 +200,11 @@ class ServerConversation {
   final bool deleted;
   final bool isLocked;
   bool starred;
+
+  bool get isRetryableSummaryFailure =>
+      status == ConversationStatus.failed &&
+      (processingError == 'conversation_summary_failed' || processingError == 'conversation_summary_recovery_failed');
+
   String? folderId;
 
   // local label

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10176,5 +10176,33 @@
         "type": "String"
       }
     }
+  },
+  "conversationNeedsProcessing": "Needs processing",
+  "@conversationNeedsProcessing": {
+    "description": "Section and status label for a conversation whose summary failed"
+  },
+  "conversationNeedsProcessingDescription": "Your transcript is safe. Ask Ella to create its summary.",
+  "@conversationNeedsProcessingDescription": {
+    "description": "Reassurance shown for a failed conversation summary"
+  },
+  "retryWithElla": "Retry with Ella",
+  "@retryWithElla": {
+    "description": "Action to ask Ella to rebuild a failed conversation summary"
+  },
+  "retryWithEllaDescription": "Ella will rebuild the summary from your saved transcript. Add any context that could help.",
+  "@retryWithEllaDescription": {
+    "description": "Explanation shown before retrying a failed summary"
+  },
+  "retryWithEllaContextLabel": "Additional context (optional)",
+  "@retryWithEllaContextLabel": {
+    "description": "Label for optional context supplied with a failed summary retry"
+  },
+  "retryWithEllaContextHint": "Example: This was a family conversation about our summer plans.",
+  "@retryWithEllaContextHint": {
+    "description": "Example context for a failed summary retry"
+  },
+  "retryNow": "Retry now",
+  "@retryNow": {
+    "description": "Confirmation action for retrying a failed summary"
   }
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -16010,6 +16010,48 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Trace: {traceId}'**
   String guardianAlertsTraceDetail(String traceId);
+
+  /// Section and status label for a conversation whose summary failed
+  ///
+  /// In en, this message translates to:
+  /// **'Needs processing'**
+  String get conversationNeedsProcessing;
+
+  /// Reassurance shown for a failed conversation summary
+  ///
+  /// In en, this message translates to:
+  /// **'Your transcript is safe. Ask Ella to create its summary.'**
+  String get conversationNeedsProcessingDescription;
+
+  /// Action to ask Ella to rebuild a failed conversation summary
+  ///
+  /// In en, this message translates to:
+  /// **'Retry with Ella'**
+  String get retryWithElla;
+
+  /// Explanation shown before retrying a failed summary
+  ///
+  /// In en, this message translates to:
+  /// **'Ella will rebuild the summary from your saved transcript. Add any context that could help.'**
+  String get retryWithEllaDescription;
+
+  /// Label for optional context supplied with a failed summary retry
+  ///
+  /// In en, this message translates to:
+  /// **'Additional context (optional)'**
+  String get retryWithEllaContextLabel;
+
+  /// Example context for a failed summary retry
+  ///
+  /// In en, this message translates to:
+  /// **'Example: This was a family conversation about our summer plans.'**
+  String get retryWithEllaContextHint;
+
+  /// Confirmation action for retrying a failed summary
+  ///
+  /// In en, this message translates to:
+  /// **'Retry now'**
+  String get retryNow;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8526,4 +8526,26 @@ class AppLocalizationsAr extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8614,4 +8614,26 @@ class AppLocalizationsBg extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8630,4 +8630,26 @@ class AppLocalizationsCa extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8577,4 +8577,26 @@ class AppLocalizationsCs extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8566,4 +8566,26 @@ class AppLocalizationsDa extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8648,4 +8648,26 @@ class AppLocalizationsDe extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8639,4 +8639,26 @@ class AppLocalizationsEl extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8579,4 +8579,26 @@ class AppLocalizationsEn extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8596,4 +8596,26 @@ class AppLocalizationsEs extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8581,4 +8581,26 @@ class AppLocalizationsEt extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8580,4 +8580,26 @@ class AppLocalizationsFi extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8655,4 +8655,26 @@ class AppLocalizationsFr extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8562,4 +8562,26 @@ class AppLocalizationsHi extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8619,4 +8619,26 @@ class AppLocalizationsHu extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8594,4 +8594,26 @@ class AppLocalizationsId extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8631,4 +8631,26 @@ class AppLocalizationsIt extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8448,4 +8448,26 @@ class AppLocalizationsJa extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8450,4 +8450,26 @@ class AppLocalizationsKo extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8587,4 +8587,26 @@ class AppLocalizationsLt extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8599,4 +8599,26 @@ class AppLocalizationsLv extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8605,4 +8605,26 @@ class AppLocalizationsMs extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8607,4 +8607,26 @@ class AppLocalizationsNl extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8577,4 +8577,26 @@ class AppLocalizationsNo extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8600,4 +8600,26 @@ class AppLocalizationsPl extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8582,4 +8582,26 @@ class AppLocalizationsPt extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8620,4 +8620,26 @@ class AppLocalizationsRo extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8607,4 +8607,26 @@ class AppLocalizationsRu extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8572,4 +8572,26 @@ class AppLocalizationsSk extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8587,4 +8587,26 @@ class AppLocalizationsSv extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8544,4 +8544,26 @@ class AppLocalizationsTh extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8595,4 +8595,26 @@ class AppLocalizationsTr extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8594,4 +8594,26 @@ class AppLocalizationsUk extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8584,4 +8584,26 @@ class AppLocalizationsVi extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8438,4 +8438,26 @@ class AppLocalizationsZh extends AppLocalizations {
   String guardianAlertsTraceDetail(String traceId) {
     return 'Trace: $traceId';
   }
+
+  @override
+  String get conversationNeedsProcessing => 'Needs processing';
+
+  @override
+  String get conversationNeedsProcessingDescription => 'Your transcript is safe. Ask Ella to create its summary.';
+
+  @override
+  String get retryWithElla => 'Retry with Ella';
+
+  @override
+  String get retryWithEllaDescription =>
+      'Ella will rebuild the summary from your saved transcript. Add any context that could help.';
+
+  @override
+  String get retryWithEllaContextLabel => 'Additional context (optional)';
+
+  @override
+  String get retryWithEllaContextHint => 'Example: This was a family conversation about our summer plans.';
+
+  @override
+  String get retryNow => 'Retry now';
 }

--- a/app/lib/pages/conversations/conversations_page.dart
+++ b/app/lib/pages/conversations/conversations_page.dart
@@ -10,6 +10,7 @@ import 'package:omi/pages/capture/widgets/widgets.dart';
 import 'package:omi/pages/conversations/widgets/daily_score_widget.dart';
 import 'package:omi/pages/conversations/widgets/daily_summaries_list.dart';
 import 'package:omi/pages/conversations/widgets/folder_tabs.dart';
+import 'package:omi/pages/conversations/widgets/failed_conversations_section.dart';
 import 'package:omi/pages/conversations/widgets/goals_widget.dart';
 import 'package:omi/pages/conversations/widgets/processing_capture.dart';
 import 'package:omi/pages/conversations/widgets/search_result_header_widget.dart';
@@ -214,6 +215,13 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
               },
             ),
             const SliverToBoxAdapter(child: SearchResultHeaderWidget()),
+            SliverToBoxAdapter(
+              child: FailedConversationsSection(
+                conversations: convoProvider.failedConversations,
+                isRetrying: convoProvider.isConversationRetrying,
+                onRetry: convoProvider.retryFailedConversation,
+              ),
+            ),
             getProcessingConversationsWidget(convoProvider.processingConversations),
 
             // Daily Score, Today's Tasks, and Goals Widgets - hide when showing daily recaps, search bar is active, or calendar filter is active
@@ -283,6 +291,7 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
             if (convoProvider.showDailySummaries)
               const DailySummariesList()
             else if (convoProvider.groupedConversations.isEmpty &&
+                convoProvider.failedConversations.isEmpty &&
                 !convoProvider.isLoadingConversations &&
                 !convoProvider.isFetchingConversations)
               SliverToBoxAdapter(
@@ -298,6 +307,8 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
             else if (convoProvider.groupedConversations.isEmpty &&
                 (convoProvider.isLoadingConversations || convoProvider.isFetchingConversations))
               _buildLoadingShimmer()
+            else if (convoProvider.groupedConversations.isEmpty)
+              const SliverToBoxAdapter(child: SizedBox.shrink())
             else
               SliverList(
                 delegate: SliverChildBuilderDelegate(

--- a/app/lib/pages/conversations/conversations_page.dart
+++ b/app/lib/pages/conversations/conversations_page.dart
@@ -173,6 +173,10 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
     Logger.debug('building conversations page');
     super.build(context);
     return Consumer<ConversationProvider>(builder: (context, convoProvider, child) {
+      final homeProvider = context.watch<HomeProvider>();
+      final isSearchActive = homeProvider.showConvoSearchBar || convoProvider.previousQuery.isNotEmpty;
+      final showFailedConversations = !isSearchActive && !convoProvider.showDailySummaries;
+
       return RefreshIndicator(
         onRefresh: () async {
           HapticFeedback.mediumImpact();
@@ -220,6 +224,8 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
                 conversations: convoProvider.failedConversations,
                 isRetrying: convoProvider.isConversationRetrying,
                 onRetry: convoProvider.retryFailedConversation,
+                isSearchActive: isSearchActive,
+                showDailySummaries: convoProvider.showDailySummaries,
               ),
             ),
             getProcessingConversationsWidget(convoProvider.processingConversations),
@@ -291,7 +297,7 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
             if (convoProvider.showDailySummaries)
               const DailySummariesList()
             else if (convoProvider.groupedConversations.isEmpty &&
-                convoProvider.failedConversations.isEmpty &&
+                (!showFailedConversations || convoProvider.failedConversations.isEmpty) &&
                 !convoProvider.isLoadingConversations &&
                 !convoProvider.isFetchingConversations)
               SliverToBoxAdapter(

--- a/app/lib/pages/conversations/widgets/failed_conversations_section.dart
+++ b/app/lib/pages/conversations/widgets/failed_conversations_section.dart
@@ -1,0 +1,302 @@
+import 'package:flutter/material.dart';
+
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/pages/conversation_detail/page.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/utils/other/temp.dart';
+
+typedef RetryFailedConversation = Future<bool> Function(String conversationId, {String? correctionText});
+
+class FailedConversationsSection extends StatelessWidget {
+  final List<ServerConversation> conversations;
+  final bool Function(String conversationId) isRetrying;
+  final RetryFailedConversation onRetry;
+
+  const FailedConversationsSection({
+    super.key,
+    required this.conversations,
+    required this.isRetrying,
+    required this.onRetry,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (conversations.isEmpty) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(left: 8, bottom: 8),
+            child: Text(
+              context.l10n.conversationNeedsProcessing,
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(color: EllaColors.textPrimary, fontWeight: FontWeight.w700),
+            ),
+          ),
+          ...conversations.map(
+            (conversation) => _FailedConversationCard(
+              conversation: conversation,
+              isRetrying: isRetrying(conversation.id),
+              onRetry: onRetry,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FailedConversationCard extends StatelessWidget {
+  final ServerConversation conversation;
+  final bool isRetrying;
+  final RetryFailedConversation onRetry;
+
+  const _FailedConversationCard({required this.conversation, required this.isRetrying, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    final recordedAt = conversation.startedAt ?? conversation.createdAt;
+    final transcript = conversation.getTranscript(maxCount: 180).replaceAll(RegExp(r'\s+'), ' ').trim();
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Material(
+        color: EllaColors.bgSecondary,
+        borderRadius: BorderRadius.circular(20),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(20),
+          onTap: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => ConversationDetailPage(conversation: conversation, initialTabIndex: 0)),
+            );
+          },
+          child: Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(color: EllaColors.warning.withValues(alpha: 0.45)),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Container(
+                      width: 36,
+                      height: 36,
+                      decoration: BoxDecoration(
+                        color: EllaColors.warning.withValues(alpha: 0.14),
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: const Icon(Icons.history_toggle_off_rounded, color: EllaColors.warning, size: 20),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            context.l10n.conversationNeedsProcessing,
+                            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                                  color: EllaColors.textPrimary,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            dateTimeFormat('MMM d, h:mm a', recordedAt),
+                            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: EllaColors.textTertiary),
+                          ),
+                        ],
+                      ),
+                    ),
+                    FilledButton.tonal(
+                      key: ValueKey('retry-conversation-${conversation.id}'),
+                      onPressed: isRetrying
+                          ? null
+                          : () {
+                              showModalBottomSheet<void>(
+                                context: context,
+                                isScrollControlled: true,
+                                backgroundColor: Colors.transparent,
+                                builder: (_) => _RetryWithEllaSheet(conversation: conversation, onRetry: onRetry),
+                              );
+                            },
+                      style: FilledButton.styleFrom(
+                        foregroundColor: EllaColors.textPrimary,
+                        backgroundColor: EllaColors.bgTertiary,
+                      ),
+                      child: Text(isRetrying ? context.l10n.processing : context.l10n.retryWithElla),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  context.l10n.conversationNeedsProcessingDescription,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: EllaColors.textSecondary),
+                ),
+                if (transcript.isNotEmpty) ...[
+                  const SizedBox(height: 10),
+                  Text(
+                    transcript,
+                    maxLines: 3,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(
+                      context,
+                    ).textTheme.bodyMedium?.copyWith(color: EllaColors.textPrimary, height: 1.35),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RetryWithEllaSheet extends StatefulWidget {
+  final ServerConversation conversation;
+  final RetryFailedConversation onRetry;
+
+  const _RetryWithEllaSheet({required this.conversation, required this.onRetry});
+
+  @override
+  State<_RetryWithEllaSheet> createState() => _RetryWithEllaSheetState();
+}
+
+class _RetryWithEllaSheetState extends State<_RetryWithEllaSheet> {
+  final TextEditingController _contextController = TextEditingController();
+  bool _isSubmitting = false;
+
+  @override
+  void dispose() {
+    _contextController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_isSubmitting) return;
+
+    setState(() => _isSubmitting = true);
+    final navigator = Navigator.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    final correctionText = _contextController.text.trim();
+    final restarted = await widget.onRetry(
+      widget.conversation.id,
+      correctionText: correctionText.isEmpty ? null : correctionText,
+    );
+
+    if (!mounted) return;
+    setState(() => _isSubmitting = false);
+    if (restarted) {
+      navigator.pop();
+    } else {
+      messenger.showSnackBar(SnackBar(content: Text(context.l10n.somethingWentWrong)));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bottomInset = MediaQuery.viewInsetsOf(context).bottom;
+
+    return Padding(
+      padding: EdgeInsets.only(bottom: bottomInset),
+      child: Container(
+        decoration: const BoxDecoration(
+          color: EllaColors.bgPrimary,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+        ),
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+        child: SafeArea(
+          top: false,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Container(
+                  width: 44,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: EllaColors.bgTertiary,
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 20),
+              Text(
+                context.l10n.retryWithElla,
+                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                      color: EllaColors.textPrimary,
+                      fontWeight: FontWeight.w700,
+                    ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                context.l10n.retryWithEllaDescription,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: EllaColors.textSecondary,
+                      height: 1.35,
+                    ),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                key: ValueKey('retry-context-${widget.conversation.id}'),
+                controller: _contextController,
+                minLines: 3,
+                maxLines: 6,
+                textInputAction: TextInputAction.newline,
+                style: const TextStyle(color: EllaColors.textPrimary),
+                decoration: InputDecoration(
+                  labelText: context.l10n.retryWithEllaContextLabel,
+                  hintText: context.l10n.retryWithEllaContextHint,
+                  labelStyle: const TextStyle(color: EllaColors.textSecondary),
+                  hintStyle: const TextStyle(color: EllaColors.textTertiary),
+                  filled: true,
+                  fillColor: EllaColors.bgSecondary,
+                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(18)),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(18),
+                    borderSide: const BorderSide(color: EllaColors.bgTertiary),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(18),
+                    borderSide: const BorderSide(color: EllaColors.primary, width: 1.5),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  key: ValueKey('submit-retry-${widget.conversation.id}'),
+                  onPressed: _isSubmitting ? null : _submit,
+                  style: FilledButton.styleFrom(
+                    backgroundColor: EllaColors.primary,
+                    foregroundColor: Colors.white,
+                    disabledBackgroundColor: EllaColors.bgTertiary,
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                  ),
+                  child: _isSubmitting
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                        )
+                      : Text(context.l10n.retryNow),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/pages/conversations/widgets/failed_conversations_section.dart
+++ b/app/lib/pages/conversations/widgets/failed_conversations_section.dart
@@ -12,17 +12,21 @@ class FailedConversationsSection extends StatelessWidget {
   final List<ServerConversation> conversations;
   final bool Function(String conversationId) isRetrying;
   final RetryFailedConversation onRetry;
+  final bool isSearchActive;
+  final bool showDailySummaries;
 
   const FailedConversationsSection({
     super.key,
     required this.conversations,
     required this.isRetrying,
     required this.onRetry,
+    this.isSearchActive = false,
+    this.showDailySummaries = false,
   });
 
   @override
   Widget build(BuildContext context) {
-    if (conversations.isEmpty) return const SizedBox.shrink();
+    if (conversations.isEmpty || isSearchActive || showDailySummaries) return const SizedBox.shrink();
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -22,9 +22,13 @@ typedef RetryConversationProcessingCall = Future<ConversationProcessingRetryResu
 typedef ConversationByIdCall = Future<ServerConversation?> Function(String conversationId);
 
 class _ProcessingRetryPoll {
+  final String requestId;
+  final String? correctionText;
   int attempts = 0;
   Timer? timer;
   bool cancelled = false;
+
+  _ProcessingRetryPoll({required this.requestId, this.correctionText});
 
   void cancel() {
     cancelled = true;
@@ -478,10 +482,13 @@ class ConversationProvider extends ChangeNotifier {
     retryingConversationIds.add(conversationId);
     notifyListeners();
 
+    final requestId = const Uuid().v4();
+    final trimmedCorrection = correctionText?.trim();
+    final normalizedCorrection = trimmedCorrection?.isNotEmpty == true ? trimmedCorrection : null;
     final result = await _retryConversationProcessing(
       conversationId,
-      const Uuid().v4(),
-      correctionText: correctionText,
+      requestId,
+      correctionText: normalizedCorrection,
     );
     if (result == null) {
       retryingConversationIds.remove(conversationId);
@@ -491,7 +498,11 @@ class ConversationProvider extends ChangeNotifier {
 
     _applyProcessingRetryState(result.conversation);
     if (result.conversation.status == ConversationStatus.processing) {
-      _startProcessingRetryPoll(conversationId);
+      _startProcessingRetryPoll(
+        conversationId,
+        requestId: requestId,
+        correctionText: normalizedCorrection,
+      );
     }
     return true;
   }
@@ -512,10 +523,18 @@ class ConversationProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  void _startProcessingRetryPoll(String conversationId) {
+  void _startProcessingRetryPoll(
+    String conversationId, {
+    required String requestId,
+    String? correctionText,
+  }) {
     _cancelProcessingRetryPoll(conversationId);
-    final poll = _ProcessingRetryPoll();
+    final poll = _ProcessingRetryPoll(requestId: requestId, correctionText: correctionText);
     _processingRetryPolls[conversationId] = poll;
+    Logger.debug(
+      'Starting conversation processing retry poll request=${poll.requestId} '
+      'has_context=${poll.correctionText?.isNotEmpty == true}',
+    );
     _scheduleProcessingRetryPoll(conversationId, poll);
   }
 
@@ -727,7 +746,7 @@ class ConversationProvider extends ChangeNotifier {
       final bDate = b.processingErrorAt ?? b.finishedAt ?? b.createdAt;
       return bDate.compareTo(aDate);
     });
-    return failed.where((conversation) => conversation.processingError == 'conversation_summary_failed').toList();
+    return failed.where((conversation) => conversation.isRetryableSummaryFailure).toList();
   }
 
   void updateActionItemState(String convoId, bool state, int i, DateTime date) {

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:uuid/uuid.dart';
 
 import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/http/api/users.dart';
@@ -12,6 +13,13 @@ import 'package:omi/services/app_review_service.dart';
 import 'package:omi/services/notifications/merge_notification_handler.dart';
 import 'package:omi/utils/analytics/mixpanel.dart';
 import 'package:omi/utils/logger.dart';
+
+typedef RetryConversationProcessingCall = Future<ConversationProcessingRetryResult?> Function(
+  String conversationId,
+  String requestId, {
+  String? correctionText,
+});
+typedef ConversationByIdCall = Future<ServerConversation?> Function(String conversationId);
 
 class ConversationProvider extends ChangeNotifier {
   List<ServerConversation> conversations = [];
@@ -40,6 +48,9 @@ class ConversationProvider extends ChangeNotifier {
   static const Duration _refreshCooldown = Duration(seconds: 60); // Minimum time between refreshes
 
   List<ServerConversation> processingConversations = [];
+  List<ServerConversation> failedConversations = [];
+  final Set<String> retryingConversationIds = {};
+  final Map<String, Timer> _processingRetryPollTimers = {};
 
   // Merge functionality state
   Set<String> mergingConversationIds = {};
@@ -48,10 +59,16 @@ class ConversationProvider extends ChangeNotifier {
   StreamSubscription<MergeCompletedEvent>? _mergeCompletedSubscription;
 
   final AppReviewService _appReviewService = AppReviewService();
+  final RetryConversationProcessingCall _retryConversationProcessing;
+  final ConversationByIdCall _getConversationById;
 
   bool isFetchingConversations = false;
 
-  ConversationProvider() {
+  ConversationProvider({
+    RetryConversationProcessingCall retryConversationProcessingCall = retryConversationProcessing,
+    ConversationByIdCall conversationByIdCall = getConversationById,
+  })  : _retryConversationProcessing = retryConversationProcessingCall,
+        _getConversationById = conversationByIdCall {
     _setupMergeListener();
     _loadSettings();
   }
@@ -68,6 +85,12 @@ class ConversationProvider extends ChangeNotifier {
     searchedConversations = [];
     groupedConversations = {};
     processingConversations = [];
+    failedConversations = [];
+    retryingConversationIds.clear();
+    for (final timer in _processingRetryPollTimers.values) {
+      timer.cancel();
+    }
+    _processingRetryPollTimers.clear();
     isLoadingConversations = false;
     isFetchingConversations = false;
     previousQuery = '';
@@ -355,7 +378,12 @@ class ConversationProvider extends ChangeNotifier {
       return;
     }
     setLoadingConversations(true);
-    List<ServerConversation> newConversations = await _getConversationsFromServer();
+    final results = await Future.wait([
+      _getConversationsFromServer(),
+      _getFailedConversationsFromServer(),
+    ]);
+    List<ServerConversation> newConversations = results[0];
+    failedConversations = results[1];
     setLoadingConversations(false);
 
     List<ServerConversation> upsertConvos = [];
@@ -397,8 +425,17 @@ class ConversationProvider extends ChangeNotifier {
     searchedConversations = [];
 
     setLoadingConversations(true);
-    conversations =
-        SharedPreferencesUtil().demoMode ? DemoFixtures.conversations() : await _getConversationsFromServer();
+    if (SharedPreferencesUtil().demoMode) {
+      conversations = DemoFixtures.conversations();
+      failedConversations = [];
+    } else {
+      final results = await Future.wait([
+        _getConversationsFromServer(),
+        _getFailedConversationsFromServer(),
+      ]);
+      conversations = results[0];
+      failedConversations = results[1];
+    }
     setLoadingConversations(false);
 
     // processing convos
@@ -420,6 +457,71 @@ class ConversationProvider extends ChangeNotifier {
     _groupConversationsByDateWithoutNotify();
 
     notifyListeners();
+  }
+
+  bool isConversationRetrying(String conversationId) => retryingConversationIds.contains(conversationId);
+
+  Future<bool> retryFailedConversation(String conversationId, {String? correctionText}) async {
+    if (retryingConversationIds.contains(conversationId)) return true;
+
+    retryingConversationIds.add(conversationId);
+    notifyListeners();
+
+    final result = await _retryConversationProcessing(
+      conversationId,
+      const Uuid().v4(),
+      correctionText: correctionText,
+    );
+    if (result == null) {
+      retryingConversationIds.remove(conversationId);
+      notifyListeners();
+      return false;
+    }
+
+    _applyProcessingRetryState(result.conversation);
+    if (result.conversation.status == ConversationStatus.processing) {
+      _startProcessingRetryPoll(conversationId);
+    }
+    return true;
+  }
+
+  void _applyProcessingRetryState(ServerConversation conversation) {
+    failedConversations.removeWhere((item) => item.id == conversation.id);
+    processingConversations.removeWhere((item) => item.id == conversation.id);
+
+    if (conversation.status == ConversationStatus.failed) {
+      failedConversations.insert(0, conversation);
+      retryingConversationIds.remove(conversation.id);
+    } else if (conversation.status == ConversationStatus.processing) {
+      processingConversations.insert(0, conversation);
+    } else if (conversation.status == ConversationStatus.completed) {
+      retryingConversationIds.remove(conversation.id);
+      upsertConversation(conversation);
+    }
+    notifyListeners();
+  }
+
+  void _startProcessingRetryPoll(String conversationId) {
+    _processingRetryPollTimers.remove(conversationId)?.cancel();
+    var attempts = 0;
+    _processingRetryPollTimers[conversationId] = Timer.periodic(const Duration(seconds: 3), (timer) async {
+      attempts += 1;
+      final conversation = await _getConversationById(conversationId);
+      if (conversation != null) {
+        _applyProcessingRetryState(conversation);
+        if (conversation.status == ConversationStatus.completed || conversation.status == ConversationStatus.failed) {
+          timer.cancel();
+          _processingRetryPollTimers.remove(conversationId);
+          return;
+        }
+      }
+      if (attempts >= 40) {
+        timer.cancel();
+        _processingRetryPollTimers.remove(conversationId);
+        retryingConversationIds.remove(conversationId);
+        notifyListeners();
+      }
+    });
   }
 
   Future getInitialConversations() async {
@@ -557,16 +659,36 @@ class ConversationProvider extends ChangeNotifier {
     );
   }
 
-  Future _getConversationsFromServer() async {
+  Future<List<ServerConversation>> _getConversationsFromServer() async {
     final (startDate, endDate) = _getDateFilterRange();
 
     return await getConversations(
+      statuses: const [ConversationStatus.processing, ConversationStatus.completed],
       includeDiscarded: showDiscardedConversations,
       startDate: startDate,
       endDate: endDate,
       folderId: selectedFolderId,
       starred: showStarredOnly ? true : null,
     );
+  }
+
+  Future<List<ServerConversation>> _getFailedConversationsFromServer() async {
+    final (startDate, endDate) = _getDateFilterRange();
+    final failed = await getConversations(
+      limit: 100,
+      statuses: const [ConversationStatus.failed],
+      includeDiscarded: true,
+      startDate: startDate,
+      endDate: endDate,
+      folderId: selectedFolderId,
+      starred: showStarredOnly ? true : null,
+    );
+    failed.sort((a, b) {
+      final aDate = a.processingErrorAt ?? a.finishedAt ?? a.createdAt;
+      final bDate = b.processingErrorAt ?? b.finishedAt ?? b.createdAt;
+      return bDate.compareTo(aDate);
+    });
+    return failed.where((conversation) => conversation.processingError == 'conversation_summary_failed').toList();
   }
 
   void updateActionItemState(String convoId, bool state, int i, DateTime date) {
@@ -587,6 +709,7 @@ class ConversationProvider extends ChangeNotifier {
 
     var newConversations = await getConversations(
       offset: conversations.length,
+      statuses: const [ConversationStatus.processing, ConversationStatus.completed],
       includeDiscarded: showDiscardedConversations,
       startDate: startDate,
       endDate: endDate,
@@ -762,6 +885,9 @@ class ConversationProvider extends ChangeNotifier {
   void dispose() {
     _processingConversationWatchTimer?.cancel();
     _refreshDebounceTimer?.cancel();
+    for (final timer in _processingRetryPollTimers.values) {
+      timer.cancel();
+    }
     _mergeCompletedSubscription?.cancel();
     super.dispose();
   }

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -19,7 +19,6 @@ typedef RetryConversationProcessingCall = Future<ConversationProcessingRetryResu
   String requestId, {
   String? correctionText,
 });
-typedef ConversationByIdCall = Future<ServerConversation?> Function(String conversationId);
 
 class _ProcessingRetryPoll {
   final String requestId;
@@ -75,15 +74,12 @@ class ConversationProvider extends ChangeNotifier {
 
   final AppReviewService _appReviewService = AppReviewService();
   final RetryConversationProcessingCall _retryConversationProcessing;
-  final ConversationByIdCall _getConversationById;
 
   bool isFetchingConversations = false;
 
   ConversationProvider({
     RetryConversationProcessingCall retryConversationProcessingCall = retryConversationProcessing,
-    ConversationByIdCall conversationByIdCall = getConversationById,
-  })  : _retryConversationProcessing = retryConversationProcessingCall,
-        _getConversationById = conversationByIdCall {
+  }) : _retryConversationProcessing = retryConversationProcessingCall {
     _setupMergeListener();
     _loadSettings();
   }
@@ -398,7 +394,13 @@ class ConversationProvider extends ChangeNotifier {
       _getFailedConversationsFromServer(),
     ]);
     List<ServerConversation> newConversations = results[0];
-    failedConversations = results[1];
+    failedConversations = _mergeRetryableFailures(
+      results[1],
+      [
+        ...conversations.where((conversation) => conversation.isRetryableEnrichmentFailure),
+        ...newConversations.where((conversation) => conversation.isRetryableEnrichmentFailure),
+      ],
+    );
     setLoadingConversations(false);
 
     List<ServerConversation> upsertConvos = [];
@@ -449,7 +451,10 @@ class ConversationProvider extends ChangeNotifier {
         _getFailedConversationsFromServer(),
       ]);
       conversations = results[0];
-      failedConversations = results[1];
+      failedConversations = _mergeRetryableFailures(
+        results[1],
+        conversations.where((conversation) => conversation.isRetryableEnrichmentFailure),
+      );
     }
     setLoadingConversations(false);
 
@@ -496,8 +501,8 @@ class ConversationProvider extends ChangeNotifier {
       return false;
     }
 
-    _applyProcessingRetryState(result.conversation);
-    if (result.conversation.status == ConversationStatus.processing) {
+    _applyProcessingRetryResult(result);
+    if (!result.isTerminal) {
       _startProcessingRetryPoll(
         conversationId,
         requestId: requestId,
@@ -507,19 +512,31 @@ class ConversationProvider extends ChangeNotifier {
     return true;
   }
 
-  void _applyProcessingRetryState(ServerConversation conversation) {
+  void _applyProcessingRetryResult(ConversationProcessingRetryResult result) {
+    final conversation = result.conversation;
     failedConversations.removeWhere((item) => item.id == conversation.id);
     processingConversations.removeWhere((item) => item.id == conversation.id);
 
-    if (conversation.status == ConversationStatus.failed) {
+    if (result.outcome == ConversationProcessingRetryOutcome.failed) {
       failedConversations.insert(0, conversation);
       retryingConversationIds.remove(conversation.id);
-    } else if (conversation.status == ConversationStatus.processing) {
-      processingConversations.insert(0, conversation);
-    } else if (conversation.status == ConversationStatus.completed) {
+      if (conversation.status == ConversationStatus.completed) {
+        upsertConversation(conversation);
+      } else {
+        conversations.removeWhere((item) => item.id == conversation.id);
+      }
+    } else if (result.outcome == ConversationProcessingRetryOutcome.processing) {
+      if (conversation.status == ConversationStatus.completed) {
+        upsertConversation(conversation);
+      } else {
+        conversations.removeWhere((item) => item.id == conversation.id);
+        processingConversations.insert(0, conversation);
+      }
+    } else {
       retryingConversationIds.remove(conversation.id);
       upsertConversation(conversation);
     }
+    _groupConversationsByDateWithoutNotify();
     notifyListeners();
   }
 
@@ -549,17 +566,21 @@ class ConversationProvider extends ChangeNotifier {
     if (!_isCurrentProcessingRetryPoll(conversationId, poll)) return;
 
     poll.attempts += 1;
-    ServerConversation? conversation;
+    ConversationProcessingRetryResult? result;
     try {
-      conversation = await _getConversationById(conversationId);
+      result = await _retryConversationProcessing(
+        conversationId,
+        poll.requestId,
+        correctionText: poll.correctionText,
+      );
     } catch (error, stackTrace) {
       Logger.error('Failed to poll conversation processing retry: $error\n$stackTrace');
     }
     if (!_isCurrentProcessingRetryPoll(conversationId, poll)) return;
 
-    if (conversation != null) {
-      _applyProcessingRetryState(conversation);
-      if (conversation.status == ConversationStatus.completed || conversation.status == ConversationStatus.failed) {
+    if (result != null) {
+      _applyProcessingRetryResult(result);
+      if (result.isTerminal) {
         _cancelProcessingRetryPoll(conversationId);
         return;
       }
@@ -749,6 +770,23 @@ class ConversationProvider extends ChangeNotifier {
     return failed.where((conversation) => conversation.isRetryableSummaryFailure).toList();
   }
 
+  List<ServerConversation> _mergeRetryableFailures(
+    Iterable<ServerConversation> processingFailures,
+    Iterable<ServerConversation> enrichmentFailures,
+  ) {
+    final byId = <String, ServerConversation>{
+      for (final conversation in processingFailures) conversation.id: conversation,
+      for (final conversation in enrichmentFailures) conversation.id: conversation,
+    };
+    final merged = byId.values.toList();
+    merged.sort((a, b) {
+      final aDate = a.processingErrorAt ?? a.finishedAt ?? a.createdAt;
+      final bDate = b.processingErrorAt ?? b.finishedAt ?? b.createdAt;
+      return bDate.compareTo(aDate);
+    });
+    return merged;
+  }
+
   void updateActionItemState(String convoId, bool state, int i, DateTime date) {
     conversations.firstWhere((element) => element.id == convoId).structured.actionItems[i].completed = state;
     groupedConversations[date]!.firstWhere((element) => element.id == convoId).structured.actionItems[i].completed =
@@ -773,6 +811,10 @@ class ConversationProvider extends ChangeNotifier {
       endDate: endDate,
       folderId: selectedFolderId,
       starred: showStarredOnly ? true : null,
+    );
+    failedConversations = _mergeRetryableFailures(
+      failedConversations,
+      newConversations.where((conversation) => conversation.isRetryableEnrichmentFailure),
     );
     conversations.addAll(newConversations);
     conversations.sort((a, b) => (b.startedAt ?? b.createdAt).compareTo(a.startedAt ?? a.createdAt));

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -21,6 +21,17 @@ typedef RetryConversationProcessingCall = Future<ConversationProcessingRetryResu
 });
 typedef ConversationByIdCall = Future<ServerConversation?> Function(String conversationId);
 
+class _ProcessingRetryPoll {
+  int attempts = 0;
+  Timer? timer;
+  bool cancelled = false;
+
+  void cancel() {
+    cancelled = true;
+    timer?.cancel();
+  }
+}
+
 class ConversationProvider extends ChangeNotifier {
   List<ServerConversation> conversations = [];
   List<ServerConversation> searchedConversations = [];
@@ -50,7 +61,7 @@ class ConversationProvider extends ChangeNotifier {
   List<ServerConversation> processingConversations = [];
   List<ServerConversation> failedConversations = [];
   final Set<String> retryingConversationIds = {};
-  final Map<String, Timer> _processingRetryPollTimers = {};
+  final Map<String, _ProcessingRetryPoll> _processingRetryPolls = {};
 
   // Merge functionality state
   Set<String> mergingConversationIds = {};
@@ -87,10 +98,10 @@ class ConversationProvider extends ChangeNotifier {
     processingConversations = [];
     failedConversations = [];
     retryingConversationIds.clear();
-    for (final timer in _processingRetryPollTimers.values) {
-      timer.cancel();
+    for (final poll in _processingRetryPolls.values) {
+      poll.cancel();
     }
-    _processingRetryPollTimers.clear();
+    _processingRetryPolls.clear();
     isLoadingConversations = false;
     isFetchingConversations = false;
     previousQuery = '';
@@ -502,26 +513,54 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   void _startProcessingRetryPoll(String conversationId) {
-    _processingRetryPollTimers.remove(conversationId)?.cancel();
-    var attempts = 0;
-    _processingRetryPollTimers[conversationId] = Timer.periodic(const Duration(seconds: 3), (timer) async {
-      attempts += 1;
-      final conversation = await _getConversationById(conversationId);
-      if (conversation != null) {
-        _applyProcessingRetryState(conversation);
-        if (conversation.status == ConversationStatus.completed || conversation.status == ConversationStatus.failed) {
-          timer.cancel();
-          _processingRetryPollTimers.remove(conversationId);
-          return;
-        }
-      }
-      if (attempts >= 40) {
-        timer.cancel();
-        _processingRetryPollTimers.remove(conversationId);
-        retryingConversationIds.remove(conversationId);
-        notifyListeners();
-      }
+    _cancelProcessingRetryPoll(conversationId);
+    final poll = _ProcessingRetryPoll();
+    _processingRetryPolls[conversationId] = poll;
+    _scheduleProcessingRetryPoll(conversationId, poll);
+  }
+
+  void _scheduleProcessingRetryPoll(String conversationId, _ProcessingRetryPoll poll) {
+    if (!_isCurrentProcessingRetryPoll(conversationId, poll)) return;
+    poll.timer = Timer(const Duration(seconds: 3), () {
+      unawaited(_runProcessingRetryPoll(conversationId, poll));
     });
+  }
+
+  Future<void> _runProcessingRetryPoll(String conversationId, _ProcessingRetryPoll poll) async {
+    if (!_isCurrentProcessingRetryPoll(conversationId, poll)) return;
+
+    poll.attempts += 1;
+    ServerConversation? conversation;
+    try {
+      conversation = await _getConversationById(conversationId);
+    } catch (error, stackTrace) {
+      Logger.error('Failed to poll conversation processing retry: $error\n$stackTrace');
+    }
+    if (!_isCurrentProcessingRetryPoll(conversationId, poll)) return;
+
+    if (conversation != null) {
+      _applyProcessingRetryState(conversation);
+      if (conversation.status == ConversationStatus.completed || conversation.status == ConversationStatus.failed) {
+        _cancelProcessingRetryPoll(conversationId);
+        return;
+      }
+    }
+    if (poll.attempts >= 40) {
+      _cancelProcessingRetryPoll(conversationId);
+      retryingConversationIds.remove(conversationId);
+      notifyListeners();
+      return;
+    }
+
+    _scheduleProcessingRetryPoll(conversationId, poll);
+  }
+
+  bool _isCurrentProcessingRetryPoll(String conversationId, _ProcessingRetryPoll poll) {
+    return !poll.cancelled && identical(_processingRetryPolls[conversationId], poll);
+  }
+
+  void _cancelProcessingRetryPoll(String conversationId) {
+    _processingRetryPolls.remove(conversationId)?.cancel();
   }
 
   Future getInitialConversations() async {
@@ -885,9 +924,10 @@ class ConversationProvider extends ChangeNotifier {
   void dispose() {
     _processingConversationWatchTimer?.cancel();
     _refreshDebounceTimer?.cancel();
-    for (final timer in _processingRetryPollTimers.values) {
-      timer.cancel();
+    for (final poll in _processingRetryPolls.values) {
+      poll.cancel();
     }
+    _processingRetryPolls.clear();
     _mergeCompletedSubscription?.cancel();
     super.dispose();
   }

--- a/app/test/backend/schema/conversation_test.dart
+++ b/app/test/backend/schema/conversation_test.dart
@@ -98,4 +98,59 @@ void main() {
     );
     expect(unrelatedFailure.isRetryableSummaryFailure, isFalse);
   });
+
+  test('keeps a completed generic summary retryable when contextual enrichment failed', () {
+    final conversation = ServerConversation.fromJson({
+      'id': 'generic-fallback',
+      'created_at': '2026-07-20T08:00:00Z',
+      'structured': {
+        'title': 'Generic title',
+        'overview': 'Usable generic summary',
+        'emoji': '',
+        'category': 'other',
+        'action_items': [],
+        'events': [],
+      },
+      'status': 'completed',
+      'enrichment_state': {
+        'status': 'failed',
+        'pending': true,
+        'error_code': 'conversation_summary_recovery_failed',
+      },
+    });
+
+    expect(conversation.isRetryableSummaryFailure, isFalse);
+    expect(conversation.isRetryableEnrichmentFailure, isTrue);
+    expect(conversation.structured.overview, 'Usable generic summary');
+    expect(conversation.toJson()['enrichment_state'], {
+      'status': 'failed',
+      'pending': true,
+      'error_code': 'conversation_summary_recovery_failed',
+    });
+  });
+
+  test('surfaces canonical and enriched-vector terminal failures without flagging active writes', () {
+    final canonicalFailure = ServerConversation(
+      id: 'canonical-failure',
+      createdAt: DateTime.utc(2026, 7, 20),
+      structured: Structured('Generic', 'Usable generic summary'),
+      enrichmentState: {'status': 'writeback_pending_canonical', 'canonical_status': 'failed', 'pending': true},
+    );
+    final vectorFailure = ServerConversation(
+      id: 'vector-failure',
+      createdAt: DateTime.utc(2026, 7, 20),
+      structured: Structured('Enriched', 'Usable enriched summary'),
+      processingRetryEnrichmentVectorStatus: 'failed',
+    );
+    final activeWrite = ServerConversation(
+      id: 'active-write',
+      createdAt: DateTime.utc(2026, 7, 20),
+      structured: Structured('Generic', 'Usable generic summary'),
+      enrichmentState: {'status': 'writeback_pending_canonical', 'pending': true},
+    );
+
+    expect(canonicalFailure.isRetryableEnrichmentFailure, isTrue);
+    expect(vectorFailure.isRetryableEnrichmentFailure, isTrue);
+    expect(activeWrite.isRetryableEnrichmentFailure, isFalse);
+  });
 }

--- a/app/test/backend/schema/conversation_test.dart
+++ b/app/test/backend/schema/conversation_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
 
 void main() {
   group('ServerConversation internal assessment', () {
@@ -71,7 +72,30 @@ void main() {
     expect(conversation.status, ConversationStatus.failed);
     expect(conversation.processingError, 'conversation_summary_failed');
     expect(conversation.processingErrorAt, isNotNull);
+    expect(conversation.isRetryableSummaryFailure, isTrue);
     expect(conversation.toJson()['processing_error'], 'conversation_summary_failed');
     expect(conversation.toJson()['processing_error_at'], '2026-07-20T08:05:00.000Z');
+  });
+
+  test('treats initial and recovery summary failures as retryable without exposing unrelated errors', () {
+    for (final error in ['conversation_summary_failed', 'conversation_summary_recovery_failed']) {
+      final conversation = ServerConversation(
+        id: error,
+        createdAt: DateTime.utc(2026, 7, 20),
+        structured: Structured('', ''),
+        status: ConversationStatus.failed,
+        processingError: error,
+      );
+      expect(conversation.isRetryableSummaryFailure, isTrue);
+    }
+
+    final unrelatedFailure = ServerConversation(
+      id: 'unrelated',
+      createdAt: DateTime.utc(2026, 7, 20),
+      structured: Structured('', ''),
+      status: ConversationStatus.failed,
+      processingError: 'provider.invalid_api_key',
+    );
+    expect(unrelatedFailure.isRetryableSummaryFailure, isFalse);
   });
 }

--- a/app/test/backend/schema/conversation_test.dart
+++ b/app/test/backend/schema/conversation_test.dart
@@ -47,4 +47,31 @@ void main() {
       });
     });
   });
+
+  test('parses and serializes retryable processing failure metadata', () {
+    final conversation = ServerConversation.fromJson({
+      'id': 'failed-conversation',
+      'created_at': '2026-07-20T08:00:00Z',
+      'structured': {
+        'title': '',
+        'overview': '',
+        'emoji': '',
+        'category': 'other',
+        'action_items': [],
+        'events': [],
+      },
+      'transcript_segments': [],
+      'apps_results': [],
+      'audio_files': [],
+      'status': 'failed',
+      'processing_error': 'conversation_summary_failed',
+      'processing_error_at': '2026-07-20T08:05:00Z',
+    });
+
+    expect(conversation.status, ConversationStatus.failed);
+    expect(conversation.processingError, 'conversation_summary_failed');
+    expect(conversation.processingErrorAt, isNotNull);
+    expect(conversation.toJson()['processing_error'], 'conversation_summary_failed');
+    expect(conversation.toJson()['processing_error_at'], '2026-07-20T08:05:00.000Z');
+  });
 }

--- a/app/test/providers/conversation_processing_retry_test.dart
+++ b/app/test/providers/conversation_processing_retry_test.dart
@@ -144,4 +144,60 @@ void main() {
 
     provider.dispose();
   });
+
+  testWidgets('processing poll stops after forty completed attempts', (tester) async {
+    final processing = _conversation(ConversationStatus.processing);
+    var pollCalls = 0;
+    final provider = ConversationProvider(
+      retryConversationProcessingCall: (_, __, {correctionText}) async => ConversationProcessingRetryResult(
+        outcome: ConversationProcessingRetryOutcome.processing,
+        conversation: processing,
+      ),
+      conversationByIdCall: (_) async {
+        pollCalls += 1;
+        return null;
+      },
+    );
+
+    expect(await provider.retryFailedConversation(processing.id), isTrue);
+    for (var attempt = 0; attempt < 40; attempt += 1) {
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pump();
+    }
+
+    expect(pollCalls, 40);
+    expect(provider.isConversationRetrying(processing.id), isFalse);
+    await tester.pump(const Duration(seconds: 30));
+    expect(pollCalls, 40);
+
+    provider.dispose();
+  });
+
+  testWidgets('completion after provider disposal cannot restart or update polling', (tester) async {
+    final processing = _conversation(ConversationStatus.processing);
+    final completed = _conversation(ConversationStatus.completed);
+    final latePoll = Completer<ServerConversation?>();
+    var pollCalls = 0;
+    final provider = ConversationProvider(
+      retryConversationProcessingCall: (_, __, {correctionText}) async => ConversationProcessingRetryResult(
+        outcome: ConversationProcessingRetryOutcome.processing,
+        conversation: processing,
+      ),
+      conversationByIdCall: (_) {
+        pollCalls += 1;
+        return latePoll.future;
+      },
+    );
+
+    expect(await provider.retryFailedConversation(processing.id), isTrue);
+    await tester.pump(const Duration(seconds: 3));
+    expect(pollCalls, 1);
+
+    provider.dispose();
+    latePoll.complete(completed);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 30));
+
+    expect(pollCalls, 1);
+  });
 }

--- a/app/test/providers/conversation_processing_retry_test.dart
+++ b/app/test/providers/conversation_processing_retry_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -90,6 +92,55 @@ void main() {
     expect(await provider.retryFailedConversation(failed.id), isTrue);
     expect(provider.failedConversations.single.id, failed.id);
     expect(provider.isConversationRetrying(failed.id), isFalse);
+
+    provider.dispose();
+  });
+
+  testWidgets('slow processing poll never overlaps another request', (tester) async {
+    final processing = _conversation(ConversationStatus.processing);
+    final completed = _conversation(ConversationStatus.completed);
+    final firstPoll = Completer<ServerConversation?>();
+    var pollCalls = 0;
+    var inFlight = 0;
+    var maxInFlight = 0;
+
+    final provider = ConversationProvider(
+      retryConversationProcessingCall: (_, __, {correctionText}) async => ConversationProcessingRetryResult(
+        outcome: ConversationProcessingRetryOutcome.processing,
+        conversation: processing,
+      ),
+      conversationByIdCall: (_) async {
+        pollCalls += 1;
+        inFlight += 1;
+        if (inFlight > maxInFlight) maxInFlight = inFlight;
+        if (pollCalls == 1) {
+          final result = await firstPoll.future;
+          inFlight -= 1;
+          return result;
+        }
+        inFlight -= 1;
+        return completed;
+      },
+    );
+
+    expect(await provider.retryFailedConversation(processing.id), isTrue);
+    await tester.pump(const Duration(seconds: 3));
+    expect(pollCalls, 1);
+    expect(inFlight, 1);
+
+    await tester.pump(const Duration(seconds: 12));
+    expect(pollCalls, 1);
+    expect(maxInFlight, 1);
+
+    firstPoll.complete(processing);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump();
+
+    expect(pollCalls, 2);
+    expect(maxInFlight, 1);
+    expect(provider.conversations.single.status, ConversationStatus.completed);
+    expect(provider.isConversationRetrying(processing.id), isFalse);
 
     provider.dispose();
   });

--- a/app/test/providers/conversation_processing_retry_test.dart
+++ b/app/test/providers/conversation_processing_retry_test.dart
@@ -9,13 +9,36 @@ import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/providers/conversation_provider.dart';
 
-ServerConversation _conversation(ConversationStatus status) {
+ServerConversation _conversation(
+  ConversationStatus status, {
+  String overview = '',
+  Map<String, dynamic>? enrichmentState,
+}) {
   return ServerConversation(
     id: 'conversation-1',
     createdAt: DateTime.utc(2026, 7, 20, 8),
-    structured: Structured(status == ConversationStatus.completed ? 'Recovered summary' : '', ''),
+    structured: Structured('Conversation', overview),
     status: status,
+    enrichmentState: enrichmentState,
     processingError: status == ConversationStatus.failed ? 'conversation_summary_failed' : null,
+  );
+}
+
+ConversationProcessingRetryResult _result(
+  ConversationProcessingRetryOutcome outcome,
+  ServerConversation conversation, {
+  String? phase,
+}) {
+  return ConversationProcessingRetryResult(
+    outcome: outcome,
+    recoveryMode: ConversationProcessingRecoveryMode.enrichmentOnly,
+    phase: phase,
+    genericStatus: 'completed',
+    genericVectorStatus: 'completed',
+    enrichmentStatus: outcome == ConversationProcessingRetryOutcome.completed ? 'completed' : 'pending',
+    vectorStatus: outcome == ConversationProcessingRetryOutcome.completed ? 'completed' : 'pending',
+    attemptCount: 1,
+    conversation: conversation,
   );
 }
 
@@ -25,119 +48,173 @@ void main() {
     await SharedPreferencesUtil.init();
   });
 
-  testWidgets('retry moves failed conversation through processing to completed', (tester) async {
-    final failed = _conversation(ConversationStatus.failed);
-    final processing = _conversation(ConversationStatus.processing);
-    final completed = _conversation(ConversationStatus.completed);
-    var retryCalls = 0;
-    var pollCalls = 0;
+  test('parses the complete processing retry receipt', () {
+    final result = ConversationProcessingRetryResult.fromJson({
+      'outcome': 'processing',
+      'recovery_mode': 'enrichment_only',
+      'phase': 'generic_completed',
+      'generic_status': 'completed',
+      'generic_vector_status': 'completed',
+      'enrichment_status': 'pending',
+      'vector_status': 'pending',
+      'lease_expires_at': '2026-07-20T08:15:00Z',
+      'attempt_count': 2,
+      'conversation': {
+        'id': 'conversation-1',
+        'created_at': '2026-07-20T08:00:00Z',
+        'structured': {
+          'title': 'Generic',
+          'overview': 'Generic summary',
+          'emoji': '',
+          'category': 'other',
+        },
+        'status': 'completed',
+      },
+    });
+
+    expect(result.outcome, ConversationProcessingRetryOutcome.processing);
+    expect(result.recoveryMode, ConversationProcessingRecoveryMode.enrichmentOnly);
+    expect(result.phase, 'generic_completed');
+    expect(result.genericStatus, 'completed');
+    expect(result.genericVectorStatus, 'completed');
+    expect(result.enrichmentStatus, 'pending');
+    expect(result.vectorStatus, 'pending');
+    expect(result.leaseExpiresAt, isNotNull);
+    expect(result.attemptCount, 2);
+    expect(result.conversation.status, ConversationStatus.completed);
+    expect(result.isTerminal, isFalse);
+  });
+
+  testWidgets('enrichment-only retry keeps generic summary visible until Hermes completes', (tester) async {
+    final failedEnrichment = _conversation(
+      ConversationStatus.completed,
+      overview: 'Generic summary',
+      enrichmentState: {'status': 'failed', 'pending': true},
+    );
+    final generic = _conversation(ConversationStatus.completed, overview: 'Generic summary');
+    final enriched = _conversation(ConversationStatus.completed, overview: 'Ella enriched summary');
+    final conversationIds = <String>[];
+    final requestIds = <String>[];
+    final contexts = <String?>[];
 
     final provider = ConversationProvider(
       retryConversationProcessingCall: (conversationId, requestId, {correctionText}) async {
-        retryCalls += 1;
-        expect(conversationId, failed.id);
-        expect(requestId, isNotEmpty);
-        expect(correctionText, 'The speakers were discussing their summer plans.');
-        return ConversationProcessingRetryResult(
-          outcome: ConversationProcessingRetryOutcome.processing,
-          conversation: processing,
-        );
-      },
-      conversationByIdCall: (conversationId) async {
-        pollCalls += 1;
-        return completed;
+        conversationIds.add(conversationId);
+        requestIds.add(requestId);
+        contexts.add(correctionText);
+        return requestIds.length == 1
+            ? _result(ConversationProcessingRetryOutcome.processing, generic, phase: 'generic_completed')
+            : _result(ConversationProcessingRetryOutcome.completed, enriched, phase: 'completed');
       },
     );
-    provider.failedConversations = [failed];
-    provider.conversations = [failed];
+    provider.failedConversations = [failedEnrichment];
+    provider.conversations = [failedEnrichment];
 
     expect(
       await provider.retryFailedConversation(
-        failed.id,
+        failedEnrichment.id,
         correctionText: 'The speakers were discussing their summer plans.',
       ),
       isTrue,
     );
-    expect(retryCalls, 1);
     expect(provider.failedConversations, isEmpty);
-    expect(provider.processingConversations.single.status, ConversationStatus.processing);
-    expect(provider.isConversationRetrying(failed.id), isTrue);
-    expect(await provider.retryFailedConversation(failed.id), isTrue);
-    expect(retryCalls, 1);
+    expect(provider.conversations.single.structured.overview, 'Generic summary');
+    expect(provider.isConversationRetrying(failedEnrichment.id), isTrue);
+    expect(await provider.retryFailedConversation(failedEnrichment.id), isTrue);
+    expect(requestIds, hasLength(1));
 
     await tester.pump(const Duration(seconds: 3));
     await tester.pump();
 
-    expect(pollCalls, 1);
-    expect(provider.processingConversations, isEmpty);
-    expect(provider.conversations.single.status, ConversationStatus.completed);
-    expect(provider.isConversationRetrying(failed.id), isFalse);
+    expect(requestIds, hasLength(2));
+    expect(conversationIds, everyElement(failedEnrichment.id));
+    expect(requestIds.toSet(), hasLength(1));
+    expect(contexts, everyElement('The speakers were discussing their summer plans.'));
+    expect(provider.failedConversations, isEmpty);
+    expect(provider.conversations.single.structured.overview, 'Ella enriched summary');
+    expect(provider.isConversationRetrying(failedEnrichment.id), isFalse);
 
     provider.dispose();
   });
 
-  testWidgets('failed retry response remains visible and retryable', (tester) async {
-    final failed = _conversation(ConversationStatus.failed);
+  testWidgets('terminal enrichment failure stays visible and a user retry gets a fresh id', (tester) async {
+    final generic = _conversation(ConversationStatus.completed, overview: 'Generic summary');
+    final failedEnrichment = _conversation(
+      ConversationStatus.completed,
+      overview: 'Generic summary',
+      enrichmentState: {'status': 'failed', 'pending': true},
+    );
+    final requestIds = <String>[];
+
     final provider = ConversationProvider(
-      retryConversationProcessingCall: (_, __, {correctionText}) async {
-        expect(correctionText, isNull);
-        return ConversationProcessingRetryResult(
-          outcome: ConversationProcessingRetryOutcome.failed,
-          conversation: failed,
-        );
+      retryConversationProcessingCall: (_, requestId, {correctionText}) async {
+        requestIds.add(requestId);
+        if (requestIds.length == 1) {
+          return _result(ConversationProcessingRetryOutcome.processing, generic);
+        }
+        return _result(ConversationProcessingRetryOutcome.failed, failedEnrichment, phase: 'failed');
       },
     );
-    provider.failedConversations = [failed];
+    provider.failedConversations = [failedEnrichment];
+    provider.conversations = [generic];
 
-    expect(await provider.retryFailedConversation(failed.id), isTrue);
-    expect(provider.failedConversations.single.id, failed.id);
-    expect(provider.isConversationRetrying(failed.id), isFalse);
+    expect(await provider.retryFailedConversation(generic.id), isTrue);
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump();
+
+    expect(requestIds, hasLength(2));
+    expect(requestIds[1], requestIds[0]);
+    expect(provider.failedConversations.single.id, generic.id);
+    expect(provider.conversations.single.structured.overview, 'Generic summary');
+    expect(provider.isConversationRetrying(generic.id), isFalse);
+
+    expect(await provider.retryFailedConversation(generic.id), isTrue);
+    expect(requestIds, hasLength(3));
+    expect(requestIds[2], isNot(requestIds[0]));
+    expect(provider.failedConversations.single.id, generic.id);
 
     provider.dispose();
   });
 
   testWidgets('slow processing poll never overlaps another request', (tester) async {
     final processing = _conversation(ConversationStatus.processing);
-    final completed = _conversation(ConversationStatus.completed);
-    final firstPoll = Completer<ServerConversation?>();
-    var pollCalls = 0;
+    final completed = _conversation(ConversationStatus.completed, overview: 'Recovered summary');
+    final firstPoll = Completer<ConversationProcessingRetryResult?>();
+    var calls = 0;
     var inFlight = 0;
     var maxInFlight = 0;
 
     final provider = ConversationProvider(
-      retryConversationProcessingCall: (_, __, {correctionText}) async => ConversationProcessingRetryResult(
-        outcome: ConversationProcessingRetryOutcome.processing,
-        conversation: processing,
-      ),
-      conversationByIdCall: (_) async {
-        pollCalls += 1;
+      retryConversationProcessingCall: (_, __, {correctionText}) async {
+        calls += 1;
+        if (calls == 1) return _result(ConversationProcessingRetryOutcome.processing, processing);
         inFlight += 1;
         if (inFlight > maxInFlight) maxInFlight = inFlight;
-        if (pollCalls == 1) {
+        if (calls == 2) {
           final result = await firstPoll.future;
           inFlight -= 1;
           return result;
         }
         inFlight -= 1;
-        return completed;
+        return _result(ConversationProcessingRetryOutcome.completed, completed);
       },
     );
 
     expect(await provider.retryFailedConversation(processing.id), isTrue);
     await tester.pump(const Duration(seconds: 3));
-    expect(pollCalls, 1);
+    expect(calls, 2);
     expect(inFlight, 1);
 
     await tester.pump(const Duration(seconds: 12));
-    expect(pollCalls, 1);
+    expect(calls, 2);
     expect(maxInFlight, 1);
 
-    firstPoll.complete(processing);
+    firstPoll.complete(_result(ConversationProcessingRetryOutcome.processing, processing));
     await tester.pump();
     await tester.pump(const Duration(seconds: 3));
     await tester.pump();
 
-    expect(pollCalls, 2);
+    expect(calls, 3);
     expect(maxInFlight, 1);
     expect(provider.conversations.single.status, ConversationStatus.completed);
     expect(provider.isConversationRetrying(processing.id), isFalse);
@@ -147,15 +224,11 @@ void main() {
 
   testWidgets('processing poll stops after forty completed attempts', (tester) async {
     final processing = _conversation(ConversationStatus.processing);
-    var pollCalls = 0;
+    var calls = 0;
     final provider = ConversationProvider(
-      retryConversationProcessingCall: (_, __, {correctionText}) async => ConversationProcessingRetryResult(
-        outcome: ConversationProcessingRetryOutcome.processing,
-        conversation: processing,
-      ),
-      conversationByIdCall: (_) async {
-        pollCalls += 1;
-        return null;
+      retryConversationProcessingCall: (_, __, {correctionText}) async {
+        calls += 1;
+        return calls == 1 ? _result(ConversationProcessingRetryOutcome.processing, processing) : null;
       },
     );
 
@@ -165,10 +238,10 @@ void main() {
       await tester.pump();
     }
 
-    expect(pollCalls, 40);
+    expect(calls, 41);
     expect(provider.isConversationRetrying(processing.id), isFalse);
     await tester.pump(const Duration(seconds: 30));
-    expect(pollCalls, 40);
+    expect(calls, 41);
 
     provider.dispose();
   });
@@ -176,28 +249,25 @@ void main() {
   testWidgets('completion after provider disposal cannot restart or update polling', (tester) async {
     final processing = _conversation(ConversationStatus.processing);
     final completed = _conversation(ConversationStatus.completed);
-    final latePoll = Completer<ServerConversation?>();
-    var pollCalls = 0;
+    final latePoll = Completer<ConversationProcessingRetryResult?>();
+    var calls = 0;
     final provider = ConversationProvider(
-      retryConversationProcessingCall: (_, __, {correctionText}) async => ConversationProcessingRetryResult(
-        outcome: ConversationProcessingRetryOutcome.processing,
-        conversation: processing,
-      ),
-      conversationByIdCall: (_) {
-        pollCalls += 1;
-        return latePoll.future;
+      retryConversationProcessingCall: (_, __, {correctionText}) async {
+        calls += 1;
+        if (calls == 1) return _result(ConversationProcessingRetryOutcome.processing, processing);
+        return await latePoll.future;
       },
     );
 
     expect(await provider.retryFailedConversation(processing.id), isTrue);
     await tester.pump(const Duration(seconds: 3));
-    expect(pollCalls, 1);
+    expect(calls, 2);
 
     provider.dispose();
-    latePoll.complete(completed);
+    latePoll.complete(_result(ConversationProcessingRetryOutcome.completed, completed));
     await tester.pump();
     await tester.pump(const Duration(seconds: 30));
 
-    expect(pollCalls, 1);
+    expect(calls, 2);
   });
 }

--- a/app/test/providers/conversation_processing_retry_test.dart
+++ b/app/test/providers/conversation_processing_retry_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/http/api/conversations.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/providers/conversation_provider.dart';
+
+ServerConversation _conversation(ConversationStatus status) {
+  return ServerConversation(
+    id: 'conversation-1',
+    createdAt: DateTime.utc(2026, 7, 20, 8),
+    structured: Structured(status == ConversationStatus.completed ? 'Recovered summary' : '', ''),
+    status: status,
+    processingError: status == ConversationStatus.failed ? 'conversation_summary_failed' : null,
+  );
+}
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  testWidgets('retry moves failed conversation through processing to completed', (tester) async {
+    final failed = _conversation(ConversationStatus.failed);
+    final processing = _conversation(ConversationStatus.processing);
+    final completed = _conversation(ConversationStatus.completed);
+    var retryCalls = 0;
+    var pollCalls = 0;
+
+    final provider = ConversationProvider(
+      retryConversationProcessingCall: (conversationId, requestId, {correctionText}) async {
+        retryCalls += 1;
+        expect(conversationId, failed.id);
+        expect(requestId, isNotEmpty);
+        expect(correctionText, 'The speakers were discussing their summer plans.');
+        return ConversationProcessingRetryResult(
+          outcome: ConversationProcessingRetryOutcome.processing,
+          conversation: processing,
+        );
+      },
+      conversationByIdCall: (conversationId) async {
+        pollCalls += 1;
+        return completed;
+      },
+    );
+    provider.failedConversations = [failed];
+    provider.conversations = [failed];
+
+    expect(
+      await provider.retryFailedConversation(
+        failed.id,
+        correctionText: 'The speakers were discussing their summer plans.',
+      ),
+      isTrue,
+    );
+    expect(retryCalls, 1);
+    expect(provider.failedConversations, isEmpty);
+    expect(provider.processingConversations.single.status, ConversationStatus.processing);
+    expect(provider.isConversationRetrying(failed.id), isTrue);
+    expect(await provider.retryFailedConversation(failed.id), isTrue);
+    expect(retryCalls, 1);
+
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump();
+
+    expect(pollCalls, 1);
+    expect(provider.processingConversations, isEmpty);
+    expect(provider.conversations.single.status, ConversationStatus.completed);
+    expect(provider.isConversationRetrying(failed.id), isFalse);
+
+    provider.dispose();
+  });
+
+  testWidgets('failed retry response remains visible and retryable', (tester) async {
+    final failed = _conversation(ConversationStatus.failed);
+    final provider = ConversationProvider(
+      retryConversationProcessingCall: (_, __, {correctionText}) async {
+        expect(correctionText, isNull);
+        return ConversationProcessingRetryResult(
+          outcome: ConversationProcessingRetryOutcome.failed,
+          conversation: failed,
+        );
+      },
+    );
+    provider.failedConversations = [failed];
+
+    expect(await provider.retryFailedConversation(failed.id), isTrue);
+    expect(provider.failedConversations.single.id, failed.id);
+    expect(provider.isConversationRetrying(failed.id), isFalse);
+
+    provider.dispose();
+  });
+}

--- a/app/test/widgets/failed_conversations_section_test.dart
+++ b/app/test/widgets/failed_conversations_section_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/conversations/widgets/failed_conversations_section.dart';
+
+ServerConversation _failedConversation() {
+  return ServerConversation(
+    id: 'failed-conversation',
+    createdAt: DateTime.utc(2026, 7, 20, 8),
+    structured: Structured('', ''),
+    transcriptSegments: [
+      TranscriptSegment(
+        id: 'segment-1',
+        text: 'The preserved transcript remains available while the summary is repaired.',
+        speaker: 'SPEAKER_00',
+        isUser: true,
+        personId: null,
+        start: 0,
+        end: 5,
+        translations: [],
+      ),
+    ],
+    status: ConversationStatus.failed,
+    processingError: 'provider.invalid_api_key secret detail',
+    processingErrorAt: DateTime.utc(2026, 7, 20, 8, 5),
+  );
+}
+
+Widget _app({required bool retrying, required RetryFailedConversation onRetry}) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: FailedConversationsSection(
+        conversations: [_failedConversation()],
+        isRetrying: (_) => retrying,
+        onRetry: onRetry,
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('shows safe copy and preserved transcript without provider internals', (tester) async {
+    await tester.pumpWidget(_app(retrying: false, onRetry: (_, {correctionText}) async => true));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Needs processing'), findsNWidgets(2));
+    expect(find.text('Your transcript is safe. Ask Ella to create its summary.'), findsOneWidget);
+    expect(find.textContaining('The preserved transcript remains available'), findsOneWidget);
+    expect(find.textContaining('invalid_api_key'), findsNothing);
+  });
+
+  testWidgets('retries the selected conversation once with optional Ella context', (tester) async {
+    var calls = 0;
+    String? retriedId;
+    String? submittedContext;
+    await tester.pumpWidget(
+      _app(
+        retrying: false,
+        onRetry: (conversationId, {correctionText}) async {
+          calls += 1;
+          retriedId = conversationId;
+          submittedContext = correctionText;
+          return true;
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('retry-conversation-failed-conversation')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Retry with Ella'), findsNWidgets(2));
+    await tester.enterText(
+      find.byKey(const ValueKey('retry-context-failed-conversation')),
+      'This was a family conversation about summer plans.',
+    );
+    await tester.tap(find.byKey(const ValueKey('submit-retry-failed-conversation')));
+    await tester.pumpAndSettle();
+
+    expect(calls, 1);
+    expect(retriedId, 'failed-conversation');
+    expect(submittedContext, 'This was a family conversation about summer plans.');
+  });
+
+  testWidgets('disables retry while processing is already restarting', (tester) async {
+    await tester.pumpWidget(_app(retrying: true, onRetry: (_, {correctionText}) async => true));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Processing...'), findsOneWidget);
+    final button = tester.widget<FilledButton>(find.byKey(const ValueKey('retry-conversation-failed-conversation')));
+    expect(button.onPressed, isNull);
+  });
+}

--- a/app/test/widgets/failed_conversations_section_test.dart
+++ b/app/test/widgets/failed_conversations_section_test.dart
@@ -30,7 +30,12 @@ ServerConversation _failedConversation() {
   );
 }
 
-Widget _app({required bool retrying, required RetryFailedConversation onRetry}) {
+Widget _app({
+  required bool retrying,
+  required RetryFailedConversation onRetry,
+  bool isSearchActive = false,
+  bool showDailySummaries = false,
+}) {
   return MaterialApp(
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
@@ -39,6 +44,8 @@ Widget _app({required bool retrying, required RetryFailedConversation onRetry}) 
         conversations: [_failedConversation()],
         isRetrying: (_) => retrying,
         onRetry: onRetry,
+        isSearchActive: isSearchActive,
+        showDailySummaries: showDailySummaries,
       ),
     ),
   );
@@ -95,5 +102,17 @@ void main() {
     expect(find.text('Processing...'), findsOneWidget);
     final button = tester.widget<FilledButton>(find.byKey(const ValueKey('retry-conversation-failed-conversation')));
     expect(button.onPressed, isNull);
+  });
+
+  testWidgets('hides failed conversations during search and Daily Summaries modes', (tester) async {
+    Future<bool> onRetry(String _, {String? correctionText}) async => true;
+
+    await tester.pumpWidget(_app(retrying: false, onRetry: onRetry, isSearchActive: true));
+    await tester.pumpAndSettle();
+    expect(find.text('Needs processing'), findsNothing);
+
+    await tester.pumpWidget(_app(retrying: false, onRetry: onRetry, showDailySummaries: true));
+    await tester.pumpAndSettle();
+    expect(find.text('Needs processing'), findsNothing);
   });
 }


### PR DESCRIPTION
## What changed

- Fetch retry-safe failed conversations separately from the normal processing/completed timeline.
- Show a localized **Needs processing** section with preserved transcript/date context and no raw provider errors.
- Keep a usable generic summary in the normal timeline when only Hermes enrichment, canonical confirmation, or enriched-vector indexing failed.
- Add a **Retry with Ella** sheet with optional user context.
- Send a fresh UUID for a user-requested retry, then poll by idempotently re-POSTing that same UUID and normalized context.
- Parse backend recovery mode, phase, generic, enrichment, vector, lease, and attempt receipt fields; terminal state follows `outcome`, not `conversation.status`.
- Preserve serialized one-shot polling and cancellation across terminal state, timeout, reset, and dispose.

## Why

The backend now preserves long-transcript summary failures and exposes a scoped two-stage recovery route. The prior app did not request failed records, and it could incorrectly stop polling an enrichment-only repair because the usable generic conversation remains `completed` while Hermes is still running.

This PR keeps the stock OMI/OpenRouter generic summary as the primary result, routes contextual recovery through Hermes, and makes every terminal summary/enrichment recovery failure visible and retryable without exposing provider details.

## Backend contract

```http
POST /v1/conversations/{conversation_id}/processing-retries
{"request_id":"<uuid>","correction_text":"<optional user context>"}
```

- Same UUID is reused for status polling, transport uncertainty, and stale-lease recovery.
- A deliberate user retry after terminal failure generates a fresh UUID.
- Generic success remains usable while Hermes is pending or failed.
- UID enforcement, atomic claim, recovery phases, summary/vector versioning, canonical writeback, and receipts remain backend-owned.
- The generic `/reprocess` route is not used.

Backend dependencies are merged and deployed via #288, #289, and #290.

## Validation

- Focused model/provider/widget suite: 15 passed.
- `app/test.sh`: capture provider 18 passed; transcript 3 passed.
- Changed-file analysis: no new findings; only pre-existing schema enum/print infos.
- `git diff --check origin/main...HEAD`: clean.

No Firebase, auth, signing, backend, or production configuration changed in this PR.