### PR TITLE
Expose failed summaries with idempotent two-stage retry

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -1174,6 +1174,7 @@ def _record_conversation_processing_retry_source_transaction(
     updated_at: datetime,
     lease_expires_at: datetime,
     attempt_count: Optional[int] = None,
+    generic_summary_sha256: Optional[str] = None,
 ):
     conversation_snapshot = conversation_ref.get(transaction=transaction)
     retry_snapshot = retry_ref.get(transaction=transaction)
@@ -1190,23 +1191,22 @@ def _record_conversation_processing_retry_source_transaction(
         return False
     if retry_data.get('outcome') != ConversationStatus.processing.value:
         return False
-    transaction.update(
-        conversation_ref,
-        {
-            'processing_retry_lease_expires_at': lease_expires_at,
-            'processing_retry_transcript_sha256': transcript_sha256,
-            'processing_retry_source_request_id': request_id,
-        },
-    )
-    transaction.update(
-        retry_ref,
-        {
-            'transcript_sha256': transcript_sha256,
-            'transcript_segment_count': segment_count,
-            'lease_expires_at': lease_expires_at,
-            'updated_at': updated_at,
-        },
-    )
+    conversation_update = {
+        'processing_retry_lease_expires_at': lease_expires_at,
+        'processing_retry_transcript_sha256': transcript_sha256,
+        'processing_retry_source_request_id': request_id,
+    }
+    retry_update = {
+        'transcript_sha256': transcript_sha256,
+        'transcript_segment_count': segment_count,
+        'lease_expires_at': lease_expires_at,
+        'updated_at': updated_at,
+    }
+    if generic_summary_sha256:
+        conversation_update['processing_retry_generic_summary_sha256'] = generic_summary_sha256
+        retry_update['generic_summary_sha256'] = generic_summary_sha256
+    transaction.update(conversation_ref, conversation_update)
+    transaction.update(retry_ref, retry_update)
     return True
 
 
@@ -1221,6 +1221,7 @@ def _record_conversation_processing_retry_source(
     updated_at: datetime,
     lease_expires_at: datetime,
     attempt_count: Optional[int],
+    generic_summary_sha256: Optional[str],
 ):
     return _record_conversation_processing_retry_source_transaction(
         transaction,
@@ -1232,6 +1233,7 @@ def _record_conversation_processing_retry_source(
         updated_at,
         lease_expires_at,
         attempt_count,
+        generic_summary_sha256,
     )
 
 
@@ -1244,6 +1246,7 @@ def record_conversation_processing_retry_source(
     updated_at: Optional[datetime] = None,
     lease_seconds: int = conversation_processing_retry_lease_seconds,
     attempt_count: Optional[int] = None,
+    generic_summary_sha256: Optional[str] = None,
 ):
     now = updated_at or datetime.now(timezone.utc)
     conversation_ref = (
@@ -1260,6 +1263,7 @@ def record_conversation_processing_retry_source(
         now,
         now + timedelta(seconds=max(1, lease_seconds)),
         attempt_count,
+        generic_summary_sha256,
     )
 
 

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 from typing import List, Tuple, Optional, Dict, Any
 
 from google.cloud import firestore
-from google.cloud.firestore_v1 import FieldFilter
+from google.cloud.firestore_v1 import FieldFilter, transactional
 
 import utils.other.hume as hume
 from database import users as users_db
@@ -24,6 +24,11 @@ from .helpers import set_data_protection_level, prepare_for_write, prepare_for_r
 from utils.other.storage import list_audio_chunks
 
 conversations_collection = 'conversations'
+conversation_processing_retries_collection = 'processing_retries'
+conversation_summary_retryable_errors = {
+    'conversation_summary_failed',
+    'conversation_summary_recovery_failed',
+}
 
 
 def _ensure_timezone_aware(dt: datetime) -> datetime:
@@ -35,6 +40,7 @@ def _ensure_timezone_aware(dt: datetime) -> datetime:
         return dt.replace(tzinfo=timezone.utc)
     return dt
 
+
 def _category_value(value: Any) -> str:
     if value is None:
         return 'other'
@@ -44,10 +50,7 @@ def _category_value(value: Any) -> str:
 
 def _has_summary_content(structured: Optional[Dict[str, Any]]) -> bool:
     structured = structured or {}
-    return any(
-        str(structured.get(field) or '').strip()
-        for field in ('title', 'overview', 'emoji', 'category')
-    )
+    return any(str(structured.get(field) or '').strip() for field in ('title', 'overview', 'emoji', 'category'))
 
 
 def _build_summary_version_payload(
@@ -112,9 +115,11 @@ def build_summary_version_update(
 ) -> Dict[str, Any]:
     now = datetime.now(timezone.utc)
     bootstrap_update = bootstrap_summary_versioning_update(conversation_data)
-    versions = copy.deepcopy(conversation_data.get('summary_versions') or bootstrap_update.get('summary_versions') or [])
-    active_summary_version_id = (
-        conversation_data.get('active_summary_version_id') or bootstrap_update.get('active_summary_version_id')
+    versions = copy.deepcopy(
+        conversation_data.get('summary_versions') or bootstrap_update.get('summary_versions') or []
+    )
+    active_summary_version_id = conversation_data.get('active_summary_version_id') or bootstrap_update.get(
+        'active_summary_version_id'
     )
 
     if activate:
@@ -142,7 +147,6 @@ def build_summary_version_update(
     }
 
 
-
 def _category_value(value: Any) -> str:
     if value is None:
         return 'other'
@@ -152,10 +156,7 @@ def _category_value(value: Any) -> str:
 
 def _has_summary_content(structured: Optional[Dict[str, Any]]) -> bool:
     structured = structured or {}
-    return any(
-        str(structured.get(field) or '').strip()
-        for field in ('title', 'overview', 'emoji', 'category')
-    )
+    return any(str(structured.get(field) or '').strip() for field in ('title', 'overview', 'emoji', 'category'))
 
 
 def _build_summary_version_payload(
@@ -218,9 +219,11 @@ def build_summary_version_update(
 ) -> Dict[str, Any]:
     now = datetime.now(timezone.utc)
     bootstrap_update = bootstrap_summary_versioning_update(conversation_data)
-    versions = copy.deepcopy(conversation_data.get('summary_versions') or bootstrap_update.get('summary_versions') or [])
-    active_summary_version_id = (
-        conversation_data.get('active_summary_version_id') or bootstrap_update.get('active_summary_version_id')
+    versions = copy.deepcopy(
+        conversation_data.get('summary_versions') or bootstrap_update.get('summary_versions') or []
+    )
+    active_summary_version_id = conversation_data.get('active_summary_version_id') or bootstrap_update.get(
+        'active_summary_version_id'
     )
 
     if activate:
@@ -888,6 +891,380 @@ def update_conversation_status(uid: str, conversation_id: str, status: str):
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
     conversation_ref.update({'status': status})
+
+
+def _claim_conversation_processing_retry_transaction(
+    transaction,
+    conversation_ref,
+    retry_ref,
+    request_id: str,
+    requested_at: datetime,
+):
+    snapshot = conversation_ref.get(transaction=transaction)
+    retry_snapshot = retry_ref.get(transaction=transaction)
+    if not snapshot.exists:
+        return {'outcome': 'not_found', 'conversation': None}
+
+    conversation = snapshot.to_dict()
+    status = getattr(conversation.get('status'), 'value', conversation.get('status'))
+
+    if conversation.get('is_locked', False):
+        return {'outcome': 'locked', 'conversation': conversation}
+
+    if retry_snapshot.exists:
+        retry_outcome = retry_snapshot.to_dict().get('outcome')
+        if retry_outcome in {'processing', 'completed', 'failed'}:
+            return {'outcome': retry_outcome, 'conversation': conversation}
+        return {'outcome': 'invalid_state', 'conversation': conversation}
+
+    if status == ConversationStatus.completed.value:
+        transaction.set(
+            retry_ref,
+            {
+                'request_id': request_id,
+                'outcome': ConversationStatus.completed.value,
+                'requested_at': requested_at,
+                'updated_at': requested_at,
+            },
+        )
+        return {'outcome': 'completed', 'conversation': conversation}
+    if status == ConversationStatus.processing.value:
+        return {'outcome': 'busy', 'conversation': conversation}
+    if status != ConversationStatus.failed.value:
+        return {'outcome': 'invalid_state', 'conversation': conversation}
+    if conversation.get('processing_error') not in conversation_summary_retryable_errors:
+        return {'outcome': 'not_retryable', 'conversation': conversation}
+
+    update_data = {
+        'status': ConversationStatus.processing.value,
+        'processing_retry_id': request_id,
+        'processing_retry_started_at': requested_at,
+        'processing_retry_completed_at': None,
+    }
+    transaction.update(conversation_ref, update_data)
+    transaction.set(
+        retry_ref,
+        {
+            'request_id': request_id,
+            'outcome': ConversationStatus.processing.value,
+            'requested_at': requested_at,
+            'updated_at': requested_at,
+        },
+    )
+    conversation.update(update_data)
+    return {'outcome': 'claimed', 'conversation': conversation}
+
+
+@transactional
+def _claim_conversation_processing_retry(
+    transaction,
+    conversation_ref,
+    retry_ref,
+    request_id: str,
+    requested_at: datetime,
+):
+    return _claim_conversation_processing_retry_transaction(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        request_id,
+        requested_at,
+    )
+
+
+def claim_conversation_processing_retry(
+    uid: str,
+    conversation_id: str,
+    request_id: str,
+    requested_at: Optional[datetime] = None,
+):
+    conversation_ref = (
+        db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
+    )
+    retry_ref = conversation_ref.collection(conversation_processing_retries_collection).document(request_id)
+    transaction = db.transaction()
+    return _claim_conversation_processing_retry(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        request_id,
+        requested_at or datetime.now(timezone.utc),
+    )
+
+
+def _record_conversation_processing_retry_summary_applied_transaction(
+    transaction,
+    conversation_ref,
+    retry_ref,
+    request_id: str,
+    summary_version_id: str,
+    applied_at: datetime,
+):
+    conversation_snapshot = conversation_ref.get(transaction=transaction)
+    retry_snapshot = retry_ref.get(transaction=transaction)
+    if not conversation_snapshot.exists or not retry_snapshot.exists:
+        return False
+
+    conversation = conversation_snapshot.to_dict()
+    retry_data = retry_snapshot.to_dict()
+    if conversation.get('processing_retry_id') != request_id or retry_data.get('request_id') != request_id:
+        return False
+
+    transaction.update(
+        conversation_ref,
+        {'processing_retry_summary_version_id': summary_version_id},
+    )
+    transaction.update(
+        retry_ref,
+        {
+            'phase': 'summary_applied',
+            'summary_version_id': summary_version_id,
+            'updated_at': applied_at,
+        },
+    )
+    return True
+
+
+@transactional
+def _record_conversation_processing_retry_summary_applied(
+    transaction,
+    conversation_ref,
+    retry_ref,
+    request_id: str,
+    summary_version_id: str,
+    applied_at: datetime,
+):
+    return _record_conversation_processing_retry_summary_applied_transaction(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        request_id,
+        summary_version_id,
+        applied_at,
+    )
+
+
+def record_conversation_processing_retry_summary_applied(
+    uid: str,
+    conversation_id: str,
+    request_id: str,
+    summary_version_id: str,
+    applied_at: Optional[datetime] = None,
+):
+    conversation_ref = (
+        db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
+    )
+    retry_ref = conversation_ref.collection(conversation_processing_retries_collection).document(request_id)
+    transaction = db.transaction()
+    return _record_conversation_processing_retry_summary_applied(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        request_id,
+        summary_version_id,
+        applied_at or datetime.now(timezone.utc),
+    )
+
+
+def _finish_conversation_processing_retry_transaction(
+    transaction,
+    conversation_ref,
+    retry_ref,
+    request_id: str,
+    outcome: str,
+    finished_at: datetime,
+    error_code: Optional[str],
+):
+    conversation_snapshot = conversation_ref.get(transaction=transaction)
+    retry_snapshot = retry_ref.get(transaction=transaction)
+    if not conversation_snapshot.exists or not retry_snapshot.exists:
+        return False
+
+    retry_data = retry_snapshot.to_dict()
+    if retry_data.get('request_id') != request_id:
+        return False
+
+    retry_update = {'outcome': outcome, 'updated_at': finished_at}
+    if error_code:
+        retry_update['error_code'] = error_code
+    transaction.update(retry_ref, retry_update)
+    conversation = conversation_snapshot.to_dict()
+    if conversation.get('processing_retry_id') != request_id:
+        return True
+
+    if outcome == ConversationStatus.completed.value:
+        transaction.update(
+            conversation_ref,
+            {
+                'status': ConversationStatus.completed.value,
+                'discarded': False,
+                'processing_error': None,
+                'processing_error_at': None,
+                'processing_retry_completed_at': finished_at,
+            },
+        )
+    else:
+        transaction.update(
+            conversation_ref,
+            {
+                'status': ConversationStatus.failed.value,
+                'discarded': False,
+                'processing_error': error_code or 'conversation_summary_failed',
+                'processing_error_at': finished_at,
+            },
+        )
+    return True
+
+
+@transactional
+def _finish_conversation_processing_retry(
+    transaction,
+    conversation_ref,
+    retry_ref,
+    request_id: str,
+    outcome: str,
+    finished_at: datetime,
+    error_code: Optional[str],
+):
+    return _finish_conversation_processing_retry_transaction(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        request_id,
+        outcome,
+        finished_at,
+        error_code,
+    )
+
+
+def finish_conversation_processing_retry(
+    uid: str,
+    conversation_id: str,
+    request_id: str,
+    outcome: str,
+    finished_at: Optional[datetime] = None,
+    error_code: Optional[str] = None,
+):
+    if outcome not in {ConversationStatus.completed.value, ConversationStatus.failed.value}:
+        raise ValueError(f'Unsupported conversation processing retry outcome: {outcome}')
+
+    conversation_ref = (
+        db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
+    )
+    retry_ref = conversation_ref.collection(conversation_processing_retries_collection).document(request_id)
+    transaction = db.transaction()
+    return _finish_conversation_processing_retry(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        request_id,
+        outcome,
+        finished_at or datetime.now(timezone.utc),
+        error_code,
+    )
+
+
+def _record_conversation_processing_retry_enrichment_transaction(
+    transaction,
+    conversation_ref,
+    retry_ref,
+    conversation_id: str,
+    request_id: str,
+    status: str,
+    updated_at: datetime,
+    summary_version_id: Optional[str],
+):
+    conversation_snapshot = conversation_ref.get(transaction=transaction)
+    retry_snapshot = retry_ref.get(transaction=transaction)
+    if not conversation_snapshot.exists or not retry_snapshot.exists:
+        return False
+
+    conversation = conversation_snapshot.to_dict()
+    retry_data = retry_snapshot.to_dict()
+    if retry_data.get('request_id') != request_id:
+        return False
+
+    retry_update = {
+        'enrichment_status': status,
+        'updated_at': updated_at,
+    }
+    if summary_version_id:
+        retry_update['enriched_summary_version_id'] = summary_version_id
+    transaction.update(retry_ref, retry_update)
+
+    if conversation.get('processing_retry_id') != request_id:
+        return True
+    if status == 'completed' and summary_version_id:
+        transaction.update(
+            conversation_ref,
+            {'processing_retry_enriched_version_id': summary_version_id},
+        )
+    elif status == 'failed':
+        transaction.update(
+            conversation_ref,
+            {
+                'enrichment_state': {
+                    'status': 'failed',
+                    'pending': True,
+                    'source': 'observer',
+                    'kind': 'recovered_enriched',
+                    'trace_id': f'summary-retry:{conversation_id}:{request_id}:hermes',
+                    'updated_at': updated_at,
+                    'error': 'hermes_temporarily_unavailable',
+                }
+            },
+        )
+    return True
+
+
+@transactional
+def _record_conversation_processing_retry_enrichment(
+    transaction,
+    conversation_ref,
+    retry_ref,
+    conversation_id: str,
+    request_id: str,
+    status: str,
+    updated_at: datetime,
+    summary_version_id: Optional[str],
+):
+    return _record_conversation_processing_retry_enrichment_transaction(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        conversation_id,
+        request_id,
+        status,
+        updated_at,
+        summary_version_id,
+    )
+
+
+def record_conversation_processing_retry_enrichment(
+    uid: str,
+    conversation_id: str,
+    request_id: str,
+    status: str,
+    summary_version_id: Optional[str] = None,
+    updated_at: Optional[datetime] = None,
+):
+    if status not in {'completed', 'failed'}:
+        raise ValueError(f'Unsupported conversation processing retry enrichment status: {status}')
+    conversation_ref = (
+        db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
+    )
+    retry_ref = conversation_ref.collection(conversation_processing_retries_collection).document(request_id)
+    transaction = db.transaction()
+    return _record_conversation_processing_retry_enrichment(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        conversation_id,
+        request_id,
+        status,
+        updated_at or datetime.now(timezone.utc),
+        summary_version_id,
+    )
 
 
 def set_conversation_as_discarded(uid: str, conversation_id: str):

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -29,6 +29,88 @@ conversation_summary_retryable_errors = {
     'conversation_summary_failed',
     'conversation_summary_recovery_failed',
 }
+conversation_enriched_summary_kinds = {
+    'observer_enriched',
+    'corrected_enriched',
+    'hermes_enriched',
+    'recovered_enriched',
+}
+conversation_processing_retry_lease_seconds = 900
+
+
+def _active_summary_version(conversation: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    versions = conversation.get('summary_versions') or []
+    active_id = conversation.get('active_summary_version_id')
+    if active_id:
+        for version in versions:
+            if str(version.get('id') or '') == str(active_id):
+                return version
+    return next((version for version in reversed(versions) if version.get('is_active')), None)
+
+
+def has_usable_conversation_summary(conversation: Dict[str, Any]) -> bool:
+    structured = conversation.get('structured') or {}
+    return bool(str(structured.get('title') or '').strip() and str(structured.get('overview') or '').strip())
+
+
+def has_enriched_conversation_summary(conversation: Dict[str, Any]) -> bool:
+    active_version = _active_summary_version(conversation) or {}
+    enrichment_state = conversation.get('enrichment_state') or {}
+    return bool(
+        active_version.get('kind') in conversation_enriched_summary_kinds
+        and enrichment_state.get('status') == 'writeback_applied'
+        and enrichment_state.get('kind') in conversation_enriched_summary_kinds
+    )
+
+
+def conversation_processing_recovery_mode(conversation: Dict[str, Any]) -> tuple[Optional[str], str]:
+    status = getattr(conversation.get('status'), 'value', conversation.get('status'))
+    if conversation.get('discarded'):
+        return None, 'intentional_discard'
+    if status == ConversationStatus.processing.value:
+        return None, 'active_processing'
+    if status == ConversationStatus.failed.value:
+        if conversation.get('processing_error') in conversation_summary_retryable_errors:
+            return 'full', 'retryable_summary_failure'
+        return None, 'non_retryable_failure'
+    if status == ConversationStatus.completed.value:
+        if has_enriched_conversation_summary(conversation):
+            if conversation.get('processing_retry_enrichment_vector_status') in {'pending', 'failed'}:
+                return 'enrichment_only', 'enriched_summary_without_confirmed_vector'
+            return None, 'already_enriched'
+        if has_usable_conversation_summary(conversation):
+            return 'enrichment_only', 'generic_summary_without_enrichment'
+        return None, 'completed_without_usable_summary'
+    return None, 'invalid_state'
+
+
+def _processing_retry_lease_expired(conversation: Dict[str, Any], now: datetime) -> bool:
+    lease_expires_at = conversation.get('processing_retry_lease_expires_at')
+    if not isinstance(lease_expires_at, datetime):
+        return True
+    return _ensure_timezone_aware(lease_expires_at) <= _ensure_timezone_aware(now)
+
+
+def _retry_claim_metadata(
+    outcome: str,
+    *,
+    retry_data: Optional[Dict[str, Any]] = None,
+    mode: Optional[str] = None,
+    reason: Optional[str] = None,
+) -> Dict[str, Any]:
+    retry_data = retry_data or {}
+    return {
+        'outcome': outcome,
+        'mode': mode if mode is not None else retry_data.get('mode'),
+        'reason': reason,
+        'phase': retry_data.get('phase'),
+        'generic_status': retry_data.get('generic_status'),
+        'generic_vector_status': retry_data.get('generic_vector_status'),
+        'enrichment_status': retry_data.get('enrichment_status'),
+        'vector_status': retry_data.get('vector_status'),
+        'lease_expires_at': retry_data.get('lease_expires_at'),
+        'attempt_count': int(retry_data.get('attempt_count') or 0),
+    }
 
 
 def _ensure_timezone_aware(dt: datetime) -> datetime:
@@ -899,60 +981,146 @@ def _claim_conversation_processing_retry_transaction(
     retry_ref,
     request_id: str,
     requested_at: datetime,
+    lease_seconds: int = conversation_processing_retry_lease_seconds,
 ):
     snapshot = conversation_ref.get(transaction=transaction)
     retry_snapshot = retry_ref.get(transaction=transaction)
     if not snapshot.exists:
-        return {'outcome': 'not_found', 'conversation': None}
+        return _retry_claim_metadata('not_found')
 
     conversation = snapshot.to_dict()
     status = getattr(conversation.get('status'), 'value', conversation.get('status'))
 
     if conversation.get('is_locked', False):
-        return {'outcome': 'locked', 'conversation': conversation}
+        return _retry_claim_metadata('locked')
+
+    lease_expires_at = requested_at + timedelta(seconds=max(1, lease_seconds))
+    retry_data = retry_snapshot.to_dict() if retry_snapshot.exists else None
+    if retry_data and retry_data.get('outcome') == ConversationStatus.completed.value:
+        return _retry_claim_metadata(ConversationStatus.completed.value, retry_data=retry_data)
+    current_retry_id = conversation.get('processing_retry_id')
+    stale_active_retry = bool(
+        current_retry_id
+        and not conversation.get('processing_retry_completed_at')
+        and _processing_retry_lease_expired(conversation, requested_at)
+    )
+    if (
+        current_retry_id
+        and current_retry_id != request_id
+        and not conversation.get('processing_retry_completed_at')
+        and not stale_active_retry
+    ):
+        return _retry_claim_metadata('busy')
 
     if retry_snapshot.exists:
-        retry_outcome = retry_snapshot.to_dict().get('outcome')
-        if retry_outcome in {'processing', 'completed', 'failed'}:
-            return {'outcome': retry_outcome, 'conversation': conversation}
-        return {'outcome': 'invalid_state', 'conversation': conversation}
-
-    if status == ConversationStatus.completed.value:
-        transaction.set(
-            retry_ref,
-            {
-                'request_id': request_id,
-                'outcome': ConversationStatus.completed.value,
-                'requested_at': requested_at,
-                'updated_at': requested_at,
-            },
+        retry_data = retry_data or {}
+        retry_outcome = retry_data.get('outcome')
+        retry_lease_expires_at = retry_data.get('lease_expires_at')
+        retry_lease_active = bool(
+            retry_outcome == ConversationStatus.processing.value
+            and isinstance(retry_lease_expires_at, datetime)
+            and _ensure_timezone_aware(retry_lease_expires_at) > _ensure_timezone_aware(requested_at)
         )
-        return {'outcome': 'completed', 'conversation': conversation}
-    if status == ConversationStatus.processing.value:
-        return {'outcome': 'busy', 'conversation': conversation}
-    if status != ConversationStatus.failed.value:
-        return {'outcome': 'invalid_state', 'conversation': conversation}
-    if conversation.get('processing_error') not in conversation_summary_retryable_errors:
-        return {'outcome': 'not_retryable', 'conversation': conversation}
+        if retry_lease_active:
+            return _retry_claim_metadata(retry_outcome, retry_data=retry_data)
+        if retry_outcome not in {ConversationStatus.processing.value, ConversationStatus.failed.value}:
+            return _retry_claim_metadata('invalid_state', retry_data=retry_data)
 
-    update_data = {
-        'status': ConversationStatus.processing.value,
-        'processing_retry_id': request_id,
-        'processing_retry_started_at': requested_at,
-        'processing_retry_completed_at': None,
-    }
-    transaction.update(conversation_ref, update_data)
-    transaction.set(
-        retry_ref,
-        {
-            'request_id': request_id,
+        current_mode, _ = conversation_processing_recovery_mode(conversation)
+        mode = current_mode or retry_data.get('mode')
+        if mode not in {'full', 'enrichment_only'}:
+            return _retry_claim_metadata('invalid_state', retry_data=retry_data)
+
+        attempt_count = int(retry_data.get('attempt_count') or 1) + 1
+        conversation_update = {
+            'processing_retry_id': request_id,
+            'processing_retry_mode': mode,
+            'processing_retry_started_at': requested_at,
+            'processing_retry_lease_expires_at': lease_expires_at,
+            'processing_retry_completed_at': None,
+            'processing_retry_attempt_count': attempt_count,
+        }
+        if mode == 'full' and not has_usable_conversation_summary(conversation):
+            conversation_update['status'] = ConversationStatus.processing.value
+        retry_update = {
             'outcome': ConversationStatus.processing.value,
+            'mode': mode,
+            'lease_expires_at': lease_expires_at,
+            'attempt_count': attempt_count,
+            'updated_at': requested_at,
+            'last_reclaimed_at': requested_at,
+        }
+        transaction.update(conversation_ref, conversation_update)
+        transaction.update(retry_ref, retry_update)
+        return _retry_claim_metadata(
+            'claimed',
+            retry_data={**retry_data, **retry_update},
+            mode=mode,
+            reason='lease_reclaimed',
+        )
+
+    if stale_active_retry and status == ConversationStatus.processing.value:
+        if has_usable_conversation_summary(conversation):
+            mode, reason = 'enrichment_only', 'stale_worker_after_generic'
+        elif conversation.get('processing_error') in conversation_summary_retryable_errors:
+            mode, reason = 'full', 'stale_worker_before_generic'
+        else:
+            mode, reason = None, 'active_processing'
+    else:
+        mode, reason = conversation_processing_recovery_mode(conversation)
+    if reason == 'already_enriched':
+        receipt = {
+            'request_id': request_id,
+            'outcome': ConversationStatus.completed.value,
+            'mode': None,
+            'phase': 'completed',
+            'generic_status': 'completed',
+            'generic_vector_status': 'completed',
+            'enrichment_status': 'completed',
+            'vector_status': 'completed',
+            'attempt_count': 0,
             'requested_at': requested_at,
             'updated_at': requested_at,
-        },
-    )
-    conversation.update(update_data)
-    return {'outcome': 'claimed', 'conversation': conversation}
+        }
+        transaction.set(
+            retry_ref,
+            receipt,
+        )
+        return _retry_claim_metadata('completed', retry_data=receipt)
+    if reason == 'active_processing':
+        return _retry_claim_metadata('busy', reason=reason)
+    if reason in {'intentional_discard', 'non_retryable_failure'}:
+        return _retry_claim_metadata('not_retryable', reason=reason)
+    if mode is None:
+        return _retry_claim_metadata('invalid_state', reason=reason)
+
+    update_data = {
+        'processing_retry_id': request_id,
+        'processing_retry_mode': mode,
+        'processing_retry_started_at': requested_at,
+        'processing_retry_lease_expires_at': lease_expires_at,
+        'processing_retry_completed_at': None,
+        'processing_retry_attempt_count': 1,
+    }
+    if mode == 'full':
+        update_data['status'] = ConversationStatus.processing.value
+    transaction.update(conversation_ref, update_data)
+    receipt = {
+        'request_id': request_id,
+        'outcome': ConversationStatus.processing.value,
+        'mode': mode,
+        'phase': 'claimed',
+        'generic_status': 'completed' if mode == 'enrichment_only' else 'pending',
+        'generic_vector_status': 'unknown' if mode == 'enrichment_only' else 'pending',
+        'enrichment_status': 'pending',
+        'vector_status': 'pending',
+        'lease_expires_at': lease_expires_at,
+        'attempt_count': 1,
+        'requested_at': requested_at,
+        'updated_at': requested_at,
+    }
+    transaction.set(retry_ref, receipt)
+    return _retry_claim_metadata('claimed', retry_data=receipt, mode=mode, reason=reason)
 
 
 @transactional
@@ -962,6 +1130,7 @@ def _claim_conversation_processing_retry(
     retry_ref,
     request_id: str,
     requested_at: datetime,
+    lease_seconds: int,
 ):
     return _claim_conversation_processing_retry_transaction(
         transaction,
@@ -969,6 +1138,7 @@ def _claim_conversation_processing_retry(
         retry_ref,
         request_id,
         requested_at,
+        lease_seconds,
     )
 
 
@@ -977,6 +1147,7 @@ def claim_conversation_processing_retry(
     conversation_id: str,
     request_id: str,
     requested_at: Optional[datetime] = None,
+    lease_seconds: int = conversation_processing_retry_lease_seconds,
 ):
     conversation_ref = (
         db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
@@ -989,6 +1160,106 @@ def claim_conversation_processing_retry(
         retry_ref,
         request_id,
         requested_at or datetime.now(timezone.utc),
+        lease_seconds,
+    )
+
+
+def _record_conversation_processing_retry_source_transaction(
+    transaction,
+    conversation_ref,
+    retry_ref,
+    request_id: str,
+    transcript_sha256: str,
+    segment_count: int,
+    updated_at: datetime,
+    lease_expires_at: datetime,
+    attempt_count: Optional[int] = None,
+):
+    conversation_snapshot = conversation_ref.get(transaction=transaction)
+    retry_snapshot = retry_ref.get(transaction=transaction)
+    if not conversation_snapshot.exists or not retry_snapshot.exists:
+        return False
+    conversation = conversation_snapshot.to_dict()
+    retry_data = retry_snapshot.to_dict()
+    if conversation.get('processing_retry_id') != request_id or retry_data.get('request_id') != request_id:
+        return False
+    if attempt_count is not None and (
+        conversation.get('processing_retry_attempt_count') != attempt_count
+        or retry_data.get('attempt_count') != attempt_count
+    ):
+        return False
+    if retry_data.get('outcome') != ConversationStatus.processing.value:
+        return False
+    transaction.update(
+        conversation_ref,
+        {
+            'processing_retry_lease_expires_at': lease_expires_at,
+            'processing_retry_transcript_sha256': transcript_sha256,
+            'processing_retry_source_request_id': request_id,
+        },
+    )
+    transaction.update(
+        retry_ref,
+        {
+            'transcript_sha256': transcript_sha256,
+            'transcript_segment_count': segment_count,
+            'lease_expires_at': lease_expires_at,
+            'updated_at': updated_at,
+        },
+    )
+    return True
+
+
+@transactional
+def _record_conversation_processing_retry_source(
+    transaction,
+    conversation_ref,
+    retry_ref,
+    request_id: str,
+    transcript_sha256: str,
+    segment_count: int,
+    updated_at: datetime,
+    lease_expires_at: datetime,
+    attempt_count: Optional[int],
+):
+    return _record_conversation_processing_retry_source_transaction(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        request_id,
+        transcript_sha256,
+        segment_count,
+        updated_at,
+        lease_expires_at,
+        attempt_count,
+    )
+
+
+def record_conversation_processing_retry_source(
+    uid: str,
+    conversation_id: str,
+    request_id: str,
+    transcript_sha256: str,
+    segment_count: int,
+    updated_at: Optional[datetime] = None,
+    lease_seconds: int = conversation_processing_retry_lease_seconds,
+    attempt_count: Optional[int] = None,
+):
+    now = updated_at or datetime.now(timezone.utc)
+    conversation_ref = (
+        db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
+    )
+    retry_ref = conversation_ref.collection(conversation_processing_retries_collection).document(request_id)
+    return _record_conversation_processing_retry_source(
+        db.transaction(),
+        conversation_ref,
+        retry_ref,
+        request_id,
+        transcript_sha256,
+        segment_count,
+        now,
+        now + timedelta(seconds=max(1, lease_seconds)),
+        attempt_count,
     )
 
 
@@ -999,6 +1270,7 @@ def _record_conversation_processing_retry_summary_applied_transaction(
     request_id: str,
     summary_version_id: str,
     applied_at: datetime,
+    attempt_count: Optional[int] = None,
 ):
     conversation_snapshot = conversation_ref.get(transaction=transaction)
     retry_snapshot = retry_ref.get(transaction=transaction)
@@ -1009,20 +1281,125 @@ def _record_conversation_processing_retry_summary_applied_transaction(
     retry_data = retry_snapshot.to_dict()
     if conversation.get('processing_retry_id') != request_id or retry_data.get('request_id') != request_id:
         return False
+    if attempt_count is not None and retry_data.get('attempt_count') != attempt_count:
+        return False
 
     transaction.update(
         conversation_ref,
-        {'processing_retry_summary_version_id': summary_version_id},
+        {
+            'status': ConversationStatus.completed.value,
+            'discarded': False,
+            'processing_error': None,
+            'processing_error_at': None,
+            'processing_retry_summary_version_id': summary_version_id,
+            'processing_retry_generic_vector_status': 'pending',
+        },
     )
     transaction.update(
         retry_ref,
         {
-            'phase': 'summary_applied',
+            'outcome': ConversationStatus.processing.value,
+            'phase': 'generic_writeback_applied',
+            'generic_status': 'writeback_applied',
+            'generic_vector_status': 'pending',
+            'enrichment_status': 'pending',
             'summary_version_id': summary_version_id,
             'updated_at': applied_at,
         },
     )
     return True
+
+
+def _record_conversation_processing_retry_generic_vector_transaction(
+    transaction,
+    conversation_ref,
+    retry_ref,
+    request_id: str,
+    status: str,
+    updated_at: datetime,
+    attempt_count: Optional[int] = None,
+):
+    conversation_snapshot = conversation_ref.get(transaction=transaction)
+    retry_snapshot = retry_ref.get(transaction=transaction)
+    if not conversation_snapshot.exists or not retry_snapshot.exists:
+        return False
+
+    conversation = conversation_snapshot.to_dict()
+    retry_data = retry_snapshot.to_dict()
+    if conversation.get('processing_retry_id') != request_id or retry_data.get('request_id') != request_id:
+        return False
+    if attempt_count is not None and retry_data.get('attempt_count') != attempt_count:
+        return False
+
+    completed = status == 'completed'
+    transaction.update(
+        conversation_ref,
+        {
+            'status': ConversationStatus.completed.value,
+            'discarded': False,
+            'processing_error': None,
+            'processing_error_at': None,
+            'processing_retry_generic_vector_status': status,
+            **({'processing_retry_completed_at': updated_at} if not completed else {}),
+        },
+    )
+    transaction.update(
+        retry_ref,
+        {
+            'outcome': ConversationStatus.processing.value if completed else ConversationStatus.failed.value,
+            'phase': 'generic_completed' if completed else 'generic_vector_failed',
+            'generic_status': 'completed' if completed else 'writeback_applied',
+            'generic_vector_status': status,
+            'updated_at': updated_at,
+        },
+    )
+    return True
+
+
+@transactional
+def _record_conversation_processing_retry_generic_vector(
+    transaction,
+    conversation_ref,
+    retry_ref,
+    request_id: str,
+    status: str,
+    updated_at: datetime,
+    attempt_count: Optional[int],
+):
+    return _record_conversation_processing_retry_generic_vector_transaction(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        request_id,
+        status,
+        updated_at,
+        attempt_count,
+    )
+
+
+def record_conversation_processing_retry_generic_vector(
+    uid: str,
+    conversation_id: str,
+    request_id: str,
+    status: str,
+    updated_at: Optional[datetime] = None,
+    attempt_count: Optional[int] = None,
+):
+    if status not in {'completed', 'failed'}:
+        raise ValueError(f'Unsupported generic vector status: {status}')
+    conversation_ref = (
+        db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
+    )
+    retry_ref = conversation_ref.collection(conversation_processing_retries_collection).document(request_id)
+    return _record_conversation_processing_retry_generic_vector(
+        db.transaction(),
+        conversation_ref,
+        retry_ref,
+        request_id,
+        status,
+        updated_at or datetime.now(timezone.utc),
+        attempt_count,
+    )
 
 
 @transactional
@@ -1033,6 +1410,7 @@ def _record_conversation_processing_retry_summary_applied(
     request_id: str,
     summary_version_id: str,
     applied_at: datetime,
+    attempt_count: Optional[int],
 ):
     return _record_conversation_processing_retry_summary_applied_transaction(
         transaction,
@@ -1041,6 +1419,7 @@ def _record_conversation_processing_retry_summary_applied(
         request_id,
         summary_version_id,
         applied_at,
+        attempt_count,
     )
 
 
@@ -1050,6 +1429,7 @@ def record_conversation_processing_retry_summary_applied(
     request_id: str,
     summary_version_id: str,
     applied_at: Optional[datetime] = None,
+    attempt_count: Optional[int] = None,
 ):
     conversation_ref = (
         db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
@@ -1063,6 +1443,7 @@ def record_conversation_processing_retry_summary_applied(
         request_id,
         summary_version_id,
         applied_at or datetime.now(timezone.utc),
+        attempt_count,
     )
 
 
@@ -1074,6 +1455,8 @@ def _finish_conversation_processing_retry_transaction(
     outcome: str,
     finished_at: datetime,
     error_code: Optional[str],
+    preserve_completed_summary: bool = False,
+    attempt_count: Optional[int] = None,
 ):
     conversation_snapshot = conversation_ref.get(transaction=transaction)
     retry_snapshot = retry_ref.get(transaction=transaction)
@@ -1083,8 +1466,14 @@ def _finish_conversation_processing_retry_transaction(
     retry_data = retry_snapshot.to_dict()
     if retry_data.get('request_id') != request_id:
         return False
+    if attempt_count is not None and retry_data.get('attempt_count') != attempt_count:
+        return False
 
-    retry_update = {'outcome': outcome, 'updated_at': finished_at}
+    retry_update = {
+        'outcome': outcome,
+        'phase': 'completed' if outcome == ConversationStatus.completed.value else 'failed',
+        'updated_at': finished_at,
+    }
     if error_code:
         retry_update['error_code'] = error_code
     transaction.update(retry_ref, retry_update)
@@ -1100,6 +1489,15 @@ def _finish_conversation_processing_retry_transaction(
                 'discarded': False,
                 'processing_error': None,
                 'processing_error_at': None,
+                'processing_retry_completed_at': finished_at,
+            },
+        )
+    elif preserve_completed_summary:
+        transaction.update(
+            conversation_ref,
+            {
+                'status': ConversationStatus.completed.value,
+                'discarded': False,
                 'processing_retry_completed_at': finished_at,
             },
         )
@@ -1125,6 +1523,8 @@ def _finish_conversation_processing_retry(
     outcome: str,
     finished_at: datetime,
     error_code: Optional[str],
+    preserve_completed_summary: bool,
+    attempt_count: Optional[int],
 ):
     return _finish_conversation_processing_retry_transaction(
         transaction,
@@ -1134,6 +1534,8 @@ def _finish_conversation_processing_retry(
         outcome,
         finished_at,
         error_code,
+        preserve_completed_summary,
+        attempt_count,
     )
 
 
@@ -1144,6 +1546,8 @@ def finish_conversation_processing_retry(
     outcome: str,
     finished_at: Optional[datetime] = None,
     error_code: Optional[str] = None,
+    preserve_completed_summary: bool = False,
+    attempt_count: Optional[int] = None,
 ):
     if outcome not in {ConversationStatus.completed.value, ConversationStatus.failed.value}:
         raise ValueError(f'Unsupported conversation processing retry outcome: {outcome}')
@@ -1161,6 +1565,8 @@ def finish_conversation_processing_retry(
         outcome,
         finished_at or datetime.now(timezone.utc),
         error_code,
+        preserve_completed_summary,
+        attempt_count,
     )
 
 
@@ -1173,6 +1579,8 @@ def _record_conversation_processing_retry_enrichment_transaction(
     status: str,
     updated_at: datetime,
     summary_version_id: Optional[str],
+    vector_content_sha256: Optional[str] = None,
+    attempt_count: Optional[int] = None,
 ):
     conversation_snapshot = conversation_ref.get(transaction=transaction)
     retry_snapshot = retry_ref.get(transaction=transaction)
@@ -1183,26 +1591,111 @@ def _record_conversation_processing_retry_enrichment_transaction(
     retry_data = retry_snapshot.to_dict()
     if retry_data.get('request_id') != request_id:
         return False
+    if attempt_count is not None and retry_data.get('attempt_count') != attempt_count:
+        return False
+    if (
+        summary_version_id
+        and status in {'canonical_completed', 'completed', 'vector_failed'}
+        and str(conversation.get('active_summary_version_id') or '') != str(summary_version_id)
+    ):
+        return False
 
-    retry_update = {
-        'enrichment_status': status,
-        'updated_at': updated_at,
-    }
+    if status == 'canonical_completed':
+        retry_update = {
+            'enrichment_status': 'canonical_completed',
+            'vector_status': 'pending',
+            'outcome': ConversationStatus.processing.value,
+            'phase': 'enrichment_canonical_completed',
+            'updated_at': updated_at,
+        }
+    elif status == 'completed':
+        retry_update = {
+            'enrichment_status': 'completed',
+            'vector_status': 'completed',
+            'outcome': ConversationStatus.completed.value,
+            'phase': 'completed',
+            'updated_at': updated_at,
+        }
+    elif status == 'canonical_failed':
+        retry_update = {
+            'enrichment_status': 'writeback_pending_canonical',
+            'vector_status': 'pending',
+            'outcome': ConversationStatus.failed.value,
+            'phase': 'enrichment_canonical_failed',
+            'updated_at': updated_at,
+        }
+    elif status == 'vector_failed':
+        retry_update = {
+            'enrichment_status': 'canonical_completed',
+            'vector_status': 'failed',
+            'outcome': ConversationStatus.failed.value,
+            'phase': 'enrichment_vector_failed',
+            'updated_at': updated_at,
+        }
+    else:
+        retry_update = {
+            'enrichment_status': 'failed',
+            'outcome': ConversationStatus.failed.value,
+            'phase': 'enrichment_failed',
+            'updated_at': updated_at,
+        }
     if summary_version_id:
         retry_update['enriched_summary_version_id'] = summary_version_id
+    if status in {'completed', 'vector_failed'} and summary_version_id:
+        retry_update['vector_summary_version_id'] = summary_version_id
+    if status in {'completed', 'vector_failed'} and vector_content_sha256:
+        retry_update['vector_content_sha256'] = vector_content_sha256
     transaction.update(retry_ref, retry_update)
 
     if conversation.get('processing_retry_id') != request_id:
         return True
-    if status == 'completed' and summary_version_id:
+    if status == 'canonical_completed' and summary_version_id:
         transaction.update(
             conversation_ref,
-            {'processing_retry_enriched_version_id': summary_version_id},
+            {
+                'status': ConversationStatus.completed.value,
+                'processing_retry_enriched_version_id': summary_version_id,
+                'processing_retry_enrichment_vector_status': 'pending',
+            },
+        )
+    elif status == 'completed' and summary_version_id:
+        transaction.update(
+            conversation_ref,
+            {
+                'status': ConversationStatus.completed.value,
+                'processing_retry_enriched_version_id': summary_version_id,
+                'processing_retry_enrichment_vector_status': 'completed',
+                'processing_retry_enrichment_vector_version_id': summary_version_id,
+                'processing_retry_enrichment_vector_sha256': vector_content_sha256,
+                'processing_retry_completed_at': updated_at,
+            },
+        )
+    elif status == 'canonical_failed':
+        transaction.update(
+            conversation_ref,
+            {
+                'status': ConversationStatus.completed.value,
+                'processing_retry_enrichment_vector_status': 'pending',
+                'processing_retry_completed_at': updated_at,
+            },
+        )
+    elif status == 'vector_failed':
+        transaction.update(
+            conversation_ref,
+            {
+                'status': ConversationStatus.completed.value,
+                'processing_retry_enrichment_vector_status': 'failed',
+                'processing_retry_enrichment_vector_version_id': summary_version_id,
+                'processing_retry_enrichment_vector_sha256': vector_content_sha256,
+                'processing_retry_completed_at': updated_at,
+            },
         )
     elif status == 'failed':
         transaction.update(
             conversation_ref,
             {
+                'status': ConversationStatus.completed.value,
+                'processing_retry_completed_at': updated_at,
                 'enrichment_state': {
                     'status': 'failed',
                     'pending': True,
@@ -1211,7 +1704,7 @@ def _record_conversation_processing_retry_enrichment_transaction(
                     'trace_id': f'summary-retry:{conversation_id}:{request_id}:hermes',
                     'updated_at': updated_at,
                     'error': 'hermes_temporarily_unavailable',
-                }
+                },
             },
         )
     return True
@@ -1227,6 +1720,8 @@ def _record_conversation_processing_retry_enrichment(
     status: str,
     updated_at: datetime,
     summary_version_id: Optional[str],
+    vector_content_sha256: Optional[str],
+    attempt_count: Optional[int],
 ):
     return _record_conversation_processing_retry_enrichment_transaction(
         transaction,
@@ -1237,6 +1732,8 @@ def _record_conversation_processing_retry_enrichment(
         status,
         updated_at,
         summary_version_id,
+        vector_content_sha256,
+        attempt_count,
     )
 
 
@@ -1247,8 +1744,10 @@ def record_conversation_processing_retry_enrichment(
     status: str,
     summary_version_id: Optional[str] = None,
     updated_at: Optional[datetime] = None,
+    vector_content_sha256: Optional[str] = None,
+    attempt_count: Optional[int] = None,
 ):
-    if status not in {'completed', 'failed'}:
+    if status not in {'canonical_completed', 'canonical_failed', 'completed', 'vector_failed', 'failed'}:
         raise ValueError(f'Unsupported conversation processing retry enrichment status: {status}')
     conversation_ref = (
         db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
@@ -1264,6 +1763,8 @@ def record_conversation_processing_retry_enrichment(
         status,
         updated_at or datetime.now(timezone.utc),
         summary_version_id,
+        vector_content_sha256,
+        attempt_count,
     )
 
 

--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -162,6 +162,32 @@ def fetch_existing_conversation_vector_ids(uid: str, conversation_ids: List[str]
         raise
 
 
+def fetch_conversation_vector_metadata(uid: str, conversation_id: str) -> Optional[dict]:
+    """Return metadata for one conversation vector, or None when it is absent."""
+    if index is None:
+        return None
+    vector_id = build_conversation_vector_id(uid, conversation_id)
+    try:
+        fetched = index.fetch(ids=[vector_id], namespace=CONVERSATIONS_NAMESPACE)
+        vectors = getattr(fetched, 'vectors', None)
+        if vectors is None and isinstance(fetched, dict):
+            vectors = fetched.get('vectors') or {}
+        vector = (vectors or {}).get(vector_id)
+        if vector is None:
+            return None
+        metadata = getattr(vector, 'metadata', None)
+        if metadata is None and isinstance(vector, dict):
+            metadata = vector.get('metadata')
+        return dict(metadata or {})
+    except Exception:
+        logger.exception(
+            'conversation_vector_metadata_fetch_failed uid=%s conversation_id=%s',
+            uid,
+            conversation_id,
+        )
+        raise
+
+
 def query_vectors_by_metadata(
     uid: str,
     vector: List[float],

--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -43,11 +43,14 @@ import database.memories as memories_db
 import database.users as users_db
 from database._client import db
 from models.conversation import CategoryEnum
-
-
 from database.ella_contacts import create_contact, delete_contact, get_contact, get_contacts, update_contact
 from ella.config import ELLA_CONFIG
-from ella.services.summary_sanitizer import SummarySanitizationError, sanitize_summary_update
+from ella.services.summary_sanitizer import SummarySanitizationError
+from ella.services.summary_writeback import (
+    ConversationSummaryNotFoundError,
+    InvalidConversationSummaryCategoryError,
+    write_conversation_summary,
+)
 from utils.notifications import send_notification
 from utils.ella.canonical_omi import write_omi_canonical_event
 from utils.other.storage import storage_client
@@ -151,14 +154,14 @@ def _upload_audio_to_gcs(audio_bytes: bytes, uid: str) -> Optional[str]:
         return None
 
 
-
-
 # ============================================================================
 # Conversation Summary Update (for n8n pipeline write-back)
 # ============================================================================
 
+
 class ConversationSummaryUpdate(BaseModel):
     """Schema for updating conversation structured summary fields."""
+
     title: Optional[str] = None
     overview: Optional[str] = None
     emoji: Optional[str] = None
@@ -205,18 +208,6 @@ def _enrichment_candidate_reason(conversation: dict) -> Optional[str]:
     if source == "observer" and kind in {"observer_enriched", "corrected_enriched"}:
         return None
     return "active_summary_not_enriched"
-
-
-def _normalize_ella_tags(tags: List[str]) -> List[str]:
-    """Normalize bounded conversation tags for app filtering and recall ranking."""
-    normalized: list[str] = []
-    for tag in tags or []:
-        clean = str(tag).strip().lower().replace(" ", "_")
-        if not clean or len(clean) > 64:
-            continue
-        if clean not in normalized:
-            normalized.append(clean)
-    return normalized[:12]
 
 
 def _update_correction_audit(
@@ -310,6 +301,8 @@ async def _fetch_internal_assessment(uid: str, conversation_id: str) -> Optional
         )
         logger.warning(str(e))
         return None
+
+
 @router.patch("/conversation/{conversation_id}/summary")
 async def update_conversation_summary(
     conversation_id: str,
@@ -324,170 +317,40 @@ async def update_conversation_summary(
     if not uid:
         raise HTTPException(status_code=400, detail="uid query parameter required")
 
-    conversation = conversations_db.get_conversation(uid, conversation_id)
-    if conversation is None:
-        raise HTTPException(status_code=404, detail="Conversation not found")
-
     try:
-        sanitized_update = sanitize_summary_update(
+        return await write_conversation_summary(
+            uid=uid,
+            conversation_id=conversation_id,
             title=update.title,
             overview=update.overview,
             emoji=update.emoji,
             category=update.category,
+            summary_source=update.summary_source,
+            summary_kind=update.summary_kind,
+            correction_id=update.correction_id,
+            based_on_version_id=update.based_on_version_id,
+            set_active=update.set_active,
+            trace_id=update.trace_id,
+            ella_tags=update.ella_tags,
+            ella_signal=update.ella_signal,
+            internal_assessment_fetcher=_fetch_internal_assessment,
+            correction_audit_updater=_update_correction_audit,
+            canonical_writer=write_omi_canonical_event,
         )
     except SummarySanitizationError as e:
         raise HTTPException(
             status_code=422,
             detail={"message": "Unsafe conversation summary", "violations": e.violations},
         )
-
-    # Build Firestore dot-notation update dict
-    update_data = {}
-    if sanitized_update.title is not None:
-        update_data["structured.title"] = sanitized_update.title
-    if sanitized_update.overview is not None:
-        update_data["structured.overview"] = sanitized_update.overview
-    if sanitized_update.emoji is not None:
-        update_data["structured.emoji"] = sanitized_update.emoji
-    if sanitized_update.category is not None:
-        try:
-            CategoryEnum(sanitized_update.category)
-        except ValueError:
-            raise HTTPException(status_code=400, detail=f"Invalid category: '{sanitized_update.category}'")
-        update_data["structured.category"] = sanitized_update.category
-
-    # Keep this internal callback in parity with the MCP tool path so the app
-    # will surface the refreshed structured overview instead of stale app output.
-    if update.overview is not None:
-        update_data["apps_results"] = []
-        update_data["plugins_results"] = []
-
-    if not update_data:
-        raise HTTPException(status_code=400, detail="No fields to update")
-
-    structured = dict((conversation.get("structured") or {}))
-    if sanitized_update.title is not None:
-        structured["title"] = sanitized_update.title
-    if sanitized_update.overview is not None:
-        structured["overview"] = sanitized_update.overview
-    if sanitized_update.emoji is not None:
-        structured["emoji"] = sanitized_update.emoji
-    if sanitized_update.category is not None:
-        structured["category"] = sanitized_update.category
-
-    version_update = conversations_db.build_summary_version_update(
-        conversation,
-        next_structured=structured,
-        source=update.summary_source,
-        kind=update.summary_kind,
-        correction_id=update.correction_id,
-        based_on_version_id=update.based_on_version_id,
-        activate=update.set_active,
-    )
-    state_updated_at = datetime.now(timezone.utc)
-    update_data["summary_versions"] = version_update["summary_versions"]
-    update_data["active_summary_version_id"] = version_update["active_summary_version_id"]
-    update_data["enrichment_state"] = {
-        "status": "writeback_applied",
-        "pending": False,
-        "source": update.summary_source,
-        "kind": update.summary_kind,
-        "trace_id": update.trace_id,
-        "updated_at": state_updated_at,
-        "error": None,
-    }
-    internal_assessment = await _fetch_internal_assessment(uid, conversation_id)
-    if internal_assessment:
-        update_data["internal_assessment"] = internal_assessment
-    ella_tags = _normalize_ella_tags(update.ella_tags)
-    if ella_tags:
-        update_data["ella_tags"] = ella_tags
-    if update.ella_signal is not None:
-        update_data["ella_signal"] = update.ella_signal
-    if update.correction_id:
-        existing_state = conversation.get("correction_state") or {}
-        update_data["correction_state"] = {
-            "correction_id": update.correction_id,
-            "status": "applied",
-            "pending": False,
-            "source": existing_state.get("source"),
-            "submitted_at": existing_state.get("submitted_at"),
-            "updated_at": state_updated_at,
-            "active_summary_version_id": version_update["active_summary_version_id"],
-        }
-
-    try:
-        conversations_db.update_conversation(uid, conversation_id, update_data)
+    except ConversationSummaryNotFoundError:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    except InvalidConversationSummaryCategoryError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid category: '{e.args[0]}'")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logging.error(f"Failed to update conversation summary: {e}")
         raise HTTPException(status_code=500, detail=str(e))
-
-    canonical_base = dict(conversation) if isinstance(conversation, dict) else {}
-    canonical_conversation = {
-        **canonical_base,
-        "id": conversation_id,
-        "structured": structured,
-        "summary_versions": version_update["summary_versions"],
-        "active_summary_version_id": version_update["active_summary_version_id"],
-        "enrichment_state": update_data.get("enrichment_state"),
-        "internal_assessment": update_data.get("internal_assessment", canonical_base.get("internal_assessment")),
-        "ella_tags": update_data.get("ella_tags", canonical_base.get("ella_tags") or []),
-        "ella_signal": update_data.get("ella_signal", canonical_base.get("ella_signal")),
-    }
-    try:
-        canonical_result = await asyncio.to_thread(
-            write_omi_canonical_event,
-            uid,
-            canonical_conversation,
-            summary_source=update.summary_source,
-            summary_kind=update.summary_kind,
-            trace_id=update.trace_id,
-        )
-        logger.info(
-            "Wrote OMI summary to canonical ledger",
-            extra={
-                "uid": uid,
-                "conversation_id": conversation_id,
-                "inserted": canonical_result.get("inserted"),
-                "duplicates": canonical_result.get("duplicates"),
-            },
-        )
-    except Exception as e:
-        logger.warning(
-            "Failed to write OMI summary to canonical ledger",
-            extra={"uid": uid, "conversation_id": conversation_id},
-        )
-        logger.warning(str(e))
-
-    if update.correction_id:
-        try:
-            _update_correction_audit(
-                uid,
-                conversation_id,
-                update.correction_id,
-                {
-                    "status": "applied",
-                    "updated_at": datetime.now(timezone.utc).isoformat(),
-                    "applied_at": datetime.now(timezone.utc).isoformat(),
-                    "applied_summary_version_id": version_update["active_summary_version_id"],
-                    "summary_version_kind": update.summary_kind,
-                    "summary_version_source": update.summary_source,
-                },
-            )
-        except Exception as e:
-            logger.warning(
-                "Failed to update correction audit after summary apply",
-                extra={"uid": uid, "conversation_id": conversation_id, "correction_id": update.correction_id},
-            )
-            logger.warning(str(e))
-
-    return {
-        "status": "ok",
-        "conversation_id": conversation_id,
-        "updated_fields": list(update_data.keys()),
-        "active_summary_version_id": version_update["active_summary_version_id"],
-        "sanitizer_warnings": sanitized_update.warnings,
-    }
 
 
 @router.get("/conversations/enrichment/reconcile-candidates")

--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -172,6 +172,7 @@ class ConversationSummaryUpdate(BaseModel):
     based_on_version_id: Optional[str] = None
     set_active: bool = True
     trace_id: Optional[str] = None
+    require_canonical: bool = False
     ella_tags: List[str] = Field(default_factory=list)
     ella_signal: Optional[Dict[str, Any]] = None
 
@@ -336,6 +337,7 @@ async def update_conversation_summary(
             internal_assessment_fetcher=_fetch_internal_assessment,
             correction_audit_updater=_update_correction_audit,
             canonical_writer=write_omi_canonical_event,
+            require_canonical=update.require_canonical,
         )
     except SummarySanitizationError as e:
         raise HTTPException(

--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -9,9 +9,9 @@ carry this custom app contract as a core patch.
 import json
 import logging
 import os
-import re
 import uuid
 from datetime import datetime, timezone
+from enum import Enum
 from typing import Any, Optional
 
 import httpx
@@ -24,7 +24,16 @@ from ella.config import ELLA_CONFIG
 from ella.routers.canonical_events import CanonicalEventIn, PostgresCanonicalEventStore
 from ella.services.correction_propagation import propagation_run_to_dict, run_correction_propagation
 from ella.services.hermes_session import canonical_omi_session_key, safe_session_component
+from ella.services.summary_recovery import (
+    SummaryProviderConfig,
+    apply_summary_update,
+    extract_json_object,
+    generate_summary_from_prompt,
+    normalize_summary,
+    recover_failed_conversation_summary,
+)
 from ella.services import proposal_ingest
+from models.conversation import Conversation
 from utils.other import endpoints as auth
 
 logger = logging.getLogger(__name__)
@@ -52,7 +61,6 @@ HERMES_CORRECTION_MODEL = os.getenv(
 )
 DIRECT_CORRECTION_API_URL = os.getenv("ELLA_CORRECTION_API_URL", "https://api.x.ai/v1/chat/completions")
 DIRECT_CORRECTION_MODEL = os.getenv("ELLA_CORRECTION_MODEL", "grok-4.3")
-DIRECT_CORRECTION_INTERNAL_BASE_URL = os.getenv("ELLA_INTERNAL_BASE_URL", "http://127.0.0.1:8000")
 DIRECT_CORRECTION_TIMEOUT_SECONDS = float(os.getenv("ELLA_CORRECTION_TIMEOUT_SECONDS", "45"))
 N8N_CORRECTION_FALLBACK_ENABLED = os.getenv("ELLA_CORRECTION_N8N_FALLBACK_ENABLED", "false").lower() in {
     "1",
@@ -79,7 +87,6 @@ CORRECTION_OBSERVER_WORK_INLINE_WITHOUT_BACKGROUND = os.getenv(
     "false",
     "no",
 }
-JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
 _canonical_event_store = PostgresCanonicalEventStore()
 
 
@@ -116,6 +123,27 @@ class ConversationCorrectionResponse(BaseModel):
     status: str
     queued: bool
     proposal_id: Optional[str] = None
+
+
+class ConversationProcessingRetryOutcome(str, Enum):
+    processing = "processing"
+    completed = "completed"
+    failed = "failed"
+
+
+class RetryConversationProcessingRequest(BaseModel):
+    request_id: uuid.UUID
+    correction_text: Optional[str] = Field(
+        default=None,
+        max_length=4000,
+        validation_alias=AliasChoices("correction_text", "context"),
+        serialization_alias="correction_text",
+    )
+
+
+class RetryConversationProcessingResponse(BaseModel):
+    outcome: ConversationProcessingRetryOutcome
+    conversation: Conversation
 
 
 def _now_iso() -> str:
@@ -174,16 +202,7 @@ def _compact_text(value: str, limit: int) -> str:
 
 
 def _extract_json_object(content: str) -> dict[str, Any]:
-    try:
-        parsed = json.loads(content)
-    except json.JSONDecodeError:
-        match = JSON_OBJECT_RE.search(content)
-        if not match:
-            raise
-        parsed = json.loads(match.group(0))
-    if not isinstance(parsed, dict):
-        raise ValueError("Correction model response was not a JSON object")
-    return parsed
+    return extract_json_object(content)
 
 
 def _legacy_correction_api_key() -> str:
@@ -276,43 +295,7 @@ Return exactly:
 
 
 def _normalize_direct_summary(result: dict[str, Any], fallback: dict[str, Any]) -> dict[str, Any]:
-    title = str(result.get("title") or fallback.get("title") or "Corrected Conversation").strip()
-    overview = str(result.get("overview") or fallback.get("overview") or "").strip()
-    if not overview:
-        raise ValueError("Correction model response missing overview")
-    if not overview.startswith("[Ella] "):
-        overview = "[Ella] " + overview.removeprefix("[Ella]").strip()
-
-    emoji = str(result.get("emoji") or fallback.get("emoji") or "🪽").strip()[:4] or "🪽"
-    category = str(result.get("category") or fallback.get("category") or "other").strip().lower()
-    tags = result.get("ella_tags")
-    if not isinstance(tags, list):
-        tags = ["omi"]
-    tags = [str(tag).strip().lower() for tag in tags if str(tag or "").strip()]
-    if "omi" not in tags:
-        tags.insert(0, "omi")
-    if "correction" not in tags:
-        tags.append("correction")
-
-    signal = result.get("ella_signal")
-    if not isinstance(signal, dict):
-        signal = {}
-
-    return {
-        "title": title,
-        "overview": overview,
-        "emoji": emoji,
-        "category": category,
-        "ella_tags": tags[:12],
-        "ella_signal": {
-            "salience": str(signal.get("salience") or "medium"),
-            "memory_promotion": str(signal.get("memory_promotion") or "none"),
-            "noise_level": str(signal.get("noise_level") or "low"),
-            "contains_media": bool(signal.get("contains_media", False)),
-            "contains_user_speech": bool(signal.get("contains_user_speech", True)),
-            "guardian_relevant": bool(signal.get("guardian_relevant", False)),
-        },
-    }
+    return normalize_summary(result, fallback, required_tags=("omi", "correction"))
 
 
 async def _generate_corrected_summary(
@@ -332,52 +315,25 @@ async def _generate_corrected_summary(
         transcript=transcript,
         segment_count=segment_count,
     )
-    provider = CORRECTION_PROVIDER
-    if provider == "hermes-api":
-        api_key = _hermes_correction_api_key()
-        if not api_key:
-            raise RuntimeError("No Hermes correction API key configured")
-        headers = {
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-            "X-Hermes-Session-Id": _correction_session_id(uid, conversation_id, correction_id),
-            "X-Hermes-Session-Key": _correction_session_key(uid),
-            "X-Trace-Id": trace_id,
-        }
-        async with httpx.AsyncClient(timeout=DIRECT_CORRECTION_TIMEOUT_SECONDS) as client:
-            response = await client.post(
-                HERMES_CORRECTION_API_URL,
-                headers=headers,
-                json={
-                    "model": HERMES_CORRECTION_MODEL,
-                    "messages": [{"role": "user", "content": prompt}],
-                    "temperature": 0.1,
-                    "max_tokens": 900,
-                },
-            )
-        response.raise_for_status()
-        body = response.json()
-        content = body["choices"][0]["message"]["content"]
-        return _normalize_direct_summary(_extract_json_object(content), structured)
-
-    api_key = _legacy_correction_api_key()
-    if not api_key:
-        raise RuntimeError("No legacy correction model API key configured")
-    async with httpx.AsyncClient(timeout=DIRECT_CORRECTION_TIMEOUT_SECONDS) as client:
-        response = await client.post(
-            DIRECT_CORRECTION_API_URL,
-            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-            json={
-                "model": DIRECT_CORRECTION_MODEL,
-                "messages": [{"role": "user", "content": prompt}],
-                "temperature": 0.1,
-                "max_tokens": 800,
-            },
-        )
-    response.raise_for_status()
-    body = response.json()
-    content = body["choices"][0]["message"]["content"]
-    return _normalize_direct_summary(_extract_json_object(content), structured)
+    return await generate_summary_from_prompt(
+        prompt=prompt,
+        fallback=structured,
+        session_id=_correction_session_id(uid, conversation_id, correction_id),
+        session_key=_correction_session_key(uid),
+        trace_id=trace_id,
+        required_tags=("omi", "correction"),
+        config=SummaryProviderConfig(
+            provider=CORRECTION_PROVIDER,
+            hermes_url=HERMES_CORRECTION_API_URL,
+            hermes_model=HERMES_CORRECTION_MODEL,
+            hermes_api_key=_hermes_correction_api_key(),
+            legacy_url=DIRECT_CORRECTION_API_URL,
+            legacy_model=DIRECT_CORRECTION_MODEL,
+            legacy_api_key=_legacy_correction_api_key(),
+            timeout_seconds=DIRECT_CORRECTION_TIMEOUT_SECONDS,
+        ),
+        async_client_factory=httpx.AsyncClient,
+    )
 
 
 async def _apply_corrected_summary(
@@ -389,28 +345,15 @@ async def _apply_corrected_summary(
     active_summary_version_id: Optional[str],
     corrected: dict[str, Any],
 ) -> dict[str, Any]:
-    url = (
-        f"{DIRECT_CORRECTION_INTERNAL_BASE_URL.rstrip('/')}"
-        f"/v1/ella/conversation/{conversation_id}/summary?uid={uid}"
+    return await apply_summary_update(
+        uid=uid,
+        conversation_id=conversation_id,
+        trace_id=trace_id,
+        active_summary_version_id=active_summary_version_id,
+        summary=corrected,
+        summary_kind="corrected_enriched",
+        correction_id=correction_id,
     )
-    payload = {
-        "title": corrected["title"],
-        "overview": corrected["overview"],
-        "emoji": corrected["emoji"],
-        "category": corrected["category"],
-        "summary_source": "observer",
-        "summary_kind": "corrected_enriched",
-        "correction_id": correction_id,
-        "based_on_version_id": active_summary_version_id,
-        "set_active": True,
-        "trace_id": trace_id,
-        "ella_tags": corrected.get("ella_tags") or ["omi", "correction"],
-        "ella_signal": corrected.get("ella_signal") or {},
-    }
-    async with httpx.AsyncClient(timeout=20.0) as client:
-        response = await client.patch(url, json=payload)
-    response.raise_for_status()
-    return response.json()
 
 
 def _audit_ref(uid: str, conversation_id: str, correction_id: str):
@@ -1268,6 +1211,51 @@ async def _submit_conversation_correction(
         queued=True,
         proposal_id=proposal_id,
     )
+
+
+@router.post(
+    "/v1/conversations/{conversation_id}/processing-retries",
+    response_model=RetryConversationProcessingResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def retry_failed_conversation_processing(
+    conversation_id: str,
+    request: RetryConversationProcessingRequest,
+    background_tasks: BackgroundTasks,
+    uid: str = Depends(auth.get_current_user_uid),
+) -> RetryConversationProcessingResponse:
+    """Atomically queue generic recovery followed by canonical Hermes enrichment."""
+
+    request_id = str(request.request_id)
+    claim = conversations_db.claim_conversation_processing_retry(uid, conversation_id, request_id)
+    outcome = claim["outcome"]
+    conversation_data = claim["conversation"]
+
+    if outcome == "not_found":
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    if outcome == "locked":
+        raise HTTPException(status_code=402, detail="Conversation locked")
+    if outcome == "not_retryable":
+        raise HTTPException(status_code=409, detail="Conversation processing cannot be retried safely")
+    if outcome == "invalid_state":
+        raise HTTPException(status_code=409, detail="Conversation is not in a retryable state")
+    if outcome == "busy":
+        raise HTTPException(status_code=409, detail="Another conversation processing retry is already active")
+
+    conversation = Conversation(**conversation_data)
+    if outcome == "claimed":
+        background_tasks.add_task(
+            recover_failed_conversation_summary,
+            uid=uid,
+            conversation_id=conversation_id,
+            request_id=request_id,
+            client_context=request.correction_text,
+        )
+        outcome = ConversationProcessingRetryOutcome.processing
+    else:
+        outcome = ConversationProcessingRetryOutcome(outcome)
+
+    return RetryConversationProcessingResponse(outcome=outcome, conversation=conversation)
 
 
 @router.post(

--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -27,13 +27,14 @@ from ella.services.hermes_session import canonical_omi_session_key, safe_session
 from ella.services.summary_recovery import (
     SummaryProviderConfig,
     apply_summary_update,
+    build_conversation_processing_retry_plan,
     extract_json_object,
     generate_summary_from_prompt,
     normalize_summary,
     recover_failed_conversation_summary,
 )
 from ella.services import proposal_ingest
-from models.conversation import Conversation
+from models.conversation import Conversation, ConversationStatus
 from utils.other import endpoints as auth
 
 logger = logging.getLogger(__name__)
@@ -131,6 +132,12 @@ class ConversationProcessingRetryOutcome(str, Enum):
     failed = "failed"
 
 
+class ConversationProcessingRecoveryMode(str, Enum):
+    none = "none"
+    full = "full"
+    enrichment_only = "enrichment_only"
+
+
 class RetryConversationProcessingRequest(BaseModel):
     request_id: uuid.UUID
     correction_text: Optional[str] = Field(
@@ -143,7 +150,44 @@ class RetryConversationProcessingRequest(BaseModel):
 
 class RetryConversationProcessingResponse(BaseModel):
     outcome: ConversationProcessingRetryOutcome
+    recovery_mode: ConversationProcessingRecoveryMode = ConversationProcessingRecoveryMode.none
+    phase: Optional[str] = None
+    generic_status: Optional[str] = None
+    generic_vector_status: Optional[str] = None
+    enrichment_status: Optional[str] = None
+    vector_status: Optional[str] = None
+    lease_expires_at: Optional[datetime] = None
+    attempt_count: int = 0
     conversation: Conversation
+
+
+class ConversationProcessingRetryPlan(BaseModel):
+    conversation_id: str
+    status: str
+    discarded: bool
+    processing_error: Optional[str] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    transcript_segment_count: int
+    transcript_character_count: int
+    transcript_sha256: str
+    structured_summary_present: bool
+    active_summary_version_id: Optional[str] = None
+    active_summary_source: Optional[str] = None
+    active_summary_kind: Optional[str] = None
+    enriched_summary_present: bool
+    canonical_provenance_confirmed: bool
+    vector_present: bool
+    vector_active_summary_version_id: Optional[str] = None
+    vector_content_sha256: Optional[str] = None
+    vector_matches_active_summary: bool
+    recovery_mode: ConversationProcessingRecoveryMode
+    retryable: bool
+    reason: str
+    profile_scope_sha256: str
+    canonical_session_scope_sha256: str
+    provider_path: list[str]
+    zero_writes: bool
 
 
 def _now_iso() -> str:
@@ -1213,6 +1257,20 @@ async def _submit_conversation_correction(
     )
 
 
+@router.get(
+    "/v1/conversations/{conversation_id}/processing-retry-plan",
+    response_model=ConversationProcessingRetryPlan,
+)
+def get_conversation_processing_retry_plan(
+    conversation_id: str,
+    uid: str = Depends(auth.get_current_user_uid),
+) -> ConversationProcessingRetryPlan:
+    plan = build_conversation_processing_retry_plan(uid, conversation_id)
+    if plan is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return ConversationProcessingRetryPlan(**plan)
+
+
 @router.post(
     "/v1/conversations/{conversation_id}/processing-retries",
     response_model=RetryConversationProcessingResponse,
@@ -1229,8 +1287,6 @@ def retry_failed_conversation_processing(
     request_id = str(request.request_id)
     claim = conversations_db.claim_conversation_processing_retry(uid, conversation_id, request_id)
     outcome = claim["outcome"]
-    conversation_data = claim["conversation"]
-
     if outcome == "not_found":
         raise HTTPException(status_code=404, detail="Conversation not found")
     if outcome == "locked":
@@ -1242,7 +1298,26 @@ def retry_failed_conversation_processing(
     if outcome == "busy":
         raise HTTPException(status_code=409, detail="Another conversation processing retry is already active")
 
-    conversation = Conversation(**conversation_data)
+    conversation_data = conversations_db.get_conversation(uid, conversation_id)
+    if conversation_data is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    try:
+        conversation = Conversation(**conversation_data)
+    except Exception as error:
+        logger.exception(
+            "Failed to decode claimed conversation processing retry",
+            extra={"uid": uid, "conversation_id": conversation_id, "request_id": request_id},
+        )
+        if outcome == "claimed":
+            conversations_db.finish_conversation_processing_retry(
+                uid,
+                conversation_id,
+                request_id,
+                ConversationStatus.failed.value,
+                error_code="conversation_transcript_decode_failed",
+                attempt_count=claim.get("attempt_count") or 1,
+            )
+        raise HTTPException(status_code=500, detail="Conversation could not be loaded safely") from error
     if outcome == "claimed":
         background_tasks.add_task(
             recover_failed_conversation_summary,
@@ -1250,12 +1325,24 @@ def retry_failed_conversation_processing(
             conversation_id=conversation_id,
             request_id=request_id,
             client_context=request.correction_text,
+            attempt_count=claim.get("attempt_count") or 1,
         )
         outcome = ConversationProcessingRetryOutcome.processing
     else:
         outcome = ConversationProcessingRetryOutcome(outcome)
 
-    return RetryConversationProcessingResponse(outcome=outcome, conversation=conversation)
+    return RetryConversationProcessingResponse(
+        outcome=outcome,
+        recovery_mode=ConversationProcessingRecoveryMode(claim.get("mode") or "none"),
+        phase=claim.get("phase"),
+        generic_status=claim.get("generic_status"),
+        generic_vector_status=claim.get("generic_vector_status"),
+        enrichment_status=claim.get("enrichment_status"),
+        vector_status=claim.get("vector_status"),
+        lease_expires_at=claim.get("lease_expires_at"),
+        attempt_count=claim.get("attempt_count") or 0,
+        conversation=conversation,
+    )
 
 
 @router.post(

--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -172,6 +172,7 @@ class ConversationProcessingRetryPlan(BaseModel):
     transcript_character_count: int
     transcript_sha256: str
     structured_summary_present: bool
+    structured_summary_sha256: Optional[str] = None
     active_summary_version_id: Optional[str] = None
     active_summary_source: Optional[str] = None
     active_summary_kind: Optional[str] = None

--- a/backend/ella/services/summary_recovery.py
+++ b/backend/ella/services/summary_recovery.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
 SUMMARY_RECOVERY_FAILED = 'conversation_summary_recovery_failed'
+LEGACY_GENERIC_SUMMARY_BASELINE = 'legacy-unversioned-summary'
 
 
 def _transcript_metadata(conversation: dict[str, Any]) -> tuple[int, int]:
@@ -95,6 +96,11 @@ def build_conversation_processing_retry_plan(uid: str, conversation_id: str) -> 
         'transcript_character_count': transcript_character_count,
         'transcript_sha256': transcript_sha256,
         'structured_summary_present': conversations_db.has_usable_conversation_summary(conversation),
+        'structured_summary_sha256': (
+            _summary_content_sha256(conversation)
+            if conversations_db.has_usable_conversation_summary(conversation)
+            else None
+        ),
         'active_summary_version_id': active_summary_version_id,
         'active_summary_source': active_version.get('source'),
         'active_summary_kind': active_version.get('kind'),
@@ -392,6 +398,7 @@ async def invoke_hermes_recovery(
         raise RuntimeError('Hermes API is required for historical enrichment recovery')
     conversation_id = str(conversation['id'])
     _, source_sha256 = build_hermes_recovery_source(conversation)
+    source_summary_sha256 = _summary_content_sha256(conversation)
     trace_id = f'summary-retry:{conversation_id}:{request_id}:hermes'
     summary = await generate_summary_from_prompt(
         prompt=_build_recovery_prompt(conversation, client_context),
@@ -409,6 +416,8 @@ async def invoke_hermes_recovery(
     _, current_source_sha256 = build_hermes_recovery_source(current)
     if current_source_sha256 != source_sha256:
         raise ConcurrentConversationRecoveryChangeError('conversation_transcript_changed_before_recovery_apply')
+    if _summary_content_sha256(current) != source_summary_sha256:
+        raise ConcurrentConversationRecoveryChangeError('conversation_summary_changed_before_recovery_apply')
     if not _is_current_retry(current, request_id, attempt_count):
         raise ConcurrentConversationRecoveryChangeError('conversation_recovery_attempt_superseded')
     if current.get('active_summary_version_id') != conversation.get('active_summary_version_id'):
@@ -455,7 +464,7 @@ def _existing_generic_version_id(conversation: dict[str, Any]) -> Optional[str]:
         return str(retry_version_id)
     if conversation.get('processing_retry_mode') == 'enrichment_only':
         active_version_id = conversation.get('active_summary_version_id')
-        return str(active_version_id) if active_version_id else 'existing-generic-summary'
+        return str(active_version_id) if active_version_id else LEGACY_GENERIC_SUMMARY_BASELINE
     enrichment_state = conversation.get('enrichment_state') or {}
     if enrichment_state.get('status') == 'writeback_applied' and enrichment_state.get('kind') in {
         'generic_recovered',
@@ -597,6 +606,13 @@ async def recover_failed_conversation_summary(
         return status or 'superseded'
 
     _, transcript_sha256 = build_hermes_recovery_source(conversation)
+    legacy_generic_summary_sha256 = (
+        _summary_content_sha256(conversation)
+        if conversation.get('processing_retry_mode') == 'enrichment_only'
+        and not conversation.get('active_summary_version_id')
+        and conversations_db.has_usable_conversation_summary(conversation)
+        else None
+    )
     if (
         conversation.get('processing_retry_source_request_id') == request_id
         and conversation.get('processing_retry_transcript_sha256')
@@ -621,6 +637,7 @@ async def recover_failed_conversation_summary(
         transcript_sha256,
         len(conversation.get('transcript_segments') or []),
         attempt_count=attempt_count,
+        generic_summary_sha256=legacy_generic_summary_sha256,
     )
     if not source_recorded:
         return 'superseded'
@@ -744,15 +761,25 @@ async def recover_failed_conversation_summary(
         transcript_sha256,
         len(latest.get('transcript_segments') or []),
         attempt_count=attempt_count,
+        generic_summary_sha256=legacy_generic_summary_sha256,
     )
     if not lease_renewed:
         return 'superseded'
     latest_enrichment_state = latest.get('enrichment_state') or {}
-    if (
+    legacy_generic_baseline_changed = bool(
+        generic_version_id == LEGACY_GENERIC_SUMMARY_BASELINE
+        and (
+            latest.get('active_summary_version_id') is not None
+            or _summary_content_sha256(latest) != legacy_generic_summary_sha256
+        )
+    )
+    versioned_generic_baseline_changed = bool(
         generic_version_id
+        and generic_version_id != LEGACY_GENERIC_SUMMARY_BASELINE
         and str(latest.get('active_summary_version_id') or '') != str(generic_version_id)
         and latest_enrichment_state.get('kind') != 'recovered_enriched'
-    ):
+    )
+    if legacy_generic_baseline_changed or versioned_generic_baseline_changed:
         await asyncio.to_thread(
             conversations_db.finish_conversation_processing_retry,
             uid,

--- a/backend/ella/services/summary_recovery.py
+++ b/backend/ella/services/summary_recovery.py
@@ -17,7 +17,7 @@ from ella.services.hermes_session import canonical_omi_session_key
 from ella.services.summary_writeback import CanonicalSummaryWriteUnconfirmedError, write_conversation_summary
 from models.conversation import CategoryEnum, Conversation, ConversationStatus
 from utils.conversations.generic_summary import generate_stock_conversation_summary
-from utils.conversations.vector import save_structured_vector
+from utils.conversations.vector import refresh_structured_summary_vector
 
 logger = logging.getLogger(__name__)
 
@@ -492,13 +492,7 @@ async def _ensure_conversation_vector(uid: str, conversation: dict[str, Any]) ->
     if not summary_version_id:
         if await asyncio.to_thread(_conversation_vector_present, uid, conversation_id):
             return
-        await asyncio.to_thread(save_structured_vector, uid, Conversation(**conversation))
-        for delay_seconds in (0, 0.2, 0.5):
-            if delay_seconds:
-                await asyncio.sleep(delay_seconds)
-            if await asyncio.to_thread(_conversation_vector_present, uid, conversation_id):
-                return
-        raise RuntimeError('conversation_vector_write_unconfirmed')
+        raise RuntimeError('conversation_summary_version_missing_for_vector_refresh')
 
     content_sha256 = _summary_content_sha256(conversation)
     metadata = await asyncio.to_thread(_conversation_vector_metadata, uid, conversation_id)
@@ -509,7 +503,7 @@ async def _ensure_conversation_vector(uid: str, conversation: dict[str, Any]) ->
     ):
         return
     write_result = await asyncio.to_thread(
-        save_structured_vector,
+        refresh_structured_summary_vector,
         uid,
         Conversation(**conversation),
         summary_version_id=summary_version_id,
@@ -530,6 +524,21 @@ async def _ensure_conversation_vector(uid: str, conversation: dict[str, Any]) ->
     raise RuntimeError('conversation_vector_metadata_unconfirmed')
 
 
+async def _ensure_generic_phase_vector(
+    uid: str,
+    conversation: dict[str, Any],
+    recovery_mode: Optional[str],
+) -> None:
+    conversation_id = str(conversation['id'])
+    if recovery_mode == 'enrichment_only' and await asyncio.to_thread(
+        _conversation_vector_present,
+        uid,
+        conversation_id,
+    ):
+        return
+    await _ensure_conversation_vector(uid, conversation)
+
+
 async def _write_and_confirm_enriched_vector(
     uid: str,
     conversation: dict[str, Any],
@@ -544,7 +553,7 @@ async def _write_and_confirm_enriched_vector(
         raise ConcurrentConversationRecoveryChangeError('active_summary_changed_before_vector_write')
     content_sha256 = _summary_content_sha256(current)
     write_result = await asyncio.to_thread(
-        save_structured_vector,
+        refresh_structured_summary_vector,
         uid,
         Conversation(**current),
         summary_version_id=summary_version_id,
@@ -618,6 +627,7 @@ async def recover_failed_conversation_summary(
 
     generic_version_id = _existing_generic_version_id(conversation)
     generic_applied = generic_version_id is not None
+    recovery_mode = conversation.get('processing_retry_mode')
     try:
         if not generic_version_id:
             stock_structured = await asyncio.to_thread(
@@ -667,7 +677,7 @@ async def recover_failed_conversation_summary(
         latest = await asyncio.to_thread(conversations_db.get_conversation, uid, conversation_id)
         if not _is_current_retry(latest, request_id, attempt_count):
             return 'superseded'
-        await _ensure_conversation_vector(uid, latest)
+        await _ensure_generic_phase_vector(uid, latest, recovery_mode)
         recorded = await asyncio.to_thread(
             conversations_db.record_conversation_processing_retry_generic_vector,
             uid,

--- a/backend/ella/services/summary_recovery.py
+++ b/backend/ella/services/summary_recovery.py
@@ -1,0 +1,474 @@
+"""Shared Hermes summary generation and failed-conversation recovery."""
+
+import asyncio
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import httpx
+
+import database.conversations as conversations_db
+from ella.services.hermes_session import canonical_omi_session_key, safe_session_component
+from ella.services.summary_writeback import write_conversation_summary
+from models.conversation import Conversation, ConversationStatus
+from utils.conversations.generic_summary import generate_stock_conversation_summary
+from utils.conversations.vector import save_structured_vector
+
+logger = logging.getLogger(__name__)
+
+JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+SUMMARY_RECOVERY_FAILED = 'conversation_summary_recovery_failed'
+
+
+@dataclass(frozen=True)
+class SummaryProviderConfig:
+    provider: str
+    hermes_url: str
+    hermes_model: str
+    hermes_api_key: str
+    legacy_url: str
+    legacy_model: str
+    legacy_api_key: str
+    timeout_seconds: float
+
+
+def default_summary_provider_config() -> SummaryProviderConfig:
+    return SummaryProviderConfig(
+        provider=os.getenv('ELLA_SUMMARY_RECOVERY_PROVIDER', 'hermes-api').strip().lower() or 'hermes-api',
+        hermes_url=os.getenv(
+            'ELLA_CORRECTION_HERMES_CHAT_URL',
+            os.getenv('HERMES_CHAT_COMPLETIONS_URL', 'http://100.76.138.56:8642/v1/chat/completions'),
+        ),
+        hermes_model=os.getenv(
+            'ELLA_CORRECTION_HERMES_MODEL',
+            os.getenv('HERMES_CORRECTION_MODEL', 'ella-plato-hermes-eval'),
+        ),
+        hermes_api_key=(
+            os.getenv('ELLA_CORRECTION_HERMES_API_KEY')
+            or os.getenv('API_SERVER_KEY')
+            or os.getenv('HERMES_API_KEY')
+            or ''
+        ),
+        legacy_url=os.getenv('ELLA_CORRECTION_API_URL', 'https://api.x.ai/v1/chat/completions'),
+        legacy_model=os.getenv('ELLA_CORRECTION_MODEL', 'grok-4.3'),
+        legacy_api_key=(
+            os.getenv('ELLA_CORRECTION_API_KEY') or os.getenv('XAI_API_KEY') or os.getenv('HERMES_API_KEY') or ''
+        ),
+        timeout_seconds=float(os.getenv('ELLA_CORRECTION_TIMEOUT_SECONDS', '45')),
+    )
+
+
+def compact_text(value: str, limit: int) -> str:
+    text = (value or '').strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + '\n\n[truncated]'
+
+
+def extract_json_object(content: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        match = JSON_OBJECT_RE.search(content)
+        if not match:
+            raise
+        parsed = json.loads(match.group(0))
+    if not isinstance(parsed, dict):
+        raise ValueError('Summary model response was not a JSON object')
+    return parsed
+
+
+def normalize_summary(
+    result: dict[str, Any],
+    fallback: dict[str, Any],
+    required_tags: tuple[str, ...] = ('omi',),
+) -> dict[str, Any]:
+    title = str(result.get('title') or fallback.get('title') or 'Recovered Conversation').strip()
+    overview = str(result.get('overview') or fallback.get('overview') or '').strip()
+    if not overview:
+        raise ValueError('Summary model response missing overview')
+    if not overview.startswith('[Ella] '):
+        overview = '[Ella] ' + overview.removeprefix('[Ella]').strip()
+
+    emoji = str(result.get('emoji') or fallback.get('emoji') or '\U0001fab6').strip()[:4] or '\U0001fab6'
+    category = str(result.get('category') or fallback.get('category') or 'other').strip().lower()
+    tags = result.get('ella_tags')
+    if not isinstance(tags, list):
+        tags = []
+    tags = [str(tag).strip().lower() for tag in tags if str(tag or '').strip()]
+    for tag in reversed(required_tags):
+        if tag not in tags:
+            tags.insert(0, tag)
+
+    signal = result.get('ella_signal')
+    if not isinstance(signal, dict):
+        signal = {}
+
+    return {
+        'title': title,
+        'overview': overview,
+        'emoji': emoji,
+        'category': category,
+        'ella_tags': tags[:12],
+        'ella_signal': {
+            'salience': str(signal.get('salience') or 'medium'),
+            'memory_promotion': str(signal.get('memory_promotion') or 'none'),
+            'noise_level': str(signal.get('noise_level') or 'low'),
+            'contains_media': bool(signal.get('contains_media', False)),
+            'contains_user_speech': bool(signal.get('contains_user_speech', True)),
+            'guardian_relevant': bool(signal.get('guardian_relevant', False)),
+        },
+    }
+
+
+async def generate_summary_from_prompt(
+    *,
+    prompt: str,
+    fallback: dict[str, Any],
+    session_id: str,
+    session_key: str,
+    trace_id: str,
+    required_tags: tuple[str, ...],
+    config: SummaryProviderConfig,
+    async_client_factory: Any = httpx.AsyncClient,
+) -> dict[str, Any]:
+    if config.provider == 'hermes-api':
+        if not config.hermes_api_key:
+            raise RuntimeError('No Hermes summary API key configured')
+        headers = {
+            'Authorization': f'Bearer {config.hermes_api_key}',
+            'Content-Type': 'application/json',
+            'X-Hermes-Session-Id': session_id,
+            'X-Hermes-Session-Key': session_key,
+            'X-Trace-Id': trace_id,
+        }
+        url = config.hermes_url
+        model = config.hermes_model
+        max_tokens = 900
+    else:
+        if not config.legacy_api_key:
+            raise RuntimeError('No legacy summary API key configured')
+        headers = {'Authorization': f'Bearer {config.legacy_api_key}', 'Content-Type': 'application/json'}
+        url = config.legacy_url
+        model = config.legacy_model
+        max_tokens = 800
+
+    async with async_client_factory(timeout=config.timeout_seconds) as client:
+        response = await client.post(
+            url,
+            headers=headers,
+            json={
+                'model': model,
+                'messages': [{'role': 'user', 'content': prompt}],
+                'temperature': 0.1,
+                'max_tokens': max_tokens,
+            },
+        )
+    response.raise_for_status()
+    body = response.json()
+    content = body['choices'][0]['message']['content']
+    return normalize_summary(extract_json_object(content), fallback, required_tags=required_tags)
+
+
+async def apply_summary_update(
+    *,
+    uid: str,
+    conversation_id: str,
+    trace_id: str,
+    active_summary_version_id: Optional[str],
+    summary: dict[str, Any],
+    summary_kind: str,
+    summary_source: str = 'observer',
+    correction_id: Optional[str] = None,
+) -> dict[str, Any]:
+    return await write_conversation_summary(
+        uid=uid,
+        conversation_id=conversation_id,
+        title=summary['title'],
+        overview=summary['overview'],
+        emoji=summary['emoji'],
+        category=summary['category'],
+        summary_source=summary_source,
+        summary_kind=summary_kind,
+        correction_id=correction_id,
+        based_on_version_id=active_summary_version_id,
+        set_active=True,
+        trace_id=trace_id,
+        ella_tags=summary.get('ella_tags') or ['omi'],
+        ella_signal=summary.get('ella_signal') or {},
+    )
+
+
+def _structured_summary(conversation: dict[str, Any]) -> dict[str, Any]:
+    structured = conversation.get('structured') or {}
+    return {
+        'title': structured.get('title') or conversation.get('title') or '',
+        'overview': structured.get('overview') or conversation.get('overview') or '',
+        'emoji': structured.get('emoji') or conversation.get('emoji') or '',
+        'category': str(structured.get('category') or conversation.get('category') or 'other'),
+    }
+
+
+def _format_transcript(conversation: dict[str, Any]) -> str:
+    lines = []
+    for segment in conversation.get('transcript_segments') or []:
+        text = str(segment.get('text') or '').strip()
+        if not text:
+            continue
+        speaker = segment.get('speaker') or segment.get('speaker_name')
+        if not speaker:
+            speaker = 'User' if segment.get('is_user') else 'Speaker'
+        lines.append(f'{speaker}: {text}')
+    return '\n\n'.join(lines)
+
+
+def _build_recovery_prompt(conversation: dict[str, Any], client_context: Optional[str]) -> str:
+    structured = _structured_summary(conversation)
+    transcript = _format_transcript(conversation)
+    return f"""You are Ella, the user's companion summary writer.
+
+Recover an OMI conversation whose first summary attempt failed. Use the complete transcript and durable companion context available in this Hermes session. Return JSON only.
+
+Rules:
+- Produce one accurate, warm, specific summary grounded in the transcript.
+- overview must start with "[Ella] ".
+- Do not invent details or expose raw speaker labels when a natural description is available.
+- title must be short and contain no markdown.
+- category should be one of: personal, family, education, health, technology, work, business, finance, legal, media, music, news, travel, other.
+- Include ella_tags and ella_signal for downstream ranking.
+
+Optional user context:
+{client_context or '[none]'}
+
+Existing partial summary:
+{json.dumps(structured, ensure_ascii=False, indent=2)}
+
+Transcript:
+{compact_text(transcript, 60000)}
+
+Return exactly:
+{{
+  "title": "short title",
+  "overview": "[Ella] recovered warm summary",
+  "emoji": "one emoji",
+  "category": "category",
+  "ella_tags": ["omi", "recovery"],
+  "ella_signal": {{
+    "salience": "low|medium|high",
+    "memory_promotion": "none|candidate|promoted",
+    "noise_level": "none|low|medium|high",
+    "contains_media": false,
+    "contains_user_speech": true,
+    "guardian_relevant": false
+  }}
+}}
+"""
+
+
+def _existing_recovered_version_id(conversation: dict[str, Any]) -> Optional[str]:
+    retry_version_id = conversation.get('processing_retry_enriched_version_id')
+    if retry_version_id:
+        return str(retry_version_id)
+    enrichment_state = conversation.get('enrichment_state') or {}
+    if enrichment_state.get('status') == 'writeback_applied' and enrichment_state.get('kind') == 'recovered_enriched':
+        active_version_id = conversation.get('active_summary_version_id')
+        return str(active_version_id) if active_version_id else None
+    return None
+
+
+def _existing_generic_version_id(conversation: dict[str, Any]) -> Optional[str]:
+    retry_version_id = conversation.get('processing_retry_summary_version_id')
+    if retry_version_id:
+        return str(retry_version_id)
+    enrichment_state = conversation.get('enrichment_state') or {}
+    if enrichment_state.get('status') == 'writeback_applied' and enrichment_state.get('kind') in {
+        'generic_recovered',
+        'recovered_enriched',
+    }:
+        active_version_id = conversation.get('active_summary_version_id')
+        return str(active_version_id) if active_version_id else None
+    return None
+
+
+def _stock_summary_payload(structured: Any) -> dict[str, Any]:
+    if hasattr(structured, 'model_dump'):
+        payload = structured.model_dump(mode='json')
+    elif isinstance(structured, dict):
+        payload = dict(structured)
+    else:
+        raise ValueError('Stock OMI summary provider returned an invalid result')
+    return normalize_summary(payload, payload, required_tags=('omi', 'recovery', 'generic'))
+
+
+def _is_current_retry(conversation: Optional[dict[str, Any]], request_id: str) -> bool:
+    return bool(conversation and conversation.get('processing_retry_id') == request_id)
+
+
+async def recover_failed_conversation_summary(
+    *,
+    uid: str,
+    conversation_id: str,
+    request_id: str,
+    client_context: Optional[str] = None,
+) -> str:
+    conversation = await asyncio.to_thread(conversations_db.get_conversation, uid, conversation_id)
+    if not _is_current_retry(conversation, request_id):
+        return 'superseded'
+    status = getattr(conversation.get('status'), 'value', conversation.get('status'))
+    if status not in {ConversationStatus.processing.value, ConversationStatus.completed.value}:
+        return status or 'superseded'
+
+    generic_version_id = _existing_generic_version_id(conversation)
+    generic_applied = generic_version_id is not None
+    try:
+        if not generic_version_id:
+            stock_structured = await asyncio.to_thread(
+                generate_stock_conversation_summary,
+                uid,
+                Conversation(**conversation),
+            )
+            generic_summary = _stock_summary_payload(stock_structured)
+            generic_trace_id = f'summary-retry:{conversation_id}:{request_id}:generic'
+            apply_result = await apply_summary_update(
+                uid=uid,
+                conversation_id=conversation_id,
+                trace_id=generic_trace_id,
+                active_summary_version_id=conversation.get('active_summary_version_id'),
+                summary=generic_summary,
+                summary_kind='generic_recovered',
+                summary_source='omi',
+            )
+            generic_version_id = apply_result.get('active_summary_version_id')
+            if not generic_version_id:
+                raise RuntimeError('Generic summary recovery did not return an active version')
+            generic_applied = True
+            recorded = await asyncio.to_thread(
+                conversations_db.record_conversation_processing_retry_summary_applied,
+                uid,
+                conversation_id,
+                request_id,
+                generic_version_id,
+            )
+            if not recorded:
+                return 'superseded'
+
+        latest = await asyncio.to_thread(conversations_db.get_conversation, uid, conversation_id)
+        if not _is_current_retry(latest, request_id):
+            return 'superseded'
+        await asyncio.to_thread(save_structured_vector, uid, Conversation(**latest))
+        finished = await asyncio.to_thread(
+            conversations_db.finish_conversation_processing_retry,
+            uid,
+            conversation_id,
+            request_id,
+            ConversationStatus.completed.value,
+        )
+        if not finished:
+            return 'superseded'
+    except Exception as error:
+        error_code = SUMMARY_RECOVERY_FAILED if generic_applied else 'conversation_summary_failed'
+        logger.exception(
+            'Failed to recover generic conversation summary',
+            extra={
+                'uid': uid,
+                'conversation_id': conversation_id,
+                'request_id': request_id,
+                'error_type': type(error).__name__,
+            },
+        )
+        await asyncio.to_thread(
+            conversations_db.finish_conversation_processing_retry,
+            uid,
+            conversation_id,
+            request_id,
+            ConversationStatus.failed.value,
+            error_code=error_code,
+        )
+        return ConversationStatus.failed.value
+
+    latest = await asyncio.to_thread(conversations_db.get_conversation, uid, conversation_id)
+    if not _is_current_retry(latest, request_id):
+        return 'superseded'
+    existing_enriched_version_id = _existing_recovered_version_id(latest)
+    if existing_enriched_version_id:
+        await asyncio.to_thread(
+            conversations_db.record_conversation_processing_retry_enrichment,
+            uid,
+            conversation_id,
+            request_id,
+            'completed',
+            summary_version_id=existing_enriched_version_id,
+        )
+        return ConversationStatus.completed.value
+
+    hermes_trace_id = f'summary-retry:{conversation_id}:{request_id}:hermes'
+    try:
+        summary = await generate_summary_from_prompt(
+            prompt=_build_recovery_prompt(latest, client_context),
+            fallback=_structured_summary(latest),
+            session_id=':'.join(
+                [
+                    'summary-recovery',
+                    safe_session_component(uid),
+                    safe_session_component(conversation_id),
+                    safe_session_component(request_id),
+                ]
+            ),
+            session_key=canonical_omi_session_key(uid),
+            trace_id=hermes_trace_id,
+            required_tags=('omi', 'recovery'),
+            config=default_summary_provider_config(),
+        )
+        apply_result = await apply_summary_update(
+            uid=uid,
+            conversation_id=conversation_id,
+            trace_id=hermes_trace_id,
+            active_summary_version_id=latest.get('active_summary_version_id'),
+            summary=summary,
+            summary_kind='recovered_enriched',
+        )
+        enriched_version_id = apply_result.get('active_summary_version_id')
+        if not enriched_version_id:
+            raise RuntimeError('Hermes summary recovery did not return an active version')
+
+        enriched = await asyncio.to_thread(conversations_db.get_conversation, uid, conversation_id)
+        if not _is_current_retry(enriched, request_id):
+            return 'superseded'
+        await asyncio.to_thread(save_structured_vector, uid, Conversation(**enriched))
+        await asyncio.to_thread(
+            conversations_db.record_conversation_processing_retry_enrichment,
+            uid,
+            conversation_id,
+            request_id,
+            'completed',
+            summary_version_id=enriched_version_id,
+        )
+    except Exception as error:
+        logger.exception(
+            'Hermes enrichment failed after generic summary recovery',
+            extra={
+                'uid': uid,
+                'conversation_id': conversation_id,
+                'request_id': request_id,
+                'error_type': type(error).__name__,
+            },
+        )
+        try:
+            await asyncio.to_thread(
+                conversations_db.record_conversation_processing_retry_enrichment,
+                uid,
+                conversation_id,
+                request_id,
+                'failed',
+            )
+        except Exception:
+            logger.exception(
+                'Failed to persist retryable Hermes enrichment state',
+                extra={'uid': uid, 'conversation_id': conversation_id, 'request_id': request_id},
+            )
+
+    return ConversationStatus.completed.value

--- a/backend/ella/services/summary_recovery.py
+++ b/backend/ella/services/summary_recovery.py
@@ -1,6 +1,7 @@
 """Shared Hermes summary generation and failed-conversation recovery."""
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -12,9 +13,9 @@ from typing import Any, Optional
 import httpx
 
 import database.conversations as conversations_db
-from ella.services.hermes_session import canonical_omi_session_key, safe_session_component
-from ella.services.summary_writeback import write_conversation_summary
-from models.conversation import Conversation, ConversationStatus
+from ella.services.hermes_session import canonical_omi_session_key
+from ella.services.summary_writeback import CanonicalSummaryWriteUnconfirmedError, write_conversation_summary
+from models.conversation import CategoryEnum, Conversation, ConversationStatus
 from utils.conversations.generic_summary import generate_stock_conversation_summary
 from utils.conversations.vector import save_structured_vector
 
@@ -22,6 +23,100 @@ logger = logging.getLogger(__name__)
 
 JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
 SUMMARY_RECOVERY_FAILED = 'conversation_summary_recovery_failed'
+
+
+def _transcript_metadata(conversation: dict[str, Any]) -> tuple[int, int]:
+    segments = conversation.get('transcript_segments') or []
+    return len(segments), sum(len(str(segment.get('text') or '')) for segment in segments)
+
+
+def _active_summary_version(conversation: dict[str, Any]) -> dict[str, Any]:
+    versions = conversation.get('summary_versions') or []
+    active_id = conversation.get('active_summary_version_id')
+    if active_id:
+        for version in versions:
+            if str(version.get('id') or '') == str(active_id):
+                return version
+    return next((version for version in reversed(versions) if version.get('is_active')), {})
+
+
+def _conversation_vector_present(uid: str, conversation_id: str) -> bool:
+    from database import vector_db
+
+    return conversation_id in vector_db.fetch_existing_conversation_vector_ids(uid, [conversation_id])
+
+
+def _conversation_vector_metadata(uid: str, conversation_id: str) -> Optional[dict[str, Any]]:
+    from database import vector_db
+
+    return vector_db.fetch_conversation_vector_metadata(uid, conversation_id)
+
+
+def _summary_content_sha256(conversation: dict[str, Any]) -> str:
+    payload = json.dumps(
+        conversation.get('structured') or {},
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(',', ':'),
+        default=str,
+    )
+    return hashlib.sha256(payload.encode('utf-8')).hexdigest()
+
+
+def build_conversation_processing_retry_plan(uid: str, conversation_id: str) -> Optional[dict[str, Any]]:
+    """Inspect one UID-owned record without writing or returning transcript content."""
+
+    conversation = conversations_db.get_conversation(uid, conversation_id)
+    if conversation is None:
+        return None
+    mode, reason = conversations_db.conversation_processing_recovery_mode(conversation)
+    segment_count, transcript_character_count = _transcript_metadata(conversation)
+    _, transcript_sha256 = build_hermes_recovery_source(conversation)
+    active_version = _active_summary_version(conversation)
+    vector_present = _conversation_vector_present(uid, conversation_id)
+    vector_metadata = _conversation_vector_metadata(uid, conversation_id) if vector_present else None
+    active_summary_version_id = conversation.get('active_summary_version_id')
+    active_summary_sha256 = _summary_content_sha256(conversation) if active_summary_version_id else None
+    enrichment_state = conversation.get('enrichment_state') or {}
+    canonical_session = canonical_omi_session_key(uid)
+    provider_path = ['hermes_api_canonical_session', 'omi_enriched_summary_writeback', 'canonical_ledger', 'vector']
+    if mode == 'full':
+        provider_path.insert(0, 'omi_stock_summary_provider')
+
+    status = getattr(conversation.get('status'), 'value', conversation.get('status'))
+    return {
+        'conversation_id': conversation_id,
+        'status': status,
+        'discarded': bool(conversation.get('discarded')),
+        'processing_error': conversation.get('processing_error'),
+        'started_at': conversation.get('started_at'),
+        'finished_at': conversation.get('finished_at'),
+        'transcript_segment_count': segment_count,
+        'transcript_character_count': transcript_character_count,
+        'transcript_sha256': transcript_sha256,
+        'structured_summary_present': conversations_db.has_usable_conversation_summary(conversation),
+        'active_summary_version_id': active_summary_version_id,
+        'active_summary_source': active_version.get('source'),
+        'active_summary_kind': active_version.get('kind'),
+        'enriched_summary_present': conversations_db.has_enriched_conversation_summary(conversation),
+        'canonical_provenance_confirmed': enrichment_state.get('canonical_status') == 'completed',
+        'vector_present': vector_present,
+        'vector_active_summary_version_id': (vector_metadata or {}).get('active_summary_version_id'),
+        'vector_content_sha256': (vector_metadata or {}).get('summary_content_sha256'),
+        'vector_matches_active_summary': bool(
+            vector_metadata
+            and active_summary_version_id
+            and (vector_metadata or {}).get('active_summary_version_id') == active_summary_version_id
+            and (vector_metadata or {}).get('summary_content_sha256') == active_summary_sha256
+        ),
+        'recovery_mode': mode or 'none',
+        'retryable': mode is not None,
+        'reason': reason,
+        'profile_scope_sha256': hashlib.sha256(uid.encode('utf-8')).hexdigest(),
+        'canonical_session_scope_sha256': hashlib.sha256(canonical_session.encode('utf-8')).hexdigest(),
+        'provider_path': provider_path,
+        'zero_writes': True,
+    }
 
 
 @dataclass(frozen=True)
@@ -34,6 +129,10 @@ class SummaryProviderConfig:
     legacy_model: str
     legacy_api_key: str
     timeout_seconds: float
+
+
+class ConcurrentConversationRecoveryChangeError(RuntimeError):
+    pass
 
 
 def default_summary_provider_config() -> SummaryProviderConfig:
@@ -62,11 +161,19 @@ def default_summary_provider_config() -> SummaryProviderConfig:
     )
 
 
-def compact_text(value: str, limit: int) -> str:
-    text = (value or '').strip()
-    if len(text) <= limit:
-        return text
-    return text[:limit].rstrip() + '\n\n[truncated]'
+def build_hermes_recovery_source(
+    conversation: dict[str, Any],
+) -> tuple[str, str]:
+    """Return a lossless canonical transcript payload and its SHA-256."""
+
+    source_document = json.dumps(
+        conversation.get('transcript_segments') or [],
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(',', ':'),
+        default=str,
+    )
+    return source_document, hashlib.sha256(source_document.encode('utf-8')).hexdigest()
 
 
 def extract_json_object(content: str) -> dict[str, Any]:
@@ -96,6 +203,12 @@ def normalize_summary(
 
     emoji = str(result.get('emoji') or fallback.get('emoji') or '\U0001fab6').strip()[:4] or '\U0001fab6'
     category = str(result.get('category') or fallback.get('category') or 'other').strip().lower()
+    category = {'media': CategoryEnum.entertainment.value, 'romance': CategoryEnum.romance.value}.get(
+        category,
+        category,
+    )
+    if category not in {item.value for item in CategoryEnum}:
+        category = CategoryEnum.other.value
     tags = result.get('ella_tags')
     if not isinstance(tags, list):
         tags = []
@@ -184,14 +297,16 @@ async def apply_summary_update(
     summary_kind: str,
     summary_source: str = 'observer',
     correction_id: Optional[str] = None,
+    require_canonical: bool = False,
+    require_based_on_match: bool = False,
 ) -> dict[str, Any]:
     return await write_conversation_summary(
         uid=uid,
         conversation_id=conversation_id,
-        title=summary['title'],
-        overview=summary['overview'],
-        emoji=summary['emoji'],
-        category=summary['category'],
+        title=summary.get('title'),
+        overview=summary.get('overview'),
+        emoji=summary.get('emoji'),
+        category=summary.get('category'),
         summary_source=summary_source,
         summary_kind=summary_kind,
         correction_id=correction_id,
@@ -200,6 +315,8 @@ async def apply_summary_update(
         trace_id=trace_id,
         ella_tags=summary.get('ella_tags') or ['omi'],
         ella_signal=summary.get('ella_signal') or {},
+        require_canonical=require_canonical,
+        require_based_on_match=require_based_on_match,
     )
 
 
@@ -213,22 +330,9 @@ def _structured_summary(conversation: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _format_transcript(conversation: dict[str, Any]) -> str:
-    lines = []
-    for segment in conversation.get('transcript_segments') or []:
-        text = str(segment.get('text') or '').strip()
-        if not text:
-            continue
-        speaker = segment.get('speaker') or segment.get('speaker_name')
-        if not speaker:
-            speaker = 'User' if segment.get('is_user') else 'Speaker'
-        lines.append(f'{speaker}: {text}')
-    return '\n\n'.join(lines)
-
-
 def _build_recovery_prompt(conversation: dict[str, Any], client_context: Optional[str]) -> str:
     structured = _structured_summary(conversation)
-    transcript = _format_transcript(conversation)
+    transcript_source, transcript_sha256 = build_hermes_recovery_source(conversation)
     return f"""You are Ella, the user's companion summary writer.
 
 Recover an OMI conversation whose first summary attempt failed. Use the complete transcript and durable companion context available in this Hermes session. Return JSON only.
@@ -238,7 +342,7 @@ Rules:
 - overview must start with "[Ella] ".
 - Do not invent details or expose raw speaker labels when a natural description is available.
 - title must be short and contain no markdown.
-- category should be one of: personal, family, education, health, technology, work, business, finance, legal, media, music, news, travel, other.
+- category should be one of: personal, education, health, finance, legal, philosophy, spiritual, science, entrepreneurship, parenting, romantic, travel, inspiration, technology, business, social, work, sports, politics, literature, history, architecture, music, weather, news, entertainment, psychology, real, design, family, economics, environment, other.
 - Include ella_tags and ella_signal for downstream ranking.
 
 Optional user context:
@@ -247,8 +351,10 @@ Optional user context:
 Existing partial summary:
 {json.dumps(structured, ensure_ascii=False, indent=2)}
 
-Transcript:
-{compact_text(transcript, 60000)}
+Authoritative transcript SHA-256: {transcript_sha256}
+
+Authoritative transcript segments (lossless JSON):
+{transcript_source}
 
 Return exactly:
 {{
@@ -269,12 +375,75 @@ Return exactly:
 """
 
 
+async def invoke_hermes_recovery(
+    *,
+    uid: str,
+    conversation: dict[str, Any],
+    request_id: str,
+    attempt_count: Optional[int] = None,
+    client_context: Optional[str] = None,
+    config: Optional[SummaryProviderConfig] = None,
+    async_client_factory: Any = httpx.AsyncClient,
+) -> dict[str, Any]:
+    """Generate and strictly apply enrichment through the canonical Hermes API session."""
+
+    config = config or default_summary_provider_config()
+    if config.provider != 'hermes-api':
+        raise RuntimeError('Hermes API is required for historical enrichment recovery')
+    conversation_id = str(conversation['id'])
+    _, source_sha256 = build_hermes_recovery_source(conversation)
+    trace_id = f'summary-retry:{conversation_id}:{request_id}:hermes'
+    summary = await generate_summary_from_prompt(
+        prompt=_build_recovery_prompt(conversation, client_context),
+        fallback=_structured_summary(conversation),
+        session_id=f'summary-recovery:{conversation_id}:{request_id}',
+        session_key=canonical_omi_session_key(uid),
+        trace_id=trace_id,
+        required_tags=('omi', 'recovery'),
+        config=config,
+        async_client_factory=async_client_factory,
+    )
+    current = await asyncio.to_thread(conversations_db.get_conversation, uid, conversation_id)
+    if current is None:
+        raise ConcurrentConversationRecoveryChangeError('conversation_removed_before_recovery_apply')
+    _, current_source_sha256 = build_hermes_recovery_source(current)
+    if current_source_sha256 != source_sha256:
+        raise ConcurrentConversationRecoveryChangeError('conversation_transcript_changed_before_recovery_apply')
+    if not _is_current_retry(current, request_id, attempt_count):
+        raise ConcurrentConversationRecoveryChangeError('conversation_recovery_attempt_superseded')
+    if current.get('active_summary_version_id') != conversation.get('active_summary_version_id'):
+        raise ConcurrentConversationRecoveryChangeError('conversation_summary_changed_before_recovery_apply')
+    apply_result = await apply_summary_update(
+        uid=uid,
+        conversation_id=conversation_id,
+        trace_id=trace_id,
+        active_summary_version_id=current.get('active_summary_version_id'),
+        summary=summary,
+        summary_kind='recovered_enriched',
+        require_canonical=True,
+        require_based_on_match=True,
+    )
+    version_id = apply_result.get('active_summary_version_id')
+    if not version_id or apply_result.get('canonical_confirmed') is not True:
+        raise CanonicalSummaryWriteUnconfirmedError('canonical_write_unconfirmed')
+    return {
+        'active_summary_version_id': version_id,
+        'canonical_confirmed': True,
+        'source_sha256': source_sha256,
+        'session_scope_sha256': hashlib.sha256(canonical_omi_session_key(uid).encode('utf-8')).hexdigest(),
+    }
+
+
 def _existing_recovered_version_id(conversation: dict[str, Any]) -> Optional[str]:
     retry_version_id = conversation.get('processing_retry_enriched_version_id')
-    if retry_version_id:
+    if retry_version_id and str(conversation.get('active_summary_version_id') or '') == str(retry_version_id):
         return str(retry_version_id)
     enrichment_state = conversation.get('enrichment_state') or {}
-    if enrichment_state.get('status') == 'writeback_applied' and enrichment_state.get('kind') == 'recovered_enriched':
+    if (
+        enrichment_state.get('status') == 'writeback_applied'
+        and enrichment_state.get('kind') == 'recovered_enriched'
+        and enrichment_state.get('canonical_status') == 'completed'
+    ):
         active_version_id = conversation.get('active_summary_version_id')
         return str(active_version_id) if active_version_id else None
     return None
@@ -284,6 +453,9 @@ def _existing_generic_version_id(conversation: dict[str, Any]) -> Optional[str]:
     retry_version_id = conversation.get('processing_retry_summary_version_id')
     if retry_version_id:
         return str(retry_version_id)
+    if conversation.get('processing_retry_mode') == 'enrichment_only':
+        active_version_id = conversation.get('active_summary_version_id')
+        return str(active_version_id) if active_version_id else 'existing-generic-summary'
     enrichment_state = conversation.get('enrichment_state') or {}
     if enrichment_state.get('status') == 'writeback_applied' and enrichment_state.get('kind') in {
         'generic_recovered',
@@ -304,8 +476,100 @@ def _stock_summary_payload(structured: Any) -> dict[str, Any]:
     return normalize_summary(payload, payload, required_tags=('omi', 'recovery', 'generic'))
 
 
-def _is_current_retry(conversation: Optional[dict[str, Any]], request_id: str) -> bool:
-    return bool(conversation and conversation.get('processing_retry_id') == request_id)
+def _is_current_retry(
+    conversation: Optional[dict[str, Any]],
+    request_id: str,
+    attempt_count: Optional[int] = None,
+) -> bool:
+    if not conversation or conversation.get('processing_retry_id') != request_id:
+        return False
+    return attempt_count is None or conversation.get('processing_retry_attempt_count') == attempt_count
+
+
+async def _ensure_conversation_vector(uid: str, conversation: dict[str, Any]) -> None:
+    conversation_id = str(conversation['id'])
+    summary_version_id = str(conversation.get('active_summary_version_id') or '')
+    if not summary_version_id:
+        if await asyncio.to_thread(_conversation_vector_present, uid, conversation_id):
+            return
+        await asyncio.to_thread(save_structured_vector, uid, Conversation(**conversation))
+        for delay_seconds in (0, 0.2, 0.5):
+            if delay_seconds:
+                await asyncio.sleep(delay_seconds)
+            if await asyncio.to_thread(_conversation_vector_present, uid, conversation_id):
+                return
+        raise RuntimeError('conversation_vector_write_unconfirmed')
+
+    content_sha256 = _summary_content_sha256(conversation)
+    metadata = await asyncio.to_thread(_conversation_vector_metadata, uid, conversation_id)
+    if (
+        metadata
+        and metadata.get('active_summary_version_id') == summary_version_id
+        and metadata.get('summary_content_sha256') == content_sha256
+    ):
+        return
+    write_result = await asyncio.to_thread(
+        save_structured_vector,
+        uid,
+        Conversation(**conversation),
+        summary_version_id=summary_version_id,
+        summary_content_sha256=content_sha256,
+    )
+    if write_result is None:
+        raise RuntimeError('conversation_vector_write_unconfirmed')
+    for delay_seconds in (0, 0.2, 0.5):
+        if delay_seconds:
+            await asyncio.sleep(delay_seconds)
+        metadata = await asyncio.to_thread(_conversation_vector_metadata, uid, conversation_id)
+        if (
+            metadata
+            and metadata.get('active_summary_version_id') == summary_version_id
+            and metadata.get('summary_content_sha256') == content_sha256
+        ):
+            return
+    raise RuntimeError('conversation_vector_metadata_unconfirmed')
+
+
+async def _write_and_confirm_enriched_vector(
+    uid: str,
+    conversation: dict[str, Any],
+    summary_version_id: str,
+) -> str:
+    current = await asyncio.to_thread(
+        conversations_db.get_conversation,
+        uid,
+        str(conversation['id']),
+    )
+    if not current or str(current.get('active_summary_version_id') or '') != str(summary_version_id):
+        raise ConcurrentConversationRecoveryChangeError('active_summary_changed_before_vector_write')
+    content_sha256 = _summary_content_sha256(current)
+    write_result = await asyncio.to_thread(
+        save_structured_vector,
+        uid,
+        Conversation(**current),
+        summary_version_id=summary_version_id,
+        summary_content_sha256=content_sha256,
+    )
+    if write_result is None:
+        raise RuntimeError('conversation_vector_write_unconfirmed')
+    for delay_seconds in (0, 0.2, 0.5):
+        if delay_seconds:
+            await asyncio.sleep(delay_seconds)
+        metadata = await asyncio.to_thread(_conversation_vector_metadata, uid, str(conversation['id']))
+        if (
+            metadata
+            and metadata.get('active_summary_version_id') == summary_version_id
+            and metadata.get('summary_content_sha256') == content_sha256
+        ):
+            current = await asyncio.to_thread(
+                conversations_db.get_conversation,
+                uid,
+                str(conversation['id']),
+            )
+            if not current or str(current.get('active_summary_version_id') or '') != str(summary_version_id):
+                raise ConcurrentConversationRecoveryChangeError('active_summary_changed_after_vector_write')
+            return content_sha256
+    raise RuntimeError('conversation_enriched_vector_metadata_unconfirmed')
 
 
 async def recover_failed_conversation_summary(
@@ -314,13 +578,43 @@ async def recover_failed_conversation_summary(
     conversation_id: str,
     request_id: str,
     client_context: Optional[str] = None,
+    attempt_count: Optional[int] = None,
 ) -> str:
     conversation = await asyncio.to_thread(conversations_db.get_conversation, uid, conversation_id)
-    if not _is_current_retry(conversation, request_id):
+    if not _is_current_retry(conversation, request_id, attempt_count):
         return 'superseded'
     status = getattr(conversation.get('status'), 'value', conversation.get('status'))
     if status not in {ConversationStatus.processing.value, ConversationStatus.completed.value}:
         return status or 'superseded'
+
+    _, transcript_sha256 = build_hermes_recovery_source(conversation)
+    if (
+        conversation.get('processing_retry_source_request_id') == request_id
+        and conversation.get('processing_retry_transcript_sha256')
+        and conversation.get('processing_retry_transcript_sha256') != transcript_sha256
+    ):
+        await asyncio.to_thread(
+            conversations_db.finish_conversation_processing_retry,
+            uid,
+            conversation_id,
+            request_id,
+            ConversationStatus.failed.value,
+            error_code='conversation_transcript_changed',
+            preserve_completed_summary=conversations_db.has_usable_conversation_summary(conversation),
+            attempt_count=attempt_count,
+        )
+        return ConversationStatus.failed.value
+    source_recorded = await asyncio.to_thread(
+        conversations_db.record_conversation_processing_retry_source,
+        uid,
+        conversation_id,
+        request_id,
+        transcript_sha256,
+        len(conversation.get('transcript_segments') or []),
+        attempt_count=attempt_count,
+    )
+    if not source_recorded:
+        return 'superseded'
 
     generic_version_id = _existing_generic_version_id(conversation)
     generic_applied = generic_version_id is not None
@@ -331,6 +625,17 @@ async def recover_failed_conversation_summary(
                 uid,
                 Conversation(**conversation),
             )
+            current_before_generic_apply = await asyncio.to_thread(
+                conversations_db.get_conversation,
+                uid,
+                conversation_id,
+            )
+            if not _is_current_retry(current_before_generic_apply, request_id, attempt_count):
+                return 'superseded'
+            if current_before_generic_apply.get('active_summary_version_id') != conversation.get(
+                'active_summary_version_id'
+            ):
+                raise ConcurrentConversationRecoveryChangeError('conversation_summary_changed_before_generic_apply')
             generic_summary = _stock_summary_payload(stock_structured)
             generic_trace_id = f'summary-retry:{conversation_id}:{request_id}:generic'
             apply_result = await apply_summary_update(
@@ -341,33 +646,37 @@ async def recover_failed_conversation_summary(
                 summary=generic_summary,
                 summary_kind='generic_recovered',
                 summary_source='omi',
+                require_based_on_match=True,
             )
             generic_version_id = apply_result.get('active_summary_version_id')
             if not generic_version_id:
                 raise RuntimeError('Generic summary recovery did not return an active version')
             generic_applied = True
+
             recorded = await asyncio.to_thread(
                 conversations_db.record_conversation_processing_retry_summary_applied,
                 uid,
                 conversation_id,
                 request_id,
                 generic_version_id,
+                attempt_count=attempt_count,
             )
             if not recorded:
                 return 'superseded'
 
         latest = await asyncio.to_thread(conversations_db.get_conversation, uid, conversation_id)
-        if not _is_current_retry(latest, request_id):
+        if not _is_current_retry(latest, request_id, attempt_count):
             return 'superseded'
-        await asyncio.to_thread(save_structured_vector, uid, Conversation(**latest))
-        finished = await asyncio.to_thread(
-            conversations_db.finish_conversation_processing_retry,
+        await _ensure_conversation_vector(uid, latest)
+        recorded = await asyncio.to_thread(
+            conversations_db.record_conversation_processing_retry_generic_vector,
             uid,
             conversation_id,
             request_id,
-            ConversationStatus.completed.value,
+            'completed',
+            attempt_count=attempt_count,
         )
-        if not finished:
+        if not recorded:
             return 'superseded'
     except Exception as error:
         error_code = SUMMARY_RECOVERY_FAILED if generic_applied else 'conversation_summary_failed'
@@ -380,73 +689,107 @@ async def recover_failed_conversation_summary(
                 'error_type': type(error).__name__,
             },
         )
+        if generic_applied:
+            await asyncio.to_thread(
+                conversations_db.record_conversation_processing_retry_generic_vector,
+                uid,
+                conversation_id,
+                request_id,
+                'failed',
+                attempt_count=attempt_count,
+            )
+        else:
+            await asyncio.to_thread(
+                conversations_db.finish_conversation_processing_retry,
+                uid,
+                conversation_id,
+                request_id,
+                ConversationStatus.failed.value,
+                error_code=error_code,
+                attempt_count=attempt_count,
+            )
+        return ConversationStatus.failed.value
+
+    latest = await asyncio.to_thread(conversations_db.get_conversation, uid, conversation_id)
+    if not _is_current_retry(latest, request_id, attempt_count):
+        return 'superseded'
+    _, latest_transcript_sha256 = build_hermes_recovery_source(latest)
+    if latest_transcript_sha256 != transcript_sha256:
         await asyncio.to_thread(
             conversations_db.finish_conversation_processing_retry,
             uid,
             conversation_id,
             request_id,
             ConversationStatus.failed.value,
-            error_code=error_code,
+            error_code='conversation_transcript_changed',
+            preserve_completed_summary=conversations_db.has_usable_conversation_summary(latest),
+            attempt_count=attempt_count,
         )
         return ConversationStatus.failed.value
-
-    latest = await asyncio.to_thread(conversations_db.get_conversation, uid, conversation_id)
-    if not _is_current_retry(latest, request_id):
+    lease_renewed = await asyncio.to_thread(
+        conversations_db.record_conversation_processing_retry_source,
+        uid,
+        conversation_id,
+        request_id,
+        transcript_sha256,
+        len(latest.get('transcript_segments') or []),
+        attempt_count=attempt_count,
+    )
+    if not lease_renewed:
         return 'superseded'
-    existing_enriched_version_id = _existing_recovered_version_id(latest)
-    if existing_enriched_version_id:
+    latest_enrichment_state = latest.get('enrichment_state') or {}
+    if (
+        generic_version_id
+        and str(latest.get('active_summary_version_id') or '') != str(generic_version_id)
+        and latest_enrichment_state.get('kind') != 'recovered_enriched'
+    ):
         await asyncio.to_thread(
-            conversations_db.record_conversation_processing_retry_enrichment,
+            conversations_db.finish_conversation_processing_retry,
             uid,
             conversation_id,
             request_id,
-            'completed',
-            summary_version_id=existing_enriched_version_id,
+            ConversationStatus.failed.value,
+            error_code='conversation_summary_changed',
+            preserve_completed_summary=True,
+            attempt_count=attempt_count,
         )
-        return ConversationStatus.completed.value
-
-    hermes_trace_id = f'summary-retry:{conversation_id}:{request_id}:hermes'
+        return ConversationStatus.failed.value
+    enriched_version_id = _existing_recovered_version_id(latest)
     try:
-        summary = await generate_summary_from_prompt(
-            prompt=_build_recovery_prompt(latest, client_context),
-            fallback=_structured_summary(latest),
-            session_id=':'.join(
-                [
-                    'summary-recovery',
-                    safe_session_component(uid),
-                    safe_session_component(conversation_id),
-                    safe_session_component(request_id),
-                ]
-            ),
-            session_key=canonical_omi_session_key(uid),
-            trace_id=hermes_trace_id,
-            required_tags=('omi', 'recovery'),
-            config=default_summary_provider_config(),
-        )
-        apply_result = await apply_summary_update(
-            uid=uid,
-            conversation_id=conversation_id,
-            trace_id=hermes_trace_id,
-            active_summary_version_id=latest.get('active_summary_version_id'),
-            summary=summary,
-            summary_kind='recovered_enriched',
-        )
-        enriched_version_id = apply_result.get('active_summary_version_id')
-        if not enriched_version_id:
-            raise RuntimeError('Hermes summary recovery did not return an active version')
-
-        enriched = await asyncio.to_thread(conversations_db.get_conversation, uid, conversation_id)
-        if not _is_current_retry(enriched, request_id):
-            return 'superseded'
-        await asyncio.to_thread(save_structured_vector, uid, Conversation(**enriched))
-        await asyncio.to_thread(
-            conversations_db.record_conversation_processing_retry_enrichment,
-            uid,
-            conversation_id,
-            request_id,
-            'completed',
-            summary_version_id=enriched_version_id,
-        )
+        pending_state = latest.get('enrichment_state') or {}
+        if enriched_version_id:
+            pass
+        elif (
+            pending_state.get('status') == 'writeback_pending_canonical'
+            and pending_state.get('kind') == 'recovered_enriched'
+            and pending_state.get('trace_id')
+            and latest.get('active_summary_version_id')
+        ):
+            apply_result = await apply_summary_update(
+                uid=uid,
+                conversation_id=conversation_id,
+                trace_id=str(pending_state['trace_id']),
+                active_summary_version_id=latest.get('active_summary_version_id'),
+                summary={},
+                summary_kind='recovered_enriched',
+                require_canonical=True,
+            )
+            enriched_version_id = apply_result.get('active_summary_version_id')
+            if not enriched_version_id or apply_result.get('canonical_confirmed') is not True:
+                raise CanonicalSummaryWriteUnconfirmedError('canonical_write_unconfirmed')
+        else:
+            apply_result = await invoke_hermes_recovery(
+                uid=uid,
+                conversation=latest,
+                request_id=request_id,
+                attempt_count=attempt_count,
+                client_context=client_context,
+            )
+            enriched_version_id = apply_result.get('active_summary_version_id')
+            if not enriched_version_id:
+                raise RuntimeError('Hermes summary recovery did not return an active version')
+            if apply_result.get('canonical_confirmed') is not True:
+                raise CanonicalSummaryWriteUnconfirmedError('canonical_write_unconfirmed')
     except Exception as error:
         logger.exception(
             'Hermes enrichment failed after generic summary recovery',
@@ -458,17 +801,89 @@ async def recover_failed_conversation_summary(
             },
         )
         try:
-            await asyncio.to_thread(
-                conversations_db.record_conversation_processing_retry_enrichment,
-                uid,
-                conversation_id,
-                request_id,
-                'failed',
-            )
+            after_error = await asyncio.to_thread(conversations_db.get_conversation, uid, conversation_id)
+            enriched_version_id = _existing_recovered_version_id(after_error or {})
+            if not _is_current_retry(after_error, request_id, attempt_count):
+                return 'superseded'
+            if not enriched_version_id:
+                after_error_state = (after_error or {}).get('enrichment_state') or {}
+                canonical_pending = bool(
+                    after_error_state.get('status') == 'writeback_pending_canonical'
+                    and after_error_state.get('kind') == 'recovered_enriched'
+                )
+                await asyncio.to_thread(
+                    conversations_db.record_conversation_processing_retry_enrichment,
+                    uid,
+                    conversation_id,
+                    request_id,
+                    (
+                        'canonical_failed'
+                        if isinstance(error, CanonicalSummaryWriteUnconfirmedError) or canonical_pending
+                        else 'failed'
+                    ),
+                    attempt_count=attempt_count,
+                )
+                return ConversationStatus.failed.value
         except Exception:
             logger.exception(
                 'Failed to persist retryable Hermes enrichment state',
                 extra={'uid': uid, 'conversation_id': conversation_id, 'request_id': request_id},
             )
+            return ConversationStatus.failed.value
 
+    enriched = await asyncio.to_thread(conversations_db.get_conversation, uid, conversation_id)
+    if not _is_current_retry(enriched, request_id, attempt_count):
+        return 'superseded'
+    recorded = await asyncio.to_thread(
+        conversations_db.record_conversation_processing_retry_enrichment,
+        uid,
+        conversation_id,
+        request_id,
+        'canonical_completed',
+        summary_version_id=enriched_version_id,
+        attempt_count=attempt_count,
+    )
+    if not recorded:
+        return 'superseded'
+
+    try:
+        enriched_vector_sha256 = await _write_and_confirm_enriched_vector(
+            uid,
+            enriched,
+            str(enriched_version_id),
+        )
+    except Exception as error:
+        logger.exception(
+            'Failed to confirm enriched conversation vector',
+            extra={
+                'uid': uid,
+                'conversation_id': conversation_id,
+                'request_id': request_id,
+                'error_type': type(error).__name__,
+            },
+        )
+        await asyncio.to_thread(
+            conversations_db.record_conversation_processing_retry_enrichment,
+            uid,
+            conversation_id,
+            request_id,
+            'vector_failed',
+            summary_version_id=enriched_version_id,
+            vector_content_sha256=_summary_content_sha256(enriched),
+            attempt_count=attempt_count,
+        )
+        return ConversationStatus.failed.value
+
+    recorded = await asyncio.to_thread(
+        conversations_db.record_conversation_processing_retry_enrichment,
+        uid,
+        conversation_id,
+        request_id,
+        'completed',
+        summary_version_id=enriched_version_id,
+        vector_content_sha256=enriched_vector_sha256,
+        attempt_count=attempt_count,
+    )
+    if not recorded:
+        return 'superseded'
     return ConversationStatus.completed.value

--- a/backend/ella/services/summary_writeback.py
+++ b/backend/ella/services/summary_writeback.py
@@ -21,6 +21,14 @@ class InvalidConversationSummaryCategoryError(Exception):
     pass
 
 
+class CanonicalSummaryWriteUnconfirmedError(RuntimeError):
+    pass
+
+
+class ConcurrentConversationSummaryChangeError(RuntimeError):
+    pass
+
+
 async def write_conversation_summary(
     *,
     uid: str,
@@ -40,16 +48,21 @@ async def write_conversation_summary(
     internal_assessment_fetcher: Optional[Callable[[str, str], Awaitable[Optional[dict]]]] = None,
     correction_audit_updater: Optional[Callable[[str, str, str, dict], None]] = None,
     canonical_writer: Callable[..., dict] = write_omi_canonical_event,
+    require_canonical: bool = False,
+    require_based_on_match: bool = False,
 ) -> dict[str, Any]:
     conversation = conversations_db.get_conversation(uid, conversation_id)
     if conversation is None:
         raise ConversationSummaryNotFoundError(conversation_id)
+    if require_based_on_match and conversation.get('active_summary_version_id') != based_on_version_id:
+        raise ConcurrentConversationSummaryChangeError('active_summary_version_changed')
 
     enrichment_state = conversation.get('enrichment_state') or {}
+    same_trace = bool(trace_id and enrichment_state.get('trace_id') == trace_id)
     if (
-        trace_id
+        same_trace
         and enrichment_state.get('status') == 'writeback_applied'
-        and enrichment_state.get('trace_id') == trace_id
+        and (not require_canonical or enrichment_state.get('canonical_status') == 'completed')
     ):
         return {
             'status': 'ok',
@@ -58,6 +71,49 @@ async def write_conversation_summary(
             'active_summary_version_id': conversation.get('active_summary_version_id'),
             'sanitizer_warnings': [],
             'idempotent_replay': True,
+            'canonical_confirmed': enrichment_state.get('canonical_status') == 'completed',
+        }
+
+    if same_trace and require_canonical and enrichment_state.get('status') == 'writeback_pending_canonical':
+        confirmed_state = {
+            **enrichment_state,
+            'status': 'writeback_applied',
+            'pending': False,
+            'canonical_status': 'completed',
+            'error': None,
+            'updated_at': datetime.now(timezone.utc),
+        }
+        canonical_conversation = {
+            **conversation,
+            'id': conversation_id,
+            'enrichment_state': confirmed_state,
+        }
+        try:
+            canonical_result = await asyncio.to_thread(
+                canonical_writer,
+                uid,
+                canonical_conversation,
+                summary_source=summary_source,
+                summary_kind=summary_kind,
+                trace_id=trace_id,
+            )
+            if not isinstance(canonical_result, dict) or canonical_result.get('ok') is not True:
+                raise RuntimeError('canonical_write_unconfirmed')
+        except Exception as error:
+            logger.exception(
+                'Failed to confirm pending conversation summary in canonical ledger',
+                extra={'uid': uid, 'conversation_id': conversation_id, 'trace_id': trace_id},
+            )
+            raise CanonicalSummaryWriteUnconfirmedError('canonical_write_unconfirmed') from error
+        conversations_db.update_conversation(uid, conversation_id, {'enrichment_state': confirmed_state})
+        return {
+            'status': 'ok',
+            'conversation_id': conversation_id,
+            'updated_fields': ['enrichment_state'],
+            'active_summary_version_id': conversation.get('active_summary_version_id'),
+            'sanitizer_warnings': [],
+            'idempotent_replay': True,
+            'canonical_confirmed': True,
         }
 
     sanitized = sanitize_summary_update(title=title, overview=overview, emoji=emoji, category=category)
@@ -102,13 +158,14 @@ async def write_conversation_summary(
     update_data['summary_versions'] = version_update['summary_versions']
     update_data['active_summary_version_id'] = version_update['active_summary_version_id']
     update_data['enrichment_state'] = {
-        'status': 'writeback_applied',
-        'pending': False,
+        'status': 'writeback_pending_canonical' if require_canonical else 'writeback_applied',
+        'pending': require_canonical,
         'source': summary_source,
         'kind': summary_kind,
         'trace_id': trace_id,
         'updated_at': state_updated_at,
         'error': None,
+        'canonical_status': 'pending' if require_canonical else 'unconfirmed',
     }
 
     if internal_assessment_fetcher:
@@ -150,8 +207,18 @@ async def write_conversation_summary(
         'ella_tags': update_data.get('ella_tags', canonical_base.get('ella_tags') or []),
         'ella_signal': update_data.get('ella_signal', canonical_base.get('ella_signal')),
     }
+    confirmed_state = {
+        **update_data['enrichment_state'],
+        'status': 'writeback_applied',
+        'pending': False,
+        'canonical_status': 'completed',
+        'error': None,
+    }
+    canonical_conversation['enrichment_state'] = confirmed_state
+    canonical_result: Optional[dict[str, Any]] = None
+    canonical_error: Optional[Exception] = None
     try:
-        await asyncio.to_thread(
+        canonical_result = await asyncio.to_thread(
             canonical_writer,
             uid,
             canonical_conversation,
@@ -159,11 +226,26 @@ async def write_conversation_summary(
             summary_kind=summary_kind,
             trace_id=trace_id,
         )
-    except Exception:
+        if require_canonical and (not isinstance(canonical_result, dict) or canonical_result.get('ok') is not True):
+            raise RuntimeError('canonical_write_unconfirmed')
+    except Exception as error:
+        canonical_error = error
         logger.exception(
             'Failed to write conversation summary to canonical ledger',
             extra={'uid': uid, 'conversation_id': conversation_id, 'trace_id': trace_id},
         )
+
+    if require_canonical:
+        if canonical_error is not None:
+            failed_state = {
+                **update_data['enrichment_state'],
+                'canonical_status': 'failed',
+                'error': 'canonical_write_unconfirmed',
+                'updated_at': datetime.now(timezone.utc),
+            }
+            conversations_db.update_conversation(uid, conversation_id, {'enrichment_state': failed_state})
+            raise CanonicalSummaryWriteUnconfirmedError('canonical_write_unconfirmed') from canonical_error
+        conversations_db.update_conversation(uid, conversation_id, {'enrichment_state': confirmed_state})
 
     if correction_id and correction_audit_updater:
         try:
@@ -192,4 +274,5 @@ async def write_conversation_summary(
         'updated_fields': list(update_data.keys()),
         'active_summary_version_id': version_update['active_summary_version_id'],
         'sanitizer_warnings': sanitized.warnings,
+        'canonical_confirmed': bool(isinstance(canonical_result, dict) and canonical_result.get('ok') is True),
     }

--- a/backend/ella/services/summary_writeback.py
+++ b/backend/ella/services/summary_writeback.py
@@ -1,0 +1,195 @@
+"""Shared direct conversation-summary writeback with version and ledger provenance."""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Optional
+
+import database.conversations as conversations_db
+from ella.services.summary_sanitizer import sanitize_summary_update
+from models.conversation import CategoryEnum
+from utils.ella.canonical_omi import write_omi_canonical_event
+
+logger = logging.getLogger(__name__)
+
+
+class ConversationSummaryNotFoundError(Exception):
+    pass
+
+
+class InvalidConversationSummaryCategoryError(Exception):
+    pass
+
+
+async def write_conversation_summary(
+    *,
+    uid: str,
+    conversation_id: str,
+    title: Optional[str] = None,
+    overview: Optional[str] = None,
+    emoji: Optional[str] = None,
+    category: Optional[str] = None,
+    summary_source: str = 'observer',
+    summary_kind: str = 'observer_enriched',
+    correction_id: Optional[str] = None,
+    based_on_version_id: Optional[str] = None,
+    set_active: bool = True,
+    trace_id: Optional[str] = None,
+    ella_tags: Optional[list[str]] = None,
+    ella_signal: Optional[dict[str, Any]] = None,
+    internal_assessment_fetcher: Optional[Callable[[str, str], Awaitable[Optional[dict]]]] = None,
+    correction_audit_updater: Optional[Callable[[str, str, str, dict], None]] = None,
+    canonical_writer: Callable[..., dict] = write_omi_canonical_event,
+) -> dict[str, Any]:
+    conversation = conversations_db.get_conversation(uid, conversation_id)
+    if conversation is None:
+        raise ConversationSummaryNotFoundError(conversation_id)
+
+    enrichment_state = conversation.get('enrichment_state') or {}
+    if (
+        trace_id
+        and enrichment_state.get('status') == 'writeback_applied'
+        and enrichment_state.get('trace_id') == trace_id
+    ):
+        return {
+            'status': 'ok',
+            'conversation_id': conversation_id,
+            'updated_fields': [],
+            'active_summary_version_id': conversation.get('active_summary_version_id'),
+            'sanitizer_warnings': [],
+            'idempotent_replay': True,
+        }
+
+    sanitized = sanitize_summary_update(title=title, overview=overview, emoji=emoji, category=category)
+    update_data: dict[str, Any] = {}
+    if sanitized.title is not None:
+        update_data['structured.title'] = sanitized.title
+    if sanitized.overview is not None:
+        update_data['structured.overview'] = sanitized.overview
+        update_data['apps_results'] = []
+        update_data['plugins_results'] = []
+    if sanitized.emoji is not None:
+        update_data['structured.emoji'] = sanitized.emoji
+    if sanitized.category is not None:
+        try:
+            CategoryEnum(sanitized.category)
+        except ValueError as error:
+            raise InvalidConversationSummaryCategoryError(sanitized.category) from error
+        update_data['structured.category'] = sanitized.category
+    if not update_data:
+        raise ValueError('No fields to update')
+
+    structured = dict(conversation.get('structured') or {})
+    if sanitized.title is not None:
+        structured['title'] = sanitized.title
+    if sanitized.overview is not None:
+        structured['overview'] = sanitized.overview
+    if sanitized.emoji is not None:
+        structured['emoji'] = sanitized.emoji
+    if sanitized.category is not None:
+        structured['category'] = sanitized.category
+
+    version_update = conversations_db.build_summary_version_update(
+        conversation,
+        next_structured=structured,
+        source=summary_source,
+        kind=summary_kind,
+        correction_id=correction_id,
+        based_on_version_id=based_on_version_id,
+        activate=set_active,
+    )
+    state_updated_at = datetime.now(timezone.utc)
+    update_data['summary_versions'] = version_update['summary_versions']
+    update_data['active_summary_version_id'] = version_update['active_summary_version_id']
+    update_data['enrichment_state'] = {
+        'status': 'writeback_applied',
+        'pending': False,
+        'source': summary_source,
+        'kind': summary_kind,
+        'trace_id': trace_id,
+        'updated_at': state_updated_at,
+        'error': None,
+    }
+
+    if internal_assessment_fetcher:
+        internal_assessment = await internal_assessment_fetcher(uid, conversation_id)
+        if internal_assessment:
+            update_data['internal_assessment'] = internal_assessment
+
+    normalized_tags = []
+    for tag in ella_tags or []:
+        clean = str(tag).strip().lower().replace(' ', '_')
+        if clean and len(clean) <= 64 and clean not in normalized_tags:
+            normalized_tags.append(clean)
+    if normalized_tags:
+        update_data['ella_tags'] = normalized_tags[:12]
+    if ella_signal is not None:
+        update_data['ella_signal'] = ella_signal
+    if correction_id:
+        existing_state = conversation.get('correction_state') or {}
+        update_data['correction_state'] = {
+            'correction_id': correction_id,
+            'status': 'applied',
+            'pending': False,
+            'source': existing_state.get('source'),
+            'submitted_at': existing_state.get('submitted_at'),
+            'updated_at': state_updated_at,
+            'active_summary_version_id': version_update['active_summary_version_id'],
+        }
+
+    conversations_db.update_conversation(uid, conversation_id, update_data)
+    canonical_base = dict(conversation)
+    canonical_conversation = {
+        **canonical_base,
+        'id': conversation_id,
+        'structured': structured,
+        'summary_versions': version_update['summary_versions'],
+        'active_summary_version_id': version_update['active_summary_version_id'],
+        'enrichment_state': update_data['enrichment_state'],
+        'internal_assessment': update_data.get('internal_assessment', canonical_base.get('internal_assessment')),
+        'ella_tags': update_data.get('ella_tags', canonical_base.get('ella_tags') or []),
+        'ella_signal': update_data.get('ella_signal', canonical_base.get('ella_signal')),
+    }
+    try:
+        await asyncio.to_thread(
+            canonical_writer,
+            uid,
+            canonical_conversation,
+            summary_source=summary_source,
+            summary_kind=summary_kind,
+            trace_id=trace_id,
+        )
+    except Exception:
+        logger.exception(
+            'Failed to write conversation summary to canonical ledger',
+            extra={'uid': uid, 'conversation_id': conversation_id, 'trace_id': trace_id},
+        )
+
+    if correction_id and correction_audit_updater:
+        try:
+            correction_audit_updater(
+                uid,
+                conversation_id,
+                correction_id,
+                {
+                    'status': 'applied',
+                    'updated_at': state_updated_at.isoformat(),
+                    'applied_at': state_updated_at.isoformat(),
+                    'applied_summary_version_id': version_update['active_summary_version_id'],
+                    'summary_version_kind': summary_kind,
+                    'summary_version_source': summary_source,
+                },
+            )
+        except Exception:
+            logger.exception(
+                'Failed to update correction audit after summary apply',
+                extra={'uid': uid, 'conversation_id': conversation_id, 'correction_id': correction_id},
+            )
+
+    return {
+        'status': 'ok',
+        'conversation_id': conversation_id,
+        'updated_fields': list(update_data.keys()),
+        'active_summary_version_id': version_update['active_summary_version_id'],
+        'sanitizer_warnings': sanitized.warnings,
+    }

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -379,10 +379,19 @@ class Conversation(BaseModel):
     processing_error: Optional[str] = None
     processing_error_at: Optional[datetime] = None
     processing_retry_id: Optional[str] = None
+    processing_retry_mode: Optional[str] = None
     processing_retry_started_at: Optional[datetime] = None
+    processing_retry_lease_expires_at: Optional[datetime] = None
     processing_retry_completed_at: Optional[datetime] = None
+    processing_retry_attempt_count: Optional[int] = None
     processing_retry_summary_version_id: Optional[str] = None
     processing_retry_enriched_version_id: Optional[str] = None
+    processing_retry_generic_vector_status: Optional[str] = None
+    processing_retry_enrichment_vector_status: Optional[str] = None
+    processing_retry_enrichment_vector_version_id: Optional[str] = None
+    processing_retry_enrichment_vector_sha256: Optional[str] = None
+    processing_retry_transcript_sha256: Optional[str] = None
+    processing_retry_source_request_id: Optional[str] = None
     is_locked: bool = False
     data_protection_level: Optional[str] = None
     folder_id: Optional[str] = Field(default=None, description="ID of the folder this conversation belongs to")

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -334,8 +334,6 @@ class ConversationPostProcessing(BaseModel):
     fail_reason: Optional[str] = None
 
 
-
-
 class Conversation(BaseModel):
     id: str
     created_at: datetime
@@ -380,6 +378,11 @@ class Conversation(BaseModel):
     status: Optional[ConversationStatus] = ConversationStatus.completed
     processing_error: Optional[str] = None
     processing_error_at: Optional[datetime] = None
+    processing_retry_id: Optional[str] = None
+    processing_retry_started_at: Optional[datetime] = None
+    processing_retry_completed_at: Optional[datetime] = None
+    processing_retry_summary_version_id: Optional[str] = None
+    processing_retry_enriched_version_id: Optional[str] = None
     is_locked: bool = False
     data_protection_level: Optional[str] = None
     folder_id: Optional[str] = Field(default=None, description="ID of the folder this conversation belongs to")

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -391,6 +391,7 @@ class Conversation(BaseModel):
     processing_retry_enrichment_vector_version_id: Optional[str] = None
     processing_retry_enrichment_vector_sha256: Optional[str] = None
     processing_retry_transcript_sha256: Optional[str] = None
+    processing_retry_generic_summary_sha256: Optional[str] = None
     processing_retry_source_request_id: Optional[str] = None
     is_locked: bool = False
     data_protection_level: Optional[str] = None

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -116,7 +116,10 @@ def reprocess_conversation(
 def get_conversations(
     limit: int = 100,
     offset: int = 0,
-    statuses: Optional[str] = "processing,completed",
+    statuses: Optional[str] = Query(
+        "processing,completed",
+        description="Comma-separated conversation statuses, including failed for retryable summary failures",
+    ),
     include_discarded: bool = True,
     start_date: Optional[datetime] = Query(None, description="Filter by start date (inclusive)"),
     end_date: Optional[datetime] = Query(None, description="Filter by end date (inclusive)"),

--- a/backend/tests/unit/test_conversation_processing_failures.py
+++ b/backend/tests/unit/test_conversation_processing_failures.py
@@ -4,6 +4,8 @@ import sys
 import types
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from models.conversation import Conversation, ConversationStatus, Structured
 from models.transcript_segment import TranscriptSegment
@@ -66,6 +68,8 @@ _stub_module(
     delete_memory_vector=_noop,
     upsert_vector2=_noop,
     update_vector_metadata=_noop,
+    delete_vector=_noop,
+    query_vectors_by_metadata=lambda *args, **kwargs: [],
 )
 _stub_module(
     "database.apps",
@@ -78,6 +82,7 @@ _stub_module(
     resolve_memory_conflict=_noop,
     extract_memories_from_text=lambda *args, **kwargs: [],
     new_memories_extractor=lambda *args, **kwargs: [],
+    identify_category_for_memory=lambda *args, **kwargs: "other",
 )
 _stub_module(
     "utils.llm.conversation_processing",
@@ -88,6 +93,7 @@ _stub_module(
     get_suggested_apps_for_conversation=lambda *args, **kwargs: [],
     get_reprocess_transcript_structure=_noop,
     assign_conversation_to_folder=lambda *args, **kwargs: (None, 0.0, ""),
+    generate_summary_with_prompt=lambda *args, **kwargs: "",
 )
 _stub_module(
     "utils.llm.external_integrations",
@@ -105,7 +111,17 @@ _stub_module(
 )
 _stub_module("utils.llm.clients", generate_embedding=lambda *args, **kwargs: [0.1, 0.2])
 _stub_module("utils.retrieval.rag", retrieve_rag_conversation_context=lambda *args, **kwargs: "")
-_stub_module("utils.other.storage", list_audio_chunks=lambda *args, **kwargs: [], precache_conversation_audio=_noop)
+_stub_module("utils.conversations.search", search_conversations=lambda *args, **kwargs: [])
+_stub_module("utils.speaker_identification", extract_speaker_samples=_noop)
+_stub_module("utils.app_integrations", trigger_external_integrations=lambda *args, **kwargs: [])
+_stub_module("utils.conversations.location", get_google_maps_location=lambda *args, **kwargs: None)
+_stub_module(
+    "utils.other.storage",
+    list_audio_chunks=lambda *args, **kwargs: [],
+    precache_conversation_audio=_noop,
+    get_conversation_recording_if_exists=lambda *args, **kwargs: None,
+    storage_client=types.SimpleNamespace(),
+)
 _stub_module(
     "utils.notifications",
     send_important_conversation_message=_noop,
@@ -150,6 +166,7 @@ from utils.conversations.failure_state import (
     apply_conversation_processing_failed,
     clear_conversation_processing_error,
 )
+from routers import conversations as conversations_router
 
 
 def _long_conversation() -> Conversation:
@@ -271,3 +288,124 @@ def test_process_conversation_intentional_discard_stays_completed_discarded(monk
     assert writes[-1][1]["discarded"] is True
     assert writes[-1][1]["status"] == ConversationStatus.completed
     assert writes[-1][1].get("processing_error") is None
+
+
+class _FakeSnapshot:
+    def __init__(self, data=None):
+        self._data = data
+        self.exists = data is not None
+
+    def to_dict(self):
+        return self._data
+
+
+class _FakeDocumentRef:
+    def __init__(self, data=None):
+        self.snapshot = _FakeSnapshot(data)
+
+    def get(self, transaction=None):
+        return self.snapshot
+
+
+class _FakeTransaction:
+    def __init__(self):
+        self.updates = []
+        self.sets = []
+
+    def update(self, ref, data):
+        self.updates.append((ref, data))
+
+    def set(self, ref, data):
+        self.sets.append((ref, data))
+
+
+def _claim_retry(conversation_data, request_id, retry_data=None):
+    transaction = _FakeTransaction()
+    conversation_ref = _FakeDocumentRef(conversation_data)
+    retry_ref = _FakeDocumentRef(retry_data)
+    requested_at = datetime(2026, 7, 21, 3, 0, tzinfo=timezone.utc)
+    result = conversation_processor.conversations_db._claim_conversation_processing_retry_transaction(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        request_id,
+        requested_at,
+    )
+    return result, transaction
+
+
+def test_retry_claim_is_atomic_and_preserves_failed_error_provenance():
+    conversation = _long_conversation()
+    apply_conversation_processing_failed(conversation)
+
+    result, transaction = _claim_retry(conversation.dict(), "request-a")
+
+    assert result["outcome"] == "claimed"
+    assert result["conversation"]["status"] == ConversationStatus.processing.value
+    assert result["conversation"]["processing_error"] == CONVERSATION_SUMMARY_FAILED
+    assert len(transaction.updates) == 1
+    assert transaction.updates[0][1]["processing_retry_id"] == "request-a"
+    assert len(transaction.sets) == 1
+    assert transaction.sets[0][1]["outcome"] == ConversationStatus.processing.value
+
+
+@pytest.mark.parametrize("stored_outcome", ["processing", "completed", "failed"])
+def test_retry_claim_reuses_durable_request_receipt_without_enqueuing(stored_outcome):
+    conversation = _long_conversation()
+    conversation.status = ConversationStatus.processing
+    conversation.processing_retry_id = "newer-request"
+
+    result, transaction = _claim_retry(
+        conversation.dict(),
+        "older-request",
+        retry_data={"request_id": "older-request", "outcome": stored_outcome},
+    )
+
+    assert result["outcome"] == stored_outcome
+    assert transaction.updates == []
+    assert transaction.sets == []
+
+
+def test_retry_claim_rejects_a_different_request_while_processing():
+    conversation = _long_conversation()
+    conversation.status = ConversationStatus.processing
+    conversation.processing_retry_id = "active-request"
+
+    result, transaction = _claim_retry(conversation.dict(), "other-request")
+
+    assert result["outcome"] == "busy"
+    assert transaction.updates == []
+    assert transaction.sets == []
+
+
+def _conversation_api_client():
+    app = FastAPI()
+    app.include_router(conversations_router.router)
+    app.dependency_overrides[conversations_router.auth.get_current_user_uid] = lambda: "authenticated-user"
+    return app, TestClient(app)
+
+
+def test_failed_conversations_api_is_uid_scoped_and_preserves_long_transcript(monkeypatch):
+    conversation = _long_conversation()
+    apply_conversation_processing_failed(conversation)
+    calls = []
+
+    def fake_get_conversations(uid, limit, offset, **kwargs):
+        calls.append((uid, limit, offset, kwargs))
+        return [conversation.dict()]
+
+    monkeypatch.setattr(conversations_router.conversations_db, "get_conversations", fake_get_conversations)
+    app, client = _conversation_api_client()
+    try:
+        response = client.get("/v1/conversations?statuses=failed&include_discarded=true")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert calls[0][0] == "authenticated-user"
+    assert calls[0][3]["statuses"] == ["failed"]
+    payload = response.json()[0]
+    assert payload["status"] == "failed"
+    assert payload["processing_error"] == CONVERSATION_SUMMARY_FAILED
+    assert payload["processing_error_at"] is not None
+    assert len(payload["transcript_segments"][0]["text"]) > 25_000

--- a/backend/tests/unit/test_conversation_processing_failures.py
+++ b/backend/tests/unit/test_conversation_processing_failures.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import os
 import sys
 import types
@@ -341,16 +341,16 @@ def test_retry_claim_is_atomic_and_preserves_failed_error_provenance():
     result, transaction = _claim_retry(conversation.dict(), "request-a")
 
     assert result["outcome"] == "claimed"
-    assert result["conversation"]["status"] == ConversationStatus.processing.value
-    assert result["conversation"]["processing_error"] == CONVERSATION_SUMMARY_FAILED
+    assert "conversation" not in result
     assert len(transaction.updates) == 1
+    assert transaction.updates[0][1]["status"] == ConversationStatus.processing.value
     assert transaction.updates[0][1]["processing_retry_id"] == "request-a"
+    assert conversation.processing_error == CONVERSATION_SUMMARY_FAILED
     assert len(transaction.sets) == 1
     assert transaction.sets[0][1]["outcome"] == ConversationStatus.processing.value
 
 
-@pytest.mark.parametrize("stored_outcome", ["processing", "completed", "failed"])
-def test_retry_claim_reuses_durable_request_receipt_without_enqueuing(stored_outcome):
+def test_retry_claim_reuses_completed_durable_request_receipt_without_enqueuing():
     conversation = _long_conversation()
     conversation.status = ConversationStatus.processing
     conversation.processing_retry_id = "newer-request"
@@ -358,10 +358,10 @@ def test_retry_claim_reuses_durable_request_receipt_without_enqueuing(stored_out
     result, transaction = _claim_retry(
         conversation.dict(),
         "older-request",
-        retry_data={"request_id": "older-request", "outcome": stored_outcome},
+        retry_data={"request_id": "older-request", "outcome": "completed"},
     )
 
-    assert result["outcome"] == stored_outcome
+    assert result["outcome"] == "completed"
     assert transaction.updates == []
     assert transaction.sets == []
 
@@ -370,6 +370,9 @@ def test_retry_claim_rejects_a_different_request_while_processing():
     conversation = _long_conversation()
     conversation.status = ConversationStatus.processing
     conversation.processing_retry_id = "active-request"
+    conversation.processing_retry_lease_expires_at = datetime(2026, 7, 21, 3, 0, tzinfo=timezone.utc) + timedelta(
+        minutes=5
+    )
 
     result, transaction = _claim_retry(conversation.dict(), "other-request")
 

--- a/backend/tests/unit/test_conversation_processing_retry.py
+++ b/backend/tests/unit/test_conversation_processing_retry.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import types
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 os.environ.setdefault("FIRESTORE_EMULATOR_HOST", "localhost:9999")
 os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "test-project")
@@ -89,55 +89,194 @@ def _claim(data, request_id='request-123', retry_data=None):
     return result, transaction
 
 
-def test_failed_summary_is_atomically_claimed_without_transcript_loss():
+def test_failed_summary_is_atomically_claimed_without_returning_protected_transcript():
     result, transaction = _claim(_failed_conversation())
 
     assert result['outcome'] == 'claimed'
-    assert result['conversation']['status'] == ConversationStatus.processing.value
-    assert result['conversation']['processing_error'] == 'conversation_summary_failed'
-    assert result['conversation']['processing_retry_id'] == 'request-123'
-    assert result['conversation']['transcript_segments'] == [{'text': 'important transcript'}]
+    assert 'conversation' not in result
     assert transaction.updates[0][1] == {
         'status': ConversationStatus.processing.value,
         'processing_retry_id': 'request-123',
+        'processing_retry_mode': 'full',
         'processing_retry_started_at': datetime(2026, 7, 20, 8, 5, tzinfo=timezone.utc),
+        'processing_retry_lease_expires_at': datetime(2026, 7, 20, 8, 20, tzinfo=timezone.utc),
         'processing_retry_completed_at': None,
+        'processing_retry_attempt_count': 1,
     }
     assert transaction.sets[0][1]['outcome'] == ConversationStatus.processing.value
 
 
-def test_repeated_failed_request_id_does_not_start_duplicate_work():
+def test_repeated_failed_request_id_reclaims_retryable_work():
     result, transaction = _claim(
         _failed_conversation(request_id='newer-request'),
-        retry_data={'request_id': 'request-123', 'outcome': ConversationStatus.failed.value},
+        retry_data={
+            'request_id': 'request-123',
+            'outcome': ConversationStatus.failed.value,
+            'mode': 'full',
+            'phase': 'enrichment_failed',
+            'attempt_count': 1,
+        },
     )
 
-    assert result['outcome'] == 'failed'
-    assert transaction.updates == []
+    assert result['outcome'] == 'claimed'
+    assert result['reason'] == 'lease_reclaimed'
+    assert result['attempt_count'] == 2
+    assert len(transaction.updates) == 2
     assert transaction.sets == []
 
 
 def test_concurrent_request_observes_processing_without_reclaiming():
     conversation = _failed_conversation(request_id='request-first')
     conversation['status'] = ConversationStatus.processing.value
+    conversation['processing_retry_lease_expires_at'] = datetime(2026, 7, 20, 8, 10, tzinfo=timezone.utc)
 
     result, transaction = _claim(conversation, request_id='request-second')
 
     assert result['outcome'] == 'busy'
-    assert result['conversation']['processing_retry_id'] == 'request-first'
+    assert 'conversation' not in result
     assert transaction.updates == []
     assert transaction.sets == []
 
 
-def test_completed_conversation_is_idempotent_for_any_retry_id():
-    conversation = _failed_conversation(request_id='request-first')
-    conversation['status'] = ConversationStatus.completed.value
+def test_expired_same_request_lease_is_reclaimed_and_requeued():
+    requested_at = datetime(2026, 7, 20, 8, 5, tzinfo=timezone.utc)
+    conversation = _failed_conversation(request_id='request-123')
+    conversation.update(
+        {
+            'status': ConversationStatus.processing.value,
+            'processing_retry_lease_expires_at': requested_at - timedelta(seconds=1),
+        }
+    )
+    retry_data = {
+        'request_id': 'request-123',
+        'outcome': ConversationStatus.processing.value,
+        'mode': 'full',
+        'phase': 'claimed',
+        'attempt_count': 1,
+        'lease_expires_at': requested_at - timedelta(seconds=1),
+    }
+
+    result, transaction = _claim(conversation, retry_data=retry_data)
+
+    assert result['outcome'] == 'claimed'
+    assert result['reason'] == 'lease_reclaimed'
+    assert result['attempt_count'] == 2
+    assert transaction.updates[1][1]['outcome'] == 'processing'
+    assert transaction.updates[1][1]['lease_expires_at'] > requested_at
+
+
+def test_active_same_request_lease_returns_processing_without_duplicate_work():
+    requested_at = datetime(2026, 7, 20, 8, 5, tzinfo=timezone.utc)
+    retry_data = {
+        'request_id': 'request-123',
+        'outcome': ConversationStatus.processing.value,
+        'mode': 'full',
+        'phase': 'claimed',
+        'attempt_count': 1,
+        'lease_expires_at': requested_at + timedelta(minutes=5),
+    }
+
+    result, transaction = _claim(_failed_conversation(request_id='request-123'), retry_data=retry_data)
+
+    assert result['outcome'] == 'processing'
+    assert result['attempt_count'] == 1
+    assert transaction.updates == []
+    assert transaction.sets == []
+
+
+def test_old_failed_receipt_cannot_supersede_newer_active_lease():
+    conversation = _failed_conversation(request_id='newer-request')
+    conversation.update(
+        {
+            'status': ConversationStatus.processing.value,
+            'processing_retry_lease_expires_at': datetime(2026, 7, 20, 8, 10, tzinfo=timezone.utc),
+        }
+    )
+    retry_data = {
+        'request_id': 'request-123',
+        'outcome': ConversationStatus.failed.value,
+        'mode': 'full',
+        'attempt_count': 1,
+    }
+
+    result, transaction = _claim(conversation, retry_data=retry_data)
+
+    assert result['outcome'] == 'busy'
+    assert transaction.updates == []
+
+
+def test_completed_enriched_conversation_is_idempotent_for_any_retry_id():
+    conversation = _failed_conversation()
+    conversation.update(
+        {
+            'status': ConversationStatus.completed.value,
+            'structured': {'title': 'Enriched', 'overview': '[Ella] Complete.'},
+            'active_summary_version_id': 'enriched-v2',
+            'summary_versions': [
+                {'id': 'enriched-v2', 'kind': 'observer_enriched', 'source': 'observer', 'is_active': True}
+            ],
+            'enrichment_state': {'status': 'writeback_applied', 'kind': 'observer_enriched'},
+        }
+    )
 
     result, transaction = _claim(conversation, request_id='request-second')
 
     assert result['outcome'] == 'completed'
     assert transaction.updates == []
     assert transaction.sets[0][1]['outcome'] == ConversationStatus.completed.value
+
+
+def test_enriched_conversation_with_unconfirmed_vector_remains_stage_two_retryable():
+    conversation = _failed_conversation()
+    conversation.update(
+        {
+            'status': ConversationStatus.completed.value,
+            'structured': {'title': 'Enriched', 'overview': '[Ella] Complete.'},
+            'active_summary_version_id': 'enriched-v2',
+            'summary_versions': [
+                {'id': 'enriched-v2', 'kind': 'recovered_enriched', 'source': 'observer', 'is_active': True}
+            ],
+            'enrichment_state': {'status': 'writeback_applied', 'kind': 'recovered_enriched'},
+            'processing_retry_enrichment_vector_status': 'failed',
+        }
+    )
+
+    result, transaction = _claim(conversation)
+
+    assert result['outcome'] == 'claimed'
+    assert result['mode'] == 'enrichment_only'
+    assert result['reason'] == 'enriched_summary_without_confirmed_vector'
+    assert 'status' not in transaction.updates[0][1]
+
+
+def test_completed_generic_conversation_claims_enrichment_only_without_changing_visibility():
+    conversation = _failed_conversation()
+    conversation.update(
+        {
+            'status': ConversationStatus.completed.value,
+            'processing_error': None,
+            'structured': {'title': 'Generic', 'overview': '[Ella] Generic summary.'},
+            'active_summary_version_id': 'generic-v1',
+            'summary_versions': [{'id': 'generic-v1', 'kind': 'generic_recovered', 'source': 'omi', 'is_active': True}],
+        }
+    )
+
+    result, transaction = _claim(conversation)
+
+    assert result['outcome'] == 'claimed'
+    assert result['mode'] == 'enrichment_only'
+    assert 'conversation' not in result
+    assert transaction.updates[0][1] == {
+        'processing_retry_id': 'request-123',
+        'processing_retry_mode': 'enrichment_only',
+        'processing_retry_started_at': datetime(2026, 7, 20, 8, 5, tzinfo=timezone.utc),
+        'processing_retry_lease_expires_at': datetime(2026, 7, 20, 8, 20, tzinfo=timezone.utc),
+        'processing_retry_completed_at': None,
+        'processing_retry_attempt_count': 1,
+    }
+    assert transaction.sets[0][1]['generic_status'] == 'completed'
+    assert transaction.sets[0][1]['generic_vector_status'] == 'unknown'
+    assert transaction.sets[0][1]['enrichment_status'] == 'pending'
 
 
 def test_generic_processing_failure_is_visible_but_not_automatically_retried():
@@ -151,12 +290,51 @@ def test_generic_processing_failure_is_visible_but_not_automatically_retried():
 def test_missing_conversation_is_not_claimed():
     result, transaction = _claim(None)
 
-    assert result == {'outcome': 'not_found', 'conversation': None}
+    assert result['outcome'] == 'not_found'
+    assert 'conversation' not in result
     assert transaction.updates == []
     assert transaction.sets == []
 
 
-def test_summary_writeback_phase_is_receipted_before_vector_completion():
+def test_decrypted_source_hash_is_receipted_without_transcript_content():
+    transaction = _FakeTransaction()
+    conversation_ref = _FakeDocumentRef(
+        {
+            'processing_retry_id': 'request-123',
+            'transcript_segments': 'encrypted-payload-must-not-be-copied',
+        }
+    )
+    retry_ref = _FakeDocumentRef({'request_id': 'request-123', 'outcome': 'processing'})
+    updated_at = datetime(2026, 7, 20, 8, 6, tzinfo=timezone.utc)
+    lease_expires_at = updated_at + timedelta(minutes=15)
+
+    result = conversations_db._record_conversation_processing_retry_source_transaction(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        'request-123',
+        'a' * 64,
+        99,
+        updated_at,
+        lease_expires_at,
+    )
+
+    assert result is True
+    assert transaction.updates[0][1] == {
+        'processing_retry_lease_expires_at': lease_expires_at,
+        'processing_retry_transcript_sha256': 'a' * 64,
+        'processing_retry_source_request_id': 'request-123',
+    }
+    assert transaction.updates[1][1] == {
+        'transcript_sha256': 'a' * 64,
+        'transcript_segment_count': 99,
+        'lease_expires_at': lease_expires_at,
+        'updated_at': updated_at,
+    }
+    assert 'transcript_segments' not in transaction.updates[1][1]
+
+
+def test_generic_completion_keeps_overall_receipt_processing_for_hermes():
     transaction = _FakeTransaction()
     conversation_ref = _FakeDocumentRef(
         {
@@ -177,9 +355,20 @@ def test_summary_writeback_phase_is_receipted_before_vector_completion():
     )
 
     assert result is True
-    assert transaction.updates[0][1] == {"processing_retry_summary_version_id": "recovered-v1"}
+    assert transaction.updates[0][1] == {
+        "status": "completed",
+        "discarded": False,
+        "processing_error": None,
+        "processing_error_at": None,
+        "processing_retry_summary_version_id": "recovered-v1",
+        "processing_retry_generic_vector_status": "pending",
+    }
     assert transaction.updates[1][1] == {
-        "phase": "summary_applied",
+        "outcome": "processing",
+        "phase": "generic_writeback_applied",
+        "generic_status": "writeback_applied",
+        "generic_vector_status": "pending",
+        "enrichment_status": "pending",
         "summary_version_id": "recovered-v1",
         "updated_at": applied_at,
     }
@@ -209,7 +398,11 @@ def test_completed_retry_atomically_clears_failure_and_discarded_state():
     )
 
     assert result is True
-    assert transaction.updates[0][1] == {"outcome": "completed", "updated_at": finished_at}
+    assert transaction.updates[0][1] == {
+        "outcome": "completed",
+        "phase": "completed",
+        "updated_at": finished_at,
+    }
     assert transaction.updates[1][1] == {
         "status": "completed",
         "discarded": False,
@@ -243,6 +436,7 @@ def test_failed_vector_completion_stays_retryable_with_stable_error_code():
 
     assert result is True
     assert transaction.updates[0][1]["error_code"] == "conversation_summary_recovery_failed"
+    assert transaction.updates[0][1]["phase"] == "failed"
     assert transaction.updates[1][1] == {
         "status": "failed",
         "discarded": False,
@@ -258,6 +452,7 @@ def test_hermes_failure_keeps_completed_generic_summary_and_marks_enrichment_ret
             "status": "completed",
             "processing_retry_id": "request-123",
             "processing_retry_summary_version_id": "generic-v1",
+            "active_summary_version_id": "enriched-v2",
         }
     )
     retry_ref = _FakeDocumentRef({"request_id": "request-123", "outcome": "completed"})
@@ -277,9 +472,13 @@ def test_hermes_failure_keeps_completed_generic_summary_and_marks_enrichment_ret
     assert result is True
     assert transaction.updates[0][1] == {
         "enrichment_status": "failed",
+        "outcome": "failed",
+        "phase": "enrichment_failed",
         "updated_at": failed_at,
     }
     assert transaction.updates[1][1] == {
+        "status": "completed",
+        "processing_retry_completed_at": failed_at,
         "enrichment_state": {
             "status": "failed",
             "pending": True,
@@ -288,7 +487,7 @@ def test_hermes_failure_keeps_completed_generic_summary_and_marks_enrichment_ret
             "trace_id": "summary-retry:conversation-1:request-123:hermes",
             "updated_at": failed_at,
             "error": "hermes_temporarily_unavailable",
-        }
+        },
     }
 
 
@@ -299,6 +498,7 @@ def test_hermes_success_records_enriched_version_without_changing_completed_stat
             "status": "completed",
             "processing_retry_id": "request-123",
             "processing_retry_summary_version_id": "generic-v1",
+            "active_summary_version_id": "enriched-v2",
         }
     )
     retry_ref = _FakeDocumentRef({"request_id": "request-123", "outcome": "completed"})
@@ -313,14 +513,81 @@ def test_hermes_success_records_enriched_version_without_changing_completed_stat
         "completed",
         completed_at,
         "enriched-v2",
+        "e" * 64,
     )
 
     assert result is True
     assert transaction.updates[0][1] == {
         "enrichment_status": "completed",
+        "vector_status": "completed",
+        "outcome": "completed",
+        "phase": "completed",
         "updated_at": completed_at,
         "enriched_summary_version_id": "enriched-v2",
+        "vector_summary_version_id": "enriched-v2",
+        "vector_content_sha256": "e" * 64,
     }
     assert transaction.updates[1][1] == {
+        "status": "completed",
         "processing_retry_enriched_version_id": "enriched-v2",
+        "processing_retry_enrichment_vector_status": "completed",
+        "processing_retry_enrichment_vector_version_id": "enriched-v2",
+        "processing_retry_enrichment_vector_sha256": "e" * 64,
+        "processing_retry_completed_at": completed_at,
     }
+
+
+def test_stale_attempt_cannot_mark_reclaimed_enrichment_complete():
+    transaction = _FakeTransaction()
+    conversation_ref = _FakeDocumentRef(
+        {
+            'status': 'completed',
+            'processing_retry_id': 'request-123',
+            'processing_retry_attempt_count': 2,
+        }
+    )
+    retry_ref = _FakeDocumentRef({'request_id': 'request-123', 'outcome': 'processing', 'attempt_count': 2})
+
+    result = conversations_db._record_conversation_processing_retry_enrichment_transaction(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        'conversation-1',
+        'request-123',
+        'completed',
+        datetime(2026, 7, 20, 8, 9, tzinfo=timezone.utc),
+        'enriched-v2',
+        attempt_count=1,
+    )
+
+    assert result is False
+    assert transaction.updates == []
+
+
+def test_changed_active_summary_cannot_mark_enriched_vector_complete():
+    transaction = _FakeTransaction()
+    conversation_ref = _FakeDocumentRef(
+        {
+            'status': 'completed',
+            'processing_retry_id': 'request-123',
+            'processing_retry_attempt_count': 2,
+            'active_summary_version_id': 'manual-v3',
+        }
+    )
+    retry_ref = _FakeDocumentRef({'request_id': 'request-123', 'outcome': 'processing', 'attempt_count': 2})
+
+    result = conversations_db._record_conversation_processing_retry_enrichment_transaction(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        'conversation-1',
+        'request-123',
+        'completed',
+        datetime(2026, 7, 20, 8, 9, tzinfo=timezone.utc),
+        'enriched-v2',
+        'e' * 64,
+        attempt_count=2,
+    )
+
+    assert result is False
+    assert transaction.updates == []

--- a/backend/tests/unit/test_conversation_processing_retry.py
+++ b/backend/tests/unit/test_conversation_processing_retry.py
@@ -1,0 +1,326 @@
+import os
+import sys
+import types
+from datetime import datetime, timezone
+
+os.environ.setdefault("FIRESTORE_EMULATOR_HOST", "localhost:9999")
+os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "test-project")
+os.environ.setdefault("ENCRYPTION_SECRET", "test-encryption-secret-32-bytes-long")
+
+if "redis" not in sys.modules:
+    redis_stub = types.ModuleType("redis")
+
+    class _RedisStub:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __getattr__(self, name):
+            return lambda *args, **kwargs: None
+
+    redis_stub.Redis = _RedisStub
+    sys.modules["redis"] = redis_stub
+
+if "stripe" not in sys.modules:
+    stripe_stub = types.ModuleType("stripe")
+    stripe_stub.api_key = None
+    sys.modules["stripe"] = stripe_stub
+
+storage_stub = types.ModuleType("utils.other.storage")
+storage_stub.list_audio_chunks = lambda *args, **kwargs: []
+sys.modules.setdefault("utils.other.storage", storage_stub)
+
+from database import conversations as conversations_db
+from models.conversation import ConversationStatus
+
+
+class _FakeSnapshot:
+    def __init__(self, data):
+        self.exists = data is not None
+        self._data = data
+
+    def to_dict(self):
+        return dict(self._data)
+
+
+class _FakeDocumentRef:
+    def __init__(self, data):
+        self.data = data
+
+    def get(self, transaction=None):
+        return _FakeSnapshot(self.data)
+
+
+class _FakeTransaction:
+    def __init__(self):
+        self.updates = []
+        self.sets = []
+
+    def update(self, document_ref, update_data):
+        self.updates.append((document_ref, update_data))
+
+    def set(self, document_ref, data):
+        self.sets.append((document_ref, data))
+
+
+def _failed_conversation(request_id=None, error='conversation_summary_failed'):
+    return {
+        'id': 'conversation-1',
+        'status': ConversationStatus.failed.value,
+        'discarded': False,
+        'processing_error': error,
+        'processing_error_at': datetime(2026, 7, 20, 8, 0, tzinfo=timezone.utc),
+        'processing_retry_id': request_id,
+        'transcript_segments': [{'text': 'important transcript'}],
+    }
+
+
+def _claim(data, request_id='request-123', retry_data=None):
+    transaction = _FakeTransaction()
+    conversation_ref = _FakeDocumentRef(data)
+    retry_ref = _FakeDocumentRef(retry_data)
+    requested_at = datetime(2026, 7, 20, 8, 5, tzinfo=timezone.utc)
+    result = conversations_db._claim_conversation_processing_retry_transaction(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        request_id,
+        requested_at,
+    )
+    return result, transaction
+
+
+def test_failed_summary_is_atomically_claimed_without_transcript_loss():
+    result, transaction = _claim(_failed_conversation())
+
+    assert result['outcome'] == 'claimed'
+    assert result['conversation']['status'] == ConversationStatus.processing.value
+    assert result['conversation']['processing_error'] == 'conversation_summary_failed'
+    assert result['conversation']['processing_retry_id'] == 'request-123'
+    assert result['conversation']['transcript_segments'] == [{'text': 'important transcript'}]
+    assert transaction.updates[0][1] == {
+        'status': ConversationStatus.processing.value,
+        'processing_retry_id': 'request-123',
+        'processing_retry_started_at': datetime(2026, 7, 20, 8, 5, tzinfo=timezone.utc),
+        'processing_retry_completed_at': None,
+    }
+    assert transaction.sets[0][1]['outcome'] == ConversationStatus.processing.value
+
+
+def test_repeated_failed_request_id_does_not_start_duplicate_work():
+    result, transaction = _claim(
+        _failed_conversation(request_id='newer-request'),
+        retry_data={'request_id': 'request-123', 'outcome': ConversationStatus.failed.value},
+    )
+
+    assert result['outcome'] == 'failed'
+    assert transaction.updates == []
+    assert transaction.sets == []
+
+
+def test_concurrent_request_observes_processing_without_reclaiming():
+    conversation = _failed_conversation(request_id='request-first')
+    conversation['status'] = ConversationStatus.processing.value
+
+    result, transaction = _claim(conversation, request_id='request-second')
+
+    assert result['outcome'] == 'busy'
+    assert result['conversation']['processing_retry_id'] == 'request-first'
+    assert transaction.updates == []
+    assert transaction.sets == []
+
+
+def test_completed_conversation_is_idempotent_for_any_retry_id():
+    conversation = _failed_conversation(request_id='request-first')
+    conversation['status'] = ConversationStatus.completed.value
+
+    result, transaction = _claim(conversation, request_id='request-second')
+
+    assert result['outcome'] == 'completed'
+    assert transaction.updates == []
+    assert transaction.sets[0][1]['outcome'] == ConversationStatus.completed.value
+
+
+def test_generic_processing_failure_is_visible_but_not_automatically_retried():
+    result, transaction = _claim(_failed_conversation(error='conversation_processing_failed'))
+
+    assert result['outcome'] == 'not_retryable'
+    assert transaction.updates == []
+    assert transaction.sets == []
+
+
+def test_missing_conversation_is_not_claimed():
+    result, transaction = _claim(None)
+
+    assert result == {'outcome': 'not_found', 'conversation': None}
+    assert transaction.updates == []
+    assert transaction.sets == []
+
+
+def test_summary_writeback_phase_is_receipted_before_vector_completion():
+    transaction = _FakeTransaction()
+    conversation_ref = _FakeDocumentRef(
+        {
+            "status": "processing",
+            "processing_retry_id": "request-123",
+        }
+    )
+    retry_ref = _FakeDocumentRef({"request_id": "request-123", "outcome": "processing"})
+    applied_at = datetime(2026, 7, 20, 8, 6, tzinfo=timezone.utc)
+
+    result = conversations_db._record_conversation_processing_retry_summary_applied_transaction(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        "request-123",
+        "recovered-v1",
+        applied_at,
+    )
+
+    assert result is True
+    assert transaction.updates[0][1] == {"processing_retry_summary_version_id": "recovered-v1"}
+    assert transaction.updates[1][1] == {
+        "phase": "summary_applied",
+        "summary_version_id": "recovered-v1",
+        "updated_at": applied_at,
+    }
+
+
+def test_completed_retry_atomically_clears_failure_and_discarded_state():
+    transaction = _FakeTransaction()
+    conversation_ref = _FakeDocumentRef(
+        {
+            "status": "processing",
+            "discarded": True,
+            "processing_error": "conversation_summary_failed",
+            "processing_retry_id": "request-123",
+        }
+    )
+    retry_ref = _FakeDocumentRef({"request_id": "request-123", "outcome": "processing"})
+    finished_at = datetime(2026, 7, 20, 8, 7, tzinfo=timezone.utc)
+
+    result = conversations_db._finish_conversation_processing_retry_transaction(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        "request-123",
+        "completed",
+        finished_at,
+        None,
+    )
+
+    assert result is True
+    assert transaction.updates[0][1] == {"outcome": "completed", "updated_at": finished_at}
+    assert transaction.updates[1][1] == {
+        "status": "completed",
+        "discarded": False,
+        "processing_error": None,
+        "processing_error_at": None,
+        "processing_retry_completed_at": finished_at,
+    }
+
+
+def test_failed_vector_completion_stays_retryable_with_stable_error_code():
+    transaction = _FakeTransaction()
+    conversation_ref = _FakeDocumentRef(
+        {
+            "status": "processing",
+            "processing_retry_id": "request-123",
+            "processing_retry_summary_version_id": "recovered-v1",
+        }
+    )
+    retry_ref = _FakeDocumentRef({"request_id": "request-123", "outcome": "processing"})
+    finished_at = datetime(2026, 7, 20, 8, 7, tzinfo=timezone.utc)
+
+    result = conversations_db._finish_conversation_processing_retry_transaction(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        "request-123",
+        "failed",
+        finished_at,
+        "conversation_summary_recovery_failed",
+    )
+
+    assert result is True
+    assert transaction.updates[0][1]["error_code"] == "conversation_summary_recovery_failed"
+    assert transaction.updates[1][1] == {
+        "status": "failed",
+        "discarded": False,
+        "processing_error": "conversation_summary_recovery_failed",
+        "processing_error_at": finished_at,
+    }
+
+
+def test_hermes_failure_keeps_completed_generic_summary_and_marks_enrichment_retryable():
+    transaction = _FakeTransaction()
+    conversation_ref = _FakeDocumentRef(
+        {
+            "status": "completed",
+            "processing_retry_id": "request-123",
+            "processing_retry_summary_version_id": "generic-v1",
+        }
+    )
+    retry_ref = _FakeDocumentRef({"request_id": "request-123", "outcome": "completed"})
+    failed_at = datetime(2026, 7, 20, 8, 8, tzinfo=timezone.utc)
+
+    result = conversations_db._record_conversation_processing_retry_enrichment_transaction(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        "conversation-1",
+        "request-123",
+        "failed",
+        failed_at,
+        None,
+    )
+
+    assert result is True
+    assert transaction.updates[0][1] == {
+        "enrichment_status": "failed",
+        "updated_at": failed_at,
+    }
+    assert transaction.updates[1][1] == {
+        "enrichment_state": {
+            "status": "failed",
+            "pending": True,
+            "source": "observer",
+            "kind": "recovered_enriched",
+            "trace_id": "summary-retry:conversation-1:request-123:hermes",
+            "updated_at": failed_at,
+            "error": "hermes_temporarily_unavailable",
+        }
+    }
+
+
+def test_hermes_success_records_enriched_version_without_changing_completed_status():
+    transaction = _FakeTransaction()
+    conversation_ref = _FakeDocumentRef(
+        {
+            "status": "completed",
+            "processing_retry_id": "request-123",
+            "processing_retry_summary_version_id": "generic-v1",
+        }
+    )
+    retry_ref = _FakeDocumentRef({"request_id": "request-123", "outcome": "completed"})
+    completed_at = datetime(2026, 7, 20, 8, 9, tzinfo=timezone.utc)
+
+    result = conversations_db._record_conversation_processing_retry_enrichment_transaction(
+        transaction,
+        conversation_ref,
+        retry_ref,
+        "conversation-1",
+        "request-123",
+        "completed",
+        completed_at,
+        "enriched-v2",
+    )
+
+    assert result is True
+    assert transaction.updates[0][1] == {
+        "enrichment_status": "completed",
+        "updated_at": completed_at,
+        "enriched_summary_version_id": "enriched-v2",
+    }
+    assert transaction.updates[1][1] == {
+        "processing_retry_enriched_version_id": "enriched-v2",
+    }

--- a/backend/tests/unit/test_conversation_processing_retry.py
+++ b/backend/tests/unit/test_conversation_processing_retry.py
@@ -317,6 +317,7 @@ def test_decrypted_source_hash_is_receipted_without_transcript_content():
         99,
         updated_at,
         lease_expires_at,
+        generic_summary_sha256='b' * 64,
     )
 
     assert result is True
@@ -324,14 +325,56 @@ def test_decrypted_source_hash_is_receipted_without_transcript_content():
         'processing_retry_lease_expires_at': lease_expires_at,
         'processing_retry_transcript_sha256': 'a' * 64,
         'processing_retry_source_request_id': 'request-123',
+        'processing_retry_generic_summary_sha256': 'b' * 64,
     }
     assert transaction.updates[1][1] == {
         'transcript_sha256': 'a' * 64,
         'transcript_segment_count': 99,
         'lease_expires_at': lease_expires_at,
         'updated_at': updated_at,
+        'generic_summary_sha256': 'b' * 64,
     }
     assert 'transcript_segments' not in transaction.updates[1][1]
+
+
+def test_legacy_generic_summary_bootstraps_version_history_before_enrichment():
+    legacy_structured = {
+        'title': 'Legacy generic summary',
+        'overview': '[Ella] The preserved generic summary.',
+        'emoji': 'brain',
+        'category': 'other',
+    }
+    enriched_structured = {
+        'title': 'Enriched summary',
+        'overview': '[Ella] The full-context enriched summary.',
+        'emoji': 'brain',
+        'category': 'personal',
+    }
+
+    update = conversations_db.build_summary_version_update(
+        {
+            'created_at': datetime(2026, 7, 20, 8, 0, tzinfo=timezone.utc),
+            'structured': legacy_structured,
+            'summary_versions': [],
+            'active_summary_version_id': None,
+        },
+        next_structured=enriched_structured,
+        source='observer',
+        kind='recovered_enriched',
+        based_on_version_id=None,
+    )
+
+    assert len(update['summary_versions']) == 2
+    legacy_version, enriched_version = update['summary_versions']
+    assert legacy_version['kind'] == 'legacy_current'
+    assert legacy_version['title'] == legacy_structured['title']
+    assert legacy_version['overview'] == legacy_structured['overview']
+    assert legacy_version['is_active'] is False
+    assert enriched_version['kind'] == 'recovered_enriched'
+    assert enriched_version['title'] == enriched_structured['title']
+    assert enriched_version['based_on_version_id'] == legacy_version['id']
+    assert enriched_version['is_active'] is True
+    assert update['active_summary_version_id'] == enriched_version['id']
 
 
 def test_generic_completion_keeps_overall_receipt_processing_for_hermes():

--- a/backend/tests/unit/test_conversation_summary_vector.py
+++ b/backend/tests/unit/test_conversation_summary_vector.py
@@ -1,0 +1,92 @@
+import importlib.util
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def test_recovery_vector_refresh_preserves_metadata_without_transcript_extraction(monkeypatch):
+    existing_metadata = {
+        "uid": "stale-user",
+        "memory_id": "stale-conversation",
+        "created_at": 123,
+        "topics": ["coffee"],
+        "people_mentioned": ["Greg"],
+        "custom_marker": "preserve-me",
+        "active_summary_version_id": "generic-v1",
+        "summary_content_sha256": "old-hash",
+    }
+    generated = []
+    upserts = []
+    forbidden = MagicMock(side_effect=AssertionError("transcript metadata extraction must not run"))
+
+    vector_db = MagicMock()
+    vector_db.fetch_conversation_vector_metadata.return_value = existing_metadata
+    vector_db.upsert_conversation_vector.side_effect = lambda uid, conversation_id, vector, metadata: upserts.append(
+        (uid, conversation_id, vector, metadata)
+    ) or {"upserted_count": 1}
+    notifications = MagicMock()
+    notifications.get_user_time_zone.side_effect = AssertionError("timezone lookup must not run")
+    llm_chat = MagicMock(
+        retrieve_metadata_fields_from_transcript=forbidden,
+        retrieve_metadata_from_message=forbidden,
+        retrieve_metadata_from_text=forbidden,
+    )
+    llm_clients = MagicMock(generate_embedding=lambda content: generated.append(content) or [0.1, 0.2])
+    monkeypatch.setitem(sys.modules, "database.notifications", notifications)
+    monkeypatch.setitem(sys.modules, "database.vector_db", vector_db)
+    monkeypatch.setitem(sys.modules, "utils.llm.chat", llm_chat)
+    monkeypatch.setitem(sys.modules, "utils.llm.clients", llm_clients)
+
+    module_path = Path(__file__).resolve().parents[2] / "utils" / "conversations" / "vector.py"
+    spec = importlib.util.spec_from_file_location("summary_vector_refresh_test_module", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+
+    structured = {
+        "title": "Cafe breakfast",
+        "overview": "[Ella] The user ordered breakfast.",
+        "category": "personal",
+    }
+    conversation = SimpleNamespace(
+        id="conversation-1",
+        created_at=datetime(2026, 7, 21, 4, 0, tzinfo=timezone.utc),
+        structured=structured,
+    )
+
+    result = module.refresh_structured_summary_vector(
+        "user-1",
+        conversation,
+        summary_version_id="enriched-v2",
+        summary_content_sha256="new-hash",
+    )
+
+    assert result == {"upserted_count": 1}
+    assert generated == [
+        json.dumps(
+            structured,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+    ]
+    assert upserts == [
+        (
+            "user-1",
+            "conversation-1",
+            [0.1, 0.2],
+            {
+                **existing_metadata,
+                "uid": "user-1",
+                "memory_id": "conversation-1",
+                "active_summary_version_id": "enriched-v2",
+                "summary_content_sha256": "new-hash",
+            },
+        )
+    ]
+    forbidden.assert_not_called()
+    notifications.get_user_time_zone.assert_not_called()

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -436,3 +436,46 @@ def test_update_conversation_summary_writes_enriched_omi_to_canonical(monkeypatc
         "summary_kind": "observer_enriched",
         "trace_id": "trace-cafe",
     }
+
+
+def test_update_conversation_summary_same_trace_is_idempotent(monkeypatch):
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: {
+            "id": conversation_id,
+            "active_summary_version_id": "recovered-v1",
+            "enrichment_state": {
+                "status": "writeback_applied",
+                "kind": "recovered_enriched",
+                "trace_id": "summary-retry:conversation-1:request-1",
+            },
+        },
+    )
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "update_conversation",
+        lambda *args, **kwargs: pytest.fail("idempotent replay must not write Firestore"),
+    )
+    monkeypatch.setattr(
+        callbacks,
+        "write_omi_canonical_event",
+        lambda *args, **kwargs: pytest.fail("idempotent replay must not duplicate the canonical event"),
+    )
+
+    result = asyncio.run(
+        callbacks.update_conversation_summary(
+            "conversation-1",
+            callbacks.ConversationSummaryUpdate(
+                title="Recovered",
+                overview="[Ella] Recovered summary with enough detail.",
+                summary_kind="recovered_enriched",
+                trace_id="summary-retry:conversation-1:request-1",
+            ),
+            uid="user-1",
+        )
+    )
+
+    assert result["status"] == "ok"
+    assert result["active_summary_version_id"] == "recovered-v1"
+    assert result["idempotent_replay"] is True

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -410,7 +410,7 @@ def test_update_conversation_summary_writes_enriched_omi_to_canonical(monkeypatc
         or {"ok": True, "inserted": 1, "duplicates": 0},
     )
 
-    asyncio.run(
+    result = asyncio.run(
         callbacks.update_conversation_summary(
             "cafe-123",
             callbacks.ConversationSummaryUpdate(
@@ -419,10 +419,13 @@ def test_update_conversation_summary_writes_enriched_omi_to_canonical(monkeypatc
                 summary_source="observer",
                 summary_kind="observer_enriched",
                 trace_id="trace-cafe",
+                require_canonical=True,
             ),
             uid="user-123",
         )
     )
+
+    assert result["canonical_confirmed"] is True
 
     assert canonical_writes[0]["uid"] == "user-123"
     assert canonical_writes[0]["conversation"]["id"] == "cafe-123"

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -1061,6 +1061,7 @@ def test_retry_plan_is_uid_scoped_metadata_only_and_zero_write(monkeypatch):
     assert payload["transcript_segment_count"] == 2
     assert payload["transcript_character_count"] == 150
     assert payload["transcript_sha256"] == summary_recovery.build_hermes_recovery_source(conversation)[1]
+    assert payload["structured_summary_sha256"] == summary_recovery._summary_content_sha256(conversation)
     assert payload["zero_writes"] is True
     assert "transcript_segments" not in payload
     assert "transcript" not in payload
@@ -1741,6 +1742,97 @@ def test_summary_recovery_resumes_hermes_after_generic_phase_completed(monkeypat
         "enrichment:canonical_completed",
         "vector:enriched-v2",
         "enrichment:completed",
+    ]
+
+
+def test_summary_recovery_enriches_legacy_generic_without_version_or_generic_rewrite(monkeypatch):
+    request_id = "84eb13fa-31d9-40ba-a742-c4de4757dc10"
+    legacy = {
+        **_retry_conversation(status="completed", request_id=request_id),
+        "processing_retry_mode": "enrichment_only",
+        "active_summary_version_id": None,
+        "summary_versions": [],
+        "structured": {
+            "title": "Legacy generic",
+            "overview": "[Ella] A preserved generic summary.",
+            "emoji": "brain",
+            "category": "other",
+        },
+    }
+    enriched = {
+        **legacy,
+        "active_summary_version_id": "enriched-v2",
+        "summary_versions": [
+            {"id": "legacy-v1", "kind": "legacy_current", "is_active": False},
+            {"id": "enriched-v2", "kind": "recovered_enriched", "is_active": True},
+        ],
+        "enrichment_state": {
+            "status": "writeback_applied",
+            "kind": "recovered_enriched",
+            "canonical_status": "completed",
+        },
+    }
+    reads = [legacy, legacy, legacy, enriched]
+    events = []
+    source_hashes = []
+    expected_summary_hash = summary_recovery._summary_content_sha256(legacy)
+    monkeypatch.setattr(summary_recovery.conversations_db, "get_conversation", lambda uid, cid: reads.pop(0))
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_source",
+        lambda *args, **kwargs: source_hashes.append(kwargs.get("generic_summary_sha256")) or True,
+    )
+    monkeypatch.setattr(
+        summary_recovery,
+        "generate_stock_conversation_summary",
+        lambda *args: pytest.fail("legacy generic content must not be regenerated"),
+    )
+    monkeypatch.setattr(summary_recovery, "_conversation_vector_present", lambda uid, cid: True)
+    monkeypatch.setattr(
+        summary_recovery,
+        "_ensure_conversation_vector",
+        lambda uid, conv: pytest.fail("the existing legacy generic vector must not be overwritten"),
+    )
+
+    async def fake_invoke(**kwargs):
+        assert kwargs["conversation"]["active_summary_version_id"] is None
+        assert summary_recovery._summary_content_sha256(kwargs["conversation"]) == expected_summary_hash
+        events.append("hermes")
+        return {"active_summary_version_id": "enriched-v2", "canonical_confirmed": True}
+
+    monkeypatch.setattr(summary_recovery, "invoke_hermes_recovery", fake_invoke)
+    monkeypatch.setattr(
+        summary_recovery,
+        "_write_and_confirm_enriched_vector",
+        lambda uid, conv, version_id: _async_event_result(events, "enriched_vector", "e" * 64),
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_generic_vector",
+        lambda *args, **kwargs: events.append("generic_vector_receipt") or True,
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_enrichment",
+        lambda *args, **kwargs: events.append(args[3]) or True,
+    )
+
+    outcome = asyncio.run(
+        summary_recovery.recover_failed_conversation_summary(
+            uid="user-1",
+            conversation_id="conversation-1",
+            request_id=request_id,
+        )
+    )
+
+    assert outcome == "completed"
+    assert source_hashes == [expected_summary_hash, expected_summary_hash]
+    assert events == [
+        "generic_vector_receipt",
+        "hermes",
+        "canonical_completed",
+        "enriched_vector",
+        "completed",
     ]
 
 

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -6,12 +6,18 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 sys.modules.setdefault("database._client", MagicMock(db=MagicMock()))
 sys.modules.setdefault("database.conversations", MagicMock())
 sys.modules.setdefault("httpx", MagicMock())
 sys.modules.setdefault("utils.other.endpoints", MagicMock())
+sys.modules.setdefault("utils.conversations.vector", MagicMock(save_structured_vector=MagicMock()))
+sys.modules.setdefault(
+    "utils.conversations.generic_summary",
+    MagicMock(generate_stock_conversation_summary=MagicMock()),
+)
 sys.modules.pop("ella.config", None)
 
 _backend_path = Path(__file__).resolve().parents[2]
@@ -24,6 +30,7 @@ corrections = importlib.util.module_from_spec(_corrections_spec)
 assert _corrections_spec is not None and _corrections_spec.loader is not None
 _corrections_spec.loader.exec_module(corrections)
 corrections.ELLA_CONFIG = SimpleNamespace(n8n_base_url="https://n8n.test")
+from ella.services import summary_recovery
 
 
 @pytest.fixture(autouse=True)
@@ -51,6 +58,41 @@ def _conversation():
             "category": "health",
         },
     }
+
+
+def _retry_conversation(status="processing", request_id="84eb13fa-31d9-40ba-a742-c4de4757dc10"):
+    return {
+        "id": "conversation-1",
+        "created_at": "2026-07-20T08:00:00+00:00",
+        "started_at": "2026-07-20T08:00:00+00:00",
+        "finished_at": "2026-07-20T08:30:00+00:00",
+        "structured": {
+            "title": "",
+            "overview": "",
+            "emoji": "brain",
+            "category": "other",
+        },
+        "transcript_segments": [
+            {
+                "is_user": True,
+                "speaker": "SPEAKER_00",
+                "text": "Important retained transcript.",
+                "start": 0,
+                "end": 10,
+            }
+        ],
+        "status": status,
+        "discarded": False,
+        "processing_error": "conversation_summary_failed" if status == "failed" else None,
+        "processing_retry_id": request_id,
+    }
+
+
+def _retry_api_client():
+    app = FastAPI()
+    app.include_router(corrections.router)
+    app.dependency_overrides[corrections.auth.get_current_user_uid] = lambda: "authenticated-user"
+    return app, TestClient(app)
 
 
 def test_submit_correction_accepts_ios_payload_and_queues(monkeypatch):
@@ -360,6 +402,46 @@ def test_submit_correction_directly_applies_when_model_path_succeeds(monkeypatch
     assert audits[-1]["direct_apply_result"]["active_summary_version_id"] == "corrected-v1"
     assert events[-1]["stage"] == "direct_apply_succeeded"
     assert conversation_updates[0]["correction_state"]["status"] == "submitted"
+
+
+def test_apply_corrected_summary_uses_shared_direct_writeback_service(monkeypatch):
+    captured = {}
+
+    async def fake_apply(**kwargs):
+        captured.update(kwargs)
+        return {"status": "ok", "active_summary_version_id": "corrected-v1"}
+
+    monkeypatch.setattr(corrections, "apply_summary_update", fake_apply)
+    corrected = {
+        "title": "Corrected",
+        "overview": "[Ella] Corrected summary.",
+        "emoji": "brain",
+        "category": "other",
+        "ella_tags": ["omi", "correction"],
+        "ella_signal": {},
+    }
+
+    result = asyncio.run(
+        corrections._apply_corrected_summary(
+            uid="user-123",
+            conversation_id="conv-123",
+            correction_id="corr-123",
+            trace_id="correction:conv-123:corr-123",
+            active_summary_version_id="legacy-v1",
+            corrected=corrected,
+        )
+    )
+
+    assert result["active_summary_version_id"] == "corrected-v1"
+    assert captured == {
+        "uid": "user-123",
+        "conversation_id": "conv-123",
+        "trace_id": "correction:conv-123:corr-123",
+        "active_summary_version_id": "legacy-v1",
+        "summary": corrected,
+        "summary_kind": "corrected_enriched",
+        "correction_id": "corr-123",
+    }
 
 
 def test_submit_correction_queues_background_direct_apply_without_waiting(monkeypatch):
@@ -869,3 +951,402 @@ def test_submit_to_n8n_accepts_async_success_body_even_with_bad_http_status(monk
         "n8n_status_code": 500,
         "n8n_response": {"status": "processing", "queued": True, "trace_id": "trace-123"},
     }
+
+
+def test_retry_api_cannot_claim_outside_authenticated_uid(monkeypatch):
+    calls = []
+
+    def fake_claim(uid, conversation_id, request_id):
+        calls.append((uid, conversation_id, request_id))
+        return {"outcome": "not_found", "conversation": None}
+
+    monkeypatch.setattr(corrections.conversations_db, "claim_conversation_processing_retry", fake_claim)
+    app, client = _retry_api_client()
+    try:
+        response = client.post(
+            "/v1/conversations/another-users-conversation/processing-retries",
+            json={"request_id": "5bd3c697-7aa6-4fc0-aab2-a7eb6cf333e8"},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 404
+    assert calls == [
+        (
+            "authenticated-user",
+            "another-users-conversation",
+            "5bd3c697-7aa6-4fc0-aab2-a7eb6cf333e8",
+        )
+    ]
+
+
+def test_retry_api_claims_once_and_queues_two_stage_recovery(monkeypatch):
+    request_id = "84eb13fa-31d9-40ba-a742-c4de4757dc10"
+    worker_calls = []
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "claim_conversation_processing_retry",
+        lambda uid, conversation_id, claimed_request_id: {
+            "outcome": "claimed",
+            "conversation": _retry_conversation(request_id=claimed_request_id),
+        },
+    )
+
+    async def fake_recover(**kwargs):
+        worker_calls.append(kwargs)
+        return "completed"
+
+    monkeypatch.setattr(corrections, "recover_failed_conversation_summary", fake_recover)
+    app, client = _retry_api_client()
+    try:
+        response = client.post(
+            "/v1/conversations/conversation-1/processing-retries",
+            json={"request_id": request_id, "correction_text": "This was the morning cafe conversation."},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 202
+    assert response.json()["outcome"] == "processing"
+    assert worker_calls == [
+        {
+            "uid": "authenticated-user",
+            "conversation_id": "conversation-1",
+            "request_id": request_id,
+            "client_context": "This was the morning cafe conversation.",
+        }
+    ]
+
+
+@pytest.mark.parametrize("stored_outcome", ["processing", "completed", "failed"])
+def test_retry_api_repeated_request_returns_receipt_without_new_work(monkeypatch, stored_outcome):
+    request_id = "45cc793c-b030-4e94-8f93-44c248488d50"
+    worker_calls = []
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "claim_conversation_processing_retry",
+        lambda uid, conversation_id, claimed_request_id: {
+            "outcome": stored_outcome,
+            "conversation": _retry_conversation(status=stored_outcome, request_id=claimed_request_id),
+        },
+    )
+    monkeypatch.setattr(
+        corrections, "recover_failed_conversation_summary", lambda **kwargs: worker_calls.append(kwargs)
+    )
+    app, client = _retry_api_client()
+    try:
+        response = client.post(
+            "/v1/conversations/conversation-1/processing-retries",
+            json={"request_id": request_id},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 202
+    assert response.json()["outcome"] == stored_outcome
+    assert worker_calls == []
+
+
+def test_retry_api_requires_uuid_request_id(monkeypatch):
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "claim_conversation_processing_retry",
+        lambda *args: pytest.fail("invalid request must not reach the claim"),
+    )
+    app, client = _retry_api_client()
+    try:
+        response = client.post(
+            "/v1/conversations/conversation-1/processing-retries",
+            json={"request_id": "not-a-uuid"},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 422
+
+
+def test_summary_recovery_preserves_full_25k_transcript_in_hermes_prompt():
+    transcript = "start " + ("important " * 3000) + "tail-marker"
+    conversation = _retry_conversation(status="failed")
+    conversation["transcript_segments"] = [{"is_user": True, "text": transcript}]
+
+    prompt = summary_recovery._build_recovery_prompt(conversation, None)
+
+    assert len(transcript) > 25_000
+    assert "tail-marker" in prompt
+    assert "[truncated]" not in prompt
+
+
+def test_summary_recovery_persists_generic_before_hermes_enrichment(monkeypatch):
+    request_id = "84eb13fa-31d9-40ba-a742-c4de4757dc10"
+    conversation = _retry_conversation(request_id=request_id)
+    generic = {
+        **conversation,
+        "active_summary_version_id": "generic-v1",
+        "processing_retry_summary_version_id": "generic-v1",
+        "structured": {
+            "title": "Generic",
+            "overview": "[Ella] Generic summary.",
+            "emoji": "brain",
+            "category": "other",
+        },
+    }
+    completed_generic = {**generic, "status": "completed", "processing_error": None}
+    enriched = {
+        **completed_generic,
+        "active_summary_version_id": "enriched-v2",
+        "enrichment_state": {"status": "writeback_applied", "kind": "recovered_enriched"},
+        "structured": {
+            "title": "Enriched",
+            "overview": "[Ella] Enriched summary.",
+            "emoji": "brain",
+            "category": "other",
+        },
+    }
+    reads = [conversation, generic, completed_generic, enriched]
+    events = []
+
+    monkeypatch.setattr(summary_recovery.conversations_db, "get_conversation", lambda uid, cid: reads.pop(0))
+    monkeypatch.setattr(
+        summary_recovery,
+        "generate_stock_conversation_summary",
+        lambda uid, conv: events.append("generic_generate")
+        or {
+            "title": "Generic",
+            "overview": "Generic summary.",
+            "emoji": "brain",
+            "category": "other",
+        },
+    )
+
+    async def fake_generate(**kwargs):
+        events.append("hermes_generate")
+        return {
+            "title": "Enriched",
+            "overview": "[Ella] Enriched summary.",
+            "emoji": "brain",
+            "category": "other",
+            "ella_tags": ["omi", "recovery"],
+            "ella_signal": {},
+        }
+
+    async def fake_apply(**kwargs):
+        events.append(f"apply:{kwargs['summary_kind']}")
+        version_id = "generic-v1" if kwargs["summary_kind"] == "generic_recovered" else "enriched-v2"
+        return {"status": "ok", "active_summary_version_id": version_id}
+
+    monkeypatch.setattr(summary_recovery, "generate_summary_from_prompt", fake_generate)
+    monkeypatch.setattr(summary_recovery, "apply_summary_update", fake_apply)
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_summary_applied",
+        lambda *args: events.append("generic_receipt") or True,
+    )
+    monkeypatch.setattr(
+        summary_recovery,
+        "save_structured_vector",
+        lambda uid, conv: events.append(f"vector:{conv.structured.title}"),
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "finish_conversation_processing_retry",
+        lambda *args, **kwargs: events.append(f"finish:{args[3]}") or True,
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_enrichment",
+        lambda *args, **kwargs: events.append(f"enrichment:{args[3]}") or True,
+    )
+
+    outcome = asyncio.run(
+        summary_recovery.recover_failed_conversation_summary(
+            uid="user-1",
+            conversation_id="conversation-1",
+            request_id=request_id,
+        )
+    )
+
+    assert outcome == "completed"
+    assert events == [
+        "generic_generate",
+        "apply:generic_recovered",
+        "generic_receipt",
+        "vector:Generic",
+        "finish:completed",
+        "hermes_generate",
+        "apply:recovered_enriched",
+        "vector:Enriched",
+        "enrichment:completed",
+    ]
+
+
+def test_summary_recovery_hermes_failure_retains_completed_generic_summary(monkeypatch):
+    request_id = "84eb13fa-31d9-40ba-a742-c4de4757dc10"
+    conversation = _retry_conversation(request_id=request_id)
+    generic = {
+        **conversation,
+        "active_summary_version_id": "generic-v1",
+        "processing_retry_summary_version_id": "generic-v1",
+        "structured": {
+            "title": "Generic",
+            "overview": "[Ella] Generic summary.",
+            "emoji": "brain",
+            "category": "other",
+        },
+    }
+    reads = [conversation, generic, {**generic, "status": "completed", "processing_error": None}]
+    events = []
+    monkeypatch.setattr(summary_recovery.conversations_db, "get_conversation", lambda uid, cid: reads.pop(0))
+    monkeypatch.setattr(
+        summary_recovery,
+        "generate_stock_conversation_summary",
+        lambda uid, conv: {
+            "title": "Generic",
+            "overview": "Generic summary.",
+            "emoji": "brain",
+            "category": "other",
+        },
+    )
+
+    async def fake_generate(**kwargs):
+        raise RuntimeError("private Hermes provider detail")
+
+    async def fake_apply(**kwargs):
+        assert kwargs["summary_kind"] == "generic_recovered"
+        return {"status": "ok", "active_summary_version_id": "generic-v1"}
+
+    monkeypatch.setattr(summary_recovery, "generate_summary_from_prompt", fake_generate)
+    monkeypatch.setattr(summary_recovery, "apply_summary_update", fake_apply)
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_summary_applied",
+        lambda *args: True,
+    )
+    monkeypatch.setattr(summary_recovery, "save_structured_vector", lambda uid, conv: events.append("vector"))
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "finish_conversation_processing_retry",
+        lambda *args, **kwargs: events.append(("finish", args[3], kwargs)) or True,
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_enrichment",
+        lambda *args, **kwargs: events.append(("enrichment", args[3], kwargs)) or True,
+    )
+
+    outcome = asyncio.run(
+        summary_recovery.recover_failed_conversation_summary(
+            uid="user-1",
+            conversation_id="conversation-1",
+            request_id=request_id,
+        )
+    )
+
+    assert outcome == "completed"
+    assert events == [
+        "vector",
+        ("finish", "completed", {}),
+        ("enrichment", "failed", {}),
+    ]
+    assert "private Hermes provider detail" not in str(events)
+
+
+def test_summary_recovery_resumes_hermes_after_generic_phase_completed(monkeypatch):
+    request_id = "84eb13fa-31d9-40ba-a742-c4de4757dc10"
+    generic = {
+        **_retry_conversation(status="completed", request_id=request_id),
+        "active_summary_version_id": "generic-v1",
+        "processing_retry_summary_version_id": "generic-v1",
+    }
+    enriched = {
+        **generic,
+        "active_summary_version_id": "enriched-v2",
+        "processing_retry_enriched_version_id": "enriched-v2",
+    }
+    reads = [generic, generic, generic, enriched]
+    events = []
+    monkeypatch.setattr(summary_recovery.conversations_db, "get_conversation", lambda uid, cid: reads.pop(0))
+    monkeypatch.setattr(
+        summary_recovery,
+        "generate_stock_conversation_summary",
+        lambda *args: pytest.fail("generic provider must not rerun after its durable receipt"),
+    )
+
+    async def fake_generate(**kwargs):
+        events.append("hermes_generate")
+        return {
+            "title": "Enriched",
+            "overview": "[Ella] Enriched summary.",
+            "emoji": "brain",
+            "category": "other",
+            "ella_tags": ["omi", "recovery"],
+            "ella_signal": {},
+        }
+
+    async def fake_apply(**kwargs):
+        events.append("hermes_apply")
+        return {"status": "ok", "active_summary_version_id": "enriched-v2"}
+
+    monkeypatch.setattr(summary_recovery, "generate_summary_from_prompt", fake_generate)
+    monkeypatch.setattr(summary_recovery, "apply_summary_update", fake_apply)
+    monkeypatch.setattr(summary_recovery, "save_structured_vector", lambda uid, conv: events.append("vector"))
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "finish_conversation_processing_retry",
+        lambda *args, **kwargs: events.append("finish") or True,
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_enrichment",
+        lambda *args, **kwargs: events.append(f"enrichment:{args[3]}") or True,
+    )
+
+    outcome = asyncio.run(
+        summary_recovery.recover_failed_conversation_summary(
+            uid="user-1",
+            conversation_id="conversation-1",
+            request_id=request_id,
+        )
+    )
+
+    assert outcome == "completed"
+    assert events == ["vector", "finish", "hermes_generate", "hermes_apply", "vector", "enrichment:completed"]
+
+
+def test_summary_recovery_vector_failure_remains_retryable_without_raw_error(monkeypatch):
+    request_id = "84eb13fa-31d9-40ba-a742-c4de4757dc10"
+    conversation = {
+        **_retry_conversation(request_id=request_id),
+        "active_summary_version_id": "recovered-v1",
+        "processing_retry_summary_version_id": "recovered-v1",
+    }
+    finish_calls = []
+    monkeypatch.setattr(summary_recovery.conversations_db, "get_conversation", lambda uid, cid: conversation)
+    monkeypatch.setattr(
+        summary_recovery,
+        "generate_stock_conversation_summary",
+        lambda *args: pytest.fail("receipted generic summary must not be regenerated"),
+    )
+    monkeypatch.setattr(
+        summary_recovery,
+        "save_structured_vector",
+        lambda uid, conv: (_ for _ in ()).throw(RuntimeError("secret provider detail")),
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "finish_conversation_processing_retry",
+        lambda *args, **kwargs: finish_calls.append((args, kwargs)) or True,
+    )
+
+    outcome = asyncio.run(
+        summary_recovery.recover_failed_conversation_summary(
+            uid="user-1",
+            conversation_id="conversation-1",
+            request_id=request_id,
+        )
+    )
+
+    assert outcome == "failed"
+    assert finish_calls[0][0][3] == "failed"
+    assert finish_calls[0][1]["error_code"] == "conversation_summary_recovery_failed"
+    assert "secret provider detail" not in str(finish_calls[0])

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -13,7 +13,10 @@ sys.modules.setdefault("database._client", MagicMock(db=MagicMock()))
 sys.modules.setdefault("database.conversations", MagicMock())
 sys.modules.setdefault("httpx", MagicMock())
 sys.modules.setdefault("utils.other.endpoints", MagicMock())
-sys.modules.setdefault("utils.conversations.vector", MagicMock(save_structured_vector=MagicMock()))
+sys.modules.setdefault(
+    "utils.conversations.vector",
+    MagicMock(refresh_structured_summary_vector=MagicMock()),
+)
 sys.modules.setdefault(
     "utils.conversations.generic_summary",
     MagicMock(generate_stock_conversation_summary=MagicMock()),
@@ -43,6 +46,7 @@ def _disable_external_observer_side_effects(monkeypatch):
 
     monkeypatch.setattr(corrections, "_emit_canonical_correction_event", noop_emit)
     monkeypatch.setattr(corrections, "_run_correction_propagation_for_submission", noop_propagate)
+    monkeypatch.setattr(summary_recovery, "_conversation_vector_present", lambda uid, cid: False)
 
 
 def _conversation():
@@ -1253,7 +1257,7 @@ def test_vector_confirmation_skips_existing_vector_without_duplicate_write(monke
             "summary_content_sha256": content_sha256,
         },
     )
-    monkeypatch.setattr(summary_recovery, "save_structured_vector", lambda *args: writes.append(args))
+    monkeypatch.setattr(summary_recovery, "refresh_structured_summary_vector", lambda *args: writes.append(args))
 
     asyncio.run(summary_recovery._ensure_conversation_vector("user-1", conversation))
 
@@ -1279,7 +1283,7 @@ def test_vector_confirmation_requires_post_write_visibility(monkeypatch):
     monkeypatch.setattr(summary_recovery, "_conversation_vector_metadata", lambda uid, cid: next(checks))
     monkeypatch.setattr(
         summary_recovery,
-        "save_structured_vector",
+        "refresh_structured_summary_vector",
         lambda uid, conv, **kwargs: writes.append((conv.id, kwargs)) or {"upserted_count": 1},
     )
 
@@ -1319,7 +1323,7 @@ def test_enriched_vector_is_force_upserted_and_verified_by_version_and_hash(monk
         "get_conversation",
         lambda uid, cid: conversation,
     )
-    monkeypatch.setattr(summary_recovery, "save_structured_vector", fake_save)
+    monkeypatch.setattr(summary_recovery, "refresh_structured_summary_vector", fake_save)
     monkeypatch.setattr(
         summary_recovery,
         "_conversation_vector_metadata",
@@ -1365,7 +1369,7 @@ def test_enriched_vector_fails_closed_when_active_summary_changes_after_upsert(m
     )
     monkeypatch.setattr(
         summary_recovery,
-        "save_structured_vector",
+        "refresh_structured_summary_vector",
         lambda uid, model, **kwargs: {"upserted_count": 1},
     )
     monkeypatch.setattr(
@@ -1693,8 +1697,13 @@ def test_summary_recovery_resumes_hermes_after_generic_phase_completed(monkeypat
     monkeypatch.setattr(summary_recovery, "invoke_hermes_recovery", fake_invoke)
     monkeypatch.setattr(
         summary_recovery,
+        "_conversation_vector_present",
+        lambda uid, cid: True,
+    )
+    monkeypatch.setattr(
+        summary_recovery,
         "_ensure_conversation_vector",
-        lambda uid, conv: _async_event(events, f"vector:{conv['active_summary_version_id']}"),
+        lambda uid, conv: pytest.fail("stage-2-only recovery must preserve the existing generic vector"),
     )
     monkeypatch.setattr(
         summary_recovery,
@@ -1727,7 +1736,6 @@ def test_summary_recovery_resumes_hermes_after_generic_phase_completed(monkeypat
 
     assert outcome == "completed"
     assert events == [
-        "vector:generic-v1",
         "generic_vector:completed",
         "hermes_provision",
         "enrichment:canonical_completed",

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -30,7 +30,7 @@ corrections = importlib.util.module_from_spec(_corrections_spec)
 assert _corrections_spec is not None and _corrections_spec.loader is not None
 _corrections_spec.loader.exec_module(corrections)
 corrections.ELLA_CONFIG = SimpleNamespace(n8n_base_url="https://n8n.test")
-from ella.services import summary_recovery
+from ella.services import summary_recovery, summary_writeback
 
 
 @pytest.fixture(autouse=True)
@@ -93,6 +93,19 @@ def _retry_api_client():
     app.include_router(corrections.router)
     app.dependency_overrides[corrections.auth.get_current_user_uid] = lambda: "authenticated-user"
     return app, TestClient(app)
+
+
+async def _async_event(events, value):
+    events.append(value)
+
+
+async def _async_raise(error):
+    raise error
+
+
+async def _async_event_result(events, value, result):
+    events.append(value)
+    return result
 
 
 def test_submit_correction_accepts_ios_payload_and_queues(monkeypatch):
@@ -980,6 +993,93 @@ def test_retry_api_cannot_claim_outside_authenticated_uid(monkeypatch):
     ]
 
 
+def test_retry_plan_is_uid_scoped_metadata_only_and_zero_write(monkeypatch):
+    conversation = {
+        **_retry_conversation(status="completed", request_id=None),
+        "structured": {
+            "title": "Generic cafe conversation",
+            "overview": "[Ella] A generic summary is available.",
+            "emoji": "brain",
+            "category": "other",
+        },
+        "active_summary_version_id": "generic-v1",
+        "summary_versions": [{"id": "generic-v1", "source": "omi", "kind": "generic_recovered", "is_active": True}],
+        "transcript_segments": [
+            {"is_user": True, "text": "a" * 100},
+            {"speaker": "Other", "text": "b" * 50},
+        ],
+    }
+    reads = []
+
+    def fake_get(uid, conversation_id):
+        reads.append((uid, conversation_id))
+        return conversation
+
+    monkeypatch.setattr(summary_recovery.conversations_db, "get_conversation", fake_get)
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "conversation_processing_recovery_mode",
+        lambda record: ("enrichment_only", "generic_summary_without_enrichment"),
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "has_usable_conversation_summary",
+        lambda record: True,
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "has_enriched_conversation_summary",
+        lambda record: False,
+    )
+    monkeypatch.setattr(summary_recovery, "_conversation_vector_present", lambda uid, cid: True)
+    monkeypatch.setattr(
+        summary_recovery,
+        "_conversation_vector_metadata",
+        lambda uid, cid: {
+            "active_summary_version_id": "generic-v1",
+            "summary_content_sha256": "generic-hash",
+        },
+    )
+    app, client = _retry_api_client()
+    try:
+        response = client.get("/v1/conversations/conversation-1/processing-retry-plan")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert reads == [("authenticated-user", "conversation-1")]
+    assert payload["recovery_mode"] == "enrichment_only"
+    assert payload["retryable"] is True
+    assert payload["vector_present"] is True
+    assert payload["vector_active_summary_version_id"] == "generic-v1"
+    assert payload["vector_matches_active_summary"] is False
+    assert payload["transcript_segment_count"] == 2
+    assert payload["transcript_character_count"] == 150
+    assert payload["transcript_sha256"] == summary_recovery.build_hermes_recovery_source(conversation)[1]
+    assert payload["zero_writes"] is True
+    assert "transcript_segments" not in payload
+    assert "transcript" not in payload
+    assert len(payload["profile_scope_sha256"]) == 64
+    assert len(payload["canonical_session_scope_sha256"]) == 64
+
+
+def test_retry_plan_404s_without_leaking_other_user_record(monkeypatch):
+    monkeypatch.setattr(summary_recovery.conversations_db, "get_conversation", lambda uid, cid: None)
+    monkeypatch.setattr(
+        summary_recovery,
+        "_conversation_vector_present",
+        lambda *args: pytest.fail("vector lookup must not run for a missing UID-owned record"),
+    )
+    app, client = _retry_api_client()
+    try:
+        response = client.get("/v1/conversations/another-users-conversation/processing-retry-plan")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 404
+
+
 def test_retry_api_claims_once_and_queues_two_stage_recovery(monkeypatch):
     request_id = "84eb13fa-31d9-40ba-a742-c4de4757dc10"
     worker_calls = []
@@ -988,8 +1088,20 @@ def test_retry_api_claims_once_and_queues_two_stage_recovery(monkeypatch):
         "claim_conversation_processing_retry",
         lambda uid, conversation_id, claimed_request_id: {
             "outcome": "claimed",
-            "conversation": _retry_conversation(request_id=claimed_request_id),
+            "mode": "full",
+            "phase": "claimed",
+            "generic_status": "pending",
+            "generic_vector_status": "pending",
+            "enrichment_status": "pending",
+            "vector_status": "pending",
+            "lease_expires_at": "2026-07-20T08:15:00+00:00",
+            "attempt_count": 1,
         },
+    )
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: _retry_conversation(request_id=request_id),
     )
 
     async def fake_recover(**kwargs):
@@ -1008,12 +1120,19 @@ def test_retry_api_claims_once_and_queues_two_stage_recovery(monkeypatch):
 
     assert response.status_code == 202
     assert response.json()["outcome"] == "processing"
+    assert response.json()["recovery_mode"] == "full"
+    assert response.json()["phase"] == "claimed"
+    assert response.json()["generic_status"] == "pending"
+    assert response.json()["enrichment_status"] == "pending"
+    assert response.json()["vector_status"] == "pending"
+    assert response.json()["attempt_count"] == 1
     assert worker_calls == [
         {
             "uid": "authenticated-user",
             "conversation_id": "conversation-1",
             "request_id": request_id,
             "client_context": "This was the morning cafe conversation.",
+            "attempt_count": 1,
         }
     ]
 
@@ -1029,6 +1148,11 @@ def test_retry_api_repeated_request_returns_receipt_without_new_work(monkeypatch
             "outcome": stored_outcome,
             "conversation": _retry_conversation(status=stored_outcome, request_id=claimed_request_id),
         },
+    )
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: _retry_conversation(status=stored_outcome, request_id=request_id),
     )
     monkeypatch.setattr(
         corrections, "recover_failed_conversation_summary", lambda **kwargs: worker_calls.append(kwargs)
@@ -1077,6 +1201,278 @@ def test_summary_recovery_preserves_full_25k_transcript_in_hermes_prompt():
     assert "[truncated]" not in prompt
 
 
+def test_reclaimed_attempt_fences_stale_worker_before_generic_writeback(monkeypatch):
+    request_id = "84eb13fa-31d9-40ba-a742-c4de4757dc10"
+    stale = {
+        **_retry_conversation(request_id=request_id),
+        "processing_retry_attempt_count": 1,
+    }
+    reclaimed = {**stale, "processing_retry_attempt_count": 2}
+    reads = [stale, reclaimed]
+    monkeypatch.setattr(summary_recovery.conversations_db, "get_conversation", lambda uid, cid: reads.pop(0))
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_source",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr(
+        summary_recovery,
+        "generate_stock_conversation_summary",
+        lambda *args: {"title": "Stale", "overview": "Must not apply", "category": "other"},
+    )
+    monkeypatch.setattr(
+        summary_recovery,
+        "apply_summary_update",
+        lambda **kwargs: pytest.fail("stale lease attempt must not write a summary version"),
+    )
+
+    outcome = asyncio.run(
+        summary_recovery.recover_failed_conversation_summary(
+            uid="user-1",
+            conversation_id="conversation-1",
+            request_id=request_id,
+            attempt_count=1,
+        )
+    )
+
+    assert outcome == "superseded"
+
+
+def test_vector_confirmation_skips_existing_vector_without_duplicate_write(monkeypatch):
+    conversation = {
+        **_retry_conversation(status="completed", request_id="request-1"),
+        "active_summary_version_id": "generic-v1",
+    }
+    writes = []
+    content_sha256 = summary_recovery._summary_content_sha256(conversation)
+    monkeypatch.setattr(
+        summary_recovery,
+        "_conversation_vector_metadata",
+        lambda uid, cid: {
+            "active_summary_version_id": "generic-v1",
+            "summary_content_sha256": content_sha256,
+        },
+    )
+    monkeypatch.setattr(summary_recovery, "save_structured_vector", lambda *args: writes.append(args))
+
+    asyncio.run(summary_recovery._ensure_conversation_vector("user-1", conversation))
+
+    assert writes == []
+
+
+def test_vector_confirmation_requires_post_write_visibility(monkeypatch):
+    conversation = {
+        **_retry_conversation(status="completed", request_id=None),
+        "active_summary_version_id": "generic-v1",
+    }
+    content_sha256 = summary_recovery._summary_content_sha256(conversation)
+    checks = iter(
+        [
+            None,
+            {
+                "active_summary_version_id": "generic-v1",
+                "summary_content_sha256": content_sha256,
+            },
+        ]
+    )
+    writes = []
+    monkeypatch.setattr(summary_recovery, "_conversation_vector_metadata", lambda uid, cid: next(checks))
+    monkeypatch.setattr(
+        summary_recovery,
+        "save_structured_vector",
+        lambda uid, conv, **kwargs: writes.append((conv.id, kwargs)) or {"upserted_count": 1},
+    )
+
+    asyncio.run(summary_recovery._ensure_conversation_vector("user-1", conversation))
+
+    assert writes == [
+        (
+            "conversation-1",
+            {
+                "summary_version_id": "generic-v1",
+                "summary_content_sha256": content_sha256,
+            },
+        )
+    ]
+
+
+def test_enriched_vector_is_force_upserted_and_verified_by_version_and_hash(monkeypatch):
+    conversation = {
+        **_retry_conversation(status="completed", request_id=None),
+        "active_summary_version_id": "enriched-v2",
+        "structured": {
+            "title": "Enriched",
+            "overview": "[Ella] Enriched summary.",
+            "emoji": "brain",
+            "category": "other",
+        },
+    }
+    writes = []
+
+    def fake_save(uid, model, **kwargs):
+        writes.append((uid, model.id, kwargs))
+        return {"upserted_count": 1}
+
+    expected_hash = summary_recovery._summary_content_sha256(conversation)
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "get_conversation",
+        lambda uid, cid: conversation,
+    )
+    monkeypatch.setattr(summary_recovery, "save_structured_vector", fake_save)
+    monkeypatch.setattr(
+        summary_recovery,
+        "_conversation_vector_metadata",
+        lambda uid, cid: {
+            "active_summary_version_id": "enriched-v2",
+            "summary_content_sha256": expected_hash,
+        },
+    )
+
+    result = asyncio.run(summary_recovery._write_and_confirm_enriched_vector("user-1", conversation, "enriched-v2"))
+
+    assert result == expected_hash
+    assert writes == [
+        (
+            "user-1",
+            "conversation-1",
+            {
+                "summary_version_id": "enriched-v2",
+                "summary_content_sha256": expected_hash,
+            },
+        )
+    ]
+
+
+def test_enriched_vector_fails_closed_when_active_summary_changes_after_upsert(monkeypatch):
+    conversation = {
+        **_retry_conversation(status="completed", request_id=None),
+        "active_summary_version_id": "enriched-v2",
+        "structured": {
+            "title": "Enriched",
+            "overview": "[Ella] Enriched summary.",
+            "emoji": "brain",
+            "category": "other",
+        },
+    }
+    changed = {**conversation, "active_summary_version_id": "manual-v3"}
+    reads = iter([conversation, changed])
+    expected_hash = summary_recovery._summary_content_sha256(conversation)
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "get_conversation",
+        lambda uid, cid: next(reads),
+    )
+    monkeypatch.setattr(
+        summary_recovery,
+        "save_structured_vector",
+        lambda uid, model, **kwargs: {"upserted_count": 1},
+    )
+    monkeypatch.setattr(
+        summary_recovery,
+        "_conversation_vector_metadata",
+        lambda uid, cid: {
+            "active_summary_version_id": "enriched-v2",
+            "summary_content_sha256": expected_hash,
+        },
+    )
+
+    with pytest.raises(
+        summary_recovery.ConcurrentConversationRecoveryChangeError,
+        match="active_summary_changed_after_vector_write",
+    ):
+        asyncio.run(
+            summary_recovery._write_and_confirm_enriched_vector(
+                "user-1",
+                conversation,
+                "enriched-v2",
+            )
+        )
+
+
+def test_hermes_recovery_uses_lossless_source_and_canonical_uid_session(monkeypatch):
+    transcript = "start " + ("important " * 3000) + "tail-marker"
+    conversation = _retry_conversation(status="completed", request_id="request-1")
+    conversation["transcript_segments"] = [{"is_user": True, "text": transcript}]
+    captured = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "content": '{"title":"Cafe","overview":"[Ella] Cafe context.",'
+                            '"emoji":"coffee","category":"media"}'
+                        }
+                    }
+                ]
+            }
+
+    class FakeClient:
+        def __init__(self, timeout):
+            captured["timeout"] = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, headers, json):
+            captured.update({"url": url, "headers": headers, "body": json})
+            return FakeResponse()
+
+    monkeypatch.setattr(summary_recovery.conversations_db, "get_conversation", lambda uid, cid: conversation)
+
+    async def fake_apply(**kwargs):
+        captured["apply"] = kwargs
+        return {"active_summary_version_id": "enriched-v2", "canonical_confirmed": True}
+
+    monkeypatch.setattr(summary_recovery, "apply_summary_update", fake_apply)
+    config = summary_recovery.SummaryProviderConfig(
+        provider="hermes-api",
+        hermes_url="http://hermes.test/v1/chat/completions",
+        hermes_model="companion-runtime",
+        hermes_api_key="test-key",
+        legacy_url="",
+        legacy_model="",
+        legacy_api_key="",
+        timeout_seconds=45,
+    )
+    result = asyncio.run(
+        summary_recovery.invoke_hermes_recovery(
+            uid="user-1",
+            conversation=conversation,
+            request_id="request-1",
+            client_context="Cafe context",
+            config=config,
+            async_client_factory=FakeClient,
+        )
+    )
+
+    assert captured["url"] == "http://hermes.test/v1/chat/completions"
+    assert captured["headers"]["Authorization"] == "Bearer test-key"
+    assert captured["headers"]["X-Hermes-Session-Key"] == summary_recovery.canonical_omi_session_key("user-1")
+    prompt = captured["body"]["messages"][0]["content"]
+    assert "tail-marker" in prompt
+    assert "Cafe context" in prompt
+    assert summary_recovery.build_hermes_recovery_source(conversation)[1] in prompt
+    assert captured["apply"]["summary"]["category"] == "entertainment"
+    assert captured["apply"]["require_canonical"] is True
+    assert result == {
+        "active_summary_version_id": "enriched-v2",
+        "canonical_confirmed": True,
+        "source_sha256": summary_recovery.build_hermes_recovery_source(conversation)[1],
+        "session_scope_sha256": summary_recovery.hashlib.sha256(
+            summary_recovery.canonical_omi_session_key("user-1").encode("utf-8")
+        ).hexdigest(),
+    }
+
+
 def test_summary_recovery_persists_generic_before_hermes_enrichment(monkeypatch):
     request_id = "84eb13fa-31d9-40ba-a742-c4de4757dc10"
     conversation = _retry_conversation(request_id=request_id)
@@ -1103,7 +1499,7 @@ def test_summary_recovery_persists_generic_before_hermes_enrichment(monkeypatch)
             "category": "other",
         },
     }
-    reads = [conversation, generic, completed_generic, enriched]
+    reads = [conversation, conversation, generic, completed_generic, enriched]
     events = []
 
     monkeypatch.setattr(summary_recovery.conversations_db, "get_conversation", lambda uid, cid: reads.pop(0))
@@ -1119,33 +1515,40 @@ def test_summary_recovery_persists_generic_before_hermes_enrichment(monkeypatch)
         },
     )
 
-    async def fake_generate(**kwargs):
-        events.append("hermes_generate")
-        return {
-            "title": "Enriched",
-            "overview": "[Ella] Enriched summary.",
-            "emoji": "brain",
-            "category": "other",
-            "ella_tags": ["omi", "recovery"],
-            "ella_signal": {},
-        }
+    async def fake_invoke(**kwargs):
+        events.append("hermes_provision")
+        return {"active_summary_version_id": "enriched-v2", "canonical_confirmed": True}
 
     async def fake_apply(**kwargs):
         events.append(f"apply:{kwargs['summary_kind']}")
         version_id = "generic-v1" if kwargs["summary_kind"] == "generic_recovered" else "enriched-v2"
-        return {"status": "ok", "active_summary_version_id": version_id}
+        return {
+            "status": "ok",
+            "active_summary_version_id": version_id,
+            "canonical_confirmed": kwargs["summary_kind"] == "recovered_enriched",
+        }
 
-    monkeypatch.setattr(summary_recovery, "generate_summary_from_prompt", fake_generate)
+    monkeypatch.setattr(summary_recovery, "invoke_hermes_recovery", fake_invoke)
     monkeypatch.setattr(summary_recovery, "apply_summary_update", fake_apply)
     monkeypatch.setattr(
         summary_recovery.conversations_db,
         "record_conversation_processing_retry_summary_applied",
-        lambda *args: events.append("generic_receipt") or True,
+        lambda *args, **kwargs: events.append("generic_receipt") or True,
     )
     monkeypatch.setattr(
         summary_recovery,
-        "save_structured_vector",
-        lambda uid, conv: events.append(f"vector:{conv.structured.title}"),
+        "_ensure_conversation_vector",
+        lambda uid, conv: _async_event(events, f"vector:{conv['structured']['title']}"),
+    )
+    monkeypatch.setattr(
+        summary_recovery,
+        "_write_and_confirm_enriched_vector",
+        lambda uid, conv, version_id: _async_event_result(events, "vector:Enriched", "e" * 64),
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_generic_vector",
+        lambda *args, **kwargs: events.append(f"generic_vector:{args[3]}") or True,
     )
     monkeypatch.setattr(
         summary_recovery.conversations_db,
@@ -1172,9 +1575,9 @@ def test_summary_recovery_persists_generic_before_hermes_enrichment(monkeypatch)
         "apply:generic_recovered",
         "generic_receipt",
         "vector:Generic",
-        "finish:completed",
-        "hermes_generate",
-        "apply:recovered_enriched",
+        "generic_vector:completed",
+        "hermes_provision",
+        "enrichment:canonical_completed",
         "vector:Enriched",
         "enrichment:completed",
     ]
@@ -1194,7 +1597,8 @@ def test_summary_recovery_hermes_failure_retains_completed_generic_summary(monke
             "category": "other",
         },
     }
-    reads = [conversation, generic, {**generic, "status": "completed", "processing_error": None}]
+    completed_generic = {**generic, "status": "completed", "processing_error": None}
+    reads = [conversation, conversation, generic, completed_generic, completed_generic]
     events = []
     monkeypatch.setattr(summary_recovery.conversations_db, "get_conversation", lambda uid, cid: reads.pop(0))
     monkeypatch.setattr(
@@ -1208,21 +1612,30 @@ def test_summary_recovery_hermes_failure_retains_completed_generic_summary(monke
         },
     )
 
-    async def fake_generate(**kwargs):
+    async def fake_invoke(**kwargs):
         raise RuntimeError("private Hermes provider detail")
 
     async def fake_apply(**kwargs):
         assert kwargs["summary_kind"] == "generic_recovered"
         return {"status": "ok", "active_summary_version_id": "generic-v1"}
 
-    monkeypatch.setattr(summary_recovery, "generate_summary_from_prompt", fake_generate)
+    monkeypatch.setattr(summary_recovery, "invoke_hermes_recovery", fake_invoke)
     monkeypatch.setattr(summary_recovery, "apply_summary_update", fake_apply)
     monkeypatch.setattr(
         summary_recovery.conversations_db,
         "record_conversation_processing_retry_summary_applied",
-        lambda *args: True,
+        lambda *args, **kwargs: True,
     )
-    monkeypatch.setattr(summary_recovery, "save_structured_vector", lambda uid, conv: events.append("vector"))
+    monkeypatch.setattr(
+        summary_recovery,
+        "_ensure_conversation_vector",
+        lambda uid, conv: _async_event(events, "vector"),
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_generic_vector",
+        lambda *args, **kwargs: events.append(("generic_vector", args[3])) or True,
+    )
     monkeypatch.setattr(
         summary_recovery.conversations_db,
         "finish_conversation_processing_retry",
@@ -1242,11 +1655,11 @@ def test_summary_recovery_hermes_failure_retains_completed_generic_summary(monke
         )
     )
 
-    assert outcome == "completed"
+    assert outcome == "failed"
     assert events == [
         "vector",
-        ("finish", "completed", {}),
-        ("enrichment", "failed", {}),
+        ("generic_vector", "completed"),
+        ("enrichment", "failed", {"attempt_count": None}),
     ]
     assert "private Hermes provider detail" not in str(events)
 
@@ -1257,6 +1670,7 @@ def test_summary_recovery_resumes_hermes_after_generic_phase_completed(monkeypat
         **_retry_conversation(status="completed", request_id=request_id),
         "active_summary_version_id": "generic-v1",
         "processing_retry_summary_version_id": "generic-v1",
+        "processing_retry_mode": "enrichment_only",
     }
     enriched = {
         **generic,
@@ -1272,24 +1686,26 @@ def test_summary_recovery_resumes_hermes_after_generic_phase_completed(monkeypat
         lambda *args: pytest.fail("generic provider must not rerun after its durable receipt"),
     )
 
-    async def fake_generate(**kwargs):
-        events.append("hermes_generate")
-        return {
-            "title": "Enriched",
-            "overview": "[Ella] Enriched summary.",
-            "emoji": "brain",
-            "category": "other",
-            "ella_tags": ["omi", "recovery"],
-            "ella_signal": {},
-        }
+    async def fake_invoke(**kwargs):
+        events.append("hermes_provision")
+        return {"status": "ok", "active_summary_version_id": "enriched-v2", "canonical_confirmed": True}
 
-    async def fake_apply(**kwargs):
-        events.append("hermes_apply")
-        return {"status": "ok", "active_summary_version_id": "enriched-v2"}
-
-    monkeypatch.setattr(summary_recovery, "generate_summary_from_prompt", fake_generate)
-    monkeypatch.setattr(summary_recovery, "apply_summary_update", fake_apply)
-    monkeypatch.setattr(summary_recovery, "save_structured_vector", lambda uid, conv: events.append("vector"))
+    monkeypatch.setattr(summary_recovery, "invoke_hermes_recovery", fake_invoke)
+    monkeypatch.setattr(
+        summary_recovery,
+        "_ensure_conversation_vector",
+        lambda uid, conv: _async_event(events, f"vector:{conv['active_summary_version_id']}"),
+    )
+    monkeypatch.setattr(
+        summary_recovery,
+        "_write_and_confirm_enriched_vector",
+        lambda uid, conv, version_id: _async_event_result(events, "vector:enriched-v2", "e" * 64),
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_generic_vector",
+        lambda *args, **kwargs: events.append(f"generic_vector:{args[3]}") or True,
+    )
     monkeypatch.setattr(
         summary_recovery.conversations_db,
         "finish_conversation_processing_retry",
@@ -1310,7 +1726,175 @@ def test_summary_recovery_resumes_hermes_after_generic_phase_completed(monkeypat
     )
 
     assert outcome == "completed"
-    assert events == ["vector", "finish", "hermes_generate", "hermes_apply", "vector", "enrichment:completed"]
+    assert events == [
+        "vector:generic-v1",
+        "generic_vector:completed",
+        "hermes_provision",
+        "enrichment:canonical_completed",
+        "vector:enriched-v2",
+        "enrichment:completed",
+    ]
+
+
+def test_summary_recovery_reconciles_transport_uncertainty_after_confirmed_writeback(monkeypatch):
+    request_id = "84eb13fa-31d9-40ba-a742-c4de4757dc10"
+    generic = {
+        **_retry_conversation(status="completed", request_id=request_id),
+        "active_summary_version_id": "generic-v1",
+        "processing_retry_summary_version_id": "generic-v1",
+        "processing_retry_mode": "enrichment_only",
+    }
+    enriched = {
+        **generic,
+        "active_summary_version_id": "enriched-v2",
+        "summary_versions": [
+            {
+                "id": "enriched-v2",
+                "created_at": "2026-07-20T08:31:00+00:00",
+                "kind": "recovered_enriched",
+                "source": "observer",
+                "is_active": True,
+            }
+        ],
+        "enrichment_state": {
+            "status": "writeback_applied",
+            "kind": "recovered_enriched",
+            "canonical_status": "completed",
+        },
+    }
+    reads = [generic, generic, generic, enriched, enriched]
+    events = []
+    monkeypatch.setattr(summary_recovery.conversations_db, "get_conversation", lambda uid, cid: reads.pop(0))
+    monkeypatch.setattr(
+        summary_recovery,
+        "generate_stock_conversation_summary",
+        lambda *args: pytest.fail("generic provider must not run for enrichment-only recovery"),
+    )
+
+    async def uncertain_invoke(**kwargs):
+        raise RuntimeError("transport closed after remote writeback")
+
+    monkeypatch.setattr(summary_recovery, "invoke_hermes_recovery", uncertain_invoke)
+    monkeypatch.setattr(
+        summary_recovery,
+        "_ensure_conversation_vector",
+        lambda uid, conv: _async_event(events, f"vector:{conv['active_summary_version_id']}"),
+    )
+    monkeypatch.setattr(
+        summary_recovery,
+        "_write_and_confirm_enriched_vector",
+        lambda uid, conv, version_id: _async_event_result(events, "vector:enriched-v2", "e" * 64),
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_generic_vector",
+        lambda *args, **kwargs: events.append(("generic_vector", args[3])) or True,
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_enrichment",
+        lambda *args, **kwargs: events.append((args[3], kwargs["summary_version_id"])) or True,
+    )
+
+    outcome = asyncio.run(
+        summary_recovery.recover_failed_conversation_summary(
+            uid="user-1",
+            conversation_id="conversation-1",
+            request_id=request_id,
+        )
+    )
+
+    assert outcome == "completed"
+    assert events == [
+        "vector:generic-v1",
+        ("generic_vector", "completed"),
+        ("canonical_completed", "enriched-v2"),
+        "vector:enriched-v2",
+        ("completed", "enriched-v2"),
+    ]
+
+
+def test_summary_recovery_retries_pending_canonical_write_without_second_model_call(monkeypatch):
+    request_id = "84eb13fa-31d9-40ba-a742-c4de4757dc10"
+    pending = {
+        **_retry_conversation(status="completed", request_id=request_id),
+        "processing_retry_mode": "enrichment_only",
+        "active_summary_version_id": "enriched-v2",
+        "processing_retry_summary_version_id": "generic-v1",
+        "enrichment_state": {
+            "status": "writeback_pending_canonical",
+            "pending": True,
+            "kind": "recovered_enriched",
+            "trace_id": "prior-hermes-trace",
+            "canonical_status": "failed",
+        },
+    }
+    confirmed = {
+        **pending,
+        "enrichment_state": {
+            **pending["enrichment_state"],
+            "status": "writeback_applied",
+            "pending": False,
+            "canonical_status": "completed",
+        },
+    }
+    reads = [pending, pending, pending, confirmed, confirmed]
+    events = []
+    monkeypatch.setattr(summary_recovery.conversations_db, "get_conversation", lambda uid, cid: reads.pop(0))
+    monkeypatch.setattr(
+        summary_recovery,
+        "generate_stock_conversation_summary",
+        lambda *args: pytest.fail("generic provider must not run for enrichment-only recovery"),
+    )
+    monkeypatch.setattr(
+        summary_recovery,
+        "invoke_hermes_recovery",
+        lambda **kwargs: pytest.fail("Hermes enrichment must not rerun while canonical write is pending"),
+    )
+
+    async def fake_apply(**kwargs):
+        events.append(("canonical_retry", kwargs["trace_id"], kwargs["summary"]))
+        return {"active_summary_version_id": "enriched-v2", "canonical_confirmed": True}
+
+    monkeypatch.setattr(summary_recovery, "apply_summary_update", fake_apply)
+    monkeypatch.setattr(
+        summary_recovery,
+        "_ensure_conversation_vector",
+        lambda uid, conv: _async_event(events, f"vector:{conv['active_summary_version_id']}"),
+    )
+    monkeypatch.setattr(
+        summary_recovery,
+        "_write_and_confirm_enriched_vector",
+        lambda uid, conv, version_id: _async_event_result(events, "vector:enriched-v2", "e" * 64),
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_generic_vector",
+        lambda *args, **kwargs: events.append(("generic_vector", args[3])) or True,
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_enrichment",
+        lambda *args, **kwargs: events.append(("enrichment", args[3], kwargs["summary_version_id"])) or True,
+    )
+
+    outcome = asyncio.run(
+        summary_recovery.recover_failed_conversation_summary(
+            uid="user-1",
+            conversation_id="conversation-1",
+            request_id=request_id,
+        )
+    )
+
+    assert outcome == "completed"
+    assert events == [
+        "vector:enriched-v2",
+        ("generic_vector", "completed"),
+        ("canonical_retry", "prior-hermes-trace", {}),
+        ("enrichment", "canonical_completed", "enriched-v2"),
+        "vector:enriched-v2",
+        ("enrichment", "completed", "enriched-v2"),
+    ]
 
 
 def test_summary_recovery_vector_failure_remains_retryable_without_raw_error(monkeypatch):
@@ -1320,7 +1904,7 @@ def test_summary_recovery_vector_failure_remains_retryable_without_raw_error(mon
         "active_summary_version_id": "recovered-v1",
         "processing_retry_summary_version_id": "recovered-v1",
     }
-    finish_calls = []
+    vector_receipts = []
     monkeypatch.setattr(summary_recovery.conversations_db, "get_conversation", lambda uid, cid: conversation)
     monkeypatch.setattr(
         summary_recovery,
@@ -1329,13 +1913,13 @@ def test_summary_recovery_vector_failure_remains_retryable_without_raw_error(mon
     )
     monkeypatch.setattr(
         summary_recovery,
-        "save_structured_vector",
-        lambda uid, conv: (_ for _ in ()).throw(RuntimeError("secret provider detail")),
+        "_ensure_conversation_vector",
+        lambda uid, conv: _async_raise(RuntimeError("secret provider detail")),
     )
     monkeypatch.setattr(
         summary_recovery.conversations_db,
-        "finish_conversation_processing_retry",
-        lambda *args, **kwargs: finish_calls.append((args, kwargs)) or True,
+        "record_conversation_processing_retry_generic_vector",
+        lambda *args, **kwargs: vector_receipts.append(args[3]) or True,
     )
 
     outcome = asyncio.run(
@@ -1347,6 +1931,255 @@ def test_summary_recovery_vector_failure_remains_retryable_without_raw_error(mon
     )
 
     assert outcome == "failed"
-    assert finish_calls[0][0][3] == "failed"
-    assert finish_calls[0][1]["error_code"] == "conversation_summary_recovery_failed"
-    assert "secret provider detail" not in str(finish_calls[0])
+    assert vector_receipts == ["failed"]
+    assert "secret provider detail" not in str(vector_receipts)
+
+
+def test_enriched_vector_failure_receipts_version_and_hash_without_rerunning_model(monkeypatch):
+    request_id = "84eb13fa-31d9-40ba-a742-c4de4757dc10"
+    enriched = {
+        **_retry_conversation(status="completed", request_id=request_id),
+        "processing_retry_mode": "enrichment_only",
+        "processing_retry_summary_version_id": "generic-v1",
+        "processing_retry_enriched_version_id": "enriched-v2",
+        "active_summary_version_id": "enriched-v2",
+        "summary_versions": [
+            {"id": "enriched-v2", "kind": "recovered_enriched", "source": "observer", "is_active": True}
+        ],
+        "enrichment_state": {
+            "status": "writeback_applied",
+            "kind": "recovered_enriched",
+            "canonical_status": "completed",
+        },
+        "structured": {
+            "title": "Enriched",
+            "overview": "[Ella] Enriched summary.",
+            "emoji": "brain",
+            "category": "other",
+        },
+    }
+    reads = [enriched, enriched, enriched, enriched]
+    receipts = []
+    monkeypatch.setattr(summary_recovery.conversations_db, "get_conversation", lambda uid, cid: reads.pop(0))
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_source",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr(summary_recovery, "_ensure_conversation_vector", lambda uid, conv: _async_event([], None))
+    monkeypatch.setattr(
+        summary_recovery,
+        "invoke_hermes_recovery",
+        lambda **kwargs: pytest.fail("confirmed enrichment must not rerun Hermes"),
+    )
+    monkeypatch.setattr(
+        summary_recovery,
+        "_write_and_confirm_enriched_vector",
+        lambda *args: _async_raise(RuntimeError("private vector provider detail")),
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_generic_vector",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr(
+        summary_recovery.conversations_db,
+        "record_conversation_processing_retry_enrichment",
+        lambda *args, **kwargs: receipts.append((args[3], kwargs)) or True,
+    )
+
+    outcome = asyncio.run(
+        summary_recovery.recover_failed_conversation_summary(
+            uid="user-1",
+            conversation_id="conversation-1",
+            request_id=request_id,
+        )
+    )
+
+    expected_hash = summary_recovery._summary_content_sha256(enriched)
+    assert outcome == "failed"
+    assert receipts == [
+        ("canonical_completed", {"summary_version_id": "enriched-v2", "attempt_count": None}),
+        (
+            "vector_failed",
+            {
+                "summary_version_id": "enriched-v2",
+                "vector_content_sha256": expected_hash,
+                "attempt_count": None,
+            },
+        ),
+    ]
+    assert "private vector provider detail" not in str(receipts)
+
+
+def test_strict_summary_writeback_confirms_canonical_before_success(monkeypatch):
+    conversation = {
+        **_retry_conversation(status="completed", request_id=None),
+        "active_summary_version_id": "generic-v1",
+        "summary_versions": [],
+    }
+    updates = []
+    canonical_calls = []
+    monkeypatch.setattr(summary_writeback.conversations_db, "get_conversation", lambda uid, cid: conversation)
+    monkeypatch.setattr(
+        summary_writeback.conversations_db,
+        "build_summary_version_update",
+        lambda *args, **kwargs: {
+            "summary_versions": [{"id": "enriched-v2", "kind": "recovered_enriched", "is_active": True}],
+            "active_summary_version_id": "enriched-v2",
+        },
+    )
+    monkeypatch.setattr(
+        summary_writeback.conversations_db,
+        "update_conversation",
+        lambda uid, cid, update: updates.append(update),
+    )
+
+    def canonical_writer(uid, record, **kwargs):
+        canonical_calls.append((uid, record, kwargs))
+        return {"ok": True, "inserted": 1, "duplicates": 0}
+
+    result = asyncio.run(
+        summary_writeback.write_conversation_summary(
+            uid="user-1",
+            conversation_id="conversation-1",
+            title="Enriched",
+            overview="[Ella] Enriched and canonicalized summary.",
+            category="other",
+            summary_kind="recovered_enriched",
+            trace_id="trace-1",
+            canonical_writer=canonical_writer,
+            require_canonical=True,
+        )
+    )
+
+    assert result["canonical_confirmed"] is True
+    assert updates[0]["enrichment_state"]["status"] == "writeback_pending_canonical"
+    assert updates[1]["enrichment_state"]["status"] == "writeback_applied"
+    assert updates[1]["enrichment_state"]["canonical_status"] == "completed"
+    assert canonical_calls[0][1]["enrichment_state"]["canonical_status"] == "completed"
+
+
+def test_recovery_writeback_fails_closed_when_active_summary_changed(monkeypatch):
+    conversation = {
+        **_retry_conversation(status="completed", request_id=None),
+        "active_summary_version_id": "newer-v2",
+    }
+    monkeypatch.setattr(summary_writeback.conversations_db, "get_conversation", lambda uid, cid: conversation)
+    monkeypatch.setattr(
+        summary_writeback.conversations_db,
+        "update_conversation",
+        lambda *args: pytest.fail("concurrent change must prevent writeback"),
+    )
+
+    with pytest.raises(
+        summary_writeback.ConcurrentConversationSummaryChangeError,
+        match="active_summary_version_changed",
+    ):
+        asyncio.run(
+            summary_writeback.write_conversation_summary(
+                uid="user-1",
+                conversation_id="conversation-1",
+                title="Stale recovery",
+                overview="[Ella] Stale recovery.",
+                category="other",
+                based_on_version_id="generic-v1",
+                require_based_on_match=True,
+            )
+        )
+
+
+def test_strict_summary_writeback_keeps_retryable_state_when_canonical_fails(monkeypatch):
+    conversation = {
+        **_retry_conversation(status="completed", request_id=None),
+        "active_summary_version_id": "generic-v1",
+        "summary_versions": [],
+    }
+    updates = []
+    monkeypatch.setattr(summary_writeback.conversations_db, "get_conversation", lambda uid, cid: conversation)
+    monkeypatch.setattr(
+        summary_writeback.conversations_db,
+        "build_summary_version_update",
+        lambda *args, **kwargs: {
+            "summary_versions": [{"id": "enriched-v2", "kind": "recovered_enriched", "is_active": True}],
+            "active_summary_version_id": "enriched-v2",
+        },
+    )
+    monkeypatch.setattr(
+        summary_writeback.conversations_db,
+        "update_conversation",
+        lambda uid, cid, update: updates.append(update),
+    )
+
+    with pytest.raises(RuntimeError, match="canonical_write_unconfirmed"):
+        asyncio.run(
+            summary_writeback.write_conversation_summary(
+                uid="user-1",
+                conversation_id="conversation-1",
+                title="Enriched",
+                overview="[Ella] Enriched summary awaiting canonical confirmation.",
+                category="other",
+                summary_kind="recovered_enriched",
+                trace_id="trace-2",
+                canonical_writer=lambda *args, **kwargs: {"ok": False, "skipped": True},
+                require_canonical=True,
+            )
+        )
+
+    assert updates[-1]["enrichment_state"]["status"] == "writeback_pending_canonical"
+    assert updates[-1]["enrichment_state"]["canonical_status"] == "failed"
+    assert updates[-1]["enrichment_state"]["pending"] is True
+
+
+def test_strict_summary_writeback_retries_only_canonical_after_transport_uncertainty(monkeypatch):
+    conversation = {
+        **_retry_conversation(status="completed", request_id=None),
+        "active_summary_version_id": "enriched-v2",
+        "summary_versions": [{"id": "enriched-v2", "kind": "recovered_enriched", "is_active": True}],
+        "enrichment_state": {
+            "status": "writeback_pending_canonical",
+            "pending": True,
+            "source": "observer",
+            "kind": "recovered_enriched",
+            "trace_id": "trace-3",
+            "canonical_status": "failed",
+        },
+    }
+    updates = []
+    monkeypatch.setattr(summary_writeback.conversations_db, "get_conversation", lambda uid, cid: conversation)
+    monkeypatch.setattr(
+        summary_writeback.conversations_db,
+        "build_summary_version_update",
+        lambda *args, **kwargs: pytest.fail("canonical replay must not append another summary version"),
+    )
+    monkeypatch.setattr(
+        summary_writeback.conversations_db,
+        "update_conversation",
+        lambda uid, cid, update: updates.append(update),
+    )
+
+    result = asyncio.run(
+        summary_writeback.write_conversation_summary(
+            uid="user-1",
+            conversation_id="conversation-1",
+            summary_kind="recovered_enriched",
+            trace_id="trace-3",
+            canonical_writer=lambda *args, **kwargs: {"ok": True, "inserted": 0, "duplicates": 1},
+            require_canonical=True,
+        )
+    )
+
+    assert result["idempotent_replay"] is True
+    assert result["canonical_confirmed"] is True
+    assert updates == [
+        {
+            "enrichment_state": {
+                **conversation["enrichment_state"],
+                "status": "writeback_applied",
+                "pending": False,
+                "canonical_status": "completed",
+                "error": None,
+                "updated_at": updates[0]["enrichment_state"]["updated_at"],
+            }
+        }
+    ]

--- a/backend/utils/conversations/generic_summary.py
+++ b/backend/utils/conversations/generic_summary.py
@@ -1,0 +1,47 @@
+"""Side-effect-free stock OMI summary generation for an existing conversation."""
+
+from datetime import datetime, timedelta, timezone
+
+import database.action_items as action_items_db
+import database.notifications as notification_db
+import database.users as users_db
+from models.conversation import CalendarMeetingContext, Conversation, Structured
+from models.other import Person
+from utils.llm.conversation_processing import get_transcript_structure
+
+
+def generate_stock_conversation_summary(uid: str, conversation: Conversation) -> Structured:
+    timezone_name = notification_db.get_user_time_zone(uid)
+    existing_action_items = None
+    try:
+        existing_action_items = action_items_db.get_action_items(
+            uid=uid,
+            start_date=datetime.now(timezone.utc) - timedelta(days=2),
+            limit=50,
+        )
+    except Exception:
+        existing_action_items = None
+
+    people = []
+    person_ids = conversation.get_person_ids()
+    if person_ids:
+        people = [Person(**person) for person in users_db.get_people_by_ids(uid, list(set(person_ids)))]
+
+    calendar_context = None
+    if conversation.external_data:
+        calendar_data = conversation.external_data.get('calendar_meeting_context')
+        if calendar_data:
+            calendar_context = CalendarMeetingContext(**calendar_data)
+
+    transcript = conversation.get_transcript(False, people=people)
+    return get_transcript_structure(
+        transcript,
+        conversation.started_at,
+        conversation.language or 'en',
+        timezone_name,
+        photos=conversation.photos,
+        existing_action_items=existing_action_items,
+        calendar_meeting_context=calendar_context,
+        uid=uid,
+        existing_conversation_id=conversation.id,
+    )

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -23,7 +23,6 @@ import database.calendar_meetings as calendar_db
 from database.vector_db import find_similar_memories, upsert_memory_vector, delete_memory_vector
 from utils.llm.memories import resolve_memory_conflict
 from database.apps import record_app_usage, get_omi_personas_by_uid_db, get_app_by_id_db
-from database.vector_db import upsert_vector2, update_vector_metadata
 from models.app import App, UsageHistoryType
 from models.memories import MemoryDB, Memory
 from models.conversation import *
@@ -55,13 +54,9 @@ from utils.llm.external_integrations import summarize_experience_text
 from utils.llm.trends import trends_extractor
 from utils.llm.goals import extract_and_update_goal_progress
 from utils.llm.chat import (
-    retrieve_metadata_from_text,
-    retrieve_metadata_from_message,
-    retrieve_metadata_fields_from_transcript,
     obtain_emotional_message,
 )
 from utils.llm.external_integrations import get_message_structure
-from utils.llm.clients import generate_embedding
 from utils.notifications import send_notification
 from utils.other.hume import get_hume, HumeJobCallbackModel, HumeJobModelPredictionResponseModel
 from utils.retrieval.rag import retrieve_rag_conversation_context
@@ -81,6 +76,7 @@ from utils.conversations.failure_state import (
     apply_conversation_processing_failed,
     clear_conversation_processing_error,
 )
+from utils.conversations.vector import save_structured_vector
 
 
 def _get_structured(
@@ -156,7 +152,10 @@ def _get_structured(
             )
 
         # Determine whether to discard the conversation based on its content (transcript and/or photos).
-        print(f"[FLOW:PROCESS] checking discard uid={uid} transcript_len={len(transcript_text) if transcript_text else 0}", flush=True)
+        print(
+            f"[FLOW:PROCESS] checking discard uid={uid} transcript_len={len(transcript_text) if transcript_text else 0}",
+            flush=True,
+        )
         discarded = should_discard_conversation(transcript_text, conversation.photos)
         if discarded:
             print(f"[FLOW:PROCESS] DISCARDED uid={uid}", flush=True)
@@ -539,41 +538,6 @@ def _save_action_items(uid: str, conversation: Conversation):
             asyncio.run(auto_sync_action_items_batch(uid, created_items))
 
         threading.Thread(target=_run_auto_sync, daemon=True).start()
-
-
-def save_structured_vector(uid: str, conversation: Conversation, update_only: bool = False):
-    vector = generate_embedding(str(conversation.structured)) if not update_only else None
-    tz = notification_db.get_user_time_zone(uid)
-
-    metadata = {}
-
-    # Extract metadata based on conversation source
-    if conversation.source == ConversationSource.external_integration:
-        text_source = conversation.external_data.get('text_source')
-        text_content = conversation.external_data.get('text')
-        if text_content and len(text_content) > 0 and text_content and len(text_content) > 0:
-            text_source_spec = conversation.external_data.get('text_source_spec')
-            if text_source == ExternalIntegrationConversationSource.message.value:
-                metadata = retrieve_metadata_from_message(
-                    uid, conversation.created_at, text_content, tz, text_source_spec
-                )
-            elif text_source == ExternalIntegrationConversationSource.other.value:
-                metadata = retrieve_metadata_from_text(uid, conversation.created_at, text_content, tz, text_source_spec)
-    else:
-        # For regular conversations with transcript segments
-        segments = [t.dict() for t in conversation.transcript_segments]
-        metadata = retrieve_metadata_fields_from_transcript(
-            uid, conversation.created_at, segments, tz, photos=conversation.photos
-        )
-
-    metadata['created_at'] = int(conversation.created_at.timestamp())
-
-    if not update_only:
-        print('save_structured_vector creating vector')
-        upsert_vector2(uid, conversation, vector, metadata)
-    else:
-        print('save_structured_vector updating metadata')
-        update_vector_metadata(uid, conversation.id, metadata)
 
 
 def _update_personas_async(uid: str):

--- a/backend/utils/conversations/vector.py
+++ b/backend/utils/conversations/vector.py
@@ -1,0 +1,57 @@
+"""Conversation vector write helpers shared by initial processing and recovery."""
+
+import database.notifications as notification_db
+from database.vector_db import upsert_vector2, update_vector_metadata
+from models.conversation import Conversation, ConversationSource, ExternalIntegrationConversationSource
+from utils.llm.chat import (
+    retrieve_metadata_fields_from_transcript,
+    retrieve_metadata_from_message,
+    retrieve_metadata_from_text,
+)
+from utils.llm.clients import generate_embedding
+
+
+def save_structured_vector(uid: str, conversation: Conversation, update_only: bool = False):
+    vector = generate_embedding(str(conversation.structured)) if not update_only else None
+    timezone = notification_db.get_user_time_zone(uid)
+    metadata = {}
+
+    if conversation.source == ConversationSource.external_integration:
+        external_data = conversation.external_data or {}
+        text_source = external_data.get('text_source')
+        text_content = external_data.get('text')
+        if text_content:
+            text_source_spec = external_data.get('text_source_spec')
+            if text_source == ExternalIntegrationConversationSource.message.value:
+                metadata = retrieve_metadata_from_message(
+                    uid,
+                    conversation.created_at,
+                    text_content,
+                    timezone,
+                    text_source_spec,
+                )
+            elif text_source == ExternalIntegrationConversationSource.other.value:
+                metadata = retrieve_metadata_from_text(
+                    uid,
+                    conversation.created_at,
+                    text_content,
+                    timezone,
+                    text_source_spec,
+                )
+    else:
+        segments = [segment.dict() for segment in conversation.transcript_segments]
+        metadata = retrieve_metadata_fields_from_transcript(
+            uid,
+            conversation.created_at,
+            segments,
+            timezone,
+            photos=conversation.photos,
+        )
+
+    metadata['created_at'] = int(conversation.created_at.timestamp())
+    if not update_only:
+        print('save_structured_vector creating vector')
+        upsert_vector2(uid, conversation, vector, metadata)
+    else:
+        print('save_structured_vector updating metadata')
+        update_vector_metadata(uid, conversation.id, metadata)

--- a/backend/utils/conversations/vector.py
+++ b/backend/utils/conversations/vector.py
@@ -1,5 +1,7 @@
 """Conversation vector write helpers shared by initial processing and recovery."""
 
+import json
+
 import database.notifications as notification_db
 from database.vector_db import upsert_vector2, update_vector_metadata
 from models.conversation import Conversation, ConversationSource, ExternalIntegrationConversationSource
@@ -11,14 +13,7 @@ from utils.llm.chat import (
 from utils.llm.clients import generate_embedding
 
 
-def save_structured_vector(
-    uid: str,
-    conversation: Conversation,
-    update_only: bool = False,
-    *,
-    summary_version_id: str | None = None,
-    summary_content_sha256: str | None = None,
-):
+def save_structured_vector(uid: str, conversation: Conversation, update_only: bool = False):
     vector = generate_embedding(str(conversation.structured)) if not update_only else None
     timezone = notification_db.get_user_time_zone(uid)
     metadata = {}
@@ -56,13 +51,44 @@ def save_structured_vector(
         )
 
     metadata['created_at'] = int(conversation.created_at.timestamp())
-    if summary_version_id:
-        metadata['active_summary_version_id'] = summary_version_id
-    if summary_content_sha256:
-        metadata['summary_content_sha256'] = summary_content_sha256
     if not update_only:
         print('save_structured_vector creating vector')
-        return upsert_vector2(uid, conversation, vector, metadata)
+        upsert_vector2(uid, conversation, vector, metadata)
     else:
         print('save_structured_vector updating metadata')
-        return update_vector_metadata(uid, conversation.id, metadata)
+        update_vector_metadata(uid, conversation.id, metadata)
+
+
+def refresh_structured_summary_vector(
+    uid: str,
+    conversation: Conversation,
+    *,
+    summary_version_id: str,
+    summary_content_sha256: str,
+):
+    """Refresh only the summary embedding while preserving existing vector metadata."""
+
+    from database.vector_db import fetch_conversation_vector_metadata, upsert_conversation_vector
+
+    structured = conversation.structured
+    if hasattr(structured, 'model_dump'):
+        structured = structured.model_dump(mode='json')
+    summary_payload = json.dumps(
+        structured,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(',', ':'),
+        default=str,
+    )
+    vector = generate_embedding(summary_payload)
+    metadata = dict(fetch_conversation_vector_metadata(uid, conversation.id) or {})
+    metadata.update(
+        {
+            'uid': uid,
+            'memory_id': conversation.id,
+            'created_at': metadata.get('created_at') or int(conversation.created_at.timestamp()),
+            'active_summary_version_id': summary_version_id,
+            'summary_content_sha256': summary_content_sha256,
+        }
+    )
+    return upsert_conversation_vector(uid, conversation.id, vector, metadata)

--- a/backend/utils/conversations/vector.py
+++ b/backend/utils/conversations/vector.py
@@ -11,7 +11,14 @@ from utils.llm.chat import (
 from utils.llm.clients import generate_embedding
 
 
-def save_structured_vector(uid: str, conversation: Conversation, update_only: bool = False):
+def save_structured_vector(
+    uid: str,
+    conversation: Conversation,
+    update_only: bool = False,
+    *,
+    summary_version_id: str | None = None,
+    summary_content_sha256: str | None = None,
+):
     vector = generate_embedding(str(conversation.structured)) if not update_only else None
     timezone = notification_db.get_user_time_zone(uid)
     metadata = {}
@@ -49,9 +56,13 @@ def save_structured_vector(uid: str, conversation: Conversation, update_only: bo
         )
 
     metadata['created_at'] = int(conversation.created_at.timestamp())
+    if summary_version_id:
+        metadata['active_summary_version_id'] = summary_version_id
+    if summary_content_sha256:
+        metadata['summary_content_sha256'] = summary_content_sha256
     if not update_only:
         print('save_structured_vector creating vector')
-        upsert_vector2(uid, conversation, vector, metadata)
+        return upsert_vector2(uid, conversation, vector, metadata)
     else:
         print('save_structured_vector updating metadata')
-        update_vector_metadata(uid, conversation.id, metadata)
+        return update_vector_metadata(uid, conversation.id, metadata)


### PR DESCRIPTION
## Summary

Backend slices for ellaaicare/ella-ai#1050 and the historical recovery contract in ellaaicare/ella-ai#1051.

- expose preserved `conversation_summary_failed` records through authenticated conversation history
- add authenticated, metadata-only `GET /v1/conversations/{conversation_id}/processing-retry-plan`
- add authenticated `POST /v1/conversations/{conversation_id}/processing-retries` with `{request_id, correction_text?}`
- atomically claim exact UID-owned records with lease/attempt fencing and replay-safe durable receipts
- fetch/decrypt the transcript only after the claim, receipt its SHA-256 without returning transcript content, and fail closed if it changes
- recover a missing generic summary through the configured stock OMI provider, then persist and vector it independently
- run stage 2 directly through the shared Hermes API-session path with the stable canonical per-user session and full lossless transcript
- strictly confirm the enriched OMI version, canonical ledger write, and enriched vector metadata before terminal success
- preserve a usable generic summary and retry only the failed enrichment/canonical/vector phase

## Exact historical behavior

A completed generic conversation with missing Hermes enrichment is classified as `enrichment_only`. It does not rerun stock summarization. If canonical writeback already succeeded, replay reuses the same trace/version and retries only canonical confirmation or the enriched vector.

Pinecone vector existence is not treated as freshness. Generic and enriched vectors carry `active_summary_version_id` and `summary_content_sha256`; the enriched phase force-upserts and verifies both values. Receipt transactions also fence the active summary version and retry attempt.

## Safety

- UID comes only from Firebase auth; clients cannot select another profile or Firestore path.
- Metadata planning performs zero writes and returns no transcript text.
- Active processing, intentional discard, locked, non-retryable, and cross-user/not-found states fail closed.
- A 15-minute lease permits same-request reclaim after worker loss while rejecting concurrent attempts.
- No n8n/OpenClaw/provision-shim dependency is added to this retry path.
- No notifications, integrations, extraction, usage accounting, batch repair, production write, or deployment is included.
- Raw provider errors are not returned to clients.

## Validation

- `./backend/test.sh`: 116 passed
- `test_ella_conversation_corrections.py`: 46 passed
- `test_conversation_processing_retry.py`: 19 passed
- `test_conversation_processing_failures.py`: 9 passed
- `test_ella_callbacks_summary_update.py`: 13 passed
- `test_llm_openrouter_provider.py`: 3 passed
- `python3 -m py_compile` for all changed backend modules: passed
- `git diff --check`: clean

## Deployment gate

Merge and deploy the OMI backend before the iOS retry UI is promoted. Do not run the #1051 historical production repair without a separate exact-record dry-run and explicit approval. The known `f541...` fixture remains stage-2-only; this PR has not mutated it or any production record.