### PR TITLE
Add authenticated isolated Hermes onboarding

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -57,6 +57,9 @@ FIREBASE_PROJECT_ID=
 # schema is migrated and a synthetic two-user 8210 canary passes.
 ELLA_HERMES_PROVISIONING_ENABLED=false
 ELLA_RUNTIME_BINDINGS_ENABLED=false
+# Enable only after the voice proxy uses authenticated Hermes context/tools and
+# has no OpenClaw fallback for isolated sessions.
+ELLA_ISOLATED_VOICE_ROUTING_ENABLED=false
 ELLA_HERMES_PROVISION_API_URL=http://100.76.138.56:8210
 ELLA_HERMES_PROVISION_API_TOKEN=
 ELLA_HERMES_GATEWAY_ALLOWED_HOSTS=

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -53,6 +53,21 @@ FIREBASE_API_KEY=
 FIREBASE_AUTH_DOMAIN=
 FIREBASE_PROJECT_ID=
 
+# Ella isolated Hermes onboarding. Keep both flags false until the provisioning
+# schema is migrated and a synthetic two-user 8210 canary passes.
+ELLA_HERMES_PROVISIONING_ENABLED=false
+ELLA_RUNTIME_BINDINGS_ENABLED=false
+ELLA_HERMES_PROVISION_API_URL=http://100.76.138.56:8210
+ELLA_HERMES_PROVISION_API_TOKEN=
+ELLA_HERMES_GATEWAY_ALLOWED_HOSTS=
+ELLA_HERMES_PROFILES_ROOT=/Users/ellaai/.hermes/profiles
+ELLA_PLATO_UID=
+ELLA_POSTGRES_HOST=127.0.0.1
+ELLA_POSTGRES_PORT=5433
+ELLA_POSTGRES_USER=postgres
+ELLA_POSTGRES_PASSWORD=
+ELLA_POSTGRES_DB=ella_ai
+
 # Encrypt the conversations, memories, chat messages
 ENCRYPTION_SECRET='omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv'
 

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -56,10 +56,13 @@ FIREBASE_PROJECT_ID=
 # Ella isolated Hermes onboarding. Keep both flags false until the provisioning
 # schema is migrated and a synthetic two-user 8210 canary passes.
 ELLA_HERMES_PROVISIONING_ENABLED=false
+ELLA_HERMES_PROVISIONING_ENABLED_UIDS=
 ELLA_RUNTIME_BINDINGS_ENABLED=false
+ELLA_RUNTIME_BINDINGS_ENABLED_UIDS=
 # Enable only after the voice proxy uses authenticated Hermes context/tools and
 # has no OpenClaw fallback for isolated sessions.
 ELLA_ISOLATED_VOICE_ROUTING_ENABLED=false
+ELLA_ISOLATED_VOICE_ROUTING_ENABLED_UIDS=
 ELLA_HERMES_PROVISION_API_URL=http://100.76.138.56:8210
 ELLA_HERMES_PROVISION_API_TOKEN=
 ELLA_HERMES_GATEWAY_ALLOWED_HOSTS=

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -349,7 +349,7 @@ class EllaProvisioningRepository:
                 health_state = EXCLUDED.health_state,
                 health_receipt = EXCLUDED.health_receipt,
                 revision = ella_runtime_bindings.revision + 1,
-                active = false,
+                active = ella_runtime_bindings.active,
                 updated_at = CURRENT_TIMESTAMP
             RETURNING *
             """,
@@ -445,15 +445,24 @@ class EllaProvisioningRepository:
         if result == "UPDATE 0":
             raise LookupError("user_not_found")
 
-    async def resolve_active_runtime(self, uid: str, role: str = "user") -> Optional[dict[str, Any]]:
+    async def resolve_active_runtime(
+        self,
+        uid: str,
+        role: str = "user",
+        template_version: Optional[str] = None,
+    ) -> Optional[dict[str, Any]]:
         row = await self.pool.fetchrow(
             """
             SELECT b.*, u.omi_uid, u.name, u.status AS user_status
             FROM ella_runtime_bindings b
             JOIN users u ON u.id = b.user_id
-            WHERE u.omi_uid = $1 AND b.role = $2 AND b.active = true
+            WHERE u.omi_uid = $1
+              AND b.role = $2
+              AND b.active = true
+              AND ($3::text IS NULL OR b.template_version = $3)
             """,
             uid,
             role,
+            template_version,
         )
         return _row_dict(row)

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -12,10 +12,32 @@ from typing import Any, Optional
 import asyncpg
 
 _pool: Optional[asyncpg.Pool] = None
+REQUIRED_PROVISIONING_INDEXES = (
+    "ella_provisioning_jobs_user_schema_key",
+    "ella_provisioning_jobs_state_updated_idx",
+    "ella_runtime_bindings_profile_name_key",
+    "ella_runtime_bindings_gateway_port_key",
+    "ella_runtime_bindings_service_label_key",
+    "ella_runtime_bindings_honcho_workspace_key",
+    "ella_runtime_bindings_observed_peer_key",
+    "ella_runtime_bindings_observer_peer_key",
+    "ella_runtime_bindings_user_role_provider_key",
+    "ella_runtime_bindings_one_active_role_key",
+    "ella_runtime_bindings_user_role_active_idx",
+    "ella_runtime_bindings_health_updated_idx",
+)
 
 
 class IdentityConflictError(RuntimeError):
     """The verified Firebase identity conflicts with an existing Ella user."""
+
+
+class ProvisioningSchemaNotReadyError(RuntimeError):
+    """The shared Ella provisioning migration has not been fully applied."""
+
+    def __init__(self, missing: list[str]):
+        self.missing = tuple(missing)
+        super().__init__("provisioning_schema_not_ready")
 
 
 async def get_pool() -> asyncpg.Pool:
@@ -40,12 +62,44 @@ def _row_dict(row: Any) -> Optional[dict[str, Any]]:
 
 
 class EllaProvisioningRepository:
-    def __init__(self, pool: asyncpg.Pool):
+    def __init__(self, pool: asyncpg.Pool, *, firestore_db: Any = None):
         self.pool = pool
+        self.firestore_db = firestore_db
 
     @classmethod
-    async def create(cls) -> "EllaProvisioningRepository":
-        return cls(await get_pool())
+    async def create(cls, *, firestore_db: Any = None) -> "EllaProvisioningRepository":
+        return cls(await get_pool(), firestore_db=firestore_db)
+
+    async def assert_schema_ready(self) -> None:
+        """Fail before identity writes when the shared Prisma migration is absent."""
+        row = await self.pool.fetchrow(
+            """
+            SELECT
+                to_regclass('public.ella_provisioning_jobs') IS NOT NULL AS jobs_table,
+                to_regclass('public.ella_runtime_bindings') IS NOT NULL AS bindings_table,
+                ARRAY(
+                    SELECT required.index_name
+                    FROM unnest($1::text[]) AS required(index_name)
+                    WHERE NOT EXISTS (
+                        SELECT 1
+                        FROM pg_indexes
+                        WHERE schemaname = 'public'
+                          AND indexname = required.index_name
+                    )
+                    ORDER BY required.index_name
+                ) AS missing_indexes
+            """,
+            list(REQUIRED_PROVISIONING_INDEXES),
+        )
+        missing = []
+        if not row or not row["jobs_table"]:
+            missing.append("table:ella_provisioning_jobs")
+        if not row or not row["bindings_table"]:
+            missing.append("table:ella_runtime_bindings")
+        if row:
+            missing.extend(f"index:{name}" for name in (row["missing_indexes"] or []))
+        if missing:
+            raise ProvisioningSchemaNotReadyError(missing)
 
     async def ensure_user_identity(
         self,
@@ -168,10 +222,11 @@ class EllaProvisioningRepository:
     ) -> bool:
         """Create the upstream OMI identity without granting data permissions."""
 
-        def _ensure() -> bool:
-            from database._client import db
+        if self.firestore_db is None:
+            raise RuntimeError("firestore_client_unavailable")
 
-            user_ref = db.collection("users").document(uid)
+        def _ensure() -> bool:
+            user_ref = self.firestore_db.collection("users").document(uid)
             snapshot = user_ref.get()
             if snapshot.exists:
                 data = snapshot.to_dict() or {}

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -1,0 +1,385 @@
+"""Postgres access for isolated Ella provisioning and runtime bindings."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from typing import Any, Optional
+
+import asyncpg
+
+_pool: Optional[asyncpg.Pool] = None
+
+
+class IdentityConflictError(RuntimeError):
+    """The verified Firebase identity conflicts with an existing Ella user."""
+
+
+async def get_pool() -> asyncpg.Pool:
+    global _pool
+    if _pool is None:
+        _pool = await asyncpg.create_pool(
+            host=os.getenv("ELLA_POSTGRES_HOST", "127.0.0.1"),
+            port=int(os.getenv("ELLA_POSTGRES_PORT", "5433")),
+            user=os.getenv("ELLA_POSTGRES_USER", "postgres"),
+            password=os.getenv("ELLA_POSTGRES_PASSWORD", "postgres"),
+            database=os.getenv("ELLA_POSTGRES_DB", "ella_ai"),
+            min_size=1,
+            max_size=10,
+        )
+    return _pool
+
+
+def _row_dict(row: Any) -> Optional[dict[str, Any]]:
+    if row is None:
+        return None
+    return dict(row)
+
+
+class EllaProvisioningRepository:
+    def __init__(self, pool: asyncpg.Pool):
+        self.pool = pool
+
+    @classmethod
+    async def create(cls) -> "EllaProvisioningRepository":
+        return cls(await get_pool())
+
+    async def ensure_user_identity(
+        self,
+        *,
+        uid: str,
+        email: str,
+        name: str,
+        timezone_name: str,
+    ) -> dict[str, Any]:
+        """Bind a verified Firebase UID to exactly one Ella user row."""
+        if not uid:
+            raise ValueError("uid required")
+        if not email:
+            raise IdentityConflictError("identity_missing_email")
+
+        async with self.pool.acquire() as connection:
+            async with connection.transaction():
+                by_uid = await connection.fetchrow(
+                    """
+                    SELECT id, omi_uid, email, name, timezone
+                    FROM users
+                    WHERE omi_uid = $1
+                    FOR UPDATE
+                    """,
+                    uid,
+                )
+                if by_uid:
+                    if str(by_uid["email"]).lower() != email.lower():
+                        raise IdentityConflictError("uid_email_mismatch")
+                    updated = await connection.fetchrow(
+                        """
+                        UPDATE users
+                        SET name = $2,
+                            timezone = $3,
+                            identities = COALESCE(identities, '{}'::jsonb)
+                                || jsonb_build_object('omi_uid', $1, 'email', email),
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE omi_uid = $1
+                        RETURNING id, omi_uid, email, name, timezone, status
+                        """,
+                        uid,
+                        name,
+                        timezone_name,
+                    )
+                    return dict(updated)
+
+                by_email = await connection.fetchrow(
+                    """
+                    SELECT id, omi_uid, email
+                    FROM users
+                    WHERE lower(email) = lower($1)
+                    FOR UPDATE
+                    """,
+                    email,
+                )
+                if by_email:
+                    existing_uid = by_email["omi_uid"]
+                    if existing_uid and existing_uid != uid:
+                        raise IdentityConflictError("email_owned_by_different_uid")
+                    updated = await connection.fetchrow(
+                        """
+                        UPDATE users
+                        SET omi_uid = $2,
+                            name = $3,
+                            timezone = $4,
+                            identities = COALESCE(identities, '{}'::jsonb)
+                                || jsonb_build_object('omi_uid', $2, 'email', email),
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE id = $5
+                        RETURNING id, omi_uid, email, name, timezone, status
+                        """,
+                        email,
+                        uid,
+                        name,
+                        timezone_name,
+                        by_email["id"],
+                    )
+                    return dict(updated)
+
+                user_id = uuid.uuid4()
+                inserted = await connection.fetchrow(
+                    """
+                    INSERT INTO users (
+                        id, email, name, timezone, omi_uid, status,
+                        identities, settings, tags, updated_at
+                    )
+                    VALUES (
+                        $1, $2, $3, $4, $5, 'PENDING',
+                        jsonb_build_object('omi_uid', $5, 'email', $2),
+                        '{}'::jsonb, ARRAY[]::text[], CURRENT_TIMESTAMP
+                    )
+                    RETURNING id, omi_uid, email, name, timezone, status
+                    """,
+                    user_id,
+                    email,
+                    name,
+                    timezone_name,
+                    uid,
+                )
+                return dict(inserted)
+
+    async def get_user_identity(self, uid: str) -> Optional[dict[str, Any]]:
+        row = await self.pool.fetchrow(
+            """
+            SELECT id, omi_uid, email, name, timezone, status
+            FROM users
+            WHERE omi_uid = $1
+            """,
+            uid,
+        )
+        return _row_dict(row)
+
+    async def acquire_job(
+        self,
+        *,
+        uid: str,
+        target_schema_version: str,
+        client_request_id: Optional[str],
+        request_payload_hash: str,
+    ) -> dict[str, Any]:
+        row = await self.pool.fetchrow(
+            """
+            INSERT INTO ella_provisioning_jobs (
+                id, user_id, target_schema_version, client_request_id,
+                request_payload_hash, state, stage, retryable
+            )
+            SELECT $1, u.id, $3, $4, $5, 'pending', 'identity_ready', true
+            FROM users u
+            WHERE u.omi_uid = $2
+            ON CONFLICT (user_id, target_schema_version) DO UPDATE
+            SET client_request_id = EXCLUDED.client_request_id
+            RETURNING *
+            """,
+            uuid.uuid4(),
+            uid,
+            target_schema_version,
+            client_request_id,
+            request_payload_hash,
+        )
+        if not row:
+            raise LookupError("user_not_found")
+        return dict(row)
+
+    async def get_job(self, uid: str, target_schema_version: str) -> Optional[dict[str, Any]]:
+        row = await self.pool.fetchrow(
+            """
+            SELECT j.*
+            FROM ella_provisioning_jobs j
+            JOIN users u ON u.id = j.user_id
+            WHERE u.omi_uid = $1 AND j.target_schema_version = $2
+            """,
+            uid,
+            target_schema_version,
+        )
+        return _row_dict(row)
+
+    async def claim_job(self, job_id: str) -> Optional[dict[str, Any]]:
+        row = await self.pool.fetchrow(
+            """
+            UPDATE ella_provisioning_jobs
+            SET state = 'provisioning',
+                stage = 'profile_ready',
+                attempts = attempts + 1,
+                retryable = true,
+                error_code = NULL,
+                error_detail = '{}'::jsonb,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = $1
+              AND state <> 'ready'
+              AND state <> 'blocked'
+              AND (
+                    state <> 'provisioning'
+                    OR updated_at < CURRENT_TIMESTAMP - INTERVAL '2 minutes'
+                  )
+            RETURNING *
+            """,
+            uuid.UUID(str(job_id)),
+        )
+        return _row_dict(row)
+
+    async def update_job(
+        self,
+        *,
+        job_id: str,
+        state: str,
+        stage: str,
+        retryable: bool,
+        error_code: Optional[str] = None,
+        error_detail: Optional[dict[str, Any]] = None,
+        receipt: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        row = await self.pool.fetchrow(
+            """
+            UPDATE ella_provisioning_jobs
+            SET state = $2,
+                stage = $3,
+                retryable = $4,
+                error_code = $5,
+                error_detail = $6::jsonb,
+                receipts = CASE
+                    WHEN $7::jsonb = '{}'::jsonb THEN receipts
+                    ELSE COALESCE(receipts, '[]'::jsonb) || jsonb_build_array($7::jsonb)
+                END,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = $1
+            RETURNING *
+            """,
+            uuid.UUID(str(job_id)),
+            state,
+            stage,
+            retryable,
+            error_code,
+            json.dumps(error_detail or {}),
+            json.dumps(receipt or {}),
+        )
+        if not row:
+            raise LookupError("provisioning_job_not_found")
+        return dict(row)
+
+    async def stage_runtime_binding(self, *, uid: str, binding: dict[str, Any]) -> dict[str, Any]:
+        row = await self.pool.fetchrow(
+            """
+            INSERT INTO ella_runtime_bindings (
+                id, user_id, role, provider, profile_name, agent_id, workspace_root,
+                internal_gateway_url, gateway_port, service_label, credential_ref,
+                honcho_workspace, observed_peer, observer_peer, template_version,
+                model_policy_version, voice_policy_version, health_state,
+                health_receipt, revision, active
+            )
+            SELECT
+                $1, u.id, $3, $4, $5, $6, $7, $8, $9, $10, $11,
+                $12, $13, $14, $15, $16, $17, $18, $19::jsonb, 1, false
+            FROM users u
+            WHERE u.omi_uid = $2
+            ON CONFLICT (user_id, role, provider) DO UPDATE
+            SET profile_name = EXCLUDED.profile_name,
+                agent_id = EXCLUDED.agent_id,
+                workspace_root = EXCLUDED.workspace_root,
+                internal_gateway_url = EXCLUDED.internal_gateway_url,
+                gateway_port = EXCLUDED.gateway_port,
+                service_label = EXCLUDED.service_label,
+                credential_ref = EXCLUDED.credential_ref,
+                honcho_workspace = EXCLUDED.honcho_workspace,
+                observed_peer = EXCLUDED.observed_peer,
+                observer_peer = EXCLUDED.observer_peer,
+                template_version = EXCLUDED.template_version,
+                model_policy_version = EXCLUDED.model_policy_version,
+                voice_policy_version = EXCLUDED.voice_policy_version,
+                health_state = EXCLUDED.health_state,
+                health_receipt = EXCLUDED.health_receipt,
+                revision = ella_runtime_bindings.revision + 1,
+                active = false,
+                updated_at = CURRENT_TIMESTAMP
+            RETURNING *
+            """,
+            uuid.uuid4(),
+            uid,
+            binding.get("role", "user"),
+            binding["provider"],
+            binding.get("profile_name"),
+            binding["agent_id"],
+            binding.get("workspace_root"),
+            binding.get("internal_gateway_url"),
+            binding.get("gateway_port"),
+            binding.get("service_label"),
+            binding.get("credential_ref"),
+            binding.get("honcho_workspace"),
+            binding.get("observed_peer"),
+            binding.get("observer_peer"),
+            binding["template_version"],
+            binding["model_policy_version"],
+            binding["voice_policy_version"],
+            binding.get("health_state", "pending"),
+            json.dumps(binding.get("health_receipt") or {}),
+        )
+        if not row:
+            raise LookupError("user_not_found")
+        return dict(row)
+
+    async def activate_runtime_binding(
+        self,
+        *,
+        uid: str,
+        provider: str,
+        role: str = "user",
+    ) -> dict[str, Any]:
+        async with self.pool.acquire() as connection:
+            async with connection.transaction():
+                selected = await connection.fetchrow(
+                    """
+                    SELECT b.*
+                    FROM ella_runtime_bindings b
+                    JOIN users u ON u.id = b.user_id
+                    WHERE u.omi_uid = $1 AND b.provider = $2 AND b.role = $3
+                    FOR UPDATE
+                    """,
+                    uid,
+                    provider,
+                    role,
+                )
+                if not selected:
+                    raise LookupError("runtime_binding_not_found")
+                if selected["health_state"] != "healthy":
+                    raise RuntimeError("runtime_binding_not_healthy")
+
+                await connection.execute(
+                    """
+                    UPDATE ella_runtime_bindings
+                    SET active = false, updated_at = CURRENT_TIMESTAMP
+                    WHERE user_id = $1 AND role = $2 AND active = true
+                    """,
+                    selected["user_id"],
+                    role,
+                )
+                activated = await connection.fetchrow(
+                    """
+                    UPDATE ella_runtime_bindings
+                    SET active = true,
+                        revision = revision + 1,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = $1
+                    RETURNING *
+                    """,
+                    selected["id"],
+                )
+                return dict(activated)
+
+    async def resolve_active_runtime(self, uid: str, role: str = "user") -> Optional[dict[str, Any]]:
+        row = await self.pool.fetchrow(
+            """
+            SELECT b.*, u.omi_uid, u.name, u.status AS user_status
+            FROM ella_runtime_bindings b
+            JOIN users u ON u.id = b.user_id
+            WHERE u.omi_uid = $1 AND b.role = $2 AND b.active = true
+            """,
+            uid,
+            role,
+        )
+        return _row_dict(row)

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -219,8 +219,9 @@ class EllaProvisioningRepository:
         email: str,
         name: str,
         timezone_name: str,
+        private_cloud_sync_default: bool = False,
     ) -> bool:
-        """Create the upstream OMI identity without granting data permissions."""
+        """Create or repair the upstream OMI identity with explicit consent defaults."""
 
         if self.firestore_db is None:
             raise RuntimeError("firestore_client_unavailable")
@@ -237,7 +238,7 @@ class EllaProvisioningRepository:
                         "email": email,
                         "name": name,
                         "time_zone": timezone_name,
-                        "private_cloud_sync_enabled": False,
+                        "private_cloud_sync_enabled": private_cloud_sync_default,
                         "store_recording_permission": False,
                     }.items()
                     if key not in data
@@ -256,7 +257,7 @@ class EllaProvisioningRepository:
                     "time_zone": timezone_name,
                     "created_at": now,
                     "updated_at": now,
-                    "private_cloud_sync_enabled": False,
+                    "private_cloud_sync_enabled": private_cloud_sync_default,
                     "store_recording_permission": False,
                 },
                 merge=False,

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import uuid
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 import asyncpg
@@ -155,6 +157,58 @@ class EllaProvisioningRepository:
             uid,
         )
         return _row_dict(row)
+
+    async def ensure_omi_user_document(
+        self,
+        *,
+        uid: str,
+        email: str,
+        name: str,
+        timezone_name: str,
+    ) -> bool:
+        """Create the upstream OMI identity without granting data permissions."""
+
+        def _ensure() -> bool:
+            from database._client import db
+
+            user_ref = db.collection("users").document(uid)
+            snapshot = user_ref.get()
+            if snapshot.exists:
+                data = snapshot.to_dict() or {}
+                missing_defaults = {
+                    key: value
+                    for key, value in {
+                        "uid": uid,
+                        "email": email,
+                        "name": name,
+                        "time_zone": timezone_name,
+                        "private_cloud_sync_enabled": False,
+                        "store_recording_permission": False,
+                    }.items()
+                    if key not in data
+                }
+                if missing_defaults:
+                    missing_defaults["updated_at"] = datetime.now(timezone.utc)
+                    user_ref.set(missing_defaults, merge=True)
+                    return True
+                return False
+            now = datetime.now(timezone.utc)
+            user_ref.set(
+                {
+                    "uid": uid,
+                    "email": email,
+                    "name": name,
+                    "time_zone": timezone_name,
+                    "created_at": now,
+                    "updated_at": now,
+                    "private_cloud_sync_enabled": False,
+                    "store_recording_permission": False,
+                },
+                merge=False,
+            )
+            return True
+
+        return await asyncio.to_thread(_ensure)
 
     async def acquire_job(
         self,
@@ -369,7 +423,27 @@ class EllaProvisioningRepository:
                     """,
                     selected["id"],
                 )
+                await connection.execute(
+                    """
+                    UPDATE users
+                    SET status = 'ACTIVE', updated_at = CURRENT_TIMESTAMP
+                    WHERE id = $1
+                    """,
+                    selected["user_id"],
+                )
                 return dict(activated)
+
+    async def activate_user(self, uid: str) -> None:
+        result = await self.pool.execute(
+            """
+            UPDATE users
+            SET status = 'ACTIVE', updated_at = CURRENT_TIMESTAMP
+            WHERE omi_uid = $1
+            """,
+            uid,
+        )
+        if result == "UPDATE 0":
+            raise LookupError("user_not_found")
 
     async def resolve_active_runtime(self, uid: str, role: str = "user") -> Optional[dict[str, Any]]:
         row = await self.pool.fetchrow(

--- a/backend/ella/README.md
+++ b/backend/ella/README.md
@@ -263,6 +263,7 @@ New-user Hermes provisioning is disabled by default and has two separate rollout
 
 - `ELLA_HERMES_PROVISIONING_ENABLED` allows authenticated, idempotent `/v1/ella/onboarding/ensure` jobs to call the Hermes-only 8210 provisioner.
 - `ELLA_RUNTIME_BINDINGS_ENABLED` makes chat, history, resolver, voice, and `/v4/listen` require the authenticated user's active healthy Hermes binding. In this mode those routes fail closed and never create/fall back to OpenClaw or a shared Plato profile.
+- `ELLA_ISOLATED_VOICE_ROUTING_ENABLED` is a separate default-off gate. Until the voice proxy sends authenticated, UID-bound Hermes context/tool requests and removes its OpenClaw fallback, isolated users receive `isolated_voice_not_ready` instead of a V2V session.
 
 Apply the `ella_provisioning_jobs` and `ella_runtime_bindings` database migration before enabling either flag. Enable provisioning first for synthetic users; enable runtime dispatch only after distinct profile, workspace, gateway, Honcho, and canonical timeline receipts pass the two-user isolation canary. Existing Plato remains valid only for the exact `ELLA_PLATO_UID` binding.
 

--- a/backend/ella/README.md
+++ b/backend/ella/README.md
@@ -265,7 +265,10 @@ New-user Hermes provisioning is disabled by default and has two separate rollout
 - `ELLA_RUNTIME_BINDINGS_ENABLED` makes chat, history, resolver, voice, and `/v4/listen` require the authenticated user's active healthy Hermes binding. In this mode those routes fail closed and never create/fall back to OpenClaw or a shared Plato profile.
 - `ELLA_ISOLATED_VOICE_ROUTING_ENABLED` is a separate default-off gate. Until the voice proxy sends authenticated, UID-bound Hermes context/tool requests and removes its OpenClaw fallback, isolated users receive `isolated_voice_not_ready` instead of a V2V session.
 
-Apply the `ella_provisioning_jobs` and `ella_runtime_bindings` database migration before enabling either flag. Enable provisioning first for synthetic users; enable runtime dispatch only after distinct profile, workspace, gateway, Honcho, and canonical timeline receipts pass the two-user isolation canary. Existing Plato remains valid only for the exact `ELLA_PLATO_UID` binding.
+Apply the shared Prisma migration from `ellaaicare/ella-ai` first:
+`packages/database/prisma/migrations/20260721000000_add_ella_provisioning_runtime/migration.sql` (merged in ella-ai PR #1066). OMI intentionally does not duplicate this schema. Both onboarding endpoints preflight the two tables and every required isolation index; an incomplete deployment returns retryable `503 provisioning_schema_not_ready` before any identity write.
+
+Enable provisioning first for two synthetic Firebase users; enable runtime dispatch only after distinct profile, workspace, gateway, Honcho, and canonical timeline receipts pass the two-user isolation canary. Existing Plato remains valid only for the exact `ELLA_PLATO_UID` binding.
 
 The ensure job also creates or repairs the UID-scoped OMI Firestore identity. Missing cloud-sync and raw-recording permissions are initialized to `false`; iOS must enable the appropriate setting only after the account-bound consent flow completes.
 

--- a/backend/ella/README.md
+++ b/backend/ella/README.md
@@ -257,6 +257,15 @@ print('Adapters:', list(get_all_adapters().keys()))
 | `ELLA_TESTING_ENABLED` | `false` | E2E testing endpoints |
 | `GROK_V2V_PROXY_URL` | `wss://voice.ella-ai-care.com/ws` | Grok proxy WebSocket URL |
 
+### Isolated Hermes onboarding
+
+New-user Hermes provisioning is disabled by default and has two separate rollout controls:
+
+- `ELLA_HERMES_PROVISIONING_ENABLED` allows authenticated, idempotent `/v1/ella/onboarding/ensure` jobs to call the Hermes-only 8210 provisioner.
+- `ELLA_RUNTIME_BINDINGS_ENABLED` makes chat, history, resolver, and voice require the authenticated user's active healthy Hermes binding. In this mode those routes fail closed and never fall back to OpenClaw or a shared Plato profile.
+
+Apply the `ella_provisioning_jobs` and `ella_runtime_bindings` database migration before enabling either flag. Enable provisioning first for synthetic users; enable runtime dispatch only after distinct profile, workspace, gateway, Honcho, and canonical timeline receipts pass the two-user isolation canary. Existing Plato remains valid only for the exact `ELLA_PLATO_UID` binding.
+
 Upstream-managed patch points are tracked in `docs/POST_MERGE_PATCHES.md`. Review that file after every Basehardware upstream sync.
 
 ---

--- a/backend/ella/README.md
+++ b/backend/ella/README.md
@@ -262,9 +262,11 @@ print('Adapters:', list(get_all_adapters().keys()))
 New-user Hermes provisioning is disabled by default and has two separate rollout controls:
 
 - `ELLA_HERMES_PROVISIONING_ENABLED` allows authenticated, idempotent `/v1/ella/onboarding/ensure` jobs to call the Hermes-only 8210 provisioner.
-- `ELLA_RUNTIME_BINDINGS_ENABLED` makes chat, history, resolver, and voice require the authenticated user's active healthy Hermes binding. In this mode those routes fail closed and never fall back to OpenClaw or a shared Plato profile.
+- `ELLA_RUNTIME_BINDINGS_ENABLED` makes chat, history, resolver, voice, and `/v4/listen` require the authenticated user's active healthy Hermes binding. In this mode those routes fail closed and never create/fall back to OpenClaw or a shared Plato profile.
 
 Apply the `ella_provisioning_jobs` and `ella_runtime_bindings` database migration before enabling either flag. Enable provisioning first for synthetic users; enable runtime dispatch only after distinct profile, workspace, gateway, Honcho, and canonical timeline receipts pass the two-user isolation canary. Existing Plato remains valid only for the exact `ELLA_PLATO_UID` binding.
+
+The ensure job also creates or repairs the UID-scoped OMI Firestore identity. Missing cloud-sync and raw-recording permissions are initialized to `false`; iOS must enable the appropriate setting only after the account-bound consent flow completes.
 
 Upstream-managed patch points are tracked in `docs/POST_MERGE_PATCHES.md`. Review that file after every Basehardware upstream sync.
 

--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -365,6 +365,15 @@ def _register_routers(app) -> None:
     except ImportError as e:
         print(f"  ⚠️ Ella settings not available: {e}", flush=True)
 
+    # Authenticated, idempotent per-user Hermes onboarding
+    try:
+        from ella.routers.onboarding import router as onboarding_router
+
+        app.include_router(onboarding_router, tags=["Ella Onboarding"])
+        print("  🌐 /v1/ella/onboarding/* - Isolated Hermes onboarding", flush=True)
+    except ImportError as e:
+        print(f"  ⚠️ Ella onboarding not available: {e}", flush=True)
+
     # Voice session management (token issuance for Ella Voice)
     if ELLA_VOICE_V2_ENABLED:
         try:

--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -21,6 +21,8 @@ See ella/README.md for full documentation.
 import os
 from typing import Optional, Callable, Dict
 
+from ella.routers.onboarding import configure_firestore_db, router as onboarding_router
+
 # =============================================================================
 # CONFIGURATION
 # =============================================================================
@@ -88,7 +90,7 @@ def get_all_adapters() -> Dict[str, Callable]:
 # =============================================================================
 
 
-def register_ella_extensions(app) -> None:
+def register_ella_extensions(app, *, firestore_db=None) -> None:
     """
     Register all Ella extensions with the FastAPI app.
 
@@ -102,6 +104,8 @@ def register_ella_extensions(app) -> None:
     if not ELLA_ENABLED:
         print("🔕 Ella extensions disabled (ELLA_ENABLED=false)", flush=True)
         return
+
+    configure_firestore_db(firestore_db)
 
     print("", flush=True)
     print("🏥 ════════════════════════════════════════════", flush=True)
@@ -367,8 +371,6 @@ def _register_routers(app) -> None:
 
     # Authenticated, idempotent per-user Hermes onboarding
     try:
-        from ella.routers.onboarding import router as onboarding_router
-
         app.include_router(onboarding_router, tags=["Ella Onboarding"])
         print("  🌐 /v1/ella/onboarding/* - Isolated Hermes onboarding", flush=True)
     except ImportError as e:

--- a/backend/ella/routers/auto_provision.py
+++ b/backend/ella/routers/auto_provision.py
@@ -155,6 +155,15 @@ async def validate_isolated_listen_runtime(uid: str, omi_user_exists=None) -> di
         return {"success": False, "error": "runtime_validation_failed"}
 
 
+async def listen_runtime_gate(uid: str, omi_user_exists=None) -> dict:
+    """Apply the same isolated-runtime gate to every authenticated listen surface."""
+    required = runtime_resolver.runtime_bindings_enabled(uid)
+    if not required:
+        return {"required": False, "success": True}
+    result = await validate_isolated_listen_runtime(uid, omi_user_exists)
+    return {"required": True, **result}
+
+
 async def auto_provision_user(uid: str, name: str = "User") -> dict:
     """Auto-provision a user: call Mac Mini API + store agent IDs in DB.
 

--- a/backend/ella/routers/auto_provision.py
+++ b/backend/ella/routers/auto_provision.py
@@ -13,10 +13,16 @@ Two-phase flow:
 import json
 import logging
 import os
+import re
+from datetime import datetime, timezone
 from typing import Optional
 
 import asyncpg
 import httpx
+
+from database.ella_provisioning import EllaProvisioningRepository
+from ella.services import runtime_resolver
+from ella.services.provisioning import ProvisioningError
 
 logger = logging.getLogger("ella.auto_provision")
 
@@ -31,7 +37,6 @@ OPENCLAW_GATEWAY_TOKEN = os.getenv("OPENCLAW_GATEWAY_TOKEN", "")
 
 def _slugify(s: str) -> str:
     """Create a safe ID slug from a string."""
-    import re
     return re.sub(r'[^a-z0-9]+', '-', s.lower()).strip('-')[:40]
 
 
@@ -81,9 +86,7 @@ async def get_agent_cluster(uid: str) -> Optional[dict]:
 
         # A cluster without userAgentId is incomplete — treat as missing
         if not agents.get("userAgentId"):
-            logger.warning(
-                f"Cluster for uid={uid} exists but missing userAgentId — needs re-provision"
-            )
+            logger.warning(f"Cluster for uid={uid} exists but missing userAgentId — needs re-provision")
             return None
 
         return {
@@ -97,7 +100,7 @@ async def get_agent_cluster(uid: str) -> Optional[dict]:
         return None
 
 
-async def ensure_firestore_user_document(uid: str) -> bool:
+async def ensure_firestore_user_document(uid: str, firestore_db=None) -> bool:
     """Create the minimal upstream OMI Firestore user doc for a known Ella user.
 
     The websocket transcription path still gates on database/users.py, which
@@ -117,10 +120,11 @@ async def ensure_firestore_user_document(uid: str) -> bool:
         )
         if not row:
             return False
+        if firestore_db is None:
+            logger.error("Cannot initialize OMI identity without an injected Firestore client")
+            return False
 
-        from database.ella_provisioning import EllaProvisioningRepository
-
-        await EllaProvisioningRepository(pool).ensure_omi_user_document(
+        await EllaProvisioningRepository(pool, firestore_db=firestore_db).ensure_omi_user_document(
             uid=uid,
             name=row["name"] or "User",
             email=row["email"],
@@ -135,17 +139,12 @@ async def ensure_firestore_user_document(uid: str) -> bool:
 
 async def validate_isolated_listen_runtime(uid: str, omi_user_exists=None) -> dict:
     """Fail closed before listen; never provision OpenClaw in isolated mode."""
-    from ella.services.provisioning import ProvisioningError
-    from ella.services.runtime_resolver import resolve_isolated_runtime
-
     try:
-        runtime = await resolve_isolated_runtime(uid)
+        runtime = await runtime_resolver.resolve_isolated_runtime(uid)
         if runtime is None:
             return {"success": False, "error": "runtime_bindings_disabled"}
         if omi_user_exists is None:
-            from database import users as user_db
-
-            omi_user_exists = user_db.is_exists_user
+            return {"success": False, "error": "omi_identity_checker_unavailable"}
         if not omi_user_exists(uid):
             return {"success": False, "error": "omi_identity_unavailable"}
         return {"success": True, "provider": "hermes"}
@@ -276,8 +275,7 @@ async def auto_provision_user(uid: str, name: str = "User") -> dict:
             "scannerGatewayUrl": scanner_gateway_url,
             "workspace": provision_result.get("workspace", ""),
             "userId": openclaw_user_id,
-            "provisionedAt": provision_result.get("provisionedAt")
-                or __import__("datetime").datetime.now(__import__("datetime").timezone.utc).isoformat(),
+            "provisionedAt": provision_result.get("provisionedAt") or datetime.now(timezone.utc).isoformat(),
         }
         for field, fallback in [
             ("userAgentId", f"ella-{openclaw_user_id}"),
@@ -286,9 +284,7 @@ async def auto_provision_user(uid: str, name: str = "User") -> dict:
             ("summarizerAgentId", "summarizer"),
         ]:
             cluster_agents_dict[field] = provision_result.get(field) or fallback
-        cluster_agents_dict["gatewayToken"] = (
-            provision_result.get("gatewayToken") or OPENCLAW_GATEWAY_TOKEN
-        )
+        cluster_agents_dict["gatewayToken"] = provision_result.get("gatewayToken") or OPENCLAW_GATEWAY_TOKEN
         cluster_agents = json.dumps(cluster_agents_dict)
 
         if user_db_id:

--- a/backend/ella/routers/auto_provision.py
+++ b/backend/ella/routers/auto_provision.py
@@ -129,6 +129,7 @@ async def ensure_firestore_user_document(uid: str, firestore_db=None) -> bool:
             name=row["name"] or "User",
             email=row["email"],
             timezone_name=row["timezone"] or "America/Los_Angeles",
+            private_cloud_sync_default=True,
         )
         logger.info(f"Created Firestore OMI user document for uid={uid}")
         return True

--- a/backend/ella/routers/auto_provision.py
+++ b/backend/ella/routers/auto_provision.py
@@ -13,7 +13,6 @@ Two-phase flow:
 import json
 import logging
 import os
-from datetime import datetime, timezone
 from typing import Optional
 
 import asyncpg
@@ -33,6 +32,7 @@ OPENCLAW_GATEWAY_TOKEN = os.getenv("OPENCLAW_GATEWAY_TOKEN", "")
 def _slugify(s: str) -> str:
     """Create a safe ID slug from a string."""
     import re
+
     return re.sub(r'[^a-z0-9]+', '-', s.lower()).strip('-')[:40]
 
 
@@ -82,9 +82,7 @@ async def get_agent_cluster(uid: str) -> Optional[dict]:
 
         # A cluster without userAgentId is incomplete — treat as missing
         if not agents.get("userAgentId"):
-            logger.warning(
-                f"Cluster for uid={uid} exists but missing userAgentId — needs re-provision"
-            )
+            logger.warning(f"Cluster for uid={uid} exists but missing userAgentId — needs re-provision")
             return None
 
         return {
@@ -119,25 +117,13 @@ async def ensure_firestore_user_document(uid: str) -> bool:
         if not row:
             return False
 
-        from database._client import db
+        from database.ella_provisioning import EllaProvisioningRepository
 
-        user_ref = db.collection("users").document(uid)
-        if user_ref.get().exists:
-            return True
-
-        now = datetime.now(timezone.utc)
-        user_ref.set(
-            {
-                "uid": uid,
-                "name": row["name"] or "User",
-                "email": row["email"],
-                "time_zone": row["timezone"] or "America/Los_Angeles",
-                "created_at": now,
-                "updated_at": now,
-                "private_cloud_sync_enabled": True,
-                "store_recording_permission": True,
-            },
-            merge=True,
+        await EllaProvisioningRepository(pool).ensure_omi_user_document(
+            uid=uid,
+            name=row["name"] or "User",
+            email=row["email"],
+            timezone_name=row["timezone"] or "America/Los_Angeles",
         )
         logger.info(f"Created Firestore OMI user document for uid={uid}")
         return True
@@ -290,7 +276,7 @@ async def auto_provision_user(uid: str, name: str = "User") -> dict:
             "workspace": provision_result.get("workspace", ""),
             "userId": openclaw_user_id,
             "provisionedAt": provision_result.get("provisionedAt")
-                or __import__("datetime").datetime.now(__import__("datetime").timezone.utc).isoformat(),
+            or __import__("datetime").datetime.now(__import__("datetime").timezone.utc).isoformat(),
         }
         for field, fallback in [
             ("userAgentId", f"ella-{openclaw_user_id}"),
@@ -299,9 +285,7 @@ async def auto_provision_user(uid: str, name: str = "User") -> dict:
             ("summarizerAgentId", "summarizer"),
         ]:
             cluster_agents_dict[field] = provision_result.get(field) or fallback
-        cluster_agents_dict["gatewayToken"] = (
-            provision_result.get("gatewayToken") or OPENCLAW_GATEWAY_TOKEN
-        )
+        cluster_agents_dict["gatewayToken"] = provision_result.get("gatewayToken") or OPENCLAW_GATEWAY_TOKEN
         cluster_agents = json.dumps(cluster_agents_dict)
 
         if user_db_id:

--- a/backend/ella/routers/auto_provision.py
+++ b/backend/ella/routers/auto_provision.py
@@ -146,6 +146,29 @@ async def ensure_firestore_user_document(uid: str) -> bool:
         return False
 
 
+async def validate_isolated_listen_runtime(uid: str, omi_user_exists=None) -> dict:
+    """Fail closed before listen; never provision OpenClaw in isolated mode."""
+    from ella.services.provisioning import ProvisioningError
+    from ella.services.runtime_resolver import resolve_isolated_runtime
+
+    try:
+        runtime = await resolve_isolated_runtime(uid)
+        if runtime is None:
+            return {"success": False, "error": "runtime_bindings_disabled"}
+        if omi_user_exists is None:
+            from database import users as user_db
+
+            omi_user_exists = user_db.is_exists_user
+        if not omi_user_exists(uid):
+            return {"success": False, "error": "omi_identity_unavailable"}
+        return {"success": True, "provider": "hermes"}
+    except ProvisioningError as exc:
+        return {"success": False, "error": exc.code}
+    except Exception:
+        logger.exception("Isolated listen runtime validation failed for uid=%s", uid)
+        return {"success": False, "error": "runtime_validation_failed"}
+
+
 async def auto_provision_user(uid: str, name: str = "User") -> dict:
     """Auto-provision a user: call Mac Mini API + store agent IDs in DB.
 

--- a/backend/ella/routers/auto_provision.py
+++ b/backend/ella/routers/auto_provision.py
@@ -32,7 +32,6 @@ OPENCLAW_GATEWAY_TOKEN = os.getenv("OPENCLAW_GATEWAY_TOKEN", "")
 def _slugify(s: str) -> str:
     """Create a safe ID slug from a string."""
     import re
-
     return re.sub(r'[^a-z0-9]+', '-', s.lower()).strip('-')[:40]
 
 
@@ -82,7 +81,9 @@ async def get_agent_cluster(uid: str) -> Optional[dict]:
 
         # A cluster without userAgentId is incomplete — treat as missing
         if not agents.get("userAgentId"):
-            logger.warning(f"Cluster for uid={uid} exists but missing userAgentId — needs re-provision")
+            logger.warning(
+                f"Cluster for uid={uid} exists but missing userAgentId — needs re-provision"
+            )
             return None
 
         return {
@@ -276,7 +277,7 @@ async def auto_provision_user(uid: str, name: str = "User") -> dict:
             "workspace": provision_result.get("workspace", ""),
             "userId": openclaw_user_id,
             "provisionedAt": provision_result.get("provisionedAt")
-            or __import__("datetime").datetime.now(__import__("datetime").timezone.utc).isoformat(),
+                or __import__("datetime").datetime.now(__import__("datetime").timezone.utc).isoformat(),
         }
         for field, fallback in [
             ("userAgentId", f"ella-{openclaw_user_id}"),
@@ -285,7 +286,9 @@ async def auto_provision_user(uid: str, name: str = "User") -> dict:
             ("summarizerAgentId", "summarizer"),
         ]:
             cluster_agents_dict[field] = provision_result.get(field) or fallback
-        cluster_agents_dict["gatewayToken"] = provision_result.get("gatewayToken") or OPENCLAW_GATEWAY_TOKEN
+        cluster_agents_dict["gatewayToken"] = (
+            provision_result.get("gatewayToken") or OPENCLAW_GATEWAY_TOKEN
+        )
         cluster_agents = json.dumps(cluster_agents_dict)
 
         if user_db_id:

--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -45,6 +45,7 @@ from database._client import db
 from models.conversation import CategoryEnum
 from database.ella_contacts import create_contact, delete_contact, get_contact, get_contacts, update_contact
 from ella.config import ELLA_CONFIG
+from ella.services.runtime_resolver import resolve_isolated_runtime, runtime_bindings_enabled
 from ella.services.summary_sanitizer import SummarySanitizationError
 from ella.services.summary_writeback import (
     ConversationSummaryNotFoundError,
@@ -268,24 +269,42 @@ async def _resolve_agent_id_for_uid(uid: str) -> Optional[str]:
     return agents.get("userAgentId")
 
 
-async def _fetch_internal_assessment(uid: str, conversation_id: str) -> Optional[dict]:
-    """Best-effort fetch of Observer sidecar internal_assessment.
+async def _resolve_workspace_target_for_uid(uid: str) -> Optional[tuple[str, str, str]]:
+    if runtime_bindings_enabled(uid):
+        runtime = await resolve_isolated_runtime(uid)
+        if runtime is None:
+            return None
+        return (
+            runtime.agent_id,
+            os.getenv("ELLA_HERMES_PROVISION_API_URL", "http://100.76.138.56:8210").rstrip("/"),
+            os.getenv("ELLA_HERMES_PROVISION_API_TOKEN", ""),
+        )
 
-    This keeps the app-facing conversation payload aligned with the OpenClaw sidecar
-    without making the summary PATCH path depend on Mac Mini reachability.
+    agent_id = await _resolve_agent_id_for_uid(uid)
+    if not agent_id:
+        return None
+    return agent_id, PROVISION_API_URL.rstrip("/"), PROVISION_API_KEY
+
+
+async def _fetch_internal_assessment(uid: str, conversation_id: str) -> Optional[dict]:
+    """Best-effort fetch of the user's Observer internal_assessment.
+
+    Isolated users fail closed on their active Hermes runtime. Legacy users retain
+    the existing 8200 lookup until the canary rollout is complete.
     """
     try:
-        agent_id = await _resolve_agent_id_for_uid(uid)
-        if not agent_id:
+        target = await _resolve_workspace_target_for_uid(uid)
+        if not target:
             return None
+        agent_id, provision_api_url, provision_api_key = target
 
         headers = {}
-        if PROVISION_API_KEY:
-            headers["Authorization"] = f"Bearer {PROVISION_API_KEY}"
+        if provision_api_key:
+            headers["Authorization"] = f"Bearer {provision_api_key}"
 
         async with httpx.AsyncClient(timeout=5.0) as client:
             resp = await client.get(
-                f"{PROVISION_API_URL}/workspace/{agent_id}/metadata/conversations/{conversation_id}",
+                f"{provision_api_url}/workspace/{agent_id}/metadata/conversations/{conversation_id}",
                 headers=headers,
             )
 

--- a/backend/ella/routers/chat.py
+++ b/backend/ella/routers/chat.py
@@ -28,7 +28,7 @@ from uuid import uuid4
 from zoneinfo import ZoneInfo
 
 import httpx
-from fastapi import APIRouter, Header, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
@@ -37,6 +37,8 @@ from ella.routers.canonical_events import CanonicalEventIn, PostgresCanonicalEve
 from ella.routers.resolve import resolve_user_routing
 from ella.routers.trace import RouteTrace, record_trace
 from ella.services.hermes_session import canonical_omi_session_key, safe_session_component
+from ella.services.provisioning import ProvisioningError
+from ella.services.runtime_resolver import IsolatedRuntime, resolve_isolated_runtime, runtime_bindings_enabled
 from utils.ella.canonical_context import (
     DEFAULT_CONTEXT_CHANNELS,
     canonical_events_to_server_messages,
@@ -44,6 +46,7 @@ from utils.ella.canonical_context import (
     format_canonical_context,
 )
 from utils.ella.time_context import timezone_name
+from utils.other import endpoints as auth
 
 logger = logging.getLogger(__name__)
 
@@ -100,9 +103,13 @@ def _hermes_chat_session_key(uid: str) -> str:
     return f"ella:omi:{safe_uid}:ios-chat:{epoch}"
 
 
-def _hermes_chat_headers(session_id: str, session_key: str | None = None) -> dict[str, str]:
+def _hermes_chat_headers(
+    session_id: str,
+    session_key: str | None = None,
+    gateway_token: str | None = None,
+) -> dict[str, str]:
     headers = {
-        "Authorization": f"Bearer {HERMES_GATEWAY_TOKEN}",
+        "Authorization": f"Bearer {gateway_token or HERMES_GATEWAY_TOKEN}",
         "Content-Type": "application/json",
         "X-Hermes-Session-Id": session_id,
     }
@@ -111,14 +118,22 @@ def _hermes_chat_headers(session_id: str, session_key: str | None = None) -> dic
     return headers
 
 
-async def _hermes_nonstream_completion(messages: list[dict], session_key: str, memory_key: str | None = None) -> str:
+async def _hermes_nonstream_completion(
+    messages: list[dict],
+    session_key: str,
+    memory_key: str | None = None,
+    *,
+    gateway_url: str = HERMES_GATEWAY_URL,
+    gateway_token: str = HERMES_GATEWAY_TOKEN,
+    agent_id: str = HERMES_MODEL,
+) -> str:
     recovery_session = f"{session_key}:empty-recovery"
     async with httpx.AsyncClient(timeout=60.0) as client:
         response = await client.post(
-            f"{HERMES_GATEWAY_URL}/v1/chat/completions",
-            headers=_hermes_chat_headers(recovery_session, memory_key or session_key),
+            f"{gateway_url}/v1/chat/completions",
+            headers=_hermes_chat_headers(recovery_session, memory_key or session_key, gateway_token),
             json={
-                "model": HERMES_MODEL,
+                "model": agent_id,
                 "messages": messages,
                 "stream": False,
             },
@@ -140,7 +155,7 @@ async def _hermes_nonstream_completion(messages: list[dict], session_key: str, m
 
 
 class EllaChatRequest(BaseModel):
-    uid: str
+    uid: str = ""
     message: str
     conversation_id: str = ""
     client_message_id: str = ""
@@ -694,13 +709,18 @@ async def _stream_hermes_chat(
     *,
     turn_id: str = "",
     client_sent_at: datetime = None,
+    runtime: IsolatedRuntime | None = None,
 ):
     """Stream iOS chat through Hermes while preserving OMI chat SSE format."""
     import time as _time
 
     _start = _time.time()
 
-    if not HERMES_GATEWAY_TOKEN:
+    gateway_url = runtime.gateway_url if runtime else HERMES_GATEWAY_URL
+    gateway_token = runtime.gateway_token if runtime else HERMES_GATEWAY_TOKEN
+    agent_id = runtime.agent_id if runtime else HERMES_MODEL
+
+    if not gateway_token:
         print(f"[FLOW:CHAT-HERMES] ERROR token_missing=true uid={uid}", flush=True)
         yield "data: Error: HERMES_API_SERVER_KEY not configured\n\n"
         return
@@ -760,7 +780,7 @@ async def _stream_hermes_chat(
     messages.append({"role": "user", "content": user_message})
     memory_key = _hermes_chat_memory_key(uid)
     print(
-        f"[FLOW:CHAT-HERMES] uid={uid} gateway={HERMES_GATEWAY_URL} session={session_key} memory_key={memory_key} session_strategy={HERMES_CHAT_SESSION_SCOPE} turn_id={turn_id} canonical_events={len(canonical_events)} temporal_events={len(temporal_events)}",
+        f"[FLOW:CHAT-HERMES] uid={uid} profile={runtime.profile_name if runtime else 'legacy-shared'} session={session_key} memory_key={memory_key} session_strategy={HERMES_CHAT_SESSION_SCOPE} turn_id={turn_id} canonical_events={len(canonical_events)} temporal_events={len(temporal_events)}",
         flush=True,
     )
 
@@ -768,10 +788,10 @@ async def _stream_hermes_chat(
         async with httpx.AsyncClient(timeout=None) as client:
             async with client.stream(
                 "POST",
-                f"{HERMES_GATEWAY_URL}/v1/chat/completions",
-                headers=_hermes_chat_headers(session_key, memory_key),
+                f"{gateway_url}/v1/chat/completions",
+                headers=_hermes_chat_headers(session_key, memory_key, gateway_token),
                 json={
-                    "model": HERMES_MODEL,
+                    "model": agent_id,
                     "messages": messages,
                     "stream": True,
                 },
@@ -807,7 +827,14 @@ async def _stream_hermes_chat(
 
         full_text = "".join(text).strip()
         if not full_text:
-            recovery_text = await _hermes_nonstream_completion(messages, session_key, memory_key)
+            recovery_text = await _hermes_nonstream_completion(
+                messages,
+                session_key,
+                memory_key,
+                gateway_url=gateway_url,
+                gateway_token=gateway_token,
+                agent_id=agent_id,
+            )
             if recovery_text:
                 text.append(recovery_text)
                 full_text = recovery_text
@@ -869,6 +896,7 @@ async def _stream_hermes_chat(
 async def ella_chat_stream(
     request: EllaChatRequest,
     raw_request: Request,
+    authenticated_uid: str = Depends(auth.get_current_user_uid),
     x_ella_debug_level: str = Header(None, alias="X-Ella-Debug-Level"),
     x_ella_client_type: str = Header(None, alias="X-Ella-Client-Type"),
     x_ella_client_version: str = Header(None, alias="X-Ella-Client-Version"),
@@ -890,13 +918,23 @@ async def ella_chat_stream(
 
     _trace_start = _time.time()
 
+    if request.uid and request.uid != authenticated_uid:
+        raise HTTPException(status_code=403, detail={"code": "ownership_mismatch"})
+    uid = authenticated_uid
+
+    runtime = None
+    try:
+        runtime = await resolve_isolated_runtime(uid)
+    except ProvisioningError as exc:
+        raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
+
     debug_level = _resolve_debug_level(x_ella_debug_level)
 
     # Comprehensive flow entry log
     client_ip = raw_request.client.host if raw_request.client else "unknown"
     client_type = x_ella_client_type or "unknown"
     print(
-        f"[FLOW:CHAT] uid={request.uid} level={debug_level} client={client_type} ip={client_ip} msg_len={len(request.message)}",
+        f"[FLOW:CHAT] uid={uid} level={debug_level} client={client_type} ip={client_ip} msg_len={len(request.message)}",
         flush=True,
     )
 
@@ -908,24 +946,24 @@ async def ella_chat_stream(
     trace.client_type = x_ella_client_type or ""
     trace.client_version = x_ella_client_version or ""
     trace.client_route = x_ella_route or ""
-    trace.uid = request.uid
+    trace.uid = uid
     trace.debug_level = debug_level
     trace.notes.append(f"message_length={len(request.message)}")
     client_sent_at = _parse_client_sent_at(request.client_sent_at)
-    turn_id = _canonical_turn_id(request.uid, request, client_sent_at)
+    turn_id = _canonical_turn_id(uid, request, client_sent_at)
     trace.notes.append(f"canonical_turn_id={turn_id}")
     # Capture all X-Ella-* headers for debugging
     trace.client_headers = {k: v for k, v in raw_request.headers.items() if k.lower().startswith("x-ella-")}
 
-    if CHAT_PLATFORM == "hermes":
-        trace.resolved_agent = HERMES_AGENT_ID
-        trace.resolve_source = "hermes_platform"
+    if CHAT_PLATFORM == "hermes" or runtime is not None:
+        trace.resolved_agent = runtime.agent_id if runtime else HERMES_AGENT_ID
+        trace.resolve_source = "isolated_runtime_binding" if runtime else "hermes_platform"
         trace.total_latency_ms = int((_time.time() - _trace_start) * 1000)
         record_trace(trace)
         return StreamingResponse(
             _stream_hermes_chat(
                 request.message,
-                request.uid,
+                uid,
                 {
                     "type": x_ella_client_type or "",
                     "version": x_ella_client_version or "",
@@ -935,6 +973,7 @@ async def ella_chat_stream(
                 },
                 turn_id=turn_id,
                 client_sent_at=client_sent_at,
+                runtime=runtime,
             ),
             media_type="text/event-stream",
         )
@@ -965,7 +1004,7 @@ async def ella_chat_stream(
         trace.total_latency_ms = int((_time.time() - _trace_start) * 1000)
         record_trace(trace)
         return StreamingResponse(
-            _stream_level_3_n8n(request.message, request.uid, request.conversation_id),
+            _stream_level_3_n8n(request.message, uid, request.conversation_id),
             media_type="text/event-stream",
         )
 
@@ -974,7 +1013,7 @@ async def ella_chat_stream(
         return StreamingResponse(
             _stream_level_4_openclaw(
                 request.message,
-                request.uid,
+                uid,
                 {
                     "type": x_ella_client_type or "",
                     "version": x_ella_client_version or "",
@@ -987,7 +1026,7 @@ async def ella_chat_stream(
         )
 
     # Level 0 (production): Direct Grok call as default production path
-    print(f"[FLOW:CHAT-L0] uid={request.uid} production path -> grok direct", flush=True)
+    print(f"[FLOW:CHAT-L0] uid={uid} production path -> grok direct", flush=True)
     trace.resolved_agent = "grok-direct (level 0)"
     trace.resolve_source = "level_0_production"
     trace.total_latency_ms = int((_time.time() - _trace_start) * 1000)
@@ -1013,9 +1052,10 @@ PROVISION_API_TOKEN = os.getenv("ELLA_PROVISION_API_TOKEN", "")
 
 @router.get("/chat/history")
 async def ella_chat_history(
-    uid: str,
+    uid: str = "",
     limit: int = 50,
     before: str = None,
+    authenticated_uid: str = Depends(auth.get_current_user_uid),
 ):
     """Return recent chat/context messages for a user from canonical timeline.
 
@@ -1033,6 +1073,15 @@ async def ella_chat_history(
     import time as _time
 
     _start = _time.time()
+
+    if uid and uid != authenticated_uid:
+        raise HTTPException(status_code=403, detail={"code": "ownership_mismatch"})
+    uid = authenticated_uid
+    if runtime_bindings_enabled():
+        try:
+            await resolve_isolated_runtime(authenticated_uid)
+        except ProvisioningError as exc:
+            raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
 
     limit = min(limit, 200)
 
@@ -1056,6 +1105,9 @@ async def ella_chat_history(
         "[FLOW:HISTORY] uid=%s source=canonical_timeline empty fallback=provision_openclaw_history_migration",
         uid,
     )
+
+    if runtime_bindings_enabled():
+        return {"messages": [], "hasMore": False, "source": "canonical_timeline_empty", "fallback": False}
 
     # Resolve user to get their OpenClaw user ID for migration fallback only.
     resolved = await resolve_user_routing(uid)

--- a/backend/ella/routers/chat.py
+++ b/backend/ella/routers/chat.py
@@ -1077,7 +1077,7 @@ async def ella_chat_history(
     if uid and uid != authenticated_uid:
         raise HTTPException(status_code=403, detail={"code": "ownership_mismatch"})
     uid = authenticated_uid
-    if runtime_bindings_enabled():
+    if runtime_bindings_enabled(authenticated_uid):
         try:
             await resolve_isolated_runtime(authenticated_uid)
         except ProvisioningError as exc:
@@ -1106,7 +1106,7 @@ async def ella_chat_history(
         uid,
     )
 
-    if runtime_bindings_enabled():
+    if runtime_bindings_enabled(uid):
         return {"messages": [], "hasMore": False, "source": "canonical_timeline_empty", "fallback": False}
 
     # Resolve user to get their OpenClaw user ID for migration fallback only.

--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -32,6 +32,7 @@ from ella.services.summary_recovery import (
     generate_summary_from_prompt,
     normalize_summary,
     recover_failed_conversation_summary,
+    summary_provider_config_for_uid,
 )
 from ella.services import proposal_ingest
 from models.conversation import Conversation, ConversationStatus
@@ -360,14 +361,9 @@ async def _generate_corrected_summary(
         transcript=transcript,
         segment_count=segment_count,
     )
-    return await generate_summary_from_prompt(
-        prompt=prompt,
-        fallback=structured,
-        session_id=_correction_session_id(uid, conversation_id, correction_id),
-        session_key=_correction_session_key(uid),
-        trace_id=trace_id,
-        required_tags=("omi", "correction"),
-        config=SummaryProviderConfig(
+    config = await summary_provider_config_for_uid(
+        uid,
+        SummaryProviderConfig(
             provider=CORRECTION_PROVIDER,
             hermes_url=HERMES_CORRECTION_API_URL,
             hermes_model=HERMES_CORRECTION_MODEL,
@@ -377,6 +373,15 @@ async def _generate_corrected_summary(
             legacy_api_key=_legacy_correction_api_key(),
             timeout_seconds=DIRECT_CORRECTION_TIMEOUT_SECONDS,
         ),
+    )
+    return await generate_summary_from_prompt(
+        prompt=prompt,
+        fallback=structured,
+        session_id=_correction_session_id(uid, conversation_id, correction_id),
+        session_key=_correction_session_key(uid),
+        trace_id=trace_id,
+        required_tags=("omi", "correction"),
+        config=config,
         async_client_factory=httpx.AsyncClient,
     )
 

--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -32,6 +32,7 @@ from pydantic import BaseModel, Field
 from ella.routers.resolve import resolve_user_routing
 from database import app_settings as app_settings_db
 from ella.services.app_settings import TTS_PROVIDERS, build_effective_voice_settings
+from ella.services.runtime_resolver import runtime_bindings_enabled
 from ella.services.escalation_policy import (
     CaregiverPolicyContext,
     EscalationEvent,
@@ -1032,6 +1033,13 @@ async def _get_recent_chat_turns(uid: str, limit: int = 5) -> list[dict]:
             f"[FLOW:GUARDIAN-CONTEXT] uid={uid} canonical_error={e} fallback=provision_openclaw_history_migration",
             flush=True,
         )
+
+    if runtime_bindings_enabled(uid):
+        print(
+            f"[FLOW:GUARDIAN-CONTEXT] uid={uid} isolated=true canonical_empty=true fallback=disabled",
+            flush=True,
+        )
+        return []
 
     try:
         resolved = await resolve_user_routing(uid)

--- a/backend/ella/routers/observer.py
+++ b/backend/ella/routers/observer.py
@@ -120,6 +120,7 @@ def create_observer_router(
         extraction = await build_extraction_result(
             source_events,
             mode=extractor_mode,
+            uid=request.uid,
             timeout_seconds=max(5.0, min(float(request.extractor_timeout_seconds or 45.0), 120.0)),
             limit=max(1, min(int(request.extractor_limit or 60), 100)),
         )

--- a/backend/ella/routers/onboarding.py
+++ b/backend/ella/routers/onboarding.py
@@ -78,7 +78,7 @@ async def ensure_onboarding(
     response: Response,
     uid: str = Depends(auth.get_current_user_uid),
 ) -> dict[str, Any]:
-    if not provisioning_enabled():
+    if not provisioning_enabled(uid):
         raise HTTPException(status_code=503, detail={"code": "provisioning_disabled"})
     if not SCHEMA_VERSION_RE.fullmatch(payload.target_schema_version):
         raise HTTPException(status_code=400, detail={"code": "invalid_target_schema_version"})
@@ -110,7 +110,7 @@ async def onboarding_status(
     target_schema_version: str = DEFAULT_TARGET_SCHEMA_VERSION,
     uid: str = Depends(auth.get_current_user_uid),
 ) -> dict[str, Any]:
-    if not provisioning_enabled():
+    if not provisioning_enabled(uid):
         raise HTTPException(status_code=503, detail={"code": "provisioning_disabled"})
     if not SCHEMA_VERSION_RE.fullmatch(target_schema_version):
         raise HTTPException(status_code=400, detail={"code": "invalid_target_schema_version"})

--- a/backend/ella/routers/onboarding.py
+++ b/backend/ella/routers/onboarding.py
@@ -9,10 +9,15 @@ from typing import Any, Optional
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response
 from pydantic import BaseModel, ConfigDict, Field
 
-from database.ella_provisioning import EllaProvisioningRepository, IdentityConflictError
+from database.ella_provisioning import (
+    EllaProvisioningRepository,
+    IdentityConflictError,
+    ProvisioningSchemaNotReadyError,
+)
 from ella.services.provisioning import (
     DEFAULT_TARGET_SCHEMA_VERSION,
     ProvisioningCoordinator,
+    ProvisioningError,
     VerifiedIdentity,
     provisioning_enabled,
     public_receipt,
@@ -22,6 +27,13 @@ from utils.other import endpoints as auth
 logger = logging.getLogger("ella.onboarding")
 router = APIRouter(prefix="/v1/ella/onboarding", tags=["ella-onboarding"])
 SCHEMA_VERSION_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{2,63}$")
+_firestore_db: Any = None
+
+
+def configure_firestore_db(firestore_db: Any) -> None:
+    """Inject the already-initialized OMI Firestore client at app startup."""
+    global _firestore_db
+    _firestore_db = firestore_db
 
 
 class OnboardingClient(BaseModel):
@@ -62,7 +74,7 @@ def _verified_identity(uid: str, payload: OnboardingEnsureRequest) -> VerifiedId
 
 
 async def _coordinator() -> ProvisioningCoordinator:
-    return ProvisioningCoordinator(await EllaProvisioningRepository.create())
+    return ProvisioningCoordinator(await EllaProvisioningRepository.create(firestore_db=_firestore_db))
 
 
 def _payload_dict(payload: OnboardingEnsureRequest) -> dict[str, Any]:
@@ -93,6 +105,11 @@ async def ensure_onboarding(
         )
     except IdentityConflictError as exc:
         raise HTTPException(status_code=409, detail={"code": str(exc)}) from exc
+    except ProvisioningError as exc:
+        raise HTTPException(
+            status_code=503 if exc.retryable else 409,
+            detail={"code": exc.code},
+        ) from exc
 
     receipt = public_receipt(job, binding)
     if claimed:
@@ -115,6 +132,11 @@ async def onboarding_status(
     if not SCHEMA_VERSION_RE.fullmatch(target_schema_version):
         raise HTTPException(status_code=400, detail={"code": "invalid_target_schema_version"})
     repository = await EllaProvisioningRepository.create()
+    try:
+        await repository.assert_schema_ready()
+    except ProvisioningSchemaNotReadyError as exc:
+        logger.error("Ella provisioning status schema is incomplete: %s", ", ".join(exc.missing))
+        raise HTTPException(status_code=503, detail={"code": "provisioning_schema_not_ready"}) from exc
     job = await repository.get_job(uid, target_schema_version)
     if not job:
         raise HTTPException(status_code=404, detail={"code": "setup_not_started"})

--- a/backend/ella/routers/onboarding.py
+++ b/backend/ella/routers/onboarding.py
@@ -118,5 +118,8 @@ async def onboarding_status(
     job = await repository.get_job(uid, target_schema_version)
     if not job:
         raise HTTPException(status_code=404, detail={"code": "setup_not_started"})
-    binding = await repository.resolve_active_runtime(uid)
+    binding = await repository.resolve_active_runtime(
+        uid,
+        template_version=target_schema_version,
+    )
     return public_receipt(job, binding)

--- a/backend/ella/routers/onboarding.py
+++ b/backend/ella/routers/onboarding.py
@@ -1,0 +1,122 @@
+"""Authenticated, idempotent Ella Hermes onboarding endpoints."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Optional
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response
+from pydantic import BaseModel, ConfigDict, Field
+
+from database.ella_provisioning import EllaProvisioningRepository, IdentityConflictError
+from ella.services.provisioning import (
+    DEFAULT_TARGET_SCHEMA_VERSION,
+    ProvisioningCoordinator,
+    VerifiedIdentity,
+    provisioning_enabled,
+    public_receipt,
+)
+from utils.other import endpoints as auth
+
+logger = logging.getLogger("ella.onboarding")
+router = APIRouter(prefix="/v1/ella/onboarding", tags=["ella-onboarding"])
+SCHEMA_VERSION_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{2,63}$")
+
+
+class OnboardingClient(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    platform: str = "ios"
+    app_version: str = "unknown"
+    locale: str = "en-US"
+    timezone: str = "America/Los_Angeles"
+
+
+class OnboardingEnsureRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    target_schema_version: str = DEFAULT_TARGET_SCHEMA_VERSION
+    client_request_id: Optional[str] = Field(default=None, max_length=128)
+    client: OnboardingClient = Field(default_factory=OnboardingClient)
+    consent_receipt_id: Optional[str] = Field(default=None, max_length=256)
+
+
+def _verified_identity(uid: str, payload: OnboardingEnsureRequest) -> VerifiedIdentity:
+    try:
+        firebase_user = auth.get_user(uid)
+    except Exception as exc:
+        logger.warning("Firebase user lookup failed for authenticated uid=%s: %s", uid, type(exc).__name__)
+        raise HTTPException(status_code=401, detail={"code": "auth_required"}) from exc
+
+    email = str(getattr(firebase_user, "email", "") or "").strip()
+    if not email:
+        raise HTTPException(status_code=409, detail={"code": "identity_missing_email"})
+    name = str(getattr(firebase_user, "display_name", "") or "").strip() or email.split("@", 1)[0]
+    return VerifiedIdentity(
+        uid=uid,
+        email=email,
+        name=name,
+        timezone=payload.client.timezone or "America/Los_Angeles",
+    )
+
+
+async def _coordinator() -> ProvisioningCoordinator:
+    return ProvisioningCoordinator(await EllaProvisioningRepository.create())
+
+
+def _payload_dict(payload: OnboardingEnsureRequest) -> dict[str, Any]:
+    if hasattr(payload, "model_dump"):
+        return payload.model_dump(mode="json")
+    return payload.dict()
+
+
+@router.post("/ensure")
+async def ensure_onboarding(
+    payload: OnboardingEnsureRequest,
+    background_tasks: BackgroundTasks,
+    response: Response,
+    uid: str = Depends(auth.get_current_user_uid),
+) -> dict[str, Any]:
+    if not provisioning_enabled():
+        raise HTTPException(status_code=503, detail={"code": "provisioning_disabled"})
+    if not SCHEMA_VERSION_RE.fullmatch(payload.target_schema_version):
+        raise HTTPException(status_code=400, detail={"code": "invalid_target_schema_version"})
+    identity = _verified_identity(uid, payload)
+    coordinator = await _coordinator()
+    try:
+        job, binding, claimed = await coordinator.ensure_job(
+            identity=identity,
+            target_schema_version=payload.target_schema_version,
+            client_request_id=payload.client_request_id,
+            request_payload=_payload_dict(payload),
+        )
+    except IdentityConflictError as exc:
+        raise HTTPException(status_code=409, detail={"code": str(exc)}) from exc
+
+    receipt = public_receipt(job, binding)
+    if claimed:
+        background_tasks.add_task(coordinator.process_claimed_job, job=job, identity=identity)
+        response.status_code = 202
+    elif receipt["state"] in {"queued", "provisioning", "degraded"}:
+        response.status_code = 202
+    elif receipt["state"] == "blocked":
+        response.status_code = 503 if receipt.get("error_code") == "provisioning_disabled" else 409
+    return receipt
+
+
+@router.get("/status")
+async def onboarding_status(
+    target_schema_version: str = DEFAULT_TARGET_SCHEMA_VERSION,
+    uid: str = Depends(auth.get_current_user_uid),
+) -> dict[str, Any]:
+    if not provisioning_enabled():
+        raise HTTPException(status_code=503, detail={"code": "provisioning_disabled"})
+    if not SCHEMA_VERSION_RE.fullmatch(target_schema_version):
+        raise HTTPException(status_code=400, detail={"code": "invalid_target_schema_version"})
+    repository = await EllaProvisioningRepository.create()
+    job = await repository.get_job(uid, target_schema_version)
+    if not job:
+        raise HTTPException(status_code=404, detail={"code": "setup_not_started"})
+    binding = await repository.resolve_active_runtime(uid)
+    return public_receipt(job, binding)

--- a/backend/ella/routers/resolve.py
+++ b/backend/ella/routers/resolve.py
@@ -24,7 +24,14 @@ import os
 from typing import Optional
 
 import asyncpg
-from fastapi import APIRouter, HTTPException, Query
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import JSONResponse
+
+from database.ella_provisioning import EllaProvisioningRepository
+from ella.services.provisioning import ProvisioningError
+from ella.services.runtime_resolver import resolve_isolated_runtime, runtime_bindings_enabled
+from utils.other import endpoints as auth
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +89,33 @@ async def resolve_user_routing(uid: str) -> Optional[dict]:
     )
     if not row:
         return None
+
+    if runtime_bindings_enabled():
+        runtime = await resolve_isolated_runtime(uid, EllaProvisioningRepository(pool))
+        return {
+            "user": {
+                "id": str(row["id"]),
+                "name": row["name"],
+                "omiUid": row["omi_uid"],
+                "status": row["status"],
+                "guardianMode": row["guardian_mode"],
+                "timezone": row["timezone"],
+                "conditions": row["conditions"],
+                "medications": row["medications"],
+            },
+            "routing": {
+                "agentId": runtime.agent_id,
+                "sessionKey": f"ella:omi:{uid.lower()}:canonical",
+                "gatewayUrl": runtime.gateway_url,
+                "token": runtime.gateway_token,
+                "historyUrl": "/v1/ella/chat/history",
+                "platform": "hermes",
+                "profileName": runtime.profile_name,
+                "bindingRevision": runtime.revision,
+                "modelPolicyVersion": runtime.model_policy_version,
+                "voicePolicyVersion": runtime.voice_policy_version,
+            },
+        }
 
     agents = json.loads(row["agents"]) if row["agents"] else None
 
@@ -145,17 +179,38 @@ async def resolve_endpoint(
     uid: Optional[str] = Query(None, description="Firebase UID (omiUid)"),
     email: Optional[str] = Query(None, description="User email"),
     phone: Optional[str] = Query(None, description="User phone (E.164)"),
+    authenticated_uid: str = Depends(auth.get_current_user_uid),
 ):
     """Resolve a user identifier to active agent routing info.
 
     Accepts one of: uid, email, phone. Returns the user's agent cluster
     routing information including agentId, sessionKey, gatewayUrl, and token.
     """
-    if not uid and not email and not phone:
-        raise HTTPException(
-            status_code=400,
-            detail="One of uid, email, or phone is required",
-        )
+    if email or phone:
+        raise HTTPException(status_code=400, detail={"code": "unsupported_identity_lookup"})
+    uid = uid or authenticated_uid
+    if uid != authenticated_uid:
+        raise HTTPException(status_code=403, detail={"code": "ownership_mismatch"})
+
+    if runtime_bindings_enabled():
+        try:
+            resolved = await resolve_user_routing(authenticated_uid)
+        except ProvisioningError as exc:
+            raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
+        if not resolved:
+            raise HTTPException(status_code=404, detail={"code": "user_not_found"})
+        routing = resolved.get("routing") or {}
+        return {
+            "user": resolved["user"],
+            "routing": {
+                "agentId": routing.get("agentId"),
+                "historyUrl": "/v1/ella/chat/history",
+                "platform": "hermes",
+                "bindingRevision": routing.get("bindingRevision"),
+                "modelPolicyVersion": routing.get("modelPolicyVersion"),
+                "voicePolicyVersion": routing.get("voicePolicyVersion"),
+            },
+        }
 
     pool = await _get_pool()
 
@@ -172,31 +227,8 @@ async def resolve_endpoint(
             """,
             uid,
         )
-    elif email:
-        row = await pool.fetchrow(
-            """
-            SELECT u.id, u.name, u.omi_uid, u.status, u.guardian_mode, u.timezone,
-                   u.conditions, u.medications,
-                   ac.agents, ac.status AS cluster_status
-            FROM users u
-            LEFT JOIN agent_clusters ac ON ac.user_id = u.id
-            WHERE u.email = $1
-            """,
-            email,
-        )
     else:
-        # Phone lookup via identities JSONB
-        row = await pool.fetchrow(
-            """
-            SELECT u.id, u.name, u.omi_uid, u.status, u.guardian_mode, u.timezone,
-                   u.conditions, u.medications,
-                   ac.agents, ac.status AS cluster_status
-            FROM users u
-            LEFT JOIN agent_clusters ac ON ac.user_id = u.id
-            WHERE u.identities->>'phone' = $1
-            """,
-            phone,
-        )
+        raise HTTPException(status_code=400, detail={"code": "uid_required"})
 
     if not row:
         identifier = uid or email or phone
@@ -262,13 +294,23 @@ async def resolve_endpoint(
 
 
 @router.get("/chat/history/{agent_id}")
-async def proxy_chat_history(agent_id: str, limit: int = 50, session_key: Optional[str] = None):
+async def proxy_chat_history(
+    agent_id: str,
+    limit: int = 50,
+    session_key: Optional[str] = None,
+    authenticated_uid: str = Depends(auth.get_current_user_uid),
+):
     """Proxy chat history requests to the Provision API on Mac Mini.
 
     The iOS app can't reach the Mac Mini's Tailscale IP directly,
     so this endpoint forwards the request.
     """
-    import httpx
+    if runtime_bindings_enabled():
+        raise HTTPException(status_code=410, detail={"code": "legacy_history_disabled"})
+
+    resolved = await resolve_user_routing(authenticated_uid)
+    if not resolved or (resolved.get("routing") or {}).get("agentId") != agent_id:
+        raise HTTPException(status_code=403, detail={"code": "ownership_mismatch"})
 
     provision_base = PROVISION_API_URL.rstrip('/')
     params = f"limit={limit}"
@@ -282,12 +324,8 @@ async def proxy_chat_history(agent_id: str, limit: int = 50, session_key: Option
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.get(url, headers={"x-api-key": PROVISION_API_KEY})
             if resp.status_code != 200:
-                from fastapi.responses import JSONResponse
-
                 return JSONResponse(status_code=resp.status_code, content={"error": "upstream_error"})
             return resp.json()
     except Exception as e:
         logger.error(f"Chat history proxy error: {e}")
-        from fastapi.responses import JSONResponse
-
         return JSONResponse(status_code=502, content={"error": "provision_unreachable"})

--- a/backend/ella/routers/resolve.py
+++ b/backend/ella/routers/resolve.py
@@ -90,7 +90,7 @@ async def resolve_user_routing(uid: str) -> Optional[dict]:
     if not row:
         return None
 
-    if runtime_bindings_enabled():
+    if runtime_bindings_enabled(uid):
         runtime = await resolve_isolated_runtime(uid, EllaProvisioningRepository(pool))
         return {
             "user": {
@@ -192,7 +192,7 @@ async def resolve_endpoint(
     if uid != authenticated_uid:
         raise HTTPException(status_code=403, detail={"code": "ownership_mismatch"})
 
-    if runtime_bindings_enabled():
+    if runtime_bindings_enabled(authenticated_uid):
         try:
             resolved = await resolve_user_routing(authenticated_uid)
         except ProvisioningError as exc:
@@ -305,7 +305,7 @@ async def proxy_chat_history(
     The iOS app can't reach the Mac Mini's Tailscale IP directly,
     so this endpoint forwards the request.
     """
-    if runtime_bindings_enabled():
+    if runtime_bindings_enabled(authenticated_uid):
         raise HTTPException(status_code=410, detail={"code": "legacy_history_disabled"})
 
     resolved = await resolve_user_routing(authenticated_uid)

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -32,7 +32,7 @@ from fastapi.responses import Response
 from pydantic import BaseModel
 
 from database.conversations import _decrypt_conversation_data
-from ella.services.provisioning import ProvisioningError, rollout_enabled
+from ella.services.provisioning import ProvisioningError
 from ella.services.runtime_resolver import resolve_isolated_runtime, runtime_bindings_enabled
 from utils.ella.canonical_context import fetch_canonical_timeline
 from utils.other import endpoints as auth
@@ -72,15 +72,6 @@ HERMES_VOICE_MEMORY_URL = os.getenv("HERMES_VOICE_MEMORY_URL", "http://100.76.13
 HERMES_VOICE_MEMORY_TOKEN = os.getenv("HERMES_VOICE_MEMORY_TOKEN", PROVISION_API_TOKEN)
 DEFAULT_GATEWAY_URL = os.getenv("OPENCLAW_URL", "http://100.76.138.56:19001")
 OPENCLAW_GATEWAY_TOKEN = os.getenv("OPENCLAW_GATEWAY_TOKEN", "")
-
-
-def isolated_voice_routing_enabled(uid: Optional[str] = None) -> bool:
-    """Keep isolated users off the legacy OpenClaw voice proxy until cutover."""
-    return rollout_enabled(
-        "ELLA_ISOLATED_VOICE_ROUTING_ENABLED",
-        "ELLA_ISOLATED_VOICE_ROUTING_ENABLED_UIDS",
-        uid,
-    )
 
 # Database connection pool (lazy-initialized, shared pattern with other Ella routers)
 _pool: Optional[asyncpg.Pool] = None
@@ -423,8 +414,9 @@ async def create_voice_session(
             await resolve_isolated_runtime(uid)
         except ProvisioningError as exc:
             raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
-        if not isolated_voice_routing_enabled(uid):
-            raise HTTPException(status_code=503, detail={"code": "isolated_voice_not_ready"})
+        # Session issuance must remain closed until every downstream voice
+        # context/tool path consumes the same active Hermes binding.
+        raise HTTPException(status_code=503, detail={"code": "isolated_voice_not_ready"})
 
     # Validate provider
     if provider not in V2V_PROVIDERS:
@@ -452,9 +444,7 @@ async def create_voice_session(
     user_display_name = None
     try:
         pool = await _get_pool()
-        row = await pool.fetchrow(
-            "SELECT name FROM users WHERE omi_uid = $1", uid
-        )
+        row = await pool.fetchrow("SELECT name FROM users WHERE omi_uid = $1", uid)
         if row:
             user_display_name = row["name"]
     except Exception as e:
@@ -567,7 +557,10 @@ async def synthesize_speech(
                 )
             _elapsed = int((time.time() - _start) * 1000)
             if response.status_code != 200:
-                print(f"[FLOW:VOICE-TTS] ERROR provider={provider} status={response.status_code} latency={_elapsed}ms", flush=True)
+                print(
+                    f"[FLOW:VOICE-TTS] ERROR provider={provider} status={response.status_code} latency={_elapsed}ms",
+                    flush=True,
+                )
                 raise HTTPException(status_code=502, detail=f"ella-tts error: {response.status_code}")
             audio_size = len(response.content)
             print(f"[FLOW:VOICE-TTS] OK provider={provider} audio_bytes={audio_size} latency={_elapsed}ms", flush=True)
@@ -589,7 +582,10 @@ async def synthesize_speech(
             print(f"[FLOW:VOICE-TTS] ERROR provider=xai-tts key_missing=true", flush=True)
             raise HTTPException(status_code=500, detail="XAI_API_KEY not configured")
         voice_id = request.voice_id if request.voice_id != DEFAULT_ELEVENLABS_VOICE_ID else XAI_TTS_VOICE_ID
-        print(f"[FLOW:VOICE-TTS] provider=xai-tts voice={voice_id} language={XAI_TTS_LANGUAGE} text_len={text_len}", flush=True)
+        print(
+            f"[FLOW:VOICE-TTS] provider=xai-tts voice={voice_id} language={XAI_TTS_LANGUAGE} text_len={text_len}",
+            flush=True,
+        )
         try:
             async with httpx.AsyncClient() as client:
                 response = await client.post(
@@ -652,7 +648,10 @@ async def synthesize_speech(
     # --- Reject unknown providers (no silent fallbacks) ---
     if provider != "elevenlabs":
         print(f"[FLOW:VOICE-TTS] ERROR unknown provider={provider!r}", flush=True)
-        raise HTTPException(status_code=400, detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, xai-tts, grok-voice, gemini-live")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, xai-tts, grok-voice, gemini-live",
+        )
 
     # --- ElevenLabs ---
     if not ELEVENLABS_API_KEY:
@@ -681,11 +680,17 @@ async def synthesize_speech(
         _elapsed = int((time.time() - _start) * 1000)
 
         if response.status_code != 200:
-            print(f"[FLOW:VOICE-TTS] ERROR provider=elevenlabs status={response.status_code} latency={_elapsed}ms body={response.text[:200]}", flush=True)
+            print(
+                f"[FLOW:VOICE-TTS] ERROR provider=elevenlabs status={response.status_code} latency={_elapsed}ms body={response.text[:200]}",
+                flush=True,
+            )
             raise HTTPException(status_code=502, detail=f"ElevenLabs error: {response.status_code}")
 
         audio_size = len(response.content)
-        print(f"[FLOW:VOICE-TTS] OK provider=elevenlabs voice={request.voice_id} audio_bytes={audio_size} latency={_elapsed}ms", flush=True)
+        print(
+            f"[FLOW:VOICE-TTS] OK provider=elevenlabs voice={request.voice_id} audio_bytes={audio_size} latency={_elapsed}ms",
+            flush=True,
+        )
 
         return Response(content=response.content, media_type="audio/mpeg")
 
@@ -730,8 +735,6 @@ async def voice_health():
 # ============================================================================
 
 
-
-
 async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
     """Fetch recent OMI conversation summaries from Firestore for voice context.
     Returns formatted string of recent conversations (title + overview)."""
@@ -739,17 +742,20 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
         # Direct Firestore query — simpler than get_conversations() to avoid
         # composite index requirements (discarded + created_at needs index)
         from google.cloud import firestore
+
         db = firestore.Client()
         convos_ref = (
-            db.collection("users").document(uid).collection("conversations")
+            db.collection("users")
+            .document(uid)
+            .collection("conversations")
             .order_by("created_at", direction=firestore.Query.DESCENDING)
             .limit(limit)
         )
         convos = [doc.to_dict() for doc in convos_ref.stream()]
-        
+
         if not convos:
             return ""
-        
+
         parts = []
         for c in convos:
             structured = c.get("structured", {})
@@ -757,7 +763,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
             overview = structured.get("overview", "")
             emoji = structured.get("emoji", "")
             created = c.get("created_at")
-            
+
             # Format timestamp
             ts = ""
             if created:
@@ -765,7 +771,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
                     ts = created.strftime("%b %d %I:%M %p")
                 else:
                     ts = str(created)[:16]
-            
+
             entry = f"- {emoji} {title}"
             if overview:
                 # Truncate long overviews
@@ -774,7 +780,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
             if ts:
                 entry += f" ({ts})"
             parts.append(entry)
-        
+
         return "\n".join(parts)
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Conversation fetch failed: {e}")
@@ -791,15 +797,15 @@ async def _fetch_memory_context(
     Returns formatted string of relevant memory snippets."""
     if not gateway_token:
         return ""
-    
+
     headers = {
         "Authorization": f"Bearer {gateway_token}",
         "Content-Type": "application/json",
     }
-    
+
     results_all = []
     queries = [f"{user_name} recent activity today schedule important"]
-    
+
     try:
         async with httpx.AsyncClient(timeout=timeout_seconds) as client:
             for query in queries:
@@ -813,6 +819,7 @@ async def _fetch_memory_context(
                         data = resp.json()
                         if data.get("ok"):
                             import json as json_mod
+
                             results_text = data["result"]["content"][0]["text"]
                             results = json_mod.loads(results_text).get("results", [])
                             for r in results[:3]:
@@ -826,10 +833,10 @@ async def _fetch_memory_context(
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Memory context fetch failed: {e}")
         return ""
-    
+
     if not results_all:
         return ""
-    
+
     # Sort by score, deduplicate, take top 5
     results_all.sort(key=lambda x: x[1], reverse=True)
     seen = set()
@@ -841,8 +848,9 @@ async def _fetch_memory_context(
             unique.append(snippet)
         if len(unique) >= 5:
             break
-    
+
     return "\n---\n".join(unique)
+
 
 def _extract_caregiver_section(user_profile: str) -> str:
     """Extract caregiver-relevant notes from USER.md content."""
@@ -923,18 +931,11 @@ async def get_voice_context(request: Request):
                 )
                 if resp.status_code == 200:
                     file_list = resp.json().get("files", [])
-                    files = {
-                        f.get("name", f.get("filename", "")): f.get("content", "")
-                        for f in file_list
-                    }
-                    logger.info(
-                        f"[FLOW:VOICE-CONTEXT] Loaded {len(files)} workspace files "
-                        f"for agent={agent_id}"
-                    )
+                    files = {f.get("name", f.get("filename", "")): f.get("content", "") for f in file_list}
+                    logger.info(f"[FLOW:VOICE-CONTEXT] Loaded {len(files)} workspace files " f"for agent={agent_id}")
                 else:
                     logger.warning(
-                        f"[FLOW:VOICE-CONTEXT] Provision API returned "
-                        f"{resp.status_code} for agent={agent_id}"
+                        f"[FLOW:VOICE-CONTEXT] Provision API returned " f"{resp.status_code} for agent={agent_id}"
                     )
         except Exception as e:
             logger.warning(f"[FLOW:VOICE-CONTEXT] Provision API error: {e}")
@@ -963,6 +964,7 @@ async def get_voice_context(request: Request):
     memory_context = ""
     try:
         import asyncio as _aio
+
         conv_task = _aio.create_task(_fetch_recent_conversations(uid, limit=8))
         timeline_task = _aio.create_task(_fetch_recent_canonical_timeline(uid, limit=40, max_chars=9000))
         mem_task = _aio.create_task(
@@ -1009,7 +1011,7 @@ async def get_voice_context(request: Request):
         except Exception as _ve:
             logger.warning(f"[FLOW:VOICE-CONTEXT] Voice daily log read error: {_ve}")
     memory = files.get("MEMORY.md", "")[:500]
-    
+
     # Additional workspace files for richer context
     tools_md = files.get("TOOLS.md", "")[:500]  # Agent capabilities awareness
     shared_reports = ""
@@ -1058,33 +1060,34 @@ async def search_omi_conversations(request: Request):
     """
     Search OMI conversations for a user. Called by Grok voice proxy during live calls
     when the user asks to look up specific past conversations.
-    
+
     Body:
         uid (str): Firebase UID of the user
         query (str): Search terms (matched against title and overview)
         limit (int, optional): Max results (default: 5, max: 10)
-    
+
     Returns list of matching conversations with title, overview, and timestamp.
     """
     body = await request.json()
     uid = body.get("uid", "")
     query = body.get("query", "")
     limit = min(body.get("limit", 5), 10)
-    
+
     if not uid:
         raise HTTPException(status_code=400, detail="uid required")
     if not query:
         raise HTTPException(status_code=400, detail="query required")
-    
+
     logger.info(f"[FLOW:VOICE-SEARCH] uid={uid} query=\"{query}\" limit={limit}")
-    
+
     try:
         from google.cloud import firestore
+
         db = firestore.Client()
-        
+
         from datetime import datetime, timedelta
         import re as re_mod
-        
+
         # Parse date hints from query for date-range filtering
         now_local = _pacific_now()
         now_local = _pacific_now()
@@ -1092,12 +1095,12 @@ async def search_omi_conversations(request: Request):
         date_filter_start = None
         date_filter_end = None
         keyword_terms = []
-        
+
         query_lower = query.lower().strip()
-        
+
         # Date patterns: "march 8", "march 8th", "3/8", "yesterday", "last week", "today"
         date_parsed = False
-        
+
         if "yesterday" in query_lower:
             d = now - timedelta(days=1)
             date_filter_start = d.replace(hour=0, minute=0, second=0)
@@ -1122,15 +1125,34 @@ async def search_omi_conversations(request: Request):
         else:
             # Try "month day" pattern: "march 8", "march 8th", "mar 8"
             month_names = {
-                "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
-                "apr": 4, "april": 4, "may": 5, "jun": 6, "june": 6, "jul": 7, "july": 7,
-                "aug": 8, "august": 8, "sep": 9, "september": 9, "oct": 10, "october": 10,
-                "nov": 11, "november": 11, "dec": 12, "december": 12,
+                "jan": 1,
+                "january": 1,
+                "feb": 2,
+                "february": 2,
+                "mar": 3,
+                "march": 3,
+                "apr": 4,
+                "april": 4,
+                "may": 5,
+                "jun": 6,
+                "june": 6,
+                "jul": 7,
+                "july": 7,
+                "aug": 8,
+                "august": 8,
+                "sep": 9,
+                "september": 9,
+                "oct": 10,
+                "october": 10,
+                "nov": 11,
+                "november": 11,
+                "dec": 12,
+                "december": 12,
             }
             date_match = re_mod.search(
                 r"(january|february|march|april|may|june|july|august|september|october|november|december|"
                 r"jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)\s+(\d{1,2})(?:st|nd|rd|th)?",
-                query_lower
+                query_lower,
             )
             if date_match:
                 month_str = date_match.group(1)
@@ -1147,24 +1169,26 @@ async def search_omi_conversations(request: Request):
                         date_filter_end = target.replace(hour=23, minute=59, second=59)
                         date_parsed = True
                         # Remove date part from query for keyword matching
-                        remaining = query_lower[:date_match.start()] + query_lower[date_match.end():]
+                        remaining = query_lower[: date_match.start()] + query_lower[date_match.end() :]
                         keyword_terms = [t for t in remaining.split() if t]
                     except ValueError:
                         pass
-        
+
         if not date_parsed:
             keyword_terms = query_lower.split()
 
         keyword_terms = _expand_query_terms(_significant_query_terms(" ".join(keyword_terms)))
         keyword_terms = _normalized_query_terms(" ".join(keyword_terms))
-        
+
         logger.info(f"[FLOW:VOICE-SEARCH] date_filter={date_filter_start}->{date_filter_end}, keywords={keyword_terms}")
-        
+
         # Fetch conversations — use date filter if we have one, otherwise get last 100
         if date_filter_start and date_filter_end:
             # Firestore query with date range
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .where("created_at", ">=", date_filter_start)
                 .where("created_at", "<=", date_filter_end)
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
@@ -1172,29 +1196,31 @@ async def search_omi_conversations(request: Request):
             )
         else:
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
                 .limit(100)
             )
         convos = [doc.to_dict() for doc in convos_ref.stream()]
-        
+
         # Client-side keyword match (skip if only date search with no keywords)
         matches = []
-        
+
         for c in convos:
             structured = c.get("structured", {})
             title = (structured.get("title", "") or "").lower()
             overview = (structured.get("overview", "") or "").lower()
             category = (structured.get("category", "") or "").lower()
-            
+
             # Include formatted date in searchable text
             created = c.get("created_at")
             date_str = ""
             if created and hasattr(created, "strftime"):
                 date_str = created.strftime("%B %d %Y %b %A").lower()  # "march 18 2026 mar monday"
-            
+
             searchable = f"{title} {overview} {category} {date_str}"
-            
+
             if keyword_terms:
                 # Score: how many keyword terms match
                 score = _keyword_score(searchable, keyword_terms)
@@ -1203,11 +1229,11 @@ async def search_omi_conversations(request: Request):
             else:
                 # Date-only search — return all conversations from that date
                 matches.append((1, c))
-        
+
         # Sort by score (desc), then by recency
         matches.sort(key=lambda x: x[0], reverse=True)
         matches = matches[:limit]
-        
+
         results = []
         for score, c in matches:
             structured = c.get("structured", {})
@@ -1222,19 +1248,21 @@ async def search_omi_conversations(request: Request):
                     ts = created.strftime("%Y-%m-%d %I:%M %p")
                 else:
                     ts = str(created)[:16]
-            
-            results.append({
-                "title": structured.get("title", "Untitled"),
-                "overview": structured.get("overview", ""),
-                "emoji": structured.get("emoji", ""),
-                "category": structured.get("category", ""),
-                "timestamp": ts,
-                "score": score,
-            })
-        
+
+            results.append(
+                {
+                    "title": structured.get("title", "Untitled"),
+                    "overview": structured.get("overview", ""),
+                    "emoji": structured.get("emoji", ""),
+                    "category": structured.get("category", ""),
+                    "timestamp": ts,
+                    "score": score,
+                }
+            )
+
         logger.info(f"[FLOW:VOICE-SEARCH] Found {len(results)} matches for \"{query}\"")
         return {"results": results, "total_searched": len(convos), "query": query}
-    
+
     except Exception as e:
         logger.error(f"[FLOW:VOICE-SEARCH] Error: {e}")
         return {"results": [], "error": str(e), "query": query}
@@ -1249,21 +1277,53 @@ async def search_omi_conversations(request: Request):
 # Privacy policy: maps agent_role -> source -> access level
 # True = full access, False = no access, "own" = own data only, "full" = full
 SEARCH_POLICY = {
-    "user":      {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": "own"},
-    "caregiver": {"timeline": True, "workspace": True, "omi_full": False, "omi_meta": True, "memories": False, "voice": False, "scanner": "full"},
-    "scanner":   {"timeline": False, "workspace": False, "omi_full": False, "omi_meta": False, "memories": False, "voice": False, "scanner": False},
-    "voice":     {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": False},
+    "user": {
+        "timeline": True,
+        "workspace": True,
+        "omi_full": True,
+        "omi_meta": True,
+        "memories": True,
+        "voice": True,
+        "scanner": "own",
+    },
+    "caregiver": {
+        "timeline": True,
+        "workspace": True,
+        "omi_full": False,
+        "omi_meta": True,
+        "memories": False,
+        "voice": False,
+        "scanner": "full",
+    },
+    "scanner": {
+        "timeline": False,
+        "workspace": False,
+        "omi_full": False,
+        "omi_meta": False,
+        "memories": False,
+        "voice": False,
+        "scanner": False,
+    },
+    "voice": {
+        "timeline": True,
+        "workspace": True,
+        "omi_full": True,
+        "omi_meta": True,
+        "memories": True,
+        "voice": True,
+        "scanner": False,
+    },
 }
 
 # Which source keys map to which request-level source names
 _SOURCE_TO_POLICY_KEYS = {
-    "timeline":  ["timeline"],
-    "channel":   ["timeline"],
+    "timeline": ["timeline"],
+    "channel": ["timeline"],
     "workspace": ["workspace"],
-    "omi":       ["omi_full", "omi_meta"],
-    "memories":  ["memories"],
-    "voice":     ["voice"],
-    "scanner":   ["scanner"],
+    "omi": ["omi_full", "omi_meta"],
+    "memories": ["memories"],
+    "voice": ["voice"],
+    "scanner": ["scanner"],
 }
 
 
@@ -1371,14 +1431,66 @@ def _snippet_around_terms(text: str, terms: list, max_chars: int = 900) -> str:
 
 def _normalized_query_terms(query: str) -> list[str]:
     stop = {
-        "the", "a", "an", "and", "or", "to", "in", "on", "of", "for", "with",
-        "what", "where", "when", "who", "why", "how", "did", "do", "does", "i",
-        "me", "my", "you", "greg", "plato", "tell", "check", "latest", "recent",
-        "memory", "memories", "after", "before", "else", "went", "go", "this",
-        "omi", "conversation", "conversations", "transcript", "transcripts",
-        "summary", "summaries", "morning", "afternoon", "evening", "today",
-        "yesterday", "raw", "happened", "happen", "heard", "hear", "catch",
-        "caught", "find", "pull", "about",
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "to",
+        "in",
+        "on",
+        "of",
+        "for",
+        "with",
+        "what",
+        "where",
+        "when",
+        "who",
+        "why",
+        "how",
+        "did",
+        "do",
+        "does",
+        "i",
+        "me",
+        "my",
+        "you",
+        "greg",
+        "plato",
+        "tell",
+        "check",
+        "latest",
+        "recent",
+        "memory",
+        "memories",
+        "after",
+        "before",
+        "else",
+        "went",
+        "go",
+        "this",
+        "omi",
+        "conversation",
+        "conversations",
+        "transcript",
+        "transcripts",
+        "summary",
+        "summaries",
+        "morning",
+        "afternoon",
+        "evening",
+        "today",
+        "yesterday",
+        "raw",
+        "happened",
+        "happen",
+        "heard",
+        "hear",
+        "catch",
+        "caught",
+        "find",
+        "pull",
+        "about",
     }
     terms = [t.strip(".,?!:;()[]{}\"'’‘“”").lower() for t in query.split()]
     filtered = [t for t in terms if len(t) > 2 and t not in stop]
@@ -1389,14 +1501,66 @@ def _significant_query_terms(query: str) -> list[str]:
     """Return only evidence-bearing terms; unlike _normalized_query_terms,
     this may return an empty list for broad temporal questions."""
     stop = {
-        "the", "a", "an", "and", "or", "to", "in", "on", "of", "for", "with",
-        "what", "where", "when", "who", "why", "how", "did", "do", "does", "i",
-        "me", "my", "you", "greg", "plato", "tell", "check", "latest", "recent",
-        "memory", "memories", "after", "before", "else", "went", "go", "this",
-        "omi", "conversation", "conversations", "transcript", "transcripts",
-        "summary", "summaries", "morning", "afternoon", "evening", "today",
-        "yesterday", "raw", "happened", "happen", "heard", "hear", "catch",
-        "caught", "find", "pull", "about",
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "to",
+        "in",
+        "on",
+        "of",
+        "for",
+        "with",
+        "what",
+        "where",
+        "when",
+        "who",
+        "why",
+        "how",
+        "did",
+        "do",
+        "does",
+        "i",
+        "me",
+        "my",
+        "you",
+        "greg",
+        "plato",
+        "tell",
+        "check",
+        "latest",
+        "recent",
+        "memory",
+        "memories",
+        "after",
+        "before",
+        "else",
+        "went",
+        "go",
+        "this",
+        "omi",
+        "conversation",
+        "conversations",
+        "transcript",
+        "transcripts",
+        "summary",
+        "summaries",
+        "morning",
+        "afternoon",
+        "evening",
+        "today",
+        "yesterday",
+        "raw",
+        "happened",
+        "happen",
+        "heard",
+        "hear",
+        "catch",
+        "caught",
+        "find",
+        "pull",
+        "about",
     }
     terms = [t.strip(".,?!:;()[]{}\"'’‘“”").lower() for t in query.split()]
     return [t for t in terms if len(t) > 2 and t not in stop]
@@ -1552,20 +1716,26 @@ async def _search_canonical_timeline(uid: str, query: str, limit: int) -> list:
             ts = row["started_at"]
             ts_text = ts.strftime("%Y-%m-%d %I:%M %p") if ts else ""
             role_boost = 15 if role == "user" else 3
-            matches.append((score, ts or datetime.min, {
-                "source": "timeline",
-                "title": f"{channel} {role}".strip(),
-                "content": text[:700],
-                "timestamp": ts_text,
-                "score": score + role_boost,
-                "metadata": {
-                    "provenance": "canonical_event",
-                    "channel": channel,
-                    "provider": provider,
-                    "role": role,
-                    "session_id": row["session_id"] or "",
-                },
-            }))
+            matches.append(
+                (
+                    score,
+                    ts or datetime.min,
+                    {
+                        "source": "timeline",
+                        "title": f"{channel} {role}".strip(),
+                        "content": text[:700],
+                        "timestamp": ts_text,
+                        "score": score + role_boost,
+                        "metadata": {
+                            "provenance": "canonical_event",
+                            "channel": channel,
+                            "provider": provider,
+                            "role": role,
+                            "session_id": row["session_id"] or "",
+                        },
+                    },
+                )
+            )
         matches.sort(key=lambda x: (x[0], x[1]), reverse=True)
         return [m[2] for m in matches[:limit]]
     except Exception as e:
@@ -1606,21 +1776,23 @@ async def _search_voice_memory_pack(uid: str, query: str, limit: int) -> list:
         top = sources[0] if sources else {}
         confidence = data.get("confidence") or "medium"
         score = 120 if confidence == "high" else 70
-        return [{
-            "source": "voice_memory",
-            "title": top.get("title") or "Hermes Voice Memory",
-            "content": answer[:900],
-            "timestamp": top.get("timestamp") or "",
-            "score": score,
-            "metadata": {
-                "provenance": "hermes_voice_memory",
-                "path": data.get("path"),
-                "confidence": confidence,
-                "latency_ms": data.get("latency_ms"),
-                "source_ref": top.get("source_ref"),
-                "channel": top.get("channel"),
-            },
-        }]
+        return [
+            {
+                "source": "voice_memory",
+                "title": top.get("title") or "Hermes Voice Memory",
+                "content": answer[:900],
+                "timestamp": top.get("timestamp") or "",
+                "score": score,
+                "metadata": {
+                    "provenance": "hermes_voice_memory",
+                    "path": data.get("path"),
+                    "confidence": confidence,
+                    "latency_ms": data.get("latency_ms"),
+                    "source_ref": top.get("source_ref"),
+                    "channel": top.get("channel"),
+                },
+            }
+        ]
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-MEMORY] lookup error: {e}")
         return []
@@ -1698,21 +1870,21 @@ async def _search_workspace(uid: str, agent_id: str, query: str, limit: int) -> 
             if resp.status_code == 200:
                 data = resp.json()
                 for item in data.get("results", [])[:limit]:
-                    results.append({
-                        "source": "workspace",
-                        "title": item.get("file", ""),
-                        "content": (item.get("snippet", "") or item.get("content", ""))[:500],
-                        "timestamp": "",
-                        "score": item.get("score", 1),
-                        "metadata": {"provenance": "hermes_workspace_mirror", "file": item.get("file", "")},
-                    })
+                    results.append(
+                        {
+                            "source": "workspace",
+                            "title": item.get("file", ""),
+                            "content": (item.get("snippet", "") or item.get("content", ""))[:500],
+                            "timestamp": "",
+                            "score": item.get("score", 1),
+                            "metadata": {"provenance": "hermes_workspace_mirror", "file": item.get("file", "")},
+                        }
+                    )
                 return results
 
             # 404 = no search endpoint; fall back to reading key files
             if resp.status_code != 404:
-                logger.warning(
-                    f"[FLOW:UNIFIED-SEARCH] Provision search returned {resp.status_code}"
-                )
+                logger.warning(f"[FLOW:UNIFIED-SEARCH] Provision search returned {resp.status_code}")
                 return results
 
             # Fallback: read files list and grep
@@ -1744,14 +1916,16 @@ async def _search_workspace(uid: str, agent_id: str, query: str, limit: int) -> 
                     if not snippet:
                         snippet = content[:200]
 
-                    results.append({
-                        "source": "workspace",
-                        "title": fname,
-                        "content": snippet,
-                        "timestamp": "",
-                        "score": score,
-                        "metadata": {"provenance": "hermes_workspace_mirror", "file": fname},
-                    })
+                    results.append(
+                        {
+                            "source": "workspace",
+                            "title": fname,
+                            "content": snippet,
+                            "timestamp": "",
+                            "score": score,
+                            "metadata": {"provenance": "hermes_workspace_mirror", "file": fname},
+                        }
+                    )
 
             # Sort by score desc, limit
             results.sort(key=lambda x: x["score"], reverse=True)
@@ -1870,36 +2044,36 @@ async def _search_canonical_omi_events(uid: str, query: str, limit: int, full_ac
     for score, _started_sort, event, title, content in matches[:limit]:
         metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
         structured = metadata.get("structured") if isinstance(metadata.get("structured"), dict) else {}
-        results.append({
-            "source": "omi",
-            "title": title,
-            "content": content[:1400],
-            "timestamp": _canonical_event_timestamp(event),
-            "score": score + (55 if window_start else 45),
-            "metadata": {
-                "provenance": "canonical_event",
-                "fallback": False,
-                "event_id": event.get("event_id"),
-                "source_identity": event.get("source_identity"),
-                "channel": event.get("channel"),
-                "provider": event.get("provider"),
-                "emoji": structured.get("emoji", ""),
-                "category": structured.get("category", ""),
-                "time_window_applied": bool(window_start and window_end),
-                "time_window_start_utc": window_start.isoformat() if window_start else "",
-                "time_window_end_utc": window_end.isoformat() if window_end else "",
-                "timestamp_timezone": "America/Los_Angeles",
-            },
-        })
+        results.append(
+            {
+                "source": "omi",
+                "title": title,
+                "content": content[:1400],
+                "timestamp": _canonical_event_timestamp(event),
+                "score": score + (55 if window_start else 45),
+                "metadata": {
+                    "provenance": "canonical_event",
+                    "fallback": False,
+                    "event_id": event.get("event_id"),
+                    "source_identity": event.get("source_identity"),
+                    "channel": event.get("channel"),
+                    "provider": event.get("provider"),
+                    "emoji": structured.get("emoji", ""),
+                    "category": structured.get("category", ""),
+                    "time_window_applied": bool(window_start and window_end),
+                    "time_window_start_utc": window_start.isoformat() if window_start else "",
+                    "time_window_end_utc": window_end.isoformat() if window_end else "",
+                    "timestamp_timezone": "America/Los_Angeles",
+                },
+            }
+        )
     return results
 
 
 async def _search_omi_canonical_first(uid: str, query: str, limit: int, full_access: bool) -> list:
     canonical_results = await _search_canonical_omi_events(uid, query, limit, full_access)
     if canonical_results:
-        logger.info(
-            f"[FLOW:UNIFIED-SEARCH] uid={uid} omi_source=canonical_event results={len(canonical_results)}"
-        )
+        logger.info(f"[FLOW:UNIFIED-SEARCH] uid={uid} omi_source=canonical_event results={len(canonical_results)}")
         return canonical_results
 
     logger.warning(
@@ -1985,10 +2159,29 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             keyword_terms = [t for t in query_lower.replace("last month", "").split() if t]
         else:
             month_names = {
-                "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
-                "apr": 4, "april": 4, "may": 5, "jun": 6, "june": 6, "jul": 7, "july": 7,
-                "aug": 8, "august": 8, "sep": 9, "september": 9, "oct": 10, "october": 10,
-                "nov": 11, "november": 11, "dec": 12, "december": 12,
+                "jan": 1,
+                "january": 1,
+                "feb": 2,
+                "february": 2,
+                "mar": 3,
+                "march": 3,
+                "apr": 4,
+                "april": 4,
+                "may": 5,
+                "jun": 6,
+                "june": 6,
+                "jul": 7,
+                "july": 7,
+                "aug": 8,
+                "august": 8,
+                "sep": 9,
+                "september": 9,
+                "oct": 10,
+                "october": 10,
+                "nov": 11,
+                "november": 11,
+                "dec": 12,
+                "december": 12,
             }
             date_match = _re.search(
                 r"(january|february|march|april|may|june|july|august|september|october|"
@@ -2022,7 +2215,9 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
         # --- Firestore query ---
         if date_filter_start and date_filter_end:
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .where("created_at", ">=", date_filter_start)
                 .where("created_at", "<=", date_filter_end)
                 .order_by("created_at", direction=_fs.Query.DESCENDING)
@@ -2030,7 +2225,9 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             )
         else:
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .order_by("created_at", direction=_fs.Query.DESCENDING)
                 .limit(100)
             )
@@ -2099,21 +2296,23 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
                         + snippet
                     )[:1400]
 
-            results.append({
-                "source": "omi",
-                "title": structured.get("title", "Untitled"),
-                "content": overview_text,
-                "timestamp": ts,
-                "score": score + 18,
-                "metadata": {
-                    "provenance": "firestore_legacy_omi",
-                    "fallback": True,
-                    "emoji": structured.get("emoji", ""),
-                    "category": structured.get("category", ""),
-                    "has_transcript_detail": bool(transcript_text and full_access),
-                    "timestamp_timezone": "America/Los_Angeles",
-                },
-            })
+            results.append(
+                {
+                    "source": "omi",
+                    "title": structured.get("title", "Untitled"),
+                    "content": overview_text,
+                    "timestamp": ts,
+                    "score": score + 18,
+                    "metadata": {
+                        "provenance": "firestore_legacy_omi",
+                        "fallback": True,
+                        "emoji": structured.get("emoji", ""),
+                        "category": structured.get("category", ""),
+                        "has_transcript_detail": bool(transcript_text and full_access),
+                        "timestamp_timezone": "America/Los_Angeles",
+                    },
+                }
+            )
 
         return results
 
@@ -2136,7 +2335,9 @@ async def _search_memories(uid: str, query: str, limit: int) -> list:
 
         # Fetch recent memories sorted by scoring (same pattern as database/memories.py)
         memories_ref = (
-            db.collection("users").document(uid).collection("memories")
+            db.collection("users")
+            .document(uid)
+            .collection("memories")
             .order_by("scoring", direction=_fs.Query.DESCENDING)
             .order_by("created_at", direction=_fs.Query.DESCENDING)
             .limit(100)
@@ -2171,17 +2372,19 @@ async def _search_memories(uid: str, query: str, limit: int) -> list:
                     ts = str(created)[:16]
 
             display_content = mem.get("structured_memory", "") or mem.get("content", "")
-            results.append({
-                "source": "memories",
-                "title": (mem.get("category", "") or "Memory").title(),
-                "content": (display_content or "")[:500],
-                "timestamp": ts,
-                "score": score,
-                "metadata": {
-                    "category": mem.get("category", ""),
-                    "id": mem.get("id", ""),
-                },
-            })
+            results.append(
+                {
+                    "source": "memories",
+                    "title": (mem.get("category", "") or "Memory").title(),
+                    "content": (display_content or "")[:500],
+                    "timestamp": ts,
+                    "score": score,
+                    "metadata": {
+                        "category": mem.get("category", ""),
+                        "id": mem.get("id", ""),
+                    },
+                }
+            )
 
         return results
 
@@ -2251,14 +2454,16 @@ async def _search_voice_logs(uid: str, agent_id: str, query: str, limit: int) ->
                     if not snippet:
                         snippet = content[:200]
 
-                    results.append({
-                        "source": "voice",
-                        "title": fname,
-                        "content": snippet,
-                        "timestamp": fname.replace("voice/", "").replace(".md", ""),
-                        "score": score,
-                        "metadata": {"file": fname},
-                    })
+                    results.append(
+                        {
+                            "source": "voice",
+                            "title": fname,
+                            "content": snippet,
+                            "timestamp": fname.replace("voice/", "").replace(".md", ""),
+                            "score": score,
+                            "metadata": {"file": fname},
+                        }
+                    )
 
             results.sort(key=lambda x: x["score"], reverse=True)
             return results[:limit]
@@ -2328,19 +2533,24 @@ async def _search_scanner_logs(uid: str, query: str, limit: int, access_level: s
                     ts = row["created_at"].strftime("%Y-%m-%d %I:%M %p")
 
                 display_content = result_data.get("summary", row["transcript_preview"] or "")
-                matches.append((score, {
-                    "source": "scanner",
-                    "title": f"[{(row['urgency'] or 'info').upper()}] {row['category'] or 'alert'}",
-                    "content": (display_content or "")[:500],
-                    "timestamp": ts,
-                    "score": score,
-                    "metadata": {
-                        "category": row["category"] or "",
-                        "urgency": row["urgency"] or "",
-                        "escalated": row["escalated"],
-                        "id": str(row["id"]),
-                    },
-                }))
+                matches.append(
+                    (
+                        score,
+                        {
+                            "source": "scanner",
+                            "title": f"[{(row['urgency'] or 'info').upper()}] {row['category'] or 'alert'}",
+                            "content": (display_content or "")[:500],
+                            "timestamp": ts,
+                            "score": score,
+                            "metadata": {
+                                "category": row["category"] or "",
+                                "urgency": row["urgency"] or "",
+                                "escalated": row["escalated"],
+                                "id": str(row["id"]),
+                            },
+                        },
+                    )
+                )
 
         matches.sort(key=lambda x: x[0], reverse=True)
         return [m[1] for m in matches[:limit]]
@@ -2382,7 +2592,9 @@ async def unified_search(request: Request):
     if not query:
         raise HTTPException(status_code=400, detail="query required")
     if agent_role not in SEARCH_POLICY:
-        raise HTTPException(status_code=400, detail=f"Invalid agent_role: {agent_role}. Must be one of: {list(SEARCH_POLICY.keys())}")
+        raise HTTPException(
+            status_code=400, detail=f"Invalid agent_role: {agent_role}. Must be one of: {list(SEARCH_POLICY.keys())}"
+        )
 
     # Validate agent-uid association
     if not _validate_agent_uid(agent_id, uid):

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -73,6 +73,16 @@ HERMES_VOICE_MEMORY_TOKEN = os.getenv("HERMES_VOICE_MEMORY_TOKEN", PROVISION_API
 DEFAULT_GATEWAY_URL = os.getenv("OPENCLAW_URL", "http://100.76.138.56:19001")
 OPENCLAW_GATEWAY_TOKEN = os.getenv("OPENCLAW_GATEWAY_TOKEN", "")
 
+
+def isolated_voice_routing_enabled() -> bool:
+    """Keep isolated users off the legacy OpenClaw voice proxy until cutover."""
+    return os.getenv("ELLA_ISOLATED_VOICE_ROUTING_ENABLED", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
 # Database connection pool (lazy-initialized, shared pattern with other Ella routers)
 _pool: Optional[asyncpg.Pool] = None
 
@@ -414,6 +424,8 @@ async def create_voice_session(
             await resolve_isolated_runtime(uid)
         except ProvisioningError as exc:
             raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
+        if not isolated_voice_routing_enabled():
+            raise HTTPException(status_code=503, detail={"code": "isolated_voice_not_ready"})
 
     # Validate provider
     if provider not in V2V_PROVIDERS:

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -32,7 +32,7 @@ from fastapi.responses import Response
 from pydantic import BaseModel
 
 from database.conversations import _decrypt_conversation_data
-from ella.services.provisioning import ProvisioningError
+from ella.services.provisioning import ProvisioningError, rollout_enabled
 from ella.services.runtime_resolver import resolve_isolated_runtime, runtime_bindings_enabled
 from utils.ella.canonical_context import fetch_canonical_timeline
 from utils.other import endpoints as auth
@@ -72,6 +72,15 @@ HERMES_VOICE_MEMORY_URL = os.getenv("HERMES_VOICE_MEMORY_URL", "http://100.76.13
 HERMES_VOICE_MEMORY_TOKEN = os.getenv("HERMES_VOICE_MEMORY_TOKEN", PROVISION_API_TOKEN)
 DEFAULT_GATEWAY_URL = os.getenv("OPENCLAW_URL", "http://100.76.138.56:19001")
 OPENCLAW_GATEWAY_TOKEN = os.getenv("OPENCLAW_GATEWAY_TOKEN", "")
+
+
+def isolated_voice_routing_enabled(uid: Optional[str] = None) -> bool:
+    """Keep isolated users off the legacy OpenClaw voice proxy until cutover."""
+    return rollout_enabled(
+        "ELLA_ISOLATED_VOICE_ROUTING_ENABLED",
+        "ELLA_ISOLATED_VOICE_ROUTING_ENABLED_UIDS",
+        uid,
+    )
 
 # Database connection pool (lazy-initialized, shared pattern with other Ella routers)
 _pool: Optional[asyncpg.Pool] = None
@@ -444,7 +453,9 @@ async def create_voice_session(
     user_display_name = None
     try:
         pool = await _get_pool()
-        row = await pool.fetchrow("SELECT name FROM users WHERE omi_uid = $1", uid)
+        row = await pool.fetchrow(
+            "SELECT name FROM users WHERE omi_uid = $1", uid
+        )
         if row:
             user_display_name = row["name"]
     except Exception as e:
@@ -557,10 +568,7 @@ async def synthesize_speech(
                 )
             _elapsed = int((time.time() - _start) * 1000)
             if response.status_code != 200:
-                print(
-                    f"[FLOW:VOICE-TTS] ERROR provider={provider} status={response.status_code} latency={_elapsed}ms",
-                    flush=True,
-                )
+                print(f"[FLOW:VOICE-TTS] ERROR provider={provider} status={response.status_code} latency={_elapsed}ms", flush=True)
                 raise HTTPException(status_code=502, detail=f"ella-tts error: {response.status_code}")
             audio_size = len(response.content)
             print(f"[FLOW:VOICE-TTS] OK provider={provider} audio_bytes={audio_size} latency={_elapsed}ms", flush=True)
@@ -582,10 +590,7 @@ async def synthesize_speech(
             print(f"[FLOW:VOICE-TTS] ERROR provider=xai-tts key_missing=true", flush=True)
             raise HTTPException(status_code=500, detail="XAI_API_KEY not configured")
         voice_id = request.voice_id if request.voice_id != DEFAULT_ELEVENLABS_VOICE_ID else XAI_TTS_VOICE_ID
-        print(
-            f"[FLOW:VOICE-TTS] provider=xai-tts voice={voice_id} language={XAI_TTS_LANGUAGE} text_len={text_len}",
-            flush=True,
-        )
+        print(f"[FLOW:VOICE-TTS] provider=xai-tts voice={voice_id} language={XAI_TTS_LANGUAGE} text_len={text_len}", flush=True)
         try:
             async with httpx.AsyncClient() as client:
                 response = await client.post(
@@ -648,10 +653,7 @@ async def synthesize_speech(
     # --- Reject unknown providers (no silent fallbacks) ---
     if provider != "elevenlabs":
         print(f"[FLOW:VOICE-TTS] ERROR unknown provider={provider!r}", flush=True)
-        raise HTTPException(
-            status_code=400,
-            detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, xai-tts, grok-voice, gemini-live",
-        )
+        raise HTTPException(status_code=400, detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, xai-tts, grok-voice, gemini-live")
 
     # --- ElevenLabs ---
     if not ELEVENLABS_API_KEY:
@@ -680,17 +682,11 @@ async def synthesize_speech(
         _elapsed = int((time.time() - _start) * 1000)
 
         if response.status_code != 200:
-            print(
-                f"[FLOW:VOICE-TTS] ERROR provider=elevenlabs status={response.status_code} latency={_elapsed}ms body={response.text[:200]}",
-                flush=True,
-            )
+            print(f"[FLOW:VOICE-TTS] ERROR provider=elevenlabs status={response.status_code} latency={_elapsed}ms body={response.text[:200]}", flush=True)
             raise HTTPException(status_code=502, detail=f"ElevenLabs error: {response.status_code}")
 
         audio_size = len(response.content)
-        print(
-            f"[FLOW:VOICE-TTS] OK provider=elevenlabs voice={request.voice_id} audio_bytes={audio_size} latency={_elapsed}ms",
-            flush=True,
-        )
+        print(f"[FLOW:VOICE-TTS] OK provider=elevenlabs voice={request.voice_id} audio_bytes={audio_size} latency={_elapsed}ms", flush=True)
 
         return Response(content=response.content, media_type="audio/mpeg")
 
@@ -735,6 +731,8 @@ async def voice_health():
 # ============================================================================
 
 
+
+
 async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
     """Fetch recent OMI conversation summaries from Firestore for voice context.
     Returns formatted string of recent conversations (title + overview)."""
@@ -742,20 +740,17 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
         # Direct Firestore query — simpler than get_conversations() to avoid
         # composite index requirements (discarded + created_at needs index)
         from google.cloud import firestore
-
         db = firestore.Client()
         convos_ref = (
-            db.collection("users")
-            .document(uid)
-            .collection("conversations")
+            db.collection("users").document(uid).collection("conversations")
             .order_by("created_at", direction=firestore.Query.DESCENDING)
             .limit(limit)
         )
         convos = [doc.to_dict() for doc in convos_ref.stream()]
-
+        
         if not convos:
             return ""
-
+        
         parts = []
         for c in convos:
             structured = c.get("structured", {})
@@ -763,7 +758,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
             overview = structured.get("overview", "")
             emoji = structured.get("emoji", "")
             created = c.get("created_at")
-
+            
             # Format timestamp
             ts = ""
             if created:
@@ -771,7 +766,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
                     ts = created.strftime("%b %d %I:%M %p")
                 else:
                     ts = str(created)[:16]
-
+            
             entry = f"- {emoji} {title}"
             if overview:
                 # Truncate long overviews
@@ -780,7 +775,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
             if ts:
                 entry += f" ({ts})"
             parts.append(entry)
-
+        
         return "\n".join(parts)
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Conversation fetch failed: {e}")
@@ -797,15 +792,15 @@ async def _fetch_memory_context(
     Returns formatted string of relevant memory snippets."""
     if not gateway_token:
         return ""
-
+    
     headers = {
         "Authorization": f"Bearer {gateway_token}",
         "Content-Type": "application/json",
     }
-
+    
     results_all = []
     queries = [f"{user_name} recent activity today schedule important"]
-
+    
     try:
         async with httpx.AsyncClient(timeout=timeout_seconds) as client:
             for query in queries:
@@ -819,7 +814,6 @@ async def _fetch_memory_context(
                         data = resp.json()
                         if data.get("ok"):
                             import json as json_mod
-
                             results_text = data["result"]["content"][0]["text"]
                             results = json_mod.loads(results_text).get("results", [])
                             for r in results[:3]:
@@ -833,10 +827,10 @@ async def _fetch_memory_context(
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Memory context fetch failed: {e}")
         return ""
-
+    
     if not results_all:
         return ""
-
+    
     # Sort by score, deduplicate, take top 5
     results_all.sort(key=lambda x: x[1], reverse=True)
     seen = set()
@@ -848,9 +842,8 @@ async def _fetch_memory_context(
             unique.append(snippet)
         if len(unique) >= 5:
             break
-
+    
     return "\n---\n".join(unique)
-
 
 def _extract_caregiver_section(user_profile: str) -> str:
     """Extract caregiver-relevant notes from USER.md content."""
@@ -931,11 +924,18 @@ async def get_voice_context(request: Request):
                 )
                 if resp.status_code == 200:
                     file_list = resp.json().get("files", [])
-                    files = {f.get("name", f.get("filename", "")): f.get("content", "") for f in file_list}
-                    logger.info(f"[FLOW:VOICE-CONTEXT] Loaded {len(files)} workspace files " f"for agent={agent_id}")
+                    files = {
+                        f.get("name", f.get("filename", "")): f.get("content", "")
+                        for f in file_list
+                    }
+                    logger.info(
+                        f"[FLOW:VOICE-CONTEXT] Loaded {len(files)} workspace files "
+                        f"for agent={agent_id}"
+                    )
                 else:
                     logger.warning(
-                        f"[FLOW:VOICE-CONTEXT] Provision API returned " f"{resp.status_code} for agent={agent_id}"
+                        f"[FLOW:VOICE-CONTEXT] Provision API returned "
+                        f"{resp.status_code} for agent={agent_id}"
                     )
         except Exception as e:
             logger.warning(f"[FLOW:VOICE-CONTEXT] Provision API error: {e}")
@@ -964,7 +964,6 @@ async def get_voice_context(request: Request):
     memory_context = ""
     try:
         import asyncio as _aio
-
         conv_task = _aio.create_task(_fetch_recent_conversations(uid, limit=8))
         timeline_task = _aio.create_task(_fetch_recent_canonical_timeline(uid, limit=40, max_chars=9000))
         mem_task = _aio.create_task(
@@ -1011,7 +1010,7 @@ async def get_voice_context(request: Request):
         except Exception as _ve:
             logger.warning(f"[FLOW:VOICE-CONTEXT] Voice daily log read error: {_ve}")
     memory = files.get("MEMORY.md", "")[:500]
-
+    
     # Additional workspace files for richer context
     tools_md = files.get("TOOLS.md", "")[:500]  # Agent capabilities awareness
     shared_reports = ""
@@ -1060,34 +1059,33 @@ async def search_omi_conversations(request: Request):
     """
     Search OMI conversations for a user. Called by Grok voice proxy during live calls
     when the user asks to look up specific past conversations.
-
+    
     Body:
         uid (str): Firebase UID of the user
         query (str): Search terms (matched against title and overview)
         limit (int, optional): Max results (default: 5, max: 10)
-
+    
     Returns list of matching conversations with title, overview, and timestamp.
     """
     body = await request.json()
     uid = body.get("uid", "")
     query = body.get("query", "")
     limit = min(body.get("limit", 5), 10)
-
+    
     if not uid:
         raise HTTPException(status_code=400, detail="uid required")
     if not query:
         raise HTTPException(status_code=400, detail="query required")
-
+    
     logger.info(f"[FLOW:VOICE-SEARCH] uid={uid} query=\"{query}\" limit={limit}")
-
+    
     try:
         from google.cloud import firestore
-
         db = firestore.Client()
-
+        
         from datetime import datetime, timedelta
         import re as re_mod
-
+        
         # Parse date hints from query for date-range filtering
         now_local = _pacific_now()
         now_local = _pacific_now()
@@ -1095,12 +1093,12 @@ async def search_omi_conversations(request: Request):
         date_filter_start = None
         date_filter_end = None
         keyword_terms = []
-
+        
         query_lower = query.lower().strip()
-
+        
         # Date patterns: "march 8", "march 8th", "3/8", "yesterday", "last week", "today"
         date_parsed = False
-
+        
         if "yesterday" in query_lower:
             d = now - timedelta(days=1)
             date_filter_start = d.replace(hour=0, minute=0, second=0)
@@ -1125,34 +1123,15 @@ async def search_omi_conversations(request: Request):
         else:
             # Try "month day" pattern: "march 8", "march 8th", "mar 8"
             month_names = {
-                "jan": 1,
-                "january": 1,
-                "feb": 2,
-                "february": 2,
-                "mar": 3,
-                "march": 3,
-                "apr": 4,
-                "april": 4,
-                "may": 5,
-                "jun": 6,
-                "june": 6,
-                "jul": 7,
-                "july": 7,
-                "aug": 8,
-                "august": 8,
-                "sep": 9,
-                "september": 9,
-                "oct": 10,
-                "october": 10,
-                "nov": 11,
-                "november": 11,
-                "dec": 12,
-                "december": 12,
+                "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
+                "apr": 4, "april": 4, "may": 5, "jun": 6, "june": 6, "jul": 7, "july": 7,
+                "aug": 8, "august": 8, "sep": 9, "september": 9, "oct": 10, "october": 10,
+                "nov": 11, "november": 11, "dec": 12, "december": 12,
             }
             date_match = re_mod.search(
                 r"(january|february|march|april|may|june|july|august|september|october|november|december|"
                 r"jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)\s+(\d{1,2})(?:st|nd|rd|th)?",
-                query_lower,
+                query_lower
             )
             if date_match:
                 month_str = date_match.group(1)
@@ -1169,26 +1148,24 @@ async def search_omi_conversations(request: Request):
                         date_filter_end = target.replace(hour=23, minute=59, second=59)
                         date_parsed = True
                         # Remove date part from query for keyword matching
-                        remaining = query_lower[: date_match.start()] + query_lower[date_match.end() :]
+                        remaining = query_lower[:date_match.start()] + query_lower[date_match.end():]
                         keyword_terms = [t for t in remaining.split() if t]
                     except ValueError:
                         pass
-
+        
         if not date_parsed:
             keyword_terms = query_lower.split()
 
         keyword_terms = _expand_query_terms(_significant_query_terms(" ".join(keyword_terms)))
         keyword_terms = _normalized_query_terms(" ".join(keyword_terms))
-
+        
         logger.info(f"[FLOW:VOICE-SEARCH] date_filter={date_filter_start}->{date_filter_end}, keywords={keyword_terms}")
-
+        
         # Fetch conversations — use date filter if we have one, otherwise get last 100
         if date_filter_start and date_filter_end:
             # Firestore query with date range
             convos_ref = (
-                db.collection("users")
-                .document(uid)
-                .collection("conversations")
+                db.collection("users").document(uid).collection("conversations")
                 .where("created_at", ">=", date_filter_start)
                 .where("created_at", "<=", date_filter_end)
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
@@ -1196,31 +1173,29 @@ async def search_omi_conversations(request: Request):
             )
         else:
             convos_ref = (
-                db.collection("users")
-                .document(uid)
-                .collection("conversations")
+                db.collection("users").document(uid).collection("conversations")
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
                 .limit(100)
             )
         convos = [doc.to_dict() for doc in convos_ref.stream()]
-
+        
         # Client-side keyword match (skip if only date search with no keywords)
         matches = []
-
+        
         for c in convos:
             structured = c.get("structured", {})
             title = (structured.get("title", "") or "").lower()
             overview = (structured.get("overview", "") or "").lower()
             category = (structured.get("category", "") or "").lower()
-
+            
             # Include formatted date in searchable text
             created = c.get("created_at")
             date_str = ""
             if created and hasattr(created, "strftime"):
                 date_str = created.strftime("%B %d %Y %b %A").lower()  # "march 18 2026 mar monday"
-
+            
             searchable = f"{title} {overview} {category} {date_str}"
-
+            
             if keyword_terms:
                 # Score: how many keyword terms match
                 score = _keyword_score(searchable, keyword_terms)
@@ -1229,11 +1204,11 @@ async def search_omi_conversations(request: Request):
             else:
                 # Date-only search — return all conversations from that date
                 matches.append((1, c))
-
+        
         # Sort by score (desc), then by recency
         matches.sort(key=lambda x: x[0], reverse=True)
         matches = matches[:limit]
-
+        
         results = []
         for score, c in matches:
             structured = c.get("structured", {})
@@ -1248,21 +1223,19 @@ async def search_omi_conversations(request: Request):
                     ts = created.strftime("%Y-%m-%d %I:%M %p")
                 else:
                     ts = str(created)[:16]
-
-            results.append(
-                {
-                    "title": structured.get("title", "Untitled"),
-                    "overview": structured.get("overview", ""),
-                    "emoji": structured.get("emoji", ""),
-                    "category": structured.get("category", ""),
-                    "timestamp": ts,
-                    "score": score,
-                }
-            )
-
+            
+            results.append({
+                "title": structured.get("title", "Untitled"),
+                "overview": structured.get("overview", ""),
+                "emoji": structured.get("emoji", ""),
+                "category": structured.get("category", ""),
+                "timestamp": ts,
+                "score": score,
+            })
+        
         logger.info(f"[FLOW:VOICE-SEARCH] Found {len(results)} matches for \"{query}\"")
         return {"results": results, "total_searched": len(convos), "query": query}
-
+    
     except Exception as e:
         logger.error(f"[FLOW:VOICE-SEARCH] Error: {e}")
         return {"results": [], "error": str(e), "query": query}
@@ -1277,53 +1250,21 @@ async def search_omi_conversations(request: Request):
 # Privacy policy: maps agent_role -> source -> access level
 # True = full access, False = no access, "own" = own data only, "full" = full
 SEARCH_POLICY = {
-    "user": {
-        "timeline": True,
-        "workspace": True,
-        "omi_full": True,
-        "omi_meta": True,
-        "memories": True,
-        "voice": True,
-        "scanner": "own",
-    },
-    "caregiver": {
-        "timeline": True,
-        "workspace": True,
-        "omi_full": False,
-        "omi_meta": True,
-        "memories": False,
-        "voice": False,
-        "scanner": "full",
-    },
-    "scanner": {
-        "timeline": False,
-        "workspace": False,
-        "omi_full": False,
-        "omi_meta": False,
-        "memories": False,
-        "voice": False,
-        "scanner": False,
-    },
-    "voice": {
-        "timeline": True,
-        "workspace": True,
-        "omi_full": True,
-        "omi_meta": True,
-        "memories": True,
-        "voice": True,
-        "scanner": False,
-    },
+    "user":      {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": "own"},
+    "caregiver": {"timeline": True, "workspace": True, "omi_full": False, "omi_meta": True, "memories": False, "voice": False, "scanner": "full"},
+    "scanner":   {"timeline": False, "workspace": False, "omi_full": False, "omi_meta": False, "memories": False, "voice": False, "scanner": False},
+    "voice":     {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": False},
 }
 
 # Which source keys map to which request-level source names
 _SOURCE_TO_POLICY_KEYS = {
-    "timeline": ["timeline"],
-    "channel": ["timeline"],
+    "timeline":  ["timeline"],
+    "channel":   ["timeline"],
     "workspace": ["workspace"],
-    "omi": ["omi_full", "omi_meta"],
-    "memories": ["memories"],
-    "voice": ["voice"],
-    "scanner": ["scanner"],
+    "omi":       ["omi_full", "omi_meta"],
+    "memories":  ["memories"],
+    "voice":     ["voice"],
+    "scanner":   ["scanner"],
 }
 
 
@@ -1431,66 +1372,14 @@ def _snippet_around_terms(text: str, terms: list, max_chars: int = 900) -> str:
 
 def _normalized_query_terms(query: str) -> list[str]:
     stop = {
-        "the",
-        "a",
-        "an",
-        "and",
-        "or",
-        "to",
-        "in",
-        "on",
-        "of",
-        "for",
-        "with",
-        "what",
-        "where",
-        "when",
-        "who",
-        "why",
-        "how",
-        "did",
-        "do",
-        "does",
-        "i",
-        "me",
-        "my",
-        "you",
-        "greg",
-        "plato",
-        "tell",
-        "check",
-        "latest",
-        "recent",
-        "memory",
-        "memories",
-        "after",
-        "before",
-        "else",
-        "went",
-        "go",
-        "this",
-        "omi",
-        "conversation",
-        "conversations",
-        "transcript",
-        "transcripts",
-        "summary",
-        "summaries",
-        "morning",
-        "afternoon",
-        "evening",
-        "today",
-        "yesterday",
-        "raw",
-        "happened",
-        "happen",
-        "heard",
-        "hear",
-        "catch",
-        "caught",
-        "find",
-        "pull",
-        "about",
+        "the", "a", "an", "and", "or", "to", "in", "on", "of", "for", "with",
+        "what", "where", "when", "who", "why", "how", "did", "do", "does", "i",
+        "me", "my", "you", "greg", "plato", "tell", "check", "latest", "recent",
+        "memory", "memories", "after", "before", "else", "went", "go", "this",
+        "omi", "conversation", "conversations", "transcript", "transcripts",
+        "summary", "summaries", "morning", "afternoon", "evening", "today",
+        "yesterday", "raw", "happened", "happen", "heard", "hear", "catch",
+        "caught", "find", "pull", "about",
     }
     terms = [t.strip(".,?!:;()[]{}\"'’‘“”").lower() for t in query.split()]
     filtered = [t for t in terms if len(t) > 2 and t not in stop]
@@ -1501,66 +1390,14 @@ def _significant_query_terms(query: str) -> list[str]:
     """Return only evidence-bearing terms; unlike _normalized_query_terms,
     this may return an empty list for broad temporal questions."""
     stop = {
-        "the",
-        "a",
-        "an",
-        "and",
-        "or",
-        "to",
-        "in",
-        "on",
-        "of",
-        "for",
-        "with",
-        "what",
-        "where",
-        "when",
-        "who",
-        "why",
-        "how",
-        "did",
-        "do",
-        "does",
-        "i",
-        "me",
-        "my",
-        "you",
-        "greg",
-        "plato",
-        "tell",
-        "check",
-        "latest",
-        "recent",
-        "memory",
-        "memories",
-        "after",
-        "before",
-        "else",
-        "went",
-        "go",
-        "this",
-        "omi",
-        "conversation",
-        "conversations",
-        "transcript",
-        "transcripts",
-        "summary",
-        "summaries",
-        "morning",
-        "afternoon",
-        "evening",
-        "today",
-        "yesterday",
-        "raw",
-        "happened",
-        "happen",
-        "heard",
-        "hear",
-        "catch",
-        "caught",
-        "find",
-        "pull",
-        "about",
+        "the", "a", "an", "and", "or", "to", "in", "on", "of", "for", "with",
+        "what", "where", "when", "who", "why", "how", "did", "do", "does", "i",
+        "me", "my", "you", "greg", "plato", "tell", "check", "latest", "recent",
+        "memory", "memories", "after", "before", "else", "went", "go", "this",
+        "omi", "conversation", "conversations", "transcript", "transcripts",
+        "summary", "summaries", "morning", "afternoon", "evening", "today",
+        "yesterday", "raw", "happened", "happen", "heard", "hear", "catch",
+        "caught", "find", "pull", "about",
     }
     terms = [t.strip(".,?!:;()[]{}\"'’‘“”").lower() for t in query.split()]
     return [t for t in terms if len(t) > 2 and t not in stop]
@@ -1716,26 +1553,20 @@ async def _search_canonical_timeline(uid: str, query: str, limit: int) -> list:
             ts = row["started_at"]
             ts_text = ts.strftime("%Y-%m-%d %I:%M %p") if ts else ""
             role_boost = 15 if role == "user" else 3
-            matches.append(
-                (
-                    score,
-                    ts or datetime.min,
-                    {
-                        "source": "timeline",
-                        "title": f"{channel} {role}".strip(),
-                        "content": text[:700],
-                        "timestamp": ts_text,
-                        "score": score + role_boost,
-                        "metadata": {
-                            "provenance": "canonical_event",
-                            "channel": channel,
-                            "provider": provider,
-                            "role": role,
-                            "session_id": row["session_id"] or "",
-                        },
-                    },
-                )
-            )
+            matches.append((score, ts or datetime.min, {
+                "source": "timeline",
+                "title": f"{channel} {role}".strip(),
+                "content": text[:700],
+                "timestamp": ts_text,
+                "score": score + role_boost,
+                "metadata": {
+                    "provenance": "canonical_event",
+                    "channel": channel,
+                    "provider": provider,
+                    "role": role,
+                    "session_id": row["session_id"] or "",
+                },
+            }))
         matches.sort(key=lambda x: (x[0], x[1]), reverse=True)
         return [m[2] for m in matches[:limit]]
     except Exception as e:
@@ -1776,23 +1607,21 @@ async def _search_voice_memory_pack(uid: str, query: str, limit: int) -> list:
         top = sources[0] if sources else {}
         confidence = data.get("confidence") or "medium"
         score = 120 if confidence == "high" else 70
-        return [
-            {
-                "source": "voice_memory",
-                "title": top.get("title") or "Hermes Voice Memory",
-                "content": answer[:900],
-                "timestamp": top.get("timestamp") or "",
-                "score": score,
-                "metadata": {
-                    "provenance": "hermes_voice_memory",
-                    "path": data.get("path"),
-                    "confidence": confidence,
-                    "latency_ms": data.get("latency_ms"),
-                    "source_ref": top.get("source_ref"),
-                    "channel": top.get("channel"),
-                },
-            }
-        ]
+        return [{
+            "source": "voice_memory",
+            "title": top.get("title") or "Hermes Voice Memory",
+            "content": answer[:900],
+            "timestamp": top.get("timestamp") or "",
+            "score": score,
+            "metadata": {
+                "provenance": "hermes_voice_memory",
+                "path": data.get("path"),
+                "confidence": confidence,
+                "latency_ms": data.get("latency_ms"),
+                "source_ref": top.get("source_ref"),
+                "channel": top.get("channel"),
+            },
+        }]
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-MEMORY] lookup error: {e}")
         return []
@@ -1870,21 +1699,21 @@ async def _search_workspace(uid: str, agent_id: str, query: str, limit: int) -> 
             if resp.status_code == 200:
                 data = resp.json()
                 for item in data.get("results", [])[:limit]:
-                    results.append(
-                        {
-                            "source": "workspace",
-                            "title": item.get("file", ""),
-                            "content": (item.get("snippet", "") or item.get("content", ""))[:500],
-                            "timestamp": "",
-                            "score": item.get("score", 1),
-                            "metadata": {"provenance": "hermes_workspace_mirror", "file": item.get("file", "")},
-                        }
-                    )
+                    results.append({
+                        "source": "workspace",
+                        "title": item.get("file", ""),
+                        "content": (item.get("snippet", "") or item.get("content", ""))[:500],
+                        "timestamp": "",
+                        "score": item.get("score", 1),
+                        "metadata": {"provenance": "hermes_workspace_mirror", "file": item.get("file", "")},
+                    })
                 return results
 
             # 404 = no search endpoint; fall back to reading key files
             if resp.status_code != 404:
-                logger.warning(f"[FLOW:UNIFIED-SEARCH] Provision search returned {resp.status_code}")
+                logger.warning(
+                    f"[FLOW:UNIFIED-SEARCH] Provision search returned {resp.status_code}"
+                )
                 return results
 
             # Fallback: read files list and grep
@@ -1916,16 +1745,14 @@ async def _search_workspace(uid: str, agent_id: str, query: str, limit: int) -> 
                     if not snippet:
                         snippet = content[:200]
 
-                    results.append(
-                        {
-                            "source": "workspace",
-                            "title": fname,
-                            "content": snippet,
-                            "timestamp": "",
-                            "score": score,
-                            "metadata": {"provenance": "hermes_workspace_mirror", "file": fname},
-                        }
-                    )
+                    results.append({
+                        "source": "workspace",
+                        "title": fname,
+                        "content": snippet,
+                        "timestamp": "",
+                        "score": score,
+                        "metadata": {"provenance": "hermes_workspace_mirror", "file": fname},
+                    })
 
             # Sort by score desc, limit
             results.sort(key=lambda x: x["score"], reverse=True)
@@ -2044,36 +1871,36 @@ async def _search_canonical_omi_events(uid: str, query: str, limit: int, full_ac
     for score, _started_sort, event, title, content in matches[:limit]:
         metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
         structured = metadata.get("structured") if isinstance(metadata.get("structured"), dict) else {}
-        results.append(
-            {
-                "source": "omi",
-                "title": title,
-                "content": content[:1400],
-                "timestamp": _canonical_event_timestamp(event),
-                "score": score + (55 if window_start else 45),
-                "metadata": {
-                    "provenance": "canonical_event",
-                    "fallback": False,
-                    "event_id": event.get("event_id"),
-                    "source_identity": event.get("source_identity"),
-                    "channel": event.get("channel"),
-                    "provider": event.get("provider"),
-                    "emoji": structured.get("emoji", ""),
-                    "category": structured.get("category", ""),
-                    "time_window_applied": bool(window_start and window_end),
-                    "time_window_start_utc": window_start.isoformat() if window_start else "",
-                    "time_window_end_utc": window_end.isoformat() if window_end else "",
-                    "timestamp_timezone": "America/Los_Angeles",
-                },
-            }
-        )
+        results.append({
+            "source": "omi",
+            "title": title,
+            "content": content[:1400],
+            "timestamp": _canonical_event_timestamp(event),
+            "score": score + (55 if window_start else 45),
+            "metadata": {
+                "provenance": "canonical_event",
+                "fallback": False,
+                "event_id": event.get("event_id"),
+                "source_identity": event.get("source_identity"),
+                "channel": event.get("channel"),
+                "provider": event.get("provider"),
+                "emoji": structured.get("emoji", ""),
+                "category": structured.get("category", ""),
+                "time_window_applied": bool(window_start and window_end),
+                "time_window_start_utc": window_start.isoformat() if window_start else "",
+                "time_window_end_utc": window_end.isoformat() if window_end else "",
+                "timestamp_timezone": "America/Los_Angeles",
+            },
+        })
     return results
 
 
 async def _search_omi_canonical_first(uid: str, query: str, limit: int, full_access: bool) -> list:
     canonical_results = await _search_canonical_omi_events(uid, query, limit, full_access)
     if canonical_results:
-        logger.info(f"[FLOW:UNIFIED-SEARCH] uid={uid} omi_source=canonical_event results={len(canonical_results)}")
+        logger.info(
+            f"[FLOW:UNIFIED-SEARCH] uid={uid} omi_source=canonical_event results={len(canonical_results)}"
+        )
         return canonical_results
 
     logger.warning(
@@ -2159,29 +1986,10 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             keyword_terms = [t for t in query_lower.replace("last month", "").split() if t]
         else:
             month_names = {
-                "jan": 1,
-                "january": 1,
-                "feb": 2,
-                "february": 2,
-                "mar": 3,
-                "march": 3,
-                "apr": 4,
-                "april": 4,
-                "may": 5,
-                "jun": 6,
-                "june": 6,
-                "jul": 7,
-                "july": 7,
-                "aug": 8,
-                "august": 8,
-                "sep": 9,
-                "september": 9,
-                "oct": 10,
-                "october": 10,
-                "nov": 11,
-                "november": 11,
-                "dec": 12,
-                "december": 12,
+                "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
+                "apr": 4, "april": 4, "may": 5, "jun": 6, "june": 6, "jul": 7, "july": 7,
+                "aug": 8, "august": 8, "sep": 9, "september": 9, "oct": 10, "october": 10,
+                "nov": 11, "november": 11, "dec": 12, "december": 12,
             }
             date_match = _re.search(
                 r"(january|february|march|april|may|june|july|august|september|october|"
@@ -2215,9 +2023,7 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
         # --- Firestore query ---
         if date_filter_start and date_filter_end:
             convos_ref = (
-                db.collection("users")
-                .document(uid)
-                .collection("conversations")
+                db.collection("users").document(uid).collection("conversations")
                 .where("created_at", ">=", date_filter_start)
                 .where("created_at", "<=", date_filter_end)
                 .order_by("created_at", direction=_fs.Query.DESCENDING)
@@ -2225,9 +2031,7 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             )
         else:
             convos_ref = (
-                db.collection("users")
-                .document(uid)
-                .collection("conversations")
+                db.collection("users").document(uid).collection("conversations")
                 .order_by("created_at", direction=_fs.Query.DESCENDING)
                 .limit(100)
             )
@@ -2296,23 +2100,21 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
                         + snippet
                     )[:1400]
 
-            results.append(
-                {
-                    "source": "omi",
-                    "title": structured.get("title", "Untitled"),
-                    "content": overview_text,
-                    "timestamp": ts,
-                    "score": score + 18,
-                    "metadata": {
-                        "provenance": "firestore_legacy_omi",
-                        "fallback": True,
-                        "emoji": structured.get("emoji", ""),
-                        "category": structured.get("category", ""),
-                        "has_transcript_detail": bool(transcript_text and full_access),
-                        "timestamp_timezone": "America/Los_Angeles",
-                    },
-                }
-            )
+            results.append({
+                "source": "omi",
+                "title": structured.get("title", "Untitled"),
+                "content": overview_text,
+                "timestamp": ts,
+                "score": score + 18,
+                "metadata": {
+                    "provenance": "firestore_legacy_omi",
+                    "fallback": True,
+                    "emoji": structured.get("emoji", ""),
+                    "category": structured.get("category", ""),
+                    "has_transcript_detail": bool(transcript_text and full_access),
+                    "timestamp_timezone": "America/Los_Angeles",
+                },
+            })
 
         return results
 
@@ -2335,9 +2137,7 @@ async def _search_memories(uid: str, query: str, limit: int) -> list:
 
         # Fetch recent memories sorted by scoring (same pattern as database/memories.py)
         memories_ref = (
-            db.collection("users")
-            .document(uid)
-            .collection("memories")
+            db.collection("users").document(uid).collection("memories")
             .order_by("scoring", direction=_fs.Query.DESCENDING)
             .order_by("created_at", direction=_fs.Query.DESCENDING)
             .limit(100)
@@ -2372,19 +2172,17 @@ async def _search_memories(uid: str, query: str, limit: int) -> list:
                     ts = str(created)[:16]
 
             display_content = mem.get("structured_memory", "") or mem.get("content", "")
-            results.append(
-                {
-                    "source": "memories",
-                    "title": (mem.get("category", "") or "Memory").title(),
-                    "content": (display_content or "")[:500],
-                    "timestamp": ts,
-                    "score": score,
-                    "metadata": {
-                        "category": mem.get("category", ""),
-                        "id": mem.get("id", ""),
-                    },
-                }
-            )
+            results.append({
+                "source": "memories",
+                "title": (mem.get("category", "") or "Memory").title(),
+                "content": (display_content or "")[:500],
+                "timestamp": ts,
+                "score": score,
+                "metadata": {
+                    "category": mem.get("category", ""),
+                    "id": mem.get("id", ""),
+                },
+            })
 
         return results
 
@@ -2454,16 +2252,14 @@ async def _search_voice_logs(uid: str, agent_id: str, query: str, limit: int) ->
                     if not snippet:
                         snippet = content[:200]
 
-                    results.append(
-                        {
-                            "source": "voice",
-                            "title": fname,
-                            "content": snippet,
-                            "timestamp": fname.replace("voice/", "").replace(".md", ""),
-                            "score": score,
-                            "metadata": {"file": fname},
-                        }
-                    )
+                    results.append({
+                        "source": "voice",
+                        "title": fname,
+                        "content": snippet,
+                        "timestamp": fname.replace("voice/", "").replace(".md", ""),
+                        "score": score,
+                        "metadata": {"file": fname},
+                    })
 
             results.sort(key=lambda x: x["score"], reverse=True)
             return results[:limit]
@@ -2533,24 +2329,19 @@ async def _search_scanner_logs(uid: str, query: str, limit: int, access_level: s
                     ts = row["created_at"].strftime("%Y-%m-%d %I:%M %p")
 
                 display_content = result_data.get("summary", row["transcript_preview"] or "")
-                matches.append(
-                    (
-                        score,
-                        {
-                            "source": "scanner",
-                            "title": f"[{(row['urgency'] or 'info').upper()}] {row['category'] or 'alert'}",
-                            "content": (display_content or "")[:500],
-                            "timestamp": ts,
-                            "score": score,
-                            "metadata": {
-                                "category": row["category"] or "",
-                                "urgency": row["urgency"] or "",
-                                "escalated": row["escalated"],
-                                "id": str(row["id"]),
-                            },
-                        },
-                    )
-                )
+                matches.append((score, {
+                    "source": "scanner",
+                    "title": f"[{(row['urgency'] or 'info').upper()}] {row['category'] or 'alert'}",
+                    "content": (display_content or "")[:500],
+                    "timestamp": ts,
+                    "score": score,
+                    "metadata": {
+                        "category": row["category"] or "",
+                        "urgency": row["urgency"] or "",
+                        "escalated": row["escalated"],
+                        "id": str(row["id"]),
+                    },
+                }))
 
         matches.sort(key=lambda x: x[0], reverse=True)
         return [m[1] for m in matches[:limit]]
@@ -2592,9 +2383,7 @@ async def unified_search(request: Request):
     if not query:
         raise HTTPException(status_code=400, detail="query required")
     if agent_role not in SEARCH_POLICY:
-        raise HTTPException(
-            status_code=400, detail=f"Invalid agent_role: {agent_role}. Must be one of: {list(SEARCH_POLICY.keys())}"
-        )
+        raise HTTPException(status_code=400, detail=f"Invalid agent_role: {agent_role}. Must be one of: {list(SEARCH_POLICY.keys())}")
 
     # Validate agent-uid association
     if not _validate_agent_uid(agent_id, uid):

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -32,7 +32,10 @@ from fastapi.responses import Response
 from pydantic import BaseModel
 
 from database.conversations import _decrypt_conversation_data
+from ella.services.provisioning import ProvisioningError
+from ella.services.runtime_resolver import resolve_isolated_runtime, runtime_bindings_enabled
 from utils.ella.canonical_context import fetch_canonical_timeline
+from utils.other import endpoints as auth
 
 # JWT handling
 try:
@@ -142,7 +145,7 @@ V2V_PROVIDERS = {
 class VoiceSessionRequest(BaseModel):
     """Request for creating a V2V voice session."""
 
-    uid: str
+    uid: Optional[str] = None
     provider: str = "grok-voice"
     voice_mode: Optional[str] = None
 
@@ -371,6 +374,7 @@ async def create_voice_session(
     uid: Optional[str] = None,
     provider: Optional[str] = None,
     voice_mode: Optional[str] = None,
+    authenticated_uid: str = Depends(auth.get_current_user_uid),
 ):
     """
     Create a voice session token for connecting to V2V service.
@@ -398,12 +402,18 @@ async def create_voice_session(
         audio_format: Required audio configuration
     """
     # Merge body and query params (body takes priority)
-    uid = (body.uid if body else None) or uid
+    requested_uid = (body.uid if body else None) or uid
+    if requested_uid and requested_uid != authenticated_uid:
+        raise HTTPException(status_code=403, detail={"code": "ownership_mismatch"})
+    uid = authenticated_uid
     provider = (body.provider if body else None) or provider or "grok-voice"
     voice_mode = (body.voice_mode if body else None) or voice_mode
 
-    if not uid:
-        raise HTTPException(status_code=400, detail="uid required")
+    if runtime_bindings_enabled():
+        try:
+            await resolve_isolated_runtime(uid)
+        except ProvisioningError as exc:
+            raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
 
     # Validate provider
     if provider not in V2V_PROVIDERS:
@@ -431,9 +441,7 @@ async def create_voice_session(
     user_display_name = None
     try:
         pool = await _get_pool()
-        row = await pool.fetchrow(
-            "SELECT name FROM users WHERE omi_uid = $1", uid
-        )
+        row = await pool.fetchrow("SELECT name FROM users WHERE omi_uid = $1", uid)
         if row:
             user_display_name = row["name"]
     except Exception as e:
@@ -546,7 +554,10 @@ async def synthesize_speech(
                 )
             _elapsed = int((time.time() - _start) * 1000)
             if response.status_code != 200:
-                print(f"[FLOW:VOICE-TTS] ERROR provider={provider} status={response.status_code} latency={_elapsed}ms", flush=True)
+                print(
+                    f"[FLOW:VOICE-TTS] ERROR provider={provider} status={response.status_code} latency={_elapsed}ms",
+                    flush=True,
+                )
                 raise HTTPException(status_code=502, detail=f"ella-tts error: {response.status_code}")
             audio_size = len(response.content)
             print(f"[FLOW:VOICE-TTS] OK provider={provider} audio_bytes={audio_size} latency={_elapsed}ms", flush=True)
@@ -568,7 +579,10 @@ async def synthesize_speech(
             print(f"[FLOW:VOICE-TTS] ERROR provider=xai-tts key_missing=true", flush=True)
             raise HTTPException(status_code=500, detail="XAI_API_KEY not configured")
         voice_id = request.voice_id if request.voice_id != DEFAULT_ELEVENLABS_VOICE_ID else XAI_TTS_VOICE_ID
-        print(f"[FLOW:VOICE-TTS] provider=xai-tts voice={voice_id} language={XAI_TTS_LANGUAGE} text_len={text_len}", flush=True)
+        print(
+            f"[FLOW:VOICE-TTS] provider=xai-tts voice={voice_id} language={XAI_TTS_LANGUAGE} text_len={text_len}",
+            flush=True,
+        )
         try:
             async with httpx.AsyncClient() as client:
                 response = await client.post(
@@ -631,7 +645,10 @@ async def synthesize_speech(
     # --- Reject unknown providers (no silent fallbacks) ---
     if provider != "elevenlabs":
         print(f"[FLOW:VOICE-TTS] ERROR unknown provider={provider!r}", flush=True)
-        raise HTTPException(status_code=400, detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, xai-tts, grok-voice, gemini-live")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, xai-tts, grok-voice, gemini-live",
+        )
 
     # --- ElevenLabs ---
     if not ELEVENLABS_API_KEY:
@@ -660,11 +677,17 @@ async def synthesize_speech(
         _elapsed = int((time.time() - _start) * 1000)
 
         if response.status_code != 200:
-            print(f"[FLOW:VOICE-TTS] ERROR provider=elevenlabs status={response.status_code} latency={_elapsed}ms body={response.text[:200]}", flush=True)
+            print(
+                f"[FLOW:VOICE-TTS] ERROR provider=elevenlabs status={response.status_code} latency={_elapsed}ms body={response.text[:200]}",
+                flush=True,
+            )
             raise HTTPException(status_code=502, detail=f"ElevenLabs error: {response.status_code}")
 
         audio_size = len(response.content)
-        print(f"[FLOW:VOICE-TTS] OK provider=elevenlabs voice={request.voice_id} audio_bytes={audio_size} latency={_elapsed}ms", flush=True)
+        print(
+            f"[FLOW:VOICE-TTS] OK provider=elevenlabs voice={request.voice_id} audio_bytes={audio_size} latency={_elapsed}ms",
+            flush=True,
+        )
 
         return Response(content=response.content, media_type="audio/mpeg")
 
@@ -709,8 +732,6 @@ async def voice_health():
 # ============================================================================
 
 
-
-
 async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
     """Fetch recent OMI conversation summaries from Firestore for voice context.
     Returns formatted string of recent conversations (title + overview)."""
@@ -718,17 +739,20 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
         # Direct Firestore query — simpler than get_conversations() to avoid
         # composite index requirements (discarded + created_at needs index)
         from google.cloud import firestore
+
         db = firestore.Client()
         convos_ref = (
-            db.collection("users").document(uid).collection("conversations")
+            db.collection("users")
+            .document(uid)
+            .collection("conversations")
             .order_by("created_at", direction=firestore.Query.DESCENDING)
             .limit(limit)
         )
         convos = [doc.to_dict() for doc in convos_ref.stream()]
-        
+
         if not convos:
             return ""
-        
+
         parts = []
         for c in convos:
             structured = c.get("structured", {})
@@ -736,7 +760,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
             overview = structured.get("overview", "")
             emoji = structured.get("emoji", "")
             created = c.get("created_at")
-            
+
             # Format timestamp
             ts = ""
             if created:
@@ -744,7 +768,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
                     ts = created.strftime("%b %d %I:%M %p")
                 else:
                     ts = str(created)[:16]
-            
+
             entry = f"- {emoji} {title}"
             if overview:
                 # Truncate long overviews
@@ -753,7 +777,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
             if ts:
                 entry += f" ({ts})"
             parts.append(entry)
-        
+
         return "\n".join(parts)
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Conversation fetch failed: {e}")
@@ -770,15 +794,15 @@ async def _fetch_memory_context(
     Returns formatted string of relevant memory snippets."""
     if not gateway_token:
         return ""
-    
+
     headers = {
         "Authorization": f"Bearer {gateway_token}",
         "Content-Type": "application/json",
     }
-    
+
     results_all = []
     queries = [f"{user_name} recent activity today schedule important"]
-    
+
     try:
         async with httpx.AsyncClient(timeout=timeout_seconds) as client:
             for query in queries:
@@ -792,6 +816,7 @@ async def _fetch_memory_context(
                         data = resp.json()
                         if data.get("ok"):
                             import json as json_mod
+
                             results_text = data["result"]["content"][0]["text"]
                             results = json_mod.loads(results_text).get("results", [])
                             for r in results[:3]:
@@ -805,10 +830,10 @@ async def _fetch_memory_context(
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Memory context fetch failed: {e}")
         return ""
-    
+
     if not results_all:
         return ""
-    
+
     # Sort by score, deduplicate, take top 5
     results_all.sort(key=lambda x: x[1], reverse=True)
     seen = set()
@@ -820,8 +845,9 @@ async def _fetch_memory_context(
             unique.append(snippet)
         if len(unique) >= 5:
             break
-    
+
     return "\n---\n".join(unique)
+
 
 def _extract_caregiver_section(user_profile: str) -> str:
     """Extract caregiver-relevant notes from USER.md content."""
@@ -902,18 +928,11 @@ async def get_voice_context(request: Request):
                 )
                 if resp.status_code == 200:
                     file_list = resp.json().get("files", [])
-                    files = {
-                        f.get("name", f.get("filename", "")): f.get("content", "")
-                        for f in file_list
-                    }
-                    logger.info(
-                        f"[FLOW:VOICE-CONTEXT] Loaded {len(files)} workspace files "
-                        f"for agent={agent_id}"
-                    )
+                    files = {f.get("name", f.get("filename", "")): f.get("content", "") for f in file_list}
+                    logger.info(f"[FLOW:VOICE-CONTEXT] Loaded {len(files)} workspace files " f"for agent={agent_id}")
                 else:
                     logger.warning(
-                        f"[FLOW:VOICE-CONTEXT] Provision API returned "
-                        f"{resp.status_code} for agent={agent_id}"
+                        f"[FLOW:VOICE-CONTEXT] Provision API returned " f"{resp.status_code} for agent={agent_id}"
                     )
         except Exception as e:
             logger.warning(f"[FLOW:VOICE-CONTEXT] Provision API error: {e}")
@@ -942,6 +961,7 @@ async def get_voice_context(request: Request):
     memory_context = ""
     try:
         import asyncio as _aio
+
         conv_task = _aio.create_task(_fetch_recent_conversations(uid, limit=8))
         timeline_task = _aio.create_task(_fetch_recent_canonical_timeline(uid, limit=40, max_chars=9000))
         mem_task = _aio.create_task(
@@ -988,7 +1008,7 @@ async def get_voice_context(request: Request):
         except Exception as _ve:
             logger.warning(f"[FLOW:VOICE-CONTEXT] Voice daily log read error: {_ve}")
     memory = files.get("MEMORY.md", "")[:500]
-    
+
     # Additional workspace files for richer context
     tools_md = files.get("TOOLS.md", "")[:500]  # Agent capabilities awareness
     shared_reports = ""
@@ -1037,33 +1057,34 @@ async def search_omi_conversations(request: Request):
     """
     Search OMI conversations for a user. Called by Grok voice proxy during live calls
     when the user asks to look up specific past conversations.
-    
+
     Body:
         uid (str): Firebase UID of the user
         query (str): Search terms (matched against title and overview)
         limit (int, optional): Max results (default: 5, max: 10)
-    
+
     Returns list of matching conversations with title, overview, and timestamp.
     """
     body = await request.json()
     uid = body.get("uid", "")
     query = body.get("query", "")
     limit = min(body.get("limit", 5), 10)
-    
+
     if not uid:
         raise HTTPException(status_code=400, detail="uid required")
     if not query:
         raise HTTPException(status_code=400, detail="query required")
-    
+
     logger.info(f"[FLOW:VOICE-SEARCH] uid={uid} query=\"{query}\" limit={limit}")
-    
+
     try:
         from google.cloud import firestore
+
         db = firestore.Client()
-        
+
         from datetime import datetime, timedelta
         import re as re_mod
-        
+
         # Parse date hints from query for date-range filtering
         now_local = _pacific_now()
         now_local = _pacific_now()
@@ -1071,12 +1092,12 @@ async def search_omi_conversations(request: Request):
         date_filter_start = None
         date_filter_end = None
         keyword_terms = []
-        
+
         query_lower = query.lower().strip()
-        
+
         # Date patterns: "march 8", "march 8th", "3/8", "yesterday", "last week", "today"
         date_parsed = False
-        
+
         if "yesterday" in query_lower:
             d = now - timedelta(days=1)
             date_filter_start = d.replace(hour=0, minute=0, second=0)
@@ -1101,15 +1122,34 @@ async def search_omi_conversations(request: Request):
         else:
             # Try "month day" pattern: "march 8", "march 8th", "mar 8"
             month_names = {
-                "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
-                "apr": 4, "april": 4, "may": 5, "jun": 6, "june": 6, "jul": 7, "july": 7,
-                "aug": 8, "august": 8, "sep": 9, "september": 9, "oct": 10, "october": 10,
-                "nov": 11, "november": 11, "dec": 12, "december": 12,
+                "jan": 1,
+                "january": 1,
+                "feb": 2,
+                "february": 2,
+                "mar": 3,
+                "march": 3,
+                "apr": 4,
+                "april": 4,
+                "may": 5,
+                "jun": 6,
+                "june": 6,
+                "jul": 7,
+                "july": 7,
+                "aug": 8,
+                "august": 8,
+                "sep": 9,
+                "september": 9,
+                "oct": 10,
+                "october": 10,
+                "nov": 11,
+                "november": 11,
+                "dec": 12,
+                "december": 12,
             }
             date_match = re_mod.search(
                 r"(january|february|march|april|may|june|july|august|september|october|november|december|"
                 r"jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)\s+(\d{1,2})(?:st|nd|rd|th)?",
-                query_lower
+                query_lower,
             )
             if date_match:
                 month_str = date_match.group(1)
@@ -1126,24 +1166,26 @@ async def search_omi_conversations(request: Request):
                         date_filter_end = target.replace(hour=23, minute=59, second=59)
                         date_parsed = True
                         # Remove date part from query for keyword matching
-                        remaining = query_lower[:date_match.start()] + query_lower[date_match.end():]
+                        remaining = query_lower[: date_match.start()] + query_lower[date_match.end() :]
                         keyword_terms = [t for t in remaining.split() if t]
                     except ValueError:
                         pass
-        
+
         if not date_parsed:
             keyword_terms = query_lower.split()
 
         keyword_terms = _expand_query_terms(_significant_query_terms(" ".join(keyword_terms)))
         keyword_terms = _normalized_query_terms(" ".join(keyword_terms))
-        
+
         logger.info(f"[FLOW:VOICE-SEARCH] date_filter={date_filter_start}->{date_filter_end}, keywords={keyword_terms}")
-        
+
         # Fetch conversations — use date filter if we have one, otherwise get last 100
         if date_filter_start and date_filter_end:
             # Firestore query with date range
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .where("created_at", ">=", date_filter_start)
                 .where("created_at", "<=", date_filter_end)
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
@@ -1151,29 +1193,31 @@ async def search_omi_conversations(request: Request):
             )
         else:
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
                 .limit(100)
             )
         convos = [doc.to_dict() for doc in convos_ref.stream()]
-        
+
         # Client-side keyword match (skip if only date search with no keywords)
         matches = []
-        
+
         for c in convos:
             structured = c.get("structured", {})
             title = (structured.get("title", "") or "").lower()
             overview = (structured.get("overview", "") or "").lower()
             category = (structured.get("category", "") or "").lower()
-            
+
             # Include formatted date in searchable text
             created = c.get("created_at")
             date_str = ""
             if created and hasattr(created, "strftime"):
                 date_str = created.strftime("%B %d %Y %b %A").lower()  # "march 18 2026 mar monday"
-            
+
             searchable = f"{title} {overview} {category} {date_str}"
-            
+
             if keyword_terms:
                 # Score: how many keyword terms match
                 score = _keyword_score(searchable, keyword_terms)
@@ -1182,11 +1226,11 @@ async def search_omi_conversations(request: Request):
             else:
                 # Date-only search — return all conversations from that date
                 matches.append((1, c))
-        
+
         # Sort by score (desc), then by recency
         matches.sort(key=lambda x: x[0], reverse=True)
         matches = matches[:limit]
-        
+
         results = []
         for score, c in matches:
             structured = c.get("structured", {})
@@ -1201,19 +1245,21 @@ async def search_omi_conversations(request: Request):
                     ts = created.strftime("%Y-%m-%d %I:%M %p")
                 else:
                     ts = str(created)[:16]
-            
-            results.append({
-                "title": structured.get("title", "Untitled"),
-                "overview": structured.get("overview", ""),
-                "emoji": structured.get("emoji", ""),
-                "category": structured.get("category", ""),
-                "timestamp": ts,
-                "score": score,
-            })
-        
+
+            results.append(
+                {
+                    "title": structured.get("title", "Untitled"),
+                    "overview": structured.get("overview", ""),
+                    "emoji": structured.get("emoji", ""),
+                    "category": structured.get("category", ""),
+                    "timestamp": ts,
+                    "score": score,
+                }
+            )
+
         logger.info(f"[FLOW:VOICE-SEARCH] Found {len(results)} matches for \"{query}\"")
         return {"results": results, "total_searched": len(convos), "query": query}
-    
+
     except Exception as e:
         logger.error(f"[FLOW:VOICE-SEARCH] Error: {e}")
         return {"results": [], "error": str(e), "query": query}
@@ -1228,21 +1274,53 @@ async def search_omi_conversations(request: Request):
 # Privacy policy: maps agent_role -> source -> access level
 # True = full access, False = no access, "own" = own data only, "full" = full
 SEARCH_POLICY = {
-    "user":      {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": "own"},
-    "caregiver": {"timeline": True, "workspace": True, "omi_full": False, "omi_meta": True, "memories": False, "voice": False, "scanner": "full"},
-    "scanner":   {"timeline": False, "workspace": False, "omi_full": False, "omi_meta": False, "memories": False, "voice": False, "scanner": False},
-    "voice":     {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": False},
+    "user": {
+        "timeline": True,
+        "workspace": True,
+        "omi_full": True,
+        "omi_meta": True,
+        "memories": True,
+        "voice": True,
+        "scanner": "own",
+    },
+    "caregiver": {
+        "timeline": True,
+        "workspace": True,
+        "omi_full": False,
+        "omi_meta": True,
+        "memories": False,
+        "voice": False,
+        "scanner": "full",
+    },
+    "scanner": {
+        "timeline": False,
+        "workspace": False,
+        "omi_full": False,
+        "omi_meta": False,
+        "memories": False,
+        "voice": False,
+        "scanner": False,
+    },
+    "voice": {
+        "timeline": True,
+        "workspace": True,
+        "omi_full": True,
+        "omi_meta": True,
+        "memories": True,
+        "voice": True,
+        "scanner": False,
+    },
 }
 
 # Which source keys map to which request-level source names
 _SOURCE_TO_POLICY_KEYS = {
-    "timeline":  ["timeline"],
-    "channel":   ["timeline"],
+    "timeline": ["timeline"],
+    "channel": ["timeline"],
     "workspace": ["workspace"],
-    "omi":       ["omi_full", "omi_meta"],
-    "memories":  ["memories"],
-    "voice":     ["voice"],
-    "scanner":   ["scanner"],
+    "omi": ["omi_full", "omi_meta"],
+    "memories": ["memories"],
+    "voice": ["voice"],
+    "scanner": ["scanner"],
 }
 
 
@@ -1350,14 +1428,66 @@ def _snippet_around_terms(text: str, terms: list, max_chars: int = 900) -> str:
 
 def _normalized_query_terms(query: str) -> list[str]:
     stop = {
-        "the", "a", "an", "and", "or", "to", "in", "on", "of", "for", "with",
-        "what", "where", "when", "who", "why", "how", "did", "do", "does", "i",
-        "me", "my", "you", "greg", "plato", "tell", "check", "latest", "recent",
-        "memory", "memories", "after", "before", "else", "went", "go", "this",
-        "omi", "conversation", "conversations", "transcript", "transcripts",
-        "summary", "summaries", "morning", "afternoon", "evening", "today",
-        "yesterday", "raw", "happened", "happen", "heard", "hear", "catch",
-        "caught", "find", "pull", "about",
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "to",
+        "in",
+        "on",
+        "of",
+        "for",
+        "with",
+        "what",
+        "where",
+        "when",
+        "who",
+        "why",
+        "how",
+        "did",
+        "do",
+        "does",
+        "i",
+        "me",
+        "my",
+        "you",
+        "greg",
+        "plato",
+        "tell",
+        "check",
+        "latest",
+        "recent",
+        "memory",
+        "memories",
+        "after",
+        "before",
+        "else",
+        "went",
+        "go",
+        "this",
+        "omi",
+        "conversation",
+        "conversations",
+        "transcript",
+        "transcripts",
+        "summary",
+        "summaries",
+        "morning",
+        "afternoon",
+        "evening",
+        "today",
+        "yesterday",
+        "raw",
+        "happened",
+        "happen",
+        "heard",
+        "hear",
+        "catch",
+        "caught",
+        "find",
+        "pull",
+        "about",
     }
     terms = [t.strip(".,?!:;()[]{}\"'’‘“”").lower() for t in query.split()]
     filtered = [t for t in terms if len(t) > 2 and t not in stop]
@@ -1368,14 +1498,66 @@ def _significant_query_terms(query: str) -> list[str]:
     """Return only evidence-bearing terms; unlike _normalized_query_terms,
     this may return an empty list for broad temporal questions."""
     stop = {
-        "the", "a", "an", "and", "or", "to", "in", "on", "of", "for", "with",
-        "what", "where", "when", "who", "why", "how", "did", "do", "does", "i",
-        "me", "my", "you", "greg", "plato", "tell", "check", "latest", "recent",
-        "memory", "memories", "after", "before", "else", "went", "go", "this",
-        "omi", "conversation", "conversations", "transcript", "transcripts",
-        "summary", "summaries", "morning", "afternoon", "evening", "today",
-        "yesterday", "raw", "happened", "happen", "heard", "hear", "catch",
-        "caught", "find", "pull", "about",
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "to",
+        "in",
+        "on",
+        "of",
+        "for",
+        "with",
+        "what",
+        "where",
+        "when",
+        "who",
+        "why",
+        "how",
+        "did",
+        "do",
+        "does",
+        "i",
+        "me",
+        "my",
+        "you",
+        "greg",
+        "plato",
+        "tell",
+        "check",
+        "latest",
+        "recent",
+        "memory",
+        "memories",
+        "after",
+        "before",
+        "else",
+        "went",
+        "go",
+        "this",
+        "omi",
+        "conversation",
+        "conversations",
+        "transcript",
+        "transcripts",
+        "summary",
+        "summaries",
+        "morning",
+        "afternoon",
+        "evening",
+        "today",
+        "yesterday",
+        "raw",
+        "happened",
+        "happen",
+        "heard",
+        "hear",
+        "catch",
+        "caught",
+        "find",
+        "pull",
+        "about",
     }
     terms = [t.strip(".,?!:;()[]{}\"'’‘“”").lower() for t in query.split()]
     return [t for t in terms if len(t) > 2 and t not in stop]
@@ -1531,20 +1713,26 @@ async def _search_canonical_timeline(uid: str, query: str, limit: int) -> list:
             ts = row["started_at"]
             ts_text = ts.strftime("%Y-%m-%d %I:%M %p") if ts else ""
             role_boost = 15 if role == "user" else 3
-            matches.append((score, ts or datetime.min, {
-                "source": "timeline",
-                "title": f"{channel} {role}".strip(),
-                "content": text[:700],
-                "timestamp": ts_text,
-                "score": score + role_boost,
-                "metadata": {
-                    "provenance": "canonical_event",
-                    "channel": channel,
-                    "provider": provider,
-                    "role": role,
-                    "session_id": row["session_id"] or "",
-                },
-            }))
+            matches.append(
+                (
+                    score,
+                    ts or datetime.min,
+                    {
+                        "source": "timeline",
+                        "title": f"{channel} {role}".strip(),
+                        "content": text[:700],
+                        "timestamp": ts_text,
+                        "score": score + role_boost,
+                        "metadata": {
+                            "provenance": "canonical_event",
+                            "channel": channel,
+                            "provider": provider,
+                            "role": role,
+                            "session_id": row["session_id"] or "",
+                        },
+                    },
+                )
+            )
         matches.sort(key=lambda x: (x[0], x[1]), reverse=True)
         return [m[2] for m in matches[:limit]]
     except Exception as e:
@@ -1585,21 +1773,23 @@ async def _search_voice_memory_pack(uid: str, query: str, limit: int) -> list:
         top = sources[0] if sources else {}
         confidence = data.get("confidence") or "medium"
         score = 120 if confidence == "high" else 70
-        return [{
-            "source": "voice_memory",
-            "title": top.get("title") or "Hermes Voice Memory",
-            "content": answer[:900],
-            "timestamp": top.get("timestamp") or "",
-            "score": score,
-            "metadata": {
-                "provenance": "hermes_voice_memory",
-                "path": data.get("path"),
-                "confidence": confidence,
-                "latency_ms": data.get("latency_ms"),
-                "source_ref": top.get("source_ref"),
-                "channel": top.get("channel"),
-            },
-        }]
+        return [
+            {
+                "source": "voice_memory",
+                "title": top.get("title") or "Hermes Voice Memory",
+                "content": answer[:900],
+                "timestamp": top.get("timestamp") or "",
+                "score": score,
+                "metadata": {
+                    "provenance": "hermes_voice_memory",
+                    "path": data.get("path"),
+                    "confidence": confidence,
+                    "latency_ms": data.get("latency_ms"),
+                    "source_ref": top.get("source_ref"),
+                    "channel": top.get("channel"),
+                },
+            }
+        ]
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-MEMORY] lookup error: {e}")
         return []
@@ -1677,21 +1867,21 @@ async def _search_workspace(uid: str, agent_id: str, query: str, limit: int) -> 
             if resp.status_code == 200:
                 data = resp.json()
                 for item in data.get("results", [])[:limit]:
-                    results.append({
-                        "source": "workspace",
-                        "title": item.get("file", ""),
-                        "content": (item.get("snippet", "") or item.get("content", ""))[:500],
-                        "timestamp": "",
-                        "score": item.get("score", 1),
-                        "metadata": {"provenance": "hermes_workspace_mirror", "file": item.get("file", "")},
-                    })
+                    results.append(
+                        {
+                            "source": "workspace",
+                            "title": item.get("file", ""),
+                            "content": (item.get("snippet", "") or item.get("content", ""))[:500],
+                            "timestamp": "",
+                            "score": item.get("score", 1),
+                            "metadata": {"provenance": "hermes_workspace_mirror", "file": item.get("file", "")},
+                        }
+                    )
                 return results
 
             # 404 = no search endpoint; fall back to reading key files
             if resp.status_code != 404:
-                logger.warning(
-                    f"[FLOW:UNIFIED-SEARCH] Provision search returned {resp.status_code}"
-                )
+                logger.warning(f"[FLOW:UNIFIED-SEARCH] Provision search returned {resp.status_code}")
                 return results
 
             # Fallback: read files list and grep
@@ -1723,14 +1913,16 @@ async def _search_workspace(uid: str, agent_id: str, query: str, limit: int) -> 
                     if not snippet:
                         snippet = content[:200]
 
-                    results.append({
-                        "source": "workspace",
-                        "title": fname,
-                        "content": snippet,
-                        "timestamp": "",
-                        "score": score,
-                        "metadata": {"provenance": "hermes_workspace_mirror", "file": fname},
-                    })
+                    results.append(
+                        {
+                            "source": "workspace",
+                            "title": fname,
+                            "content": snippet,
+                            "timestamp": "",
+                            "score": score,
+                            "metadata": {"provenance": "hermes_workspace_mirror", "file": fname},
+                        }
+                    )
 
             # Sort by score desc, limit
             results.sort(key=lambda x: x["score"], reverse=True)
@@ -1849,36 +2041,36 @@ async def _search_canonical_omi_events(uid: str, query: str, limit: int, full_ac
     for score, _started_sort, event, title, content in matches[:limit]:
         metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
         structured = metadata.get("structured") if isinstance(metadata.get("structured"), dict) else {}
-        results.append({
-            "source": "omi",
-            "title": title,
-            "content": content[:1400],
-            "timestamp": _canonical_event_timestamp(event),
-            "score": score + (55 if window_start else 45),
-            "metadata": {
-                "provenance": "canonical_event",
-                "fallback": False,
-                "event_id": event.get("event_id"),
-                "source_identity": event.get("source_identity"),
-                "channel": event.get("channel"),
-                "provider": event.get("provider"),
-                "emoji": structured.get("emoji", ""),
-                "category": structured.get("category", ""),
-                "time_window_applied": bool(window_start and window_end),
-                "time_window_start_utc": window_start.isoformat() if window_start else "",
-                "time_window_end_utc": window_end.isoformat() if window_end else "",
-                "timestamp_timezone": "America/Los_Angeles",
-            },
-        })
+        results.append(
+            {
+                "source": "omi",
+                "title": title,
+                "content": content[:1400],
+                "timestamp": _canonical_event_timestamp(event),
+                "score": score + (55 if window_start else 45),
+                "metadata": {
+                    "provenance": "canonical_event",
+                    "fallback": False,
+                    "event_id": event.get("event_id"),
+                    "source_identity": event.get("source_identity"),
+                    "channel": event.get("channel"),
+                    "provider": event.get("provider"),
+                    "emoji": structured.get("emoji", ""),
+                    "category": structured.get("category", ""),
+                    "time_window_applied": bool(window_start and window_end),
+                    "time_window_start_utc": window_start.isoformat() if window_start else "",
+                    "time_window_end_utc": window_end.isoformat() if window_end else "",
+                    "timestamp_timezone": "America/Los_Angeles",
+                },
+            }
+        )
     return results
 
 
 async def _search_omi_canonical_first(uid: str, query: str, limit: int, full_access: bool) -> list:
     canonical_results = await _search_canonical_omi_events(uid, query, limit, full_access)
     if canonical_results:
-        logger.info(
-            f"[FLOW:UNIFIED-SEARCH] uid={uid} omi_source=canonical_event results={len(canonical_results)}"
-        )
+        logger.info(f"[FLOW:UNIFIED-SEARCH] uid={uid} omi_source=canonical_event results={len(canonical_results)}")
         return canonical_results
 
     logger.warning(
@@ -1964,10 +2156,29 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             keyword_terms = [t for t in query_lower.replace("last month", "").split() if t]
         else:
             month_names = {
-                "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
-                "apr": 4, "april": 4, "may": 5, "jun": 6, "june": 6, "jul": 7, "july": 7,
-                "aug": 8, "august": 8, "sep": 9, "september": 9, "oct": 10, "october": 10,
-                "nov": 11, "november": 11, "dec": 12, "december": 12,
+                "jan": 1,
+                "january": 1,
+                "feb": 2,
+                "february": 2,
+                "mar": 3,
+                "march": 3,
+                "apr": 4,
+                "april": 4,
+                "may": 5,
+                "jun": 6,
+                "june": 6,
+                "jul": 7,
+                "july": 7,
+                "aug": 8,
+                "august": 8,
+                "sep": 9,
+                "september": 9,
+                "oct": 10,
+                "october": 10,
+                "nov": 11,
+                "november": 11,
+                "dec": 12,
+                "december": 12,
             }
             date_match = _re.search(
                 r"(january|february|march|april|may|june|july|august|september|october|"
@@ -2001,7 +2212,9 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
         # --- Firestore query ---
         if date_filter_start and date_filter_end:
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .where("created_at", ">=", date_filter_start)
                 .where("created_at", "<=", date_filter_end)
                 .order_by("created_at", direction=_fs.Query.DESCENDING)
@@ -2009,7 +2222,9 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             )
         else:
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .order_by("created_at", direction=_fs.Query.DESCENDING)
                 .limit(100)
             )
@@ -2078,21 +2293,23 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
                         + snippet
                     )[:1400]
 
-            results.append({
-                "source": "omi",
-                "title": structured.get("title", "Untitled"),
-                "content": overview_text,
-                "timestamp": ts,
-                "score": score + 18,
-                "metadata": {
-                    "provenance": "firestore_legacy_omi",
-                    "fallback": True,
-                    "emoji": structured.get("emoji", ""),
-                    "category": structured.get("category", ""),
-                    "has_transcript_detail": bool(transcript_text and full_access),
-                    "timestamp_timezone": "America/Los_Angeles",
-                },
-            })
+            results.append(
+                {
+                    "source": "omi",
+                    "title": structured.get("title", "Untitled"),
+                    "content": overview_text,
+                    "timestamp": ts,
+                    "score": score + 18,
+                    "metadata": {
+                        "provenance": "firestore_legacy_omi",
+                        "fallback": True,
+                        "emoji": structured.get("emoji", ""),
+                        "category": structured.get("category", ""),
+                        "has_transcript_detail": bool(transcript_text and full_access),
+                        "timestamp_timezone": "America/Los_Angeles",
+                    },
+                }
+            )
 
         return results
 
@@ -2115,7 +2332,9 @@ async def _search_memories(uid: str, query: str, limit: int) -> list:
 
         # Fetch recent memories sorted by scoring (same pattern as database/memories.py)
         memories_ref = (
-            db.collection("users").document(uid).collection("memories")
+            db.collection("users")
+            .document(uid)
+            .collection("memories")
             .order_by("scoring", direction=_fs.Query.DESCENDING)
             .order_by("created_at", direction=_fs.Query.DESCENDING)
             .limit(100)
@@ -2150,17 +2369,19 @@ async def _search_memories(uid: str, query: str, limit: int) -> list:
                     ts = str(created)[:16]
 
             display_content = mem.get("structured_memory", "") or mem.get("content", "")
-            results.append({
-                "source": "memories",
-                "title": (mem.get("category", "") or "Memory").title(),
-                "content": (display_content or "")[:500],
-                "timestamp": ts,
-                "score": score,
-                "metadata": {
-                    "category": mem.get("category", ""),
-                    "id": mem.get("id", ""),
-                },
-            })
+            results.append(
+                {
+                    "source": "memories",
+                    "title": (mem.get("category", "") or "Memory").title(),
+                    "content": (display_content or "")[:500],
+                    "timestamp": ts,
+                    "score": score,
+                    "metadata": {
+                        "category": mem.get("category", ""),
+                        "id": mem.get("id", ""),
+                    },
+                }
+            )
 
         return results
 
@@ -2230,14 +2451,16 @@ async def _search_voice_logs(uid: str, agent_id: str, query: str, limit: int) ->
                     if not snippet:
                         snippet = content[:200]
 
-                    results.append({
-                        "source": "voice",
-                        "title": fname,
-                        "content": snippet,
-                        "timestamp": fname.replace("voice/", "").replace(".md", ""),
-                        "score": score,
-                        "metadata": {"file": fname},
-                    })
+                    results.append(
+                        {
+                            "source": "voice",
+                            "title": fname,
+                            "content": snippet,
+                            "timestamp": fname.replace("voice/", "").replace(".md", ""),
+                            "score": score,
+                            "metadata": {"file": fname},
+                        }
+                    )
 
             results.sort(key=lambda x: x["score"], reverse=True)
             return results[:limit]
@@ -2307,19 +2530,24 @@ async def _search_scanner_logs(uid: str, query: str, limit: int, access_level: s
                     ts = row["created_at"].strftime("%Y-%m-%d %I:%M %p")
 
                 display_content = result_data.get("summary", row["transcript_preview"] or "")
-                matches.append((score, {
-                    "source": "scanner",
-                    "title": f"[{(row['urgency'] or 'info').upper()}] {row['category'] or 'alert'}",
-                    "content": (display_content or "")[:500],
-                    "timestamp": ts,
-                    "score": score,
-                    "metadata": {
-                        "category": row["category"] or "",
-                        "urgency": row["urgency"] or "",
-                        "escalated": row["escalated"],
-                        "id": str(row["id"]),
-                    },
-                }))
+                matches.append(
+                    (
+                        score,
+                        {
+                            "source": "scanner",
+                            "title": f"[{(row['urgency'] or 'info').upper()}] {row['category'] or 'alert'}",
+                            "content": (display_content or "")[:500],
+                            "timestamp": ts,
+                            "score": score,
+                            "metadata": {
+                                "category": row["category"] or "",
+                                "urgency": row["urgency"] or "",
+                                "escalated": row["escalated"],
+                                "id": str(row["id"]),
+                            },
+                        },
+                    )
+                )
 
         matches.sort(key=lambda x: x[0], reverse=True)
         return [m[1] for m in matches[:limit]]
@@ -2361,7 +2589,9 @@ async def unified_search(request: Request):
     if not query:
         raise HTTPException(status_code=400, detail="query required")
     if agent_role not in SEARCH_POLICY:
-        raise HTTPException(status_code=400, detail=f"Invalid agent_role: {agent_role}. Must be one of: {list(SEARCH_POLICY.keys())}")
+        raise HTTPException(
+            status_code=400, detail=f"Invalid agent_role: {agent_role}. Must be one of: {list(SEARCH_POLICY.keys())}"
+        )
 
     # Validate agent-uid association
     if not _validate_agent_uid(agent_id, uid):

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -32,7 +32,7 @@ from fastapi.responses import Response
 from pydantic import BaseModel
 
 from database.conversations import _decrypt_conversation_data
-from ella.services.provisioning import ProvisioningError
+from ella.services.provisioning import ProvisioningError, rollout_enabled
 from ella.services.runtime_resolver import resolve_isolated_runtime, runtime_bindings_enabled
 from utils.ella.canonical_context import fetch_canonical_timeline
 from utils.other import endpoints as auth
@@ -74,14 +74,14 @@ DEFAULT_GATEWAY_URL = os.getenv("OPENCLAW_URL", "http://100.76.138.56:19001")
 OPENCLAW_GATEWAY_TOKEN = os.getenv("OPENCLAW_GATEWAY_TOKEN", "")
 
 
-def isolated_voice_routing_enabled() -> bool:
+def isolated_voice_routing_enabled(uid: Optional[str] = None) -> bool:
     """Keep isolated users off the legacy OpenClaw voice proxy until cutover."""
-    return os.getenv("ELLA_ISOLATED_VOICE_ROUTING_ENABLED", "false").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
+    return rollout_enabled(
+        "ELLA_ISOLATED_VOICE_ROUTING_ENABLED",
+        "ELLA_ISOLATED_VOICE_ROUTING_ENABLED_UIDS",
+        uid,
+    )
+
 
 # Database connection pool (lazy-initialized, shared pattern with other Ella routers)
 _pool: Optional[asyncpg.Pool] = None
@@ -419,12 +419,12 @@ async def create_voice_session(
     provider = (body.provider if body else None) or provider or "grok-voice"
     voice_mode = (body.voice_mode if body else None) or voice_mode
 
-    if runtime_bindings_enabled():
+    if runtime_bindings_enabled(uid):
         try:
             await resolve_isolated_runtime(uid)
         except ProvisioningError as exc:
             raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
-        if not isolated_voice_routing_enabled():
+        if not isolated_voice_routing_enabled(uid):
             raise HTTPException(status_code=503, detail={"code": "isolated_voice_not_ready"})
 
     # Validate provider
@@ -453,9 +453,7 @@ async def create_voice_session(
     user_display_name = None
     try:
         pool = await _get_pool()
-        row = await pool.fetchrow(
-            "SELECT name FROM users WHERE omi_uid = $1", uid
-        )
+        row = await pool.fetchrow("SELECT name FROM users WHERE omi_uid = $1", uid)
         if row:
             user_display_name = row["name"]
     except Exception as e:
@@ -568,7 +566,10 @@ async def synthesize_speech(
                 )
             _elapsed = int((time.time() - _start) * 1000)
             if response.status_code != 200:
-                print(f"[FLOW:VOICE-TTS] ERROR provider={provider} status={response.status_code} latency={_elapsed}ms", flush=True)
+                print(
+                    f"[FLOW:VOICE-TTS] ERROR provider={provider} status={response.status_code} latency={_elapsed}ms",
+                    flush=True,
+                )
                 raise HTTPException(status_code=502, detail=f"ella-tts error: {response.status_code}")
             audio_size = len(response.content)
             print(f"[FLOW:VOICE-TTS] OK provider={provider} audio_bytes={audio_size} latency={_elapsed}ms", flush=True)
@@ -590,7 +591,10 @@ async def synthesize_speech(
             print(f"[FLOW:VOICE-TTS] ERROR provider=xai-tts key_missing=true", flush=True)
             raise HTTPException(status_code=500, detail="XAI_API_KEY not configured")
         voice_id = request.voice_id if request.voice_id != DEFAULT_ELEVENLABS_VOICE_ID else XAI_TTS_VOICE_ID
-        print(f"[FLOW:VOICE-TTS] provider=xai-tts voice={voice_id} language={XAI_TTS_LANGUAGE} text_len={text_len}", flush=True)
+        print(
+            f"[FLOW:VOICE-TTS] provider=xai-tts voice={voice_id} language={XAI_TTS_LANGUAGE} text_len={text_len}",
+            flush=True,
+        )
         try:
             async with httpx.AsyncClient() as client:
                 response = await client.post(
@@ -653,7 +657,10 @@ async def synthesize_speech(
     # --- Reject unknown providers (no silent fallbacks) ---
     if provider != "elevenlabs":
         print(f"[FLOW:VOICE-TTS] ERROR unknown provider={provider!r}", flush=True)
-        raise HTTPException(status_code=400, detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, xai-tts, grok-voice, gemini-live")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, xai-tts, grok-voice, gemini-live",
+        )
 
     # --- ElevenLabs ---
     if not ELEVENLABS_API_KEY:
@@ -682,11 +689,17 @@ async def synthesize_speech(
         _elapsed = int((time.time() - _start) * 1000)
 
         if response.status_code != 200:
-            print(f"[FLOW:VOICE-TTS] ERROR provider=elevenlabs status={response.status_code} latency={_elapsed}ms body={response.text[:200]}", flush=True)
+            print(
+                f"[FLOW:VOICE-TTS] ERROR provider=elevenlabs status={response.status_code} latency={_elapsed}ms body={response.text[:200]}",
+                flush=True,
+            )
             raise HTTPException(status_code=502, detail=f"ElevenLabs error: {response.status_code}")
 
         audio_size = len(response.content)
-        print(f"[FLOW:VOICE-TTS] OK provider=elevenlabs voice={request.voice_id} audio_bytes={audio_size} latency={_elapsed}ms", flush=True)
+        print(
+            f"[FLOW:VOICE-TTS] OK provider=elevenlabs voice={request.voice_id} audio_bytes={audio_size} latency={_elapsed}ms",
+            flush=True,
+        )
 
         return Response(content=response.content, media_type="audio/mpeg")
 
@@ -731,8 +744,6 @@ async def voice_health():
 # ============================================================================
 
 
-
-
 async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
     """Fetch recent OMI conversation summaries from Firestore for voice context.
     Returns formatted string of recent conversations (title + overview)."""
@@ -740,17 +751,20 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
         # Direct Firestore query — simpler than get_conversations() to avoid
         # composite index requirements (discarded + created_at needs index)
         from google.cloud import firestore
+
         db = firestore.Client()
         convos_ref = (
-            db.collection("users").document(uid).collection("conversations")
+            db.collection("users")
+            .document(uid)
+            .collection("conversations")
             .order_by("created_at", direction=firestore.Query.DESCENDING)
             .limit(limit)
         )
         convos = [doc.to_dict() for doc in convos_ref.stream()]
-        
+
         if not convos:
             return ""
-        
+
         parts = []
         for c in convos:
             structured = c.get("structured", {})
@@ -758,7 +772,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
             overview = structured.get("overview", "")
             emoji = structured.get("emoji", "")
             created = c.get("created_at")
-            
+
             # Format timestamp
             ts = ""
             if created:
@@ -766,7 +780,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
                     ts = created.strftime("%b %d %I:%M %p")
                 else:
                     ts = str(created)[:16]
-            
+
             entry = f"- {emoji} {title}"
             if overview:
                 # Truncate long overviews
@@ -775,7 +789,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
             if ts:
                 entry += f" ({ts})"
             parts.append(entry)
-        
+
         return "\n".join(parts)
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Conversation fetch failed: {e}")
@@ -792,15 +806,15 @@ async def _fetch_memory_context(
     Returns formatted string of relevant memory snippets."""
     if not gateway_token:
         return ""
-    
+
     headers = {
         "Authorization": f"Bearer {gateway_token}",
         "Content-Type": "application/json",
     }
-    
+
     results_all = []
     queries = [f"{user_name} recent activity today schedule important"]
-    
+
     try:
         async with httpx.AsyncClient(timeout=timeout_seconds) as client:
             for query in queries:
@@ -814,6 +828,7 @@ async def _fetch_memory_context(
                         data = resp.json()
                         if data.get("ok"):
                             import json as json_mod
+
                             results_text = data["result"]["content"][0]["text"]
                             results = json_mod.loads(results_text).get("results", [])
                             for r in results[:3]:
@@ -827,10 +842,10 @@ async def _fetch_memory_context(
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Memory context fetch failed: {e}")
         return ""
-    
+
     if not results_all:
         return ""
-    
+
     # Sort by score, deduplicate, take top 5
     results_all.sort(key=lambda x: x[1], reverse=True)
     seen = set()
@@ -842,8 +857,9 @@ async def _fetch_memory_context(
             unique.append(snippet)
         if len(unique) >= 5:
             break
-    
+
     return "\n---\n".join(unique)
+
 
 def _extract_caregiver_section(user_profile: str) -> str:
     """Extract caregiver-relevant notes from USER.md content."""
@@ -924,18 +940,11 @@ async def get_voice_context(request: Request):
                 )
                 if resp.status_code == 200:
                     file_list = resp.json().get("files", [])
-                    files = {
-                        f.get("name", f.get("filename", "")): f.get("content", "")
-                        for f in file_list
-                    }
-                    logger.info(
-                        f"[FLOW:VOICE-CONTEXT] Loaded {len(files)} workspace files "
-                        f"for agent={agent_id}"
-                    )
+                    files = {f.get("name", f.get("filename", "")): f.get("content", "") for f in file_list}
+                    logger.info(f"[FLOW:VOICE-CONTEXT] Loaded {len(files)} workspace files " f"for agent={agent_id}")
                 else:
                     logger.warning(
-                        f"[FLOW:VOICE-CONTEXT] Provision API returned "
-                        f"{resp.status_code} for agent={agent_id}"
+                        f"[FLOW:VOICE-CONTEXT] Provision API returned " f"{resp.status_code} for agent={agent_id}"
                     )
         except Exception as e:
             logger.warning(f"[FLOW:VOICE-CONTEXT] Provision API error: {e}")
@@ -964,6 +973,7 @@ async def get_voice_context(request: Request):
     memory_context = ""
     try:
         import asyncio as _aio
+
         conv_task = _aio.create_task(_fetch_recent_conversations(uid, limit=8))
         timeline_task = _aio.create_task(_fetch_recent_canonical_timeline(uid, limit=40, max_chars=9000))
         mem_task = _aio.create_task(
@@ -1010,7 +1020,7 @@ async def get_voice_context(request: Request):
         except Exception as _ve:
             logger.warning(f"[FLOW:VOICE-CONTEXT] Voice daily log read error: {_ve}")
     memory = files.get("MEMORY.md", "")[:500]
-    
+
     # Additional workspace files for richer context
     tools_md = files.get("TOOLS.md", "")[:500]  # Agent capabilities awareness
     shared_reports = ""
@@ -1059,33 +1069,34 @@ async def search_omi_conversations(request: Request):
     """
     Search OMI conversations for a user. Called by Grok voice proxy during live calls
     when the user asks to look up specific past conversations.
-    
+
     Body:
         uid (str): Firebase UID of the user
         query (str): Search terms (matched against title and overview)
         limit (int, optional): Max results (default: 5, max: 10)
-    
+
     Returns list of matching conversations with title, overview, and timestamp.
     """
     body = await request.json()
     uid = body.get("uid", "")
     query = body.get("query", "")
     limit = min(body.get("limit", 5), 10)
-    
+
     if not uid:
         raise HTTPException(status_code=400, detail="uid required")
     if not query:
         raise HTTPException(status_code=400, detail="query required")
-    
+
     logger.info(f"[FLOW:VOICE-SEARCH] uid={uid} query=\"{query}\" limit={limit}")
-    
+
     try:
         from google.cloud import firestore
+
         db = firestore.Client()
-        
+
         from datetime import datetime, timedelta
         import re as re_mod
-        
+
         # Parse date hints from query for date-range filtering
         now_local = _pacific_now()
         now_local = _pacific_now()
@@ -1093,12 +1104,12 @@ async def search_omi_conversations(request: Request):
         date_filter_start = None
         date_filter_end = None
         keyword_terms = []
-        
+
         query_lower = query.lower().strip()
-        
+
         # Date patterns: "march 8", "march 8th", "3/8", "yesterday", "last week", "today"
         date_parsed = False
-        
+
         if "yesterday" in query_lower:
             d = now - timedelta(days=1)
             date_filter_start = d.replace(hour=0, minute=0, second=0)
@@ -1123,15 +1134,34 @@ async def search_omi_conversations(request: Request):
         else:
             # Try "month day" pattern: "march 8", "march 8th", "mar 8"
             month_names = {
-                "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
-                "apr": 4, "april": 4, "may": 5, "jun": 6, "june": 6, "jul": 7, "july": 7,
-                "aug": 8, "august": 8, "sep": 9, "september": 9, "oct": 10, "october": 10,
-                "nov": 11, "november": 11, "dec": 12, "december": 12,
+                "jan": 1,
+                "january": 1,
+                "feb": 2,
+                "february": 2,
+                "mar": 3,
+                "march": 3,
+                "apr": 4,
+                "april": 4,
+                "may": 5,
+                "jun": 6,
+                "june": 6,
+                "jul": 7,
+                "july": 7,
+                "aug": 8,
+                "august": 8,
+                "sep": 9,
+                "september": 9,
+                "oct": 10,
+                "october": 10,
+                "nov": 11,
+                "november": 11,
+                "dec": 12,
+                "december": 12,
             }
             date_match = re_mod.search(
                 r"(january|february|march|april|may|june|july|august|september|october|november|december|"
                 r"jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)\s+(\d{1,2})(?:st|nd|rd|th)?",
-                query_lower
+                query_lower,
             )
             if date_match:
                 month_str = date_match.group(1)
@@ -1148,24 +1178,26 @@ async def search_omi_conversations(request: Request):
                         date_filter_end = target.replace(hour=23, minute=59, second=59)
                         date_parsed = True
                         # Remove date part from query for keyword matching
-                        remaining = query_lower[:date_match.start()] + query_lower[date_match.end():]
+                        remaining = query_lower[: date_match.start()] + query_lower[date_match.end() :]
                         keyword_terms = [t for t in remaining.split() if t]
                     except ValueError:
                         pass
-        
+
         if not date_parsed:
             keyword_terms = query_lower.split()
 
         keyword_terms = _expand_query_terms(_significant_query_terms(" ".join(keyword_terms)))
         keyword_terms = _normalized_query_terms(" ".join(keyword_terms))
-        
+
         logger.info(f"[FLOW:VOICE-SEARCH] date_filter={date_filter_start}->{date_filter_end}, keywords={keyword_terms}")
-        
+
         # Fetch conversations — use date filter if we have one, otherwise get last 100
         if date_filter_start and date_filter_end:
             # Firestore query with date range
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .where("created_at", ">=", date_filter_start)
                 .where("created_at", "<=", date_filter_end)
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
@@ -1173,29 +1205,31 @@ async def search_omi_conversations(request: Request):
             )
         else:
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
                 .limit(100)
             )
         convos = [doc.to_dict() for doc in convos_ref.stream()]
-        
+
         # Client-side keyword match (skip if only date search with no keywords)
         matches = []
-        
+
         for c in convos:
             structured = c.get("structured", {})
             title = (structured.get("title", "") or "").lower()
             overview = (structured.get("overview", "") or "").lower()
             category = (structured.get("category", "") or "").lower()
-            
+
             # Include formatted date in searchable text
             created = c.get("created_at")
             date_str = ""
             if created and hasattr(created, "strftime"):
                 date_str = created.strftime("%B %d %Y %b %A").lower()  # "march 18 2026 mar monday"
-            
+
             searchable = f"{title} {overview} {category} {date_str}"
-            
+
             if keyword_terms:
                 # Score: how many keyword terms match
                 score = _keyword_score(searchable, keyword_terms)
@@ -1204,11 +1238,11 @@ async def search_omi_conversations(request: Request):
             else:
                 # Date-only search — return all conversations from that date
                 matches.append((1, c))
-        
+
         # Sort by score (desc), then by recency
         matches.sort(key=lambda x: x[0], reverse=True)
         matches = matches[:limit]
-        
+
         results = []
         for score, c in matches:
             structured = c.get("structured", {})
@@ -1223,19 +1257,21 @@ async def search_omi_conversations(request: Request):
                     ts = created.strftime("%Y-%m-%d %I:%M %p")
                 else:
                     ts = str(created)[:16]
-            
-            results.append({
-                "title": structured.get("title", "Untitled"),
-                "overview": structured.get("overview", ""),
-                "emoji": structured.get("emoji", ""),
-                "category": structured.get("category", ""),
-                "timestamp": ts,
-                "score": score,
-            })
-        
+
+            results.append(
+                {
+                    "title": structured.get("title", "Untitled"),
+                    "overview": structured.get("overview", ""),
+                    "emoji": structured.get("emoji", ""),
+                    "category": structured.get("category", ""),
+                    "timestamp": ts,
+                    "score": score,
+                }
+            )
+
         logger.info(f"[FLOW:VOICE-SEARCH] Found {len(results)} matches for \"{query}\"")
         return {"results": results, "total_searched": len(convos), "query": query}
-    
+
     except Exception as e:
         logger.error(f"[FLOW:VOICE-SEARCH] Error: {e}")
         return {"results": [], "error": str(e), "query": query}
@@ -1250,21 +1286,53 @@ async def search_omi_conversations(request: Request):
 # Privacy policy: maps agent_role -> source -> access level
 # True = full access, False = no access, "own" = own data only, "full" = full
 SEARCH_POLICY = {
-    "user":      {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": "own"},
-    "caregiver": {"timeline": True, "workspace": True, "omi_full": False, "omi_meta": True, "memories": False, "voice": False, "scanner": "full"},
-    "scanner":   {"timeline": False, "workspace": False, "omi_full": False, "omi_meta": False, "memories": False, "voice": False, "scanner": False},
-    "voice":     {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": False},
+    "user": {
+        "timeline": True,
+        "workspace": True,
+        "omi_full": True,
+        "omi_meta": True,
+        "memories": True,
+        "voice": True,
+        "scanner": "own",
+    },
+    "caregiver": {
+        "timeline": True,
+        "workspace": True,
+        "omi_full": False,
+        "omi_meta": True,
+        "memories": False,
+        "voice": False,
+        "scanner": "full",
+    },
+    "scanner": {
+        "timeline": False,
+        "workspace": False,
+        "omi_full": False,
+        "omi_meta": False,
+        "memories": False,
+        "voice": False,
+        "scanner": False,
+    },
+    "voice": {
+        "timeline": True,
+        "workspace": True,
+        "omi_full": True,
+        "omi_meta": True,
+        "memories": True,
+        "voice": True,
+        "scanner": False,
+    },
 }
 
 # Which source keys map to which request-level source names
 _SOURCE_TO_POLICY_KEYS = {
-    "timeline":  ["timeline"],
-    "channel":   ["timeline"],
+    "timeline": ["timeline"],
+    "channel": ["timeline"],
     "workspace": ["workspace"],
-    "omi":       ["omi_full", "omi_meta"],
-    "memories":  ["memories"],
-    "voice":     ["voice"],
-    "scanner":   ["scanner"],
+    "omi": ["omi_full", "omi_meta"],
+    "memories": ["memories"],
+    "voice": ["voice"],
+    "scanner": ["scanner"],
 }
 
 
@@ -1372,14 +1440,66 @@ def _snippet_around_terms(text: str, terms: list, max_chars: int = 900) -> str:
 
 def _normalized_query_terms(query: str) -> list[str]:
     stop = {
-        "the", "a", "an", "and", "or", "to", "in", "on", "of", "for", "with",
-        "what", "where", "when", "who", "why", "how", "did", "do", "does", "i",
-        "me", "my", "you", "greg", "plato", "tell", "check", "latest", "recent",
-        "memory", "memories", "after", "before", "else", "went", "go", "this",
-        "omi", "conversation", "conversations", "transcript", "transcripts",
-        "summary", "summaries", "morning", "afternoon", "evening", "today",
-        "yesterday", "raw", "happened", "happen", "heard", "hear", "catch",
-        "caught", "find", "pull", "about",
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "to",
+        "in",
+        "on",
+        "of",
+        "for",
+        "with",
+        "what",
+        "where",
+        "when",
+        "who",
+        "why",
+        "how",
+        "did",
+        "do",
+        "does",
+        "i",
+        "me",
+        "my",
+        "you",
+        "greg",
+        "plato",
+        "tell",
+        "check",
+        "latest",
+        "recent",
+        "memory",
+        "memories",
+        "after",
+        "before",
+        "else",
+        "went",
+        "go",
+        "this",
+        "omi",
+        "conversation",
+        "conversations",
+        "transcript",
+        "transcripts",
+        "summary",
+        "summaries",
+        "morning",
+        "afternoon",
+        "evening",
+        "today",
+        "yesterday",
+        "raw",
+        "happened",
+        "happen",
+        "heard",
+        "hear",
+        "catch",
+        "caught",
+        "find",
+        "pull",
+        "about",
     }
     terms = [t.strip(".,?!:;()[]{}\"'’‘“”").lower() for t in query.split()]
     filtered = [t for t in terms if len(t) > 2 and t not in stop]
@@ -1390,14 +1510,66 @@ def _significant_query_terms(query: str) -> list[str]:
     """Return only evidence-bearing terms; unlike _normalized_query_terms,
     this may return an empty list for broad temporal questions."""
     stop = {
-        "the", "a", "an", "and", "or", "to", "in", "on", "of", "for", "with",
-        "what", "where", "when", "who", "why", "how", "did", "do", "does", "i",
-        "me", "my", "you", "greg", "plato", "tell", "check", "latest", "recent",
-        "memory", "memories", "after", "before", "else", "went", "go", "this",
-        "omi", "conversation", "conversations", "transcript", "transcripts",
-        "summary", "summaries", "morning", "afternoon", "evening", "today",
-        "yesterday", "raw", "happened", "happen", "heard", "hear", "catch",
-        "caught", "find", "pull", "about",
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "to",
+        "in",
+        "on",
+        "of",
+        "for",
+        "with",
+        "what",
+        "where",
+        "when",
+        "who",
+        "why",
+        "how",
+        "did",
+        "do",
+        "does",
+        "i",
+        "me",
+        "my",
+        "you",
+        "greg",
+        "plato",
+        "tell",
+        "check",
+        "latest",
+        "recent",
+        "memory",
+        "memories",
+        "after",
+        "before",
+        "else",
+        "went",
+        "go",
+        "this",
+        "omi",
+        "conversation",
+        "conversations",
+        "transcript",
+        "transcripts",
+        "summary",
+        "summaries",
+        "morning",
+        "afternoon",
+        "evening",
+        "today",
+        "yesterday",
+        "raw",
+        "happened",
+        "happen",
+        "heard",
+        "hear",
+        "catch",
+        "caught",
+        "find",
+        "pull",
+        "about",
     }
     terms = [t.strip(".,?!:;()[]{}\"'’‘“”").lower() for t in query.split()]
     return [t for t in terms if len(t) > 2 and t not in stop]
@@ -1553,20 +1725,26 @@ async def _search_canonical_timeline(uid: str, query: str, limit: int) -> list:
             ts = row["started_at"]
             ts_text = ts.strftime("%Y-%m-%d %I:%M %p") if ts else ""
             role_boost = 15 if role == "user" else 3
-            matches.append((score, ts or datetime.min, {
-                "source": "timeline",
-                "title": f"{channel} {role}".strip(),
-                "content": text[:700],
-                "timestamp": ts_text,
-                "score": score + role_boost,
-                "metadata": {
-                    "provenance": "canonical_event",
-                    "channel": channel,
-                    "provider": provider,
-                    "role": role,
-                    "session_id": row["session_id"] or "",
-                },
-            }))
+            matches.append(
+                (
+                    score,
+                    ts or datetime.min,
+                    {
+                        "source": "timeline",
+                        "title": f"{channel} {role}".strip(),
+                        "content": text[:700],
+                        "timestamp": ts_text,
+                        "score": score + role_boost,
+                        "metadata": {
+                            "provenance": "canonical_event",
+                            "channel": channel,
+                            "provider": provider,
+                            "role": role,
+                            "session_id": row["session_id"] or "",
+                        },
+                    },
+                )
+            )
         matches.sort(key=lambda x: (x[0], x[1]), reverse=True)
         return [m[2] for m in matches[:limit]]
     except Exception as e:
@@ -1607,21 +1785,23 @@ async def _search_voice_memory_pack(uid: str, query: str, limit: int) -> list:
         top = sources[0] if sources else {}
         confidence = data.get("confidence") or "medium"
         score = 120 if confidence == "high" else 70
-        return [{
-            "source": "voice_memory",
-            "title": top.get("title") or "Hermes Voice Memory",
-            "content": answer[:900],
-            "timestamp": top.get("timestamp") or "",
-            "score": score,
-            "metadata": {
-                "provenance": "hermes_voice_memory",
-                "path": data.get("path"),
-                "confidence": confidence,
-                "latency_ms": data.get("latency_ms"),
-                "source_ref": top.get("source_ref"),
-                "channel": top.get("channel"),
-            },
-        }]
+        return [
+            {
+                "source": "voice_memory",
+                "title": top.get("title") or "Hermes Voice Memory",
+                "content": answer[:900],
+                "timestamp": top.get("timestamp") or "",
+                "score": score,
+                "metadata": {
+                    "provenance": "hermes_voice_memory",
+                    "path": data.get("path"),
+                    "confidence": confidence,
+                    "latency_ms": data.get("latency_ms"),
+                    "source_ref": top.get("source_ref"),
+                    "channel": top.get("channel"),
+                },
+            }
+        ]
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-MEMORY] lookup error: {e}")
         return []
@@ -1699,21 +1879,21 @@ async def _search_workspace(uid: str, agent_id: str, query: str, limit: int) -> 
             if resp.status_code == 200:
                 data = resp.json()
                 for item in data.get("results", [])[:limit]:
-                    results.append({
-                        "source": "workspace",
-                        "title": item.get("file", ""),
-                        "content": (item.get("snippet", "") or item.get("content", ""))[:500],
-                        "timestamp": "",
-                        "score": item.get("score", 1),
-                        "metadata": {"provenance": "hermes_workspace_mirror", "file": item.get("file", "")},
-                    })
+                    results.append(
+                        {
+                            "source": "workspace",
+                            "title": item.get("file", ""),
+                            "content": (item.get("snippet", "") or item.get("content", ""))[:500],
+                            "timestamp": "",
+                            "score": item.get("score", 1),
+                            "metadata": {"provenance": "hermes_workspace_mirror", "file": item.get("file", "")},
+                        }
+                    )
                 return results
 
             # 404 = no search endpoint; fall back to reading key files
             if resp.status_code != 404:
-                logger.warning(
-                    f"[FLOW:UNIFIED-SEARCH] Provision search returned {resp.status_code}"
-                )
+                logger.warning(f"[FLOW:UNIFIED-SEARCH] Provision search returned {resp.status_code}")
                 return results
 
             # Fallback: read files list and grep
@@ -1745,14 +1925,16 @@ async def _search_workspace(uid: str, agent_id: str, query: str, limit: int) -> 
                     if not snippet:
                         snippet = content[:200]
 
-                    results.append({
-                        "source": "workspace",
-                        "title": fname,
-                        "content": snippet,
-                        "timestamp": "",
-                        "score": score,
-                        "metadata": {"provenance": "hermes_workspace_mirror", "file": fname},
-                    })
+                    results.append(
+                        {
+                            "source": "workspace",
+                            "title": fname,
+                            "content": snippet,
+                            "timestamp": "",
+                            "score": score,
+                            "metadata": {"provenance": "hermes_workspace_mirror", "file": fname},
+                        }
+                    )
 
             # Sort by score desc, limit
             results.sort(key=lambda x: x["score"], reverse=True)
@@ -1871,36 +2053,36 @@ async def _search_canonical_omi_events(uid: str, query: str, limit: int, full_ac
     for score, _started_sort, event, title, content in matches[:limit]:
         metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
         structured = metadata.get("structured") if isinstance(metadata.get("structured"), dict) else {}
-        results.append({
-            "source": "omi",
-            "title": title,
-            "content": content[:1400],
-            "timestamp": _canonical_event_timestamp(event),
-            "score": score + (55 if window_start else 45),
-            "metadata": {
-                "provenance": "canonical_event",
-                "fallback": False,
-                "event_id": event.get("event_id"),
-                "source_identity": event.get("source_identity"),
-                "channel": event.get("channel"),
-                "provider": event.get("provider"),
-                "emoji": structured.get("emoji", ""),
-                "category": structured.get("category", ""),
-                "time_window_applied": bool(window_start and window_end),
-                "time_window_start_utc": window_start.isoformat() if window_start else "",
-                "time_window_end_utc": window_end.isoformat() if window_end else "",
-                "timestamp_timezone": "America/Los_Angeles",
-            },
-        })
+        results.append(
+            {
+                "source": "omi",
+                "title": title,
+                "content": content[:1400],
+                "timestamp": _canonical_event_timestamp(event),
+                "score": score + (55 if window_start else 45),
+                "metadata": {
+                    "provenance": "canonical_event",
+                    "fallback": False,
+                    "event_id": event.get("event_id"),
+                    "source_identity": event.get("source_identity"),
+                    "channel": event.get("channel"),
+                    "provider": event.get("provider"),
+                    "emoji": structured.get("emoji", ""),
+                    "category": structured.get("category", ""),
+                    "time_window_applied": bool(window_start and window_end),
+                    "time_window_start_utc": window_start.isoformat() if window_start else "",
+                    "time_window_end_utc": window_end.isoformat() if window_end else "",
+                    "timestamp_timezone": "America/Los_Angeles",
+                },
+            }
+        )
     return results
 
 
 async def _search_omi_canonical_first(uid: str, query: str, limit: int, full_access: bool) -> list:
     canonical_results = await _search_canonical_omi_events(uid, query, limit, full_access)
     if canonical_results:
-        logger.info(
-            f"[FLOW:UNIFIED-SEARCH] uid={uid} omi_source=canonical_event results={len(canonical_results)}"
-        )
+        logger.info(f"[FLOW:UNIFIED-SEARCH] uid={uid} omi_source=canonical_event results={len(canonical_results)}")
         return canonical_results
 
     logger.warning(
@@ -1986,10 +2168,29 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             keyword_terms = [t for t in query_lower.replace("last month", "").split() if t]
         else:
             month_names = {
-                "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
-                "apr": 4, "april": 4, "may": 5, "jun": 6, "june": 6, "jul": 7, "july": 7,
-                "aug": 8, "august": 8, "sep": 9, "september": 9, "oct": 10, "october": 10,
-                "nov": 11, "november": 11, "dec": 12, "december": 12,
+                "jan": 1,
+                "january": 1,
+                "feb": 2,
+                "february": 2,
+                "mar": 3,
+                "march": 3,
+                "apr": 4,
+                "april": 4,
+                "may": 5,
+                "jun": 6,
+                "june": 6,
+                "jul": 7,
+                "july": 7,
+                "aug": 8,
+                "august": 8,
+                "sep": 9,
+                "september": 9,
+                "oct": 10,
+                "october": 10,
+                "nov": 11,
+                "november": 11,
+                "dec": 12,
+                "december": 12,
             }
             date_match = _re.search(
                 r"(january|february|march|april|may|june|july|august|september|october|"
@@ -2023,7 +2224,9 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
         # --- Firestore query ---
         if date_filter_start and date_filter_end:
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .where("created_at", ">=", date_filter_start)
                 .where("created_at", "<=", date_filter_end)
                 .order_by("created_at", direction=_fs.Query.DESCENDING)
@@ -2031,7 +2234,9 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             )
         else:
             convos_ref = (
-                db.collection("users").document(uid).collection("conversations")
+                db.collection("users")
+                .document(uid)
+                .collection("conversations")
                 .order_by("created_at", direction=_fs.Query.DESCENDING)
                 .limit(100)
             )
@@ -2100,21 +2305,23 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
                         + snippet
                     )[:1400]
 
-            results.append({
-                "source": "omi",
-                "title": structured.get("title", "Untitled"),
-                "content": overview_text,
-                "timestamp": ts,
-                "score": score + 18,
-                "metadata": {
-                    "provenance": "firestore_legacy_omi",
-                    "fallback": True,
-                    "emoji": structured.get("emoji", ""),
-                    "category": structured.get("category", ""),
-                    "has_transcript_detail": bool(transcript_text and full_access),
-                    "timestamp_timezone": "America/Los_Angeles",
-                },
-            })
+            results.append(
+                {
+                    "source": "omi",
+                    "title": structured.get("title", "Untitled"),
+                    "content": overview_text,
+                    "timestamp": ts,
+                    "score": score + 18,
+                    "metadata": {
+                        "provenance": "firestore_legacy_omi",
+                        "fallback": True,
+                        "emoji": structured.get("emoji", ""),
+                        "category": structured.get("category", ""),
+                        "has_transcript_detail": bool(transcript_text and full_access),
+                        "timestamp_timezone": "America/Los_Angeles",
+                    },
+                }
+            )
 
         return results
 
@@ -2137,7 +2344,9 @@ async def _search_memories(uid: str, query: str, limit: int) -> list:
 
         # Fetch recent memories sorted by scoring (same pattern as database/memories.py)
         memories_ref = (
-            db.collection("users").document(uid).collection("memories")
+            db.collection("users")
+            .document(uid)
+            .collection("memories")
             .order_by("scoring", direction=_fs.Query.DESCENDING)
             .order_by("created_at", direction=_fs.Query.DESCENDING)
             .limit(100)
@@ -2172,17 +2381,19 @@ async def _search_memories(uid: str, query: str, limit: int) -> list:
                     ts = str(created)[:16]
 
             display_content = mem.get("structured_memory", "") or mem.get("content", "")
-            results.append({
-                "source": "memories",
-                "title": (mem.get("category", "") or "Memory").title(),
-                "content": (display_content or "")[:500],
-                "timestamp": ts,
-                "score": score,
-                "metadata": {
-                    "category": mem.get("category", ""),
-                    "id": mem.get("id", ""),
-                },
-            })
+            results.append(
+                {
+                    "source": "memories",
+                    "title": (mem.get("category", "") or "Memory").title(),
+                    "content": (display_content or "")[:500],
+                    "timestamp": ts,
+                    "score": score,
+                    "metadata": {
+                        "category": mem.get("category", ""),
+                        "id": mem.get("id", ""),
+                    },
+                }
+            )
 
         return results
 
@@ -2252,14 +2463,16 @@ async def _search_voice_logs(uid: str, agent_id: str, query: str, limit: int) ->
                     if not snippet:
                         snippet = content[:200]
 
-                    results.append({
-                        "source": "voice",
-                        "title": fname,
-                        "content": snippet,
-                        "timestamp": fname.replace("voice/", "").replace(".md", ""),
-                        "score": score,
-                        "metadata": {"file": fname},
-                    })
+                    results.append(
+                        {
+                            "source": "voice",
+                            "title": fname,
+                            "content": snippet,
+                            "timestamp": fname.replace("voice/", "").replace(".md", ""),
+                            "score": score,
+                            "metadata": {"file": fname},
+                        }
+                    )
 
             results.sort(key=lambda x: x["score"], reverse=True)
             return results[:limit]
@@ -2329,19 +2542,24 @@ async def _search_scanner_logs(uid: str, query: str, limit: int, access_level: s
                     ts = row["created_at"].strftime("%Y-%m-%d %I:%M %p")
 
                 display_content = result_data.get("summary", row["transcript_preview"] or "")
-                matches.append((score, {
-                    "source": "scanner",
-                    "title": f"[{(row['urgency'] or 'info').upper()}] {row['category'] or 'alert'}",
-                    "content": (display_content or "")[:500],
-                    "timestamp": ts,
-                    "score": score,
-                    "metadata": {
-                        "category": row["category"] or "",
-                        "urgency": row["urgency"] or "",
-                        "escalated": row["escalated"],
-                        "id": str(row["id"]),
-                    },
-                }))
+                matches.append(
+                    (
+                        score,
+                        {
+                            "source": "scanner",
+                            "title": f"[{(row['urgency'] or 'info').upper()}] {row['category'] or 'alert'}",
+                            "content": (display_content or "")[:500],
+                            "timestamp": ts,
+                            "score": score,
+                            "metadata": {
+                                "category": row["category"] or "",
+                                "urgency": row["urgency"] or "",
+                                "escalated": row["escalated"],
+                                "id": str(row["id"]),
+                            },
+                        },
+                    )
+                )
 
         matches.sort(key=lambda x: x[0], reverse=True)
         return [m[1] for m in matches[:limit]]
@@ -2383,7 +2601,9 @@ async def unified_search(request: Request):
     if not query:
         raise HTTPException(status_code=400, detail="query required")
     if agent_role not in SEARCH_POLICY:
-        raise HTTPException(status_code=400, detail=f"Invalid agent_role: {agent_role}. Must be one of: {list(SEARCH_POLICY.keys())}")
+        raise HTTPException(
+            status_code=400, detail=f"Invalid agent_role: {agent_role}. Must be one of: {list(SEARCH_POLICY.keys())}"
+        )
 
     # Validate agent-uid association
     if not _validate_agent_uid(agent_id, uid):

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -82,7 +82,6 @@ def isolated_voice_routing_enabled(uid: Optional[str] = None) -> bool:
         uid,
     )
 
-
 # Database connection pool (lazy-initialized, shared pattern with other Ella routers)
 _pool: Optional[asyncpg.Pool] = None
 
@@ -453,7 +452,9 @@ async def create_voice_session(
     user_display_name = None
     try:
         pool = await _get_pool()
-        row = await pool.fetchrow("SELECT name FROM users WHERE omi_uid = $1", uid)
+        row = await pool.fetchrow(
+            "SELECT name FROM users WHERE omi_uid = $1", uid
+        )
         if row:
             user_display_name = row["name"]
     except Exception as e:
@@ -566,10 +567,7 @@ async def synthesize_speech(
                 )
             _elapsed = int((time.time() - _start) * 1000)
             if response.status_code != 200:
-                print(
-                    f"[FLOW:VOICE-TTS] ERROR provider={provider} status={response.status_code} latency={_elapsed}ms",
-                    flush=True,
-                )
+                print(f"[FLOW:VOICE-TTS] ERROR provider={provider} status={response.status_code} latency={_elapsed}ms", flush=True)
                 raise HTTPException(status_code=502, detail=f"ella-tts error: {response.status_code}")
             audio_size = len(response.content)
             print(f"[FLOW:VOICE-TTS] OK provider={provider} audio_bytes={audio_size} latency={_elapsed}ms", flush=True)
@@ -591,10 +589,7 @@ async def synthesize_speech(
             print(f"[FLOW:VOICE-TTS] ERROR provider=xai-tts key_missing=true", flush=True)
             raise HTTPException(status_code=500, detail="XAI_API_KEY not configured")
         voice_id = request.voice_id if request.voice_id != DEFAULT_ELEVENLABS_VOICE_ID else XAI_TTS_VOICE_ID
-        print(
-            f"[FLOW:VOICE-TTS] provider=xai-tts voice={voice_id} language={XAI_TTS_LANGUAGE} text_len={text_len}",
-            flush=True,
-        )
+        print(f"[FLOW:VOICE-TTS] provider=xai-tts voice={voice_id} language={XAI_TTS_LANGUAGE} text_len={text_len}", flush=True)
         try:
             async with httpx.AsyncClient() as client:
                 response = await client.post(
@@ -657,10 +652,7 @@ async def synthesize_speech(
     # --- Reject unknown providers (no silent fallbacks) ---
     if provider != "elevenlabs":
         print(f"[FLOW:VOICE-TTS] ERROR unknown provider={provider!r}", flush=True)
-        raise HTTPException(
-            status_code=400,
-            detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, xai-tts, grok-voice, gemini-live",
-        )
+        raise HTTPException(status_code=400, detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, xai-tts, grok-voice, gemini-live")
 
     # --- ElevenLabs ---
     if not ELEVENLABS_API_KEY:
@@ -689,17 +681,11 @@ async def synthesize_speech(
         _elapsed = int((time.time() - _start) * 1000)
 
         if response.status_code != 200:
-            print(
-                f"[FLOW:VOICE-TTS] ERROR provider=elevenlabs status={response.status_code} latency={_elapsed}ms body={response.text[:200]}",
-                flush=True,
-            )
+            print(f"[FLOW:VOICE-TTS] ERROR provider=elevenlabs status={response.status_code} latency={_elapsed}ms body={response.text[:200]}", flush=True)
             raise HTTPException(status_code=502, detail=f"ElevenLabs error: {response.status_code}")
 
         audio_size = len(response.content)
-        print(
-            f"[FLOW:VOICE-TTS] OK provider=elevenlabs voice={request.voice_id} audio_bytes={audio_size} latency={_elapsed}ms",
-            flush=True,
-        )
+        print(f"[FLOW:VOICE-TTS] OK provider=elevenlabs voice={request.voice_id} audio_bytes={audio_size} latency={_elapsed}ms", flush=True)
 
         return Response(content=response.content, media_type="audio/mpeg")
 
@@ -744,6 +730,8 @@ async def voice_health():
 # ============================================================================
 
 
+
+
 async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
     """Fetch recent OMI conversation summaries from Firestore for voice context.
     Returns formatted string of recent conversations (title + overview)."""
@@ -751,20 +739,17 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
         # Direct Firestore query — simpler than get_conversations() to avoid
         # composite index requirements (discarded + created_at needs index)
         from google.cloud import firestore
-
         db = firestore.Client()
         convos_ref = (
-            db.collection("users")
-            .document(uid)
-            .collection("conversations")
+            db.collection("users").document(uid).collection("conversations")
             .order_by("created_at", direction=firestore.Query.DESCENDING)
             .limit(limit)
         )
         convos = [doc.to_dict() for doc in convos_ref.stream()]
-
+        
         if not convos:
             return ""
-
+        
         parts = []
         for c in convos:
             structured = c.get("structured", {})
@@ -772,7 +757,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
             overview = structured.get("overview", "")
             emoji = structured.get("emoji", "")
             created = c.get("created_at")
-
+            
             # Format timestamp
             ts = ""
             if created:
@@ -780,7 +765,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
                     ts = created.strftime("%b %d %I:%M %p")
                 else:
                     ts = str(created)[:16]
-
+            
             entry = f"- {emoji} {title}"
             if overview:
                 # Truncate long overviews
@@ -789,7 +774,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
             if ts:
                 entry += f" ({ts})"
             parts.append(entry)
-
+        
         return "\n".join(parts)
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Conversation fetch failed: {e}")
@@ -806,15 +791,15 @@ async def _fetch_memory_context(
     Returns formatted string of relevant memory snippets."""
     if not gateway_token:
         return ""
-
+    
     headers = {
         "Authorization": f"Bearer {gateway_token}",
         "Content-Type": "application/json",
     }
-
+    
     results_all = []
     queries = [f"{user_name} recent activity today schedule important"]
-
+    
     try:
         async with httpx.AsyncClient(timeout=timeout_seconds) as client:
             for query in queries:
@@ -828,7 +813,6 @@ async def _fetch_memory_context(
                         data = resp.json()
                         if data.get("ok"):
                             import json as json_mod
-
                             results_text = data["result"]["content"][0]["text"]
                             results = json_mod.loads(results_text).get("results", [])
                             for r in results[:3]:
@@ -842,10 +826,10 @@ async def _fetch_memory_context(
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Memory context fetch failed: {e}")
         return ""
-
+    
     if not results_all:
         return ""
-
+    
     # Sort by score, deduplicate, take top 5
     results_all.sort(key=lambda x: x[1], reverse=True)
     seen = set()
@@ -857,9 +841,8 @@ async def _fetch_memory_context(
             unique.append(snippet)
         if len(unique) >= 5:
             break
-
+    
     return "\n---\n".join(unique)
-
 
 def _extract_caregiver_section(user_profile: str) -> str:
     """Extract caregiver-relevant notes from USER.md content."""
@@ -940,11 +923,18 @@ async def get_voice_context(request: Request):
                 )
                 if resp.status_code == 200:
                     file_list = resp.json().get("files", [])
-                    files = {f.get("name", f.get("filename", "")): f.get("content", "") for f in file_list}
-                    logger.info(f"[FLOW:VOICE-CONTEXT] Loaded {len(files)} workspace files " f"for agent={agent_id}")
+                    files = {
+                        f.get("name", f.get("filename", "")): f.get("content", "")
+                        for f in file_list
+                    }
+                    logger.info(
+                        f"[FLOW:VOICE-CONTEXT] Loaded {len(files)} workspace files "
+                        f"for agent={agent_id}"
+                    )
                 else:
                     logger.warning(
-                        f"[FLOW:VOICE-CONTEXT] Provision API returned " f"{resp.status_code} for agent={agent_id}"
+                        f"[FLOW:VOICE-CONTEXT] Provision API returned "
+                        f"{resp.status_code} for agent={agent_id}"
                     )
         except Exception as e:
             logger.warning(f"[FLOW:VOICE-CONTEXT] Provision API error: {e}")
@@ -973,7 +963,6 @@ async def get_voice_context(request: Request):
     memory_context = ""
     try:
         import asyncio as _aio
-
         conv_task = _aio.create_task(_fetch_recent_conversations(uid, limit=8))
         timeline_task = _aio.create_task(_fetch_recent_canonical_timeline(uid, limit=40, max_chars=9000))
         mem_task = _aio.create_task(
@@ -1020,7 +1009,7 @@ async def get_voice_context(request: Request):
         except Exception as _ve:
             logger.warning(f"[FLOW:VOICE-CONTEXT] Voice daily log read error: {_ve}")
     memory = files.get("MEMORY.md", "")[:500]
-
+    
     # Additional workspace files for richer context
     tools_md = files.get("TOOLS.md", "")[:500]  # Agent capabilities awareness
     shared_reports = ""
@@ -1069,34 +1058,33 @@ async def search_omi_conversations(request: Request):
     """
     Search OMI conversations for a user. Called by Grok voice proxy during live calls
     when the user asks to look up specific past conversations.
-
+    
     Body:
         uid (str): Firebase UID of the user
         query (str): Search terms (matched against title and overview)
         limit (int, optional): Max results (default: 5, max: 10)
-
+    
     Returns list of matching conversations with title, overview, and timestamp.
     """
     body = await request.json()
     uid = body.get("uid", "")
     query = body.get("query", "")
     limit = min(body.get("limit", 5), 10)
-
+    
     if not uid:
         raise HTTPException(status_code=400, detail="uid required")
     if not query:
         raise HTTPException(status_code=400, detail="query required")
-
+    
     logger.info(f"[FLOW:VOICE-SEARCH] uid={uid} query=\"{query}\" limit={limit}")
-
+    
     try:
         from google.cloud import firestore
-
         db = firestore.Client()
-
+        
         from datetime import datetime, timedelta
         import re as re_mod
-
+        
         # Parse date hints from query for date-range filtering
         now_local = _pacific_now()
         now_local = _pacific_now()
@@ -1104,12 +1092,12 @@ async def search_omi_conversations(request: Request):
         date_filter_start = None
         date_filter_end = None
         keyword_terms = []
-
+        
         query_lower = query.lower().strip()
-
+        
         # Date patterns: "march 8", "march 8th", "3/8", "yesterday", "last week", "today"
         date_parsed = False
-
+        
         if "yesterday" in query_lower:
             d = now - timedelta(days=1)
             date_filter_start = d.replace(hour=0, minute=0, second=0)
@@ -1134,34 +1122,15 @@ async def search_omi_conversations(request: Request):
         else:
             # Try "month day" pattern: "march 8", "march 8th", "mar 8"
             month_names = {
-                "jan": 1,
-                "january": 1,
-                "feb": 2,
-                "february": 2,
-                "mar": 3,
-                "march": 3,
-                "apr": 4,
-                "april": 4,
-                "may": 5,
-                "jun": 6,
-                "june": 6,
-                "jul": 7,
-                "july": 7,
-                "aug": 8,
-                "august": 8,
-                "sep": 9,
-                "september": 9,
-                "oct": 10,
-                "october": 10,
-                "nov": 11,
-                "november": 11,
-                "dec": 12,
-                "december": 12,
+                "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
+                "apr": 4, "april": 4, "may": 5, "jun": 6, "june": 6, "jul": 7, "july": 7,
+                "aug": 8, "august": 8, "sep": 9, "september": 9, "oct": 10, "october": 10,
+                "nov": 11, "november": 11, "dec": 12, "december": 12,
             }
             date_match = re_mod.search(
                 r"(january|february|march|april|may|june|july|august|september|october|november|december|"
                 r"jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)\s+(\d{1,2})(?:st|nd|rd|th)?",
-                query_lower,
+                query_lower
             )
             if date_match:
                 month_str = date_match.group(1)
@@ -1178,26 +1147,24 @@ async def search_omi_conversations(request: Request):
                         date_filter_end = target.replace(hour=23, minute=59, second=59)
                         date_parsed = True
                         # Remove date part from query for keyword matching
-                        remaining = query_lower[: date_match.start()] + query_lower[date_match.end() :]
+                        remaining = query_lower[:date_match.start()] + query_lower[date_match.end():]
                         keyword_terms = [t for t in remaining.split() if t]
                     except ValueError:
                         pass
-
+        
         if not date_parsed:
             keyword_terms = query_lower.split()
 
         keyword_terms = _expand_query_terms(_significant_query_terms(" ".join(keyword_terms)))
         keyword_terms = _normalized_query_terms(" ".join(keyword_terms))
-
+        
         logger.info(f"[FLOW:VOICE-SEARCH] date_filter={date_filter_start}->{date_filter_end}, keywords={keyword_terms}")
-
+        
         # Fetch conversations — use date filter if we have one, otherwise get last 100
         if date_filter_start and date_filter_end:
             # Firestore query with date range
             convos_ref = (
-                db.collection("users")
-                .document(uid)
-                .collection("conversations")
+                db.collection("users").document(uid).collection("conversations")
                 .where("created_at", ">=", date_filter_start)
                 .where("created_at", "<=", date_filter_end)
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
@@ -1205,31 +1172,29 @@ async def search_omi_conversations(request: Request):
             )
         else:
             convos_ref = (
-                db.collection("users")
-                .document(uid)
-                .collection("conversations")
+                db.collection("users").document(uid).collection("conversations")
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
                 .limit(100)
             )
         convos = [doc.to_dict() for doc in convos_ref.stream()]
-
+        
         # Client-side keyword match (skip if only date search with no keywords)
         matches = []
-
+        
         for c in convos:
             structured = c.get("structured", {})
             title = (structured.get("title", "") or "").lower()
             overview = (structured.get("overview", "") or "").lower()
             category = (structured.get("category", "") or "").lower()
-
+            
             # Include formatted date in searchable text
             created = c.get("created_at")
             date_str = ""
             if created and hasattr(created, "strftime"):
                 date_str = created.strftime("%B %d %Y %b %A").lower()  # "march 18 2026 mar monday"
-
+            
             searchable = f"{title} {overview} {category} {date_str}"
-
+            
             if keyword_terms:
                 # Score: how many keyword terms match
                 score = _keyword_score(searchable, keyword_terms)
@@ -1238,11 +1203,11 @@ async def search_omi_conversations(request: Request):
             else:
                 # Date-only search — return all conversations from that date
                 matches.append((1, c))
-
+        
         # Sort by score (desc), then by recency
         matches.sort(key=lambda x: x[0], reverse=True)
         matches = matches[:limit]
-
+        
         results = []
         for score, c in matches:
             structured = c.get("structured", {})
@@ -1257,21 +1222,19 @@ async def search_omi_conversations(request: Request):
                     ts = created.strftime("%Y-%m-%d %I:%M %p")
                 else:
                     ts = str(created)[:16]
-
-            results.append(
-                {
-                    "title": structured.get("title", "Untitled"),
-                    "overview": structured.get("overview", ""),
-                    "emoji": structured.get("emoji", ""),
-                    "category": structured.get("category", ""),
-                    "timestamp": ts,
-                    "score": score,
-                }
-            )
-
+            
+            results.append({
+                "title": structured.get("title", "Untitled"),
+                "overview": structured.get("overview", ""),
+                "emoji": structured.get("emoji", ""),
+                "category": structured.get("category", ""),
+                "timestamp": ts,
+                "score": score,
+            })
+        
         logger.info(f"[FLOW:VOICE-SEARCH] Found {len(results)} matches for \"{query}\"")
         return {"results": results, "total_searched": len(convos), "query": query}
-
+    
     except Exception as e:
         logger.error(f"[FLOW:VOICE-SEARCH] Error: {e}")
         return {"results": [], "error": str(e), "query": query}
@@ -1286,53 +1249,21 @@ async def search_omi_conversations(request: Request):
 # Privacy policy: maps agent_role -> source -> access level
 # True = full access, False = no access, "own" = own data only, "full" = full
 SEARCH_POLICY = {
-    "user": {
-        "timeline": True,
-        "workspace": True,
-        "omi_full": True,
-        "omi_meta": True,
-        "memories": True,
-        "voice": True,
-        "scanner": "own",
-    },
-    "caregiver": {
-        "timeline": True,
-        "workspace": True,
-        "omi_full": False,
-        "omi_meta": True,
-        "memories": False,
-        "voice": False,
-        "scanner": "full",
-    },
-    "scanner": {
-        "timeline": False,
-        "workspace": False,
-        "omi_full": False,
-        "omi_meta": False,
-        "memories": False,
-        "voice": False,
-        "scanner": False,
-    },
-    "voice": {
-        "timeline": True,
-        "workspace": True,
-        "omi_full": True,
-        "omi_meta": True,
-        "memories": True,
-        "voice": True,
-        "scanner": False,
-    },
+    "user":      {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": "own"},
+    "caregiver": {"timeline": True, "workspace": True, "omi_full": False, "omi_meta": True, "memories": False, "voice": False, "scanner": "full"},
+    "scanner":   {"timeline": False, "workspace": False, "omi_full": False, "omi_meta": False, "memories": False, "voice": False, "scanner": False},
+    "voice":     {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": False},
 }
 
 # Which source keys map to which request-level source names
 _SOURCE_TO_POLICY_KEYS = {
-    "timeline": ["timeline"],
-    "channel": ["timeline"],
+    "timeline":  ["timeline"],
+    "channel":   ["timeline"],
     "workspace": ["workspace"],
-    "omi": ["omi_full", "omi_meta"],
-    "memories": ["memories"],
-    "voice": ["voice"],
-    "scanner": ["scanner"],
+    "omi":       ["omi_full", "omi_meta"],
+    "memories":  ["memories"],
+    "voice":     ["voice"],
+    "scanner":   ["scanner"],
 }
 
 
@@ -1440,66 +1371,14 @@ def _snippet_around_terms(text: str, terms: list, max_chars: int = 900) -> str:
 
 def _normalized_query_terms(query: str) -> list[str]:
     stop = {
-        "the",
-        "a",
-        "an",
-        "and",
-        "or",
-        "to",
-        "in",
-        "on",
-        "of",
-        "for",
-        "with",
-        "what",
-        "where",
-        "when",
-        "who",
-        "why",
-        "how",
-        "did",
-        "do",
-        "does",
-        "i",
-        "me",
-        "my",
-        "you",
-        "greg",
-        "plato",
-        "tell",
-        "check",
-        "latest",
-        "recent",
-        "memory",
-        "memories",
-        "after",
-        "before",
-        "else",
-        "went",
-        "go",
-        "this",
-        "omi",
-        "conversation",
-        "conversations",
-        "transcript",
-        "transcripts",
-        "summary",
-        "summaries",
-        "morning",
-        "afternoon",
-        "evening",
-        "today",
-        "yesterday",
-        "raw",
-        "happened",
-        "happen",
-        "heard",
-        "hear",
-        "catch",
-        "caught",
-        "find",
-        "pull",
-        "about",
+        "the", "a", "an", "and", "or", "to", "in", "on", "of", "for", "with",
+        "what", "where", "when", "who", "why", "how", "did", "do", "does", "i",
+        "me", "my", "you", "greg", "plato", "tell", "check", "latest", "recent",
+        "memory", "memories", "after", "before", "else", "went", "go", "this",
+        "omi", "conversation", "conversations", "transcript", "transcripts",
+        "summary", "summaries", "morning", "afternoon", "evening", "today",
+        "yesterday", "raw", "happened", "happen", "heard", "hear", "catch",
+        "caught", "find", "pull", "about",
     }
     terms = [t.strip(".,?!:;()[]{}\"'’‘“”").lower() for t in query.split()]
     filtered = [t for t in terms if len(t) > 2 and t not in stop]
@@ -1510,66 +1389,14 @@ def _significant_query_terms(query: str) -> list[str]:
     """Return only evidence-bearing terms; unlike _normalized_query_terms,
     this may return an empty list for broad temporal questions."""
     stop = {
-        "the",
-        "a",
-        "an",
-        "and",
-        "or",
-        "to",
-        "in",
-        "on",
-        "of",
-        "for",
-        "with",
-        "what",
-        "where",
-        "when",
-        "who",
-        "why",
-        "how",
-        "did",
-        "do",
-        "does",
-        "i",
-        "me",
-        "my",
-        "you",
-        "greg",
-        "plato",
-        "tell",
-        "check",
-        "latest",
-        "recent",
-        "memory",
-        "memories",
-        "after",
-        "before",
-        "else",
-        "went",
-        "go",
-        "this",
-        "omi",
-        "conversation",
-        "conversations",
-        "transcript",
-        "transcripts",
-        "summary",
-        "summaries",
-        "morning",
-        "afternoon",
-        "evening",
-        "today",
-        "yesterday",
-        "raw",
-        "happened",
-        "happen",
-        "heard",
-        "hear",
-        "catch",
-        "caught",
-        "find",
-        "pull",
-        "about",
+        "the", "a", "an", "and", "or", "to", "in", "on", "of", "for", "with",
+        "what", "where", "when", "who", "why", "how", "did", "do", "does", "i",
+        "me", "my", "you", "greg", "plato", "tell", "check", "latest", "recent",
+        "memory", "memories", "after", "before", "else", "went", "go", "this",
+        "omi", "conversation", "conversations", "transcript", "transcripts",
+        "summary", "summaries", "morning", "afternoon", "evening", "today",
+        "yesterday", "raw", "happened", "happen", "heard", "hear", "catch",
+        "caught", "find", "pull", "about",
     }
     terms = [t.strip(".,?!:;()[]{}\"'’‘“”").lower() for t in query.split()]
     return [t for t in terms if len(t) > 2 and t not in stop]
@@ -1725,26 +1552,20 @@ async def _search_canonical_timeline(uid: str, query: str, limit: int) -> list:
             ts = row["started_at"]
             ts_text = ts.strftime("%Y-%m-%d %I:%M %p") if ts else ""
             role_boost = 15 if role == "user" else 3
-            matches.append(
-                (
-                    score,
-                    ts or datetime.min,
-                    {
-                        "source": "timeline",
-                        "title": f"{channel} {role}".strip(),
-                        "content": text[:700],
-                        "timestamp": ts_text,
-                        "score": score + role_boost,
-                        "metadata": {
-                            "provenance": "canonical_event",
-                            "channel": channel,
-                            "provider": provider,
-                            "role": role,
-                            "session_id": row["session_id"] or "",
-                        },
-                    },
-                )
-            )
+            matches.append((score, ts or datetime.min, {
+                "source": "timeline",
+                "title": f"{channel} {role}".strip(),
+                "content": text[:700],
+                "timestamp": ts_text,
+                "score": score + role_boost,
+                "metadata": {
+                    "provenance": "canonical_event",
+                    "channel": channel,
+                    "provider": provider,
+                    "role": role,
+                    "session_id": row["session_id"] or "",
+                },
+            }))
         matches.sort(key=lambda x: (x[0], x[1]), reverse=True)
         return [m[2] for m in matches[:limit]]
     except Exception as e:
@@ -1785,23 +1606,21 @@ async def _search_voice_memory_pack(uid: str, query: str, limit: int) -> list:
         top = sources[0] if sources else {}
         confidence = data.get("confidence") or "medium"
         score = 120 if confidence == "high" else 70
-        return [
-            {
-                "source": "voice_memory",
-                "title": top.get("title") or "Hermes Voice Memory",
-                "content": answer[:900],
-                "timestamp": top.get("timestamp") or "",
-                "score": score,
-                "metadata": {
-                    "provenance": "hermes_voice_memory",
-                    "path": data.get("path"),
-                    "confidence": confidence,
-                    "latency_ms": data.get("latency_ms"),
-                    "source_ref": top.get("source_ref"),
-                    "channel": top.get("channel"),
-                },
-            }
-        ]
+        return [{
+            "source": "voice_memory",
+            "title": top.get("title") or "Hermes Voice Memory",
+            "content": answer[:900],
+            "timestamp": top.get("timestamp") or "",
+            "score": score,
+            "metadata": {
+                "provenance": "hermes_voice_memory",
+                "path": data.get("path"),
+                "confidence": confidence,
+                "latency_ms": data.get("latency_ms"),
+                "source_ref": top.get("source_ref"),
+                "channel": top.get("channel"),
+            },
+        }]
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-MEMORY] lookup error: {e}")
         return []
@@ -1879,21 +1698,21 @@ async def _search_workspace(uid: str, agent_id: str, query: str, limit: int) -> 
             if resp.status_code == 200:
                 data = resp.json()
                 for item in data.get("results", [])[:limit]:
-                    results.append(
-                        {
-                            "source": "workspace",
-                            "title": item.get("file", ""),
-                            "content": (item.get("snippet", "") or item.get("content", ""))[:500],
-                            "timestamp": "",
-                            "score": item.get("score", 1),
-                            "metadata": {"provenance": "hermes_workspace_mirror", "file": item.get("file", "")},
-                        }
-                    )
+                    results.append({
+                        "source": "workspace",
+                        "title": item.get("file", ""),
+                        "content": (item.get("snippet", "") or item.get("content", ""))[:500],
+                        "timestamp": "",
+                        "score": item.get("score", 1),
+                        "metadata": {"provenance": "hermes_workspace_mirror", "file": item.get("file", "")},
+                    })
                 return results
 
             # 404 = no search endpoint; fall back to reading key files
             if resp.status_code != 404:
-                logger.warning(f"[FLOW:UNIFIED-SEARCH] Provision search returned {resp.status_code}")
+                logger.warning(
+                    f"[FLOW:UNIFIED-SEARCH] Provision search returned {resp.status_code}"
+                )
                 return results
 
             # Fallback: read files list and grep
@@ -1925,16 +1744,14 @@ async def _search_workspace(uid: str, agent_id: str, query: str, limit: int) -> 
                     if not snippet:
                         snippet = content[:200]
 
-                    results.append(
-                        {
-                            "source": "workspace",
-                            "title": fname,
-                            "content": snippet,
-                            "timestamp": "",
-                            "score": score,
-                            "metadata": {"provenance": "hermes_workspace_mirror", "file": fname},
-                        }
-                    )
+                    results.append({
+                        "source": "workspace",
+                        "title": fname,
+                        "content": snippet,
+                        "timestamp": "",
+                        "score": score,
+                        "metadata": {"provenance": "hermes_workspace_mirror", "file": fname},
+                    })
 
             # Sort by score desc, limit
             results.sort(key=lambda x: x["score"], reverse=True)
@@ -2053,36 +1870,36 @@ async def _search_canonical_omi_events(uid: str, query: str, limit: int, full_ac
     for score, _started_sort, event, title, content in matches[:limit]:
         metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
         structured = metadata.get("structured") if isinstance(metadata.get("structured"), dict) else {}
-        results.append(
-            {
-                "source": "omi",
-                "title": title,
-                "content": content[:1400],
-                "timestamp": _canonical_event_timestamp(event),
-                "score": score + (55 if window_start else 45),
-                "metadata": {
-                    "provenance": "canonical_event",
-                    "fallback": False,
-                    "event_id": event.get("event_id"),
-                    "source_identity": event.get("source_identity"),
-                    "channel": event.get("channel"),
-                    "provider": event.get("provider"),
-                    "emoji": structured.get("emoji", ""),
-                    "category": structured.get("category", ""),
-                    "time_window_applied": bool(window_start and window_end),
-                    "time_window_start_utc": window_start.isoformat() if window_start else "",
-                    "time_window_end_utc": window_end.isoformat() if window_end else "",
-                    "timestamp_timezone": "America/Los_Angeles",
-                },
-            }
-        )
+        results.append({
+            "source": "omi",
+            "title": title,
+            "content": content[:1400],
+            "timestamp": _canonical_event_timestamp(event),
+            "score": score + (55 if window_start else 45),
+            "metadata": {
+                "provenance": "canonical_event",
+                "fallback": False,
+                "event_id": event.get("event_id"),
+                "source_identity": event.get("source_identity"),
+                "channel": event.get("channel"),
+                "provider": event.get("provider"),
+                "emoji": structured.get("emoji", ""),
+                "category": structured.get("category", ""),
+                "time_window_applied": bool(window_start and window_end),
+                "time_window_start_utc": window_start.isoformat() if window_start else "",
+                "time_window_end_utc": window_end.isoformat() if window_end else "",
+                "timestamp_timezone": "America/Los_Angeles",
+            },
+        })
     return results
 
 
 async def _search_omi_canonical_first(uid: str, query: str, limit: int, full_access: bool) -> list:
     canonical_results = await _search_canonical_omi_events(uid, query, limit, full_access)
     if canonical_results:
-        logger.info(f"[FLOW:UNIFIED-SEARCH] uid={uid} omi_source=canonical_event results={len(canonical_results)}")
+        logger.info(
+            f"[FLOW:UNIFIED-SEARCH] uid={uid} omi_source=canonical_event results={len(canonical_results)}"
+        )
         return canonical_results
 
     logger.warning(
@@ -2168,29 +1985,10 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             keyword_terms = [t for t in query_lower.replace("last month", "").split() if t]
         else:
             month_names = {
-                "jan": 1,
-                "january": 1,
-                "feb": 2,
-                "february": 2,
-                "mar": 3,
-                "march": 3,
-                "apr": 4,
-                "april": 4,
-                "may": 5,
-                "jun": 6,
-                "june": 6,
-                "jul": 7,
-                "july": 7,
-                "aug": 8,
-                "august": 8,
-                "sep": 9,
-                "september": 9,
-                "oct": 10,
-                "october": 10,
-                "nov": 11,
-                "november": 11,
-                "dec": 12,
-                "december": 12,
+                "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
+                "apr": 4, "april": 4, "may": 5, "jun": 6, "june": 6, "jul": 7, "july": 7,
+                "aug": 8, "august": 8, "sep": 9, "september": 9, "oct": 10, "october": 10,
+                "nov": 11, "november": 11, "dec": 12, "december": 12,
             }
             date_match = _re.search(
                 r"(january|february|march|april|may|june|july|august|september|october|"
@@ -2224,9 +2022,7 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
         # --- Firestore query ---
         if date_filter_start and date_filter_end:
             convos_ref = (
-                db.collection("users")
-                .document(uid)
-                .collection("conversations")
+                db.collection("users").document(uid).collection("conversations")
                 .where("created_at", ">=", date_filter_start)
                 .where("created_at", "<=", date_filter_end)
                 .order_by("created_at", direction=_fs.Query.DESCENDING)
@@ -2234,9 +2030,7 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             )
         else:
             convos_ref = (
-                db.collection("users")
-                .document(uid)
-                .collection("conversations")
+                db.collection("users").document(uid).collection("conversations")
                 .order_by("created_at", direction=_fs.Query.DESCENDING)
                 .limit(100)
             )
@@ -2305,23 +2099,21 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
                         + snippet
                     )[:1400]
 
-            results.append(
-                {
-                    "source": "omi",
-                    "title": structured.get("title", "Untitled"),
-                    "content": overview_text,
-                    "timestamp": ts,
-                    "score": score + 18,
-                    "metadata": {
-                        "provenance": "firestore_legacy_omi",
-                        "fallback": True,
-                        "emoji": structured.get("emoji", ""),
-                        "category": structured.get("category", ""),
-                        "has_transcript_detail": bool(transcript_text and full_access),
-                        "timestamp_timezone": "America/Los_Angeles",
-                    },
-                }
-            )
+            results.append({
+                "source": "omi",
+                "title": structured.get("title", "Untitled"),
+                "content": overview_text,
+                "timestamp": ts,
+                "score": score + 18,
+                "metadata": {
+                    "provenance": "firestore_legacy_omi",
+                    "fallback": True,
+                    "emoji": structured.get("emoji", ""),
+                    "category": structured.get("category", ""),
+                    "has_transcript_detail": bool(transcript_text and full_access),
+                    "timestamp_timezone": "America/Los_Angeles",
+                },
+            })
 
         return results
 
@@ -2344,9 +2136,7 @@ async def _search_memories(uid: str, query: str, limit: int) -> list:
 
         # Fetch recent memories sorted by scoring (same pattern as database/memories.py)
         memories_ref = (
-            db.collection("users")
-            .document(uid)
-            .collection("memories")
+            db.collection("users").document(uid).collection("memories")
             .order_by("scoring", direction=_fs.Query.DESCENDING)
             .order_by("created_at", direction=_fs.Query.DESCENDING)
             .limit(100)
@@ -2381,19 +2171,17 @@ async def _search_memories(uid: str, query: str, limit: int) -> list:
                     ts = str(created)[:16]
 
             display_content = mem.get("structured_memory", "") or mem.get("content", "")
-            results.append(
-                {
-                    "source": "memories",
-                    "title": (mem.get("category", "") or "Memory").title(),
-                    "content": (display_content or "")[:500],
-                    "timestamp": ts,
-                    "score": score,
-                    "metadata": {
-                        "category": mem.get("category", ""),
-                        "id": mem.get("id", ""),
-                    },
-                }
-            )
+            results.append({
+                "source": "memories",
+                "title": (mem.get("category", "") or "Memory").title(),
+                "content": (display_content or "")[:500],
+                "timestamp": ts,
+                "score": score,
+                "metadata": {
+                    "category": mem.get("category", ""),
+                    "id": mem.get("id", ""),
+                },
+            })
 
         return results
 
@@ -2463,16 +2251,14 @@ async def _search_voice_logs(uid: str, agent_id: str, query: str, limit: int) ->
                     if not snippet:
                         snippet = content[:200]
 
-                    results.append(
-                        {
-                            "source": "voice",
-                            "title": fname,
-                            "content": snippet,
-                            "timestamp": fname.replace("voice/", "").replace(".md", ""),
-                            "score": score,
-                            "metadata": {"file": fname},
-                        }
-                    )
+                    results.append({
+                        "source": "voice",
+                        "title": fname,
+                        "content": snippet,
+                        "timestamp": fname.replace("voice/", "").replace(".md", ""),
+                        "score": score,
+                        "metadata": {"file": fname},
+                    })
 
             results.sort(key=lambda x: x["score"], reverse=True)
             return results[:limit]
@@ -2542,24 +2328,19 @@ async def _search_scanner_logs(uid: str, query: str, limit: int, access_level: s
                     ts = row["created_at"].strftime("%Y-%m-%d %I:%M %p")
 
                 display_content = result_data.get("summary", row["transcript_preview"] or "")
-                matches.append(
-                    (
-                        score,
-                        {
-                            "source": "scanner",
-                            "title": f"[{(row['urgency'] or 'info').upper()}] {row['category'] or 'alert'}",
-                            "content": (display_content or "")[:500],
-                            "timestamp": ts,
-                            "score": score,
-                            "metadata": {
-                                "category": row["category"] or "",
-                                "urgency": row["urgency"] or "",
-                                "escalated": row["escalated"],
-                                "id": str(row["id"]),
-                            },
-                        },
-                    )
-                )
+                matches.append((score, {
+                    "source": "scanner",
+                    "title": f"[{(row['urgency'] or 'info').upper()}] {row['category'] or 'alert'}",
+                    "content": (display_content or "")[:500],
+                    "timestamp": ts,
+                    "score": score,
+                    "metadata": {
+                        "category": row["category"] or "",
+                        "urgency": row["urgency"] or "",
+                        "escalated": row["escalated"],
+                        "id": str(row["id"]),
+                    },
+                }))
 
         matches.sort(key=lambda x: x[0], reverse=True)
         return [m[1] for m in matches[:limit]]
@@ -2601,9 +2382,7 @@ async def unified_search(request: Request):
     if not query:
         raise HTTPException(status_code=400, detail="query required")
     if agent_role not in SEARCH_POLICY:
-        raise HTTPException(
-            status_code=400, detail=f"Invalid agent_role: {agent_role}. Must be one of: {list(SEARCH_POLICY.keys())}"
-        )
+        raise HTTPException(status_code=400, detail=f"Invalid agent_role: {agent_role}. Must be one of: {list(SEARCH_POLICY.keys())}")
 
     # Validate agent-uid association
     if not _validate_agent_uid(agent_id, uid):

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -441,7 +441,9 @@ async def create_voice_session(
     user_display_name = None
     try:
         pool = await _get_pool()
-        row = await pool.fetchrow("SELECT name FROM users WHERE omi_uid = $1", uid)
+        row = await pool.fetchrow(
+            "SELECT name FROM users WHERE omi_uid = $1", uid
+        )
         if row:
             user_display_name = row["name"]
     except Exception as e:
@@ -554,10 +556,7 @@ async def synthesize_speech(
                 )
             _elapsed = int((time.time() - _start) * 1000)
             if response.status_code != 200:
-                print(
-                    f"[FLOW:VOICE-TTS] ERROR provider={provider} status={response.status_code} latency={_elapsed}ms",
-                    flush=True,
-                )
+                print(f"[FLOW:VOICE-TTS] ERROR provider={provider} status={response.status_code} latency={_elapsed}ms", flush=True)
                 raise HTTPException(status_code=502, detail=f"ella-tts error: {response.status_code}")
             audio_size = len(response.content)
             print(f"[FLOW:VOICE-TTS] OK provider={provider} audio_bytes={audio_size} latency={_elapsed}ms", flush=True)
@@ -579,10 +578,7 @@ async def synthesize_speech(
             print(f"[FLOW:VOICE-TTS] ERROR provider=xai-tts key_missing=true", flush=True)
             raise HTTPException(status_code=500, detail="XAI_API_KEY not configured")
         voice_id = request.voice_id if request.voice_id != DEFAULT_ELEVENLABS_VOICE_ID else XAI_TTS_VOICE_ID
-        print(
-            f"[FLOW:VOICE-TTS] provider=xai-tts voice={voice_id} language={XAI_TTS_LANGUAGE} text_len={text_len}",
-            flush=True,
-        )
+        print(f"[FLOW:VOICE-TTS] provider=xai-tts voice={voice_id} language={XAI_TTS_LANGUAGE} text_len={text_len}", flush=True)
         try:
             async with httpx.AsyncClient() as client:
                 response = await client.post(
@@ -645,10 +641,7 @@ async def synthesize_speech(
     # --- Reject unknown providers (no silent fallbacks) ---
     if provider != "elevenlabs":
         print(f"[FLOW:VOICE-TTS] ERROR unknown provider={provider!r}", flush=True)
-        raise HTTPException(
-            status_code=400,
-            detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, xai-tts, grok-voice, gemini-live",
-        )
+        raise HTTPException(status_code=400, detail=f"Unknown TTS provider: {provider!r}. Valid: elevenlabs, fish-audio, fish-audio-s1, fish-audio-s2, kokoro, inworld, xai-tts, grok-voice, gemini-live")
 
     # --- ElevenLabs ---
     if not ELEVENLABS_API_KEY:
@@ -677,17 +670,11 @@ async def synthesize_speech(
         _elapsed = int((time.time() - _start) * 1000)
 
         if response.status_code != 200:
-            print(
-                f"[FLOW:VOICE-TTS] ERROR provider=elevenlabs status={response.status_code} latency={_elapsed}ms body={response.text[:200]}",
-                flush=True,
-            )
+            print(f"[FLOW:VOICE-TTS] ERROR provider=elevenlabs status={response.status_code} latency={_elapsed}ms body={response.text[:200]}", flush=True)
             raise HTTPException(status_code=502, detail=f"ElevenLabs error: {response.status_code}")
 
         audio_size = len(response.content)
-        print(
-            f"[FLOW:VOICE-TTS] OK provider=elevenlabs voice={request.voice_id} audio_bytes={audio_size} latency={_elapsed}ms",
-            flush=True,
-        )
+        print(f"[FLOW:VOICE-TTS] OK provider=elevenlabs voice={request.voice_id} audio_bytes={audio_size} latency={_elapsed}ms", flush=True)
 
         return Response(content=response.content, media_type="audio/mpeg")
 
@@ -732,6 +719,8 @@ async def voice_health():
 # ============================================================================
 
 
+
+
 async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
     """Fetch recent OMI conversation summaries from Firestore for voice context.
     Returns formatted string of recent conversations (title + overview)."""
@@ -739,20 +728,17 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
         # Direct Firestore query — simpler than get_conversations() to avoid
         # composite index requirements (discarded + created_at needs index)
         from google.cloud import firestore
-
         db = firestore.Client()
         convos_ref = (
-            db.collection("users")
-            .document(uid)
-            .collection("conversations")
+            db.collection("users").document(uid).collection("conversations")
             .order_by("created_at", direction=firestore.Query.DESCENDING)
             .limit(limit)
         )
         convos = [doc.to_dict() for doc in convos_ref.stream()]
-
+        
         if not convos:
             return ""
-
+        
         parts = []
         for c in convos:
             structured = c.get("structured", {})
@@ -760,7 +746,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
             overview = structured.get("overview", "")
             emoji = structured.get("emoji", "")
             created = c.get("created_at")
-
+            
             # Format timestamp
             ts = ""
             if created:
@@ -768,7 +754,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
                     ts = created.strftime("%b %d %I:%M %p")
                 else:
                     ts = str(created)[:16]
-
+            
             entry = f"- {emoji} {title}"
             if overview:
                 # Truncate long overviews
@@ -777,7 +763,7 @@ async def _fetch_recent_conversations(uid: str, limit: int = 5) -> str:
             if ts:
                 entry += f" ({ts})"
             parts.append(entry)
-
+        
         return "\n".join(parts)
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Conversation fetch failed: {e}")
@@ -794,15 +780,15 @@ async def _fetch_memory_context(
     Returns formatted string of relevant memory snippets."""
     if not gateway_token:
         return ""
-
+    
     headers = {
         "Authorization": f"Bearer {gateway_token}",
         "Content-Type": "application/json",
     }
-
+    
     results_all = []
     queries = [f"{user_name} recent activity today schedule important"]
-
+    
     try:
         async with httpx.AsyncClient(timeout=timeout_seconds) as client:
             for query in queries:
@@ -816,7 +802,6 @@ async def _fetch_memory_context(
                         data = resp.json()
                         if data.get("ok"):
                             import json as json_mod
-
                             results_text = data["result"]["content"][0]["text"]
                             results = json_mod.loads(results_text).get("results", [])
                             for r in results[:3]:
@@ -830,10 +815,10 @@ async def _fetch_memory_context(
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Memory context fetch failed: {e}")
         return ""
-
+    
     if not results_all:
         return ""
-
+    
     # Sort by score, deduplicate, take top 5
     results_all.sort(key=lambda x: x[1], reverse=True)
     seen = set()
@@ -845,9 +830,8 @@ async def _fetch_memory_context(
             unique.append(snippet)
         if len(unique) >= 5:
             break
-
+    
     return "\n---\n".join(unique)
-
 
 def _extract_caregiver_section(user_profile: str) -> str:
     """Extract caregiver-relevant notes from USER.md content."""
@@ -928,11 +912,18 @@ async def get_voice_context(request: Request):
                 )
                 if resp.status_code == 200:
                     file_list = resp.json().get("files", [])
-                    files = {f.get("name", f.get("filename", "")): f.get("content", "") for f in file_list}
-                    logger.info(f"[FLOW:VOICE-CONTEXT] Loaded {len(files)} workspace files " f"for agent={agent_id}")
+                    files = {
+                        f.get("name", f.get("filename", "")): f.get("content", "")
+                        for f in file_list
+                    }
+                    logger.info(
+                        f"[FLOW:VOICE-CONTEXT] Loaded {len(files)} workspace files "
+                        f"for agent={agent_id}"
+                    )
                 else:
                     logger.warning(
-                        f"[FLOW:VOICE-CONTEXT] Provision API returned " f"{resp.status_code} for agent={agent_id}"
+                        f"[FLOW:VOICE-CONTEXT] Provision API returned "
+                        f"{resp.status_code} for agent={agent_id}"
                     )
         except Exception as e:
             logger.warning(f"[FLOW:VOICE-CONTEXT] Provision API error: {e}")
@@ -961,7 +952,6 @@ async def get_voice_context(request: Request):
     memory_context = ""
     try:
         import asyncio as _aio
-
         conv_task = _aio.create_task(_fetch_recent_conversations(uid, limit=8))
         timeline_task = _aio.create_task(_fetch_recent_canonical_timeline(uid, limit=40, max_chars=9000))
         mem_task = _aio.create_task(
@@ -1008,7 +998,7 @@ async def get_voice_context(request: Request):
         except Exception as _ve:
             logger.warning(f"[FLOW:VOICE-CONTEXT] Voice daily log read error: {_ve}")
     memory = files.get("MEMORY.md", "")[:500]
-
+    
     # Additional workspace files for richer context
     tools_md = files.get("TOOLS.md", "")[:500]  # Agent capabilities awareness
     shared_reports = ""
@@ -1057,34 +1047,33 @@ async def search_omi_conversations(request: Request):
     """
     Search OMI conversations for a user. Called by Grok voice proxy during live calls
     when the user asks to look up specific past conversations.
-
+    
     Body:
         uid (str): Firebase UID of the user
         query (str): Search terms (matched against title and overview)
         limit (int, optional): Max results (default: 5, max: 10)
-
+    
     Returns list of matching conversations with title, overview, and timestamp.
     """
     body = await request.json()
     uid = body.get("uid", "")
     query = body.get("query", "")
     limit = min(body.get("limit", 5), 10)
-
+    
     if not uid:
         raise HTTPException(status_code=400, detail="uid required")
     if not query:
         raise HTTPException(status_code=400, detail="query required")
-
+    
     logger.info(f"[FLOW:VOICE-SEARCH] uid={uid} query=\"{query}\" limit={limit}")
-
+    
     try:
         from google.cloud import firestore
-
         db = firestore.Client()
-
+        
         from datetime import datetime, timedelta
         import re as re_mod
-
+        
         # Parse date hints from query for date-range filtering
         now_local = _pacific_now()
         now_local = _pacific_now()
@@ -1092,12 +1081,12 @@ async def search_omi_conversations(request: Request):
         date_filter_start = None
         date_filter_end = None
         keyword_terms = []
-
+        
         query_lower = query.lower().strip()
-
+        
         # Date patterns: "march 8", "march 8th", "3/8", "yesterday", "last week", "today"
         date_parsed = False
-
+        
         if "yesterday" in query_lower:
             d = now - timedelta(days=1)
             date_filter_start = d.replace(hour=0, minute=0, second=0)
@@ -1122,34 +1111,15 @@ async def search_omi_conversations(request: Request):
         else:
             # Try "month day" pattern: "march 8", "march 8th", "mar 8"
             month_names = {
-                "jan": 1,
-                "january": 1,
-                "feb": 2,
-                "february": 2,
-                "mar": 3,
-                "march": 3,
-                "apr": 4,
-                "april": 4,
-                "may": 5,
-                "jun": 6,
-                "june": 6,
-                "jul": 7,
-                "july": 7,
-                "aug": 8,
-                "august": 8,
-                "sep": 9,
-                "september": 9,
-                "oct": 10,
-                "october": 10,
-                "nov": 11,
-                "november": 11,
-                "dec": 12,
-                "december": 12,
+                "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
+                "apr": 4, "april": 4, "may": 5, "jun": 6, "june": 6, "jul": 7, "july": 7,
+                "aug": 8, "august": 8, "sep": 9, "september": 9, "oct": 10, "october": 10,
+                "nov": 11, "november": 11, "dec": 12, "december": 12,
             }
             date_match = re_mod.search(
                 r"(january|february|march|april|may|june|july|august|september|october|november|december|"
                 r"jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)\s+(\d{1,2})(?:st|nd|rd|th)?",
-                query_lower,
+                query_lower
             )
             if date_match:
                 month_str = date_match.group(1)
@@ -1166,26 +1136,24 @@ async def search_omi_conversations(request: Request):
                         date_filter_end = target.replace(hour=23, minute=59, second=59)
                         date_parsed = True
                         # Remove date part from query for keyword matching
-                        remaining = query_lower[: date_match.start()] + query_lower[date_match.end() :]
+                        remaining = query_lower[:date_match.start()] + query_lower[date_match.end():]
                         keyword_terms = [t for t in remaining.split() if t]
                     except ValueError:
                         pass
-
+        
         if not date_parsed:
             keyword_terms = query_lower.split()
 
         keyword_terms = _expand_query_terms(_significant_query_terms(" ".join(keyword_terms)))
         keyword_terms = _normalized_query_terms(" ".join(keyword_terms))
-
+        
         logger.info(f"[FLOW:VOICE-SEARCH] date_filter={date_filter_start}->{date_filter_end}, keywords={keyword_terms}")
-
+        
         # Fetch conversations — use date filter if we have one, otherwise get last 100
         if date_filter_start and date_filter_end:
             # Firestore query with date range
             convos_ref = (
-                db.collection("users")
-                .document(uid)
-                .collection("conversations")
+                db.collection("users").document(uid).collection("conversations")
                 .where("created_at", ">=", date_filter_start)
                 .where("created_at", "<=", date_filter_end)
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
@@ -1193,31 +1161,29 @@ async def search_omi_conversations(request: Request):
             )
         else:
             convos_ref = (
-                db.collection("users")
-                .document(uid)
-                .collection("conversations")
+                db.collection("users").document(uid).collection("conversations")
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
                 .limit(100)
             )
         convos = [doc.to_dict() for doc in convos_ref.stream()]
-
+        
         # Client-side keyword match (skip if only date search with no keywords)
         matches = []
-
+        
         for c in convos:
             structured = c.get("structured", {})
             title = (structured.get("title", "") or "").lower()
             overview = (structured.get("overview", "") or "").lower()
             category = (structured.get("category", "") or "").lower()
-
+            
             # Include formatted date in searchable text
             created = c.get("created_at")
             date_str = ""
             if created and hasattr(created, "strftime"):
                 date_str = created.strftime("%B %d %Y %b %A").lower()  # "march 18 2026 mar monday"
-
+            
             searchable = f"{title} {overview} {category} {date_str}"
-
+            
             if keyword_terms:
                 # Score: how many keyword terms match
                 score = _keyword_score(searchable, keyword_terms)
@@ -1226,11 +1192,11 @@ async def search_omi_conversations(request: Request):
             else:
                 # Date-only search — return all conversations from that date
                 matches.append((1, c))
-
+        
         # Sort by score (desc), then by recency
         matches.sort(key=lambda x: x[0], reverse=True)
         matches = matches[:limit]
-
+        
         results = []
         for score, c in matches:
             structured = c.get("structured", {})
@@ -1245,21 +1211,19 @@ async def search_omi_conversations(request: Request):
                     ts = created.strftime("%Y-%m-%d %I:%M %p")
                 else:
                     ts = str(created)[:16]
-
-            results.append(
-                {
-                    "title": structured.get("title", "Untitled"),
-                    "overview": structured.get("overview", ""),
-                    "emoji": structured.get("emoji", ""),
-                    "category": structured.get("category", ""),
-                    "timestamp": ts,
-                    "score": score,
-                }
-            )
-
+            
+            results.append({
+                "title": structured.get("title", "Untitled"),
+                "overview": structured.get("overview", ""),
+                "emoji": structured.get("emoji", ""),
+                "category": structured.get("category", ""),
+                "timestamp": ts,
+                "score": score,
+            })
+        
         logger.info(f"[FLOW:VOICE-SEARCH] Found {len(results)} matches for \"{query}\"")
         return {"results": results, "total_searched": len(convos), "query": query}
-
+    
     except Exception as e:
         logger.error(f"[FLOW:VOICE-SEARCH] Error: {e}")
         return {"results": [], "error": str(e), "query": query}
@@ -1274,53 +1238,21 @@ async def search_omi_conversations(request: Request):
 # Privacy policy: maps agent_role -> source -> access level
 # True = full access, False = no access, "own" = own data only, "full" = full
 SEARCH_POLICY = {
-    "user": {
-        "timeline": True,
-        "workspace": True,
-        "omi_full": True,
-        "omi_meta": True,
-        "memories": True,
-        "voice": True,
-        "scanner": "own",
-    },
-    "caregiver": {
-        "timeline": True,
-        "workspace": True,
-        "omi_full": False,
-        "omi_meta": True,
-        "memories": False,
-        "voice": False,
-        "scanner": "full",
-    },
-    "scanner": {
-        "timeline": False,
-        "workspace": False,
-        "omi_full": False,
-        "omi_meta": False,
-        "memories": False,
-        "voice": False,
-        "scanner": False,
-    },
-    "voice": {
-        "timeline": True,
-        "workspace": True,
-        "omi_full": True,
-        "omi_meta": True,
-        "memories": True,
-        "voice": True,
-        "scanner": False,
-    },
+    "user":      {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": "own"},
+    "caregiver": {"timeline": True, "workspace": True, "omi_full": False, "omi_meta": True, "memories": False, "voice": False, "scanner": "full"},
+    "scanner":   {"timeline": False, "workspace": False, "omi_full": False, "omi_meta": False, "memories": False, "voice": False, "scanner": False},
+    "voice":     {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": False},
 }
 
 # Which source keys map to which request-level source names
 _SOURCE_TO_POLICY_KEYS = {
-    "timeline": ["timeline"],
-    "channel": ["timeline"],
+    "timeline":  ["timeline"],
+    "channel":   ["timeline"],
     "workspace": ["workspace"],
-    "omi": ["omi_full", "omi_meta"],
-    "memories": ["memories"],
-    "voice": ["voice"],
-    "scanner": ["scanner"],
+    "omi":       ["omi_full", "omi_meta"],
+    "memories":  ["memories"],
+    "voice":     ["voice"],
+    "scanner":   ["scanner"],
 }
 
 
@@ -1428,66 +1360,14 @@ def _snippet_around_terms(text: str, terms: list, max_chars: int = 900) -> str:
 
 def _normalized_query_terms(query: str) -> list[str]:
     stop = {
-        "the",
-        "a",
-        "an",
-        "and",
-        "or",
-        "to",
-        "in",
-        "on",
-        "of",
-        "for",
-        "with",
-        "what",
-        "where",
-        "when",
-        "who",
-        "why",
-        "how",
-        "did",
-        "do",
-        "does",
-        "i",
-        "me",
-        "my",
-        "you",
-        "greg",
-        "plato",
-        "tell",
-        "check",
-        "latest",
-        "recent",
-        "memory",
-        "memories",
-        "after",
-        "before",
-        "else",
-        "went",
-        "go",
-        "this",
-        "omi",
-        "conversation",
-        "conversations",
-        "transcript",
-        "transcripts",
-        "summary",
-        "summaries",
-        "morning",
-        "afternoon",
-        "evening",
-        "today",
-        "yesterday",
-        "raw",
-        "happened",
-        "happen",
-        "heard",
-        "hear",
-        "catch",
-        "caught",
-        "find",
-        "pull",
-        "about",
+        "the", "a", "an", "and", "or", "to", "in", "on", "of", "for", "with",
+        "what", "where", "when", "who", "why", "how", "did", "do", "does", "i",
+        "me", "my", "you", "greg", "plato", "tell", "check", "latest", "recent",
+        "memory", "memories", "after", "before", "else", "went", "go", "this",
+        "omi", "conversation", "conversations", "transcript", "transcripts",
+        "summary", "summaries", "morning", "afternoon", "evening", "today",
+        "yesterday", "raw", "happened", "happen", "heard", "hear", "catch",
+        "caught", "find", "pull", "about",
     }
     terms = [t.strip(".,?!:;()[]{}\"'’‘“”").lower() for t in query.split()]
     filtered = [t for t in terms if len(t) > 2 and t not in stop]
@@ -1498,66 +1378,14 @@ def _significant_query_terms(query: str) -> list[str]:
     """Return only evidence-bearing terms; unlike _normalized_query_terms,
     this may return an empty list for broad temporal questions."""
     stop = {
-        "the",
-        "a",
-        "an",
-        "and",
-        "or",
-        "to",
-        "in",
-        "on",
-        "of",
-        "for",
-        "with",
-        "what",
-        "where",
-        "when",
-        "who",
-        "why",
-        "how",
-        "did",
-        "do",
-        "does",
-        "i",
-        "me",
-        "my",
-        "you",
-        "greg",
-        "plato",
-        "tell",
-        "check",
-        "latest",
-        "recent",
-        "memory",
-        "memories",
-        "after",
-        "before",
-        "else",
-        "went",
-        "go",
-        "this",
-        "omi",
-        "conversation",
-        "conversations",
-        "transcript",
-        "transcripts",
-        "summary",
-        "summaries",
-        "morning",
-        "afternoon",
-        "evening",
-        "today",
-        "yesterday",
-        "raw",
-        "happened",
-        "happen",
-        "heard",
-        "hear",
-        "catch",
-        "caught",
-        "find",
-        "pull",
-        "about",
+        "the", "a", "an", "and", "or", "to", "in", "on", "of", "for", "with",
+        "what", "where", "when", "who", "why", "how", "did", "do", "does", "i",
+        "me", "my", "you", "greg", "plato", "tell", "check", "latest", "recent",
+        "memory", "memories", "after", "before", "else", "went", "go", "this",
+        "omi", "conversation", "conversations", "transcript", "transcripts",
+        "summary", "summaries", "morning", "afternoon", "evening", "today",
+        "yesterday", "raw", "happened", "happen", "heard", "hear", "catch",
+        "caught", "find", "pull", "about",
     }
     terms = [t.strip(".,?!:;()[]{}\"'’‘“”").lower() for t in query.split()]
     return [t for t in terms if len(t) > 2 and t not in stop]
@@ -1713,26 +1541,20 @@ async def _search_canonical_timeline(uid: str, query: str, limit: int) -> list:
             ts = row["started_at"]
             ts_text = ts.strftime("%Y-%m-%d %I:%M %p") if ts else ""
             role_boost = 15 if role == "user" else 3
-            matches.append(
-                (
-                    score,
-                    ts or datetime.min,
-                    {
-                        "source": "timeline",
-                        "title": f"{channel} {role}".strip(),
-                        "content": text[:700],
-                        "timestamp": ts_text,
-                        "score": score + role_boost,
-                        "metadata": {
-                            "provenance": "canonical_event",
-                            "channel": channel,
-                            "provider": provider,
-                            "role": role,
-                            "session_id": row["session_id"] or "",
-                        },
-                    },
-                )
-            )
+            matches.append((score, ts or datetime.min, {
+                "source": "timeline",
+                "title": f"{channel} {role}".strip(),
+                "content": text[:700],
+                "timestamp": ts_text,
+                "score": score + role_boost,
+                "metadata": {
+                    "provenance": "canonical_event",
+                    "channel": channel,
+                    "provider": provider,
+                    "role": role,
+                    "session_id": row["session_id"] or "",
+                },
+            }))
         matches.sort(key=lambda x: (x[0], x[1]), reverse=True)
         return [m[2] for m in matches[:limit]]
     except Exception as e:
@@ -1773,23 +1595,21 @@ async def _search_voice_memory_pack(uid: str, query: str, limit: int) -> list:
         top = sources[0] if sources else {}
         confidence = data.get("confidence") or "medium"
         score = 120 if confidence == "high" else 70
-        return [
-            {
-                "source": "voice_memory",
-                "title": top.get("title") or "Hermes Voice Memory",
-                "content": answer[:900],
-                "timestamp": top.get("timestamp") or "",
-                "score": score,
-                "metadata": {
-                    "provenance": "hermes_voice_memory",
-                    "path": data.get("path"),
-                    "confidence": confidence,
-                    "latency_ms": data.get("latency_ms"),
-                    "source_ref": top.get("source_ref"),
-                    "channel": top.get("channel"),
-                },
-            }
-        ]
+        return [{
+            "source": "voice_memory",
+            "title": top.get("title") or "Hermes Voice Memory",
+            "content": answer[:900],
+            "timestamp": top.get("timestamp") or "",
+            "score": score,
+            "metadata": {
+                "provenance": "hermes_voice_memory",
+                "path": data.get("path"),
+                "confidence": confidence,
+                "latency_ms": data.get("latency_ms"),
+                "source_ref": top.get("source_ref"),
+                "channel": top.get("channel"),
+            },
+        }]
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-MEMORY] lookup error: {e}")
         return []
@@ -1867,21 +1687,21 @@ async def _search_workspace(uid: str, agent_id: str, query: str, limit: int) -> 
             if resp.status_code == 200:
                 data = resp.json()
                 for item in data.get("results", [])[:limit]:
-                    results.append(
-                        {
-                            "source": "workspace",
-                            "title": item.get("file", ""),
-                            "content": (item.get("snippet", "") or item.get("content", ""))[:500],
-                            "timestamp": "",
-                            "score": item.get("score", 1),
-                            "metadata": {"provenance": "hermes_workspace_mirror", "file": item.get("file", "")},
-                        }
-                    )
+                    results.append({
+                        "source": "workspace",
+                        "title": item.get("file", ""),
+                        "content": (item.get("snippet", "") or item.get("content", ""))[:500],
+                        "timestamp": "",
+                        "score": item.get("score", 1),
+                        "metadata": {"provenance": "hermes_workspace_mirror", "file": item.get("file", "")},
+                    })
                 return results
 
             # 404 = no search endpoint; fall back to reading key files
             if resp.status_code != 404:
-                logger.warning(f"[FLOW:UNIFIED-SEARCH] Provision search returned {resp.status_code}")
+                logger.warning(
+                    f"[FLOW:UNIFIED-SEARCH] Provision search returned {resp.status_code}"
+                )
                 return results
 
             # Fallback: read files list and grep
@@ -1913,16 +1733,14 @@ async def _search_workspace(uid: str, agent_id: str, query: str, limit: int) -> 
                     if not snippet:
                         snippet = content[:200]
 
-                    results.append(
-                        {
-                            "source": "workspace",
-                            "title": fname,
-                            "content": snippet,
-                            "timestamp": "",
-                            "score": score,
-                            "metadata": {"provenance": "hermes_workspace_mirror", "file": fname},
-                        }
-                    )
+                    results.append({
+                        "source": "workspace",
+                        "title": fname,
+                        "content": snippet,
+                        "timestamp": "",
+                        "score": score,
+                        "metadata": {"provenance": "hermes_workspace_mirror", "file": fname},
+                    })
 
             # Sort by score desc, limit
             results.sort(key=lambda x: x["score"], reverse=True)
@@ -2041,36 +1859,36 @@ async def _search_canonical_omi_events(uid: str, query: str, limit: int, full_ac
     for score, _started_sort, event, title, content in matches[:limit]:
         metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
         structured = metadata.get("structured") if isinstance(metadata.get("structured"), dict) else {}
-        results.append(
-            {
-                "source": "omi",
-                "title": title,
-                "content": content[:1400],
-                "timestamp": _canonical_event_timestamp(event),
-                "score": score + (55 if window_start else 45),
-                "metadata": {
-                    "provenance": "canonical_event",
-                    "fallback": False,
-                    "event_id": event.get("event_id"),
-                    "source_identity": event.get("source_identity"),
-                    "channel": event.get("channel"),
-                    "provider": event.get("provider"),
-                    "emoji": structured.get("emoji", ""),
-                    "category": structured.get("category", ""),
-                    "time_window_applied": bool(window_start and window_end),
-                    "time_window_start_utc": window_start.isoformat() if window_start else "",
-                    "time_window_end_utc": window_end.isoformat() if window_end else "",
-                    "timestamp_timezone": "America/Los_Angeles",
-                },
-            }
-        )
+        results.append({
+            "source": "omi",
+            "title": title,
+            "content": content[:1400],
+            "timestamp": _canonical_event_timestamp(event),
+            "score": score + (55 if window_start else 45),
+            "metadata": {
+                "provenance": "canonical_event",
+                "fallback": False,
+                "event_id": event.get("event_id"),
+                "source_identity": event.get("source_identity"),
+                "channel": event.get("channel"),
+                "provider": event.get("provider"),
+                "emoji": structured.get("emoji", ""),
+                "category": structured.get("category", ""),
+                "time_window_applied": bool(window_start and window_end),
+                "time_window_start_utc": window_start.isoformat() if window_start else "",
+                "time_window_end_utc": window_end.isoformat() if window_end else "",
+                "timestamp_timezone": "America/Los_Angeles",
+            },
+        })
     return results
 
 
 async def _search_omi_canonical_first(uid: str, query: str, limit: int, full_access: bool) -> list:
     canonical_results = await _search_canonical_omi_events(uid, query, limit, full_access)
     if canonical_results:
-        logger.info(f"[FLOW:UNIFIED-SEARCH] uid={uid} omi_source=canonical_event results={len(canonical_results)}")
+        logger.info(
+            f"[FLOW:UNIFIED-SEARCH] uid={uid} omi_source=canonical_event results={len(canonical_results)}"
+        )
         return canonical_results
 
     logger.warning(
@@ -2156,29 +1974,10 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             keyword_terms = [t for t in query_lower.replace("last month", "").split() if t]
         else:
             month_names = {
-                "jan": 1,
-                "january": 1,
-                "feb": 2,
-                "february": 2,
-                "mar": 3,
-                "march": 3,
-                "apr": 4,
-                "april": 4,
-                "may": 5,
-                "jun": 6,
-                "june": 6,
-                "jul": 7,
-                "july": 7,
-                "aug": 8,
-                "august": 8,
-                "sep": 9,
-                "september": 9,
-                "oct": 10,
-                "october": 10,
-                "nov": 11,
-                "november": 11,
-                "dec": 12,
-                "december": 12,
+                "jan": 1, "january": 1, "feb": 2, "february": 2, "mar": 3, "march": 3,
+                "apr": 4, "april": 4, "may": 5, "jun": 6, "june": 6, "jul": 7, "july": 7,
+                "aug": 8, "august": 8, "sep": 9, "september": 9, "oct": 10, "october": 10,
+                "nov": 11, "november": 11, "dec": 12, "december": 12,
             }
             date_match = _re.search(
                 r"(january|february|march|april|may|june|july|august|september|october|"
@@ -2212,9 +2011,7 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
         # --- Firestore query ---
         if date_filter_start and date_filter_end:
             convos_ref = (
-                db.collection("users")
-                .document(uid)
-                .collection("conversations")
+                db.collection("users").document(uid).collection("conversations")
                 .where("created_at", ">=", date_filter_start)
                 .where("created_at", "<=", date_filter_end)
                 .order_by("created_at", direction=_fs.Query.DESCENDING)
@@ -2222,9 +2019,7 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
             )
         else:
             convos_ref = (
-                db.collection("users")
-                .document(uid)
-                .collection("conversations")
+                db.collection("users").document(uid).collection("conversations")
                 .order_by("created_at", direction=_fs.Query.DESCENDING)
                 .limit(100)
             )
@@ -2293,23 +2088,21 @@ async def _search_omi_conversations(uid: str, query: str, limit: int, full_acces
                         + snippet
                     )[:1400]
 
-            results.append(
-                {
-                    "source": "omi",
-                    "title": structured.get("title", "Untitled"),
-                    "content": overview_text,
-                    "timestamp": ts,
-                    "score": score + 18,
-                    "metadata": {
-                        "provenance": "firestore_legacy_omi",
-                        "fallback": True,
-                        "emoji": structured.get("emoji", ""),
-                        "category": structured.get("category", ""),
-                        "has_transcript_detail": bool(transcript_text and full_access),
-                        "timestamp_timezone": "America/Los_Angeles",
-                    },
-                }
-            )
+            results.append({
+                "source": "omi",
+                "title": structured.get("title", "Untitled"),
+                "content": overview_text,
+                "timestamp": ts,
+                "score": score + 18,
+                "metadata": {
+                    "provenance": "firestore_legacy_omi",
+                    "fallback": True,
+                    "emoji": structured.get("emoji", ""),
+                    "category": structured.get("category", ""),
+                    "has_transcript_detail": bool(transcript_text and full_access),
+                    "timestamp_timezone": "America/Los_Angeles",
+                },
+            })
 
         return results
 
@@ -2332,9 +2125,7 @@ async def _search_memories(uid: str, query: str, limit: int) -> list:
 
         # Fetch recent memories sorted by scoring (same pattern as database/memories.py)
         memories_ref = (
-            db.collection("users")
-            .document(uid)
-            .collection("memories")
+            db.collection("users").document(uid).collection("memories")
             .order_by("scoring", direction=_fs.Query.DESCENDING)
             .order_by("created_at", direction=_fs.Query.DESCENDING)
             .limit(100)
@@ -2369,19 +2160,17 @@ async def _search_memories(uid: str, query: str, limit: int) -> list:
                     ts = str(created)[:16]
 
             display_content = mem.get("structured_memory", "") or mem.get("content", "")
-            results.append(
-                {
-                    "source": "memories",
-                    "title": (mem.get("category", "") or "Memory").title(),
-                    "content": (display_content or "")[:500],
-                    "timestamp": ts,
-                    "score": score,
-                    "metadata": {
-                        "category": mem.get("category", ""),
-                        "id": mem.get("id", ""),
-                    },
-                }
-            )
+            results.append({
+                "source": "memories",
+                "title": (mem.get("category", "") or "Memory").title(),
+                "content": (display_content or "")[:500],
+                "timestamp": ts,
+                "score": score,
+                "metadata": {
+                    "category": mem.get("category", ""),
+                    "id": mem.get("id", ""),
+                },
+            })
 
         return results
 
@@ -2451,16 +2240,14 @@ async def _search_voice_logs(uid: str, agent_id: str, query: str, limit: int) ->
                     if not snippet:
                         snippet = content[:200]
 
-                    results.append(
-                        {
-                            "source": "voice",
-                            "title": fname,
-                            "content": snippet,
-                            "timestamp": fname.replace("voice/", "").replace(".md", ""),
-                            "score": score,
-                            "metadata": {"file": fname},
-                        }
-                    )
+                    results.append({
+                        "source": "voice",
+                        "title": fname,
+                        "content": snippet,
+                        "timestamp": fname.replace("voice/", "").replace(".md", ""),
+                        "score": score,
+                        "metadata": {"file": fname},
+                    })
 
             results.sort(key=lambda x: x["score"], reverse=True)
             return results[:limit]
@@ -2530,24 +2317,19 @@ async def _search_scanner_logs(uid: str, query: str, limit: int, access_level: s
                     ts = row["created_at"].strftime("%Y-%m-%d %I:%M %p")
 
                 display_content = result_data.get("summary", row["transcript_preview"] or "")
-                matches.append(
-                    (
-                        score,
-                        {
-                            "source": "scanner",
-                            "title": f"[{(row['urgency'] or 'info').upper()}] {row['category'] or 'alert'}",
-                            "content": (display_content or "")[:500],
-                            "timestamp": ts,
-                            "score": score,
-                            "metadata": {
-                                "category": row["category"] or "",
-                                "urgency": row["urgency"] or "",
-                                "escalated": row["escalated"],
-                                "id": str(row["id"]),
-                            },
-                        },
-                    )
-                )
+                matches.append((score, {
+                    "source": "scanner",
+                    "title": f"[{(row['urgency'] or 'info').upper()}] {row['category'] or 'alert'}",
+                    "content": (display_content or "")[:500],
+                    "timestamp": ts,
+                    "score": score,
+                    "metadata": {
+                        "category": row["category"] or "",
+                        "urgency": row["urgency"] or "",
+                        "escalated": row["escalated"],
+                        "id": str(row["id"]),
+                    },
+                }))
 
         matches.sort(key=lambda x: x[0], reverse=True)
         return [m[1] for m in matches[:limit]]
@@ -2589,9 +2371,7 @@ async def unified_search(request: Request):
     if not query:
         raise HTTPException(status_code=400, detail="query required")
     if agent_role not in SEARCH_POLICY:
-        raise HTTPException(
-            status_code=400, detail=f"Invalid agent_role: {agent_role}. Must be one of: {list(SEARCH_POLICY.keys())}"
-        )
+        raise HTTPException(status_code=400, detail=f"Invalid agent_role: {agent_role}. Must be one of: {list(SEARCH_POLICY.keys())}")
 
     # Validate agent-uid association
     if not _validate_agent_uid(agent_id, uid):

--- a/backend/ella/services/observer_extractor.py
+++ b/backend/ella/services/observer_extractor.py
@@ -408,6 +408,7 @@ async def build_extraction_result(
     events: list[dict[str, Any]],
     *,
     mode: str,
+    uid: str = "",
     timeout_seconds: float = 45.0,
     limit: int = MAX_EXTRACTOR_EVENTS,
 ) -> ExtractionResult:
@@ -418,7 +419,32 @@ async def build_extraction_result(
         return _heuristic_extraction_result(events)
 
     heuristic = _heuristic_extraction_result(events)
-    hermes = await hermes_candidate_extraction(events, timeout_seconds=timeout_seconds, limit=limit)
+    hermes_kwargs: dict[str, str] = {}
+    if uid:
+        from ella.services.runtime_resolver import resolve_isolated_runtime, runtime_bindings_enabled
+
+        if runtime_bindings_enabled(uid):
+            runtime = await resolve_isolated_runtime(uid)
+            if runtime is None:
+                return ExtractionResult(
+                    candidates_by_event_id=heuristic.candidates_by_event_id,
+                    metadata={
+                        "extractor": "hermes_plus_heuristic",
+                        "heuristic": heuristic.metadata,
+                        "hermes": {"error": "isolated_runtime_unavailable"},
+                    },
+                )
+            hermes_kwargs = {
+                "gateway_url": runtime.gateway_url,
+                "token": runtime.gateway_token,
+                "model": runtime.agent_id,
+            }
+    hermes = await hermes_candidate_extraction(
+        events,
+        timeout_seconds=timeout_seconds,
+        limit=limit,
+        **hermes_kwargs,
+    )
     merged = {event_id: list(candidates) for event_id, candidates in heuristic.candidates_by_event_id.items()}
     for event_id, candidates in hermes.candidates_by_event_id.items():
         merged.setdefault(event_id, []).extend(candidates)

--- a/backend/ella/services/observer_extractor.py
+++ b/backend/ella/services/observer_extractor.py
@@ -17,6 +17,7 @@ from typing import Any
 import httpx
 
 from ella.services.observer import ObserverCandidate, structured_candidate_extractor
+from ella.services import runtime_resolver
 
 MAX_EXTRACTOR_EVENTS = 60
 MAX_EVENT_TEXT_CHARS = 1800
@@ -421,10 +422,8 @@ async def build_extraction_result(
     heuristic = _heuristic_extraction_result(events)
     hermes_kwargs: dict[str, str] = {}
     if uid:
-        from ella.services.runtime_resolver import resolve_isolated_runtime, runtime_bindings_enabled
-
-        if runtime_bindings_enabled(uid):
-            runtime = await resolve_isolated_runtime(uid)
+        if runtime_resolver.runtime_bindings_enabled(uid):
+            runtime = await runtime_resolver.resolve_isolated_runtime(uid)
             if runtime is None:
                 return ExtractionResult(
                     candidates_by_event_id=heuristic.candidates_by_event_id,

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -110,7 +110,16 @@ def validate_internal_gateway_url(value: str) -> str:
     """Accept only loopback, tailnet, or explicitly allowlisted internal gateways."""
     parsed = urlparse(value)
     host = (parsed.hostname or "").lower()
-    if parsed.scheme != "http" or not host or parsed.username or parsed.password:
+    if (
+        parsed.scheme != "http"
+        or not host
+        or parsed.username
+        or parsed.password
+        or parsed.path not in {"", "/"}
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
         raise ProvisioningError("invalid_internal_gateway_url", retryable=False)
 
     allowlisted = {
@@ -179,7 +188,11 @@ class HermesProvisionClient:
         return result
 
 
-def extract_runtime_binding(result: dict[str, Any], uid: str) -> dict[str, Any]:
+def extract_runtime_binding(
+    result: dict[str, Any],
+    uid: str,
+    expected_template_version: Optional[str] = None,
+) -> dict[str, Any]:
     raw = result.get("runtimeBinding") or result.get("runtime_binding")
     if not isinstance(raw, dict):
         raise ProvisioningError("runtime_receipt_missing", retryable=True)
@@ -233,6 +246,10 @@ def extract_runtime_binding(result: dict[str, Any], uid: str) -> dict[str, Any]:
         raise ProvisioningError("gateway_port_mismatch", retryable=False)
     validate_gateway_credential_ref(str(credential_ref))
 
+    template_version = str(raw.get("templateVersion") or DEFAULT_TEMPLATE_VERSION)
+    if expected_template_version and template_version != expected_template_version:
+        raise ProvisioningError("runtime_template_version_mismatch", retryable=True)
+
     return {
         "role": "user",
         "provider": "hermes",
@@ -246,7 +263,7 @@ def extract_runtime_binding(result: dict[str, Any], uid: str) -> dict[str, Any]:
         "honcho_workspace": str(honcho_workspace),
         "observed_peer": str(observed_peer),
         "observer_peer": str(observer_peer),
-        "template_version": str(raw.get("templateVersion") or DEFAULT_TEMPLATE_VERSION),
+        "template_version": template_version,
         "model_policy_version": str(raw.get("modelPolicyVersion") or DEFAULT_MODEL_POLICY_VERSION),
         "voice_policy_version": str(raw.get("voicePolicyVersion") or DEFAULT_VOICE_POLICY_VERSION),
         "health_state": "healthy",
@@ -300,7 +317,10 @@ class ProvisioningCoordinator:
                 error_code="omi_identity_unavailable",
             )
             return job, None, False
-        binding = await self.repository.resolve_active_runtime(identity.uid)
+        binding = await self.repository.resolve_active_runtime(
+            identity.uid,
+            template_version=target_schema_version,
+        )
         if binding:
             if str(binding.get("user_status") or "") != "ACTIVE":
                 await self.repository.activate_user(identity.uid)
@@ -328,7 +348,11 @@ class ProvisioningCoordinator:
     async def process_claimed_job(self, *, job: dict[str, Any], identity: VerifiedIdentity) -> None:
         try:
             result = await self.client.provision(identity, str(job["target_schema_version"]))
-            binding_data = extract_runtime_binding(result, identity.uid)
+            binding_data = extract_runtime_binding(
+                result,
+                identity.uid,
+                expected_template_version=str(job["target_schema_version"]),
+            )
             binding = await self.repository.stage_runtime_binding(uid=identity.uid, binding=binding_data)
             await self.repository.update_job(
                 job_id=str(job["id"]),

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -15,7 +15,10 @@ from urllib.parse import urlparse
 
 import httpx
 
-from database.ella_provisioning import EllaProvisioningRepository
+from database.ella_provisioning import (
+    EllaProvisioningRepository,
+    ProvisioningSchemaNotReadyError,
+)
 
 DEFAULT_TARGET_SCHEMA_VERSION = "hermes-user-v1"
 DEFAULT_TEMPLATE_VERSION = "hermes-user-v1"
@@ -303,6 +306,12 @@ class ProvisioningCoordinator:
         client_request_id: Optional[str],
         request_payload: dict[str, Any],
     ) -> tuple[dict[str, Any], Optional[dict[str, Any]], bool]:
+        try:
+            await self.repository.assert_schema_ready()
+        except ProvisioningSchemaNotReadyError as exc:
+            logger.error("Ella provisioning schema is incomplete: %s", ", ".join(exc.missing))
+            raise ProvisioningError("provisioning_schema_not_ready", retryable=True) from exc
+
         await self.repository.ensure_user_identity(
             uid=identity.uid,
             email=identity.email,

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -1,0 +1,353 @@
+"""Hermes-only Ella onboarding orchestration and public receipts."""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import logging
+import os
+import posixpath
+import re
+from dataclasses import dataclass
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+import httpx
+
+from database.ella_provisioning import EllaProvisioningRepository
+
+DEFAULT_TARGET_SCHEMA_VERSION = "hermes-user-v1"
+DEFAULT_TEMPLATE_VERSION = "hermes-user-v1"
+DEFAULT_MODEL_POLICY_VERSION = "frontier-v1"
+DEFAULT_VOICE_POLICY_VERSION = "ella-voice-v1"
+PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{2,63}$")
+AGENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
+ALLOWED_CREDENTIAL_ENV_RE = re.compile(r"^(HERMES_API_SERVER_KEY|ELLA_HERMES_GATEWAY_KEY_[A-Z0-9_]+)$")
+logger = logging.getLogger("ella.provisioning")
+
+
+class ProvisioningError(RuntimeError):
+    def __init__(self, code: str, *, retryable: bool, detail: Optional[dict[str, Any]] = None):
+        super().__init__(code)
+        self.code = code
+        self.retryable = retryable
+        self.detail = detail or {}
+
+
+@dataclass(frozen=True)
+class VerifiedIdentity:
+    uid: str
+    email: str
+    name: str
+    timezone: str
+
+
+def provisioning_enabled() -> bool:
+    return os.getenv("ELLA_HERMES_PROVISIONING_ENABLED", "false").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def stable_payload_hash(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def public_receipt(job: dict[str, Any], binding: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    state = str(job.get("state") or "pending")
+    stage = str(job.get("stage") or "identity_ready")
+    public_state = {
+        "pending": "queued",
+        "provisioning": "provisioning",
+        "ready": "ready",
+        "degraded": "degraded",
+        "blocked": "blocked",
+    }.get(state, "degraded")
+    public_stage = {
+        "identity_ready": "preparing_account",
+        "profile_ready": "preparing_memory",
+        "runtime_ready": "starting_assistant",
+        "smoke_passed": "validating",
+        "active": "ready",
+    }.get(stage, "validating")
+    job_id = str(job["id"])
+    result = {
+        "job_id": job_id,
+        "state": public_state,
+        "stage": public_stage,
+        "retryable": bool(job.get("retryable", True)),
+        "retry_after_ms": 2000 if public_state in {"queued", "provisioning", "degraded"} else None,
+        "support_code": f"ELLA-{job_id.split('-')[0].upper()}",
+        "target_schema_version": job["target_schema_version"],
+        "binding_state": "active" if binding and binding.get("active") else "inactive",
+        "binding_revision": int(binding.get("revision", 0)) if binding else 0,
+        "effective_policy_revision": (
+            f"{binding['model_policy_version']}:{binding['voice_policy_version']}" if binding else None
+        ),
+    }
+    if job.get("error_code"):
+        result["error_code"] = job["error_code"]
+    return result
+
+
+def validate_gateway_credential_ref(credential_ref: Optional[str]) -> str:
+    if not credential_ref or not credential_ref.startswith("env:"):
+        raise ProvisioningError("invalid_credential_reference", retryable=False)
+    variable = credential_ref[4:]
+    if not ALLOWED_CREDENTIAL_ENV_RE.fullmatch(variable):
+        raise ProvisioningError("invalid_credential_reference", retryable=False)
+    return variable
+
+
+def resolve_gateway_credential(credential_ref: Optional[str]) -> str:
+    variable = validate_gateway_credential_ref(credential_ref)
+    value = os.getenv(variable, "")
+    if not value:
+        raise ProvisioningError("gateway_credential_unavailable", retryable=True)
+    return value
+
+
+def validate_internal_gateway_url(value: str) -> str:
+    """Accept only loopback, tailnet, or explicitly allowlisted internal gateways."""
+    parsed = urlparse(value)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "http" or not host or parsed.username or parsed.password:
+        raise ProvisioningError("invalid_internal_gateway_url", retryable=False)
+
+    allowlisted = {
+        item.strip().lower() for item in os.getenv("ELLA_HERMES_GATEWAY_ALLOWED_HOSTS", "").split(",") if item.strip()
+    }
+    allowed = host in {"localhost", "127.0.0.1", "::1"} or host in allowlisted
+    if not allowed:
+        try:
+            allowed = ipaddress.ip_address(host) in ipaddress.ip_network("100.64.0.0/10")
+        except ValueError:
+            allowed = False
+    if not allowed:
+        raise ProvisioningError("invalid_internal_gateway_url", retryable=False)
+    return value.rstrip("/")
+
+
+class HermesProvisionClient:
+    def __init__(self, *, base_url: Optional[str] = None, token: Optional[str] = None):
+        self.base_url = (base_url or os.getenv("ELLA_HERMES_PROVISION_API_URL", "http://100.76.138.56:8210")).rstrip(
+            "/"
+        )
+        self.token = token if token is not None else os.getenv("ELLA_HERMES_PROVISION_API_TOKEN", "")
+
+    async def provision(self, identity: VerifiedIdentity, target_schema_version: str) -> dict[str, Any]:
+        if not self.token:
+            raise ProvisioningError("provision_service_credential_unavailable", retryable=True)
+        payload = {
+            "userId": identity.uid,
+            "omiUid": identity.uid,
+            "firebaseUid": identity.uid,
+            "email": identity.email,
+            "label": identity.name,
+            "timezone": identity.timezone,
+            "hermes_only": True,
+            "targetSchemaVersion": target_schema_version,
+        }
+        try:
+            async with httpx.AsyncClient(timeout=60.0) as client:
+                response = await client.post(
+                    f"{self.base_url}/provision",
+                    headers={"Authorization": f"Bearer {self.token}"},
+                    json=payload,
+                )
+        except httpx.TimeoutException as exc:
+            raise ProvisioningError("provision_service_timeout", retryable=True) from exc
+        except httpx.HTTPError as exc:
+            raise ProvisioningError("provision_service_unavailable", retryable=True) from exc
+
+        if response.status_code == 409:
+            raise ProvisioningError("runtime_capacity", retryable=True)
+        if response.status_code in {401, 403}:
+            raise ProvisioningError("provision_service_auth_failed", retryable=False)
+        if response.status_code >= 500:
+            raise ProvisioningError("provision_service_unavailable", retryable=True)
+        if response.status_code >= 400:
+            raise ProvisioningError(
+                "provision_request_rejected", retryable=False, detail={"status": response.status_code}
+            )
+
+        try:
+            result = response.json()
+        except ValueError as exc:
+            raise ProvisioningError("invalid_provision_receipt", retryable=True) from exc
+        if result.get("provisionMode") != "hermes_only" or result.get("mode") != "hermes_only":
+            raise ProvisioningError("non_hermes_provision_rejected", retryable=False)
+        return result
+
+
+def extract_runtime_binding(result: dict[str, Any], uid: str) -> dict[str, Any]:
+    raw = result.get("runtimeBinding") or result.get("runtime_binding")
+    if not isinstance(raw, dict):
+        raise ProvisioningError("runtime_receipt_missing", retryable=True)
+
+    provider = str(raw.get("provider") or "").lower()
+    profile_name = str(raw.get("profileName") or raw.get("profile_name") or "")
+    agent_id = str(raw.get("agentId") or raw.get("agent_id") or "")
+    workspace_root = raw.get("workspaceRoot") or raw.get("workspace_root")
+    internal_gateway_url = raw.get("internalGatewayUrl") or raw.get("internal_gateway_url")
+    gateway_port = raw.get("gatewayPort") or raw.get("gateway_port")
+    service_label = raw.get("serviceLabel") or raw.get("service_label")
+    credential_ref = raw.get("credentialRef") or raw.get("credential_ref")
+    health_state = str(raw.get("healthState") or raw.get("health_state") or "").lower()
+    health_receipt = raw.get("healthReceipt") or raw.get("health_receipt") or {}
+    if not isinstance(health_receipt, dict):
+        raise ProvisioningError("invalid_health_receipt", retryable=True)
+    smoke_passed = bool(raw.get("smokePassed") or raw.get("smoke_passed") or health_receipt.get("smoke_passed"))
+
+    if provider != "hermes":
+        raise ProvisioningError("invalid_runtime_provider", retryable=False)
+    if not PROFILE_NAME_RE.fullmatch(profile_name):
+        raise ProvisioningError("invalid_profile_name", retryable=False)
+    if not AGENT_ID_RE.fullmatch(agent_id):
+        raise ProvisioningError("invalid_agent_id", retryable=False)
+    plato_uid = os.getenv("ELLA_PLATO_UID", "").strip()
+    if profile_name == "plato-eval" and uid != plato_uid:
+        raise ProvisioningError("plato_binding_forbidden", retryable=False)
+    if not all([agent_id, workspace_root, internal_gateway_url, gateway_port, service_label, credential_ref]):
+        raise ProvisioningError("runtime_receipt_incomplete", retryable=True)
+    if health_state != "healthy" or not smoke_passed:
+        raise ProvisioningError("runtime_smoke_incomplete", retryable=True)
+
+    honcho = raw.get("honcho") if isinstance(raw.get("honcho"), dict) else {}
+    honcho_workspace = honcho.get("workspace")
+    observed_peer = honcho.get("observedPeer") or honcho.get("observed_peer")
+    observer_peer = honcho.get("observerPeer") or honcho.get("observer_peer")
+    if not all([honcho_workspace, observed_peer, observer_peer]):
+        raise ProvisioningError("honcho_receipt_incomplete", retryable=True)
+
+    profiles_root = os.getenv("ELLA_HERMES_PROFILES_ROOT", "/Users/ellaai/.hermes/profiles")
+    expected_workspace = posixpath.normpath(f"{profiles_root.rstrip('/')}/{profile_name}/workspace")
+    if posixpath.normpath(str(workspace_root)) != expected_workspace:
+        raise ProvisioningError("workspace_ownership_mismatch", retryable=False)
+
+    try:
+        parsed_port = int(gateway_port)
+    except (TypeError, ValueError) as exc:
+        raise ProvisioningError("invalid_gateway_port", retryable=False) from exc
+    gateway_url = validate_internal_gateway_url(str(internal_gateway_url))
+    if not 1024 <= parsed_port <= 65535 or urlparse(gateway_url).port != parsed_port:
+        raise ProvisioningError("gateway_port_mismatch", retryable=False)
+    validate_gateway_credential_ref(str(credential_ref))
+
+    return {
+        "role": "user",
+        "provider": "hermes",
+        "profile_name": profile_name,
+        "agent_id": agent_id,
+        "workspace_root": str(workspace_root),
+        "internal_gateway_url": gateway_url,
+        "gateway_port": parsed_port,
+        "service_label": str(service_label),
+        "credential_ref": str(credential_ref),
+        "honcho_workspace": str(honcho_workspace),
+        "observed_peer": str(observed_peer),
+        "observer_peer": str(observer_peer),
+        "template_version": str(raw.get("templateVersion") or DEFAULT_TEMPLATE_VERSION),
+        "model_policy_version": str(raw.get("modelPolicyVersion") or DEFAULT_MODEL_POLICY_VERSION),
+        "voice_policy_version": str(raw.get("voicePolicyVersion") or DEFAULT_VOICE_POLICY_VERSION),
+        "health_state": "healthy",
+        "health_receipt": health_receipt,
+    }
+
+
+class ProvisioningCoordinator:
+    def __init__(
+        self,
+        repository: EllaProvisioningRepository,
+        client: Optional[HermesProvisionClient] = None,
+    ):
+        self.repository = repository
+        self.client = client or HermesProvisionClient()
+
+    async def ensure_job(
+        self,
+        *,
+        identity: VerifiedIdentity,
+        target_schema_version: str,
+        client_request_id: Optional[str],
+        request_payload: dict[str, Any],
+    ) -> tuple[dict[str, Any], Optional[dict[str, Any]], bool]:
+        await self.repository.ensure_user_identity(
+            uid=identity.uid,
+            email=identity.email,
+            name=identity.name,
+            timezone_name=identity.timezone,
+        )
+        job = await self.repository.acquire_job(
+            uid=identity.uid,
+            target_schema_version=target_schema_version,
+            client_request_id=client_request_id,
+            request_payload_hash=stable_payload_hash(request_payload),
+        )
+        binding = await self.repository.resolve_active_runtime(identity.uid)
+        if binding:
+            if job.get("state") != "ready":
+                job = await self.repository.update_job(
+                    job_id=str(job["id"]),
+                    state="ready",
+                    stage="active",
+                    retryable=False,
+                    receipt={"type": "active_binding_reconciled", "binding_revision": binding["revision"]},
+                )
+            return job, binding, False
+        if not provisioning_enabled():
+            job = await self.repository.update_job(
+                job_id=str(job["id"]),
+                state="degraded",
+                stage="identity_ready",
+                retryable=True,
+                error_code="provisioning_disabled",
+            )
+            return job, None, False
+        claimed = await self.repository.claim_job(str(job["id"]))
+        return claimed or job, None, claimed is not None
+
+    async def process_claimed_job(self, *, job: dict[str, Any], identity: VerifiedIdentity) -> None:
+        try:
+            result = await self.client.provision(identity, str(job["target_schema_version"]))
+            binding_data = extract_runtime_binding(result, identity.uid)
+            binding = await self.repository.stage_runtime_binding(uid=identity.uid, binding=binding_data)
+            await self.repository.update_job(
+                job_id=str(job["id"]),
+                state="provisioning",
+                stage="smoke_passed",
+                retryable=True,
+                receipt={
+                    "type": "runtime_smoke_passed",
+                    "profile": binding["profile_name"],
+                    "binding_revision": binding["revision"],
+                },
+            )
+            activated = await self.repository.activate_runtime_binding(uid=identity.uid, provider="hermes")
+            await self.repository.update_job(
+                job_id=str(job["id"]),
+                state="ready",
+                stage="active",
+                retryable=False,
+                receipt={
+                    "type": "binding_activated",
+                    "binding_revision": activated["revision"],
+                },
+            )
+        except ProvisioningError as exc:
+            await self.repository.update_job(
+                job_id=str(job["id"]),
+                state="degraded" if exc.retryable else "blocked",
+                stage="runtime_ready",
+                retryable=exc.retryable,
+                error_code=exc.code,
+                error_detail=exc.detail,
+            )
+        except Exception:
+            logger.exception("Unexpected Hermes provisioning failure for uid=%s", identity.uid)
+            await self.repository.update_job(
+                job_id=str(job["id"]),
+                state="degraded",
+                stage="runtime_ready",
+                retryable=True,
+                error_code="provisioning_internal_error",
+            )

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -227,7 +227,15 @@ def extract_runtime_binding(
     health_receipt = raw.get("healthReceipt") or raw.get("health_receipt") or {}
     if not isinstance(health_receipt, dict):
         raise ProvisioningError("invalid_health_receipt", retryable=True)
-    smoke_passed = bool(raw.get("smokePassed") or raw.get("smoke_passed") or health_receipt.get("smoke_passed"))
+    smoke_values = []
+    for source, key in (
+        (raw, "smokePassed"),
+        (raw, "smoke_passed"),
+        (health_receipt, "smoke_passed"),
+    ):
+        if key in source:
+            smoke_values.append(source[key])
+    smoke_passed = bool(smoke_values) and all(value is True for value in smoke_values)
 
     if provider != "hermes":
         raise ProvisioningError("invalid_runtime_provider", retryable=False)

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -231,6 +231,7 @@ def extract_runtime_binding(
     for source, key in (
         (raw, "smokePassed"),
         (raw, "smoke_passed"),
+        (health_receipt, "smokePassed"),
         (health_receipt, "smoke_passed"),
     ):
         if key in source:

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -25,6 +25,7 @@ PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{2,63}$")
 AGENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
 ALLOWED_CREDENTIAL_ENV_RE = re.compile(r"^(HERMES_API_SERVER_KEY|ELLA_HERMES_GATEWAY_KEY_[A-Z0-9_]+)$")
 logger = logging.getLogger("ella.provisioning")
+TRUE_VALUES = {"1", "true", "yes", "on"}
 
 
 class ProvisioningError(RuntimeError):
@@ -43,8 +44,22 @@ class VerifiedIdentity:
     timezone: str
 
 
-def provisioning_enabled() -> bool:
-    return os.getenv("ELLA_HERMES_PROVISIONING_ENABLED", "false").strip().lower() in {"1", "true", "yes", "on"}
+def rollout_enabled(global_flag: str, uid_allowlist: str, uid: Optional[str] = None) -> bool:
+    """Enable a rollout globally or for an exact Firebase UID canary."""
+    if os.getenv(global_flag, "false").strip().lower() in TRUE_VALUES:
+        return True
+    if not uid:
+        return False
+    allowed_uids = {value.strip() for value in os.getenv(uid_allowlist, "").split(",") if value.strip()}
+    return uid in allowed_uids
+
+
+def provisioning_enabled(uid: Optional[str] = None) -> bool:
+    return rollout_enabled(
+        "ELLA_HERMES_PROVISIONING_ENABLED",
+        "ELLA_HERMES_PROVISIONING_ENABLED_UIDS",
+        uid,
+    )
 
 
 def stable_payload_hash(payload: dict[str, Any]) -> str:
@@ -333,7 +348,7 @@ class ProvisioningCoordinator:
                     receipt={"type": "active_binding_reconciled", "binding_revision": binding["revision"]},
                 )
             return job, binding, False
-        if not provisioning_enabled():
+        if not provisioning_enabled(identity.uid):
             job = await self.repository.update_job(
                 job_id=str(job["id"]),
                 state="degraded",

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -283,8 +283,27 @@ class ProvisioningCoordinator:
             client_request_id=client_request_id,
             request_payload_hash=stable_payload_hash(request_payload),
         )
+        try:
+            await self.repository.ensure_omi_user_document(
+                uid=identity.uid,
+                email=identity.email,
+                name=identity.name,
+                timezone_name=identity.timezone,
+            )
+        except Exception:
+            logger.exception("OMI identity initialization failed for uid=%s", identity.uid)
+            job = await self.repository.update_job(
+                job_id=str(job["id"]),
+                state="degraded",
+                stage="identity_ready",
+                retryable=True,
+                error_code="omi_identity_unavailable",
+            )
+            return job, None, False
         binding = await self.repository.resolve_active_runtime(identity.uid)
         if binding:
+            if str(binding.get("user_status") or "") != "ACTIVE":
+                await self.repository.activate_user(identity.uid)
             if job.get("state") != "ready":
                 job = await self.repository.update_job(
                     job_id=str(job["id"]),

--- a/backend/ella/services/runtime_resolver.py
+++ b/backend/ella/services/runtime_resolver.py
@@ -1,0 +1,75 @@
+"""Resolve authenticated users to active, isolated Hermes runtime bindings."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from database.ella_provisioning import EllaProvisioningRepository
+from ella.services.provisioning import (
+    PROFILE_NAME_RE,
+    ProvisioningError,
+    resolve_gateway_credential,
+    validate_internal_gateway_url,
+)
+
+
+def runtime_bindings_enabled() -> bool:
+    return os.getenv("ELLA_RUNTIME_BINDINGS_ENABLED", "false").strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class IsolatedRuntime:
+    uid: str
+    profile_name: str
+    agent_id: str
+    gateway_url: str
+    gateway_token: str
+    model_policy_version: str
+    voice_policy_version: str
+    revision: int
+
+
+def runtime_from_binding(binding: dict, uid: str) -> IsolatedRuntime:
+    if binding.get("omi_uid") != uid:
+        raise ProvisioningError("runtime_ownership_mismatch", retryable=False)
+    if str(binding.get("provider") or "").lower() != "hermes":
+        raise ProvisioningError("invalid_runtime_provider", retryable=False)
+    if binding.get("active") is not True or binding.get("health_state") != "healthy":
+        raise ProvisioningError("runtime_not_ready", retryable=True)
+
+    profile_name = str(binding.get("profile_name") or "")
+    agent_id = str(binding.get("agent_id") or "")
+    if not PROFILE_NAME_RE.fullmatch(profile_name):
+        raise ProvisioningError("invalid_profile_name", retryable=False)
+    if not agent_id:
+        raise ProvisioningError("runtime_receipt_incomplete", retryable=False)
+    plato_uid = os.getenv("ELLA_PLATO_UID", "").strip()
+    if profile_name == "plato-eval" and uid != plato_uid:
+        raise ProvisioningError("plato_binding_forbidden", retryable=False)
+
+    return IsolatedRuntime(
+        uid=uid,
+        profile_name=profile_name,
+        agent_id=agent_id,
+        gateway_url=validate_internal_gateway_url(str(binding.get("internal_gateway_url") or "")),
+        gateway_token=resolve_gateway_credential(binding.get("credential_ref")),
+        model_policy_version=str(binding.get("model_policy_version") or ""),
+        voice_policy_version=str(binding.get("voice_policy_version") or ""),
+        revision=int(binding.get("revision") or 0),
+    )
+
+
+async def resolve_isolated_runtime(
+    uid: str,
+    repository: Optional[EllaProvisioningRepository] = None,
+) -> Optional[IsolatedRuntime]:
+    """Return None while shadow mode is disabled; otherwise fail closed."""
+    if not runtime_bindings_enabled():
+        return None
+    repository = repository or await EllaProvisioningRepository.create()
+    binding = await repository.resolve_active_runtime(uid)
+    if not binding:
+        raise ProvisioningError("hermes_not_provisioned", retryable=True)
+    return runtime_from_binding(binding, uid)

--- a/backend/ella/services/runtime_resolver.py
+++ b/backend/ella/services/runtime_resolver.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import os
+import posixpath
 from dataclasses import dataclass
 from typing import Optional
+from urllib.parse import urlparse
 
 from database.ella_provisioning import EllaProvisioningRepository
 from ella.services.provisioning import (
@@ -26,6 +28,10 @@ class IsolatedRuntime:
     agent_id: str
     gateway_url: str
     gateway_token: str
+    workspace_root: str
+    honcho_workspace: str
+    observed_peer: str
+    observer_peer: str
     model_policy_version: str
     voice_policy_version: str
     revision: int
@@ -49,15 +55,42 @@ def runtime_from_binding(binding: dict, uid: str) -> IsolatedRuntime:
     if profile_name == "plato-eval" and uid != plato_uid:
         raise ProvisioningError("plato_binding_forbidden", retryable=False)
 
+    workspace_root = str(binding.get("workspace_root") or "")
+    profiles_root = os.getenv("ELLA_HERMES_PROFILES_ROOT", "/Users/ellaai/.hermes/profiles")
+    expected_workspace = posixpath.normpath(f"{profiles_root.rstrip('/')}/{profile_name}/workspace")
+    if posixpath.normpath(workspace_root) != expected_workspace:
+        raise ProvisioningError("workspace_ownership_mismatch", retryable=False)
+
+    gateway_url = validate_internal_gateway_url(str(binding.get("internal_gateway_url") or ""))
+    try:
+        gateway_port = int(binding.get("gateway_port") or 0)
+    except (TypeError, ValueError) as exc:
+        raise ProvisioningError("invalid_gateway_port", retryable=False) from exc
+    if not 1024 <= gateway_port <= 65535 or urlparse(gateway_url).port != gateway_port:
+        raise ProvisioningError("gateway_port_mismatch", retryable=False)
+
+    honcho_workspace = str(binding.get("honcho_workspace") or "")
+    observed_peer = str(binding.get("observed_peer") or "")
+    observer_peer = str(binding.get("observer_peer") or "")
+    if not all([honcho_workspace, observed_peer, observer_peer]):
+        raise ProvisioningError("honcho_receipt_incomplete", retryable=False)
+    revision = int(binding.get("revision") or 0)
+    if revision < 1:
+        raise ProvisioningError("invalid_binding_revision", retryable=False)
+
     return IsolatedRuntime(
         uid=uid,
         profile_name=profile_name,
         agent_id=agent_id,
-        gateway_url=validate_internal_gateway_url(str(binding.get("internal_gateway_url") or "")),
+        gateway_url=gateway_url,
         gateway_token=resolve_gateway_credential(binding.get("credential_ref")),
+        workspace_root=workspace_root,
+        honcho_workspace=honcho_workspace,
+        observed_peer=observed_peer,
+        observer_peer=observer_peer,
         model_policy_version=str(binding.get("model_policy_version") or ""),
         voice_policy_version=str(binding.get("voice_policy_version") or ""),
-        revision=int(binding.get("revision") or 0),
+        revision=revision,
     )
 
 

--- a/backend/ella/services/runtime_resolver.py
+++ b/backend/ella/services/runtime_resolver.py
@@ -13,12 +13,17 @@ from ella.services.provisioning import (
     PROFILE_NAME_RE,
     ProvisioningError,
     resolve_gateway_credential,
+    rollout_enabled,
     validate_internal_gateway_url,
 )
 
 
-def runtime_bindings_enabled() -> bool:
-    return os.getenv("ELLA_RUNTIME_BINDINGS_ENABLED", "false").strip().lower() in {"1", "true", "yes", "on"}
+def runtime_bindings_enabled(uid: Optional[str] = None) -> bool:
+    return rollout_enabled(
+        "ELLA_RUNTIME_BINDINGS_ENABLED",
+        "ELLA_RUNTIME_BINDINGS_ENABLED_UIDS",
+        uid,
+    )
 
 
 @dataclass(frozen=True)
@@ -99,7 +104,7 @@ async def resolve_isolated_runtime(
     repository: Optional[EllaProvisioningRepository] = None,
 ) -> Optional[IsolatedRuntime]:
     """Return None while shadow mode is disabled; otherwise fail closed."""
-    if not runtime_bindings_enabled():
+    if not runtime_bindings_enabled(uid):
         return None
     repository = repository or await EllaProvisioningRepository.create()
     binding = await repository.resolve_active_runtime(uid)

--- a/backend/ella/services/summary_recovery.py
+++ b/backend/ella/services/summary_recovery.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -14,6 +14,7 @@ import httpx
 
 import database.conversations as conversations_db
 from ella.services.hermes_session import canonical_omi_session_key
+from ella.services.runtime_resolver import resolve_isolated_runtime
 from ella.services.summary_writeback import CanonicalSummaryWriteUnconfirmedError, write_conversation_summary
 from models.conversation import CategoryEnum, Conversation, ConversationStatus
 from utils.conversations.generic_summary import generate_stock_conversation_summary
@@ -164,6 +165,25 @@ def default_summary_provider_config() -> SummaryProviderConfig:
             os.getenv('ELLA_CORRECTION_API_KEY') or os.getenv('XAI_API_KEY') or os.getenv('HERMES_API_KEY') or ''
         ),
         timeout_seconds=float(os.getenv('ELLA_CORRECTION_TIMEOUT_SECONDS', '45')),
+    )
+
+
+async def summary_provider_config_for_uid(
+    uid: str,
+    config: Optional[SummaryProviderConfig] = None,
+) -> SummaryProviderConfig:
+    """Bind Hermes summary work to the active isolated runtime when selected."""
+    selected = config or default_summary_provider_config()
+    runtime = await resolve_isolated_runtime(uid)
+    if runtime is None:
+        return selected
+    return replace(
+        selected,
+        provider='hermes-api',
+        hermes_url=f"{runtime.gateway_url.rstrip('/')}/v1/chat/completions",
+        hermes_model=runtime.agent_id,
+        hermes_api_key=runtime.gateway_token,
+        legacy_api_key='',
     )
 
 
@@ -600,6 +620,7 @@ async def recover_failed_conversation_summary(
     request_id: str,
     client_context: Optional[str] = None,
     attempt_count: Optional[int] = None,
+    config: Optional[SummaryProviderConfig] = None,
 ) -> str:
     conversation = await asyncio.to_thread(conversations_db.get_conversation, uid, conversation_id)
     if not _is_current_retry(conversation, request_id, attempt_count):
@@ -818,12 +839,14 @@ async def recover_failed_conversation_summary(
             if not enriched_version_id or apply_result.get('canonical_confirmed') is not True:
                 raise CanonicalSummaryWriteUnconfirmedError('canonical_write_unconfirmed')
         else:
+            isolated_config = await summary_provider_config_for_uid(uid, config)
             apply_result = await invoke_hermes_recovery(
                 uid=uid,
                 conversation=latest,
                 request_id=request_id,
                 attempt_count=attempt_count,
                 client_context=client_context,
+                config=isolated_config,
             )
             enriched_version_id = apply_result.get('active_summary_version_id')
             if not enriched_version_id:

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,6 +5,7 @@ import firebase_admin
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from database._client import db as firestore_db
 from modal import Image, App, asgi_app, Secret
 from routers import (
     workflow,
@@ -156,6 +157,7 @@ for path in paths:
 # ============================================================================
 try:
     from ella import register_ella_extensions
-    register_ella_extensions(app)
+
+    register_ella_extensions(app, firestore_db=firestore_db)
 except ImportError:
     pass  # Running vanilla OMI

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -2033,7 +2033,9 @@ async def _stream_handler(
     elif codec == 'lc3':
         lc3_decoder = lc3.Decoder(lc3_frame_duration_us, sample_rate)
 
-    async def receive_data(dg_socket, dg_profile_socket, soniox_sock, soniox_profile_sock, speechmatics_sock, grok_sock):
+    async def receive_data(
+        dg_socket, dg_profile_socket, soniox_sock, soniox_profile_sock, speechmatics_sock, grok_sock
+    ):
         nonlocal websocket_active, websocket_close_code, last_audio_received_time, last_activity_time, current_conversation_id
         nonlocal realtime_photo_buffers, speaker_to_person_map, first_audio_byte_timestamp, last_usage_record_timestamp
         nonlocal soniox_profile_socket, deepgram_profile_socket, audio_ring_buffer
@@ -2099,6 +2101,7 @@ async def _stream_handler(
                 # Proactively reconnect if Grok closed the connection (internal error, timeout, etc.)
                 try:
                     from websockets.connection import State as _WsState
+
                     _grok_dead = grok_sock.state != _WsState.OPEN
                 except Exception:
                     _grok_dead = False
@@ -2362,7 +2365,12 @@ async def _stream_handler(
         # Tasks
         data_process_task = asyncio.create_task(
             receive_data(
-                deepgram_socket, deepgram_profile_socket, soniox_socket, soniox_profile_socket, speechmatics_socket, grok_socket
+                deepgram_socket,
+                deepgram_profile_socket,
+                soniox_socket,
+                soniox_profile_socket,
+                speechmatics_socket,
+                grok_socket,
             )
         )
         stream_transcript_task = asyncio.create_task(stream_transcript_process())
@@ -2523,16 +2531,11 @@ async def listen_handler(
     speaker_auto_assign_enabled = speaker_auto_assign == 'enabled'
 
     # Ella sidecar: require isolated Hermes when the runtime cutover flag is on.
-    isolated_runtime_cutover = os.getenv("ELLA_RUNTIME_BINDINGS_ENABLED", "false").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
+    isolated_runtime_cutover = False
     try:
         from ella.services.runtime_resolver import runtime_bindings_enabled
 
-        isolated_runtime_cutover = runtime_bindings_enabled()
+        isolated_runtime_cutover = runtime_bindings_enabled(uid)
         if isolated_runtime_cutover:
             from ella.routers.auto_provision import validate_isolated_listen_runtime
 

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -2033,9 +2033,7 @@ async def _stream_handler(
     elif codec == 'lc3':
         lc3_decoder = lc3.Decoder(lc3_frame_duration_us, sample_rate)
 
-    async def receive_data(
-        dg_socket, dg_profile_socket, soniox_sock, soniox_profile_sock, speechmatics_sock, grok_sock
-    ):
+    async def receive_data(dg_socket, dg_profile_socket, soniox_sock, soniox_profile_sock, speechmatics_sock, grok_sock):
         nonlocal websocket_active, websocket_close_code, last_audio_received_time, last_activity_time, current_conversation_id
         nonlocal realtime_photo_buffers, speaker_to_person_map, first_audio_byte_timestamp, last_usage_record_timestamp
         nonlocal soniox_profile_socket, deepgram_profile_socket, audio_ring_buffer
@@ -2101,7 +2099,6 @@ async def _stream_handler(
                 # Proactively reconnect if Grok closed the connection (internal error, timeout, etc.)
                 try:
                     from websockets.connection import State as _WsState
-
                     _grok_dead = grok_sock.state != _WsState.OPEN
                 except Exception:
                     _grok_dead = False
@@ -2365,12 +2362,7 @@ async def _stream_handler(
         # Tasks
         data_process_task = asyncio.create_task(
             receive_data(
-                deepgram_socket,
-                deepgram_profile_socket,
-                soniox_socket,
-                soniox_profile_socket,
-                speechmatics_socket,
-                grok_socket,
+                deepgram_socket, deepgram_profile_socket, soniox_socket, soniox_profile_socket, speechmatics_socket, grok_socket
             )
         )
         stream_transcript_task = asyncio.create_task(stream_transcript_process())

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -2522,25 +2522,50 @@ async def listen_handler(
     onboarding_mode = onboarding == 'enabled'
     speaker_auto_assign_enabled = speaker_auto_assign == 'enabled'
 
-    # Ella sidecar: auto-provision check
+    # Ella sidecar: require isolated Hermes when the runtime cutover flag is on.
+    isolated_runtime_cutover = os.getenv("ELLA_RUNTIME_BINDINGS_ENABLED", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
     try:
-        from ella.routers.auto_provision import (
-            auto_provision_user,
-            ensure_firestore_user_document,
-            get_agent_cluster,
-        )
+        from ella.services.runtime_resolver import runtime_bindings_enabled
 
-        await ensure_firestore_user_document(uid)
-        cluster = await get_agent_cluster(uid)
-        if not cluster:
-            logger = logging.getLogger(__name__)
-            logger.info(f"No agent cluster for uid={uid}, auto-provisioning...")
-            result = await auto_provision_user(uid)
+        isolated_runtime_cutover = runtime_bindings_enabled()
+        if isolated_runtime_cutover:
+            from ella.routers.auto_provision import validate_isolated_listen_runtime
+
+            result = await validate_isolated_listen_runtime(uid, user_db.is_exists_user)
             if not result.get("success"):
-                logger.warning(f"Auto-provision failed: {result.get('error')}")
+                logging.getLogger(__name__).warning(
+                    "Isolated Ella listen setup incomplete for uid=%s code=%s",
+                    uid,
+                    result.get("error"),
+                )
+                await websocket.close(code=1013, reason="Ella setup incomplete")
+                return
+        else:
+            from ella.routers.auto_provision import (
+                auto_provision_user,
+                ensure_firestore_user_document,
+                get_agent_cluster,
+            )
+
+            await ensure_firestore_user_document(uid)
+            cluster = await get_agent_cluster(uid)
+            if not cluster:
+                logger = logging.getLogger(__name__)
+                logger.info(f"No agent cluster for uid={uid}, auto-provisioning...")
+                result = await auto_provision_user(uid)
+                if not result.get("success"):
+                    logger.warning(f"Auto-provision failed: {result.get('error')}")
     except Exception as e:
         logger = logging.getLogger(__name__)
         logger.error(f"Auto-provision check error: {e}")
+        if isolated_runtime_cutover:
+            await websocket.close(code=1013, reason="Ella setup incomplete")
+            return
 
     await _listen(
         websocket,

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -100,9 +100,8 @@ from ella.routers.auto_provision import (
     auto_provision_user,
     ensure_firestore_user_document,
     get_agent_cluster,
-    validate_isolated_listen_runtime,
+    listen_runtime_gate,
 )
-from ella.services.runtime_resolver import runtime_bindings_enabled
 
 from utils.aac import AACDecoder
 from utils.audio import AudioRingBuffer
@@ -2540,14 +2539,14 @@ async def listen_handler(
     # Ella sidecar: require isolated Hermes when the runtime cutover flag is on.
     isolated_runtime_cutover = False
     try:
-        isolated_runtime_cutover = runtime_bindings_enabled(uid)
+        runtime_gate = await listen_runtime_gate(uid, user_db.is_exists_user)
+        isolated_runtime_cutover = runtime_gate.get("required", False)
         if isolated_runtime_cutover:
-            result = await validate_isolated_listen_runtime(uid, user_db.is_exists_user)
-            if not result.get("success"):
+            if not runtime_gate.get("success"):
                 logging.getLogger(__name__).warning(
                     "Isolated Ella listen setup incomplete for uid=%s code=%s",
                     uid,
-                    result.get("error"),
+                    runtime_gate.get("error"),
                 )
                 await websocket.close(code=1013, reason="Ella setup incomplete")
                 return
@@ -2634,6 +2633,23 @@ async def web_listen_handler(
         print(f"web_listen_handler: auth error {e}")
         await websocket.send_json({"type": "auth_response", "success": False})
         await websocket.close(code=1008, reason="Auth error")
+        return
+
+    runtime_gate = await listen_runtime_gate(uid, user_db.is_exists_user)
+    if runtime_gate.get("required") and not runtime_gate.get("success"):
+        logging.getLogger(__name__).warning(
+            "Isolated Ella web listen setup incomplete for uid=%s code=%s",
+            uid,
+            runtime_gate.get("error"),
+        )
+        await websocket.send_json(
+            {
+                "type": "auth_response",
+                "success": False,
+                "error": "ella_setup_incomplete",
+            }
+        )
+        await websocket.close(code=1013, reason="Ella setup incomplete")
         return
 
     # Send success response

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -96,6 +96,13 @@ from utils.translation import TranslationService
 from utils.translation_cache import TranscriptSegmentLanguageCache
 from utils.webhooks import get_audio_bytes_webhook_seconds
 from utils.onboarding import OnboardingHandler
+from ella.routers.auto_provision import (
+    auto_provision_user,
+    ensure_firestore_user_document,
+    get_agent_cluster,
+    validate_isolated_listen_runtime,
+)
+from ella.services.runtime_resolver import runtime_bindings_enabled
 
 from utils.aac import AACDecoder
 from utils.audio import AudioRingBuffer
@@ -2033,7 +2040,9 @@ async def _stream_handler(
     elif codec == 'lc3':
         lc3_decoder = lc3.Decoder(lc3_frame_duration_us, sample_rate)
 
-    async def receive_data(dg_socket, dg_profile_socket, soniox_sock, soniox_profile_sock, speechmatics_sock, grok_sock):
+    async def receive_data(
+        dg_socket, dg_profile_socket, soniox_sock, soniox_profile_sock, speechmatics_sock, grok_sock
+    ):
         nonlocal websocket_active, websocket_close_code, last_audio_received_time, last_activity_time, current_conversation_id
         nonlocal realtime_photo_buffers, speaker_to_person_map, first_audio_byte_timestamp, last_usage_record_timestamp
         nonlocal soniox_profile_socket, deepgram_profile_socket, audio_ring_buffer
@@ -2099,6 +2108,7 @@ async def _stream_handler(
                 # Proactively reconnect if Grok closed the connection (internal error, timeout, etc.)
                 try:
                     from websockets.connection import State as _WsState
+
                     _grok_dead = grok_sock.state != _WsState.OPEN
                 except Exception:
                     _grok_dead = False
@@ -2362,7 +2372,12 @@ async def _stream_handler(
         # Tasks
         data_process_task = asyncio.create_task(
             receive_data(
-                deepgram_socket, deepgram_profile_socket, soniox_socket, soniox_profile_socket, speechmatics_socket, grok_socket
+                deepgram_socket,
+                deepgram_profile_socket,
+                soniox_socket,
+                soniox_profile_socket,
+                speechmatics_socket,
+                grok_socket,
             )
         )
         stream_transcript_task = asyncio.create_task(stream_transcript_process())
@@ -2525,12 +2540,8 @@ async def listen_handler(
     # Ella sidecar: require isolated Hermes when the runtime cutover flag is on.
     isolated_runtime_cutover = False
     try:
-        from ella.services.runtime_resolver import runtime_bindings_enabled
-
         isolated_runtime_cutover = runtime_bindings_enabled(uid)
         if isolated_runtime_cutover:
-            from ella.routers.auto_provision import validate_isolated_listen_runtime
-
             result = await validate_isolated_listen_runtime(uid, user_db.is_exists_user)
             if not result.get("success"):
                 logging.getLogger(__name__).warning(
@@ -2541,13 +2552,7 @@ async def listen_handler(
                 await websocket.close(code=1013, reason="Ella setup incomplete")
                 return
         else:
-            from ella.routers.auto_provision import (
-                auto_provision_user,
-                ensure_firestore_user_document,
-                get_agent_cluster,
-            )
-
-            await ensure_firestore_user_document(uid)
+            await ensure_firestore_user_document(uid, user_db.db)
             cluster = await get_agent_cluster(uid)
             if not cluster:
                 logger = logging.getLogger(__name__)

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -371,6 +371,55 @@ def test_update_conversation_summary_persists_internal_assessment_when_available
     assert captured["update_data"]["internal_assessment"]["reason_codes"] == ["likely_media_or_background_audio"]
 
 
+def test_isolated_internal_assessment_uses_active_hermes_runtime(monkeypatch):
+    requests = []
+    runtime = MagicMock(agent_id="omi-isolated")
+
+    async def fake_runtime(uid):
+        assert uid == "uid-isolated"
+        return runtime
+
+    async def fail_legacy(_uid):
+        raise AssertionError("isolated summary metadata must not use OpenClaw routing")
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"internal_assessment": {"risk_level": "none"}}
+
+    class FakeClient:
+        def __init__(self, timeout):
+            assert timeout == 5.0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get(self, url, headers=None):
+            requests.append((url, headers))
+            return FakeResponse()
+
+    monkeypatch.setattr(callbacks, "runtime_bindings_enabled", lambda uid=None: uid == "uid-isolated")
+    monkeypatch.setattr(callbacks, "resolve_isolated_runtime", fake_runtime)
+    monkeypatch.setattr(callbacks, "_resolve_agent_id_for_uid", fail_legacy)
+    monkeypatch.setattr(callbacks.httpx, "AsyncClient", FakeClient)
+    monkeypatch.setenv("ELLA_HERMES_PROVISION_API_URL", "http://hermes-provision/")
+    monkeypatch.setenv("ELLA_HERMES_PROVISION_API_TOKEN", "hermes-token")
+
+    result = asyncio.run(callbacks._fetch_internal_assessment("uid-isolated", "conv-123"))
+
+    assert result == {"risk_level": "none"}
+    assert requests == [
+        (
+            "http://hermes-provision/workspace/omi-isolated/metadata/conversations/conv-123",
+            {"Authorization": "Bearer hermes-token"},
+        )
+    ]
+
+
 def test_update_conversation_summary_writes_enriched_omi_to_canonical(monkeypatch):
     canonical_writes = []
 

--- a/backend/tests/unit/test_ella_canonical_context.py
+++ b/backend/tests/unit/test_ella_canonical_context.py
@@ -93,6 +93,21 @@ def test_guardian_recent_turns_prefers_canonical_timeline(monkeypatch):
     assert turns == [{"role": "user", "content": _cafe_event()["text"]}]
 
 
+def test_guardian_isolated_context_never_uses_openclaw_history(monkeypatch):
+    async def no_events(uid, **kwargs):
+        assert uid == "uid-isolated"
+        return []
+
+    async def fail_resolve(_uid):
+        raise AssertionError("isolated Guardian context must not use OpenClaw history")
+
+    monkeypatch.setattr(guardian, "fetch_canonical_timeline", no_events)
+    monkeypatch.setattr(guardian, "runtime_bindings_enabled", lambda uid=None: True)
+    monkeypatch.setattr(guardian, "resolve_user_routing", fail_resolve)
+
+    assert asyncio.run(guardian._get_recent_chat_turns("uid-isolated", limit=3)) == []
+
+
 def test_canonical_events_to_chat_turns_newest_first_for_guardian():
     first = {**_cafe_event(), "event_id": "first", "text": "first"}
     second = {**_cafe_event(), "event_id": "second", "text": "second", "role": "assistant"}

--- a/backend/tests/unit/test_ella_canonical_context.py
+++ b/backend/tests/unit/test_ella_canonical_context.py
@@ -70,7 +70,7 @@ def test_chat_history_prefers_canonical_timeline(monkeypatch):
     monkeypatch.setattr(ella_chat, "_fetch_chat_canonical_events", fake_events)
     monkeypatch.setattr(ella_chat, "resolve_user_routing", fail_resolve)
 
-    result = asyncio.run(ella_chat.ella_chat_history("uid-1", limit=5))
+    result = asyncio.run(ella_chat.ella_chat_history("uid-1", limit=5, authenticated_uid="uid-1"))
 
     assert result["source"] == "canonical_timeline"
     assert result["fallback"] is False

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -748,6 +748,35 @@ def test_correction_session_key_matches_chat_memory_scope(monkeypatch):
     assert corrections._correction_session_key("abc123") == chat._hermes_chat_memory_key("abc123")
 
 
+def test_isolated_summary_config_uses_uid_runtime_and_removes_legacy_key(monkeypatch):
+    async def fake_runtime(uid):
+        assert uid == "user-a"
+        return SimpleNamespace(
+            gateway_url="http://100.76.138.56:8701",
+            gateway_token="isolated-secret",
+            agent_id="omi-user-a",
+        )
+
+    monkeypatch.setattr(summary_recovery, "resolve_isolated_runtime", fake_runtime)
+    base = summary_recovery.SummaryProviderConfig(
+        provider="legacy",
+        hermes_url="http://shared.test/v1/chat/completions",
+        hermes_model="shared-plato",
+        hermes_api_key="shared-secret",
+        legacy_url="https://legacy.test/v1/chat/completions",
+        legacy_model="legacy-model",
+        legacy_api_key="legacy-secret",
+        timeout_seconds=45,
+    )
+
+    selected = asyncio.run(summary_recovery.summary_provider_config_for_uid("user-a", base))
+
+    assert selected.provider == "hermes-api"
+    assert selected.hermes_url == "http://100.76.138.56:8701/v1/chat/completions"
+    assert selected.hermes_model == "omi-user-a"
+    assert selected.hermes_api_key == "isolated-secret"
+    assert selected.legacy_api_key == ""
+
 def test_generate_corrected_summary_can_use_legacy_provider(monkeypatch):
     calls = []
 

--- a/backend/tests/unit/test_ella_listen_runtime_gate.py
+++ b/backend/tests/unit/test_ella_listen_runtime_gate.py
@@ -71,3 +71,36 @@ def test_listen_runtime_gate_fails_closed_for_isolated_users(monkeypatch):
         "success": False,
         "error": "hermes_not_provisioned",
     }
+
+
+def test_legacy_firestore_repair_requests_historical_cloud_sync_default(monkeypatch):
+    captured = {}
+
+    class FakePool:
+        async def fetchrow(self, _query, uid):
+            assert uid == "legacy-user"
+            return {
+                "name": "Legacy User",
+                "email": "legacy@example.com",
+                "timezone": "America/Los_Angeles",
+            }
+
+    class FakeRepository:
+        def __init__(self, pool, *, firestore_db):
+            assert isinstance(pool, FakePool)
+            assert firestore_db == "firestore"
+
+        async def ensure_omi_user_document(self, **kwargs):
+            captured.update(kwargs)
+            return True
+
+    async def get_pool():
+        return FakePool()
+
+    monkeypatch.setattr(auto_provision, "_get_pool", get_pool)
+    monkeypatch.setattr(auto_provision, "EllaProvisioningRepository", FakeRepository)
+
+    result = asyncio.run(auto_provision.ensure_firestore_user_document("legacy-user", "firestore"))
+
+    assert result is True
+    assert captured["private_cloud_sync_default"] is True

--- a/backend/tests/unit/test_ella_listen_runtime_gate.py
+++ b/backend/tests/unit/test_ella_listen_runtime_gate.py
@@ -10,9 +10,7 @@ def test_isolated_listen_accepts_owned_runtime_and_existing_omi_user(monkeypatch
         return SimpleNamespace(uid=uid)
 
     monkeypatch.setattr("ella.services.runtime_resolver.resolve_isolated_runtime", resolve)
-    result = asyncio.run(
-        auto_provision.validate_isolated_listen_runtime("user-a", lambda uid: uid == "user-a")
-    )
+    result = asyncio.run(auto_provision.validate_isolated_listen_runtime("user-a", lambda uid: uid == "user-a"))
 
     assert result == {"success": True, "provider": "hermes"}
 
@@ -41,3 +39,35 @@ def test_isolated_listen_requires_omi_identity(monkeypatch):
     result = asyncio.run(auto_provision.validate_isolated_listen_runtime("user-a", lambda _uid: False))
 
     assert result == {"success": False, "error": "omi_identity_unavailable"}
+
+
+def test_listen_runtime_gate_skips_legacy_users(monkeypatch):
+    monkeypatch.setattr(auto_provision.runtime_resolver, "runtime_bindings_enabled", lambda _uid: False)
+    monkeypatch.setattr(
+        auto_provision,
+        "validate_isolated_listen_runtime",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected validation")),
+    )
+
+    result = asyncio.run(auto_provision.listen_runtime_gate("legacy-user", lambda _uid: True))
+
+    assert result == {"required": False, "success": True}
+
+
+def test_listen_runtime_gate_fails_closed_for_isolated_users(monkeypatch):
+    monkeypatch.setattr(auto_provision.runtime_resolver, "runtime_bindings_enabled", lambda _uid: True)
+
+    async def validate(uid, checker):
+        assert uid == "isolated-user"
+        assert checker(uid) is True
+        return {"success": False, "error": "hermes_not_provisioned"}
+
+    monkeypatch.setattr(auto_provision, "validate_isolated_listen_runtime", validate)
+
+    result = asyncio.run(auto_provision.listen_runtime_gate("isolated-user", lambda _uid: True))
+
+    assert result == {
+        "required": True,
+        "success": False,
+        "error": "hermes_not_provisioned",
+    }

--- a/backend/tests/unit/test_ella_listen_runtime_gate.py
+++ b/backend/tests/unit/test_ella_listen_runtime_gate.py
@@ -1,0 +1,43 @@
+import asyncio
+from types import SimpleNamespace
+
+from ella.routers import auto_provision
+from ella.services.provisioning import ProvisioningError
+
+
+def test_isolated_listen_accepts_owned_runtime_and_existing_omi_user(monkeypatch):
+    async def resolve(uid):
+        return SimpleNamespace(uid=uid)
+
+    monkeypatch.setattr("ella.services.runtime_resolver.resolve_isolated_runtime", resolve)
+    result = asyncio.run(
+        auto_provision.validate_isolated_listen_runtime("user-a", lambda uid: uid == "user-a")
+    )
+
+    assert result == {"success": True, "provider": "hermes"}
+
+
+def test_isolated_listen_never_falls_back_when_binding_is_missing(monkeypatch):
+    async def resolve(_uid):
+        raise ProvisioningError("hermes_not_provisioned", retryable=True)
+
+    monkeypatch.setattr("ella.services.runtime_resolver.resolve_isolated_runtime", resolve)
+    monkeypatch.setattr(
+        auto_provision,
+        "auto_provision_user",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("OpenClaw fallback invoked")),
+    )
+
+    result = asyncio.run(auto_provision.validate_isolated_listen_runtime("user-a", lambda _uid: True))
+
+    assert result == {"success": False, "error": "hermes_not_provisioned"}
+
+
+def test_isolated_listen_requires_omi_identity(monkeypatch):
+    async def resolve(uid):
+        return SimpleNamespace(uid=uid)
+
+    monkeypatch.setattr("ella.services.runtime_resolver.resolve_isolated_runtime", resolve)
+    result = asyncio.run(auto_provision.validate_isolated_listen_runtime("user-a", lambda _uid: False))
+
+    assert result == {"success": False, "error": "omi_identity_unavailable"}

--- a/backend/tests/unit/test_ella_observer.py
+++ b/backend/tests/unit/test_ella_observer.py
@@ -392,11 +392,13 @@ def test_observer_router_can_use_extraction_result(monkeypatch):
         )
     )
 
-    async def fake_build_extraction_result(events, *, mode, timeout_seconds=45.0, limit=60):
+    async def fake_build_extraction_result(events, *, mode, uid="", timeout_seconds=45.0, limit=60):
         assert mode == "heuristic"
+        assert uid == "user-1"
         return await extractor_module.build_extraction_result(
             events,
             mode=mode,
+            uid=uid,
             timeout_seconds=timeout_seconds,
             limit=limit,
         )
@@ -419,6 +421,44 @@ def test_observer_router_can_use_extraction_result(monkeypatch):
     assert body["proposal_count"] == 1
     assert body["model_metadata"]["extractor_mode"] == "heuristic"
     assert body["model_metadata"]["extractor"] == "heuristic_candidate_extractor"
+
+
+def test_observer_extractor_uses_isolated_runtime_for_hermes(monkeypatch):
+    import asyncio
+
+    sys.modules.pop("ella.services.observer_extractor", None)
+    extractor_module = importlib.import_module("ella.services.observer_extractor")
+    runtime_module = types.ModuleType("ella.services.runtime_resolver")
+    captured = {}
+
+    async def fake_runtime(uid):
+        assert uid == "uid-isolated"
+        return types.SimpleNamespace(
+            gateway_url="http://isolated-hermes:8642",
+            gateway_token="isolated-token",
+            agent_id="omi-isolated",
+        )
+
+    async def fake_hermes(events, **kwargs):
+        captured.update(kwargs)
+        return extractor_module.ExtractionResult(metadata={"extractor": "hermes"})
+
+    runtime_module.runtime_bindings_enabled = lambda uid=None: uid == "uid-isolated"
+    runtime_module.resolve_isolated_runtime = fake_runtime
+    monkeypatch.setitem(sys.modules, "ella.services.runtime_resolver", runtime_module)
+    monkeypatch.setattr(extractor_module, "hermes_candidate_extraction", fake_hermes)
+
+    asyncio.run(
+        extractor_module.build_extraction_result(
+            [_event()],
+            mode="hermes",
+            uid="uid-isolated",
+        )
+    )
+
+    assert captured["gateway_url"] == "http://isolated-hermes:8642"
+    assert captured["token"] == "isolated-token"
+    assert captured["model"] == "omi-isolated"
 
 
 def test_model_extractor_rejects_assistant_only_evidence():

--- a/backend/tests/unit/test_ella_observer.py
+++ b/backend/tests/unit/test_ella_observer.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import sys
 import types
@@ -299,8 +300,6 @@ def test_observer_router_runs_against_in_memory_test_ledger(monkeypatch):
     event_store = canonical_module.InMemoryCanonicalEventStore()
     log_store = logs_module.InMemoryObserverRunLogStore()
 
-    import asyncio
-
     asyncio.run(
         event_store.write_batch(
             [
@@ -371,8 +370,6 @@ def test_observer_router_can_use_extraction_result(monkeypatch):
     event_store = canonical_module.InMemoryCanonicalEventStore()
     log_store = logs_module.InMemoryObserverRunLogStore()
 
-    import asyncio
-
     asyncio.run(
         event_store.write_batch(
             [
@@ -424,11 +421,8 @@ def test_observer_router_can_use_extraction_result(monkeypatch):
 
 
 def test_observer_extractor_uses_isolated_runtime_for_hermes(monkeypatch):
-    import asyncio
-
     sys.modules.pop("ella.services.observer_extractor", None)
     extractor_module = importlib.import_module("ella.services.observer_extractor")
-    runtime_module = types.ModuleType("ella.services.runtime_resolver")
     captured = {}
 
     async def fake_runtime(uid):
@@ -443,9 +437,12 @@ def test_observer_extractor_uses_isolated_runtime_for_hermes(monkeypatch):
         captured.update(kwargs)
         return extractor_module.ExtractionResult(metadata={"extractor": "hermes"})
 
-    runtime_module.runtime_bindings_enabled = lambda uid=None: uid == "uid-isolated"
-    runtime_module.resolve_isolated_runtime = fake_runtime
-    monkeypatch.setitem(sys.modules, "ella.services.runtime_resolver", runtime_module)
+    monkeypatch.setattr(
+        extractor_module.runtime_resolver,
+        "runtime_bindings_enabled",
+        lambda uid=None: uid == "uid-isolated",
+    )
+    monkeypatch.setattr(extractor_module.runtime_resolver, "resolve_isolated_runtime", fake_runtime)
     monkeypatch.setattr(extractor_module, "hermes_candidate_extraction", fake_hermes)
 
     asyncio.run(
@@ -539,8 +536,6 @@ def test_observer_apply_pending_writes_safe_memory_event(monkeypatch):
     assert body["decisions"][0]["action"] == "applied"
     proposals_db.update_proposal_status.assert_called_once()
 
-    import asyncio
-
     events = asyncio.run(event_store.timeline(uid="user-1", since=None, limit=10, channels=["observer_memory"]))
     assert len(events) == 1
     assert events[0]["channel"] == "observer_memory"
@@ -595,8 +590,6 @@ def test_observer_apply_pending_accepts_trusted_mcp_memory_proposal(monkeypatch)
     assert body["applied_count"] == 1
     assert body["decisions"][0]["action"] == "applied"
     assert body["decisions"][0]["confidence"] == 0.92
-
-    import asyncio
 
     events = asyncio.run(event_store.timeline(uid="user-1", since=None, limit=10, channels=["observer_memory"]))
     assert len(events) == 1

--- a/backend/tests/unit/test_ella_onboarding_contract.py
+++ b/backend/tests/unit/test_ella_onboarding_contract.py
@@ -1,0 +1,108 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import BackgroundTasks, Response
+from pydantic import ValidationError
+
+from ella.routers import onboarding
+
+
+def test_ensure_contract_forbids_caller_supplied_identity():
+    with pytest.raises(ValidationError):
+        onboarding.OnboardingEnsureRequest(uid="attacker", client={"platform": "ios"})
+    with pytest.raises(ValidationError):
+        onboarding.OnboardingEnsureRequest(client={"platform": "ios", "gateway_token": "secret"})
+
+
+def test_verified_identity_comes_from_firebase_subject(monkeypatch):
+    monkeypatch.setattr(
+        onboarding.auth,
+        "get_user",
+        lambda uid: SimpleNamespace(email="verified@example.com", display_name="Verified User"),
+    )
+    payload = onboarding.OnboardingEnsureRequest(client={"timezone": "America/New_York"})
+
+    identity = onboarding._verified_identity("firebase-subject", payload)
+
+    assert identity.uid == "firebase-subject"
+    assert identity.email == "verified@example.com"
+    assert identity.name == "Verified User"
+    assert identity.timezone == "America/New_York"
+
+
+def test_verified_identity_requires_firebase_email(monkeypatch):
+    monkeypatch.setattr(onboarding.auth, "get_user", lambda uid: SimpleNamespace(email=None, display_name=None))
+    with pytest.raises(onboarding.HTTPException) as error:
+        onboarding._verified_identity("firebase-subject", onboarding.OnboardingEnsureRequest())
+    assert error.value.status_code == 409
+    assert error.value.detail == {"code": "identity_missing_email"}
+
+
+def test_ensure_schedules_only_authenticated_subject(monkeypatch):
+    captured = {}
+
+    class FakeCoordinator:
+        async def ensure_job(self, **kwargs):
+            captured.update(kwargs)
+            return (
+                {
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "target_schema_version": "hermes-user-v1",
+                    "state": "provisioning",
+                    "stage": "profile_ready",
+                    "retryable": True,
+                },
+                None,
+                True,
+            )
+
+        async def process_claimed_job(self, **kwargs):
+            return None
+
+    monkeypatch.setattr(
+        onboarding.auth,
+        "get_user",
+        lambda uid: SimpleNamespace(email="verified@example.com", display_name="Verified User"),
+    )
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "true")
+
+    async def fake_coordinator():
+        return FakeCoordinator()
+
+    monkeypatch.setattr(onboarding, "_coordinator", fake_coordinator)
+    response = Response()
+    tasks = BackgroundTasks()
+    result = asyncio.run(
+        onboarding.ensure_onboarding(
+            onboarding.OnboardingEnsureRequest(client_request_id="request-a"),
+            tasks,
+            response,
+            uid="firebase-subject",
+        )
+    )
+
+    assert response.status_code == 202
+    assert result["state"] == "provisioning"
+    assert captured["identity"].uid == "firebase-subject"
+    assert len(tasks.tasks) == 1
+
+
+def test_disabled_endpoint_returns_without_touching_database(monkeypatch):
+    async def forbidden_coordinator():
+        raise AssertionError("disabled onboarding must not touch provisioning storage")
+
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
+    monkeypatch.setattr(onboarding, "_coordinator", forbidden_coordinator)
+
+    with pytest.raises(onboarding.HTTPException) as error:
+        asyncio.run(
+            onboarding.ensure_onboarding(
+                onboarding.OnboardingEnsureRequest(),
+                BackgroundTasks(),
+                Response(),
+                uid="firebase-subject",
+            )
+        )
+    assert error.value.status_code == 503
+    assert error.value.detail == {"code": "provisioning_disabled"}

--- a/backend/tests/unit/test_ella_onboarding_contract.py
+++ b/backend/tests/unit/test_ella_onboarding_contract.py
@@ -6,6 +6,7 @@ from fastapi import BackgroundTasks, Response
 from pydantic import ValidationError
 
 from ella.routers import onboarding
+from ella.services.provisioning import ProvisioningError
 
 
 def test_ensure_contract_forbids_caller_supplied_identity():
@@ -150,3 +151,33 @@ def test_uid_allowlist_canaries_onboarding_without_global_cutover(monkeypatch):
 
     assert result["state"] == "provisioning"
     assert captured["identity"].uid == "canary-user"
+
+
+def test_schema_not_ready_returns_retryable_service_unavailable(monkeypatch):
+    class FakeCoordinator:
+        async def ensure_job(self, **_kwargs):
+            raise ProvisioningError("provisioning_schema_not_ready", retryable=True)
+
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "true")
+    monkeypatch.setattr(
+        onboarding.auth,
+        "get_user",
+        lambda uid: SimpleNamespace(email="canary@example.com", display_name="Canary"),
+    )
+
+    async def fake_coordinator():
+        return FakeCoordinator()
+
+    monkeypatch.setattr(onboarding, "_coordinator", fake_coordinator)
+    with pytest.raises(onboarding.HTTPException) as error:
+        asyncio.run(
+            onboarding.ensure_onboarding(
+                onboarding.OnboardingEnsureRequest(),
+                BackgroundTasks(),
+                Response(),
+                uid="canary-user",
+            )
+        )
+
+    assert error.value.status_code == 503
+    assert error.value.detail == {"code": "provisioning_schema_not_ready"}

--- a/backend/tests/unit/test_ella_onboarding_contract.py
+++ b/backend/tests/unit/test_ella_onboarding_contract.py
@@ -93,6 +93,7 @@ def test_disabled_endpoint_returns_without_touching_database(monkeypatch):
         raise AssertionError("disabled onboarding must not touch provisioning storage")
 
     monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
+    monkeypatch.delenv("ELLA_HERMES_PROVISIONING_ENABLED_UIDS", raising=False)
     monkeypatch.setattr(onboarding, "_coordinator", forbidden_coordinator)
 
     with pytest.raises(onboarding.HTTPException) as error:
@@ -106,3 +107,46 @@ def test_disabled_endpoint_returns_without_touching_database(monkeypatch):
         )
     assert error.value.status_code == 503
     assert error.value.detail == {"code": "provisioning_disabled"}
+
+
+def test_uid_allowlist_canaries_onboarding_without_global_cutover(monkeypatch):
+    captured = {}
+
+    class FakeCoordinator:
+        async def ensure_job(self, **kwargs):
+            captured.update(kwargs)
+            return (
+                {
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "target_schema_version": "hermes-user-v1",
+                    "state": "provisioning",
+                    "stage": "profile_ready",
+                    "retryable": True,
+                },
+                None,
+                False,
+            )
+
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED_UIDS", "canary-user")
+    monkeypatch.setattr(
+        onboarding.auth,
+        "get_user",
+        lambda uid: SimpleNamespace(email="canary@example.com", display_name="Canary"),
+    )
+
+    async def fake_coordinator():
+        return FakeCoordinator()
+
+    monkeypatch.setattr(onboarding, "_coordinator", fake_coordinator)
+    result = asyncio.run(
+        onboarding.ensure_onboarding(
+            onboarding.OnboardingEnsureRequest(),
+            BackgroundTasks(),
+            Response(),
+            uid="canary-user",
+        )
+    )
+
+    assert result["state"] == "provisioning"
+    assert captured["identity"].uid == "canary-user"

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -222,6 +222,27 @@ def test_omi_identity_defaults_do_not_grant_cloud_or_recording_permission():
     assert payload["store_recording_permission"] is False
 
 
+def test_legacy_omi_identity_repair_preserves_cloud_sync_default():
+    document = _FakeDocument(exists=True, data={"onboarding": {"completed": True}})
+    repository = EllaProvisioningRepository(pool=None, firestore_db=_FakeFirestore(document))
+
+    changed = asyncio.run(
+        repository.ensure_omi_user_document(
+            uid="legacy-user",
+            email="legacy@example.com",
+            name="Legacy",
+            timezone_name="America/Los_Angeles",
+            private_cloud_sync_default=True,
+        )
+    )
+
+    assert changed is True
+    payload, merge = document.writes[0]
+    assert merge is True
+    assert payload["private_cloud_sync_enabled"] is True
+    assert payload["store_recording_permission"] is False
+
+
 def test_repository_schema_preflight_reports_missing_objects():
     pool = _FakeSchemaPool(
         {

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -11,11 +11,13 @@ from ella.services.provisioning import (
     VerifiedIdentity,
     extract_runtime_binding,
     public_receipt,
+    provisioning_enabled,
     resolve_gateway_credential,
+    rollout_enabled,
     stable_payload_hash,
     validate_internal_gateway_url,
 )
-from ella.services.runtime_resolver import runtime_from_binding
+from ella.services.runtime_resolver import runtime_bindings_enabled, runtime_from_binding
 
 
 def _job(**overrides):
@@ -155,6 +157,30 @@ class _FakeFirestore:
 def test_payload_hash_is_stable_and_sensitive_to_values():
     assert stable_payload_hash({"b": 2, "a": 1}) == stable_payload_hash({"a": 1, "b": 2})
     assert stable_payload_hash({"a": 1}) != stable_payload_hash({"a": 2})
+
+
+def test_uid_scoped_rollout_is_exact_and_global_flag_still_wins(monkeypatch):
+    monkeypatch.setenv("TEST_ROLLOUT_ENABLED", "false")
+    monkeypatch.setenv("TEST_ROLLOUT_UIDS", "firebase-A, firebase-B")
+
+    assert rollout_enabled("TEST_ROLLOUT_ENABLED", "TEST_ROLLOUT_UIDS", "firebase-A") is True
+    assert rollout_enabled("TEST_ROLLOUT_ENABLED", "TEST_ROLLOUT_UIDS", "firebase-a") is False
+    assert rollout_enabled("TEST_ROLLOUT_ENABLED", "TEST_ROLLOUT_UIDS", None) is False
+
+    monkeypatch.setenv("TEST_ROLLOUT_ENABLED", "true")
+    assert rollout_enabled("TEST_ROLLOUT_ENABLED", "TEST_ROLLOUT_UIDS", "unlisted") is True
+
+
+def test_provisioning_and_runtime_canary_allowlists_are_independent(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED_UIDS", "provision-user")
+    monkeypatch.setenv("ELLA_RUNTIME_BINDINGS_ENABLED", "false")
+    monkeypatch.setenv("ELLA_RUNTIME_BINDINGS_ENABLED_UIDS", "runtime-user")
+
+    assert provisioning_enabled("provision-user") is True
+    assert provisioning_enabled("runtime-user") is False
+    assert runtime_bindings_enabled("runtime-user") is True
+    assert runtime_bindings_enabled("provision-user") is False
 
 
 def test_omi_identity_defaults_do_not_grant_cloud_or_recording_permission(monkeypatch):

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -1,5 +1,7 @@
 import asyncio
+import sys
 import uuid
+from types import ModuleType
 
 import pytest
 
@@ -57,11 +59,14 @@ def _runtime_receipt(profile_name="omi-user-a"):
 
 
 class FakeRepository:
-    def __init__(self, *, binding=None):
+    def __init__(self, *, binding=None, omi_identity_error=None):
         self.job = _job()
         self.binding = binding
+        self.omi_identity_error = omi_identity_error
         self.staged = None
         self.identity_calls = []
+        self.omi_identity_calls = []
+        self.user_active = False
 
     async def ensure_user_identity(self, **kwargs):
         self.identity_calls.append(kwargs)
@@ -69,6 +74,12 @@ class FakeRepository:
 
     async def acquire_job(self, **kwargs):
         return dict(self.job)
+
+    async def ensure_omi_user_document(self, **kwargs):
+        if self.omi_identity_error:
+            raise self.omi_identity_error
+        self.omi_identity_calls.append(kwargs)
+        return True
 
     async def resolve_active_runtime(self, uid):
         return self.binding
@@ -94,7 +105,11 @@ class FakeRepository:
 
     async def activate_runtime_binding(self, *, uid, provider):
         self.binding = dict(self.staged, active=True, revision=2)
+        self.user_active = True
         return self.binding
+
+    async def activate_user(self, uid):
+        self.user_active = True
 
 
 class FakeProvisionClient:
@@ -107,9 +122,62 @@ class FakeProvisionClient:
         return self.result
 
 
+class _FakeDocument:
+    def __init__(self, *, exists, data=None):
+        self.exists = exists
+        self.data = data or {}
+        self.writes = []
+
+    def get(self):
+        return self
+
+    def to_dict(self):
+        return dict(self.data)
+
+    def set(self, payload, *, merge):
+        self.writes.append((payload, merge))
+
+
+class _FakeFirestore:
+    def __init__(self, document):
+        self.document_ref = document
+
+    def collection(self, name):
+        assert name == "users"
+        return self
+
+    def document(self, _uid):
+        return self.document_ref
+
+
 def test_payload_hash_is_stable_and_sensitive_to_values():
     assert stable_payload_hash({"b": 2, "a": 1}) == stable_payload_hash({"a": 1, "b": 2})
     assert stable_payload_hash({"a": 1}) != stable_payload_hash({"a": 2})
+
+
+def test_omi_identity_defaults_do_not_grant_cloud_or_recording_permission(monkeypatch):
+    from database.ella_provisioning import EllaProvisioningRepository
+
+    document = _FakeDocument(exists=True, data={"onboarding": {"completed": True}})
+    client_module = ModuleType("database._client")
+    client_module.db = _FakeFirestore(document)
+    monkeypatch.setitem(sys.modules, "database._client", client_module)
+    repository = EllaProvisioningRepository(pool=None)
+
+    changed = asyncio.run(
+        repository.ensure_omi_user_document(
+            uid="user-a",
+            email="a@example.com",
+            name="A",
+            timezone_name="America/Los_Angeles",
+        )
+    )
+
+    assert changed is True
+    payload, merge = document.writes[0]
+    assert merge is True
+    assert payload["private_cloud_sync_enabled"] is False
+    assert payload["store_recording_permission"] is False
 
 
 def test_public_receipt_does_not_expose_runtime_secrets():
@@ -220,6 +288,51 @@ def test_disabled_provisioning_stays_retryable_and_can_resume(monkeypatch):
     assert claimed is True
 
 
+def test_omi_identity_failure_is_durable_and_does_not_call_hermes(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "true")
+    repository = FakeRepository(omi_identity_error=RuntimeError("firestore unavailable"))
+    client = FakeProvisionClient(_runtime_receipt())
+    coordinator = ProvisioningCoordinator(repository, client)
+    identity = VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles")
+
+    job, binding, claimed = asyncio.run(
+        coordinator.ensure_job(
+            identity=identity,
+            target_schema_version="hermes-user-v1",
+            client_request_id="request-a",
+            request_payload={"client": "ios"},
+        )
+    )
+
+    assert (job["state"], job["error_code"], binding, claimed) == (
+        "degraded",
+        "omi_identity_unavailable",
+        None,
+        False,
+    )
+    assert client.calls == []
+
+
+def test_existing_binding_reconciles_pending_user_to_active(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "true")
+    binding = {"revision": 4, "user_status": "PENDING", "active": True}
+    repository = FakeRepository(binding=binding)
+    coordinator = ProvisioningCoordinator(repository, FakeProvisionClient(_runtime_receipt()))
+    identity = VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles")
+
+    job, resolved, claimed = asyncio.run(
+        coordinator.ensure_job(
+            identity=identity,
+            target_schema_version="hermes-user-v1",
+            client_request_id="request-a",
+            request_payload={"client": "ios"},
+        )
+    )
+
+    assert (job["state"], resolved, claimed) == ("ready", binding, False)
+    assert repository.user_active is True
+
+
 def test_successful_provision_stages_then_activates_binding(monkeypatch):
     monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "true")
     repository = FakeRepository()
@@ -241,6 +354,15 @@ def test_successful_provision_stages_then_activates_binding(monkeypatch):
     assert repository.job["state"] == "ready"
     assert repository.binding["active"] is True
     assert repository.binding["provider"] == "hermes"
+    assert repository.user_active is True
+    assert repository.omi_identity_calls == [
+        {
+            "uid": "user-a",
+            "email": "a@example.com",
+            "name": "A",
+            "timezone_name": "America/Los_Angeles",
+        }
+    ]
     assert client.calls == [(identity, "hermes-user-v1")]
 
 

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -81,7 +81,9 @@ class FakeRepository:
         self.omi_identity_calls.append(kwargs)
         return True
 
-    async def resolve_active_runtime(self, uid):
+    async def resolve_active_runtime(self, uid, template_version=None):
+        if self.binding and template_version and self.binding.get("template_version") != template_version:
+            return None
         return self.binding
 
     async def claim_job(self, job_id):
@@ -215,6 +217,13 @@ def test_internal_gateway_is_limited_to_loopback_tailnet_or_allowlist(monkeypatc
     assert validate_internal_gateway_url("http://100.76.138.56:8701/") == "http://100.76.138.56:8701"
     with pytest.raises(ProvisioningError, match="invalid_internal_gateway_url"):
         validate_internal_gateway_url("https://example.com/runtime")
+    for invalid in (
+        "http://100.76.138.56:8701/admin",
+        "http://100.76.138.56:8701/?token=secret",
+        "http://100.76.138.56:8701/#fragment",
+    ):
+        with pytest.raises(ProvisioningError, match="invalid_internal_gateway_url"):
+            validate_internal_gateway_url(invalid)
     monkeypatch.setenv("ELLA_HERMES_GATEWAY_ALLOWED_HOSTS", "hermes.internal")
     assert validate_internal_gateway_url("http://hermes.internal:8701") == "http://hermes.internal:8701"
 
@@ -247,6 +256,13 @@ def test_runtime_receipt_requires_owned_workspace_port_and_honcho():
     with pytest.raises(ProvisioningError, match="honcho_receipt_incomplete"):
         extract_runtime_binding(no_honcho, "user-a")
 
+    with pytest.raises(ProvisioningError, match="runtime_template_version_mismatch"):
+        extract_runtime_binding(
+            _runtime_receipt(),
+            "user-a",
+            expected_template_version="hermes-user-v2",
+        )
+
 
 def test_runtime_resolver_enforces_owner_health_and_credential(monkeypatch):
     monkeypatch.setenv("ELLA_HERMES_GATEWAY_KEY_USER_A", "secret-value")
@@ -257,6 +273,14 @@ def test_runtime_resolver_enforces_owner_health_and_credential(monkeypatch):
     assert runtime.gateway_token == "secret-value"
     with pytest.raises(ProvisioningError, match="runtime_ownership_mismatch"):
         runtime_from_binding(binding, "user-b")
+
+    invalid_honcho = dict(binding, honcho_workspace="")
+    with pytest.raises(ProvisioningError, match="honcho_receipt_incomplete"):
+        runtime_from_binding(invalid_honcho, "user-a")
+
+    invalid_workspace = dict(binding, workspace_root="/Users/ellaai/.hermes/profiles/another-user/workspace")
+    with pytest.raises(ProvisioningError, match="workspace_ownership_mismatch"):
+        runtime_from_binding(invalid_workspace, "user-a")
 
 
 def test_disabled_provisioning_stays_retryable_and_can_resume(monkeypatch):
@@ -315,7 +339,12 @@ def test_omi_identity_failure_is_durable_and_does_not_call_hermes(monkeypatch):
 
 def test_existing_binding_reconciles_pending_user_to_active(monkeypatch):
     monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "true")
-    binding = {"revision": 4, "user_status": "PENDING", "active": True}
+    binding = {
+        "revision": 4,
+        "user_status": "PENDING",
+        "active": True,
+        "template_version": "hermes-user-v1",
+    }
     repository = FakeRepository(binding=binding)
     coordinator = ProvisioningCoordinator(repository, FakeProvisionClient(_runtime_receipt()))
     identity = VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles")

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -344,6 +344,23 @@ def test_runtime_receipt_requires_owned_workspace_port_and_honcho():
         )
 
 
+@pytest.mark.parametrize("invalid_value", [False, "false", "0", 0, 1, None])
+def test_runtime_receipt_requires_strict_boolean_smoke_evidence(invalid_value):
+    receipt = _runtime_receipt()
+    receipt["runtimeBinding"]["smokePassed"] = invalid_value
+
+    with pytest.raises(ProvisioningError, match="runtime_smoke_incomplete"):
+        extract_runtime_binding(receipt, "user-a")
+
+
+def test_runtime_receipt_rejects_conflicting_smoke_evidence():
+    receipt = _runtime_receipt()
+    receipt["runtimeBinding"]["healthReceipt"]["smoke_passed"] = False
+
+    with pytest.raises(ProvisioningError, match="runtime_smoke_incomplete"):
+        extract_runtime_binding(receipt, "user-a")
+
+
 def test_runtime_resolver_enforces_owner_health_and_credential(monkeypatch):
     monkeypatch.setenv("ELLA_HERMES_GATEWAY_KEY_USER_A", "secret-value")
     binding = extract_runtime_binding(_runtime_receipt(), "user-a")

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -1,10 +1,12 @@
 import asyncio
-import sys
 import uuid
-from types import ModuleType
 
 import pytest
 
+from database.ella_provisioning import (
+    EllaProvisioningRepository,
+    ProvisioningSchemaNotReadyError,
+)
 from ella.services.provisioning import (
     ProvisioningCoordinator,
     ProvisioningError,
@@ -61,14 +63,21 @@ def _runtime_receipt(profile_name="omi-user-a"):
 
 
 class FakeRepository:
-    def __init__(self, *, binding=None, omi_identity_error=None):
+    def __init__(self, *, binding=None, omi_identity_error=None, schema_error=None):
         self.job = _job()
         self.binding = binding
         self.omi_identity_error = omi_identity_error
+        self.schema_error = schema_error
         self.staged = None
         self.identity_calls = []
         self.omi_identity_calls = []
         self.user_active = False
+        self.schema_checks = 0
+
+    async def assert_schema_ready(self):
+        self.schema_checks += 1
+        if self.schema_error:
+            raise self.schema_error
 
     async def ensure_user_identity(self, **kwargs):
         self.identity_calls.append(kwargs)
@@ -154,6 +163,16 @@ class _FakeFirestore:
         return self.document_ref
 
 
+class _FakeSchemaPool:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    async def fetchrow(self, query, *args):
+        self.calls.append((query, args))
+        return self.result
+
+
 def test_payload_hash_is_stable_and_sensitive_to_values():
     assert stable_payload_hash({"b": 2, "a": 1}) == stable_payload_hash({"a": 1, "b": 2})
     assert stable_payload_hash({"a": 1}) != stable_payload_hash({"a": 2})
@@ -183,14 +202,9 @@ def test_provisioning_and_runtime_canary_allowlists_are_independent(monkeypatch)
     assert runtime_bindings_enabled("provision-user") is False
 
 
-def test_omi_identity_defaults_do_not_grant_cloud_or_recording_permission(monkeypatch):
-    from database.ella_provisioning import EllaProvisioningRepository
-
+def test_omi_identity_defaults_do_not_grant_cloud_or_recording_permission():
     document = _FakeDocument(exists=True, data={"onboarding": {"completed": True}})
-    client_module = ModuleType("database._client")
-    client_module.db = _FakeFirestore(document)
-    monkeypatch.setitem(sys.modules, "database._client", client_module)
-    repository = EllaProvisioningRepository(pool=None)
+    repository = EllaProvisioningRepository(pool=None, firestore_db=_FakeFirestore(document))
 
     changed = asyncio.run(
         repository.ensure_omi_user_document(
@@ -206,6 +220,46 @@ def test_omi_identity_defaults_do_not_grant_cloud_or_recording_permission(monkey
     assert merge is True
     assert payload["private_cloud_sync_enabled"] is False
     assert payload["store_recording_permission"] is False
+
+
+def test_repository_schema_preflight_reports_missing_objects():
+    pool = _FakeSchemaPool(
+        {
+            "jobs_table": True,
+            "bindings_table": False,
+            "missing_indexes": ["ella_runtime_bindings_one_active_role_key"],
+        }
+    )
+    repository = EllaProvisioningRepository(pool)
+
+    with pytest.raises(ProvisioningSchemaNotReadyError) as error:
+        asyncio.run(repository.assert_schema_ready())
+
+    assert error.value.missing == (
+        "table:ella_runtime_bindings",
+        "index:ella_runtime_bindings_one_active_role_key",
+    )
+    assert len(pool.calls) == 1
+
+
+def test_schema_preflight_runs_before_identity_mutation():
+    repository = FakeRepository(schema_error=ProvisioningSchemaNotReadyError(["table:ella_provisioning_jobs"]))
+    coordinator = ProvisioningCoordinator(repository, FakeProvisionClient(_runtime_receipt()))
+    identity = VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles")
+
+    with pytest.raises(ProvisioningError, match="provisioning_schema_not_ready") as error:
+        asyncio.run(
+            coordinator.ensure_job(
+                identity=identity,
+                target_schema_version="hermes-user-v1",
+                client_request_id="request-a",
+                request_payload={"client": "ios"},
+            )
+        )
+
+    assert error.value.retryable is True
+    assert repository.schema_checks == 1
+    assert repository.identity_calls == []
 
 
 def test_public_receipt_does_not_expose_runtime_secrets():

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -1,0 +1,260 @@
+import asyncio
+import uuid
+
+import pytest
+
+from ella.services.provisioning import (
+    ProvisioningCoordinator,
+    ProvisioningError,
+    VerifiedIdentity,
+    extract_runtime_binding,
+    public_receipt,
+    resolve_gateway_credential,
+    stable_payload_hash,
+    validate_internal_gateway_url,
+)
+from ella.services.runtime_resolver import runtime_from_binding
+
+
+def _job(**overrides):
+    value = {
+        "id": uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        "target_schema_version": "hermes-user-v1",
+        "state": "pending",
+        "stage": "identity_ready",
+        "retryable": True,
+    }
+    value.update(overrides)
+    return value
+
+
+def _runtime_receipt(profile_name="omi-user-a"):
+    return {
+        "mode": "hermes_only",
+        "provisionMode": "hermes_only",
+        "runtimeBinding": {
+            "provider": "hermes",
+            "profileName": profile_name,
+            "agentId": "hermes",
+            "workspaceRoot": f"/Users/ellaai/.hermes/profiles/{profile_name}/workspace",
+            "internalGatewayUrl": "http://100.76.138.56:8701",
+            "gatewayPort": 8701,
+            "serviceLabel": f"com.ella.hermes.{profile_name}",
+            "credentialRef": "env:ELLA_HERMES_GATEWAY_KEY_USER_A",
+            "healthState": "healthy",
+            "smokePassed": True,
+            "healthReceipt": {"smoke_passed": True, "probe": "synthetic"},
+            "templateVersion": "hermes-user-v1",
+            "modelPolicyVersion": "frontier-v1",
+            "voicePolicyVersion": "ella-voice-v1",
+            "honcho": {
+                "workspace": "honcho-user-a",
+                "observedPeer": "user-a",
+                "observerPeer": "ella-user-a",
+            },
+        },
+    }
+
+
+class FakeRepository:
+    def __init__(self, *, binding=None):
+        self.job = _job()
+        self.binding = binding
+        self.staged = None
+        self.identity_calls = []
+
+    async def ensure_user_identity(self, **kwargs):
+        self.identity_calls.append(kwargs)
+        return {"omi_uid": kwargs["uid"]}
+
+    async def acquire_job(self, **kwargs):
+        return dict(self.job)
+
+    async def resolve_active_runtime(self, uid):
+        return self.binding
+
+    async def claim_job(self, job_id):
+        if self.job["state"] in {"ready", "blocked", "provisioning"}:
+            return None
+        self.job.update(state="provisioning", stage="profile_ready")
+        return dict(self.job)
+
+    async def update_job(self, **kwargs):
+        self.job.update(
+            state=kwargs["state"],
+            stage=kwargs["stage"],
+            retryable=kwargs["retryable"],
+            error_code=kwargs.get("error_code"),
+        )
+        return dict(self.job)
+
+    async def stage_runtime_binding(self, *, uid, binding):
+        self.staged = dict(binding, omi_uid=uid, revision=1, active=False)
+        return self.staged
+
+    async def activate_runtime_binding(self, *, uid, provider):
+        self.binding = dict(self.staged, active=True, revision=2)
+        return self.binding
+
+
+class FakeProvisionClient:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    async def provision(self, identity, target_schema_version):
+        self.calls.append((identity, target_schema_version))
+        return self.result
+
+
+def test_payload_hash_is_stable_and_sensitive_to_values():
+    assert stable_payload_hash({"b": 2, "a": 1}) == stable_payload_hash({"a": 1, "b": 2})
+    assert stable_payload_hash({"a": 1}) != stable_payload_hash({"a": 2})
+
+
+def test_public_receipt_does_not_expose_runtime_secrets():
+    receipt = public_receipt(
+        _job(state="ready", stage="active", retryable=False),
+        {
+            "active": True,
+            "revision": 7,
+            "model_policy_version": "frontier-v1",
+            "voice_policy_version": "ella-voice-v1",
+            "credential_ref": "env:TOP_SECRET",
+            "internal_gateway_url": "http://100.76.138.56:8701",
+            "workspace_root": "/private/workspace",
+        },
+    )
+
+    assert receipt["state"] == "ready"
+    assert receipt["binding_revision"] == 7
+    serialized = str(receipt)
+    assert "TOP_SECRET" not in serialized
+    assert "100.76.138.56" not in serialized
+    assert "/private/workspace" not in serialized
+
+
+def test_gateway_credentials_are_server_env_references_only(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_GATEWAY_KEY_USER_A", "secret-value")
+    assert resolve_gateway_credential("env:ELLA_HERMES_GATEWAY_KEY_USER_A") == "secret-value"
+    for invalid in (None, "secret-value", "file:/tmp/key", "env:PATH", "env:OPENAI_API_KEY"):
+        with pytest.raises(ProvisioningError, match="invalid_credential_reference"):
+            resolve_gateway_credential(invalid)
+
+
+def test_internal_gateway_is_limited_to_loopback_tailnet_or_allowlist(monkeypatch):
+    assert validate_internal_gateway_url("http://127.0.0.1:8701") == "http://127.0.0.1:8701"
+    assert validate_internal_gateway_url("http://100.76.138.56:8701/") == "http://100.76.138.56:8701"
+    with pytest.raises(ProvisioningError, match="invalid_internal_gateway_url"):
+        validate_internal_gateway_url("https://example.com/runtime")
+    monkeypatch.setenv("ELLA_HERMES_GATEWAY_ALLOWED_HOSTS", "hermes.internal")
+    assert validate_internal_gateway_url("http://hermes.internal:8701") == "http://hermes.internal:8701"
+
+
+def test_runtime_receipt_rejects_non_hermes_and_plato_cross_user(monkeypatch):
+    non_hermes = _runtime_receipt()
+    non_hermes["runtimeBinding"]["provider"] = "openclaw"
+    with pytest.raises(ProvisioningError, match="invalid_runtime_provider"):
+        extract_runtime_binding(non_hermes, "user-a")
+
+    monkeypatch.setenv("ELLA_PLATO_UID", "plato-owner")
+    with pytest.raises(ProvisioningError, match="plato_binding_forbidden"):
+        extract_runtime_binding(_runtime_receipt("plato-eval"), "user-a")
+    assert extract_runtime_binding(_runtime_receipt("plato-eval"), "plato-owner")["profile_name"] == "plato-eval"
+
+
+def test_runtime_receipt_requires_owned_workspace_port_and_honcho():
+    wrong_workspace = _runtime_receipt()
+    wrong_workspace["runtimeBinding"]["workspaceRoot"] = "/Users/ellaai/.hermes/profiles/plato-eval/workspace"
+    with pytest.raises(ProvisioningError, match="workspace_ownership_mismatch"):
+        extract_runtime_binding(wrong_workspace, "user-a")
+
+    wrong_port = _runtime_receipt()
+    wrong_port["runtimeBinding"]["gatewayPort"] = 8702
+    with pytest.raises(ProvisioningError, match="gateway_port_mismatch"):
+        extract_runtime_binding(wrong_port, "user-a")
+
+    no_honcho = _runtime_receipt()
+    no_honcho["runtimeBinding"]["honcho"] = {}
+    with pytest.raises(ProvisioningError, match="honcho_receipt_incomplete"):
+        extract_runtime_binding(no_honcho, "user-a")
+
+
+def test_runtime_resolver_enforces_owner_health_and_credential(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_GATEWAY_KEY_USER_A", "secret-value")
+    binding = extract_runtime_binding(_runtime_receipt(), "user-a")
+    binding.update(omi_uid="user-a", active=True, revision=4)
+    runtime = runtime_from_binding(binding, "user-a")
+    assert runtime.profile_name == "omi-user-a"
+    assert runtime.gateway_token == "secret-value"
+    with pytest.raises(ProvisioningError, match="runtime_ownership_mismatch"):
+        runtime_from_binding(binding, "user-b")
+
+
+def test_disabled_provisioning_stays_retryable_and_can_resume(monkeypatch):
+    repository = FakeRepository()
+    identity = VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles")
+    coordinator = ProvisioningCoordinator(repository, FakeProvisionClient(_runtime_receipt()))
+
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
+    job, binding, claimed = asyncio.run(
+        coordinator.ensure_job(
+            identity=identity,
+            target_schema_version="hermes-user-v1",
+            client_request_id="request-a",
+            request_payload={"client": "ios"},
+        )
+    )
+    assert (job["state"], job["retryable"], claimed, binding) == ("degraded", True, False, None)
+
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "true")
+    job, _, claimed = asyncio.run(
+        coordinator.ensure_job(
+            identity=identity,
+            target_schema_version="hermes-user-v1",
+            client_request_id="request-b",
+            request_payload={"client": "ios"},
+        )
+    )
+    assert job["state"] == "provisioning"
+    assert claimed is True
+
+
+def test_successful_provision_stages_then_activates_binding(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "true")
+    repository = FakeRepository()
+    client = FakeProvisionClient(_runtime_receipt())
+    identity = VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles")
+    coordinator = ProvisioningCoordinator(repository, client)
+    job, _, claimed = asyncio.run(
+        coordinator.ensure_job(
+            identity=identity,
+            target_schema_version="hermes-user-v1",
+            client_request_id="request-a",
+            request_payload={"client": "ios"},
+        )
+    )
+    assert claimed is True
+
+    asyncio.run(coordinator.process_claimed_job(job=job, identity=identity))
+
+    assert repository.job["state"] == "ready"
+    assert repository.binding["active"] is True
+    assert repository.binding["provider"] == "hermes"
+    assert client.calls == [(identity, "hermes-user-v1")]
+
+
+def test_legacy_8210_receipt_cannot_activate(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "true")
+    repository = FakeRepository()
+    identity = VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles")
+    coordinator = ProvisioningCoordinator(
+        repository,
+        FakeProvisionClient({"mode": "hermes_only", "provisionMode": "hermes_only"}),
+    )
+
+    asyncio.run(coordinator.process_claimed_job(job=_job(state="provisioning"), identity=identity))
+
+    assert repository.job["state"] == "degraded"
+    assert repository.job["error_code"] == "runtime_receipt_missing"
+    assert repository.binding is None

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -361,6 +361,14 @@ def test_runtime_receipt_rejects_conflicting_smoke_evidence():
         extract_runtime_binding(receipt, "user-a")
 
 
+def test_runtime_receipt_rejects_conflicting_camel_case_health_smoke_evidence():
+    receipt = _runtime_receipt()
+    receipt["runtimeBinding"]["healthReceipt"]["smokePassed"] = False
+
+    with pytest.raises(ProvisioningError, match="runtime_smoke_incomplete"):
+        extract_runtime_binding(receipt, "user-a")
+
+
 def test_runtime_resolver_enforces_owner_health_and_credential(monkeypatch):
     monkeypatch.setenv("ELLA_HERMES_GATEWAY_KEY_USER_A", "secret-value")
     binding = extract_runtime_binding(_runtime_receipt(), "user-a")

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -148,3 +148,22 @@ def test_voice_session_requires_active_runtime_when_isolation_enabled(monkeypatc
         )
     assert error.value.status_code == 503
     assert error.value.detail == {"code": "hermes_not_provisioned"}
+
+
+def test_voice_session_cannot_fall_back_to_openclaw_before_isolated_proxy_cutover(monkeypatch):
+    async def ready_runtime(uid):
+        return object()
+
+    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda: True)
+    monkeypatch.setattr(voice, "resolve_isolated_runtime", ready_runtime)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda: False)
+
+    with pytest.raises(HTTPException) as error:
+        asyncio.run(
+            voice.create_voice_session(
+                body=voice.VoiceSessionRequest(uid="user-a", provider="grok-voice"),
+                authenticated_uid="user-a",
+            )
+        )
+    assert error.value.status_code == 503
+    assert error.value.detail == {"code": "isolated_voice_not_ready"}

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -1,0 +1,150 @@
+import asyncio
+import sys
+from types import ModuleType
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException, Request
+
+sys.modules.setdefault("websockets", ModuleType("websockets"))
+conversations_module = ModuleType("database.conversations")
+conversations_module._decrypt_conversation_data = lambda value: value
+sys.modules.setdefault("database.conversations", conversations_module)
+
+from ella.routers import chat, resolve, voice
+from ella.services.provisioning import ProvisioningError
+
+
+def _request():
+    return Request({"type": "http", "method": "POST", "path": "/v1/ella/chat/stream", "headers": []})
+
+
+def test_chat_rejects_body_uid_that_differs_from_firebase_subject():
+    with pytest.raises(HTTPException) as error:
+        asyncio.run(
+            chat.ella_chat_stream(
+                chat.EllaChatRequest(uid="user-b", message="hello"),
+                _request(),
+                authenticated_uid="user-a",
+            )
+        )
+    assert error.value.status_code == 403
+    assert error.value.detail == {"code": "ownership_mismatch"}
+
+
+def test_chat_history_rejects_query_uid_that_differs_from_firebase_subject():
+    with pytest.raises(HTTPException) as error:
+        asyncio.run(chat.ella_chat_history("user-b", authenticated_uid="user-a"))
+    assert error.value.status_code == 403
+
+
+def test_isolated_history_never_uses_openclaw_fallback(monkeypatch):
+    async def fake_runtime(uid):
+        assert uid == "user-a"
+        return SimpleNamespace(profile_name="omi-user-a")
+
+    async def no_events(uid, *, limit, before=None):
+        return []
+
+    async def forbidden_legacy(uid):
+        raise AssertionError("OpenClaw fallback must not run in isolated mode")
+
+    monkeypatch.setattr(chat, "runtime_bindings_enabled", lambda: True)
+    monkeypatch.setattr(chat, "resolve_isolated_runtime", fake_runtime)
+    monkeypatch.setattr(chat, "_fetch_chat_canonical_events", no_events)
+    monkeypatch.setattr(chat, "resolve_user_routing", forbidden_legacy)
+
+    result = asyncio.run(chat.ella_chat_history("user-a", authenticated_uid="user-a"))
+
+    assert result == {
+        "messages": [],
+        "hasMore": False,
+        "source": "canonical_timeline_empty",
+        "fallback": False,
+    }
+
+
+def test_isolated_history_fails_closed_without_binding(monkeypatch):
+    async def missing_runtime(uid):
+        raise ProvisioningError("hermes_not_provisioned", retryable=True)
+
+    monkeypatch.setattr(chat, "runtime_bindings_enabled", lambda: True)
+    monkeypatch.setattr(chat, "resolve_isolated_runtime", missing_runtime)
+
+    with pytest.raises(HTTPException) as error:
+        asyncio.run(chat.ella_chat_history("user-a", authenticated_uid="user-a"))
+    assert error.value.status_code == 503
+    assert error.value.detail == {"code": "hermes_not_provisioned"}
+
+
+def test_public_resolver_is_authenticated_and_redacts_internal_runtime(monkeypatch):
+    async def fake_resolve(uid):
+        assert uid == "user-a"
+        return {
+            "user": {"id": "1", "omiUid": uid, "name": "A"},
+            "routing": {
+                "agentId": "hermes",
+                "gatewayUrl": "http://100.76.138.56:8701",
+                "token": "secret",
+                "profileName": "omi-user-a",
+                "bindingRevision": 3,
+                "modelPolicyVersion": "frontier-v1",
+                "voicePolicyVersion": "ella-voice-v1",
+            },
+        }
+
+    monkeypatch.setattr(resolve, "runtime_bindings_enabled", lambda: True)
+    monkeypatch.setattr(resolve, "resolve_user_routing", fake_resolve)
+
+    result = asyncio.run(resolve.resolve_endpoint(uid="user-a", email=None, phone=None, authenticated_uid="user-a"))
+
+    assert result["routing"] == {
+        "agentId": "hermes",
+        "historyUrl": "/v1/ella/chat/history",
+        "platform": "hermes",
+        "bindingRevision": 3,
+        "modelPolicyVersion": "frontier-v1",
+        "voicePolicyVersion": "ella-voice-v1",
+    }
+    assert "secret" not in str(result)
+    assert "gatewayUrl" not in result["routing"]
+    assert "profileName" not in result["routing"]
+
+
+def test_public_resolver_rejects_cross_user_and_email_lookup():
+    with pytest.raises(HTTPException) as mismatch:
+        asyncio.run(resolve.resolve_endpoint(uid="user-b", email=None, phone=None, authenticated_uid="user-a"))
+    assert mismatch.value.status_code == 403
+
+    with pytest.raises(HTTPException) as unsupported:
+        asyncio.run(resolve.resolve_endpoint(uid=None, email="a@example.com", phone=None, authenticated_uid="user-a"))
+    assert unsupported.value.status_code == 400
+
+
+def test_voice_session_rejects_cross_user_before_issuing_token():
+    with pytest.raises(HTTPException) as error:
+        asyncio.run(
+            voice.create_voice_session(
+                body=voice.VoiceSessionRequest(uid="user-b", provider="grok-voice"),
+                authenticated_uid="user-a",
+            )
+        )
+    assert error.value.status_code == 403
+
+
+def test_voice_session_requires_active_runtime_when_isolation_enabled(monkeypatch):
+    async def missing_runtime(uid):
+        raise ProvisioningError("hermes_not_provisioned", retryable=True)
+
+    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda: True)
+    monkeypatch.setattr(voice, "resolve_isolated_runtime", missing_runtime)
+
+    with pytest.raises(HTTPException) as error:
+        asyncio.run(
+            voice.create_voice_session(
+                body=voice.VoiceSessionRequest(uid="user-a", provider="grok-voice"),
+                authenticated_uid="user-a",
+            )
+        )
+    assert error.value.status_code == 503
+    assert error.value.detail == {"code": "hermes_not_provisioned"}

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -150,13 +150,13 @@ def test_voice_session_requires_active_runtime_when_isolation_enabled(monkeypatc
     assert error.value.detail == {"code": "hermes_not_provisioned"}
 
 
-def test_voice_session_cannot_fall_back_to_openclaw_before_isolated_proxy_cutover(monkeypatch):
+def test_voice_session_stays_closed_even_when_isolated_voice_flag_is_enabled(monkeypatch):
     async def ready_runtime(uid):
         return object()
 
     monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: True)
     monkeypatch.setattr(voice, "resolve_isolated_runtime", ready_runtime)
-    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
+    monkeypatch.setenv("ELLA_ISOLATED_VOICE_ROUTING_ENABLED", "true")
 
     with pytest.raises(HTTPException) as error:
         asyncio.run(

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -49,7 +49,7 @@ def test_isolated_history_never_uses_openclaw_fallback(monkeypatch):
     async def forbidden_legacy(uid):
         raise AssertionError("OpenClaw fallback must not run in isolated mode")
 
-    monkeypatch.setattr(chat, "runtime_bindings_enabled", lambda: True)
+    monkeypatch.setattr(chat, "runtime_bindings_enabled", lambda uid=None: True)
     monkeypatch.setattr(chat, "resolve_isolated_runtime", fake_runtime)
     monkeypatch.setattr(chat, "_fetch_chat_canonical_events", no_events)
     monkeypatch.setattr(chat, "resolve_user_routing", forbidden_legacy)
@@ -68,7 +68,7 @@ def test_isolated_history_fails_closed_without_binding(monkeypatch):
     async def missing_runtime(uid):
         raise ProvisioningError("hermes_not_provisioned", retryable=True)
 
-    monkeypatch.setattr(chat, "runtime_bindings_enabled", lambda: True)
+    monkeypatch.setattr(chat, "runtime_bindings_enabled", lambda uid=None: True)
     monkeypatch.setattr(chat, "resolve_isolated_runtime", missing_runtime)
 
     with pytest.raises(HTTPException) as error:
@@ -93,7 +93,7 @@ def test_public_resolver_is_authenticated_and_redacts_internal_runtime(monkeypat
             },
         }
 
-    monkeypatch.setattr(resolve, "runtime_bindings_enabled", lambda: True)
+    monkeypatch.setattr(resolve, "runtime_bindings_enabled", lambda uid=None: True)
     monkeypatch.setattr(resolve, "resolve_user_routing", fake_resolve)
 
     result = asyncio.run(resolve.resolve_endpoint(uid="user-a", email=None, phone=None, authenticated_uid="user-a"))
@@ -136,7 +136,7 @@ def test_voice_session_requires_active_runtime_when_isolation_enabled(monkeypatc
     async def missing_runtime(uid):
         raise ProvisioningError("hermes_not_provisioned", retryable=True)
 
-    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda: True)
+    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: True)
     monkeypatch.setattr(voice, "resolve_isolated_runtime", missing_runtime)
 
     with pytest.raises(HTTPException) as error:
@@ -154,9 +154,9 @@ def test_voice_session_cannot_fall_back_to_openclaw_before_isolated_proxy_cutove
     async def ready_runtime(uid):
         return object()
 
-    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda: True)
+    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: True)
     monkeypatch.setattr(voice, "resolve_isolated_runtime", ready_runtime)
-    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda: False)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
 
     with pytest.raises(HTTPException) as error:
         asyncio.run(

--- a/backend/tests/unit/test_scanner_keyterms.py
+++ b/backend/tests/unit/test_scanner_keyterms.py
@@ -1,8 +1,8 @@
 import asyncio
 import time
+from types import SimpleNamespace
 
 from utils.ella import scanner_keyterms
-
 
 SCANNER_TUNING = """
 ## @runtime: current-state
@@ -189,6 +189,65 @@ def test_refresh_scanner_keyterms_fetches_provision_file(monkeypatch):
         )
     ]
     assert scanner_keyterms.cache_status("uid-1")["count"] == len(terms)
+
+
+def test_isolated_scanner_uses_hermes_workspace_and_drops_legacy_cache(monkeypatch):
+    requests = []
+
+    async def fake_runtime(uid):
+        assert uid == "uid-isolated"
+        return SimpleNamespace(agent_id="omi-isolated")
+
+    class FakeResponse:
+        status_code = 200
+        text = ""
+
+        def json(self):
+            return {"content": SCANNER_TUNING}
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get(self, url, headers=None):
+            requests.append((url, headers))
+            return FakeResponse()
+
+    scanner_keyterms._cache["uid-isolated"] = scanner_keyterms.KeytermCacheEntry(
+        terms=["shared-term"],
+        agent_id="legacy-agent",
+        fetched_at=time.time(),
+        source="provision_api",
+    )
+    scanner_keyterms._uid_agent_ids["uid-isolated"] = "legacy-agent"
+    monkeypatch.setenv("ELLA_RUNTIME_BINDINGS_ENABLED", "false")
+    monkeypatch.setenv("ELLA_RUNTIME_BINDINGS_ENABLED_UIDS", "uid-isolated")
+    monkeypatch.setenv("ELLA_HERMES_PROVISION_API_URL", "http://hermes-provision")
+    monkeypatch.setenv("ELLA_HERMES_PROVISION_API_TOKEN", "hermes-token")
+    monkeypatch.setenv("ELLA_SCANNER_KEYTERMS_ALLOW_SHARED_FALLBACK", "true")
+    monkeypatch.setattr(scanner_keyterms, "resolve_isolated_runtime", fake_runtime)
+    monkeypatch.setattr(scanner_keyterms.httpx, "AsyncClient", FakeClient)
+
+    terms = asyncio.run(scanner_keyterms.refresh_scanner_keyterms("uid-isolated"))
+
+    assert "Hey Ella" in terms
+    assert "shared-term" not in terms
+    assert requests == [
+        (
+            "http://hermes-provision/workspace/omi-isolated/files/scanner-tuning.md",
+            {"Authorization": "Bearer hermes-token"},
+        )
+    ]
+    assert scanner_keyterms._cache["uid-isolated"].source == "hermes_provision_api"
 
 
 def test_fetch_scanner_tuning_does_not_use_shared_fallback_by_default(monkeypatch):

--- a/backend/utils/ella/scanner_keyterms.py
+++ b/backend/utils/ella/scanner_keyterms.py
@@ -10,6 +10,8 @@ from typing import Optional
 
 import httpx
 
+from ella.services.runtime_resolver import resolve_isolated_runtime, runtime_bindings_enabled
+
 logger = logging.getLogger("ella.scanner_keyterms")
 
 DEFAULT_PROVISION_API_URL = "http://100.76.138.56:8200"
@@ -60,7 +62,9 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-def _provision_url() -> str:
+def _provision_url(uid: str = "") -> str:
+    if uid and runtime_bindings_enabled(uid):
+        return os.getenv("ELLA_HERMES_PROVISION_API_URL", "http://100.76.138.56:8210").rstrip("/")
     return (
         os.getenv("ELLA_PROVISION_API_URL")
         or os.getenv("ELLA_PROVISION_URL")
@@ -69,7 +73,9 @@ def _provision_url() -> str:
     ).rstrip("/")
 
 
-def _provision_token() -> str:
+def _provision_token(uid: str = "") -> str:
+    if uid and runtime_bindings_enabled(uid):
+        return os.getenv("ELLA_HERMES_PROVISION_API_TOKEN", "")
     return (
         os.getenv("ELLA_PROVISION_API_TOKEN")
         or os.getenv("ELLA_PROVISION_API_KEY")
@@ -106,7 +112,9 @@ def _enabled() -> bool:
     return os.getenv("ELLA_SCANNER_KEYTERMS_ENABLED", "true").lower() not in {"0", "false", "no", "off"}
 
 
-def _allow_shared_fallback() -> bool:
+def _allow_shared_fallback(uid: str = "") -> bool:
+    if uid and runtime_bindings_enabled(uid):
+        return False
     return os.getenv("ELLA_SCANNER_KEYTERMS_ALLOW_SHARED_FALLBACK", "false").lower() in {"1", "true", "yes", "on"}
 
 
@@ -130,6 +138,13 @@ async def _get_pool():
 async def _resolve_agent_id(uid: str) -> str:
     if not uid:
         return ""
+
+    if runtime_bindings_enabled(uid):
+        runtime = await resolve_isolated_runtime(uid)
+        if runtime is None:
+            return ""
+        _uid_agent_ids[uid] = runtime.agent_id
+        return runtime.agent_id
 
     if uid in _uid_agent_ids:
         return _uid_agent_ids[uid]
@@ -362,14 +377,14 @@ def combine_deepgram_keyterms(vocabulary: list[str], scanner_terms: list[str]) -
     )
 
 
-async def _fetch_scanner_tuning(agent_id: str) -> str:
-    token = _provision_token()
+async def _fetch_scanner_tuning(agent_id: str, uid: str = "") -> str:
+    token = _provision_token(uid)
     headers = {"Authorization": f"Bearer {token}"} if token else {}
-    url = f"{_provision_url()}/workspace/{agent_id}/files/scanner-tuning.md"
+    url = f"{_provision_url(uid)}/workspace/{agent_id}/files/scanner-tuning.md"
     async with httpx.AsyncClient(timeout=_timeout_seconds()) as client:
         response = await client.get(url, headers=headers)
-        if response.status_code == 404 and _allow_shared_fallback():
-            shared = f"{_provision_url()}/workspace/shared/files/scanner-tuning.md"
+        if response.status_code == 404 and _allow_shared_fallback(uid):
+            shared = f"{_provision_url(uid)}/workspace/shared/files/scanner-tuning.md"
             response = await client.get(shared, headers=headers)
         response.raise_for_status()
         try:
@@ -386,14 +401,16 @@ async def refresh_scanner_keyterms(uid: str, agent_id: Optional[str] = None) -> 
     if not _enabled() or not uid:
         return []
 
-    resolved_agent_id = agent_id or await _resolve_agent_id(uid)
+    isolated = runtime_bindings_enabled(uid)
+    resolved_agent_id = await _resolve_agent_id(uid) if isolated else agent_id or await _resolve_agent_id(uid)
     key = resolved_agent_id or uid
     _refreshing.add(key)
     started = time.time()
     try:
-        content = await _fetch_scanner_tuning(resolved_agent_id)
+        content = await _fetch_scanner_tuning(resolved_agent_id, uid=uid)
         terms = parse_scanner_tuning_keyterms(content)
-        entry = KeytermCacheEntry(terms=terms, agent_id=resolved_agent_id, fetched_at=time.time(), source="provision_api")
+        source = "hermes_provision_api" if isolated else "provision_api"
+        entry = KeytermCacheEntry(terms=terms, agent_id=resolved_agent_id, fetched_at=time.time(), source=source)
         _cache[key] = entry
         _cache[uid] = entry
         _uid_agent_ids[uid] = resolved_agent_id
@@ -407,6 +424,8 @@ async def refresh_scanner_keyterms(uid: str, agent_id: Optional[str] = None) -> 
         return terms
     except Exception as e:
         stale = _cache.get(key) or _cache.get(uid)
+        if isolated and stale and stale.source != "hermes_provision_api":
+            stale = None
         if stale:
             stale.error = str(e)
         logger.warning("scanner_keyterms_refresh_failed uid=%s agent_id=%s error=%s", uid, resolved_agent_id, e)
@@ -440,6 +459,8 @@ async def get_scanner_keyterms(uid: str, agent_id: Optional[str] = None) -> list
 
     resolved_key = agent_id or _uid_agent_ids.get(uid) or uid
     entry = _cache.get(resolved_key) or _cache.get(uid)
+    if runtime_bindings_enabled(uid) and entry and entry.source != "hermes_provision_api":
+        entry = None
     now = time.time()
     if entry and now - entry.fetched_at <= _ttl_seconds():
         return entry.terms


### PR DESCRIPTION
## Summary

Implements the OMI side of ellaaicare/ella-ai#1089 behind disabled-by-default, exact-UID rollout flags.

- adds authenticated, idempotent `/v1/ella/onboarding/ensure` and `/status`
- binds users from the verified Firebase subject and rejects caller-supplied identity authority
- persists durable provisioning jobs and staged runtime bindings through the schema merged in ellaaicare/ella-ai#1066
- preflights both provisioning tables and all 12 isolation indexes before any identity mutation; missing/partial schema returns retryable `503 provisioning_schema_not_ready`
- injects the existing Firestore client explicitly; no hidden/in-function import or import-time cloud initialization
- accepts only complete Hermes-only 8210 receipts with exact profile/workspace ownership, matching internal URL/port, healthy synthetic smoke, server-held credential refs, and complete Honcho peers
- activates a binding atomically only after validation
- makes chat/history/resolve/voice require the authenticated user’s active runtime when `ELLA_RUNTIME_BINDINGS_ENABLED` is enabled for that exact UID
- removes OpenClaw history/listen fallback in isolated mode and redacts all internal gateway/profile/credential fields from public resolution
- permits legacy behavior only while the per-UID isolation flag is off

## Schema gate

Schema remains single-sourced in ella-ai: `packages/database/prisma/migrations/20260721000000_add_ella_provisioning_runtime/migration.sql` (PR #1066). OMI intentionally does not carry a second copy. Apply it before enabling either flag.

## Rollout

Both global flags default false and exact-UID allowlists are supported:

- `ELLA_HERMES_PROVISIONING_ENABLED` / `ELLA_HERMES_PROVISIONING_ENABLED_UIDS`
- `ELLA_RUNTIME_BINDINGS_ENABLED` / `ELLA_RUNTIME_BINDINGS_ENABLED_UIDS`

Use two disposable Firebase users first. Do not use or mutate `plato-eval` for the initial canary. Provisioning is enabled before runtime dispatch; production-wide flags stay off until distinct profile, workspace, gateway, Honcho, and canonical timeline receipts pass.

## Verification

- 51 focused onboarding, auth, receipt, observer, listen-gate, and route-isolation tests pass
- `backend/test.sh`: 116 existing backend tests pass
- Python compile, Black, and `git diff --check` pass
- schema failure test proves no identity mutation occurs
- public receipt/resolve tests verify no token, internal URL, workspace, profile, or credential leakage

No live environment, migration, flag, user, or `plato-eval` file was changed by this PR.

## Dependencies

- schema: ellaaicare/ella-ai#1066 (merged; deployment still required)
- Hermes runtime provisioner: ellaaicare/ella-ai#1064 / PR #1067
- iOS receipt gate: ellaaicare/ella-ai#1090 / draft PR ellaaicare/omi#297

Closes ellaaicare/ella-ai#1089 after dependency integration and canary, not on merge alone.