### PR TITLE
Return terminal summary retry failures without requeue

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -1012,6 +1012,9 @@ def _claim_conversation_processing_retry_transaction(
     ):
         return _retry_claim_metadata('busy')
 
+    if retry_data and retry_data.get('outcome') == ConversationStatus.failed.value:
+        return _retry_claim_metadata(ConversationStatus.failed.value, retry_data=retry_data)
+
     if retry_snapshot.exists:
         retry_data = retry_data or {}
         retry_outcome = retry_data.get('outcome')
@@ -1023,7 +1026,7 @@ def _claim_conversation_processing_retry_transaction(
         )
         if retry_lease_active:
             return _retry_claim_metadata(retry_outcome, retry_data=retry_data)
-        if retry_outcome not in {ConversationStatus.processing.value, ConversationStatus.failed.value}:
+        if retry_outcome != ConversationStatus.processing.value:
             return _retry_claim_metadata('invalid_state', retry_data=retry_data)
 
         current_mode, _ = conversation_processing_recovery_mode(conversation)

--- a/backend/tests/unit/test_conversation_processing_retry.py
+++ b/backend/tests/unit/test_conversation_processing_retry.py
@@ -106,7 +106,7 @@ def test_failed_summary_is_atomically_claimed_without_returning_protected_transc
     assert transaction.sets[0][1]['outcome'] == ConversationStatus.processing.value
 
 
-def test_repeated_failed_request_id_reclaims_retryable_work():
+def test_repeated_failed_request_id_returns_terminal_receipt_without_requeue():
     result, transaction = _claim(
         _failed_conversation(request_id='newer-request'),
         retry_data={
@@ -118,11 +118,24 @@ def test_repeated_failed_request_id_reclaims_retryable_work():
         },
     )
 
-    assert result['outcome'] == 'claimed'
-    assert result['reason'] == 'lease_reclaimed'
-    assert result['attempt_count'] == 2
-    assert len(transaction.updates) == 2
+    assert result['outcome'] == 'failed'
+    assert result['phase'] == 'enrichment_failed'
+    assert result['attempt_count'] == 1
+    assert transaction.updates == []
     assert transaction.sets == []
+
+
+def test_new_request_id_can_retry_after_terminal_failure():
+    conversation = _failed_conversation(request_id='request-123')
+    conversation['processing_retry_completed_at'] = datetime(2026, 7, 20, 8, 4, tzinfo=timezone.utc)
+
+    result, transaction = _claim(conversation, request_id='request-456')
+
+    assert result['outcome'] == 'claimed'
+    assert result['mode'] == 'full'
+    assert result['attempt_count'] == 1
+    assert transaction.updates[0][1]['processing_retry_id'] == 'request-456'
+    assert transaction.sets[0][1]['request_id'] == 'request-456'
 
 
 def test_concurrent_request_observes_processing_without_reclaiming():


### PR DESCRIPTION
Follow-up contract hardening for #1050.

A repeated POST with the same request UUID now returns a terminal failed receipt without silently requeueing provider work. Stale `processing` leases still reclaim with the same UUID; a deliberate user retry uses a fresh UUID and remains allowed.

This lets iOS polling surface **Needs processing** instead of repeatedly invoking Hermes after a terminal failure.

Validation:
- retry transaction/receipt suite: 21 passed
- correction/recovery suite: 47 passed
- diff check: clean