### PR TITLE
Gate iOS Home on authenticated isolated Hermes provisioning

### DIFF
--- a/app/lib/backend/http/api/messages.dart
+++ b/app/lib/backend/http/api/messages.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:omi/backend/http/shared.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/message.dart';
+import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/other/string_utils.dart';
@@ -143,7 +144,7 @@ Stream<ServerMessageChunk> sendEllaMessageStream(
     url: url,
     headers: headers,
     body: jsonEncode({
-      'uid': uid,
+      if (!isHermesProvisioningGateEnabled) 'uid': uid,
       'message': text,
       'conversation_id': '',
       'client_message_id': requestClientMessageId,

--- a/app/lib/backend/http/api/users.dart
+++ b/app/lib/backend/http/api/users.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
-import 'package:http/http.dart' as http;
 
 import 'package:omi/backend/http/shared.dart';
 import 'package:omi/backend/preferences.dart';
@@ -712,75 +711,4 @@ Future<bool> setMentorNotificationSettings(int frequency) async {
 
   Logger.debug('setMentorNotificationSettings response: ${response.body}');
   return response.statusCode == 200;
-}
-
-// Ella Dashboard Provisioning
-
-const String _ellaDashboardBase = 'https://www.ella-ai-care.com';
-
-/// Result from provisionEllaUser.
-/// [isPreProvisioned] is true when the user was already set up by an admin
-/// and the iOS app should skip onboarding and go straight to chat.
-class EllaProvisionResult {
-  final bool isPreProvisioned;
-  EllaProvisionResult({required this.isPreProvisioned});
-}
-
-Future<EllaProvisionResult> provisionEllaUser({
-  required String firebaseUid,
-  required String email,
-  required String name,
-  required String timezone,
-}) async {
-  try {
-    final response = await http
-        .post(
-          Uri.parse('$_ellaDashboardBase/api/onboarding'),
-          headers: {'Content-Type': 'application/json'},
-          body: jsonEncode({'firebaseUid': firebaseUid, 'email': email, 'name': name, 'timezone': timezone}),
-        )
-        .timeout(const Duration(seconds: 60));
-
-    if (response.statusCode == 200 || response.statusCode == 201) {
-      final data = jsonDecode(response.body);
-      final userId = data['userId'] as String?;
-      final ellaKey = data['ellaKey'] as String?;
-      if (userId != null && userId.isNotEmpty) {
-        SharedPreferencesUtil().ellaUserId = userId;
-      }
-      if (ellaKey != null && ellaKey.isNotEmpty) {
-        SharedPreferencesUtil().ellaKey = ellaKey;
-      }
-
-      // Store OpenClaw agent config if present
-      final agents = data['agents'] as Map<String, dynamic>?;
-      if (agents != null) {
-        final gatewayUrl = agents['gatewayUrl'] as String?;
-        final userAgentId = agents['userAgentId'] as String?;
-        final gatewayToken = agents['gatewayToken'] as String?;
-        if (gatewayUrl != null && gatewayUrl.isNotEmpty) {
-          SharedPreferencesUtil().ellaGatewayUrl = gatewayUrl;
-        }
-        if (userAgentId != null && userAgentId.isNotEmpty) {
-          SharedPreferencesUtil().ellaAgentId = userAgentId;
-        }
-        if (gatewayToken != null && gatewayToken.isNotEmpty) {
-          SharedPreferencesUtil().ellaGatewayToken = gatewayToken;
-        }
-      }
-
-      // provisioned: false + agents != null → pre-provisioned by admin → skip onboarding
-      final provisioned = data['provisioned'] as bool? ?? true;
-      final isPreProvisioned = !provisioned && agents != null;
-      Logger.debug(
-        'Ella provisioning success: userId=$userId provisioned=$provisioned preProvisioned=$isPreProvisioned',
-      );
-      return EllaProvisionResult(isPreProvisioned: isPreProvisioned);
-    } else {
-      Logger.debug('Ella provisioning failed: ${response.statusCode} ${response.body}');
-    }
-  } catch (e) {
-    Logger.debug('Ella provisioning error: $e');
-  }
-  return EllaProvisionResult(isPreProvisioned: false);
 }

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -518,6 +518,74 @@ class SharedPreferencesUtil {
     }
   }
 
+  String _ellaProvisioningReceiptKey(String uid) => 'ellaProvisioningReceipt:$uid';
+
+  Map<String, dynamic>? getEllaProvisioningReceipt(String uid) {
+    final encoded = getString(_ellaProvisioningReceiptKey(uid));
+    if (encoded.isEmpty) return null;
+    try {
+      final decoded = jsonDecode(encoded);
+      return decoded is Map<String, dynamic> ? decoded : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> saveEllaProvisioningReceipt(String uid, Map<String, dynamic> receipt) async {
+    await saveString(_ellaProvisioningReceiptKey(uid), jsonEncode(receipt));
+  }
+
+  String get ellaProvisionedVoiceMode {
+    final receipt = getEllaProvisioningReceipt(uid);
+    final value = receipt?['effective_voice_mode'];
+    return value is String ? value : '';
+  }
+
+  /// Clears account-scoped state before the authenticated provisioning gate
+  /// evaluates a different Firebase user. A cached receipt is never authority;
+  /// the gate still requires a fresh server-confirmed ready response.
+  Future<void> prepareEllaProvisioningAccount(String newUid) async {
+    final previousUid = getString('ellaProvisioningAccountUid');
+
+    // These values are never valid authority in a gated build, even when the
+    // same user returns from an older fail-open build.
+    for (final key in const [
+      'ellaUserId',
+      'ellaKey',
+      'ellaGatewayUrl',
+      'ellaAgentId',
+      'ellaGatewayToken',
+      'ellaResolvedEndpoint',
+    ]) {
+      await remove(key);
+    }
+
+    if (previousUid == newUid) return;
+
+    if (previousUid.isNotEmpty) {
+      await remove(_ellaProvisioningReceiptKey(previousUid));
+    }
+    await remove(_ellaProvisioningReceiptKey(newUid));
+
+    for (final key in const [
+      'devTtsProvider',
+      'ellaSettingsVoiceModeDirty',
+      'ellaSettingsPendingVoiceMode',
+      'ellaSettingsLastSyncedVoiceMode',
+      'ellaSettingsLastSyncedAt',
+      'ellaSettingsLastSyncError',
+      'aiConsentAccepted',
+      'aiConsentAcceptedAt',
+    ]) {
+      await remove(key);
+    }
+
+    demoMode = false;
+    publicMode = false;
+    clearUserCaches();
+    await saveString('ellaProvisioningAccountUid', newUid);
+  }
+
   // Pending memories - memories created offline that need to be synced
   List<Memory> get pendingMemories {
     final memories = getStringList('pendingMemories');

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -560,22 +560,22 @@ class SharedPreferencesUtil {
   Future<void> prepareEllaProvisioningAccount(String newUid) async {
     final previousUid = getString('ellaProvisioningAccountUid');
 
-    // These values are never valid authority in a gated build, even when the
-    // same user returns from an older fail-open build.
-    for (final key in const [
-      'ellaUserId',
-      'ellaKey',
-      'ellaGatewayUrl',
-      'ellaAgentId',
-      'ellaGatewayToken',
-      'ellaResolvedEndpoint',
-    ]) {
-      await remove(key);
-    }
-
     if (previousUid == newUid) return;
 
     if (previousUid.isNotEmpty) {
+      // Retained users keep compatibility preferences when returning to the
+      // same account. They are cleared only on an actual account switch and
+      // are never authority for the authenticated provisioning gate.
+      for (final key in const [
+        'ellaUserId',
+        'ellaKey',
+        'ellaGatewayUrl',
+        'ellaAgentId',
+        'ellaGatewayToken',
+        'ellaResolvedEndpoint',
+      ]) {
+        await remove(key);
+      }
       await remove(_ellaProvisioningReceiptKey(previousUid));
     }
     await remove(_ellaProvisioningReceiptKey(newUid));

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -201,14 +201,27 @@ class SharedPreferencesUtil {
 
   String get aiConsentAcceptedAt => getString('aiConsentAcceptedAt');
 
-  void acceptAiConsent() {
+  String get aiConsentReceiptId => getString('aiConsentReceiptId');
+
+  String get aiConsentReceiptUid => getString('aiConsentReceiptUid');
+
+  bool hasAccountBoundAiConsent(String uid) =>
+      uid.isNotEmpty && aiConsentAccepted && aiConsentReceiptId.isNotEmpty && aiConsentReceiptUid == uid;
+
+  void acceptAiConsent({String receiptId = '', String uid = ''}) {
     aiConsentAccepted = true;
     aiConsentAcceptedAt = DateTime.now().toUtc().toIso8601String();
+    if (receiptId.isNotEmpty && uid.isNotEmpty) {
+      saveString('aiConsentReceiptId', receiptId);
+      saveString('aiConsentReceiptUid', uid);
+    }
   }
 
   void declineAiConsent() {
     aiConsentAccepted = false;
     remove('aiConsentAcceptedAt');
+    remove('aiConsentReceiptId');
+    remove('aiConsentReceiptUid');
   }
 
   // Notification frequency (0-5): 0 = off, 5 = most frequent. Default is 0 (disabled)
@@ -576,6 +589,8 @@ class SharedPreferencesUtil {
       'ellaSettingsLastSyncError',
       'aiConsentAccepted',
       'aiConsentAcceptedAt',
+      'aiConsentReceiptId',
+      'aiConsentReceiptUid',
     ]) {
       await remove(key);
     }

--- a/app/lib/core/app_shell.dart
+++ b/app/lib/core/app_shell.dart
@@ -3,11 +3,14 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import 'package:app_links/app_links.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:provider/provider.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/desktop/desktop_app.dart';
 import 'package:omi/ella/widgets/ai_consent_sheet.dart';
+import 'package:omi/ella/services/ella_ai_consent_service.dart';
+import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/mobile/mobile_app.dart';
 import 'package:omi/pages/apps/app_detail/app_detail.dart';
 import 'package:omi/pages/settings/asana_settings_page.dart';
@@ -18,6 +21,7 @@ import 'package:omi/providers/app_provider.dart';
 import 'package:omi/providers/auth_provider.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/device_provider.dart';
+import 'package:omi/providers/ella_provisioning_provider.dart';
 import 'package:omi/providers/home_provider.dart';
 import 'package:omi/providers/integration_provider.dart';
 import 'package:omi/providers/message_provider.dart';
@@ -73,7 +77,7 @@ class _AppShellState extends State<AppShell> {
           if (mounted) {
             Navigator.of(context).push(MaterialPageRoute(builder: (context) => AppDetailPage(app: app)));
           }
-        } else {
+        } else if (mounted) {
           Logger.debug('App not found: ${uri.pathSegments[1]}');
           AppSnackbar.showSnackbarError(context.l10n.appNotAvailable);
         }
@@ -359,13 +363,42 @@ class _AppShellState extends State<AppShell> {
   }
 
   Future<void> _showConsentIfNeeded() async {
-    if (SharedPreferencesUtil().aiConsentAccepted || _consentPromptPresented) return;
+    if (_consentPromptPresented) return;
+
+    final preferences = SharedPreferencesUtil();
+    final uid = FirebaseAuth.instance.currentUser?.uid ?? '';
+    if (isHermesProvisioningGateEnabled) {
+      if (uid.isEmpty) return;
+      await preferences.prepareEllaProvisioningAccount(uid);
+      if (!mounted || _consentPromptPresented) return;
+      if (preferences.hasAccountBoundAiConsent(uid)) return;
+
+      // Legacy local consent is not sufficient for a newly isolated account.
+      preferences.declineAiConsent();
+    } else if (preferences.aiConsentAccepted) {
+      return;
+    }
+
     _consentPromptPresented = true;
-    final accepted = await AiConsentSheet.show(context);
+    final accepted = await AiConsentSheet.show(
+      context,
+      onAccept: isHermesProvisioningGateEnabled
+          ? () async {
+              final receiptId = await EllaAiConsentService().acknowledgePrivateCloudSync(uid: uid);
+              if (receiptId == null) return false;
+              if (mounted) context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
+              return true;
+            }
+          : null,
+    );
     if (accepted == true && mounted) {
-      await context.read<CaptureProvider>().streamDeviceRecording(
-            device: context.read<DeviceProvider>().connectedDevice,
-          );
+      final captureProvider = context.read<CaptureProvider>();
+      final device = context.read<DeviceProvider>().connectedDevice;
+      await captureProvider.streamDeviceRecording(device: device);
+    } else if (accepted == false && mounted && isHermesProvisioningGateEnabled) {
+      final captureProvider = context.read<CaptureProvider>();
+      await captureProvider.stopStreamDeviceRecording();
+      await captureProvider.stopStreamRecording();
     }
   }
 

--- a/app/lib/ella/pages/ella_provisioning_gate_page.dart
+++ b/app/lib/ella/pages/ella_provisioning_gate_page.dart
@@ -5,6 +5,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:provider/provider.dart';
 
+import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/ella_theme.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/pages/home/page.dart';
@@ -40,12 +41,15 @@ class _EllaProvisioningGatePageState extends State<EllaProvisioningGatePage> wit
     }
     if (!mounted) return;
 
+    final preferences = SharedPreferencesUtil();
+
     await context.read<EllaProvisioningProvider>().start(
           uid: user.uid,
           requestContext: EllaProvisioningRequestContext(
             appVersion: PlatformManager.instance.appVersion,
             locale: Localizations.localeOf(context).toLanguageTag(),
             timezone: timezone,
+            consentReceiptId: preferences.hasAccountBoundAiConsent(user.uid) ? preferences.aiConsentReceiptId : '',
           ),
         );
   }

--- a/app/lib/ella/pages/ella_provisioning_gate_page.dart
+++ b/app/lib/ella/pages/ella_provisioning_gate_page.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/ella/services/ella_provisioning_service.dart';
+import 'package:omi/pages/home/page.dart';
+import 'package:omi/providers/ella_provisioning_provider.dart';
+import 'package:omi/utils/auth_utils.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/utils/platform/platform_manager.dart';
+
+class EllaProvisioningGatePage extends StatefulWidget {
+  const EllaProvisioningGatePage({super.key});
+
+  @override
+  State<EllaProvisioningGatePage> createState() => _EllaProvisioningGatePageState();
+}
+
+class _EllaProvisioningGatePageState extends State<EllaProvisioningGatePage> with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _start());
+  }
+
+  Future<void> _start() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null || !mounted) return;
+
+    String timezone;
+    try {
+      timezone = await FlutterTimezone.getLocalTimezone();
+    } catch (_) {
+      timezone = DateTime.now().timeZoneName;
+    }
+    if (!mounted) return;
+
+    await context.read<EllaProvisioningProvider>().start(
+          uid: user.uid,
+          requestContext: EllaProvisioningRequestContext(
+            appVersion: PlatformManager.instance.appVersion,
+            locale: Localizations.localeOf(context).toLanguageTag(),
+            timezone: timezone,
+          ),
+        );
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (!mounted) return;
+    context.read<EllaProvisioningProvider>().setForeground(state == AppLifecycleState.resumed);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  Future<void> _signOut() async {
+    context.read<EllaProvisioningProvider>().reset();
+    await signOutAndClearUserData(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<EllaProvisioningProvider>(
+      builder: (context, provider, _) {
+        if (provider.isOperational) {
+          return const HomePageWrapper();
+        }
+
+        final isWorking = provider.state == EllaProvisioningState.idle ||
+            provider.state == EllaProvisioningState.checking ||
+            provider.state == EllaProvisioningState.queued ||
+            provider.state == EllaProvisioningState.provisioning;
+        final isBlocked = provider.state == EllaProvisioningState.blocked;
+        final canRetry =
+            provider.state == EllaProvisioningState.degraded || (isBlocked && (provider.receipt?.retryable ?? false));
+
+        final title = switch (provider.state) {
+          EllaProvisioningState.idle || EllaProvisioningState.checking => context.l10n.settingUp,
+          EllaProvisioningState.queued || EllaProvisioningState.provisioning => context.l10n.settingUp,
+          EllaProvisioningState.degraded => context.l10n.connectionError,
+          EllaProvisioningState.blocked => context.l10n.somethingWentWrong,
+          EllaProvisioningState.ready => context.l10n.settingUp,
+        };
+        final body = switch (provider.state) {
+          EllaProvisioningState.idle || EllaProvisioningState.checking => context.l10n.pleaseWait,
+          EllaProvisioningState.queued || EllaProvisioningState.provisioning => context.l10n.pleaseWait,
+          EllaProvisioningState.degraded => context.l10n.connectionErrorDesc,
+          EllaProvisioningState.blocked => context.l10n.contactSupport,
+          EllaProvisioningState.ready => context.l10n.pleaseWait,
+        };
+
+        return Scaffold(
+          backgroundColor: EllaColors.paper,
+          body: SafeArea(
+            child: Center(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(EllaSizes.screenPadding),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 480),
+                  child: Container(
+                    padding: const EdgeInsets.all(28),
+                    decoration: BoxDecoration(
+                      color: EllaColors.card,
+                      borderRadius: BorderRadius.circular(EllaSizes.cardRadius),
+                    ),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Container(
+                          width: 72,
+                          height: 72,
+                          decoration: const BoxDecoration(color: EllaColors.cardDeep, shape: BoxShape.circle),
+                          child: isWorking
+                              ? const Padding(
+                                  padding: EdgeInsets.all(22),
+                                  child: CircularProgressIndicator(color: EllaColors.tealDeep, strokeWidth: 3),
+                                )
+                              : Icon(
+                                  isBlocked ? Icons.lock_outline_rounded : Icons.cloud_off_outlined,
+                                  color: isBlocked ? EllaColors.error : EllaColors.warning,
+                                  size: 32,
+                                ),
+                        ),
+                        const SizedBox(height: 24),
+                        Text(title, style: EllaTextStyles.display, textAlign: TextAlign.center),
+                        const SizedBox(height: 12),
+                        Text(body, style: EllaTextStyles.secondary, textAlign: TextAlign.center),
+                        if (provider.supportCode.isNotEmpty) ...[
+                          const SizedBox(height: 20),
+                          Semantics(
+                            button: true,
+                            label: context.l10n.copy,
+                            child: InkWell(
+                              borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+                              onTap: () async {
+                                await Clipboard.setData(ClipboardData(text: provider.supportCode));
+                                if (!context.mounted) return;
+                                ScaffoldMessenger.of(
+                                  context,
+                                ).showSnackBar(SnackBar(content: Text(context.l10n.copied)));
+                              },
+                              child: Container(
+                                width: double.infinity,
+                                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                                decoration: BoxDecoration(
+                                  color: EllaColors.paper,
+                                  borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+                                ),
+                                child: Text(
+                                  provider.supportCode,
+                                  style: EllaTextStyles.caption.copyWith(fontWeight: FontWeight.w600),
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                        if (canRetry) ...[
+                          const SizedBox(height: 24),
+                          SizedBox(
+                            width: double.infinity,
+                            child: FilledButton(
+                              onPressed: provider.retry,
+                              style: FilledButton.styleFrom(
+                                backgroundColor: EllaColors.tealDeep,
+                                foregroundColor: EllaColors.paper,
+                                minimumSize: const Size.fromHeight(EllaSizes.minTouchTarget),
+                              ),
+                              child: Text(context.l10n.retry),
+                            ),
+                          ),
+                        ],
+                        const SizedBox(height: 12),
+                        TextButton(
+                          onPressed: _signOut,
+                          child: Text(
+                            context.l10n.ellaSettingsSignOut,
+                            style: const TextStyle(color: EllaColors.inkSoft),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/app/lib/ella/pages/ella_provisioning_gate_page.dart
+++ b/app/lib/ella/pages/ella_provisioning_gate_page.dart
@@ -15,7 +15,9 @@ import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 
 class EllaProvisioningGatePage extends StatefulWidget {
-  const EllaProvisioningGatePage({super.key});
+  const EllaProvisioningGatePage({super.key, this.startOnMount = true});
+
+  final bool startOnMount;
 
   @override
   State<EllaProvisioningGatePage> createState() => _EllaProvisioningGatePageState();
@@ -26,7 +28,9 @@ class _EllaProvisioningGatePageState extends State<EllaProvisioningGatePage> wit
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    WidgetsBinding.instance.addPostFrameCallback((_) => _start());
+    if (widget.startOnMount) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _start());
+    }
   }
 
   Future<void> _start() async {

--- a/app/lib/ella/pages/ella_settings_page.dart
+++ b/app/lib/ella/pages/ella_settings_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -18,6 +19,8 @@ import 'package:omi/ella/models/guardian_mode.dart';
 import 'package:omi/ella/pages/guardian_alert_history_page.dart';
 import 'package:omi/ella/pages/guardian_mode_page.dart';
 import 'package:omi/ella/services/caregiver_api.dart' as caregiver_api;
+import 'package:omi/ella/services/ella_ai_consent_service.dart';
+import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/ella/services/guardian_mode_api.dart' as guardian_api;
 import 'package:omi/ella/widgets/ella_settings_row.dart';
 import 'package:omi/ella/widgets/ai_consent_sheet.dart';
@@ -26,6 +29,7 @@ import 'package:omi/pages/settings/settings_drawer.dart';
 import 'package:omi/providers/device_provider.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/developer_mode_provider.dart';
+import 'package:omi/providers/ella_provisioning_provider.dart';
 import 'package:omi/providers/user_provider.dart';
 import 'package:omi/utils/auth_utils.dart';
 import 'package:omi/utils/l10n_extensions.dart';
@@ -159,7 +163,18 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
   }
 
   Future<void> _openListeningConsent() async {
-    final accepted = await AiConsentSheet.show(context);
+    final uid = FirebaseAuth.instance.currentUser?.uid ?? '';
+    final accepted = await AiConsentSheet.show(
+      context,
+      onAccept: isHermesProvisioningGateEnabled
+          ? () async {
+              final receiptId = await EllaAiConsentService().acknowledgePrivateCloudSync(uid: uid);
+              if (receiptId == null) return false;
+              if (mounted) context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
+              return true;
+            }
+          : null,
+    );
     if (!mounted) return;
     final captureProvider = context.read<CaptureProvider>();
     if (accepted == true) {

--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -18,6 +18,7 @@ import 'package:omi/ella/services/ella_chat_service.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/ella/ella_theme.dart';
 import 'package:omi/ella/services/elevenlabs_tts.dart';
+import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/ella/services/v2v_client.dart';
 import 'package:omi/ella/widgets/ella_voice_orb.dart';
 import 'package:omi/ella/widgets/ella_breathing_dot.dart';
@@ -94,6 +95,10 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   /// Check if current TTS provider is a V2V provider.
   static bool _isV2VProvider(String provider) => provider == 'grok-voice' || provider == 'gemini-live';
 
+  String get _effectiveVoiceProvider => isHermesProvisioningGateEnabled
+      ? SharedPreferencesUtil().ellaProvisionedVoiceMode
+      : SharedPreferencesUtil().ttsProvider;
+
   @override
   bool get wantKeepAlive => true;
 
@@ -126,7 +131,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       if (isOnVoiceTab && !_wasOnVoiceTab && !_voiceModeActive) {
         debugPrint('[VoiceChat] Voice tab became active, auto-starting');
         _voiceModeActive = true;
-        final provider = SharedPreferencesUtil().ttsProvider;
+        final provider = _effectiveVoiceProvider;
         Future.delayed(const Duration(milliseconds: 300), () {
           if (mounted && _orbState == VoiceOrbState.idle) {
             if (_isV2VProvider(provider)) {
@@ -220,7 +225,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     if (!_voiceModeActive) {
       // Resume voice mode — check if V2V provider is selected
       _voiceModeActive = true;
-      final provider = SharedPreferencesUtil().ttsProvider;
+      final provider = _effectiveVoiceProvider;
       if (_isV2VProvider(provider)) {
         await _startV2V(provider);
       } else {

--- a/app/lib/ella/services/elevenlabs_tts.dart
+++ b/app/lib/ella/services/elevenlabs_tts.dart
@@ -7,6 +7,7 @@ import 'package:path_provider/path_provider.dart';
 
 import 'package:omi/backend/http/shared.dart';
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/utils/logger.dart';
 
@@ -28,7 +29,10 @@ class ElevenLabsTts {
     try {
       final response = await makeApiCall(
         url: url,
-        headers: {'Content-Type': 'application/json', 'X-TTS-Provider': SharedPreferencesUtil().ttsProvider},
+        headers: {
+          'Content-Type': 'application/json',
+          if (!isHermesProvisioningGateEnabled) 'X-TTS-Provider': SharedPreferencesUtil().ttsProvider,
+        },
         body: '{"text": ${_jsonEscapeString(text)}}',
         method: 'POST',
         timeout: const Duration(seconds: 30),

--- a/app/lib/ella/services/ella_ai_consent_service.dart
+++ b/app/lib/ella/services/ella_ai_consent_service.dart
@@ -1,0 +1,48 @@
+import 'package:uuid/uuid.dart';
+
+import 'package:omi/backend/http/api/users.dart' as users_api;
+import 'package:omi/backend/preferences.dart';
+
+abstract class EllaAiConsentTransport {
+  Future<bool> setPrivateCloudSync(bool value);
+
+  Future<bool> getPrivateCloudSyncEnabled();
+}
+
+class EllaAiConsentHttpTransport implements EllaAiConsentTransport {
+  const EllaAiConsentHttpTransport();
+
+  @override
+  Future<bool> setPrivateCloudSync(bool value) => users_api.setPrivateCloudSyncEnabled(value);
+
+  @override
+  Future<bool> getPrivateCloudSyncEnabled() => users_api.getPrivateCloudSyncEnabled();
+}
+
+class EllaAiConsentService {
+  EllaAiConsentService({
+    EllaAiConsentTransport? transport,
+    SharedPreferencesUtil? preferences,
+    String Function()? receiptIdFactory,
+  })  : _transport = transport ?? const EllaAiConsentHttpTransport(),
+        _preferences = preferences ?? SharedPreferencesUtil(),
+        _receiptIdFactory = receiptIdFactory ?? (() => const Uuid().v4());
+
+  final EllaAiConsentTransport _transport;
+  final SharedPreferencesUtil _preferences;
+  final String Function() _receiptIdFactory;
+
+  Future<String?> acknowledgePrivateCloudSync({required String uid}) async {
+    if (uid.isEmpty) return null;
+
+    final updated = await _transport.setPrivateCloudSync(true);
+    if (!updated) return null;
+
+    final confirmed = await _transport.getPrivateCloudSyncEnabled();
+    if (!confirmed) return null;
+
+    final receiptId = 'ios-private-cloud-sync:${_receiptIdFactory()}';
+    _preferences.acceptAiConsent(receiptId: receiptId, uid: uid);
+    return receiptId;
+  }
+}

--- a/app/lib/ella/services/ella_chat_service.dart
+++ b/app/lib/ella/services/ella_chat_service.dart
@@ -8,14 +8,10 @@ import 'package:omi/backend/http/shared.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/ella/demo/demo_fixtures.dart';
+import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
-
-/// Feature flag — direct gateway chat bypasses backend canonical writeback.
-/// Keep disabled so iOS chat routes through /v1/ella/chat/stream, hydrates from
-/// the shared canonical timeline, and writes ios_chat turns to /v1/ella/events.
-const bool _useDirectChat = false;
 
 /// Build Ella-specific debug headers for routing observability (Issue #216).
 /// Backend trace.py captures these to correlate client requests with server routing decisions.
@@ -25,160 +21,9 @@ Map<String, String> _ellaDebugHeaders({required String routeSource}) {
     'X-Ella-Client': 'ios-app',
     'X-Ella-Client-Version': PlatformManager.instance.appVersion,
     'X-Ella-Route-Source': routeSource,
-    'X-Ella-Session-Key': 'ella:$uid',
-    'X-TTS-Provider': SharedPreferencesUtil().ttsProvider,
+    if (!isHermesProvisioningGateEnabled) 'X-Ella-Session-Key': 'ella:$uid',
+    if (!isHermesProvisioningGateEnabled) 'X-TTS-Provider': SharedPreferencesUtil().ttsProvider,
   };
-}
-
-/// Cached resolve result with expiry.
-class _ResolvedEndpoint {
-  final String agentId;
-  final String sessionKey;
-  final String gatewayUrl;
-  final String token;
-  final String historyUrl;
-  final DateTime expiresAt;
-
-  _ResolvedEndpoint({
-    required this.agentId,
-    required this.sessionKey,
-    required this.gatewayUrl,
-    required this.token,
-    this.historyUrl = '',
-    required this.expiresAt,
-  });
-
-  bool get isExpired => DateTime.now().isAfter(expiresAt);
-
-  Map<String, dynamic> toJson() => {
-        'agentId': agentId,
-        'sessionKey': sessionKey,
-        'gatewayUrl': gatewayUrl,
-        'token': token,
-        'historyUrl': historyUrl,
-        'expiresAt': expiresAt.toIso8601String(),
-      };
-
-  factory _ResolvedEndpoint.fromJson(Map<String, dynamic> json) => _ResolvedEndpoint(
-        agentId: json['agentId'] ?? '',
-        sessionKey: json['sessionKey'] ?? '',
-        gatewayUrl: json['gatewayUrl'] ?? '',
-        token: json['token'] ?? '',
-        historyUrl: json['historyUrl'] ?? '',
-        expiresAt: DateTime.tryParse(json['expiresAt'] ?? '') ?? DateTime(2000),
-      );
-}
-
-/// In-memory cache (fast path).
-_ResolvedEndpoint? _cachedEndpoint;
-
-/// Resolve the user's active Ella endpoint. Returns null on any failure.
-Future<_ResolvedEndpoint?> _resolveEndpoint() async {
-  final uid = SharedPreferencesUtil().uid;
-  if (uid.isEmpty) return null;
-
-  // 1. Check in-memory cache
-  if (_cachedEndpoint != null && !_cachedEndpoint!.isExpired) {
-    return _cachedEndpoint;
-  }
-
-  // 2. Check SharedPreferences cache
-  final cached = SharedPreferencesUtil().getString('ellaResolvedEndpoint');
-  if (cached.isNotEmpty) {
-    try {
-      final endpoint = _ResolvedEndpoint.fromJson(jsonDecode(cached));
-      if (!endpoint.isExpired) {
-        _cachedEndpoint = endpoint;
-        return endpoint;
-      }
-    } catch (_) {
-      // Corrupted cache, proceed to network call
-    }
-  }
-
-  // 3. Call resolve endpoint
-  try {
-    final response = await makeApiCall(
-      url: '${Env.apiBaseUrl}v1/ella/resolve?uid=$uid',
-      headers: _ellaDebugHeaders(routeSource: 'resolve'),
-      method: 'GET',
-      body: '',
-      timeout: const Duration(seconds: 5),
-    );
-
-    if (response == null || response.statusCode != 200) {
-      Logger.debug('[EllaChat] Resolve failed: ${response?.statusCode}');
-      return null;
-    }
-
-    // Log trace ID for routing observability (Issue #216)
-    final traceId = response.headers['x-ella-trace-id'];
-    if (traceId != null) {
-      Logger.debug('[EllaChat] Resolve trace: $traceId');
-    }
-
-    final data = jsonDecode(response.body) as Map<String, dynamic>;
-    final routing = data['routing'] as Map<String, dynamic>? ?? data;
-    final endpoint = _ResolvedEndpoint(
-      agentId: routing['agentId'] ?? '',
-      sessionKey: routing['sessionKey'] ?? '',
-      gatewayUrl: routing['gatewayUrl'] ?? '',
-      token: routing['token'] ?? '',
-      historyUrl: routing['historyUrl'] ?? '',
-      expiresAt: DateTime.now().add(const Duration(hours: 1)),
-    );
-
-    // Validate — must have gatewayUrl and token at minimum
-    if (endpoint.gatewayUrl.isEmpty || endpoint.token.isEmpty) {
-      Logger.debug('[EllaChat] Resolve returned incomplete data');
-      return null;
-    }
-
-    // Cache it
-    _cachedEndpoint = endpoint;
-    SharedPreferencesUtil().saveString(
-      'ellaResolvedEndpoint',
-      jsonEncode(endpoint.toJson()),
-    );
-
-    return endpoint;
-  } catch (e) {
-    Logger.debug('[EllaChat] Resolve error: $e');
-    return null;
-  }
-}
-
-/// Invalidate the resolve cache (call on gateway auth failures).
-void _invalidateResolveCache() {
-  _cachedEndpoint = null;
-  SharedPreferencesUtil().remove('ellaResolvedEndpoint');
-}
-
-/// Parse one line of OpenAI SSE into a ServerMessageChunk.
-/// Returns null for non-content lines (comments, empty, malformed).
-ServerMessageChunk? _parseOpenAiSseChunk(String line, String messageId) {
-  if (line.startsWith(':')) return null;
-  if (!line.startsWith('data: ')) return null;
-
-  final payload = line.substring(6).trim();
-  if (payload == '[DONE]') return null;
-
-  try {
-    final json = jsonDecode(payload) as Map<String, dynamic>;
-    final choices = json['choices'] as List<dynamic>?;
-    if (choices == null || choices.isEmpty) return null;
-
-    final delta = choices[0]['delta'] as Map<String, dynamic>?;
-    if (delta == null) return null;
-
-    final content = delta['content'] as String?;
-    if (content == null || content.isEmpty) return null;
-
-    return ServerMessageChunk(messageId, content, MessageChunkType.data);
-  } catch (e) {
-    Logger.debug('[EllaChat] Failed to parse OpenAI SSE chunk: $e');
-    return null;
-  }
 }
 
 /// Fetch chat history from the VPS proxy endpoint.
@@ -188,18 +33,13 @@ Future<List<ServerMessage>> fetchEllaChatHistory({int limit = 50}) async {
     return DemoFixtures.chatMessages();
   }
 
-  final endpoint = await _resolveEndpoint();
-  if (endpoint == null || endpoint.historyUrl.isEmpty) {
-    Logger.debug(
-      '[EllaChat] Cannot fetch history: no resolved endpoint or historyUrl',
-    );
-    return [];
-  }
-
   try {
     final uid = SharedPreferencesUtil().uid;
-    final url =
-        '${Env.apiBaseUrl}${endpoint.historyUrl.replaceFirst(RegExp(r'^/'), '')}?uid=${Uri.encodeComponent(uid)}&limit=$limit';
+    final query = <String, String>{
+      'limit': '$limit',
+      if (!isHermesProvisioningGateEnabled) 'uid': uid,
+    };
+    final url = Uri.parse('${Env.apiBaseUrl}v1/ella/chat/history').replace(queryParameters: query).toString();
     final response = await makeApiCall(
       url: url,
       headers: _ellaDebugHeaders(routeSource: 'chat-history'),
@@ -270,103 +110,10 @@ Stream<ServerMessageChunk> sendEllaChatStream(String text) async* {
     return;
   }
 
-  // Feature flag — delegate to existing proxy path if disabled
-  if (!_useDirectChat) {
-    yield* sendEllaMessageStream(
-      text,
-      headers: _ellaDebugHeaders(routeSource: 'proxy-canonical'),
-      clientMessageId: const Uuid().v4(),
-      clientSentAt: DateTime.now().toUtc(),
-    );
-    return;
-  }
-
-  // Attempt to resolve the user's agent endpoint when direct mode is enabled.
-  final endpoint = await _resolveEndpoint();
-  if (endpoint == null) {
-    Logger.debug('[EllaChat] Resolve unavailable, using proxy fallback');
-    yield* sendEllaMessageStream(
-      text,
-      headers: _ellaDebugHeaders(routeSource: 'proxy-resolve-fail'),
-      clientMessageId: const Uuid().v4(),
-      clientSentAt: DateTime.now().toUtc(),
-    );
-    return;
-  }
-
-  // Legacy direct gateway path. Production keeps this disabled so canonical
-  // writeback remains centralized in the backend.
-  const messageId = '1000';
-  final accumulatedText = StringBuffer();
-
-  try {
-    await for (var line in makeStreamingApiCall(
-      url: '${endpoint.gatewayUrl}/v1/chat/completions',
-      headers: {
-        'Authorization': 'Bearer ${endpoint.token}',
-        'x-openclaw-scopes': 'operator.write',
-        if (endpoint.sessionKey.isNotEmpty) 'x-openclaw-session-key': endpoint.sessionKey,
-        ..._ellaDebugHeaders(routeSource: 'pattern-c'),
-      },
-      body: jsonEncode({
-        'model': 'openclaw:${endpoint.agentId}',
-        'messages': [
-          {'role': 'user', 'content': text},
-        ],
-        'stream': true,
-      }),
-    )) {
-      if (line.trim().isEmpty || line.startsWith(':')) continue;
-
-      // Check for stream terminator
-      if (line.trim() == 'data: [DONE]') break;
-
-      final chunk = _parseOpenAiSseChunk(line, messageId);
-      if (chunk != null) {
-        accumulatedText.write(chunk.text);
-        yield chunk;
-      }
-    }
-  } catch (e) {
-    Logger.error('[EllaChat] Direct stream error: $e');
-
-    // No text accumulated — invalidate cache and retry via proxy
-    if (accumulatedText.isEmpty) {
-      _invalidateResolveCache();
-      yield* sendEllaMessageStream(
-        text,
-        headers: _ellaDebugHeaders(routeSource: 'proxy-gateway-error'),
-        clientMessageId: const Uuid().v4(),
-        clientSentAt: DateTime.now().toUtc(),
-      );
-      return;
-    }
-    // Partial text accumulated — fall through to synthesize done chunk below
-  }
-
-  // Synthesize the done chunk from accumulated text
-  final fullText = accumulatedText.toString();
-  if (fullText.isNotEmpty) {
-    final serverMessage = ServerMessage(
-      const Uuid().v4(),
-      DateTime.now(),
-      fullText,
-      MessageSender.ai,
-      MessageType.text,
-      null,
-      false,
-      [],
-      [],
-      [],
-      askForNps: false,
-    );
-    yield ServerMessageChunk(
-      messageId,
-      jsonEncode(serverMessage.toJson()),
-      MessageChunkType.done,
-      message: serverMessage,
-    );
-  } else {
-    yield ServerMessageChunk.failedMessage();
-  }
+  yield* sendEllaMessageStream(
+    text,
+    headers: _ellaDebugHeaders(routeSource: 'proxy-canonical'),
+    clientMessageId: const Uuid().v4(),
+    clientSentAt: DateTime.now().toUtc(),
+  );
 }

--- a/app/lib/ella/services/ella_provisioning_service.dart
+++ b/app/lib/ella/services/ella_provisioning_service.dart
@@ -7,7 +7,7 @@ import 'package:omi/env/env.dart';
 
 const bool isHermesProvisioningGateEnabled = bool.fromEnvironment('ELLA_HERMES_PROVISIONING_GATE', defaultValue: false);
 
-const String ellaProvisioningTargetSchema = 'hermes-onboarding-v1';
+const String ellaProvisioningTargetSchema = 'hermes-user-v1';
 
 enum EllaProvisioningState { idle, checking, queued, provisioning, ready, degraded, blocked }
 
@@ -17,18 +17,29 @@ class EllaProvisioningRequestContext {
     required this.locale,
     required this.timezone,
     String? clientRequestId,
+    this.consentReceiptId = '',
   }) : clientRequestId = clientRequestId ?? const Uuid().v4();
 
   final String appVersion;
   final String locale;
   final String timezone;
   final String clientRequestId;
+  final String consentReceiptId;
 
   Map<String, dynamic> toJson() => {
         'target_schema_version': ellaProvisioningTargetSchema,
         'client_request_id': clientRequestId,
         'client': {'platform': 'ios', 'app_version': appVersion, 'locale': locale, 'timezone': timezone},
+        if (consentReceiptId.isNotEmpty) 'consent_receipt_id': consentReceiptId,
       };
+
+  EllaProvisioningRequestContext copyWithConsentReceiptId(String value) => EllaProvisioningRequestContext(
+        appVersion: appVersion,
+        locale: locale,
+        timezone: timezone,
+        clientRequestId: clientRequestId,
+        consentReceiptId: value,
+      );
 }
 
 class EllaProvisioningReceipt {
@@ -41,7 +52,7 @@ class EllaProvisioningReceipt {
     this.supportCode = '',
     this.targetSchemaVersion = '',
     this.bindingState = '',
-    this.bindingRevision = '',
+    this.bindingRevision = 0,
     this.effectivePolicyRevision = '',
     this.effectiveVoiceMode = '',
     this.effectiveModel = '',
@@ -56,7 +67,7 @@ class EllaProvisioningReceipt {
   final String supportCode;
   final String targetSchemaVersion;
   final String bindingState;
-  final String bindingRevision;
+  final int bindingRevision;
   final String effectivePolicyRevision;
   final String effectiveVoiceMode;
   final String effectiveModel;
@@ -65,6 +76,7 @@ class EllaProvisioningReceipt {
   bool get isOperational =>
       state == EllaProvisioningState.ready &&
       bindingState.toLowerCase() == 'active' &&
+      bindingRevision > 0 &&
       effectivePolicyRevision.isNotEmpty;
 
   Map<String, dynamic> toCacheJson() => {
@@ -97,6 +109,8 @@ class EllaProvisioningReceipt {
     final policy = _mapValue(receipt, const ['effective_policy', 'policy']) ?? const <String, dynamic>{};
     final errorValue = responseJson['error'] ?? receipt['error'];
     final error = errorValue is Map ? errorValue.map((key, value) => MapEntry(key.toString(), value)) : null;
+    final detailValue = responseJson['detail'];
+    final detail = detailValue is Map ? detailValue.map((key, value) => MapEntry(key.toString(), value)) : null;
 
     final rawState = _stringValue(receipt, const ['state', 'status']) ??
         _stringValue(responseJson, const ['state', 'status']) ??
@@ -117,9 +131,9 @@ class EllaProvisioningReceipt {
       bindingState: _stringValue(binding, const ['state', 'status']) ??
           _stringValue(receipt, const ['binding_state', 'bindingState']) ??
           '',
-      bindingRevision: _stringValue(binding, const ['revision', 'binding_revision']) ??
-          _stringValue(receipt, const ['binding_revision', 'bindingRevision']) ??
-          '',
+      bindingRevision: _intValue(binding, const ['revision', 'binding_revision']) ??
+          _intValue(receipt, const ['binding_revision', 'bindingRevision']) ??
+          0,
       effectivePolicyRevision: _stringValue(policy, const ['revision', 'policy_revision']) ??
           _stringValue(receipt, const ['effective_policy_revision', 'policy_revision', 'policyRevision']) ??
           '',
@@ -130,7 +144,9 @@ class EllaProvisioningReceipt {
           _stringValue(receipt, const ['effective_model', 'model', 'chat_model', 'chatModel']) ??
           '',
       errorCode: _stringValue(error, const ['code']) ??
+          _stringValue(detail, const ['code']) ??
           (errorValue is String ? errorValue : null) ??
+          (detailValue is String ? detailValue : null) ??
           _stringValue(receipt, const ['error_code', 'errorCode']) ??
           '',
     );
@@ -199,7 +215,7 @@ class EllaProvisioningHttpTransport implements EllaProvisioningTransport {
   @override
   Future<EllaProvisioningResponse> status() async {
     final response = await makeApiCall(
-      url: '${Env.apiBaseUrl}v1/ella/onboarding/status',
+      url: buildEllaProvisioningStatusUrl(Env.apiBaseUrl),
       headers: _headers,
       body: '',
       method: 'GET',
@@ -224,6 +240,10 @@ class EllaProvisioningHttpTransport implements EllaProvisioningTransport {
     }
   }
 }
+
+String buildEllaProvisioningStatusUrl(String? apiBaseUrl) => Uri.parse(
+      '${apiBaseUrl ?? ''}v1/ella/onboarding/status',
+    ).replace(queryParameters: {'target_schema_version': ellaProvisioningTargetSchema}).toString();
 
 Map<String, dynamic>? _mapValue(Map<String, dynamic> source, List<String> keys) {
   for (final key in keys) {

--- a/app/lib/ella/services/ella_provisioning_service.dart
+++ b/app/lib/ella/services/ella_provisioning_service.dart
@@ -5,7 +5,7 @@ import 'package:uuid/uuid.dart';
 import 'package:omi/backend/http/shared.dart';
 import 'package:omi/env/env.dart';
 
-const bool isHermesProvisioningGateEnabled = bool.fromEnvironment('ELLA_HERMES_PROVISIONING_GATE', defaultValue: false);
+const bool isHermesProvisioningGateEnabled = bool.fromEnvironment('ELLA_HERMES_PROVISIONING_GATE', defaultValue: true);
 
 const String ellaProvisioningTargetSchema = 'hermes-user-v1';
 
@@ -202,7 +202,7 @@ class EllaProvisioningHttpTransport implements EllaProvisioningTransport {
   @override
   Future<EllaProvisioningResponse> ensure(EllaProvisioningRequestContext context) async {
     final response = await makeApiCall(
-      url: '${Env.apiBaseUrl}v1/ella/onboarding/ensure',
+      url: buildEllaProvisioningEnsureUrl(Env.apiBaseUrl),
       headers: _headers,
       body: jsonEncode(context.toJson()),
       method: 'POST',
@@ -240,6 +240,8 @@ class EllaProvisioningHttpTransport implements EllaProvisioningTransport {
     }
   }
 }
+
+String buildEllaProvisioningEnsureUrl(String? apiBaseUrl) => '${apiBaseUrl ?? ''}v1/ella/onboarding/ensure';
 
 String buildEllaProvisioningStatusUrl(String? apiBaseUrl) => Uri.parse(
       '${apiBaseUrl ?? ''}v1/ella/onboarding/status',

--- a/app/lib/ella/services/ella_provisioning_service.dart
+++ b/app/lib/ella/services/ella_provisioning_service.dart
@@ -1,0 +1,301 @@
+import 'dart:convert';
+
+import 'package:uuid/uuid.dart';
+
+import 'package:omi/backend/http/shared.dart';
+import 'package:omi/env/env.dart';
+
+const bool isHermesProvisioningGateEnabled = bool.fromEnvironment('ELLA_HERMES_PROVISIONING_GATE', defaultValue: false);
+
+const String ellaProvisioningTargetSchema = 'hermes-onboarding-v1';
+
+enum EllaProvisioningState { idle, checking, queued, provisioning, ready, degraded, blocked }
+
+class EllaProvisioningRequestContext {
+  EllaProvisioningRequestContext({
+    required this.appVersion,
+    required this.locale,
+    required this.timezone,
+    String? clientRequestId,
+  }) : clientRequestId = clientRequestId ?? const Uuid().v4();
+
+  final String appVersion;
+  final String locale;
+  final String timezone;
+  final String clientRequestId;
+
+  Map<String, dynamic> toJson() => {
+        'target_schema_version': ellaProvisioningTargetSchema,
+        'client_request_id': clientRequestId,
+        'client': {'platform': 'ios', 'app_version': appVersion, 'locale': locale, 'timezone': timezone},
+      };
+}
+
+class EllaProvisioningReceipt {
+  const EllaProvisioningReceipt({
+    required this.state,
+    this.jobId = '',
+    this.stage = '',
+    this.retryable = false,
+    this.retryAfter = const Duration(seconds: 2),
+    this.supportCode = '',
+    this.targetSchemaVersion = '',
+    this.bindingState = '',
+    this.bindingRevision = '',
+    this.effectivePolicyRevision = '',
+    this.effectiveVoiceMode = '',
+    this.effectiveModel = '',
+    this.errorCode = '',
+  });
+
+  final EllaProvisioningState state;
+  final String jobId;
+  final String stage;
+  final bool retryable;
+  final Duration retryAfter;
+  final String supportCode;
+  final String targetSchemaVersion;
+  final String bindingState;
+  final String bindingRevision;
+  final String effectivePolicyRevision;
+  final String effectiveVoiceMode;
+  final String effectiveModel;
+  final String errorCode;
+
+  bool get isOperational =>
+      state == EllaProvisioningState.ready &&
+      bindingState.toLowerCase() == 'active' &&
+      effectivePolicyRevision.isNotEmpty;
+
+  Map<String, dynamic> toCacheJson() => {
+        'state': state.name,
+        'job_id': jobId,
+        'stage': stage,
+        'retryable': retryable,
+        'retry_after_ms': retryAfter.inMilliseconds,
+        'support_code': supportCode,
+        'target_schema_version': targetSchemaVersion,
+        'binding_state': bindingState,
+        'binding_revision': bindingRevision,
+        'effective_policy_revision': effectivePolicyRevision,
+        'effective_voice_mode': effectiveVoiceMode,
+        'effective_model': effectiveModel,
+        'error_code': errorCode,
+      };
+
+  factory EllaProvisioningReceipt.fromJson(Map<String, dynamic> responseJson) {
+    if (_containsForbiddenCredentialField(responseJson)) {
+      return const EllaProvisioningReceipt(
+        state: EllaProvisioningState.blocked,
+        supportCode: 'IOS-UNSAFE-PROVISIONING-CONTRACT',
+        errorCode: 'unsafe_response_contract',
+      );
+    }
+
+    final receipt = _mapValue(responseJson, const ['receipt', 'provisioning']) ?? responseJson;
+    final binding = _mapValue(receipt, const ['binding', 'hermes_binding']) ?? const <String, dynamic>{};
+    final policy = _mapValue(receipt, const ['effective_policy', 'policy']) ?? const <String, dynamic>{};
+    final errorValue = responseJson['error'] ?? receipt['error'];
+    final error = errorValue is Map ? errorValue.map((key, value) => MapEntry(key.toString(), value)) : null;
+
+    final rawState = _stringValue(receipt, const ['state', 'status']) ??
+        _stringValue(responseJson, const ['state', 'status']) ??
+        'blocked';
+    final retryAfterMs = _intValue(receipt, const ['retry_after_ms', 'retryAfterMs']) ??
+        ((_intValue(receipt, const ['retry_after_seconds', 'retry_after', 'retryAfter']) ?? 2) * 1000);
+
+    return EllaProvisioningReceipt(
+      state: _parseState(rawState),
+      jobId: _stringValue(receipt, const ['job_id', 'jobId']) ?? '',
+      stage: _stringValue(receipt, const ['stage']) ?? '',
+      retryable: _boolValue(receipt, const ['retryable']) ?? false,
+      retryAfter: Duration(milliseconds: retryAfterMs.clamp(500, 15000)),
+      supportCode: _stringValue(receipt, const ['support_code', 'supportCode']) ??
+          _stringValue(responseJson, const ['support_code', 'supportCode']) ??
+          '',
+      targetSchemaVersion: _stringValue(receipt, const ['target_schema_version', 'targetSchemaVersion']) ?? '',
+      bindingState: _stringValue(binding, const ['state', 'status']) ??
+          _stringValue(receipt, const ['binding_state', 'bindingState']) ??
+          '',
+      bindingRevision: _stringValue(binding, const ['revision', 'binding_revision']) ??
+          _stringValue(receipt, const ['binding_revision', 'bindingRevision']) ??
+          '',
+      effectivePolicyRevision: _stringValue(policy, const ['revision', 'policy_revision']) ??
+          _stringValue(receipt, const ['effective_policy_revision', 'policy_revision', 'policyRevision']) ??
+          '',
+      effectiveVoiceMode: _stringValue(policy, const ['voice_mode', 'voiceMode']) ??
+          _stringValue(receipt, const ['effective_voice_mode', 'voice_mode', 'voiceMode']) ??
+          '',
+      effectiveModel: _stringValue(policy, const ['model', 'chat_model', 'chatModel']) ??
+          _stringValue(receipt, const ['effective_model', 'model', 'chat_model', 'chatModel']) ??
+          '',
+      errorCode: _stringValue(error, const ['code']) ??
+          (errorValue is String ? errorValue : null) ??
+          _stringValue(receipt, const ['error_code', 'errorCode']) ??
+          '',
+    );
+  }
+
+  static EllaProvisioningState _parseState(String value) {
+    switch (value.toLowerCase().replaceAll('-', '_')) {
+      case 'checking':
+        return EllaProvisioningState.checking;
+      case 'queued':
+        return EllaProvisioningState.queued;
+      case 'provisioning':
+      case 'running':
+      case 'in_progress':
+        return EllaProvisioningState.provisioning;
+      case 'ready':
+      case 'complete':
+      case 'completed':
+        return EllaProvisioningState.ready;
+      case 'degraded':
+      case 'retrying':
+        return EllaProvisioningState.degraded;
+      case 'blocked':
+      case 'failed':
+      case 'error':
+        return EllaProvisioningState.blocked;
+      default:
+        return EllaProvisioningState.blocked;
+    }
+  }
+}
+
+class EllaProvisioningResponse {
+  const EllaProvisioningResponse({required this.statusCode, this.receipt});
+
+  final int statusCode;
+  final EllaProvisioningReceipt? receipt;
+
+  bool get isAccepted => statusCode == 200 || statusCode == 201 || statusCode == 202;
+}
+
+abstract class EllaProvisioningTransport {
+  Future<EllaProvisioningResponse> ensure(EllaProvisioningRequestContext context);
+
+  Future<EllaProvisioningResponse> status();
+}
+
+class EllaProvisioningHttpTransport implements EllaProvisioningTransport {
+  const EllaProvisioningHttpTransport();
+
+  static const _headers = {'X-Ella-Client': 'ios-app', 'X-Ella-Route-Source': 'authenticated-provisioning'};
+
+  @override
+  Future<EllaProvisioningResponse> ensure(EllaProvisioningRequestContext context) async {
+    final response = await makeApiCall(
+      url: '${Env.apiBaseUrl}v1/ella/onboarding/ensure',
+      headers: _headers,
+      body: jsonEncode(context.toJson()),
+      method: 'POST',
+      timeout: const Duration(seconds: 20),
+      retries: 0,
+    );
+    return _decode(response?.statusCode ?? 0, response?.body);
+  }
+
+  @override
+  Future<EllaProvisioningResponse> status() async {
+    final response = await makeApiCall(
+      url: '${Env.apiBaseUrl}v1/ella/onboarding/status',
+      headers: _headers,
+      body: '',
+      method: 'GET',
+      timeout: const Duration(seconds: 10),
+      retries: 0,
+    );
+    return _decode(response?.statusCode ?? 0, response?.body);
+  }
+
+  EllaProvisioningResponse _decode(int statusCode, String? body) {
+    if (body == null || body.isEmpty) {
+      return EllaProvisioningResponse(statusCode: statusCode);
+    }
+    try {
+      final json = jsonDecode(body);
+      if (json is! Map<String, dynamic>) {
+        return EllaProvisioningResponse(statusCode: statusCode);
+      }
+      return EllaProvisioningResponse(statusCode: statusCode, receipt: EllaProvisioningReceipt.fromJson(json));
+    } catch (_) {
+      return EllaProvisioningResponse(statusCode: statusCode);
+    }
+  }
+}
+
+Map<String, dynamic>? _mapValue(Map<String, dynamic> source, List<String> keys) {
+  for (final key in keys) {
+    final value = source[key];
+    if (value is Map<String, dynamic>) return value;
+    if (value is Map) return value.map((key, value) => MapEntry(key.toString(), value));
+  }
+  return null;
+}
+
+String? _stringValue(Map<String, dynamic>? source, List<String> keys) {
+  if (source == null) return null;
+  for (final key in keys) {
+    final value = source[key];
+    if (value is String && value.trim().isNotEmpty) return value.trim();
+  }
+  return null;
+}
+
+int? _intValue(Map<String, dynamic> source, List<String> keys) {
+  for (final key in keys) {
+    final value = source[key];
+    if (value is int) return value;
+    if (value is num) return value.round();
+    if (value is String) return int.tryParse(value);
+  }
+  return null;
+}
+
+bool? _boolValue(Map<String, dynamic> source, List<String> keys) {
+  for (final key in keys) {
+    final value = source[key];
+    if (value is bool) return value;
+    if (value is String) {
+      if (value.toLowerCase() == 'true') return true;
+      if (value.toLowerCase() == 'false') return false;
+    }
+  }
+  return null;
+}
+
+bool _containsForbiddenCredentialField(Object? value) {
+  const forbidden = {
+    'token',
+    'access_token',
+    'gateway_token',
+    'gateway_url',
+    'credential',
+    'credentials',
+    'api_key',
+    'password',
+    'secret',
+  };
+  if (value is Map) {
+    for (final entry in value.entries) {
+      final normalizedKey = entry.key
+          .toString()
+          .replaceAllMapped(RegExp(r'([a-z0-9])([A-Z])'), (match) => '${match.group(1)}_${match.group(2)}')
+          .toLowerCase();
+      if (forbidden.contains(normalizedKey) ||
+          normalizedKey.endsWith('_token') ||
+          normalizedKey.endsWith('_secret') ||
+          normalizedKey.endsWith('_password') ||
+          normalizedKey.endsWith('_api_key')) {
+        return true;
+      }
+      if (_containsForbiddenCredentialField(entry.value)) return true;
+    }
+  } else if (value is Iterable) {
+    for (final item in value) {
+      if (_containsForbiddenCredentialField(item)) return true;
+    }
+  }
+  return false;
+}

--- a/app/lib/ella/services/v2v_client.dart
+++ b/app/lib/ella/services/v2v_client.dart
@@ -11,6 +11,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 
 import 'package:omi/backend/http/shared.dart';
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/utils/logger.dart';
 
@@ -177,7 +178,10 @@ class V2VClient {
       final response = await makeApiCall(
         url: '${Env.apiBaseUrl}v1/voice/session',
         headers: {'Content-Type': 'application/json'},
-        body: jsonEncode({'uid': uid, 'provider': provider}),
+        body: jsonEncode({
+          if (!isHermesProvisioningGateEnabled) 'uid': uid,
+          if (!isHermesProvisioningGateEnabled) 'provider': provider,
+        }),
         method: 'POST',
         timeout: const Duration(seconds: 10),
       );

--- a/app/lib/ella/widgets/ai_consent_sheet.dart
+++ b/app/lib/ella/widgets/ai_consent_sheet.dart
@@ -6,12 +6,14 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/ella_theme.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
-class AiConsentSheet extends StatelessWidget {
+class AiConsentSheet extends StatefulWidget {
   static final Uri privacyPolicyUri = Uri.parse('https://ella-ai-care.com/privacy');
 
-  const AiConsentSheet({super.key});
+  const AiConsentSheet({super.key, this.onAccept});
 
-  static Future<bool?> show(BuildContext context) {
+  final Future<bool> Function()? onAccept;
+
+  static Future<bool?> show(BuildContext context, {Future<bool> Function()? onAccept}) {
     return showModalBottomSheet<bool>(
       context: context,
       isDismissible: false,
@@ -20,8 +22,43 @@ class AiConsentSheet extends StatelessWidget {
       useSafeArea: true,
       backgroundColor: EllaColors.paper,
       shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(28))),
-      builder: (_) => const AiConsentSheet(),
+      builder: (_) => AiConsentSheet(onAccept: onAccept),
     );
+  }
+
+  @override
+  State<AiConsentSheet> createState() => _AiConsentSheetState();
+}
+
+class _AiConsentSheetState extends State<AiConsentSheet> {
+  bool _isSubmitting = false;
+  bool _hasError = false;
+
+  Future<void> _accept() async {
+    if (_isSubmitting) return;
+    setState(() {
+      _isSubmitting = true;
+      _hasError = false;
+    });
+
+    try {
+      final accepted = await (widget.onAccept?.call() ?? Future<bool>.value(true));
+      if (!mounted) return;
+      if (accepted) {
+        if (widget.onAccept == null) SharedPreferencesUtil().acceptAiConsent();
+        Navigator.of(context).pop(true);
+        return;
+      }
+    } catch (_) {
+      // Keep the consent surface open and capture disabled on acknowledgement failure.
+    }
+
+    if (mounted) {
+      setState(() {
+        _isSubmitting = false;
+        _hasError = true;
+      });
+    }
   }
 
   @override
@@ -64,23 +101,33 @@ class AiConsentSheet extends StatelessWidget {
                   decoration: TextDecoration.underline,
                   decorationColor: EllaColors.primary,
                 ),
-                recognizer: TapGestureRecognizer()..onTap = () => launchUrl(privacyPolicyUri),
+                recognizer: TapGestureRecognizer()..onTap = () => launchUrl(AiConsentSheet.privacyPolicyUri),
               ),
             ),
             const SizedBox(height: 28),
+            if (_hasError) ...[
+              Text(
+                context.l10n.somethingWentWrongTryAgain,
+                style: bodyStyle?.copyWith(color: EllaColors.error),
+              ),
+              const SizedBox(height: 12),
+            ],
             SizedBox(
               width: double.infinity,
               height: 56,
               child: FilledButton(
-                onPressed: () {
-                  SharedPreferencesUtil().acceptAiConsent();
-                  Navigator.of(context).pop(true);
-                },
+                onPressed: _isSubmitting ? null : _accept,
                 style: FilledButton.styleFrom(
                   backgroundColor: EllaColors.tealDeep,
                   shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(EllaSizes.cardRadius)),
                 ),
-                child: Text(context.l10n.allowAndContinue, style: const TextStyle(fontSize: 17)),
+                child: _isSubmitting
+                    ? const SizedBox(
+                        width: 22,
+                        height: 22,
+                        child: CircularProgressIndicator(strokeWidth: 2, color: EllaColors.paper),
+                      )
+                    : Text(context.l10n.allowAndContinue, style: const TextStyle(fontSize: 17)),
               ),
             ),
             const SizedBox(height: 10),
@@ -88,10 +135,12 @@ class AiConsentSheet extends StatelessWidget {
               width: double.infinity,
               height: 50,
               child: TextButton(
-                onPressed: () {
-                  SharedPreferencesUtil().declineAiConsent();
-                  Navigator.of(context).pop(false);
-                },
+                onPressed: _isSubmitting
+                    ? null
+                    : () {
+                        SharedPreferencesUtil().declineAiConsent();
+                        Navigator.of(context).pop(false);
+                      },
                 child: Text(
                   context.l10n.notNow,
                   style: const TextStyle(

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -44,6 +44,7 @@ import 'package:omi/providers/connectivity_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/providers/developer_mode_provider.dart';
 import 'package:omi/providers/device_provider.dart';
+import 'package:omi/providers/ella_provisioning_provider.dart';
 import 'package:omi/providers/folder_provider.dart';
 import 'package:omi/providers/goals_provider.dart';
 import 'package:omi/providers/home_provider.dart';
@@ -325,6 +326,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
         providers: [
           ListenableProvider(create: (context) => ConnectivityProvider()),
           ChangeNotifierProvider(create: (context) => AuthenticationProvider()),
+          ChangeNotifierProvider(create: (context) => EllaProvisioningProvider()),
           ChangeNotifierProvider(create: (context) => ConversationProvider()),
           ListenableProvider(create: (context) => AppProvider()),
           ChangeNotifierProvider(create: (context) => PeopleProvider()),

--- a/app/lib/mobile/mobile_app.dart
+++ b/app/lib/mobile/mobile_app.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/pages/ella_provisioning_gate_page.dart';
+import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/pages/home/page.dart';
 import 'package:omi/pages/onboarding/device_selection.dart';
 import 'package:omi/pages/onboarding/ella/ella_onboarding.dart';
@@ -32,7 +34,7 @@ class _MobileAppState extends State<MobileApp> {
     const debugAutoCall = bool.fromEnvironment('DEBUG_AUTO_CALL');
 
     // Debug mode: bypass auth and go straight to home
-    if (debugAutoCall) {
+    if (debugAutoCall && !isHermesProvisioningGateEnabled) {
       return const HomePageWrapper();
     }
 
@@ -41,7 +43,7 @@ class _MobileAppState extends State<MobileApp> {
       return Consumer<AuthenticationProvider>(
         builder: (context, authProvider, child) {
           if (authProvider.isSignedIn() && SharedPreferencesUtil().onboardingCompleted) {
-            return const HomePageWrapper();
+            return isHermesProvisioningGateEnabled ? const EllaProvisioningGatePage() : const HomePageWrapper();
           }
 
           // Self-healing: if signed in but onboardingCompleted is false,

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -30,6 +30,7 @@ import 'package:omi/pages/settings/settings_drawer.dart';
 import 'package:omi/pages/settings/wrapped_2025_page.dart';
 import 'package:omi/ella/pages/ella_settings_page.dart';
 import 'package:omi/ella/pages/ella_voice_chat_page.dart';
+import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/providers/app_provider.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/connectivity_provider.dart';
@@ -402,6 +403,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
   }
 
   void _provisionEllaIfNeeded() async {
+    if (isHermesProvisioningGateEnabled) return;
     if (SharedPreferencesUtil().ellaUserId.isNotEmpty) return;
     final user = FirebaseAuth.instance.currentUser;
     if (user == null) return;

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -9,9 +9,6 @@ import 'package:upgrader/upgrader.dart';
 
 import 'package:uuid/uuid.dart';
 
-import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter_timezone/flutter_timezone.dart';
-
 import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/backend/http/api/users.dart';
@@ -30,7 +27,6 @@ import 'package:omi/pages/settings/settings_drawer.dart';
 import 'package:omi/pages/settings/wrapped_2025_page.dart';
 import 'package:omi/ella/pages/ella_settings_page.dart';
 import 'package:omi/ella/pages/ella_voice_chat_page.dart';
-import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/providers/app_provider.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/connectivity_provider.dart';
@@ -394,27 +390,11 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
     _listenToMessagesFromNotification();
     _listenToFreemiumThreshold();
     _checkForAnnouncements();
-    _provisionEllaIfNeeded();
 
     super.initState();
 
     // After init
     FlutterForegroundTask.addTaskDataCallback(_onReceiveTaskData);
-  }
-
-  void _provisionEllaIfNeeded() async {
-    if (isHermesProvisioningGateEnabled) return;
-    if (SharedPreferencesUtil().ellaUserId.isNotEmpty) return;
-    final user = FirebaseAuth.instance.currentUser;
-    if (user == null) return;
-    final timezone = await FlutterTimezone.getLocalTimezone();
-    final name = '${SharedPreferencesUtil().givenName} ${SharedPreferencesUtil().familyName}'.trim();
-    provisionEllaUser(
-      firebaseUid: user.uid,
-      email: user.email ?? '',
-      name: name.isNotEmpty ? name : (user.displayName ?? ''),
-      timezone: timezone,
-    );
   }
 
   void _checkForAnnouncements() {

--- a/app/lib/pages/onboarding/ella/ella_onboarding.dart
+++ b/app/lib/pages/onboarding/ella/ella_onboarding.dart
@@ -6,12 +6,15 @@ import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/ella/pages/ella_provisioning_gate_page.dart';
+import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/pages/home/page.dart';
 import 'package:omi/pages/onboarding/auth.dart';
 import 'package:omi/pages/onboarding/ella/ella_connect.dart';
 import 'package:omi/pages/onboarding/ella/ella_emergency.dart';
 import 'package:omi/pages/onboarding/ella/ella_welcome.dart';
 import 'package:omi/services/auth_service.dart';
+import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/other/temp.dart';
 
 class EllaOnboarding extends StatefulWidget {
@@ -33,7 +36,7 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (AuthService.instance.isSignedIn()) {
         if (SharedPreferencesUtil().onboardingCompleted) {
-          routeToPage(context, const HomePageWrapper(), replace: true);
+          _routeToAuthenticatedHome();
         } else {
           _onSignedIn();
         }
@@ -50,8 +53,10 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
   Future<void> _onSignedIn() async {
     setState(() {
       _isSignedIn = true;
-      _checkingProvision = true;
+      _checkingProvision = !isHermesProvisioningGateEnabled;
     });
+    if (isHermesProvisioningGateEnabled) return;
+
     // Check if user is pre-provisioned by admin — skip wizard if so
     final user = FirebaseAuth.instance.currentUser;
     if (user != null) {
@@ -67,7 +72,7 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
       if (result.isPreProvisioned) {
         SharedPreferencesUtil().onboardingCompleted = true;
         updateUserOnboardingState(completed: true);
-        routeToPage(context, const HomePageWrapper(), replace: true);
+        _routeToAuthenticatedHome();
         return;
       }
     }
@@ -87,11 +92,20 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
     SharedPreferencesUtil().onboardingCompleted = true;
     if (AuthService.instance.isSignedIn()) {
       updateUserOnboardingState(completed: true);
-      // Provision is already called at sign-in; call again to ensure
-      // new users are provisioned after completing the wizard
-      _reprovisionElla();
+      if (!isHermesProvisioningGateEnabled) {
+        // Legacy path retained until the authenticated ensure contract is live.
+        _reprovisionElla();
+      }
     }
-    routeToPage(context, const HomePageWrapper(), replace: true);
+    _routeToAuthenticatedHome();
+  }
+
+  void _routeToAuthenticatedHome() {
+    routeToPage(
+      context,
+      isHermesProvisioningGateEnabled ? const EllaProvisioningGatePage() : const HomePageWrapper(),
+      replace: true,
+    );
   }
 
   void _reprovisionElla() async {
@@ -116,7 +130,7 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
         body: AuthComponent(
           onSignIn: () {
             if (SharedPreferencesUtil().onboardingCompleted) {
-              routeToPage(context, const HomePageWrapper(), replace: true);
+              _routeToAuthenticatedHome();
             } else {
               _onSignedIn();
             }
@@ -132,11 +146,11 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              CircularProgressIndicator(color: EllaColors.primary),
+              const CircularProgressIndicator(color: EllaColors.primary),
               const SizedBox(height: 24),
               Text(
-                'Setting up your account...',
-                style: TextStyle(color: EllaColors.textSecondary, fontSize: 16),
+                context.l10n.settingUp,
+                style: const TextStyle(color: EllaColors.textSecondary, fontSize: 16),
               ),
             ],
           ),

--- a/app/lib/pages/onboarding/ella/ella_onboarding.dart
+++ b/app/lib/pages/onboarding/ella/ella_onboarding.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_timezone/flutter_timezone.dart';
+import 'package:provider/provider.dart';
 
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
@@ -13,9 +16,10 @@ import 'package:omi/pages/onboarding/auth.dart';
 import 'package:omi/pages/onboarding/ella/ella_connect.dart';
 import 'package:omi/pages/onboarding/ella/ella_emergency.dart';
 import 'package:omi/pages/onboarding/ella/ella_welcome.dart';
+import 'package:omi/providers/ella_provisioning_provider.dart';
 import 'package:omi/services/auth_service.dart';
-import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/other/temp.dart';
+import 'package:omi/utils/platform/platform_manager.dart';
 
 class EllaOnboarding extends StatefulWidget {
   const EllaOnboarding({super.key});
@@ -28,7 +32,6 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
   final PageController _pageController = PageController();
   int _currentPage = 0;
   bool _isSignedIn = false;
-  bool _checkingProvision = false;
 
   @override
   void initState() {
@@ -51,32 +54,32 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
   }
 
   Future<void> _onSignedIn() async {
-    setState(() {
-      _isSignedIn = true;
-      _checkingProvision = !isHermesProvisioningGateEnabled;
-    });
-    if (isHermesProvisioningGateEnabled) return;
+    setState(() => _isSignedIn = true);
+    if (isHermesProvisioningGateEnabled) unawaited(_startHermesProvisioning());
+  }
 
-    // Check if user is pre-provisioned by admin — skip wizard if so
+  Future<void> _startHermesProvisioning() async {
     final user = FirebaseAuth.instance.currentUser;
-    if (user != null) {
-      final timezone = await FlutterTimezone.getLocalTimezone();
-      final name = '${SharedPreferencesUtil().givenName} ${SharedPreferencesUtil().familyName}'.trim();
-      final result = await provisionEllaUser(
-        firebaseUid: user.uid,
-        email: user.email ?? '',
-        name: name.isNotEmpty ? name : (user.displayName ?? ''),
-        timezone: timezone,
-      );
-      if (!mounted) return;
-      if (result.isPreProvisioned) {
-        SharedPreferencesUtil().onboardingCompleted = true;
-        updateUserOnboardingState(completed: true);
-        _routeToAuthenticatedHome();
-        return;
-      }
+    if (user == null || !mounted) return;
+
+    String timezone;
+    try {
+      timezone = await FlutterTimezone.getLocalTimezone();
+    } catch (_) {
+      timezone = DateTime.now().timeZoneName;
     }
-    if (mounted) setState(() => _checkingProvision = false);
+    if (!mounted) return;
+
+    final preferences = SharedPreferencesUtil();
+    await context.read<EllaProvisioningProvider>().start(
+          uid: user.uid,
+          requestContext: EllaProvisioningRequestContext(
+            appVersion: PlatformManager.instance.appVersion,
+            locale: Localizations.localeOf(context).toLanguageTag(),
+            timezone: timezone,
+            consentReceiptId: preferences.hasAccountBoundAiConsent(user.uid) ? preferences.aiConsentReceiptId : '',
+          ),
+        );
   }
 
   void _goToPage(int page) {
@@ -92,10 +95,7 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
     SharedPreferencesUtil().onboardingCompleted = true;
     if (AuthService.instance.isSignedIn()) {
       updateUserOnboardingState(completed: true);
-      if (!isHermesProvisioningGateEnabled) {
-        // Legacy path retained until the authenticated ensure contract is live.
-        _reprovisionElla();
-      }
+      if (isHermesProvisioningGateEnabled) unawaited(_startHermesProvisioning());
     }
     _routeToAuthenticatedHome();
   }
@@ -105,19 +105,6 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
       context,
       isHermesProvisioningGateEnabled ? const EllaProvisioningGatePage() : const HomePageWrapper(),
       replace: true,
-    );
-  }
-
-  void _reprovisionElla() async {
-    final user = FirebaseAuth.instance.currentUser;
-    if (user == null) return;
-    final timezone = await FlutterTimezone.getLocalTimezone();
-    final name = '${SharedPreferencesUtil().givenName} ${SharedPreferencesUtil().familyName}'.trim();
-    provisionEllaUser(
-      firebaseUid: user.uid,
-      email: user.email ?? '',
-      name: name.isNotEmpty ? name : (user.displayName ?? ''),
-      timezone: timezone,
     );
   }
 
@@ -139,25 +126,6 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
       );
     }
 
-    if (_checkingProvision) {
-      return Scaffold(
-        backgroundColor: EllaColors.bgPrimary,
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const CircularProgressIndicator(color: EllaColors.primary),
-              const SizedBox(height: 24),
-              Text(
-                context.l10n.settingUp,
-                style: const TextStyle(color: EllaColors.textSecondary, fontSize: 16),
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-
     return Scaffold(
       backgroundColor: EllaColors.bgPrimary,
       body: Stack(
@@ -171,7 +139,6 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
                 onNext: () => _goToPage(1),
                 onSignOut: () => setState(() {
                   _isSignedIn = false;
-                  _checkingProvision = false;
                 }),
               ),
               EllaConnect(

--- a/app/lib/providers/ella_provisioning_provider.dart
+++ b/app/lib/providers/ella_provisioning_provider.dart
@@ -58,7 +58,21 @@ class EllaProvisioningProvider extends ChangeNotifier {
       _setFailure('auth_required', blocked: true);
       return;
     }
-    if (_activeUid == uid && isOperational) return;
+    if (_activeUid == uid) {
+      final consentReceiptId = requestContext.consentReceiptId;
+      if (consentReceiptId.isNotEmpty && consentReceiptId != _requestContext?.consentReceiptId) {
+        setConsentReceiptId(consentReceiptId);
+      }
+      if (isOperational ||
+          _requestInFlight ||
+          _pollHandle != null ||
+          _shouldPoll ||
+          state == EllaProvisioningState.blocked) {
+        return;
+      }
+      await retry();
+      return;
+    }
 
     final generation = ++_generation;
     _cancelPoll();

--- a/app/lib/providers/ella_provisioning_provider.dart
+++ b/app/lib/providers/ella_provisioning_provider.dart
@@ -1,0 +1,265 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ella_provisioning_service.dart';
+import 'package:omi/utils/logger.dart';
+
+abstract class EllaProvisioningPollHandle {
+  void cancel();
+}
+
+class _TimerPollHandle implements EllaProvisioningPollHandle {
+  _TimerPollHandle(Duration delay, VoidCallback callback) : _timer = Timer(delay, callback);
+
+  final Timer _timer;
+
+  @override
+  void cancel() => _timer.cancel();
+}
+
+typedef EllaProvisioningScheduler = EllaProvisioningPollHandle Function(Duration delay, VoidCallback callback);
+
+class EllaProvisioningProvider extends ChangeNotifier {
+  EllaProvisioningProvider({
+    EllaProvisioningTransport? transport,
+    SharedPreferencesUtil? preferences,
+    EllaProvisioningScheduler? scheduler,
+    this.maxPollAttempts = 30,
+  })  : _transport = transport ?? const EllaProvisioningHttpTransport(),
+        _preferences = preferences ?? SharedPreferencesUtil(),
+        _scheduler = scheduler ?? ((delay, callback) => _TimerPollHandle(delay, callback));
+
+  final EllaProvisioningTransport _transport;
+  final SharedPreferencesUtil _preferences;
+  final EllaProvisioningScheduler _scheduler;
+  final int maxPollAttempts;
+
+  EllaProvisioningState state = EllaProvisioningState.idle;
+  EllaProvisioningReceipt? receipt;
+  String errorCode = '';
+  bool isForeground = true;
+
+  String _activeUid = '';
+  EllaProvisioningRequestContext? _requestContext;
+  EllaProvisioningPollHandle? _pollHandle;
+  int _pollAttempts = 0;
+  int _generation = 0;
+  bool _requestInFlight = false;
+
+  bool get isOperational => state == EllaProvisioningState.ready && receipt?.isOperational == true;
+
+  String get supportCode => receipt?.supportCode ?? '';
+
+  Future<void> start({required String uid, required EllaProvisioningRequestContext requestContext}) async {
+    if (uid.isEmpty) {
+      _setFailure('auth_required', blocked: true);
+      return;
+    }
+    if (_activeUid == uid && isOperational) return;
+
+    final generation = ++_generation;
+    _cancelPoll();
+    _activeUid = uid;
+    _requestContext = requestContext;
+    _pollAttempts = 0;
+    _requestInFlight = false;
+    state = EllaProvisioningState.checking;
+    errorCode = '';
+
+    await _preferences.prepareEllaProvisioningAccount(uid);
+    if (generation != _generation) return;
+
+    final cached = _preferences.getEllaProvisioningReceipt(uid);
+    if (cached != null) {
+      receipt = EllaProvisioningReceipt.fromJson(cached);
+    } else {
+      receipt = null;
+    }
+    notifyListeners();
+    await _ensure(generation);
+  }
+
+  Future<void> retry() async {
+    if (_activeUid.isEmpty || _requestContext == null) return;
+    final generation = ++_generation;
+    _cancelPoll();
+    _pollAttempts = 0;
+    state = EllaProvisioningState.checking;
+    errorCode = '';
+    notifyListeners();
+    await _ensure(generation);
+  }
+
+  void setForeground(bool value) {
+    if (isForeground == value) return;
+    isForeground = value;
+    if (!value) {
+      _cancelPoll();
+      return;
+    }
+    if (_shouldPoll && !_requestInFlight) {
+      final generation = ++_generation;
+      _schedulePoll(generation, const Duration(milliseconds: 250));
+    }
+  }
+
+  void reset() {
+    _generation++;
+    _cancelPoll();
+    _activeUid = '';
+    _requestContext = null;
+    _pollAttempts = 0;
+    _requestInFlight = false;
+    receipt = null;
+    errorCode = '';
+    state = EllaProvisioningState.idle;
+    notifyListeners();
+  }
+
+  Future<void> _ensure(int generation) async {
+    final context = _requestContext;
+    if (context == null || generation != _generation || _requestInFlight) return;
+    _requestInFlight = true;
+    try {
+      final response = await _transport.ensure(context);
+      if (generation != _generation) return;
+      await _applyResponse(response, generation);
+    } catch (error) {
+      if (generation != _generation) return;
+      Logger.debug('[ProvisioningGate] Ensure failed: $error');
+      _setFailure('network_unavailable');
+      _schedulePoll(generation, _backoffDelay);
+    } finally {
+      if (generation == _generation) _requestInFlight = false;
+    }
+  }
+
+  Future<void> _poll(int generation) async {
+    if (generation != _generation || _requestInFlight || !isForeground) return;
+    if (_pollAttempts >= maxPollAttempts) {
+      _setFailure('provisioning_timeout');
+      return;
+    }
+
+    _pollAttempts++;
+    _requestInFlight = true;
+    try {
+      final response = await _transport.status();
+      if (generation != _generation) return;
+      await _applyResponse(response, generation);
+    } catch (error) {
+      if (generation != _generation) return;
+      Logger.debug('[ProvisioningGate] Status failed: $error');
+      _setFailure('network_unavailable');
+      _schedulePoll(generation, _backoffDelay);
+    } finally {
+      if (generation == _generation) _requestInFlight = false;
+    }
+  }
+
+  Future<void> _applyResponse(EllaProvisioningResponse response, int generation) async {
+    final nextReceipt = response.receipt;
+    if (!response.isAccepted || nextReceipt == null) {
+      if (nextReceipt != null) {
+        receipt = nextReceipt;
+        await _preferences.saveEllaProvisioningReceipt(_activeUid, nextReceipt.toCacheJson());
+        if (generation != _generation) return;
+      }
+      final code = nextReceipt?.errorCode.isNotEmpty == true
+          ? nextReceipt!.errorCode
+          : switch (response.statusCode) {
+              401 => 'auth_required',
+              403 || 409 => 'identity_conflict',
+              426 => 'upgrade_required',
+              429 => 'quota_exceeded',
+              >= 500 => 'provider_unavailable',
+              _ => 'invalid_provisioning_response',
+            };
+      final blocked = response.statusCode == 401 ||
+          response.statusCode == 403 ||
+          response.statusCode == 409 ||
+          (nextReceipt?.state == EllaProvisioningState.blocked && nextReceipt?.retryable != true);
+      _setFailure(code, blocked: blocked);
+      if (_shouldPoll) _schedulePoll(generation, _backoffDelay);
+      return;
+    }
+
+    receipt = nextReceipt;
+    errorCode = nextReceipt.errorCode;
+    await _preferences.saveEllaProvisioningReceipt(_activeUid, nextReceipt.toCacheJson());
+    if (generation != _generation) return;
+
+    if (nextReceipt.state == EllaProvisioningState.ready && !nextReceipt.isOperational) {
+      state = EllaProvisioningState.blocked;
+      errorCode = 'incomplete_ready_receipt';
+    } else if (_pollAttempts >= maxPollAttempts &&
+        (nextReceipt.state == EllaProvisioningState.queued ||
+            nextReceipt.state == EllaProvisioningState.provisioning ||
+            nextReceipt.state == EllaProvisioningState.degraded)) {
+      state = EllaProvisioningState.degraded;
+      errorCode = 'provisioning_timeout';
+    } else {
+      state = nextReceipt.state;
+    }
+    notifyListeners();
+
+    if (_shouldPoll) {
+      _schedulePoll(generation, _pollDelay(nextReceipt));
+    } else {
+      _cancelPoll();
+    }
+  }
+
+  void _setFailure(String code, {bool blocked = false}) {
+    errorCode = code;
+    state = blocked ? EllaProvisioningState.blocked : EllaProvisioningState.degraded;
+    notifyListeners();
+  }
+
+  bool get _shouldPoll =>
+      isForeground &&
+      _pollAttempts < maxPollAttempts &&
+      (state == EllaProvisioningState.checking ||
+          state == EllaProvisioningState.queued ||
+          state == EllaProvisioningState.provisioning ||
+          (state == EllaProvisioningState.degraded &&
+              (receipt?.retryable == true ||
+                  errorCode == 'network_unavailable' ||
+                  errorCode == 'invalid_provisioning_response' ||
+                  errorCode == 'provider_unavailable' ||
+                  errorCode == 'quota_exceeded')));
+
+  Duration get _backoffDelay {
+    final exponent = _pollAttempts.clamp(0, 4);
+    final milliseconds = 1000 * (1 << exponent) + ((_pollAttempts % 4) * 173);
+    return Duration(milliseconds: milliseconds.clamp(1000, 15000));
+  }
+
+  Duration _pollDelay(EllaProvisioningReceipt nextReceipt) {
+    final jitter = (_pollAttempts % 4) * 173;
+    return Duration(milliseconds: (nextReceipt.retryAfter.inMilliseconds + jitter).clamp(500, 15000));
+  }
+
+  void _schedulePoll(int generation, Duration delay) {
+    if (!_shouldPoll || generation != _generation) return;
+    _cancelPoll();
+    _pollHandle = _scheduler(delay, () {
+      _pollHandle = null;
+      _poll(generation);
+    });
+  }
+
+  void _cancelPoll() {
+    _pollHandle?.cancel();
+    _pollHandle = null;
+  }
+
+  @override
+  void dispose() {
+    _generation++;
+    _cancelPoll();
+    super.dispose();
+  }
+}

--- a/app/lib/providers/ella_provisioning_provider.dart
+++ b/app/lib/providers/ella_provisioning_provider.dart
@@ -47,6 +47,7 @@ class EllaProvisioningProvider extends ChangeNotifier {
   int _pollAttempts = 0;
   int _generation = 0;
   bool _requestInFlight = false;
+  bool _retryEnsureAfterCurrentRequest = false;
 
   bool get isOperational => state == EllaProvisioningState.ready && receipt?.isOperational == true;
 
@@ -65,6 +66,7 @@ class EllaProvisioningProvider extends ChangeNotifier {
     _requestContext = requestContext;
     _pollAttempts = 0;
     _requestInFlight = false;
+    _retryEnsureAfterCurrentRequest = false;
     state = EllaProvisioningState.checking;
     errorCode = '';
 
@@ -83,6 +85,10 @@ class EllaProvisioningProvider extends ChangeNotifier {
 
   Future<void> retry() async {
     if (_activeUid.isEmpty || _requestContext == null) return;
+    if (_requestInFlight) {
+      _retryEnsureAfterCurrentRequest = true;
+      return;
+    }
     final generation = ++_generation;
     _cancelPoll();
     _pollAttempts = 0;
@@ -90,6 +96,14 @@ class EllaProvisioningProvider extends ChangeNotifier {
     errorCode = '';
     notifyListeners();
     await _ensure(generation);
+  }
+
+  void setConsentReceiptId(String receiptId) {
+    final context = _requestContext;
+    if (receiptId.isEmpty || context == null || context.consentReceiptId == receiptId) return;
+    _requestContext = context.copyWithConsentReceiptId(receiptId);
+    if (isOperational) return;
+    unawaited(retry());
   }
 
   void setForeground(bool value) {
@@ -112,6 +126,7 @@ class EllaProvisioningProvider extends ChangeNotifier {
     _requestContext = null;
     _pollAttempts = 0;
     _requestInFlight = false;
+    _retryEnsureAfterCurrentRequest = false;
     receipt = null;
     errorCode = '';
     state = EllaProvisioningState.idle;
@@ -132,7 +147,7 @@ class EllaProvisioningProvider extends ChangeNotifier {
       _setFailure('network_unavailable');
       _schedulePoll(generation, _backoffDelay);
     } finally {
-      if (generation == _generation) _requestInFlight = false;
+      _finishRequest(generation);
     }
   }
 
@@ -155,7 +170,7 @@ class EllaProvisioningProvider extends ChangeNotifier {
       _setFailure('network_unavailable');
       _schedulePoll(generation, _backoffDelay);
     } finally {
-      if (generation == _generation) _requestInFlight = false;
+      _finishRequest(generation);
     }
   }
 
@@ -254,6 +269,15 @@ class EllaProvisioningProvider extends ChangeNotifier {
   void _cancelPoll() {
     _pollHandle?.cancel();
     _pollHandle = null;
+  }
+
+  void _finishRequest(int generation) {
+    if (generation != _generation) return;
+    _requestInFlight = false;
+    if (_retryEnsureAfterCurrentRequest) {
+      _retryEnsureAfterCurrentRequest = false;
+      unawaited(retry());
+    }
   }
 
   @override

--- a/app/test/ella/pages/ella_provisioning_gate_page_test.dart
+++ b/app/test/ella/pages/ella_provisioning_gate_page_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/ella/pages/ella_provisioning_gate_page.dart';
+import 'package:omi/ella/services/ella_provisioning_service.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/home/page.dart';
+import 'package:omi/providers/ella_provisioning_provider.dart';
+
+void main() {
+  testWidgets('setup failure remains fail closed and exposes its support code', (tester) async {
+    final provider = EllaProvisioningProvider()
+      ..state = EllaProvisioningState.blocked
+      ..receipt = const EllaProvisioningReceipt(
+        state: EllaProvisioningState.blocked,
+        supportCode: 'ELLA-SUPPORT-301',
+        errorCode: 'provisioning_disabled',
+      );
+    addTearDown(provider.dispose);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: provider,
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: EllaProvisioningGatePage(startOnMount: false),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('ELLA-SUPPORT-301'), findsOneWidget);
+    expect(find.byType(HomePageWrapper), findsNothing);
+    expect(find.byIcon(Icons.lock_outline_rounded), findsOneWidget);
+  });
+}

--- a/app/test/ella/services/ella_provisioning_service_test.dart
+++ b/app/test/ella/services/ella_provisioning_service_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ella_ai_consent_service.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/providers/ella_provisioning_provider.dart';
 
@@ -20,12 +21,14 @@ void main() {
       locale: 'en-US',
       timezone: 'America/Los_Angeles',
       clientRequestId: 'request-1',
+      consentReceiptId: 'consent-1',
     );
 
     final payload = context.toJson();
 
     expect(payload['target_schema_version'], ellaProvisioningTargetSchema);
     expect(payload['client_request_id'], 'request-1');
+    expect(payload['consent_receipt_id'], 'consent-1');
     expect(payload['client'], {
       'platform': 'ios',
       'app_version': '1.0.524+800',
@@ -37,29 +40,48 @@ void main() {
     expect(payload.toString(), isNot(contains('token')));
   });
 
-  test('ready receipt is operational only with active binding and policy revision', () {
+  test('exact backend ready receipt requires positive numeric binding revision', () {
     final ready = EllaProvisioningReceipt.fromJson({
-      'receipt': {
-        'state': 'ready',
-        'job_id': 'job-1',
-        'target_schema_version': ellaProvisioningTargetSchema,
-        'binding': {'state': 'active', 'revision': 'binding-2'},
-        'effective_policy': {
-          'revision': 'policy-3',
-          'voice_mode': 'gemini-native-live',
-          'model': 'grok-voice-think-fast-1.0',
-        },
-      },
+      'job_id': '11111111-1111-1111-1111-111111111111',
+      'state': 'ready',
+      'stage': 'ready',
+      'retryable': false,
+      'retry_after_ms': null,
+      'support_code': 'ELLA-11111111',
+      'target_schema_version': 'hermes-user-v1',
+      'binding_state': 'active',
+      'binding_revision': 2,
+      'effective_policy_revision': 'frontier-v1:ella-voice-v1',
     });
     final incomplete = EllaProvisioningReceipt.fromJson({
       'state': 'ready',
       'binding_state': 'active',
+      'binding_revision': 0,
+      'effective_policy_revision': 'frontier-v1:ella-voice-v1',
     });
 
     expect(ready.isOperational, isTrue);
-    expect(ready.effectiveVoiceMode, 'gemini-native-live');
-    expect(ready.effectiveModel, 'grok-voice-think-fast-1.0');
+    expect(ready.bindingRevision, 2);
     expect(incomplete.isOperational, isFalse);
+  });
+
+  test('status request uses the same canonical schema as ensure', () {
+    final uri = Uri.parse(buildEllaProvisioningStatusUrl('https://api.example.test/'));
+
+    expect(uri.path, '/v1/ella/onboarding/status');
+    expect(uri.queryParameters, {'target_schema_version': 'hermes-user-v1'});
+  });
+
+  test('FastAPI detail error is exposed as a blocked receipt code', () {
+    final receipt = EllaProvisioningReceipt.fromJson({
+      'detail': {'code': 'provisioning_disabled'},
+    });
+    final stringDetail = EllaProvisioningReceipt.fromJson({'detail': 'auth_required'});
+
+    expect(receipt.state, EllaProvisioningState.blocked);
+    expect(receipt.errorCode, 'provisioning_disabled');
+    expect(receipt.isOperational, isFalse);
+    expect(stringDetail.errorCode, 'auth_required');
   });
 
   test('receipt carrying gateway credentials fails closed and is not cacheable authority', () {
@@ -89,6 +111,8 @@ void main() {
       'ellaSettingsVoiceModeDirty': true,
       'aiConsentAccepted': true,
       'aiConsentAcceptedAt': '2026-01-01T00:00:00Z',
+      'aiConsentReceiptId': 'consent-a',
+      'aiConsentReceiptUid': 'uid-a',
       'demoMode': true,
       'publicMode': true,
       'cachedMessages': ['{"id":"old-user-message"}'],
@@ -107,6 +131,8 @@ void main() {
     expect(preferences.getString('devTtsProvider'), isEmpty);
     expect(preferences.getBool('ellaSettingsVoiceModeDirty'), isFalse);
     expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.aiConsentReceiptId, isEmpty);
+    expect(preferences.aiConsentReceiptUid, isEmpty);
     expect(preferences.demoMode, isFalse);
     expect(preferences.publicMode, isFalse);
     expect(preferences.getStringList('cachedMessages'), isEmpty);
@@ -119,6 +145,8 @@ void main() {
       'ellaGatewayToken': 'secret',
       'ellaKey': 'legacy-key',
       'aiConsentAccepted': true,
+      'aiConsentReceiptId': 'consent-a',
+      'aiConsentReceiptUid': 'uid-a',
     });
     await SharedPreferencesUtil.init();
     final preferences = SharedPreferencesUtil();
@@ -129,6 +157,7 @@ void main() {
     expect(preferences.ellaGatewayToken, isEmpty);
     expect(preferences.ellaKey, isEmpty);
     expect(preferences.aiConsentAccepted, isTrue);
+    expect(preferences.hasAccountBoundAiConsent('uid-a'), isTrue);
   });
 
   test('provider opens Home authority only for a complete ready receipt', () async {
@@ -139,6 +168,7 @@ void main() {
           receipt: EllaProvisioningReceipt.fromJson({
             'state': 'ready',
             'binding_state': 'active',
+            'binding_revision': 1,
             'effective_policy_revision': 'policy-1',
           }),
         ),
@@ -201,6 +231,69 @@ void main() {
     expect(provider.errorCode, 'provisioning_timeout');
     expect(provider.isOperational, isFalse);
   });
+
+  test('provider retries pending ensure with a newly acknowledged consent receipt', () async {
+    final scheduled = <_FakePollHandle>[];
+    final transport = _FakeTransport(
+      ensureResponses: const [
+        EllaProvisioningResponse(
+          statusCode: 202,
+          receipt: EllaProvisioningReceipt(state: EllaProvisioningState.queued, retryable: true),
+        ),
+        EllaProvisioningResponse(
+          statusCode: 202,
+          receipt: EllaProvisioningReceipt(state: EllaProvisioningState.queued, retryable: true),
+        ),
+      ],
+    );
+    final provider = EllaProvisioningProvider(
+      transport: transport,
+      scheduler: (delay, callback) {
+        final handle = _FakePollHandle(delay, callback);
+        scheduled.add(handle);
+        return handle;
+      },
+    );
+
+    await provider.start(uid: 'uid-a', requestContext: _requestContext);
+    provider.setConsentReceiptId('consent-2');
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(transport.ensureCalls, 2);
+    expect(transport.ensureContexts.last.consentReceiptId, 'consent-2');
+    provider.dispose();
+  });
+
+  test('AI consent becomes account-bound only after private cloud sync acknowledgement', () async {
+    final transport = _FakeConsentTransport(updateResult: true, confirmedEnabled: true);
+    final service = EllaAiConsentService(
+      transport: transport,
+      receiptIdFactory: () => 'receipt-1',
+    );
+
+    final receiptId = await service.acknowledgePrivateCloudSync(uid: 'uid-a');
+
+    expect(receiptId, 'ios-private-cloud-sync:receipt-1');
+    expect(transport.values, [true]);
+    expect(transport.getCalls, 1);
+    expect(SharedPreferencesUtil().hasAccountBoundAiConsent('uid-a'), isTrue);
+    expect(SharedPreferencesUtil().aiConsentReceiptId, receiptId);
+  });
+
+  test('AI consent stays disabled when private cloud sync cannot be confirmed', () async {
+    final transport = _FakeConsentTransport(updateResult: true, confirmedEnabled: false);
+    final service = EllaAiConsentService(
+      transport: transport,
+      receiptIdFactory: () => 'receipt-1',
+    );
+
+    final receiptId = await service.acknowledgePrivateCloudSync(uid: 'uid-a');
+
+    expect(receiptId, isNull);
+    expect(SharedPreferencesUtil().aiConsentAccepted, isFalse);
+    expect(SharedPreferencesUtil().aiConsentReceiptId, isEmpty);
+  });
 }
 
 final _requestContext = EllaProvisioningRequestContext(
@@ -215,11 +308,13 @@ class _FakeTransport implements EllaProvisioningTransport {
 
   final List<EllaProvisioningResponse> ensureResponses;
   final List<EllaProvisioningResponse> statusResponses;
+  final List<EllaProvisioningRequestContext> ensureContexts = [];
   int ensureCalls = 0;
   int statusCalls = 0;
 
   @override
   Future<EllaProvisioningResponse> ensure(EllaProvisioningRequestContext context) async {
+    ensureContexts.add(context);
     return ensureResponses[ensureCalls++];
   }
 
@@ -242,4 +337,25 @@ class _FakePollHandle implements EllaProvisioningPollHandle {
 
   @override
   void cancel() => canceled = true;
+}
+
+class _FakeConsentTransport implements EllaAiConsentTransport {
+  _FakeConsentTransport({required this.updateResult, required this.confirmedEnabled});
+
+  final bool updateResult;
+  final bool confirmedEnabled;
+  final List<bool> values = [];
+  int getCalls = 0;
+
+  @override
+  Future<bool> setPrivateCloudSync(bool value) async {
+    values.add(value);
+    return updateResult;
+  }
+
+  @override
+  Future<bool> getPrivateCloudSyncEnabled() async {
+    getCalls++;
+    return confirmedEnabled;
+  }
 }

--- a/app/test/ella/services/ella_provisioning_service_test.dart
+++ b/app/test/ella/services/ella_provisioning_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -13,6 +15,10 @@ void main() {
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
     await SharedPreferencesUtil.init();
+  });
+
+  test('authenticated provisioning gate is enabled by default', () {
+    expect(isHermesProvisioningGateEnabled, isTrue);
   });
 
   test('ensure request contains client context but no caller identity', () {
@@ -66,8 +72,11 @@ void main() {
   });
 
   test('status request uses the same canonical schema as ensure', () {
+    final ensureUri = Uri.parse(buildEllaProvisioningEnsureUrl('https://api.example.test/'));
     final uri = Uri.parse(buildEllaProvisioningStatusUrl('https://api.example.test/'));
 
+    expect(ensureUri.path, '/v1/ella/onboarding/ensure');
+    expect(ensureUri.host, 'api.example.test');
     expect(uri.path, '/v1/ella/onboarding/status');
     expect(uri.queryParameters, {'target_schema_version': 'hermes-user-v1'});
   });
@@ -138,7 +147,7 @@ void main() {
     expect(preferences.getStringList('cachedMessages'), isEmpty);
   });
 
-  test('same account still purges credentials left by an older fail-open build', () async {
+  test('same retained account preserves legacy preferences without making them provisioning authority', () async {
     SharedPreferences.setMockInitialValues({
       'ellaProvisioningAccountUid': 'uid-a',
       'ellaGatewayUrl': 'https://gateway.invalid',
@@ -153,9 +162,9 @@ void main() {
 
     await preferences.prepareEllaProvisioningAccount('uid-a');
 
-    expect(preferences.ellaGatewayUrl, isEmpty);
-    expect(preferences.ellaGatewayToken, isEmpty);
-    expect(preferences.ellaKey, isEmpty);
+    expect(preferences.ellaGatewayUrl, 'https://gateway.invalid');
+    expect(preferences.ellaGatewayToken, 'secret');
+    expect(preferences.ellaKey, 'legacy-key');
     expect(preferences.aiConsentAccepted, isTrue);
     expect(preferences.hasAccountBoundAiConsent('uid-a'), isTrue);
   });
@@ -182,6 +191,77 @@ void main() {
     expect(provider.isOperational, isTrue);
     expect(transport.ensureCalls, 1);
     expect(transport.statusCalls, 0);
+  });
+
+  test('duplicate starts for one account share a single ensure request', () async {
+    final transport = _DeferredEnsureTransport();
+    final provider = EllaProvisioningProvider(transport: transport);
+
+    final firstStart = provider.start(uid: 'uid-a', requestContext: _requestContext);
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+    final duplicateStart = provider.start(
+      uid: 'uid-a',
+      requestContext: EllaProvisioningRequestContext(
+        appVersion: '1.0.524+800',
+        locale: 'en-US',
+        timezone: 'America/Los_Angeles',
+        clientRequestId: 'duplicate-request-must-not-send',
+      ),
+    );
+
+    expect(transport.ensureCalls, 1);
+    transport.complete(
+      EllaProvisioningResponse(
+        statusCode: 200,
+        receipt: EllaProvisioningReceipt.fromJson({
+          'state': 'ready',
+          'binding_state': 'active',
+          'binding_revision': 1,
+          'effective_policy_revision': 'policy-1',
+        }),
+      ),
+    );
+    await Future.wait([firstStart, duplicateStart]);
+
+    expect(provider.isOperational, isTrue);
+    expect(transport.ensureCalls, 1);
+  });
+
+  test('provisioning writes only a safe receipt and leaves retained compatibility values unchanged', () async {
+    SharedPreferences.setMockInitialValues({
+      'ellaProvisioningAccountUid': 'uid-a',
+      'ellaUserId': 'retained-user',
+      'ellaGatewayUrl': 'https://retained.invalid',
+      'ellaGatewayToken': 'retained-token',
+    });
+    await SharedPreferencesUtil.init();
+    final transport = _FakeTransport(
+      ensureResponses: [
+        EllaProvisioningResponse(
+          statusCode: 200,
+          receipt: EllaProvisioningReceipt.fromJson({
+            'state': 'ready',
+            'binding_state': 'active',
+            'binding_revision': 1,
+            'effective_policy_revision': 'policy-1',
+            'support_code': 'ELLA-SAFE',
+          }),
+        ),
+      ],
+    );
+    final provider = EllaProvisioningProvider(transport: transport);
+
+    await provider.start(uid: 'uid-a', requestContext: _requestContext);
+
+    final preferences = SharedPreferencesUtil();
+    final cachedReceipt = preferences.getEllaProvisioningReceipt('uid-a');
+    expect(preferences.ellaUserId, 'retained-user');
+    expect(preferences.ellaGatewayUrl, 'https://retained.invalid');
+    expect(preferences.ellaGatewayToken, 'retained-token');
+    expect(cachedReceipt?['support_code'], 'ELLA-SAFE');
+    expect(cachedReceipt.toString(), isNot(contains('gateway')));
+    expect(cachedReceipt.toString(), isNot(contains('token')));
   });
 
   test('provider bounds polling and surfaces timeout without entering Home', () async {
@@ -337,6 +417,22 @@ class _FakePollHandle implements EllaProvisioningPollHandle {
 
   @override
   void cancel() => canceled = true;
+}
+
+class _DeferredEnsureTransport implements EllaProvisioningTransport {
+  final Completer<EllaProvisioningResponse> _completer = Completer<EllaProvisioningResponse>();
+  int ensureCalls = 0;
+
+  @override
+  Future<EllaProvisioningResponse> ensure(EllaProvisioningRequestContext context) {
+    ensureCalls++;
+    return _completer.future;
+  }
+
+  void complete(EllaProvisioningResponse response) => _completer.complete(response);
+
+  @override
+  Future<EllaProvisioningResponse> status() => throw StateError('status should not be called');
 }
 
 class _FakeConsentTransport implements EllaAiConsentTransport {

--- a/app/test/ella/services/ella_provisioning_service_test.dart
+++ b/app/test/ella/services/ella_provisioning_service_test.dart
@@ -1,0 +1,245 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ella_provisioning_service.dart';
+import 'package:omi/providers/ella_provisioning_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('ensure request contains client context but no caller identity', () {
+    final context = EllaProvisioningRequestContext(
+      appVersion: '1.0.524+800',
+      locale: 'en-US',
+      timezone: 'America/Los_Angeles',
+      clientRequestId: 'request-1',
+    );
+
+    final payload = context.toJson();
+
+    expect(payload['target_schema_version'], ellaProvisioningTargetSchema);
+    expect(payload['client_request_id'], 'request-1');
+    expect(payload['client'], {
+      'platform': 'ios',
+      'app_version': '1.0.524+800',
+      'locale': 'en-US',
+      'timezone': 'America/Los_Angeles',
+    });
+    expect(payload.containsKey('uid'), isFalse);
+    expect(payload.containsKey('email'), isFalse);
+    expect(payload.toString(), isNot(contains('token')));
+  });
+
+  test('ready receipt is operational only with active binding and policy revision', () {
+    final ready = EllaProvisioningReceipt.fromJson({
+      'receipt': {
+        'state': 'ready',
+        'job_id': 'job-1',
+        'target_schema_version': ellaProvisioningTargetSchema,
+        'binding': {'state': 'active', 'revision': 'binding-2'},
+        'effective_policy': {
+          'revision': 'policy-3',
+          'voice_mode': 'gemini-native-live',
+          'model': 'grok-voice-think-fast-1.0',
+        },
+      },
+    });
+    final incomplete = EllaProvisioningReceipt.fromJson({
+      'state': 'ready',
+      'binding_state': 'active',
+    });
+
+    expect(ready.isOperational, isTrue);
+    expect(ready.effectiveVoiceMode, 'gemini-native-live');
+    expect(ready.effectiveModel, 'grok-voice-think-fast-1.0');
+    expect(incomplete.isOperational, isFalse);
+  });
+
+  test('receipt carrying gateway credentials fails closed and is not cacheable authority', () {
+    final receipt = EllaProvisioningReceipt.fromJson({
+      'state': 'ready',
+      'binding_state': 'active',
+      'policy_revision': 'policy-1',
+      'gatewayUrl': 'https://example.invalid',
+      'accessToken': 'must-not-reach-the-client',
+    });
+
+    expect(receipt.state, EllaProvisioningState.blocked);
+    expect(receipt.errorCode, 'unsafe_response_contract');
+    expect(receipt.isOperational, isFalse);
+    expect(receipt.toCacheJson().toString(), isNot(contains('must-not-reach-the-client')));
+  });
+
+  test('account switch clears legacy authority, consent, demo state, settings, and receipts', () async {
+    SharedPreferences.setMockInitialValues({
+      'ellaProvisioningAccountUid': 'uid-a',
+      'ellaProvisioningReceipt:uid-a': '{"state":"ready"}',
+      'ellaProvisioningReceipt:uid-b': '{"state":"ready"}',
+      'ellaGatewayUrl': 'https://gateway.invalid',
+      'ellaGatewayToken': 'secret',
+      'ellaResolvedEndpoint': '{"token":"secret"}',
+      'devTtsProvider': 'grok-voice',
+      'ellaSettingsVoiceModeDirty': true,
+      'aiConsentAccepted': true,
+      'aiConsentAcceptedAt': '2026-01-01T00:00:00Z',
+      'demoMode': true,
+      'publicMode': true,
+      'cachedMessages': ['{"id":"old-user-message"}'],
+    });
+    await SharedPreferencesUtil.init();
+    final preferences = SharedPreferencesUtil();
+
+    await preferences.prepareEllaProvisioningAccount('uid-b');
+
+    expect(preferences.getString('ellaProvisioningAccountUid'), 'uid-b');
+    expect(preferences.getEllaProvisioningReceipt('uid-a'), isNull);
+    expect(preferences.getEllaProvisioningReceipt('uid-b'), isNull);
+    expect(preferences.ellaGatewayUrl, isEmpty);
+    expect(preferences.ellaGatewayToken, isEmpty);
+    expect(preferences.getString('ellaResolvedEndpoint'), isEmpty);
+    expect(preferences.getString('devTtsProvider'), isEmpty);
+    expect(preferences.getBool('ellaSettingsVoiceModeDirty'), isFalse);
+    expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.demoMode, isFalse);
+    expect(preferences.publicMode, isFalse);
+    expect(preferences.getStringList('cachedMessages'), isEmpty);
+  });
+
+  test('same account still purges credentials left by an older fail-open build', () async {
+    SharedPreferences.setMockInitialValues({
+      'ellaProvisioningAccountUid': 'uid-a',
+      'ellaGatewayUrl': 'https://gateway.invalid',
+      'ellaGatewayToken': 'secret',
+      'ellaKey': 'legacy-key',
+      'aiConsentAccepted': true,
+    });
+    await SharedPreferencesUtil.init();
+    final preferences = SharedPreferencesUtil();
+
+    await preferences.prepareEllaProvisioningAccount('uid-a');
+
+    expect(preferences.ellaGatewayUrl, isEmpty);
+    expect(preferences.ellaGatewayToken, isEmpty);
+    expect(preferences.ellaKey, isEmpty);
+    expect(preferences.aiConsentAccepted, isTrue);
+  });
+
+  test('provider opens Home authority only for a complete ready receipt', () async {
+    final transport = _FakeTransport(
+      ensureResponses: [
+        EllaProvisioningResponse(
+          statusCode: 200,
+          receipt: EllaProvisioningReceipt.fromJson({
+            'state': 'ready',
+            'binding_state': 'active',
+            'effective_policy_revision': 'policy-1',
+          }),
+        ),
+      ],
+    );
+    final provider = EllaProvisioningProvider(transport: transport);
+
+    await provider.start(uid: 'uid-a', requestContext: _requestContext);
+
+    expect(provider.state, EllaProvisioningState.ready);
+    expect(provider.isOperational, isTrue);
+    expect(transport.ensureCalls, 1);
+    expect(transport.statusCalls, 0);
+  });
+
+  test('provider bounds polling and surfaces timeout without entering Home', () async {
+    final scheduled = <_FakePollHandle>[];
+    final transport = _FakeTransport(
+      ensureResponses: [
+        const EllaProvisioningResponse(
+          statusCode: 202,
+          receipt: EllaProvisioningReceipt(
+            state: EllaProvisioningState.queued,
+            retryable: true,
+            retryAfter: Duration(milliseconds: 500),
+          ),
+        ),
+      ],
+      statusResponses: [
+        const EllaProvisioningResponse(
+          statusCode: 202,
+          receipt: EllaProvisioningReceipt(
+            state: EllaProvisioningState.provisioning,
+            retryable: true,
+            retryAfter: Duration(milliseconds: 500),
+          ),
+        ),
+      ],
+    );
+    final provider = EllaProvisioningProvider(
+      transport: transport,
+      maxPollAttempts: 1,
+      scheduler: (delay, callback) {
+        final handle = _FakePollHandle(delay, callback);
+        scheduled.add(handle);
+        return handle;
+      },
+    );
+
+    await provider.start(uid: 'uid-a', requestContext: _requestContext);
+    expect(provider.state, EllaProvisioningState.queued);
+    expect(scheduled, hasLength(1));
+
+    scheduled.single.fire();
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(transport.statusCalls, 1);
+    expect(provider.state, EllaProvisioningState.degraded);
+    expect(provider.errorCode, 'provisioning_timeout');
+    expect(provider.isOperational, isFalse);
+  });
+}
+
+final _requestContext = EllaProvisioningRequestContext(
+  appVersion: '1.0.524+800',
+  locale: 'en-US',
+  timezone: 'America/Los_Angeles',
+  clientRequestId: 'request-1',
+);
+
+class _FakeTransport implements EllaProvisioningTransport {
+  _FakeTransport({required this.ensureResponses, this.statusResponses = const []});
+
+  final List<EllaProvisioningResponse> ensureResponses;
+  final List<EllaProvisioningResponse> statusResponses;
+  int ensureCalls = 0;
+  int statusCalls = 0;
+
+  @override
+  Future<EllaProvisioningResponse> ensure(EllaProvisioningRequestContext context) async {
+    return ensureResponses[ensureCalls++];
+  }
+
+  @override
+  Future<EllaProvisioningResponse> status() async {
+    return statusResponses[statusCalls++];
+  }
+}
+
+class _FakePollHandle implements EllaProvisioningPollHandle {
+  _FakePollHandle(this.delay, this.callback);
+
+  final Duration delay;
+  final VoidCallback callback;
+  bool canceled = false;
+
+  void fire() {
+    if (!canceled) callback();
+  }
+
+  @override
+  void cancel() => canceled = true;
+}


### PR DESCRIPTION
## Summary
- route fresh iOS OAuth onboarding through the Firebase-authenticated `/v1/ella/onboarding/ensure` contract and enable the fail-closed Hermes gate by default
- remove the unauthenticated dashboard provisioner, caller UID/email/name payload, and all onboarding writes of OpenClaw gateway/key/token/agent credentials
- make sign-in, onboarding completion, and gate startup share one idempotent ensure/poll loop
- keep Home closed until a fresh server receipt confirms an active binding, positive binding revision, and effective policy revision
- preserve same-account compatibility preferences non-destructively while clearing them only on an actual account switch
- retain bounded lifecycle-aware polling, retry/sign-out/support-code UX, first-party chat/history/voice routes, and private-cloud consent acknowledgement

## Backend contract
- `POST ${Env.apiBaseUrl}v1/ella/onboarding/ensure` through `makeApiCall`
- request body: `target_schema_version`, app version, locale, timezone, client request ID, and account-bound consent receipt when available
- no caller UID, email, name, provider authority, gateway URL, token, secret, or agent ID
- `GET ${Env.apiBaseUrl}v1/ella/onboarding/status?target_schema_version=hermes-user-v1`
- accepts `202` queued/provisioning receipts and polls with bounded backoff/`retry_after_ms`
- rejects credential-bearing responses and caches only non-secret receipt/support state

## Validation
- provisioning service/state/widget tests: 16 passed
- focused `flutter analyze --no-pub`: no issues
- `./test.sh`: capture provider 18 passed; transcript widgets 3 passed
- prod iOS Simulator build succeeded for iPhone 17 Pro/iOS 26.5
- `com.ellaaicare.ella` installed and launched successfully in Simulator
- `git diff --check`: clean
- GitNexus reindex was attempted but its parser workers timed out on generated `app_localizations_*.dart` files; generated partial cache was removed and this does not affect app validation

## Rollout gate
Backend ellaaicare/ella-ai#1091 is deployed immutable/default-off, but its two synthetic Firebase UID isolation canary is still pending. Keep this PR draft and do not upload TestFlight until that canary proves distinct Hermes profiles, cross-user denial, retained-user compatibility, and fail-closed isolated voice.

This PR targets `feature/phase-a-testflight`, the active parent of PR ellaaicare/omi#284.

Tracks ellaaicare/ella-ai#1090 and ellaaicare/ella-ai#1092
Parent: ellaaicare/ella-ai#1063