### PR TITLE
Guard every iOS Home entry behind Hermes provisioning

### DIFF
--- a/app/lib/ella/pages/ella_provisioning_gate_page.dart
+++ b/app/lib/ella/pages/ella_provisioning_gate_page.dart
@@ -8,15 +8,15 @@ import 'package:provider/provider.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/ella_theme.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
-import 'package:omi/pages/home/page.dart';
 import 'package:omi/providers/ella_provisioning_provider.dart';
 import 'package:omi/utils/auth_utils.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 
 class EllaProvisioningGatePage extends StatefulWidget {
-  const EllaProvisioningGatePage({super.key, this.startOnMount = true});
+  const EllaProvisioningGatePage({super.key, required this.readyChild, this.startOnMount = true});
 
+  final Widget readyChild;
   final bool startOnMount;
 
   @override
@@ -80,7 +80,7 @@ class _EllaProvisioningGatePageState extends State<EllaProvisioningGatePage> wit
     return Consumer<EllaProvisioningProvider>(
       builder: (context, provider, _) {
         if (provider.isOperational) {
-          return const HomePageWrapper();
+          return widget.readyChild;
         }
 
         final isWorking = provider.state == EllaProvisioningState.idle ||

--- a/app/lib/mobile/mobile_app.dart
+++ b/app/lib/mobile/mobile_app.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:omi/backend/preferences.dart';
-import 'package:omi/ella/pages/ella_provisioning_gate_page.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/pages/home/page.dart';
 import 'package:omi/pages/onboarding/device_selection.dart';
@@ -43,7 +42,7 @@ class _MobileAppState extends State<MobileApp> {
       return Consumer<AuthenticationProvider>(
         builder: (context, authProvider, child) {
           if (authProvider.isSignedIn() && SharedPreferencesUtil().onboardingCompleted) {
-            return isHermesProvisioningGateEnabled ? const EllaProvisioningGatePage() : const HomePageWrapper();
+            return const HomePageWrapper();
           }
 
           // Self-healing: if signed in but onboardingCompleted is false,
@@ -71,9 +70,7 @@ class _MobileAppState extends State<MobileApp> {
             }
             // Show loading while checking server — avoids flashing onboarding
             if (_restoringOnboarding) {
-              return const Scaffold(
-                body: Center(child: CircularProgressIndicator()),
-              );
+              return const Scaffold(body: Center(child: CircularProgressIndicator()));
             }
           }
 

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -16,6 +16,8 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/app.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/geolocation.dart';
+import 'package:omi/ella/pages/ella_provisioning_gate_page.dart';
+import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/main.dart';
 import 'package:omi/pages/apps/app_detail/app_detail.dart';
 import 'package:omi/pages/chat/page.dart';
@@ -52,7 +54,16 @@ import 'today_page.dart';
 class HomePageWrapper extends StatefulWidget {
   final String? navigateToRoute;
   final String? autoMessage;
-  const HomePageWrapper({super.key, this.navigateToRoute, this.autoMessage});
+  final bool provisioningGateStartOnMount;
+
+  const HomePageWrapper({super.key, this.navigateToRoute, this.autoMessage, this.provisioningGateStartOnMount = true})
+      : _provisioningVerified = false;
+
+  const HomePageWrapper._provisioned({this.navigateToRoute, this.autoMessage})
+      : provisioningGateStartOnMount = true,
+        _provisioningVerified = true;
+
+  final bool _provisioningVerified;
 
   @override
   State<HomePageWrapper> createState() => _HomePageWrapperState();
@@ -64,28 +75,38 @@ class _HomePageWrapperState extends State<HomePageWrapper> {
 
   @override
   void initState() {
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      if (mounted) {
-        context.read<DeviceProvider>().periodicConnect('coming from HomePageWrapper', boundDeviceOnly: true);
-      }
-      if (SharedPreferencesUtil().notificationsEnabled) {
-        NotificationService.instance.register();
-        NotificationService.instance.saveNotificationToken();
-
-        // Schedule daily reflection notification if enabled
-        if (SharedPreferencesUtil().dailyReflectionEnabled) {
-          DailyReflectionNotification.scheduleDailyNotification(channelKey: 'channel');
+    if (!_requiresProvisioningGate) {
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        if (mounted) {
+          context.read<DeviceProvider>().periodicConnect('coming from HomePageWrapper', boundDeviceOnly: true);
         }
-      }
-    });
+        if (SharedPreferencesUtil().notificationsEnabled) {
+          NotificationService.instance.register();
+          NotificationService.instance.saveNotificationToken();
+
+          // Schedule daily reflection notification if enabled
+          if (SharedPreferencesUtil().dailyReflectionEnabled) {
+            DailyReflectionNotification.scheduleDailyNotification(channelKey: 'channel');
+          }
+        }
+      });
+    }
     _navigateToRoute = widget.navigateToRoute;
     _autoMessage = widget.autoMessage;
 
     super.initState();
   }
 
+  bool get _requiresProvisioningGate => isHermesProvisioningGateEnabled && !widget._provisioningVerified;
+
   @override
   Widget build(BuildContext context) {
+    if (_requiresProvisioningGate) {
+      return EllaProvisioningGatePage(
+        startOnMount: widget.provisioningGateStartOnMount,
+        readyChild: HomePageWrapper._provisioned(navigateToRoute: _navigateToRoute, autoMessage: _autoMessage),
+      );
+    }
     return HomePage(navigateToRoute: _navigateToRoute, autoMessage: _autoMessage);
   }
 }
@@ -152,9 +173,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
   }
 
   ///Screens with respect to subpage
-  final Map<String, Widget> screensWithRespectToPath = {
-    '/facts': const MemoriesPage(),
-  };
+  final Map<String, Widget> screensWithRespectToPath = {'/facts': const MemoriesPage()};
   bool? previousConnection;
 
   void _onReceiveTaskData(dynamic data) async {
@@ -228,8 +247,10 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
         await Provider.of<HomeProvider>(context, listen: false).setUserPeople();
       }
       if (mounted) {
-        await Provider.of<CaptureProvider>(context, listen: false)
-            .streamDeviceRecording(device: Provider.of<DeviceProvider>(context, listen: false).connectedDevice);
+        await Provider.of<CaptureProvider>(
+          context,
+          listen: false,
+        ).streamDeviceRecording(device: Provider.of<DeviceProvider>(context, listen: false).connectedDevice);
       }
 
       // Navigate
@@ -240,12 +261,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
             final appProvider = context.read<AppProvider>();
             var app = await appProvider.getAppFromId(detailPageId);
             if (app != null && mounted) {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => AppDetailPage(app: app),
-                ),
-              );
+              Navigator.push(context, MaterialPageRoute(builder: (context) => AppDetailPage(app: app)));
             }
           }
           break;
