### PR TITLE
Fix native V2V provider routing and explicit fallback

### DIFF
--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -20,12 +20,14 @@ import 'package:omi/ella/ella_theme.dart';
 import 'package:omi/ella/services/elevenlabs_tts.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/ella/services/v2v_client.dart';
+import 'package:omi/ella/widgets/v2v_fallback_dialog.dart';
 import 'package:omi/ella/widgets/ella_voice_orb.dart';
 import 'package:omi/ella/widgets/ella_breathing_dot.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/home_provider.dart';
 import 'package:omi/providers/message_provider.dart';
 import 'package:omi/utils/enums.dart';
+import 'package:omi/utils/l10n_extensions.dart';
 
 /// Voice-to-voice chat page for Ella.
 ///
@@ -71,6 +73,8 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   /// V2V client for WebSocket-based voice-to-voice mode
   V2VClient? _v2vClient;
   bool _isV2VMode = false;
+  String _activeV2VProvider = '';
+  bool _usingElevenLabsFallback = false;
 
   /// Track whether we've injected chat messages for the current V2V turn
   bool _v2vTurnInjected = false;
@@ -93,11 +97,12 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   );
 
   /// Check if current TTS provider is a V2V provider.
-  static bool _isV2VProvider(String provider) => provider == 'grok-voice' || provider == 'gemini-live';
+  static bool _isV2VProvider(String provider) => V2VClient.isSessionProvider(provider);
 
-  String get _effectiveVoiceProvider => isHermesProvisioningGateEnabled
-      ? SharedPreferencesUtil().ellaProvisionedVoiceMode
-      : SharedPreferencesUtil().ttsProvider;
+  String get _effectiveVoiceProvider => V2VClient.resolveEffectiveProvider(
+        provisionedProvider: isHermesProvisioningGateEnabled ? SharedPreferencesUtil().ellaProvisionedVoiceMode : '',
+        selectedProvider: SharedPreferencesUtil().ttsProvider,
+      );
 
   @override
   bool get wantKeepAlive => true;
@@ -471,8 +476,11 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
   Future<void> _startV2V(String provider) async {
     if (!SharedPreferencesUtil().aiConsentAccepted) return;
+    provider = V2VClient.normalizeProvider(provider);
+    final providerName = localizedV2VProviderName(context, provider);
     debugPrint('[VoiceChat] Starting V2V mode with provider: $provider');
     _isV2VMode = true;
+    _usingElevenLabsFallback = false;
 
     // Stop any existing mic recording from CaptureProvider
     if (mounted) {
@@ -488,7 +496,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
     setState(() {
       _orbState = VoiceOrbState.processing;
-      _statusText = 'Connecting...';
+      _statusText = context.l10n.voiceV2vConnecting(providerName);
       _audioLevel = 0.0;
     });
 
@@ -513,21 +521,53 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       },
     );
 
-    final success = await _v2vClient!.connect(provider: provider);
+    final receipt = await _v2vClient!.connect(provider: provider);
     if (!mounted) return;
 
-    if (!success) {
-      debugPrint('[VoiceChat] V2V connect failed, falling back to STT mode');
+    if (!receipt.connected) {
+      debugPrint('[VoiceChat] V2V connect failed: ${receipt.toDebugFields()}');
+      await _v2vClient?.disconnect();
+      if (!mounted) return;
       _isV2VMode = false;
       _v2vClient = null;
-      // Fall back to standard STT→LLM→TTS
-      _startListening();
+      _voiceModeActive = false;
+      setState(() {
+        _orbState = VoiceOrbState.idle;
+        _statusText = receipt.safeDetail;
+        _audioLevel = 0.0;
+      });
+
+      final choice = await showV2VFallbackDialog(context, receipt);
+      if (!mounted) return;
+      switch (choice) {
+        case V2VFailureChoice.retry:
+          _voiceModeActive = true;
+          await _startV2V(provider);
+          break;
+        case V2VFailureChoice.useElevenLabs:
+          _usingElevenLabsFallback = true;
+          _voiceModeActive = true;
+          setState(() {
+            _statusText = context.l10n.voiceElevenLabsFallbackActive;
+          });
+          await _startListening();
+          break;
+        case V2VFailureChoice.stop:
+          _usingElevenLabsFallback = false;
+          _activeV2VProvider = '';
+          setState(() {
+            _statusText = context.l10n.voiceTapToTalk;
+          });
+          break;
+      }
       return;
     }
 
+    _activeV2VProvider = providerName;
+    _usingElevenLabsFallback = false;
     setState(() {
       _orbState = VoiceOrbState.listening;
-      _statusText = 'V2V Active — Tap to Stop';
+      _statusText = context.l10n.voiceV2vActive(providerName);
     });
   }
 
@@ -535,6 +575,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     debugPrint('[VoiceChat] Stopping V2V mode');
     await _v2vClient?.disconnect();
     _v2vClient = null;
+    _activeV2VProvider = '';
     _pauseVoiceMode();
   }
 
@@ -578,7 +619,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
         if (_isV2VMode) {
           setState(() {
             _orbState = VoiceOrbState.listening;
-            _statusText = 'V2V Active — Tap to Stop';
+            _statusText = context.l10n.voiceV2vActive(_activeV2VProvider);
           });
         }
         break;
@@ -608,6 +649,9 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
         setState(() {
           _statusText = event.text ?? '';
         });
+        break;
+      case 'connection_receipt':
+        // The connect caller owns the explicit success/failure UI.
         break;
       case 'error':
         debugPrint('[VoiceChat] V2V error: ${event.text}');
@@ -912,7 +956,13 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
                       const SizedBox(width: 10),
                     ],
                     Text(
-                      _orbState == VoiceOrbState.listening ? 'Listening' : _statusText,
+                      _orbState == VoiceOrbState.listening
+                          ? _usingElevenLabsFallback
+                              ? context.l10n.voiceElevenLabsFallbackActive
+                              : _isV2VMode && _activeV2VProvider.isNotEmpty
+                                  ? context.l10n.voiceV2vActive(_activeV2VProvider)
+                                  : context.l10n.voiceListening
+                          : _statusText,
                       style: EllaTextStyles.body.copyWith(fontWeight: FontWeight.w600),
                       textAlign: TextAlign.center,
                     ),

--- a/app/lib/ella/services/v2v_client.dart
+++ b/app/lib/ella/services/v2v_client.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:audio_session/audio_session.dart';
-import 'package:just_audio/just_audio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_sound/flutter_sound.dart';
 import 'package:record/record.dart';
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -13,6 +13,7 @@ import 'package:omi/backend/http/shared.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/env/env.dart';
+import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 
 /// JSON event from the V2V proxy WebSocket.
@@ -23,25 +24,91 @@ class V2VEvent {
   V2VEvent({required this.type, this.text});
 }
 
+enum V2VConnectionStage { consent, identity, providerRegistry, session, audioSession, websocket, microphone, connected }
+
+/// Redacted connection result safe to show in UI and persist in debug logs.
+/// It intentionally excludes session tokens, endpoint URLs, and response bodies.
+class V2VConnectionReceipt {
+  const V2VConnectionReceipt({
+    required this.connected,
+    required this.provider,
+    required this.stage,
+    this.voiceMode = '',
+    this.httpStatus,
+    this.errorCode = '',
+  });
+
+  final bool connected;
+  final String provider;
+  final String voiceMode;
+  final V2VConnectionStage stage;
+  final int? httpStatus;
+  final String errorCode;
+
+  String get safeDetail {
+    final parts = <String>[
+      if (httpStatus != null) 'HTTP $httpStatus',
+      if (errorCode.isNotEmpty) errorCode,
+    ];
+    return parts.isEmpty ? stage.name : parts.join(' · ');
+  }
+
+  Map<String, Object?> toDebugFields() => {
+        'connected': connected,
+        'provider': provider,
+        'voice_mode': voiceMode,
+        'stage': stage.name,
+        if (httpStatus != null) 'http_status': httpStatus,
+        if (errorCode.isNotEmpty) 'error_code': errorCode,
+      };
+}
+
+class _V2VSessionResult {
+  const _V2VSessionResult({this.data, required this.receipt});
+
+  final Map<String, dynamic>? data;
+  final V2VConnectionReceipt receipt;
+}
+
 /// Voice-to-voice WebSocket client for half-duplex PCM16 audio streaming.
 ///
