### PR TITLE
Preserve unrelated results during historical recovery

### DIFF
--- a/backend/ella/services/summary_recovery.py
+++ b/backend/ella/services/summary_recovery.py
@@ -305,6 +305,7 @@ async def apply_summary_update(
     correction_id: Optional[str] = None,
     require_canonical: bool = False,
     require_based_on_match: bool = False,
+    preserve_generated_results: bool = False,
 ) -> dict[str, Any]:
     return await write_conversation_summary(
         uid=uid,
@@ -323,6 +324,7 @@ async def apply_summary_update(
         ella_signal=summary.get('ella_signal') or {},
         require_canonical=require_canonical,
         require_based_on_match=require_based_on_match,
+        preserve_generated_results=preserve_generated_results,
     )
 
 
@@ -431,6 +433,7 @@ async def invoke_hermes_recovery(
         summary_kind='recovered_enriched',
         require_canonical=True,
         require_based_on_match=True,
+        preserve_generated_results=True,
     )
     version_id = apply_result.get('active_summary_version_id')
     if not version_id or apply_result.get('canonical_confirmed') is not True:

--- a/backend/ella/services/summary_writeback.py
+++ b/backend/ella/services/summary_writeback.py
@@ -50,6 +50,7 @@ async def write_conversation_summary(
     canonical_writer: Callable[..., dict] = write_omi_canonical_event,
     require_canonical: bool = False,
     require_based_on_match: bool = False,
+    preserve_generated_results: bool = False,
 ) -> dict[str, Any]:
     conversation = conversations_db.get_conversation(uid, conversation_id)
     if conversation is None:
@@ -122,8 +123,9 @@ async def write_conversation_summary(
         update_data['structured.title'] = sanitized.title
     if sanitized.overview is not None:
         update_data['structured.overview'] = sanitized.overview
-        update_data['apps_results'] = []
-        update_data['plugins_results'] = []
+        if not preserve_generated_results:
+            update_data['apps_results'] = []
+            update_data['plugins_results'] = []
     if sanitized.emoji is not None:
         update_data['structured.emoji'] = sanitized.emoji
     if sanitized.category is not None:

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -1468,6 +1468,7 @@ def test_hermes_recovery_uses_lossless_source_and_canonical_uid_session(monkeypa
     assert summary_recovery.build_hermes_recovery_source(conversation)[1] in prompt
     assert captured["apply"]["summary"]["category"] == "entertainment"
     assert captured["apply"]["require_canonical"] is True
+    assert captured["apply"]["preserve_generated_results"] is True
     assert result == {
         "active_summary_version_id": "enriched-v2",
         "canonical_confirmed": True,
@@ -2117,6 +2118,8 @@ def test_strict_summary_writeback_confirms_canonical_before_success(monkeypatch)
         **_retry_conversation(status="completed", request_id=None),
         "active_summary_version_id": "generic-v1",
         "summary_versions": [],
+        "apps_results": [{"app_id": "preserve-me"}],
+        "plugins_results": [{"plugin_id": "preserve-me"}],
     }
     updates = []
     canonical_calls = []
@@ -2150,11 +2153,14 @@ def test_strict_summary_writeback_confirms_canonical_before_success(monkeypatch)
             trace_id="trace-1",
             canonical_writer=canonical_writer,
             require_canonical=True,
+            preserve_generated_results=True,
         )
     )
 
     assert result["canonical_confirmed"] is True
     assert updates[0]["enrichment_state"]["status"] == "writeback_pending_canonical"
+    assert "apps_results" not in updates[0]
+    assert "plugins_results" not in updates[0]
     assert updates[1]["enrichment_state"]["status"] == "writeback_applied"
     assert updates[1]["enrichment_state"]["canonical_status"] == "completed"
     assert canonical_calls[0][1]["enrichment_state"]["canonical_status"] == "completed"


### PR DESCRIPTION
Follow-up guard for #1050 after the exact historical-recovery canary.

Historical Hermes recovery now preserves unrelated `apps_results` and `plugins_results` while normal correction behavior remains unchanged.

Validation:
- correction/recovery suite: 47 passed
- callback writeback suite: 13 passed
- diff check: clean

The exact canary had already completed successfully; this guard is required before any wider repair batch.