@@ -309,19 +325,11 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
             }
           });
           if (detailPageId == 'data-privacy') {
-            MyApp.navigatorKey.currentState?.push(
-              MaterialPageRoute(
-                builder: (context) => const DataPrivacyPage(),
-              ),
-            );
+            MyApp.navigatorKey.currentState?.push(MaterialPageRoute(builder: (context) => const DataPrivacyPage()));
           }
           break;
         case "facts":
-          MyApp.navigatorKey.currentState?.push(
-            MaterialPageRoute(
-              builder: (context) => const MemoriesPage(),
-            ),
-          );
+          MyApp.navigatorKey.currentState?.push(MaterialPageRoute(builder: (context) => const MemoriesPage()));
           break;
         case "conversation":
           // Handle conversation deep link: /conversation/{id}?share=1
@@ -339,10 +347,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (context) => ConversationDetailPage(
-                      conversation: conversation,
-                      openShareToContactsOnLoad: shouldOpenShare,
-                    ),
+                    builder: (context) =>
+                        ConversationDetailPage(conversation: conversation, openShareToContactsOnLoad: shouldOpenShare),
                   ),
                 );
               } else {
@@ -363,9 +369,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
               if (mounted) {
                 Navigator.push(
                   context,
-                  MaterialPageRoute(
-                    builder: (context) => DailySummaryDetailPage(summaryId: detailPageId!),
-                  ),
+                  MaterialPageRoute(builder: (context) => DailySummaryDetailPage(summaryId: detailPageId!)),
                 );
               }
             });
@@ -374,12 +378,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
         case "wrapped":
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (mounted) {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const Wrapped2025Page(),
-                ),
-              );
+              Navigator.push(context, MaterialPageRoute(builder: (context) => const Wrapped2025Page()));
             }
           });
           break;
