### PR TITLE
Fix Recent Memories infinite loading

### DIFF
--- a/app/lib/pages/home/today_page.dart
+++ b/app/lib/pages/home/today_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
@@ -76,6 +78,10 @@ class TodayPageState extends State<TodayPage> {
     super.initState();
     _loadDailySummary();
     _loadWhisperState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(context.read<ConversationProvider>().ensureFreshConversations());
+    });
   }
 
   @override

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -20,6 +20,8 @@ typedef RetryConversationProcessingCall = Future<ConversationProcessingRetryResu
   String? correctionText,
 });
 
+typedef ConversationsFetchCall = Future<ConversationsFetchResult> Function();
+
 class _ProcessingRetryPoll {
   final String requestId;
   final String? correctionText;
@@ -79,11 +81,24 @@ class ConversationProvider extends ChangeNotifier {
 
   final AppReviewService _appReviewService = AppReviewService();
   final RetryConversationProcessingCall _retryConversationProcessing;
+  final ConversationsFetchCall? _conversationsFetch;
+  final ConversationsFetchCall? _failedConversationsFetch;
+  final Duration _conversationsFetchTimeout;
+  final Duration _failedConversationsFetchTimeout;
 
   bool isFetchingConversations = false;
 
-  ConversationProvider({RetryConversationProcessingCall retryConversationProcessingCall = retryConversationProcessing})
-      : _retryConversationProcessing = retryConversationProcessingCall {
+  ConversationProvider({
+    RetryConversationProcessingCall retryConversationProcessingCall = retryConversationProcessing,
+    ConversationsFetchCall? conversationsFetchCall,
+    ConversationsFetchCall? failedConversationsFetchCall,
+    Duration conversationsFetchTimeout = const Duration(seconds: 15),
+    Duration failedConversationsFetchTimeout = const Duration(seconds: 8),
+  })  : _retryConversationProcessing = retryConversationProcessingCall,
+        _conversationsFetch = conversationsFetchCall,
+        _failedConversationsFetch = failedConversationsFetchCall,
+        _conversationsFetchTimeout = conversationsFetchTimeout,
+        _failedConversationsFetchTimeout = failedConversationsFetchTimeout {
     _setupMergeListener();
     _loadSettings();
   }
@@ -400,15 +415,17 @@ class ConversationProvider extends ChangeNotifier {
     }
     if (isLoadingConversations) return;
     setLoadingConversations(true);
+    final requestId = _fetchRequestId;
     try {
       final conversationsFuture = _getConversationsFromServer();
       final failuresFuture = _getFailedConversationsFromServer();
-      final result = await conversationsFuture;
-      final retryableFailures = await failuresFuture;
+      unawaited(_applyFailedConversations(requestId, failuresFuture));
+      final result = await _waitForConversations(conversationsFuture);
+      if (requestId != _fetchRequestId) return;
       if (!result.succeeded) return;
 
       final newConversations = result.conversations;
-      failedConversations = _mergeRetryableFailures(retryableFailures, [
+      failedConversations = _mergeRetryableFailures(failedConversations, [
         ...conversations.where((conversation) => conversation.isRetryableEnrichmentFailure),
         ...newConversations.where((conversation) => conversation.isRetryableEnrichmentFailure),
       ]);
@@ -464,15 +481,14 @@ class ConversationProvider extends ChangeNotifier {
     setLoadingConversations(true);
     try {
       late final List<ServerConversation> fetchedConversations;
-      late final List<ServerConversation> fetchedFailures;
       if (SharedPreferencesUtil().demoMode) {
         fetchedConversations = DemoFixtures.conversations();
-        fetchedFailures = [];
+        failedConversations = [];
       } else {
         final conversationsFuture = _getConversationsFromServer();
         final failuresFuture = _getFailedConversationsFromServer();
-        final result = await conversationsFuture;
-        fetchedFailures = await failuresFuture;
+        unawaited(_applyFailedConversations(requestId, failuresFuture));
+        final result = await _waitForConversations(conversationsFuture);
         if (requestId != _fetchRequestId) return;
         if (!result.succeeded) {
           if (conversations.isEmpty && selectedFolderId == null) {
@@ -492,7 +508,7 @@ class ConversationProvider extends ChangeNotifier {
       if (requestId != _fetchRequestId) return;
       conversations = fetchedConversations;
       failedConversations = _mergeRetryableFailures(
-        fetchedFailures,
+        failedConversations,
         conversations.where((conversation) => conversation.isRetryableEnrichmentFailure),
       );
       hasFreshConversations = true;
@@ -782,6 +798,9 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   Future<ConversationsFetchResult> _getConversationsFromServer() async {
+    final fetch = _conversationsFetch;
+    if (fetch != null) return fetch();
+
     final (startDate, endDate) = _getDateFilterRange();
 
     return getConversationsResult(
@@ -794,23 +813,62 @@ class ConversationProvider extends ChangeNotifier {
     );
   }
 
-  Future<List<ServerConversation>> _getFailedConversationsFromServer() async {
-    final (startDate, endDate) = _getDateFilterRange();
-    final failed = await getConversations(
-      limit: 100,
-      statuses: const [ConversationStatus.failed],
-      includeDiscarded: true,
-      startDate: startDate,
-      endDate: endDate,
-      folderId: selectedFolderId,
-      starred: showStarredOnly ? true : null,
-    );
+  Future<ConversationsFetchResult> _getFailedConversationsFromServer() async {
+    final fetch = _failedConversationsFetch;
+    final ConversationsFetchResult result;
+    if (fetch != null) {
+      result = await fetch();
+    } else {
+      final (startDate, endDate) = _getDateFilterRange();
+      result = await getConversationsResult(
+        limit: 100,
+        statuses: const [ConversationStatus.failed],
+        includeDiscarded: true,
+        startDate: startDate,
+        endDate: endDate,
+        folderId: selectedFolderId,
+        starred: showStarredOnly ? true : null,
+      );
+    }
+    if (!result.succeeded) return result;
+
+    final failed = [...result.conversations];
     failed.sort((a, b) {
       final aDate = a.processingErrorAt ?? a.finishedAt ?? a.createdAt;
       final bDate = b.processingErrorAt ?? b.finishedAt ?? b.createdAt;
       return bDate.compareTo(aDate);
     });
-    return failed.where((conversation) => conversation.isRetryableSummaryFailure).toList();
+    return ConversationsFetchResult.success(
+      failed.where((conversation) => conversation.isRetryableSummaryFailure).toList(),
+    );
+  }
+
+  Future<ConversationsFetchResult> _waitForConversations(Future<ConversationsFetchResult> request) async {
+    try {
+      return await request.timeout(_conversationsFetchTimeout);
+    } on TimeoutException {
+      Logger.error('Timed out loading recent memories after ${_conversationsFetchTimeout.inSeconds}s');
+      return const ConversationsFetchResult.failure();
+    }
+  }
+
+  Future<void> _applyFailedConversations(int requestId, Future<ConversationsFetchResult> request) async {
+    try {
+      final result = await request.timeout(_failedConversationsFetchTimeout);
+      if (requestId != _fetchRequestId || !result.succeeded) return;
+      failedConversations = _mergeRetryableFailures(
+        result.conversations,
+        conversations.where((conversation) => conversation.isRetryableEnrichmentFailure),
+      );
+      notifyListeners();
+    } on TimeoutException {
+      Logger.debug(
+        'Timed out refreshing failed conversations after ${_failedConversationsFetchTimeout.inSeconds}s; '
+        'recent memories remain available',
+      );
+    } catch (error, stackTrace) {
+      Logger.error('Failed to refresh failed conversations: $error\n$stackTrace');
+    }
   }
 
   List<ServerConversation> _mergeRetryableFailures(

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.525+794
+version: 1.0.525+795
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/test/providers/conversation_provider_visibility_test.dart
+++ b/app/test/providers/conversation_provider_visibility_test.dart
@@ -1,8 +1,10 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/structured.dart';
@@ -63,5 +65,75 @@ void main() {
     await SharedPreferencesUtil.init();
 
     expect(SharedPreferencesUtil().cachedConversations.single.id, 'current');
+  });
+
+  test('primary memories finish loading while failed-summary request is still pending', () async {
+    final failedRequest = Completer<ConversationsFetchResult>();
+    final provider = ConversationProvider(
+      conversationsFetchCall: () async => ConversationsFetchResult.success([conversation('recent')]),
+      failedConversationsFetchCall: () => failedRequest.future,
+    );
+    addTearDown(() {
+      if (!failedRequest.isCompleted) {
+        failedRequest.complete(const ConversationsFetchResult.failure());
+      }
+      provider.dispose();
+    });
+
+    await provider.fetchConversations().timeout(const Duration(seconds: 1));
+
+    expect(provider.hasLoadedConversations, isTrue);
+    expect(provider.isLoadingConversations, isFalse);
+    expect(provider.hasFreshConversations, isTrue);
+    expect(provider.visibleConversations.map((item) => item.id), ['recent']);
+  });
+
+  test('failed-summary refresh updates separately after primary memories load', () async {
+    final failedRequest = Completer<ConversationsFetchResult>();
+    final startedAt = DateTime.parse('2026-07-08T19:00:00Z');
+    final failedWithReason = ServerConversation(
+      id: 'failed-summary',
+      createdAt: startedAt,
+      startedAt: startedAt,
+      finishedAt: startedAt.add(const Duration(minutes: 10)),
+      structured: Structured('Failed memory', 'Overview'),
+      status: ConversationStatus.failed,
+      processingError: 'conversation_summary_failed',
+    );
+    final provider = ConversationProvider(
+      conversationsFetchCall: () async => ConversationsFetchResult.success([conversation('recent')]),
+      failedConversationsFetchCall: () => failedRequest.future,
+    );
+    addTearDown(provider.dispose);
+
+    await provider.fetchConversations();
+    expect(provider.failedConversations, isEmpty);
+
+    failedRequest.complete(ConversationsFetchResult.success([failedWithReason]));
+    await pumpEventQueue();
+
+    expect(provider.failedConversations.map((item) => item.id), ['failed-summary']);
+    expect(provider.visibleConversations.map((item) => item.id), ['recent']);
+  });
+
+  test('primary memory timeout releases the loading state', () async {
+    final primaryRequest = Completer<ConversationsFetchResult>();
+    final provider = ConversationProvider(
+      conversationsFetchCall: () => primaryRequest.future,
+      failedConversationsFetchCall: () async => const ConversationsFetchResult.success([]),
+      conversationsFetchTimeout: const Duration(milliseconds: 10),
+    );
+    addTearDown(() {
+      if (!primaryRequest.isCompleted) {
+        primaryRequest.complete(const ConversationsFetchResult.failure());
+      }
+      provider.dispose();
+    });
+
+    await provider.fetchConversations();
+
+    expect(provider.hasLoadedConversations, isTrue);
+    expect(provider.isLoadingConversations, isFalse);
+    expect(provider.hasFreshConversations, isFalse);
   });
 }


### PR DESCRIPTION
Fixes ellaaicare/ella-ai#1088

## What changed

- Today now starts the provider's deduplicated initial conversation load directly instead of depending on another tab/connectivity callback.
- Primary recent-memory results publish without waiting for the ancillary failed-summary query.
- Primary and failed-summary requests have bounded waits; primary failure retains the existing UID-scoped cache fallback.
- Late failed-summary results remain request-generation-safe and update independently.
- Build bumped to `1.0.525+795`.

## Validation

- `./app/test.sh`: pass (21 tests)
- `flutter test test/providers/conversation_provider_visibility_test.dart test/ella/design_v2_claims_test.dart`: pass (10 tests)
- `flutter analyze lib/providers/conversation_provider.dart lib/pages/home/today_page.dart test/providers/conversation_provider_visibility_test.dart`: no issues
- Prod flavor launched on iPhone 17 Pro / iOS 26.5 simulator and reached the first-run system permission prompt.
- Firebase/signing/auth configuration unchanged.

AgentStatus: ready-for-review
