### PR TITLE
Show structured Ella enrichment badge

### DIFF
--- a/app/lib/backend/schema/conversation.dart
+++ b/app/lib/backend/schema/conversation.dart
@@ -171,6 +171,38 @@ class AudioFile {
       };
 }
 
+class ConversationSummaryVersion {
+  final String id;
+  final String source;
+  final String kind;
+  final bool isActive;
+  final Map<String, dynamic> _payload;
+
+  ConversationSummaryVersion({
+    required this.id,
+    required this.source,
+    required this.kind,
+    this.isActive = false,
+    Map<String, dynamic> payload = const {},
+  }) : _payload = payload;
+
+  factory ConversationSummaryVersion.fromJson(Map<String, dynamic> json) => ConversationSummaryVersion(
+        id: json['id']?.toString() ?? '',
+        source: json['source']?.toString() ?? '',
+        kind: json['kind']?.toString() ?? '',
+        isActive: json['is_active'] == true,
+        payload: json,
+      );
+
+  Map<String, dynamic> toJson() => {
+        ..._payload,
+        'id': id,
+        'source': source,
+        'kind': kind,
+        'is_active': isActive,
+      };
+}
+
 class ServerConversation {
   final String id;
   final DateTime createdAt;
@@ -193,6 +225,8 @@ class ServerConversation {
   final List<String> ellaTags;
   final Map<String, dynamic>? ellaSignal;
   final Map<String, dynamic>? enrichmentState;
+  final List<ConversationSummaryVersion> summaryVersions;
+  final String? activeSummaryVersionId;
   final String? processingRetryEnrichmentVectorStatus;
   final String? processingError;
   final DateTime? processingErrorAt;
@@ -212,6 +246,23 @@ class ServerConversation {
       (enrichmentState?['status'] == 'failed' ||
           enrichmentState?['canonical_status'] == 'failed' ||
           processingRetryEnrichmentVectorStatus == 'failed');
+
+  ConversationSummaryVersion? get activeSummaryVersion {
+    final activeId = activeSummaryVersionId;
+    if (activeId != null && activeId.isNotEmpty) {
+      return summaryVersions.firstWhereOrNull((version) => version.id == activeId);
+    }
+    return summaryVersions.lastWhereOrNull((version) => version.isActive);
+  }
+
+  bool get isEllaEnriched {
+    final version = activeSummaryVersion;
+    final state = enrichmentState;
+    return version?.kind == 'hermes_enriched' &&
+        version?.source == 'hermes_parallel' &&
+        state?['status'] == 'writeback_applied' &&
+        state?['pending'] != true;
+  }
 
   String? folderId;
 
@@ -239,6 +290,8 @@ class ServerConversation {
     this.ellaTags = const [],
     this.ellaSignal,
     this.enrichmentState,
+    this.summaryVersions = const [],
+    this.activeSummaryVersionId,
     this.processingRetryEnrichmentVectorStatus,
     this.processingError,
     this.processingErrorAt,
@@ -249,6 +302,7 @@ class ServerConversation {
   });
 
   factory ServerConversation.fromJson(Map<String, dynamic> json) {
+    final summaryVersions = json['summary_versions'];
     return ServerConversation(
       id: json['id'],
       createdAt: DateTime.parse(json['created_at']).toLocal(),
@@ -277,6 +331,13 @@ class ServerConversation {
       ellaTags: ((json['ella_tags'] ?? []) as List<dynamic>).map((tag) => tag.toString()).toList(),
       ellaSignal: json['ella_signal'] is Map ? Map<String, dynamic>.from(json['ella_signal']) : null,
       enrichmentState: json['enrichment_state'] is Map ? Map<String, dynamic>.from(json['enrichment_state']) : null,
+      summaryVersions: summaryVersions is List
+          ? summaryVersions
+              .whereType<Map>()
+              .map((version) => ConversationSummaryVersion.fromJson(Map<String, dynamic>.from(version)))
+              .toList()
+          : const [],
+      activeSummaryVersionId: json['active_summary_version_id']?.toString(),
       processingRetryEnrichmentVectorStatus: json['processing_retry_enrichment_vector_status'],
       processingError: json['processing_error'],
       processingErrorAt:
@@ -311,6 +372,8 @@ class ServerConversation {
       'ella_tags': ellaTags,
       'ella_signal': ellaSignal,
       'enrichment_state': enrichmentState,
+      'summary_versions': summaryVersions.map((version) => version.toJson()).toList(),
+      'active_summary_version_id': activeSummaryVersionId,
       'processing_retry_enrichment_vector_status': processingRetryEnrichmentVectorStatus,
       'processing_error': processingError,
       'processing_error_at': processingErrorAt?.toUtc().toIso8601String(),

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10204,5 +10204,13 @@
   "retryNow": "Retry now",
   "@retryNow": {
     "description": "Confirmation action for retrying a failed summary"
+  },
+  "conversationEllaEnrichedBadge": "Ella",
+  "@conversationEllaEnrichedBadge": {
+    "description": "Compact badge text for a memory summary enriched by Ella"
+  },
+  "conversationEllaEnrichedLabel": "Summary enriched by Ella",
+  "@conversationEllaEnrichedLabel": {
+    "description": "Accessible label and tooltip for the Ella-enriched memory badge"
   }
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -16052,6 +16052,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Retry now'**
   String get retryNow;
+
+  /// Compact badge text for a memory summary enriched by Ella
+  ///
+  /// In en, this message translates to:
+  /// **'Ella'**
+  String get conversationEllaEnrichedBadge;
+
+  /// Accessible label and tooltip for the Ella-enriched memory badge
+  ///
+  /// In en, this message translates to:
+  /// **'Summary enriched by Ella'**
+  String get conversationEllaEnrichedLabel;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8548,4 +8548,10 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8636,4 +8636,10 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8652,4 +8652,10 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8599,4 +8599,10 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8588,4 +8588,10 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8670,4 +8670,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8661,4 +8661,10 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8601,4 +8601,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8618,4 +8618,10 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8603,4 +8603,10 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8602,4 +8602,10 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8677,4 +8677,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8584,4 +8584,10 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8641,4 +8641,10 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8616,4 +8616,10 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8653,4 +8653,10 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8470,4 +8470,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8472,4 +8472,10 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8609,4 +8609,10 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8621,4 +8621,10 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8627,4 +8627,10 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8629,4 +8629,10 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8599,4 +8599,10 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8622,4 +8622,10 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8604,4 +8604,10 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8642,4 +8642,10 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8629,4 +8629,10 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8594,4 +8594,10 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8609,4 +8609,10 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8566,4 +8566,10 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8617,4 +8617,10 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8616,4 +8616,10 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8606,4 +8606,10 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8460,4 +8460,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get retryNow => 'Retry now';
+
+  @override
+  String get conversationEllaEnrichedBadge => 'Ella';
+
+  @override
+  String get conversationEllaEnrichedLabel => 'Summary enriched by Ella';
 }

--- a/app/lib/pages/conversations/widgets/conversation_list_item.dart
+++ b/app/lib/pages/conversations/widgets/conversation_list_item.dart
@@ -9,8 +9,10 @@ import 'package:provider/provider.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/ella/ella_theme.dart';
 import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
 import 'package:omi/pages/conversation_detail/page.dart';
+import 'package:omi/pages/conversations/widgets/ella_enriched_badge.dart';
 import 'package:omi/pages/settings/usage_page.dart';
 import 'package:omi/providers/connectivity_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
@@ -21,7 +23,6 @@ import 'package:omi/utils/other/time_utils.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 import 'package:omi/widgets/dialog.dart';
 import 'package:omi/widgets/extensions/string.dart';
-import 'package:omi/ella/ella_theme.dart';
 
 class ConversationListItem extends StatefulWidget {
   final bool isFromOnboarding;
@@ -285,14 +286,21 @@ class _ConversationListItemState extends State<ConversationListItem> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        widget.conversation.discarded
-                            ? widget.conversation.getTranscript(maxCount: 100)
-                            : widget.conversation.structured.title.decodeString,
-                        style: Theme.of(context).textTheme.titleMedium,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
+                      if (widget.conversation.discarded)
+                        Text(
+                          widget.conversation.getTranscript(maxCount: 100),
+                          style: Theme.of(context).textTheme.titleMedium,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        )
+                      else
+                        ConversationTitleWithEllaBadge(
+                          conversation: widget.conversation,
+                          title: widget.conversation.structured.title.decodeString,
+                          style: Theme.of(context).textTheme.titleMedium,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
                       const SizedBox(height: 8),
                       // Duration and time below title (or New status)
                       isNew
@@ -407,8 +415,9 @@ class _ConversationListItemState extends State<ConversationListItem> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          widget.conversation.structured.title.decodeString,
+        ConversationTitleWithEllaBadge(
+          conversation: widget.conversation,
+          title: widget.conversation.structured.title.decodeString,
           style: Theme.of(context).textTheme.titleLarge,
         ),
       ],

--- a/app/lib/pages/conversations/widgets/ella_enriched_badge.dart
+++ b/app/lib/pages/conversations/widgets/ella_enriched_badge.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+
+class ConversationTitleWithEllaBadge extends StatelessWidget {
+  const ConversationTitleWithEllaBadge({
+    super.key,
+    required this.conversation,
+    required this.title,
+    this.style,
+    this.maxLines,
+    this.overflow,
+  });
+
+  final ServerConversation conversation;
+  final String title;
+  final TextStyle? style;
+  final int? maxLines;
+  final TextOverflow? overflow;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      key: ValueKey('conversation-title-${conversation.id}'),
+      children: [
+        Expanded(
+          child: Text(title, style: style, maxLines: maxLines, overflow: overflow),
+        ),
+        if (conversation.isEllaEnriched) ...[
+          const SizedBox(width: 8),
+          _EllaEnrichedBadge(conversationId: conversation.id),
+        ],
+      ],
+    );
+  }
+}
+
+class _EllaEnrichedBadge extends StatelessWidget {
+  const _EllaEnrichedBadge({required this.conversationId});
+
+  final String conversationId;
+
+  @override
+  Widget build(BuildContext context) {
+    final accessibilityLabel = context.l10n.conversationEllaEnrichedLabel;
+    return Tooltip(
+      message: accessibilityLabel,
+      child: Semantics(
+        key: ValueKey('ella-enriched-badge-$conversationId'),
+        container: true,
+        label: accessibilityLabel,
+        child: ExcludeSemantics(
+          child: Container(
+            height: 20,
+            padding: const EdgeInsets.symmetric(horizontal: 6),
+            decoration: BoxDecoration(
+              color: EllaColors.primarySubtle,
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(color: EllaColors.primaryLight),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.auto_awesome_rounded, size: 11, color: EllaColors.primaryDark),
+                const SizedBox(width: 3),
+                Text(
+                  context.l10n.conversationEllaEnrichedBadge,
+                  style: const TextStyle(
+                    color: EllaColors.primaryDark,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    height: 1,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/backend/schema/conversation_test.dart
+++ b/app/test/backend/schema/conversation_test.dart
@@ -153,4 +153,76 @@ void main() {
     expect(vectorFailure.isRetryableEnrichmentFailure, isTrue);
     expect(activeWrite.isRetryableEnrichmentFailure, isFalse);
   });
+
+  group('structured Ella enrichment', () {
+    ServerConversation conversation({
+      required String activeKind,
+      required String activeSource,
+      required Map<String, dynamic> enrichmentState,
+      String title = 'A structured title',
+    }) {
+      return ServerConversation.fromJson({
+        'id': 'enrichment-conversation',
+        'created_at': '2026-07-21T08:00:00Z',
+        'structured': {
+          'title': title,
+          'overview': 'Overview',
+          'emoji': '',
+          'category': 'other',
+          'action_items': [],
+          'events': [],
+        },
+        'summary_versions': [
+          {'id': 'generic-v1', 'source': 'omi', 'kind': 'generic', 'is_active': false},
+          {
+            'id': 'active-v2',
+            'source': activeSource,
+            'kind': activeKind,
+            'is_active': true,
+            'title': 'Preserved version title',
+          },
+        ],
+        'active_summary_version_id': 'active-v2',
+        'enrichment_state': enrichmentState,
+      });
+    }
+
+    test('uses the active Hermes version and applied state instead of title decoration', () {
+      final enriched = conversation(
+        activeKind: 'hermes_enriched',
+        activeSource: 'hermes_parallel',
+        enrichmentState: {'status': 'writeback_applied', 'pending': false, 'canonical_status': 'unconfirmed'},
+      );
+      final wingOnly = conversation(
+        activeKind: 'generic',
+        activeSource: 'omi',
+        enrichmentState: const {},
+        title: '\u{1FABD} Legacy title marker',
+      );
+
+      expect(enriched.isEllaEnriched, isTrue);
+      expect(enriched.activeSummaryVersion?.id, 'active-v2');
+      expect(wingOnly.isEllaEnriched, isFalse);
+      expect(enriched.toJson()['active_summary_version_id'], 'active-v2');
+      expect(enriched.toJson()['summary_versions'][1]['title'], 'Preserved version title');
+    });
+
+    test('does not badge generic, pending, or failed enrichment', () {
+      final generic = conversation(activeKind: 'generic', activeSource: 'omi', enrichmentState: const {});
+      final pending = conversation(
+        activeKind: 'hermes_enriched',
+        activeSource: 'hermes_parallel',
+        enrichmentState: {'status': 'writeback_pending_canonical', 'pending': true},
+      );
+      final failed = conversation(
+        activeKind: 'hermes_enriched',
+        activeSource: 'hermes_parallel',
+        enrichmentState: {'status': 'failed', 'pending': false},
+      );
+
+      expect(generic.isEllaEnriched, isFalse);
+      expect(pending.isEllaEnriched, isFalse);
+      expect(failed.isEllaEnriched, isFalse);
+    });
+  });
 }

--- a/app/test/widgets/ella_enriched_badge_test.dart
+++ b/app/test/widgets/ella_enriched_badge_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/conversations/widgets/ella_enriched_badge.dart';
+
+ServerConversation _conversation(String id, {required String state, bool generic = false}) {
+  return ServerConversation(
+    id: id,
+    createdAt: DateTime.utc(2026, 7, 21),
+    structured: Structured('A long memory title that must remain on one line', 'Overview'),
+    summaryVersions: [
+      ConversationSummaryVersion(
+        id: 'active-v2',
+        source: generic ? 'omi' : 'hermes_parallel',
+        kind: generic ? 'generic' : 'hermes_enriched',
+        isActive: true,
+      ),
+    ],
+    activeSummaryVersionId: 'active-v2',
+    enrichmentState: {'status': state, 'pending': state == 'writeback_pending_canonical'},
+  );
+}
+
+Widget _app(List<ServerConversation> conversations) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: SizedBox(
+        width: 240,
+        child: Column(
+          children: [
+            for (final conversation in conversations)
+              ConversationTitleWithEllaBadge(
+                conversation: conversation,
+                title: conversation.structured.title,
+                style: const TextStyle(fontSize: 16, height: 1.5),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('shows an accessible badge only for applied structured Ella enrichment', (tester) async {
+    final conversations = [
+      _conversation('generic', state: 'writeback_applied', generic: true),
+      _conversation('pending', state: 'writeback_pending_canonical'),
+      _conversation('failed', state: 'failed'),
+      _conversation('applied', state: 'writeback_applied'),
+    ];
+
+    await tester.pumpWidget(_app(conversations));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('ella-enriched-badge-generic')), findsNothing);
+    expect(find.byKey(const ValueKey('ella-enriched-badge-pending')), findsNothing);
+    expect(find.byKey(const ValueKey('ella-enriched-badge-failed')), findsNothing);
+    expect(find.byKey(const ValueKey('ella-enriched-badge-applied')), findsOneWidget);
+    expect(find.bySemanticsLabel('Summary enriched by Ella'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+
+    final heights = conversations
+        .map((conversation) => tester.getSize(find.byKey(ValueKey('conversation-title-${conversation.id}'))).height)
+        .toSet();
+    expect(heights, hasLength(1));
+  });
+}


### PR DESCRIPTION
## Summary
- retain `summary_versions` and `active_summary_version_id` in the iOS conversation model
- derive Ella-enriched state only from the active `hermes_enriched` / `hermes_parallel` version with `writeback_applied` state
- show a compact localized, accessible Ella badge beside Recent Memories titles without changing failed/pending retry UI
- keep legacy title decoration backward-compatible but never use it to derive state

## Validation
- `./app/test.sh` (capture provider 18/18, transcript widgets 3/3)
- `flutter test --no-pub test/backend/schema/conversation_test.dart test/widgets/ella_enriched_badge_test.dart` (8/8)
- focused analyzer for the new badge/widget test: no issues
- broader focused analyzer: no errors; 9 pre-existing info-level lints in touched legacy files
- narrow-width widget coverage verifies generic, pending, failed, and applied rows have no vertical layout shift

Refs ellaaicare/ella-ai#1094