@@ -577,10 +576,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                       Column(
                         children: [
                           Expanded(
-                            child: IndexedStack(
-                              index: context.watch<HomeProvider>().selectedIndex,
-                              children: _pages,
-                            ),
+                            child: IndexedStack(index: context.watch<HomeProvider>().selectedIndex, children: _pages),
                           ),
                           // Settings and other non-home tabs just need nav bar clearance
                           if (context.watch<HomeProvider>().selectedIndex == 3)

--- a/app/lib/pages/onboarding/ella/ella_onboarding.dart
+++ b/app/lib/pages/onboarding/ella/ella_onboarding.dart
@@ -9,7 +9,6 @@ import 'package:provider/provider.dart';
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/ella_theme.dart';
-import 'package:omi/ella/pages/ella_provisioning_gate_page.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/pages/home/page.dart';
 import 'package:omi/pages/onboarding/auth.dart';
@@ -83,11 +82,7 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
   }
 
   void _goToPage(int page) {
-    _pageController.animateToPage(
-      page,
-      duration: const Duration(milliseconds: 300),
-      curve: Curves.easeInOut,
-    );
+    _pageController.animateToPage(page, duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
     setState(() => _currentPage = page);
   }
 
@@ -101,11 +96,7 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
   }
 
   void _routeToAuthenticatedHome() {
-    routeToPage(
-      context,
-      isHermesProvisioningGateEnabled ? const EllaProvisioningGatePage() : const HomePageWrapper(),
-      replace: true,
-    );
+    routeToPage(context, const HomePageWrapper(), replace: true);
   }
 
   @override
@@ -147,11 +138,7 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
                 onBack: () => _goToPage(0),
               ),
               if (!publicMode)
-                EllaEmergency(
-                  onComplete: _completeOnboarding,
-                  onSkip: _completeOnboarding,
-                  onBack: () => _goToPage(1),
-                ),
+                EllaEmergency(onComplete: _completeOnboarding, onSkip: _completeOnboarding, onBack: () => _goToPage(1)),
             ],
           ),
           Positioned(

--- a/app/test/ella/pages/ella_provisioning_gate_page_test.dart
+++ b/app/test/ella/pages/ella_provisioning_gate_page_test.dart
@@ -25,7 +25,7 @@ void main() {
         child: const MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: EllaProvisioningGatePage(startOnMount: false),
+          home: EllaProvisioningGatePage(readyChild: SizedBox(), startOnMount: false),
         ),
       ),
     );

--- a/app/test/ella/pages/home_provisioning_gate_test.dart
+++ b/app/test/ella/pages/home_provisioning_gate_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/ella/pages/ella_provisioning_gate_page.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/home/page.dart';
+import 'package:omi/providers/ella_provisioning_provider.dart';
+
+void main() {
+  testWidgets('every HomePageWrapper entry remains gated and preserves pending navigation', (tester) async {
+    final provider = EllaProvisioningProvider();
+    addTearDown(provider.dispose);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: provider,
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: HomePageWrapper(
+            navigateToRoute: '/chat',
+            autoMessage: 'pending notification message',
+            provisioningGateStartOnMount: false,
+          ),
+        ),
+      ),
+    );
+
+    final gate = tester.widget<EllaProvisioningGatePage>(find.byType(EllaProvisioningGatePage));
+    final readyHome = gate.readyChild as HomePageWrapper;
+
+    expect(find.byType(HomePage), findsNothing);
+    expect(readyHome.navigateToRoute, '/chat');
+    expect(readyHome.autoMessage, 'pending notification message');
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- make `HomePageWrapper` the authoritative Hermes provisioning guard so notifications and every direct navigation path fail closed
- suppress device-connect and notification side effects until provisioning is operational
- preserve pending deep-link route and auto-message values across the setup gate
- keep the post-verification Home constructor private so external routes cannot opt out
- make the gate render an explicit verified child rather than constructing Home itself

## Root cause
PR ellaaicare/omi#297 guarded the root `MobileApp` route, but notification, onboarding, firmware, capture, speech-profile, and conversation-detail flows still constructed `HomePageWrapper` directly. Those paths could render Home without an operational isolated Hermes receipt.

Resolves the P1 review at https://github.com/ellaaicare/omi/pull/297#discussion_r3626240763.

## Validation
- `flutter test --no-pub test/ella/services/ella_provisioning_service_test.dart test/ella/pages/ella_provisioning_gate_page_test.dart test/ella/pages/home_provisioning_gate_test.dart`: 17 passed
- focused `flutter analyze --no-pub`: no issues
- `./test.sh`: capture provider 18 passed; transcript widgets 3 passed
- `git diff --check`: clean
- GitNexus index refreshed successfully: 44,679 nodes / 87,814 edges

## Release
Target is `feature/phase-a-testflight`. Merge before producing the ellaaicare/ella-ai#1092 internal TestFlight build. Global rollout flags and UID allowlists remain unchanged.

Tracks ellaaicare/ella-ai#1092 and parent ellaaicare/ella-ai#1063.