### PR TITLE
Preserve MCP observation write discovery

### DIFF
--- a/backend/ella/routers/mcp_well_known.py
+++ b/backend/ella/routers/mcp_well_known.py
@@ -56,6 +56,7 @@ async def get_oauth_protected_resource():
             "scopes_supported": [
                 "context:read",
                 "memory:read",
+                "observations:write",
                 "profile:read",
                 "startup:read",
                 "timeline:read",
@@ -89,6 +90,7 @@ async def get_oauth_authorization_server():
             "scopes_supported": [
                 "context:read",
                 "memory:read",
+                "observations:write",
                 "profile:read",
                 "startup:read",
                 "timeline:read",

--- a/backend/tests/unit/test_ella_mcp_well_known.py
+++ b/backend/tests/unit/test_ella_mcp_well_known.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ella.routers.mcp_well_known import router
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_protected_resource_advertises_observation_writes():
+    response = _client().get("/.well-known/oauth-protected-resource")
+
+    assert response.status_code == 200
+    assert "observations:write" in response.json()["scopes_supported"]
+
+
+def test_authorization_server_advertises_observation_writes():
+    response = _client().get("/.well-known/oauth-authorization-server")
+
+    assert response.status_code == 200
+    assert "observations:write" in response.json()["scopes_supported"]


### PR DESCRIPTION
## Summary
- advertise the existing `observations:write` grant from both MCP OAuth discovery documents
- add regression coverage for protected-resource and authorization-server metadata

## Why
Production reconciliation for ellaaicare/ella-ai#1091 found this as the only required live-only behavior not present in merged main. Omitting it would make Grok and other dynamic MCP clients request an incomplete scope set after the clean release cutover.

## Validation
- 50 focused onboarding, provisioning, runtime, listen, and discovery tests passed
- 42 MCP identity/server tests passed
- canonical `backend/test.sh`: 116 passed
- Black, Python compile, and `git diff --check` passed

No production service, rollout flag, credential, user binding, or `plato-eval` state changed.

Closes no issue; deployment checkpoint for ellaaicare/ella-ai#1091.