### PR TITLE
Preserve retained users through Hermes onboarding gate

### DIFF
--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -501,6 +501,25 @@ class EllaProvisioningRepository:
         if result == "UPDATE 0":
             raise LookupError("user_not_found")
 
+    async def has_active_retained_runtime(self, uid: str) -> bool:
+        """Return whether an authenticated legacy user still has usable routing."""
+        row = await self.pool.fetchrow(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM users u
+                JOIN agent_clusters ac ON ac.user_id = u.id
+                WHERE u.omi_uid = $1
+                  AND u.status = 'ACTIVE'
+                  AND ac.status = 'ACTIVE'
+                  AND jsonb_typeof(ac.agents) = 'object'
+                  AND NULLIF(BTRIM(ac.agents->>'userAgentId'), '') IS NOT NULL
+            ) AS eligible
+            """,
+            uid,
+        )
+        return bool(row and row["eligible"])
+
     async def resolve_active_runtime(
         self,
         uid: str,

--- a/backend/ella/routers/onboarding.py
+++ b/backend/ella/routers/onboarding.py
@@ -23,6 +23,7 @@ from ella.services.provisioning import (
     public_receipt,
     retained_compatibility_receipt,
 )
+from ella.services.runtime_resolver import runtime_bindings_enabled
 from utils.other import endpoints as auth
 
 logger = logging.getLogger("ella.onboarding")
@@ -80,7 +81,7 @@ async def _coordinator() -> ProvisioningCoordinator:
 
 async def _retained_receipt(uid: str, target_schema_version: str) -> Optional[dict[str, Any]]:
     """Return a public receipt only for an already-routed retained account."""
-    if target_schema_version != DEFAULT_TARGET_SCHEMA_VERSION:
+    if target_schema_version != DEFAULT_TARGET_SCHEMA_VERSION or runtime_bindings_enabled(uid):
         return None
     try:
         repository = await EllaProvisioningRepository.create()

--- a/backend/ella/routers/onboarding.py
+++ b/backend/ella/routers/onboarding.py
@@ -21,6 +21,7 @@ from ella.services.provisioning import (
     VerifiedIdentity,
     provisioning_enabled,
     public_receipt,
+    retained_compatibility_receipt,
 )
 from utils.other import endpoints as auth
 
@@ -77,6 +78,19 @@ async def _coordinator() -> ProvisioningCoordinator:
     return ProvisioningCoordinator(await EllaProvisioningRepository.create(firestore_db=_firestore_db))
 
 
+async def _retained_receipt(uid: str, target_schema_version: str) -> Optional[dict[str, Any]]:
+    """Return a public receipt only for an already-routed retained account."""
+    try:
+        repository = await EllaProvisioningRepository.create()
+        if await repository.has_active_retained_runtime(uid):
+            logger.info("Using retained-account onboarding compatibility for uid=%s", uid)
+            return retained_compatibility_receipt(target_schema_version)
+    except Exception as exc:
+        logger.exception("Retained-account onboarding lookup failed for uid=%s", uid)
+        raise HTTPException(status_code=503, detail={"code": "provisioning_unavailable"}) from exc
+    return None
+
+
 def _payload_dict(payload: OnboardingEnsureRequest) -> dict[str, Any]:
     if hasattr(payload, "model_dump"):
         return payload.model_dump(mode="json")
@@ -90,10 +104,13 @@ async def ensure_onboarding(
     response: Response,
     uid: str = Depends(auth.get_current_user_uid),
 ) -> dict[str, Any]:
-    if not provisioning_enabled(uid):
-        raise HTTPException(status_code=503, detail={"code": "provisioning_disabled"})
     if not SCHEMA_VERSION_RE.fullmatch(payload.target_schema_version):
         raise HTTPException(status_code=400, detail={"code": "invalid_target_schema_version"})
+    if not provisioning_enabled(uid):
+        receipt = await _retained_receipt(uid, payload.target_schema_version)
+        if receipt:
+            return receipt
+        raise HTTPException(status_code=503, detail={"code": "provisioning_disabled"})
     identity = _verified_identity(uid, payload)
     coordinator = await _coordinator()
     try:
@@ -127,10 +144,13 @@ async def onboarding_status(
     target_schema_version: str = DEFAULT_TARGET_SCHEMA_VERSION,
     uid: str = Depends(auth.get_current_user_uid),
 ) -> dict[str, Any]:
-    if not provisioning_enabled(uid):
-        raise HTTPException(status_code=503, detail={"code": "provisioning_disabled"})
     if not SCHEMA_VERSION_RE.fullmatch(target_schema_version):
         raise HTTPException(status_code=400, detail={"code": "invalid_target_schema_version"})
+    if not provisioning_enabled(uid):
+        receipt = await _retained_receipt(uid, target_schema_version)
+        if receipt:
+            return receipt
+        raise HTTPException(status_code=503, detail={"code": "provisioning_disabled"})
     repository = await EllaProvisioningRepository.create()
     try:
         await repository.assert_schema_ready()

--- a/backend/ella/routers/onboarding.py
+++ b/backend/ella/routers/onboarding.py
@@ -80,6 +80,8 @@ async def _coordinator() -> ProvisioningCoordinator:
 
 async def _retained_receipt(uid: str, target_schema_version: str) -> Optional[dict[str, Any]]:
     """Return a public receipt only for an already-routed retained account."""
+    if target_schema_version != DEFAULT_TARGET_SCHEMA_VERSION:
+        return None
     try:
         repository = await EllaProvisioningRepository.create()
         if await repository.has_active_retained_runtime(uid):

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -33,6 +33,7 @@ TRUE_VALUES = {"1", "true", "yes", "on"}
 DEFAULT_PROVISION_TIMEOUT_SECONDS = 180.0
 MIN_PROVISION_TIMEOUT_SECONDS = 30.0
 MAX_PROVISION_TIMEOUT_SECONDS = 300.0
+RETAINED_COMPATIBILITY_POLICY_REVISION = "retained-compatibility-v1"
 
 
 class ProvisioningError(RuntimeError):
@@ -133,6 +134,23 @@ def public_receipt(job: dict[str, Any], binding: Optional[dict[str, Any]] = None
     if job.get("error_code"):
         result["error_code"] = job["error_code"]
     return result
+
+
+def retained_compatibility_receipt(target_schema_version: str) -> dict[str, Any]:
+    """Describe an existing routed account without exposing legacy runtime details."""
+    return {
+        "job_id": "retained-compatibility",
+        "state": "ready",
+        "stage": "ready",
+        "retryable": False,
+        "retry_after_ms": None,
+        "support_code": "",
+        "target_schema_version": target_schema_version,
+        "binding_state": "active",
+        "binding_revision": 1,
+        "effective_policy_revision": RETAINED_COMPATIBILITY_POLICY_REVISION,
+        "compatibility_mode": "retained",
+    }
 
 
 def validate_gateway_credential_ref(credential_ref: Optional[str]) -> str:

--- a/backend/tests/unit/test_ella_onboarding_contract.py
+++ b/backend/tests/unit/test_ella_onboarding_contract.py
@@ -97,6 +97,11 @@ def test_disabled_endpoint_returns_without_touching_database(monkeypatch):
     monkeypatch.delenv("ELLA_HERMES_PROVISIONING_ENABLED_UIDS", raising=False)
     monkeypatch.setattr(onboarding, "_coordinator", forbidden_coordinator)
 
+    async def no_retained_receipt(_uid, _target_schema_version):
+        return None
+
+    monkeypatch.setattr(onboarding, "_retained_receipt", no_retained_receipt)
+
     with pytest.raises(onboarding.HTTPException) as error:
         asyncio.run(
             onboarding.ensure_onboarding(
@@ -108,6 +113,78 @@ def test_disabled_endpoint_returns_without_touching_database(monkeypatch):
         )
     assert error.value.status_code == 503
     assert error.value.detail == {"code": "provisioning_disabled"}
+
+
+def test_disabled_endpoint_allows_existing_retained_account_without_provisioning(monkeypatch):
+    async def forbidden_coordinator():
+        raise AssertionError("retained onboarding must not start Hermes provisioning")
+
+    async def retained_receipt(uid, target_schema_version):
+        assert uid == "retained-user"
+        assert target_schema_version == "hermes-user-v1"
+        return {
+            "state": "ready",
+            "stage": "ready",
+            "binding_state": "active",
+            "binding_revision": 1,
+            "effective_policy_revision": "retained-compatibility-v1",
+        }
+
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
+    monkeypatch.delenv("ELLA_HERMES_PROVISIONING_ENABLED_UIDS", raising=False)
+    monkeypatch.setattr(onboarding, "_coordinator", forbidden_coordinator)
+    monkeypatch.setattr(onboarding, "_retained_receipt", retained_receipt)
+    monkeypatch.setattr(
+        onboarding.auth,
+        "get_user",
+        lambda _uid: (_ for _ in ()).throw(AssertionError("retained compatibility must not query Firebase")),
+    )
+
+    result = asyncio.run(
+        onboarding.ensure_onboarding(
+            onboarding.OnboardingEnsureRequest(),
+            BackgroundTasks(),
+            Response(),
+            uid="retained-user",
+        )
+    )
+
+    assert result["state"] == "ready"
+    assert result["binding_state"] == "active"
+
+
+def test_disabled_status_allows_existing_retained_account(monkeypatch):
+    async def retained_receipt(uid, target_schema_version):
+        assert uid == "retained-user"
+        assert target_schema_version == "hermes-user-v1"
+        return {"state": "ready", "binding_state": "active", "binding_revision": 1}
+
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
+    monkeypatch.delenv("ELLA_HERMES_PROVISIONING_ENABLED_UIDS", raising=False)
+    monkeypatch.setattr(onboarding, "_retained_receipt", retained_receipt)
+
+    result = asyncio.run(onboarding.onboarding_status(uid="retained-user"))
+
+    assert result == {"state": "ready", "binding_state": "active", "binding_revision": 1}
+
+
+def test_retained_receipt_uses_authenticated_uid_and_public_contract(monkeypatch):
+    class FakeRepository:
+        async def has_active_retained_runtime(self, uid):
+            assert uid == "retained-user"
+            return True
+
+    async def fake_create(**_kwargs):
+        return FakeRepository()
+
+    monkeypatch.setattr(onboarding.EllaProvisioningRepository, "create", fake_create)
+
+    result = asyncio.run(onboarding._retained_receipt("retained-user", "hermes-user-v1"))
+
+    assert result["state"] == "ready"
+    assert result["binding_state"] == "active"
+    assert result["binding_revision"] > 0
+    assert result["effective_policy_revision"] == "retained-compatibility-v1"
 
 
 def test_uid_allowlist_canaries_onboarding_without_global_cutover(monkeypatch):

--- a/backend/tests/unit/test_ella_onboarding_contract.py
+++ b/backend/tests/unit/test_ella_onboarding_contract.py
@@ -187,6 +187,39 @@ def test_retained_receipt_uses_authenticated_uid_and_public_contract(monkeypatch
     assert result["effective_policy_revision"] == "retained-compatibility-v1"
 
 
+def test_retained_receipt_rejects_unknown_schema_without_database_lookup(monkeypatch):
+    async def forbidden_create(**_kwargs):
+        raise AssertionError("future schemas must not use retained compatibility")
+
+    monkeypatch.setattr(onboarding.EllaProvisioningRepository, "create", forbidden_create)
+
+    result = asyncio.run(onboarding._retained_receipt("retained-user", "hermes-user-v2"))
+
+    assert result is None
+
+
+def test_disabled_endpoint_does_not_claim_future_schema_for_retained_account(monkeypatch):
+    async def forbidden_create(**_kwargs):
+        raise AssertionError("future schemas must not use retained compatibility")
+
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
+    monkeypatch.delenv("ELLA_HERMES_PROVISIONING_ENABLED_UIDS", raising=False)
+    monkeypatch.setattr(onboarding.EllaProvisioningRepository, "create", forbidden_create)
+
+    with pytest.raises(onboarding.HTTPException) as error:
+        asyncio.run(
+            onboarding.ensure_onboarding(
+                onboarding.OnboardingEnsureRequest(target_schema_version="hermes-user-v2"),
+                BackgroundTasks(),
+                Response(),
+                uid="retained-user",
+            )
+        )
+
+    assert error.value.status_code == 503
+    assert error.value.detail == {"code": "provisioning_disabled"}
+
+
 def test_uid_allowlist_canaries_onboarding_without_global_cutover(monkeypatch):
     captured = {}
 

--- a/backend/tests/unit/test_ella_onboarding_contract.py
+++ b/backend/tests/unit/test_ella_onboarding_contract.py
@@ -177,6 +177,7 @@ def test_retained_receipt_uses_authenticated_uid_and_public_contract(monkeypatch
     async def fake_create(**_kwargs):
         return FakeRepository()
 
+    monkeypatch.setattr(onboarding, "runtime_bindings_enabled", lambda _uid: False)
     monkeypatch.setattr(onboarding.EllaProvisioningRepository, "create", fake_create)
 
     result = asyncio.run(onboarding._retained_receipt("retained-user", "hermes-user-v1"))
@@ -194,6 +195,18 @@ def test_retained_receipt_rejects_unknown_schema_without_database_lookup(monkeyp
     monkeypatch.setattr(onboarding.EllaProvisioningRepository, "create", forbidden_create)
 
     result = asyncio.run(onboarding._retained_receipt("retained-user", "hermes-user-v2"))
+
+    assert result is None
+
+
+def test_retained_receipt_rejects_uid_in_isolated_runtime_cutover(monkeypatch):
+    async def forbidden_create(**_kwargs):
+        raise AssertionError("isolated runtime cutover must not use retained compatibility")
+
+    monkeypatch.setattr(onboarding, "runtime_bindings_enabled", lambda uid: uid == "cutover-user")
+    monkeypatch.setattr(onboarding.EllaProvisioningRepository, "create", forbidden_create)
+
+    result = asyncio.run(onboarding._retained_receipt("cutover-user", "hermes-user-v1"))
 
     assert result is None
 

--- a/backend/tests/unit/test_ella_provisioning_repository.py
+++ b/backend/tests/unit/test_ella_provisioning_repository.py
@@ -47,6 +47,16 @@ class _Pool:
         return _AsyncContext(self.connection)
 
 
+class _LookupPool:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    async def fetchrow(self, query, *args):
+        self.calls.append((query, args))
+        return self.result
+
+
 def test_fresh_identity_insert_casts_jsonb_parameters():
     connection = _Connection()
     repository = EllaProvisioningRepository(_Pool(connection))
@@ -70,3 +80,21 @@ def test_fresh_identity_insert_casts_jsonb_parameters():
     }
     assert isinstance(result["id"], uuid.UUID)
     assert len(connection.queries) == 3
+
+
+def test_retained_runtime_requires_active_owned_cluster_with_agent_id():
+    pool = _LookupPool({"eligible": True})
+    repository = EllaProvisioningRepository(pool)
+
+    assert asyncio.run(repository.has_active_retained_runtime("firebase-user-1")) is True
+    query, args = pool.calls[0]
+    assert "u.status = 'ACTIVE'" in query
+    assert "ac.status = 'ACTIVE'" in query
+    assert "ac.agents->>'userAgentId'" in query
+    assert args == ("firebase-user-1",)
+
+
+def test_retained_runtime_rejects_unknown_or_inactive_account():
+    repository = EllaProvisioningRepository(_LookupPool({"eligible": False}))
+
+    assert asyncio.run(repository.has_active_retained_runtime("unknown-user")) is False

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -15,6 +15,7 @@ from ella.services.provisioning import (
     provision_timeout_seconds,
     public_receipt,
     provisioning_enabled,
+    retained_compatibility_receipt,
     resolve_gateway_credential,
     rollout_enabled,
     stable_payload_hash,
@@ -325,6 +326,19 @@ def test_public_receipt_does_not_expose_runtime_secrets():
     assert "TOP_SECRET" not in serialized
     assert "100.76.138.56" not in serialized
     assert "/private/workspace" not in serialized
+
+
+def test_retained_compatibility_receipt_is_operational_and_credential_free():
+    receipt = retained_compatibility_receipt("hermes-user-v1")
+
+    assert receipt["state"] == "ready"
+    assert receipt["binding_state"] == "active"
+    assert receipt["binding_revision"] > 0
+    assert receipt["effective_policy_revision"]
+    assert receipt["compatibility_mode"] == "retained"
+    serialized = str(receipt).lower()
+    for forbidden in ("credential", "token", "gateway", "workspace", "http"):
+        assert forbidden not in serialized
 
 
 def test_gateway_credentials_are_server_env_references_only(monkeypatch):


### PR DESCRIPTION
## Root cause

TestFlight 1.0.525 (797) correctly requires an operational onboarding receipt before Home, but the backend returned `provisioning_disabled` before checking whether the authenticated UID already owned a healthy retained runtime. This blocked existing production users while global Hermes rollout remained safely off.

## Change

- Return a credential-free operational compatibility receipt only when the authenticated UID owns an `ACTIVE` user row and `ACTIVE` retained `agent_clusters` row with a non-empty `userAgentId`.
- Apply the same contract to onboarding `ensure` and `status`.
- Keep fresh, unknown, inactive, and unallowlisted users fail-closed with HTTP 503.
- Do not provision/migrate Hermes, change `plato-eval`, expose legacy runtime details, or change rollout/allowlist flags.

## Validation

- `pytest -q tests/unit/test_ella_onboarding_contract.py tests/unit/test_ella_provisioning_service.py tests/unit/test_ella_provisioning_repository.py` (`47 passed`)
- `backend/test.sh` (all standard smoke groups passed)
- `git diff --check`
- `npx gitnexus analyze`

Retained-user unblock for ellaaicare/ella-ai#1092. Fresh two-account rollout validation remains open. Related production cutover: ellaaicare/ella-ai#1063.