### PR TITLE
Cast fresh identity JSONB parameters

### DIFF
--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -135,7 +135,7 @@ class EllaProvisioningRepository:
                         SET name = $2,
                             timezone = $3,
                             identities = COALESCE(identities, '{}'::jsonb)
-                                || jsonb_build_object('omi_uid', $1, 'email', email),
+                                || jsonb_build_object('omi_uid', $1::text, 'email', email),
                             updated_at = CURRENT_TIMESTAMP
                         WHERE omi_uid = $1
                         RETURNING id, omi_uid, email, name, timezone, status
@@ -166,7 +166,7 @@ class EllaProvisioningRepository:
                             name = $3,
                             timezone = $4,
                             identities = COALESCE(identities, '{}'::jsonb)
-                                || jsonb_build_object('omi_uid', $2, 'email', email),
+                                || jsonb_build_object('omi_uid', $2::text, 'email', email),
                             updated_at = CURRENT_TIMESTAMP
                         WHERE id = $5
                         RETURNING id, omi_uid, email, name, timezone, status
@@ -188,7 +188,7 @@ class EllaProvisioningRepository:
                     )
                     VALUES (
                         $1, $2, $3, $4, $5, 'PENDING',
-                        jsonb_build_object('omi_uid', $5, 'email', $2),
+                        jsonb_build_object('omi_uid', $5::text, 'email', $2::text),
                         '{}'::jsonb, ARRAY[]::text[], CURRENT_TIMESTAMP
                     )
                     RETURNING id, omi_uid, email, name, timezone, status

--- a/backend/tests/unit/test_ella_provisioning_repository.py
+++ b/backend/tests/unit/test_ella_provisioning_repository.py
@@ -1,0 +1,72 @@
+import asyncio
+import uuid
+
+from database.ella_provisioning import EllaProvisioningRepository
+
+
+class _AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, _exc_type, _exc, _traceback):
+        return False
+
+
+class _Connection:
+    def __init__(self):
+        self.queries = []
+
+    def transaction(self):
+        return _AsyncContext(self)
+
+    async def fetchrow(self, query, *args):
+        self.queries.append(query)
+        if "INSERT INTO users" not in query:
+            return None
+
+        assert "$5::text" in query
+        assert "$2::text" in query
+        return {
+            "id": args[0],
+            "omi_uid": args[4],
+            "email": args[1],
+            "name": args[2],
+            "timezone": args[3],
+            "status": "PENDING",
+        }
+
+
+class _Pool:
+    def __init__(self, connection):
+        self.connection = connection
+
+    def acquire(self):
+        return _AsyncContext(self.connection)
+
+
+def test_fresh_identity_insert_casts_jsonb_parameters():
+    connection = _Connection()
+    repository = EllaProvisioningRepository(_Pool(connection))
+
+    result = asyncio.run(
+        repository.ensure_user_identity(
+            uid="firebase-user-1",
+            email="user@example.com",
+            name="Test User",
+            timezone_name="America/Los_Angeles",
+        )
+    )
+
+    assert result == {
+        "id": result["id"],
+        "omi_uid": "firebase-user-1",
+        "email": "user@example.com",
+        "name": "Test User",
+        "timezone": "America/Los_Angeles",
+        "status": "PENDING",
+    }
+    assert isinstance(result["id"], uuid.UUID)
+    assert len(connection.queries) == 3


### PR DESCRIPTION
## Summary
- Cast identity values passed through `jsonb_build_object` during provisioning.
- Cover the fresh Firebase identity insert path with a repository regression test.

## Production finding
The first authenticated two-user isolation canary reached the clean production release but failed before provisioning with `asyncpg.exceptions.AmbiguousParameterError` for parameter `$5`. PostgreSQL could not infer the polymorphic JSONB value type. No Hermes workspace or runtime binding was created before the failure.

## Verification
- `bash backend/test.sh`
- `PYTHONPATH=backend pytest -q backend/tests/unit/test_ella_runtime_route_isolation.py` (9 passed)
- `PYTHONPATH=backend pytest -q backend/tests/unit/test_ella_listen_runtime_gate.py` (6 passed)
- provisioning/onboarding focused suite (34 passed)
- Black and `git diff --check`

Continues ellaaicare/ella-ai#1091.