### PR TITLE
Guard overlapping Recent Memories refreshes

### DIFF
--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -467,7 +467,9 @@ class ConversationProvider extends ChangeNotifier {
       _groupConversationsByDateWithoutNotify();
       notifyListeners();
     } finally {
-      setLoadingConversations(false);
+      if (requestId == _fetchRequestId) {
+        setLoadingConversations(false);
+      }
     }
   }
 

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.525+795
+version: 1.0.525+796
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/test/providers/conversation_provider_visibility_test.dart
+++ b/app/test/providers/conversation_provider_visibility_test.dart
@@ -136,4 +136,42 @@ void main() {
     expect(provider.isLoadingConversations, isFalse);
     expect(provider.hasFreshConversations, isFalse);
   });
+
+  test('stale background refresh cannot clear a newer primary loading state', () async {
+    final staleRequest = Completer<ConversationsFetchResult>();
+    final currentRequest = Completer<ConversationsFetchResult>();
+    var requestCount = 0;
+    final provider = ConversationProvider(
+      conversationsFetchCall: () {
+        requestCount += 1;
+        return requestCount == 1 ? staleRequest.future : currentRequest.future;
+      },
+      failedConversationsFetchCall: () async => const ConversationsFetchResult.success([]),
+    );
+    addTearDown(() {
+      if (!staleRequest.isCompleted) {
+        staleRequest.complete(const ConversationsFetchResult.failure());
+      }
+      if (!currentRequest.isCompleted) {
+        currentRequest.complete(const ConversationsFetchResult.failure());
+      }
+      provider.dispose();
+    });
+
+    final staleRefresh = provider.forceRefreshConversations();
+    final currentRefresh = provider.fetchConversations();
+    expect(provider.isLoadingConversations, isTrue);
+
+    staleRequest.complete(ConversationsFetchResult.success([conversation('stale')]));
+    await staleRefresh;
+
+    expect(provider.isLoadingConversations, isTrue);
+    expect(provider.visibleConversations, isEmpty);
+
+    currentRequest.complete(ConversationsFetchResult.success([conversation('current')]));
+    await currentRefresh;
+
+    expect(provider.isLoadingConversations, isFalse);
+    expect(provider.visibleConversations.map((item) => item.id), ['current']);
+  });
 }


### PR DESCRIPTION
Fixes ellaaicare/ella-ai#1088 follow-up from the build 795 review.

## What changed
- Keep the loading spinner owned by the newest request generation.
- Prevent a stale background refresh from clearing a newer primary fetch state.
- Add an overlap regression test.
- Reserve TestFlight build 1.0.525+796.

## Validation
- `flutter test test/providers/conversation_provider_visibility_test.dart test/ella/design_v2_claims_test.dart` (11 passed)
- `flutter analyze lib/providers/conversation_provider.dart test/providers/conversation_provider_visibility_test.dart`
- `./test.sh` (capture provider 18 passed; transcript widget 3 passed)

No auth, Firebase, backend, signing, or endpoint changes.