-/// Uses `record` package for mic input and `just_audio` for WAV playback.
-/// Mic is muted during playback to prevent echo→VAD interruption on Grok's side.
+/// Uses `record` package for mic input and FlutterSound for PCM playback.
+/// The mic recorder is suspended during playback so provider VAD cannot hear
+/// Ella's own response audio or post-turn background noise.
 class V2VClient {
+  static const int _pcmSampleRate = 24000;
+  static const int _pcmBytesPerSample = 2;
+  static const int _pcmChannels = 1;
+  static const Duration _postPlaybackMicCooldown = Duration(seconds: 2);
+  static const Duration _playbackFinishQuietPeriod = Duration(milliseconds: 900);
+
+  static V2VClient? _activeClient;
+
   WebSocketChannel? _channel;
   AudioRecorder? _recorder;
   StreamSubscription? _micSub;
   StreamSubscription? _wsSub;
   bool _isConnected = false;
+  bool _connectionAnnounced = false;
   bool _isPlaying = false;
   bool _micMuted = false;
+  bool _micSuspendedForPlayback = false;
+  int _micChunksSent = 0;
+  int _micBytesSent = 0;
+  Future<void> _micGateFuture = Future.value();
 
   /// PCM buffer for accumulating audio chunks before WAV playback
   final BytesBuilder _pcmBuffer = BytesBuilder(copy: false);
   int _chunkCount = 0;
 
-  /// just_audio player for WAV playback
-  final AudioPlayer _audioPlayer = AudioPlayer();
+  /// Low-latency PCM stream player for provider-native V2V audio.
+  final FlutterSoundPlayer _streamPlayer = FlutterSoundPlayer();
+  bool _streamPlayerOpen = false;
+  bool _streamPlaybackStarted = false;
+  DateTime? _streamPlaybackStartedAt;
+  Future<void> _streamFeedFuture = Future.value();
+  Timer? _finishPlaybackTimer;
+  bool _finishingPlayback = false;
 
   /// Callback for JSON events (transcripts, errors, etc.)
   final void Function(V2VEvent event)? onEvent;
@@ -53,32 +120,217 @@ class V2VClient {
 
   bool get isConnected => _isConnected;
 
+  V2VConnectionReceipt? get lastConnectionReceipt => _lastConnectionReceipt;
+
+  V2VConnectionReceipt? _lastConnectionReceipt;
+
+  static String normalizeProvider(String provider) => switch (provider) {
+        // Legacy values may remain in SharedPreferences after TestFlight upgrades.
+        'gemini-live' => 'gemini-native-live',
+        'openai-realtime' => 'openai-native-realtime',
+        _ => provider,
+      };
+
+  static bool isSessionProvider(String provider) =>
+      normalizeProvider(provider) == 'openclaw-direct' ||
+      normalizeProvider(provider) == 'openai-native-realtime' ||
+      normalizeProvider(provider) == 'grok-voice' ||
+      normalizeProvider(provider) == 'gemini-native-live';
+
+  static String? sessionVoiceMode(String provider) => switch (normalizeProvider(provider)) {
+        'openclaw-direct' => 'openclaw-direct-v1',
+        'openai-native-realtime' => 'openai-native-realtime-v1',
+        'gemini-native-live' => 'gemini-native-live-v1',
+        _ => null,
+      };
+
+  static String providerDisplayName(String provider) => switch (normalizeProvider(provider)) {
+        'grok-voice' => 'Grok Native Realtime',
+        'gemini-native-live' => 'Gemini Native Live',
+        'openai-native-realtime' => 'OpenAI Native Realtime',
+        'openclaw-direct' => 'OpenClaw Direct',
+        _ => provider,
+      };
+
+  static String resolveEffectiveProvider({required String provisionedProvider, required String selectedProvider}) {
+    final provisioned = normalizeProvider(provisionedProvider.trim());
+    return provisioned.isNotEmpty ? provisioned : normalizeProvider(selectedProvider.trim());
+  }
+
+  @visibleForTesting
+  static Map<String, dynamic> buildSessionRequestBody({
+    required String uid,
+    required String provider,
+    required bool includeUid,
+  }) {
+    final canonicalProvider = normalizeProvider(provider);
+    final voiceMode = sessionVoiceMode(canonicalProvider);
+    return {
+      if (includeUid) 'uid': uid,
+      'provider': canonicalProvider,
+      if (voiceMode != null) 'voice_mode': voiceMode,
+    };
+  }
+
+  @visibleForTesting
+  static Set<String> availableSessionProviders(Object? responseJson) {
+    if (responseJson is! Map) return const {};
+    final providers = responseJson['providers'];
+    if (providers is! List) return const {};
+
+    return providers.whereType<Map>().where((item) {
+      return item['type'] == 'v2v' && item['available'] == true;
+    }).map((item) {
+      return normalizeProvider(item['id']?.toString() ?? '');
+    }).where((provider) {
+      return provider.isNotEmpty;
+    }).toSet();
+  }
+
+  @visibleForTesting
+  static String safeErrorCode(String body, {String fallback = 'request_failed'}) {
+    Object? decoded;
+    try {
+      decoded = jsonDecode(body);
+    } catch (_) {
+      decoded = null;
+    }
+
+    String? candidate;
+    if (decoded is Map) {
+      final detail = decoded['detail'];
+      final error = decoded['error'];
+      if (detail is Map) candidate = detail['code']?.toString();
+      if (candidate == null && error is Map) candidate = error['code']?.toString();
+      candidate ??= decoded['code']?.toString();
+      if (candidate == null && detail is String && !detail.contains(' ') && !detail.contains('.')) candidate = detail;
+      if (candidate == null && error is String && !error.contains(' ') && !error.contains('.')) candidate = error;
+      final humanDetail = detail is String
+          ? detail.toLowerCase()
+          : error is String
+              ? error.toLowerCase()
+              : '';
+      if (candidate == null && humanDetail.contains('missing api key')) candidate = 'provider_not_configured';
+      if (candidate == null && humanDetail.contains('unknown v2v provider')) candidate = 'unknown_provider';
+      if (candidate == null && humanDetail.contains('uid required')) candidate = 'uid_required';
+    }
+
+    if (candidate != null && candidate.length > 64) candidate = null;
+
+    final normalized = (candidate ?? fallback)
+        .toLowerCase()
+        .replaceAll(RegExp('[^a-z0-9_-]+'), '_')
+        .replaceAll(RegExp('_+'), '_')
+        .replaceAll(RegExp('^_|_\$'), '');
+    if (normalized.isEmpty) return fallback;
+    return normalized.length <= 64 ? normalized : normalized.substring(0, 64);
+  }
+
   /// Start a V2V session: get session token, connect WebSocket, start audio.
-  Future<bool> connect({required String provider}) async {
-    if (!SharedPreferencesUtil().aiConsentAccepted) return false;
+  Future<V2VConnectionReceipt> connect({required String provider}) async {
+    provider = normalizeProvider(provider);
+    if (_activeClient != null && _activeClient != this) {
+      Logger.debug('[V2V] Closing existing active V2V client before provider=$provider connect');
+      await _activeClient!.disconnect();
+    }
+    _activeClient = this;
+
+    if (_isConnected || _channel != null || _recorder != null) {
+      Logger.debug('[V2V] connect() called with existing session state, disconnecting first');
+      await disconnect();
+      _activeClient = this;
+    }
+
+    if (!SharedPreferencesUtil().aiConsentAccepted) {
+      return _completeReceipt(V2VConnectionReceipt(
+        connected: false,
+        provider: provider,
+        stage: V2VConnectionStage.consent,
+        errorCode: 'ai_consent_required',
+      ));
+    }
+
+    if (!isSessionProvider(provider)) {
+      return _completeReceipt(V2VConnectionReceipt(
+        connected: false,
+        provider: provider,
+        stage: V2VConnectionStage.providerRegistry,
+        errorCode: 'unsupported_provider',
+      ));
+    }
+
     final uid = SharedPreferencesUtil().uid;
     if (uid.isEmpty) {
       Logger.debug('[V2V] No uid, cannot connect');
-      return false;
+      if (_activeClient == this) _activeClient = null;
+      return _completeReceipt(V2VConnectionReceipt(
+        connected: false,
+        provider: provider,
+        stage: V2VConnectionStage.identity,
+        errorCode: 'missing_authenticated_identity',
+      ));
+    }
+
+    final registryFailure = await _validateProviderRegistry(provider);
+    if (registryFailure != null) {
+      if (_activeClient == this) _activeClient = null;
+      return _completeReceipt(registryFailure);
     }
 
     // 1. Get session token from backend
-    final sessionData = await _createSession(uid, provider);
-    if (sessionData == null) return false;
+    final sessionResult = await _createSession(uid, provider);
+    final sessionData = sessionResult.data;
+    if (sessionData == null) {
+      if (_activeClient == this) _activeClient = null;
+      return _completeReceipt(sessionResult.receipt);
+    }
 
     final token = sessionData['session_token'] as String? ?? '';
     final endpoint = sessionData['voice_endpoint'] as String? ?? '';
+    final confirmedProvider = normalizeProvider(sessionData['provider'] as String? ?? provider);
+    final confirmedVoiceMode = sessionData['voice_mode'] as String? ?? sessionVoiceMode(provider) ?? '';
     if (token.isEmpty || endpoint.isEmpty) {
       Logger.debug('[V2V] Invalid session data');
-      return false;
+      if (_activeClient == this) _activeClient = null;
+      return _completeReceipt(V2VConnectionReceipt(
+        connected: false,
+        provider: provider,
+        voiceMode: confirmedVoiceMode,
+        stage: V2VConnectionStage.session,
+        httpStatus: 200,
+        errorCode: 'invalid_session_contract',
+      ));
+    }
+    if (confirmedProvider != provider) {
+      if (_activeClient == this) _activeClient = null;
+      return _completeReceipt(V2VConnectionReceipt(
+        connected: false,
+        provider: provider,
+        voiceMode: confirmedVoiceMode,
+        stage: V2VConnectionStage.session,
+        httpStatus: 200,
+        errorCode: 'provider_mismatch',
+      ));
     }
 
     // 2. Configure iOS audio session for playAndRecord with Bluetooth + speaker routing
-    await _configureAudioSession();
+    try {
+      await _configureAudioSession();
+    } catch (error) {
+      Logger.error('[V2V] Audio session setup failed for provider=$provider');
+      if (_activeClient == this) _activeClient = null;
+      return _completeReceipt(V2VConnectionReceipt(
+        connected: false,
+        provider: provider,
+        voiceMode: confirmedVoiceMode,
+        stage: V2VConnectionStage.audioSession,
+        errorCode: _safeExceptionCode(error, fallback: 'audio_session_failed'),
+      ));
+    }
 
     // 3. Connect WebSocket
     final wsUrl = _withSessionToken(endpoint, token);
-    Logger.debug('[V2V] Connecting to WebSocket...');
+    Logger.debug('[V2V] Connecting to WebSocket for provider=$provider...');
 
     try {
       _channel = IOWebSocketChannel.connect(
@@ -86,44 +338,69 @@ class V2VClient {
         pingInterval: const Duration(seconds: 30),
       );
 
-      _isConnected = true;
-      onConnectionChanged?.call(true);
+      await _channel!.ready.timeout(const Duration(seconds: 12));
 
       // 3. Listen for messages from proxy
+      _isConnected = true;
       _wsSub = _channel!.stream.listen(
         _handleMessage,
         onError: (error) {
-          Logger.error('[V2V] WebSocket error: $error');
+          Logger.error('[V2V] WebSocket error: ${error.runtimeType}');
           disconnect();
         },
         onDone: () {
           Logger.debug('[V2V] WebSocket closed');
           _isConnected = false;
-          onConnectionChanged?.call(false);
+          if (_connectionAnnounced) {
+            _connectionAnnounced = false;
+            onConnectionChanged?.call(false);
+          }
         },
       );
 
       // 4. Start recording mic audio and streaming to WebSocket
-      await _startMicStream();
+      final micStarted = await _startMicStream();
+      if (!micStarted || !_isConnected) {
+        await disconnect();
+        return _completeReceipt(V2VConnectionReceipt(
+          connected: false,
+          provider: provider,
+          voiceMode: confirmedVoiceMode,
+          stage: micStarted ? V2VConnectionStage.websocket : V2VConnectionStage.microphone,
+          errorCode: micStarted ? 'websocket_closed' : 'microphone_unavailable',
+        ));
+      }
+      _connectionAnnounced = true;
+      onConnectionChanged?.call(true);
 
-      // 5. Listen for playback completion
-      _audioPlayer.playerStateStream.listen((state) {
-        if (state.processingState == ProcessingState.completed && _isPlaying) {
-          _onPlaybackComplete();
-        }
-      });
-
-      return true;
-    } catch (e) {
-      Logger.error('[V2V] WebSocket connect failed: $e');
-      return false;
+      return _completeReceipt(V2VConnectionReceipt(
+        connected: true,
+        provider: provider,
+        voiceMode: confirmedVoiceMode,
+        stage: V2VConnectionStage.connected,
+      ));
+    } catch (error) {
+      Logger.error('[V2V] WebSocket handshake failed for provider=$provider');
+      await disconnect();
+      return _completeReceipt(V2VConnectionReceipt(
+        connected: false,
+        provider: provider,
+        voiceMode: confirmedVoiceMode,
+        stage: V2VConnectionStage.websocket,
+        errorCode: _safeExceptionCode(error, fallback: 'websocket_handshake_failed'),
+      ));
     }
   }
 
   /// Disconnect and clean up all resources.
   Future<void> disconnect() async {
+    final shouldAnnounceDisconnect = _connectionAnnounced;
     _isConnected = false;
-    onConnectionChanged?.call(false);
+    _connectionAnnounced = false;
+    if (shouldAnnounceDisconnect) onConnectionChanged?.call(false);
+    if (_activeClient == this) {
+      _activeClient = null;
+    }
 
     _wsSub?.cancel();
     _wsSub = null;
@@ -133,24 +410,62 @@ class V2VClient {
     } catch (_) {}
     _channel = null;
 
-    await _stopMicStream();
+    await _stopMicStream(reason: 'disconnect');
     try {
-      await _audioPlayer.stop();
-      await _audioPlayer.dispose();
+      await _stopStreamingPlayback();
+      if (_streamPlayerOpen) {
+        await _streamPlayer.closePlayer();
+        _streamPlayerOpen = false;
+      }
     } catch (_) {}
+    _resetTurnState();
   }
 
   /// Interrupt current playback (e.g., user started speaking).
   Future<void> interruptPlayback() async {
     if (_isPlaying) {
       try {
-        await _audioPlayer.stop();
+        await _stopStreamingPlayback();
       } catch (_) {}
       _isPlaying = false;
     }
+    _micSuspendedForPlayback = false;
     _micMuted = false;
     _pcmBuffer.clear();
     _chunkCount = 0;
+    _streamPlaybackStartedAt = null;
+  }
+
+  void _suspendMicForPlayback(String reason) {
+    if (_micMuted && _micSuspendedForPlayback) return;
+    _micMuted = true;
+    _micSuspendedForPlayback = true;
+    Logger.debug('[V2V] Mic gate closed for playback: reason=$reason sent=$_micChunksSent chunks/$_micBytesSent bytes');
+    onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic gate closed: $reason'));
+
+    _micGateFuture = _micGateFuture.then((_) async {
+      await _stopMicStream(reason: 'playback_gate:$reason');
+    }).catchError((error) {
+      Logger.error('[V2V] Mic gate close failed: $error');
+      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic gate close failed: $error'));
+    });
+  }
+
+  void _resetTurnState() {
+    _isPlaying = false;
+    _micMuted = false;
+    _micSuspendedForPlayback = false;
+    _pcmBuffer.clear();
+    _chunkCount = 0;
+    _micChunksSent = 0;
+    _micBytesSent = 0;
+    _streamPlaybackStarted = false;
+    _streamPlaybackStartedAt = null;
+    _streamFeedFuture = Future.value();
+    _finishPlaybackTimer?.cancel();
+    _finishPlaybackTimer = null;
+    _finishingPlayback = false;
+    _micGateFuture = Future.value();
   }
 
   // --- Audio session ---
@@ -173,31 +488,124 @@ class V2VClient {
 
   // --- Session management ---
 
-  Future<Map<String, dynamic>?> _createSession(String uid, String provider) async {
+  Future<V2VConnectionReceipt?> _validateProviderRegistry(String provider) async {
     try {
+      final response = await makeApiCall(
+        url: '${Env.apiBaseUrl}v1/voice/providers',
+        headers: const {},
+        body: '',
+        method: 'GET',
+        timeout: const Duration(seconds: 5),
+        retries: 0,
+      );
+      if (response == null || response.statusCode != 200) {
+        _logRegistryReceipt(provider, response?.statusCode, 'registry_unavailable');
+        return null;
+      }
+
+      final providers = availableSessionProviders(jsonDecode(response.body));
+      if (!providers.contains(provider)) {
+        return V2VConnectionReceipt(
+          connected: false,
+          provider: provider,
+          stage: V2VConnectionStage.providerRegistry,
+          httpStatus: response.statusCode,
+          errorCode: 'provider_unavailable',
+        );
+      }
+      _logRegistryReceipt(provider, response.statusCode, 'available');
+    } catch (_) {
+      _logRegistryReceipt(provider, null, 'registry_unavailable');
+    }
+    return null;
+  }
+
+  Future<_V2VSessionResult> _createSession(String uid, String provider) async {
+    try {
+      provider = normalizeProvider(provider);
+      final voiceMode = sessionVoiceMode(provider);
+      final requestBody = buildSessionRequestBody(
+        uid: uid,
+        provider: provider,
+        includeUid: !isHermesProvisioningGateEnabled,
+      );
+
       final response = await makeApiCall(
         url: '${Env.apiBaseUrl}v1/voice/session',
         headers: {'Content-Type': 'application/json'},
-        body: jsonEncode({
-          if (!isHermesProvisioningGateEnabled) 'uid': uid,
-          if (!isHermesProvisioningGateEnabled) 'provider': provider,
-        }),
+        body: jsonEncode(requestBody),
         method: 'POST',
         timeout: const Duration(seconds: 10),
       );
 
       if (response == null || response.statusCode != 200) {
         Logger.debug('[V2V] Session create failed: ${response?.statusCode}');
-        return null;
+        return _V2VSessionResult(
+          receipt: V2VConnectionReceipt(
+            connected: false,
+            provider: provider,
+            voiceMode: voiceMode ?? '',
+            stage: V2VConnectionStage.session,
+            httpStatus: response?.statusCode,
+            errorCode: response == null
+                ? 'session_request_failed'
+                : safeErrorCode(response.body, fallback: 'session_request_failed'),
+          ),
+        );
       }
 
       final data = jsonDecode(response.body) as Map<String, dynamic>;
-      Logger.debug('[V2V] Session created: provider=$provider');
-      return data;
-    } catch (e) {
-      Logger.error('[V2V] Session create error: $e');
-      return null;
+      Logger.debug('[V2V] Session created: provider=$provider voice_mode=${voiceMode ?? "default"}');
+      return _V2VSessionResult(
+        data: data,
+        receipt: V2VConnectionReceipt(
+          connected: false,
+          provider: provider,
+          voiceMode: data['voice_mode'] as String? ?? voiceMode ?? '',
+          stage: V2VConnectionStage.session,
+          httpStatus: response.statusCode,
+        ),
+      );
+    } catch (error) {
+      Logger.error('[V2V] Session create error for provider=$provider');
+      return _V2VSessionResult(
+        receipt: V2VConnectionReceipt(
+          connected: false,
+          provider: provider,
+          voiceMode: sessionVoiceMode(provider) ?? '',
+          stage: V2VConnectionStage.session,
+          errorCode: _safeExceptionCode(error, fallback: 'session_request_failed'),
+        ),
+      );
     }
+  }
+
+  V2VConnectionReceipt _completeReceipt(V2VConnectionReceipt receipt) {
+    if (!receipt.connected && !_isConnected && _channel == null && _activeClient == this) {
+      _activeClient = null;
+    }
+    _lastConnectionReceipt = receipt;
+    final fields = receipt.toDebugFields();
+    Logger.debug('[V2V] Connection receipt: $fields');
+    unawaited(DebugLogManager.logEvent('v2v_connection_receipt', fields));
+    onEvent?.call(V2VEvent(type: 'connection_receipt', text: receipt.safeDetail));
+    return receipt;
+  }
+
+  void _logRegistryReceipt(String provider, int? status, String result) {
+    final fields = <String, Object?>{
+      'provider': provider,
+      'stage': V2VConnectionStage.providerRegistry.name,
+      'result': result,
+      if (status != null) 'http_status': status,
+    };
+    Logger.debug('[V2V] Provider registry receipt: $fields');
+    unawaited(DebugLogManager.logEvent('v2v_provider_registry_receipt', fields));
+  }
+
+  static String _safeExceptionCode(Object error, {required String fallback}) {
+    final raw = error.runtimeType.toString();
+    return safeErrorCode('{"code":"$raw"}', fallback: fallback);
   }
 
   static String _withSessionToken(String endpoint, String token) {
@@ -209,17 +617,95 @@ class V2VClient {
     return '$endpoint${separator}token=$token';
   }
 
+  static String? _eventText(Map<String, dynamic> json) {
+    for (final key in ['text', 'transcript', 'delta', 'content', 'message']) {
+      final value = json[key];
+      if (value is String && value.isNotEmpty) return value;
+    }
+
+    final response = json['response'];
+    if (response is Map<String, dynamic>) {
+      return _eventText(response);
+    }
+
+    final item = json['item'];
+    if (item is Map<String, dynamic>) {
+      return _eventText(item);
+    }
+
+    return null;
+  }
+
+  static bool _isUserTranscriptEvent(String type) {
+    final normalized = type.toLowerCase();
+    return normalized == 'user_transcript' ||
+        normalized == 'input_transcript' ||
+        normalized == 'input_audio_transcription.completed' ||
+        normalized.contains('input_audio_transcription') ||
+        (normalized.contains('user') && normalized.contains('transcript'));
+  }
+
+  static bool _isAssistantTranscriptEvent(String type) {
+    final normalized = type.toLowerCase();
+    return normalized == 'transcript' ||
+        normalized == 'transcript_delta' ||
+        normalized == 'assistant_transcript' ||
+        normalized == 'output_transcript' ||
+        normalized == 'response_text' ||
+        normalized == 'response.audio_transcript.delta' ||
+        normalized == 'response.audio_transcript.done' ||
+        normalized == 'response.text.delta' ||
+        normalized == 'response.text.done' ||
+        normalized.contains('output_audio_transcription') ||
+        (normalized.contains('assistant') && normalized.contains('transcript'));
+  }
+
+  @visibleForTesting
+  static bool treatsAsAssistantTranscriptEvent(String type) {
+    return _isAssistantTranscriptEvent(type);
+  }
+
+  static bool _isAudioDoneEvent(String type) {
+    final normalized = type.toLowerCase();
+    return normalized == 'audio_done' ||
+        normalized == 'response.audio.done' ||
+        normalized == 'output_audio.done' ||
+        normalized == 'audio.done';
+  }
+
+  static bool _isResponseCompleteEvent(String type) {
+    final normalized = type.toLowerCase();
+    return normalized == 'turn_complete' || normalized == 'response.done';
+  }
+
+  @visibleForTesting
+  static bool treatsAsAudioDoneEvent(String type) {
+    return _isAudioDoneEvent(type);
+  }
+
+  @visibleForTesting
+  static bool treatsAsResponseCompleteEvent(String type) {
+    return _isResponseCompleteEvent(type);
+  }
+
   // --- Mic recording (PCM16, 24kHz, mono) using `record` package ---
 
-  Future<void> _startMicStream() async {
+  Future<bool> _startMicStream() async {
     try {
+      if (_recorder != null || _micSub != null) {
+        Logger.debug('[V2V] Mic stream already active, not starting duplicate recorder');
+        return true;
+      }
+
       _recorder = AudioRecorder();
 
       final hasPermission = await _recorder!.hasPermission();
       if (!hasPermission) {
         Logger.error('[V2V] Mic permission denied');
         onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic permission denied'));
-        return;
+        await _recorder?.dispose();
+        _recorder = null;
+        return false;
       }
 
       final stream = await _recorder!.startStream(const RecordConfig(
@@ -231,171 +717,226 @@ class V2VClient {
         noiseSuppress: true,
       ));
 
+      _micChunksSent = 0;
+      _micBytesSent = 0;
       _micSub = stream.listen((data) {
-        if (_isConnected && _channel != null && !_micMuted && SharedPreferencesUtil().aiConsentAccepted) {
+        if (_isConnected &&
+            _channel != null &&
+            !_micMuted &&
+            !_isPlaying &&
+            !_micSuspendedForPlayback &&
+            SharedPreferencesUtil().aiConsentAccepted) {
           _channel!.sink.add(data);
+          _micChunksSent++;
+          _micBytesSent += data.length;
+          if (_micChunksSent % 50 == 0) {
+            Logger.debug('[V2V] Mic streamed $_micChunksSent chunks, $_micBytesSent bytes');
+          }
         }
       });
 
       _micMuted = false;
-      Logger.debug('[V2V] Mic recording started at 24kHz');
+      _micSuspendedForPlayback = false;
+      Logger.debug('[V2V] Mic gate open: recording at 24kHz');
       onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic active'));
-    } catch (e) {
-      Logger.error('[V2V] Mic start failed: $e');
-      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic error: $e'));
+      return true;
+    } catch (error) {
+      Logger.error('[V2V] Mic start failed: ${error.runtimeType}');
+      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic unavailable'));
+      return false;
     }
   }
 
-  Future<void> _stopMicStream() async {
-    _micSub?.cancel();
+  Future<void> _stopMicStream({required String reason}) async {
+    final hadMic = _micSub != null || _recorder != null;
+    if (hadMic) {
+      Logger.debug('[V2V] Mic stream stopping: reason=$reason');
+    }
+
+    await _micSub?.cancel();
     _micSub = null;
     try {
       await _recorder?.stop();
       await _recorder?.dispose();
     } catch (_) {}
     _recorder = null;
+
+    if (hadMic) {
+      Logger.debug('[V2V] Mic stream stopped: reason=$reason');
+    }
   }
 
-  // --- Audio playback using just_audio (WAV file) ---
+  Future<void> _resumeMicAfterPlayback() async {
+    if (!_micSuspendedForPlayback) {
+      _micMuted = false;
+      return;
+    }
 
-  /// Buffer incoming PCM16 audio chunk.
-  void _bufferAudioChunk(Uint8List pcmData) {
+    Logger.debug('[V2V] Mic gate cooldown: ${_postPlaybackMicCooldown.inMilliseconds}ms');
+    onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Mic gate cooldown'));
+    await Future.delayed(_postPlaybackMicCooldown);
+    await _micGateFuture;
+
+    if (!_isConnected || _channel == null) {
+      Logger.debug('[V2V] Mic gate remains closed: session disconnected');
+      _micSuspendedForPlayback = false;
+      _micMuted = false;
+      return;
+    }
+
+    if (_isPlaying || _streamPlaybackStarted) {
+      Logger.debug('[V2V] Mic gate remains closed: playback still active');
+      return;
+    }
+
+    Logger.debug('[V2V] Mic gate reopening after playback cooldown');
+    await _startMicStream();
+  }
+
+  // --- Low-latency PCM streaming playback ---
+
+  /// Stream incoming PCM16 audio chunk to the platform player.
+  void _streamAudioChunk(Uint8List pcmData) {
     if (pcmData.isEmpty) return;
 
+    // Gate the microphone before enqueueing playback so provider VAD cannot
+    // hear Ella's own response audio and interrupt the active turn.
+    _suspendMicForPlayback('audio_chunk');
+    _deferPendingPlaybackFinish('audio_chunk');
     _chunkCount++;
     _pcmBuffer.add(pcmData);
 
-    // Mute mic on first chunk
-    if (!_micMuted) {
-      _micMuted = true;
-      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Buffering audio (mic muted)'));
-      Logger.debug('[V2V] First audio chunk, mic muted');
+    _streamFeedFuture = _streamFeedFuture.then((_) async {
+      await _ensureStreamingPlaybackStarted();
+      _streamPlayer.uint8ListSink?.add(pcmData);
+    }).catchError((error) {
+      Logger.error('[V2V] Stream playback feed error: $error');
+      onEvent?.call(V2VEvent(type: 'error', text: 'Audio stream error: $error'));
+    });
+
+    if (_chunkCount == 1) {
+      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Streaming response audio'));
+      Logger.debug('[V2V] First audio chunk, streaming playback gate active');
     }
 
     if (_chunkCount % 20 == 0) {
-      Logger.debug('[V2V] Buffered $_chunkCount chunks, ${_pcmBuffer.length}B');
+      Logger.debug('[V2V] Streamed $_chunkCount chunks, ${_pcmBuffer.length}B');
     }
   }
 
-  /// Called on audio_done — write WAV and play with just_audio.
-  Future<void> _finishPlayback() async {
+  Future<void> _ensureStreamingPlaybackStarted() async {
+    if (!_streamPlayerOpen) {
+      await _streamPlayer.openPlayer();
+      _streamPlayerOpen = true;
+    }
+
+    if (_streamPlaybackStarted) return;
+
+    _isPlaying = true;
+    _streamPlaybackStarted = true;
+    await _streamPlayer.startPlayerFromStream(
+      codec: Codec.pcm16,
+      sampleRate: _pcmSampleRate,
+      numChannels: _pcmChannels,
+      bufferSize: 4096,
+    );
+    _streamPlaybackStartedAt = DateTime.now();
+    Logger.debug('[V2V] PCM stream player started');
+  }
+
+  Future<void> _stopStreamingPlayback() async {
+    if (!_streamPlaybackStarted) return;
+    try {
+      await _streamPlayer.stopPlayer();
+    } catch (_) {}
+    _streamPlaybackStarted = false;
+  }
+
+  void _scheduleFinishPlayback(String reason) {
+    _finishPlaybackTimer?.cancel();
+    Logger.debug('[V2V] Playback finish scheduled after quiet period: reason=$reason');
+    onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Playback finish pending: $reason'));
+    _finishPlaybackTimer = Timer(_playbackFinishQuietPeriod, () {
+      _finishPlaybackTimer = null;
+      Future<void>(() async {
+        await _finishPlayback(reason: reason);
+      });
+    });
+  }
+
+  void _deferPendingPlaybackFinish(String reason) {
+    if (_finishPlaybackTimer == null) return;
+    _scheduleFinishPlayback(reason);
+  }
+
+  /// Called after audio/output completion quiets — wait for queued PCM to drain,
+  /// then return to listening.
+  Future<void> _finishPlayback({required String reason}) async {
+    if (_finishingPlayback) {
+      Logger.debug('[V2V] Playback finish already in progress, ignoring reason=$reason');
+      return;
+    }
+    _finishingPlayback = true;
     final pcmBytes = _pcmBuffer.toBytes();
     final stats = '$_chunkCount chunks, ${(pcmBytes.length / 1024).toStringAsFixed(1)}KB';
-    Logger.debug('[V2V] Audio done: $stats');
-    onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Playing: $stats'));
+    Logger.debug('[V2V] Audio stream done: reason=$reason $stats');
+    onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Finishing audio: $stats'));
 
     _pcmBuffer.clear();
     _chunkCount = 0;
 
     if (pcmBytes.isEmpty) {
       Logger.debug('[V2V] No audio data to play');
-      _micMuted = false;
-      onEvent?.call(V2VEvent(type: 'playback_complete'));
+      await _onPlaybackComplete();
+      _finishingPlayback = false;
       return;
     }
 
-    // Stop mic recording before switching audio session to playback
-    await _stopMicStream();
-
-    // Write WAV file
-    final wavPath = '${Directory.systemTemp.path}/v2v_response.wav';
-    final wavBytes = _buildWav(Uint8List.fromList(pcmBytes), sampleRate: 24000, numChannels: 1, bitsPerSample: 16);
-    await File(wavPath).writeAsBytes(wavBytes);
-    final durationMs = (pcmBytes.length / (24000 * 2)) * 1000;
-    Logger.debug('[V2V] WAV written: ${wavBytes.length}B, ${durationMs.toStringAsFixed(0)}ms');
-
-    // Play with just_audio
     try {
-      _isPlaying = true;
-      await _audioPlayer.setVolume(1.0);
-      await _audioPlayer.setFilePath(wavPath);
-      await _audioPlayer.play();
-      Logger.debug('[V2V] Playback started');
+      await _streamFeedFuture.timeout(const Duration(seconds: 5));
 
-      // Safety timeout — if playerStateStream doesn't fire completion within
-      // expected duration + 3s buffer, force restart mic anyway
-      final timeoutMs = durationMs.toInt() + 3000;
-      Future.delayed(Duration(milliseconds: timeoutMs), () {
-        if (_isPlaying) {
-          Logger.debug('[V2V] Playback safety timeout after ${timeoutMs}ms, forcing mic restart');
-          _onPlaybackComplete();
-        }
-      });
+      // `audio_done` means the proxy finished sending bytes, not that the
+      // native PCM player has drained its internal queue. Stop too early and
+      // the user hears only the first words even though transcript is complete.
+      final startedAt = _streamPlaybackStartedAt;
+      final totalAudioMs = (pcmBytes.length / (_pcmSampleRate * _pcmBytesPerSample * _pcmChannels) * 1000).ceil();
+      final elapsedMs = startedAt == null ? 0 : DateTime.now().difference(startedAt).inMilliseconds;
+      final remainingMs = totalAudioMs - elapsedMs;
+      final drainDelayMs = remainingMs > 0 ? remainingMs + 300 : 300;
+      Logger.debug('[V2V] Waiting ${drainDelayMs}ms for PCM drain ($totalAudioMs ms audio, $elapsedMs ms elapsed)');
+      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Playing audio: ${(totalAudioMs / 1000).toStringAsFixed(1)}s'));
+      await Future.delayed(Duration(milliseconds: drainDelayMs.clamp(300, 30000)));
+      await _onPlaybackComplete();
     } catch (e) {
-      Logger.error('[V2V] Playback error: $e');
-      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Play error: $e'));
+      Logger.error('[V2V] Stream playback error: $e');
+      onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Stream play error: $e'));
       _isPlaying = false;
-      _micMuted = false;
-      // Restart mic even on error
-      if (_isConnected) await _startMicStream();
+      _streamPlaybackStartedAt = null;
+      await _resumeMicAfterPlayback();
       onEvent?.call(V2VEvent(type: 'playback_complete'));
+    } finally {
+      _finishingPlayback = false;
     }
   }
 
-  /// Called when just_audio finishes playing.
+  /// Called when streaming playback finishes.
   Future<void> _onPlaybackComplete() async {
     if (!_isPlaying && !_micMuted) return; // Already handled
     Logger.debug('[V2V] Playback complete, restarting mic');
+    await _stopStreamingPlayback();
     _isPlaying = false;
-    _micMuted = false;
-
-    // Restart mic recording
-    if (_isConnected) {
-      await _startMicStream();
-    }
+    _streamPlaybackStartedAt = null;
+    await _resumeMicAfterPlayback();
 
     onEvent?.call(V2VEvent(type: 'playback_complete'));
-  }
-
-  /// Build a WAV file from raw PCM16 data.
-  static Uint8List _buildWav(Uint8List pcmData, {int sampleRate = 24000, int numChannels = 1, int bitsPerSample = 16}) {
-    final byteRate = sampleRate * numChannels * (bitsPerSample ~/ 8);
-    final blockAlign = numChannels * (bitsPerSample ~/ 8);
-    final dataSize = pcmData.length;
-    final fileSize = 36 + dataSize;
-
-    final header = ByteData(44);
-    // RIFF header
-    header.setUint8(0, 0x52); // R
-    header.setUint8(1, 0x49); // I
-    header.setUint8(2, 0x46); // F
-    header.setUint8(3, 0x46); // F
-    header.setUint32(4, fileSize, Endian.little);
-    header.setUint8(8, 0x57); // W
-    header.setUint8(9, 0x41); // A
-    header.setUint8(10, 0x56); // V
-    header.setUint8(11, 0x45); // E
-    // fmt chunk
-    header.setUint8(12, 0x66); // f
-    header.setUint8(13, 0x6D); // m
-    header.setUint8(14, 0x74); // t
-    header.setUint8(15, 0x20); // (space)
-    header.setUint32(16, 16, Endian.little); // chunk size
-    header.setUint16(20, 1, Endian.little); // PCM format
-    header.setUint16(22, numChannels, Endian.little);
-    header.setUint32(24, sampleRate, Endian.little);
-    header.setUint32(28, byteRate, Endian.little);
-    header.setUint16(32, blockAlign, Endian.little);
-    header.setUint16(34, bitsPerSample, Endian.little);
-    // data chunk
-    header.setUint8(36, 0x64); // d
-    header.setUint8(37, 0x61); // a
-    header.setUint8(38, 0x74); // t
-    header.setUint8(39, 0x61); // a
-    header.setUint32(40, dataSize, Endian.little);
-
-    final wav = Uint8List(44 + dataSize);
-    wav.setRange(0, 44, header.buffer.asUint8List());
-    wav.setRange(44, 44 + dataSize, pcmData);
-    return wav;
   }
 
   // --- WebSocket message handling ---
 
   void _handleMessage(dynamic message) {
     if (message is List<int>) {
-      // Binary frame = raw PCM16 audio from proxy — buffer for WAV playback
-      _bufferAudioChunk(Uint8List.fromList(message));
+      // Binary frame = raw PCM16 audio from proxy — stream directly to playback.
+      _streamAudioChunk(Uint8List.fromList(message));
       return;
     }
 
@@ -405,20 +946,38 @@ class V2VClient {
       try {
         final json = jsonDecode(message) as Map<String, dynamic>;
         final type = json['type'] as String? ?? 'unknown';
-        final text = json['text'] as String? ?? json['transcript'] as String?;
+        final text = _eventText(json);
+
+        if (_isUserTranscriptEvent(type)) {
+          onEvent?.call(V2VEvent(type: 'user_transcript', text: text));
+          return;
+        }
+
+        if (_isAssistantTranscriptEvent(type)) {
+          _suspendMicForPlayback(type);
+          _deferPendingPlaybackFinish(type);
+          onEvent?.call(V2VEvent(type: 'transcript', text: text));
+          return;
+        }
+
+        if (_isAudioDoneEvent(type)) {
+          _scheduleFinishPlayback(type);
+          onEvent?.call(V2VEvent(type: 'audio_done'));
+          return;
+        }
+
+        if (_isResponseCompleteEvent(type)) {
+          _scheduleFinishPlayback(type);
+          return;
+        }
 
         switch (type) {
-          case 'user_transcript':
-            onEvent?.call(V2VEvent(type: 'user_transcript', text: text));
-            break;
-          case 'transcript':
-            onEvent?.call(V2VEvent(type: 'transcript', text: text));
-            break;
-          case 'audio_done':
-            _finishPlayback();
-            onEvent?.call(V2VEvent(type: 'audio_done'));
-            break;
           case 'speech_started':
+            if (_isPlaying || _micMuted || _micSuspendedForPlayback || _streamPlaybackStarted) {
+              Logger.debug('[V2V] Ignoring speech_started while playback gate is active');
+              onEvent?.call(V2VEvent(type: 'v2v_debug', text: 'Ignoring speech_started during response'));
+              break;
+            }
             interruptPlayback();
             onEvent?.call(V2VEvent(type: 'speech_started'));
             break;

--- a/app/lib/ella/widgets/v2v_fallback_dialog.dart
+++ b/app/lib/ella/widgets/v2v_fallback_dialog.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/ella/services/v2v_client.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+
+enum V2VFailureChoice { retry, useElevenLabs, stop }
+
+String localizedV2VProviderName(BuildContext context, String provider) {
+  return switch (V2VClient.normalizeProvider(provider)) {
+    'grok-voice' => context.l10n.voiceProviderGrokNative,
+    'gemini-native-live' => context.l10n.voiceProviderGeminiNative,
+    'openai-native-realtime' => context.l10n.voiceProviderOpenAiNative,
+    'openclaw-direct' => context.l10n.voiceProviderOpenClawDirect,
+    _ => V2VClient.providerDisplayName(provider),
+  };
+}
+
+class V2VFallbackDialog extends StatelessWidget {
+  const V2VFallbackDialog({required this.receipt, super.key});
+
+  final V2VConnectionReceipt receipt;
+
+  @override
+  Widget build(BuildContext context) {
+    final providerName = localizedV2VProviderName(context, receipt.provider);
+    return AlertDialog(
+      backgroundColor: EllaColors.card,
+      title: Text(
+        context.l10n.voiceV2vUnavailableTitle(providerName),
+        style: EllaTextStyles.display.copyWith(fontSize: 22),
+      ),
+      content: Text(
+        context.l10n.voiceV2vUnavailableBody(receipt.stage.name, receipt.safeDetail),
+        style: EllaTextStyles.body,
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(V2VFailureChoice.stop),
+          child: Text(context.l10n.notNow),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(V2VFailureChoice.useElevenLabs),
+          child: Text(context.l10n.voiceUseElevenLabs),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(V2VFailureChoice.retry),
+          child: Text(context.l10n.retry),
+        ),
+      ],
+    );
+  }
+}
+
+Future<V2VFailureChoice> showV2VFallbackDialog(
+  BuildContext context,
+  V2VConnectionReceipt receipt,
+) async {
+  return await showDialog<V2VFailureChoice>(
+        context: context,
+        barrierDismissible: false,
+        builder: (_) => V2VFallbackDialog(receipt: receipt),
+      ) ??
+      V2VFailureChoice.stop;
+}

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10109,6 +10109,69 @@
   "@voiceMicPermissionRequired": {
     "description": "Microphone permission error message"
   },
+  "voiceV2vUnavailableTitle": "{provider} couldn't connect",
+  "@voiceV2vUnavailableTitle": {
+    "description": "Title shown when a native realtime voice provider cannot connect",
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      }
+    }
+  },
+  "voiceV2vUnavailableBody": "The live voice session failed at {stage} ({detail}). Retry it, use ElevenLabs standard voice for this call, or stop.",
+  "@voiceV2vUnavailableBody": {
+    "description": "Redacted V2V connection failure and explicit fallback explanation",
+    "placeholders": {
+      "stage": {
+        "type": "String"
+      },
+      "detail": {
+        "type": "String"
+      }
+    }
+  },
+  "voiceUseElevenLabs": "Use ElevenLabs",
+  "@voiceUseElevenLabs": {
+    "description": "Button to explicitly use standard ElevenLabs voice after V2V fails"
+  },
+  "voiceElevenLabsFallbackActive": "Listening with ElevenLabs standard voice",
+  "@voiceElevenLabsFallbackActive": {
+    "description": "Voice status after the user explicitly chooses ElevenLabs fallback"
+  },
+  "voiceV2vConnecting": "Connecting to {provider}...",
+  "@voiceV2vConnecting": {
+    "description": "V2V provider connection status",
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      }
+    }
+  },
+  "voiceV2vActive": "{provider} active - Tap to stop",
+  "@voiceV2vActive": {
+    "description": "Connected V2V provider status",
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      }
+    }
+  },
+  "voiceProviderGrokNative": "Grok Native Realtime",
+  "@voiceProviderGrokNative": {
+    "description": "Grok native realtime provider label"
+  },
+  "voiceProviderGeminiNative": "Gemini Native Live",
+  "@voiceProviderGeminiNative": {
+    "description": "Gemini native live provider label"
+  },
+  "voiceProviderOpenAiNative": "OpenAI Native Realtime",
+  "@voiceProviderOpenAiNative": {
+    "description": "OpenAI native realtime provider label"
+  },
+  "voiceProviderOpenClawDirect": "OpenClaw Direct",
+  "@voiceProviderOpenClawDirect": {
+    "description": "OpenClaw direct provider label"
+  },
   "ellaAddCaregiverErrorNameRequired": "Name is required",
   "ellaAddCaregiverErrorEmailRequired": "Email is required",
   "ellaAddCaregiverErrorEmailInvalid": "Please enter a valid email",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -15729,6 +15729,66 @@ abstract class AppLocalizations {
   /// **'Microphone permission is required for voice chat'**
   String get voiceMicPermissionRequired;
 
+  /// Title shown when a native realtime voice provider cannot connect
+  ///
+  /// In en, this message translates to:
+  /// **'{provider} couldn\'t connect'**
+  String voiceV2vUnavailableTitle(String provider);
+
+  /// Redacted V2V connection failure and explicit fallback explanation
+  ///
+  /// In en, this message translates to:
+  /// **'The live voice session failed at {stage} ({detail}). Retry it, use ElevenLabs standard voice for this call, or stop.'**
+  String voiceV2vUnavailableBody(String stage, String detail);
+
+  /// Button to explicitly use standard ElevenLabs voice after V2V fails
+  ///
+  /// In en, this message translates to:
+  /// **'Use ElevenLabs'**
+  String get voiceUseElevenLabs;
+
+  /// Voice status after the user explicitly chooses ElevenLabs fallback
+  ///
+  /// In en, this message translates to:
+  /// **'Listening with ElevenLabs standard voice'**
+  String get voiceElevenLabsFallbackActive;
+
+  /// V2V provider connection status
+  ///
+  /// In en, this message translates to:
+  /// **'Connecting to {provider}...'**
+  String voiceV2vConnecting(String provider);
+
+  /// Connected V2V provider status
+  ///
+  /// In en, this message translates to:
+  /// **'{provider} active - Tap to stop'**
+  String voiceV2vActive(String provider);
+
+  /// Grok native realtime provider label
+  ///
+  /// In en, this message translates to:
+  /// **'Grok Native Realtime'**
+  String get voiceProviderGrokNative;
+
+  /// Gemini native live provider label
+  ///
+  /// In en, this message translates to:
+  /// **'Gemini Native Live'**
+  String get voiceProviderGeminiNative;
+
+  /// OpenAI native realtime provider label
+  ///
+  /// In en, this message translates to:
+  /// **'OpenAI Native Realtime'**
+  String get voiceProviderOpenAiNative;
+
+  /// OpenClaw direct provider label
+  ///
+  /// In en, this message translates to:
+  /// **'OpenClaw Direct'**
+  String get voiceProviderOpenClawDirect;
+
   /// No description provided for @ellaAddCaregiverErrorNameRequired.
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8378,6 +8378,44 @@ class AppLocalizationsAr extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8466,6 +8466,44 @@ class AppLocalizationsBg extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8482,6 +8482,44 @@ class AppLocalizationsCa extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8429,6 +8429,44 @@ class AppLocalizationsCs extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8418,6 +8418,44 @@ class AppLocalizationsDa extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8500,6 +8500,44 @@ class AppLocalizationsDe extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8491,6 +8491,44 @@ class AppLocalizationsEl extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8431,6 +8431,44 @@ class AppLocalizationsEn extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8448,6 +8448,44 @@ class AppLocalizationsEs extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8433,6 +8433,44 @@ class AppLocalizationsEt extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8432,6 +8432,44 @@ class AppLocalizationsFi extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8507,6 +8507,44 @@ class AppLocalizationsFr extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8414,6 +8414,44 @@ class AppLocalizationsHi extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8471,6 +8471,44 @@ class AppLocalizationsHu extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8446,6 +8446,44 @@ class AppLocalizationsId extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8483,6 +8483,44 @@ class AppLocalizationsIt extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8300,6 +8300,44 @@ class AppLocalizationsJa extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8302,6 +8302,44 @@ class AppLocalizationsKo extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8439,6 +8439,44 @@ class AppLocalizationsLt extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8451,6 +8451,44 @@ class AppLocalizationsLv extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8457,6 +8457,44 @@ class AppLocalizationsMs extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8459,6 +8459,44 @@ class AppLocalizationsNl extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8429,6 +8429,44 @@ class AppLocalizationsNo extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8452,6 +8452,44 @@ class AppLocalizationsPl extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8434,6 +8434,44 @@ class AppLocalizationsPt extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8472,6 +8472,44 @@ class AppLocalizationsRo extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8459,6 +8459,44 @@ class AppLocalizationsRu extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8424,6 +8424,44 @@ class AppLocalizationsSk extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8439,6 +8439,44 @@ class AppLocalizationsSv extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8396,6 +8396,44 @@ class AppLocalizationsTh extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8447,6 +8447,44 @@ class AppLocalizationsTr extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8446,6 +8446,44 @@ class AppLocalizationsUk extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8436,6 +8436,44 @@ class AppLocalizationsVi extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8290,6 +8290,44 @@ class AppLocalizationsZh extends AppLocalizations {
   String get voiceMicPermissionRequired => 'Microphone permission is required for voice chat';
 
   @override
+  String voiceV2vUnavailableTitle(String provider) {
+    return '$provider couldn\'t connect';
+  }
+
+  @override
+  String voiceV2vUnavailableBody(String stage, String detail) {
+    return 'The live voice session failed at $stage ($detail). Retry it, use ElevenLabs standard voice for this call, or stop.';
+  }
+
+  @override
+  String get voiceUseElevenLabs => 'Use ElevenLabs';
+
+  @override
+  String get voiceElevenLabsFallbackActive => 'Listening with ElevenLabs standard voice';
+
+  @override
+  String voiceV2vConnecting(String provider) {
+    return 'Connecting to $provider...';
+  }
+
+  @override
+  String voiceV2vActive(String provider) {
+    return '$provider active - Tap to stop';
+  }
+
+  @override
+  String get voiceProviderGrokNative => 'Grok Native Realtime';
+
+  @override
+  String get voiceProviderGeminiNative => 'Gemini Native Live';
+
+  @override
+  String get voiceProviderOpenAiNative => 'OpenAI Native Realtime';
+
+  @override
+  String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -14,6 +14,7 @@ import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/http/api/knowledge_graph_api.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/ella/services/v2v_client.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/models/stt_provider.dart';
 import 'package:omi/pages/persona/persona_profile.dart';
@@ -843,17 +844,29 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                           ),
                         ),
                         DropdownButton<String>(
-                          value: SharedPreferencesUtil().ttsProvider,
+                          value: {
+                            'elevenlabs',
+                            'fish-audio-s2',
+                            'kokoro',
+                            'inworld',
+                            'grok-voice',
+                            'gemini-native-live',
+                          }.contains(V2VClient.normalizeProvider(SharedPreferencesUtil().ttsProvider))
+                              ? V2VClient.normalizeProvider(SharedPreferencesUtil().ttsProvider)
+                              : 'elevenlabs',
                           dropdownColor: const Color(0xFF2A2A2E),
                           underline: const SizedBox.shrink(),
                           style: const TextStyle(color: Colors.white, fontSize: 14),
-                          items: const [
-                            DropdownMenuItem(value: 'elevenlabs', child: Text('ElevenLabs')),
-                            DropdownMenuItem(value: 'fish-audio-s2', child: Text('Fish Audio S2')),
-                            DropdownMenuItem(value: 'kokoro', child: Text('Kokoro (local)')),
-                            DropdownMenuItem(value: 'inworld', child: Text('Inworld TTS (cloud, ~120ms)')),
-                            DropdownMenuItem(value: 'grok-voice', child: Text('Grok Voice (V2V)')),
-                            DropdownMenuItem(value: 'gemini-live', child: Text('Gemini Live (V2V)')),
+                          items: [
+                            const DropdownMenuItem(value: 'elevenlabs', child: Text('ElevenLabs')),
+                            const DropdownMenuItem(value: 'fish-audio-s2', child: Text('Fish Audio S2')),
+                            const DropdownMenuItem(value: 'kokoro', child: Text('Kokoro (local)')),
+                            const DropdownMenuItem(value: 'inworld', child: Text('Inworld TTS (cloud, ~120ms)')),
+                            DropdownMenuItem(value: 'grok-voice', child: Text(context.l10n.voiceProviderGrokNative)),
+                            DropdownMenuItem(
+                              value: 'gemini-native-live',
+                              child: Text(context.l10n.voiceProviderGeminiNative),
+                            ),
                           ],
                           onChanged: (value) {
                             if (value != null) {

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.525+796
+version: 1.0.525+798
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/test/ella/services/v2v_client_test.dart
+++ b/app/test/ella/services/v2v_client_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/ella/services/v2v_client.dart';
+
+void main() {
+  group('V2VClient provider contract', () {
+    test('normalizes legacy provider ids and recognizes canonical session providers', () {
+      expect(V2VClient.normalizeProvider('gemini-live'), 'gemini-native-live');
+      expect(V2VClient.normalizeProvider('openai-realtime'), 'openai-native-realtime');
+      expect(V2VClient.isSessionProvider('grok-voice'), isTrue);
+      expect(V2VClient.isSessionProvider('gemini-live'), isTrue);
+      expect(V2VClient.isSessionProvider('gemini-native-live'), isTrue);
+      expect(V2VClient.isSessionProvider('elevenlabs'), isFalse);
+    });
+
+    test('retained compatibility receipt falls back to selected local provider', () {
+      expect(
+        V2VClient.resolveEffectiveProvider(provisionedProvider: '', selectedProvider: 'gemini-live'),
+        'gemini-native-live',
+      );
+      expect(
+        V2VClient.resolveEffectiveProvider(
+          provisionedProvider: 'grok-voice',
+          selectedProvider: 'gemini-native-live',
+        ),
+        'grok-voice',
+      );
+    });
+
+    test('authenticated session body preserves provider and mode while omitting uid', () {
+      expect(
+        V2VClient.buildSessionRequestBody(
+          uid: 'firebase-user-1',
+          provider: 'gemini-live',
+          includeUid: false,
+        ),
+        {
+          'provider': 'gemini-native-live',
+          'voice_mode': 'gemini-native-live-v1',
+        },
+      );
+    });
+
+    test('legacy session body includes uid without changing canonical provider', () {
+      expect(
+        V2VClient.buildSessionRequestBody(
+          uid: 'legacy-user-1',
+          provider: 'grok-voice',
+          includeUid: true,
+        ),
+        {
+          'uid': 'legacy-user-1',
+          'provider': 'grok-voice',
+        },
+      );
+    });
+
+    test('provider registry filters unavailable and non-V2V entries and deduplicates aliases', () {
+      final providers = V2VClient.availableSessionProviders({
+        'providers': [
+          {'id': 'elevenlabs', 'type': 'tts', 'available': true},
+          {'id': 'grok-voice', 'type': 'v2v', 'available': false},
+          {'id': 'gemini-live', 'type': 'v2v', 'available': true},
+          {'id': 'gemini-native-live', 'type': 'v2v', 'available': true},
+        ],
+      });
+
+      expect(providers, {'gemini-native-live'});
+    });
+
+    test('failure receipts extract bounded codes without retaining opaque tokens', () {
+      expect(
+        V2VClient.safeErrorCode('{"detail":{"code":"isolated_voice_not_ready"}}'),
+        'isolated_voice_not_ready',
+      );
+      expect(
+        V2VClient.safeErrorCode(
+          '{"detail":"eyJhbGciOiJIUzI1NiJ9.payload.signature"}',
+          fallback: 'session_request_failed',
+        ),
+        'session_request_failed',
+      );
+      expect(
+        V2VClient.safeErrorCode('{"detail":"Provider grok-voice is not configured (missing API key)"}'),
+        'provider_not_configured',
+      );
+    });
+  });
+
+  group('V2VClient proxy event mapping', () {
+    test('maps transcript deltas as assistant transcripts', () {
+      expect(V2VClient.treatsAsAssistantTranscriptEvent('transcript'), isTrue);
+      expect(V2VClient.treatsAsAssistantTranscriptEvent('transcript_delta'), isTrue);
+      expect(V2VClient.treatsAsAssistantTranscriptEvent('response.audio_transcript.delta'), isTrue);
+      expect(V2VClient.treatsAsAssistantTranscriptEvent('user_transcript'), isFalse);
+    });
+
+    test('separates audio completion from generic response completion', () {
+      expect(V2VClient.treatsAsAudioDoneEvent('response.audio.done'), isTrue);
+      expect(V2VClient.treatsAsAudioDoneEvent('response.done'), isFalse);
+      expect(V2VClient.treatsAsResponseCompleteEvent('response.done'), isTrue);
+      expect(V2VClient.treatsAsResponseCompleteEvent('audio_done'), isFalse);
+    });
+  });
+}

--- a/app/test/ella/widgets/v2v_fallback_dialog_test.dart
+++ b/app/test/ella/widgets/v2v_fallback_dialog_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/ella/services/v2v_client.dart';
+import 'package:omi/ella/widgets/v2v_fallback_dialog.dart';
+import 'package:omi/l10n/app_localizations.dart';
+
+void main() {
+  const receipt = V2VConnectionReceipt(
+    connected: false,
+    provider: 'gemini-native-live',
+    voiceMode: 'gemini-native-live-v1',
+    stage: V2VConnectionStage.session,
+    httpStatus: 503,
+    errorCode: 'isolated_voice_not_ready',
+  );
+
+  Widget buildApp() => const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: V2VFallbackDialog(receipt: receipt)),
+      );
+
+  testWidgets('names failed provider, safe receipt, and explicit ElevenLabs fallback', (tester) async {
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    expect(find.text("Gemini Native Live couldn't connect"), findsOneWidget);
+    expect(find.textContaining('session'), findsOneWidget);
+    expect(find.textContaining('HTTP 503'), findsOneWidget);
+    expect(find.textContaining('isolated_voice_not_ready'), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+    expect(find.text('Use ElevenLabs'), findsOneWidget);
+    expect(find.text('Not now'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Fixes ellaaicare/ella-ai#1093

## Root cause
- Build 797 ignored `devTtsProvider` whenever the Hermes provisioning gate was enabled. Retained compatibility receipts have no `effective_voice_mode`, so Grok/Gemini resolved to empty and entered standard STT/TTS.
- The gated `/v1/voice/session` body omitted both UID and provider. Omitting the authenticated UID is correct; omitting provider made Gemini default to Grok.
- The release recognized only legacy `gemini-live` and silently started ElevenLabs after any V2V failure.

## Change
- Resolve a non-empty provisioned override first, otherwise preserve the selected local provider; normalize canonical aliases.
- Validate against `/v1/voice/providers`, always send canonical provider/mode with app auth, verify the provider echoed by `/v1/voice/session`, and await WebSocket handshake readiness.
- Emit bounded token-free registry/session/connection receipts.
- Replace silent fallback with Retry / Use ElevenLabs / Not now and keep the selected V2V preference unchanged.
- Restore proven PCM streaming playback, transcript-delta handling, single-session ownership, and mic gating from the prior native V2V lineage.
- Bump the candidate to `1.0.525+798`.

## Validation
- `flutter test --no-pub test/ella/services/v2v_client_test.dart test/ella/widgets/v2v_fallback_dialog_test.dart` (9 passed)
- `./test.sh` (capture provider 18 passed; transcript 3 passed)
- provisioning tests (17 passed)
- focused analyzer: no errors; existing deprecation infos only
- prod simulator build and launch: `com.ellaaicare.ella`, `1.0.525 (798)`, iPhone 17 Pro iOS 26.5

No Firebase, auth, bundle ID, provisioning, signing, backend key, or rollout flag changes.