### PR TITLE
Version voice AI processor consent

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -19,6 +19,7 @@ class SharedPreferencesUtil {
 
   static const bool isPublicBuild = bool.fromEnvironment('ELLA_PUBLIC_BUILD');
   static const String currentAiConsentContractVersion = 'voice-ai-processors-v2';
+  static const String currentAiConsentReceiptPrefix = 'ios-private-cloud-sync:$currentAiConsentContractVersion:';
 
   factory SharedPreferencesUtil() {
     return _instance;
@@ -210,15 +211,21 @@ class SharedPreferencesUtil {
   String get aiConsentContractVersion => getString('aiConsentContractVersion');
 
   bool hasAccountBoundAiConsent(String uid) =>
-      uid.isNotEmpty && aiConsentAccepted && aiConsentReceiptId.isNotEmpty && aiConsentReceiptUid == uid;
+      uid.isNotEmpty &&
+      aiConsentAccepted &&
+      aiConsentReceiptId.startsWith(currentAiConsentReceiptPrefix) &&
+      aiConsentReceiptUid == uid;
 
   void acceptAiConsent({String receiptId = '', String uid = ''}) {
     aiConsentAccepted = true;
     aiConsentAcceptedAt = DateTime.now().toUtc().toIso8601String();
     saveString('aiConsentContractVersion', currentAiConsentContractVersion);
-    if (receiptId.isNotEmpty && uid.isNotEmpty) {
+    if (receiptId.startsWith(currentAiConsentReceiptPrefix) && uid.isNotEmpty) {
       saveString('aiConsentReceiptId', receiptId);
       saveString('aiConsentReceiptUid', uid);
+    } else {
+      remove('aiConsentReceiptId');
+      remove('aiConsentReceiptUid');
     }
   }
 

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -18,6 +18,7 @@ class SharedPreferencesUtil {
   static SharedPreferences? _preferences;
 
   static const bool isPublicBuild = bool.fromEnvironment('ELLA_PUBLIC_BUILD');
+  static const String currentAiConsentContractVersion = 'voice-ai-processors-v2';
 
   factory SharedPreferencesUtil() {
     return _instance;
@@ -195,7 +196,8 @@ class SharedPreferencesUtil {
 
   set aiConsentAccepted(bool value) => saveBool('aiConsentAccepted', value);
 
-  bool get aiConsentAccepted => getBool('aiConsentAccepted', defaultValue: false);
+  bool get aiConsentAccepted =>
+      getBool('aiConsentAccepted', defaultValue: false) && aiConsentContractVersion == currentAiConsentContractVersion;
 
   set aiConsentAcceptedAt(String value) => saveString('aiConsentAcceptedAt', value);
 
@@ -205,12 +207,15 @@ class SharedPreferencesUtil {
 
   String get aiConsentReceiptUid => getString('aiConsentReceiptUid');
 
+  String get aiConsentContractVersion => getString('aiConsentContractVersion');
+
   bool hasAccountBoundAiConsent(String uid) =>
       uid.isNotEmpty && aiConsentAccepted && aiConsentReceiptId.isNotEmpty && aiConsentReceiptUid == uid;
 
   void acceptAiConsent({String receiptId = '', String uid = ''}) {
     aiConsentAccepted = true;
     aiConsentAcceptedAt = DateTime.now().toUtc().toIso8601String();
+    saveString('aiConsentContractVersion', currentAiConsentContractVersion);
     if (receiptId.isNotEmpty && uid.isNotEmpty) {
       saveString('aiConsentReceiptId', receiptId);
       saveString('aiConsentReceiptUid', uid);
@@ -222,6 +227,7 @@ class SharedPreferencesUtil {
     remove('aiConsentAcceptedAt');
     remove('aiConsentReceiptId');
     remove('aiConsentReceiptUid');
+    remove('aiConsentContractVersion');
   }
 
   // Notification frequency (0-5): 0 = off, 5 = most frequent. Default is 0 (disabled)
@@ -591,6 +597,7 @@ class SharedPreferencesUtil {
       'aiConsentAcceptedAt',
       'aiConsentReceiptId',
       'aiConsentReceiptUid',
+      'aiConsentContractVersion',
     ]) {
       await remove(key);
     }

--- a/app/lib/ella/services/elevenlabs_tts.dart
+++ b/app/lib/ella/services/elevenlabs_tts.dart
@@ -22,7 +22,7 @@ class ElevenLabsTts {
   /// Synthesize [text] to speech via the backend TTS proxy.
   /// Returns the path to a temporary audio file, or null on failure.
   static Future<String?> synthesize(String text) async {
-    if (text.trim().isEmpty) return null;
+    if (text.trim().isEmpty || !SharedPreferencesUtil().aiConsentAccepted) return null;
 
     final url = '${Env.apiBaseUrl}v1/voice/tts';
 

--- a/app/lib/ella/services/ella_ai_consent_service.dart
+++ b/app/lib/ella/services/ella_ai_consent_service.dart
@@ -41,7 +41,8 @@ class EllaAiConsentService {
     final confirmed = await _transport.getPrivateCloudSyncEnabled();
     if (!confirmed) return null;
 
-    final receiptId = 'ios-private-cloud-sync:${_receiptIdFactory()}';
+    final receiptId =
+        'ios-private-cloud-sync:${SharedPreferencesUtil.currentAiConsentContractVersion}:${_receiptIdFactory()}';
     _preferences.acceptAiConsent(receiptId: receiptId, uid: uid);
     return receiptId;
   }

--- a/app/lib/ella/services/ella_ai_consent_service.dart
+++ b/app/lib/ella/services/ella_ai_consent_service.dart
@@ -41,8 +41,7 @@ class EllaAiConsentService {
     final confirmed = await _transport.getPrivateCloudSyncEnabled();
     if (!confirmed) return null;
 
-    final receiptId =
-        'ios-private-cloud-sync:${SharedPreferencesUtil.currentAiConsentContractVersion}:${_receiptIdFactory()}';
+    final receiptId = '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}${_receiptIdFactory()}';
     _preferences.acceptAiConsent(receiptId: receiptId, uid: uid);
     return receiptId;
   }

--- a/app/lib/ella/widgets/ai_consent_sheet.dart
+++ b/app/lib/ella/widgets/ai_consent_sheet.dart
@@ -88,6 +88,8 @@ class _AiConsentSheetState extends State<AiConsentSheet> {
                   TextSpan(text: context.l10n.aiConsentDeepgram, style: const TextStyle(fontWeight: FontWeight.w700)),
                   TextSpan(text: context.l10n.aiConsentBodyMiddle),
                   TextSpan(text: context.l10n.aiConsentAiPartners, style: const TextStyle(fontWeight: FontWeight.w700)),
+                  TextSpan(text: context.l10n.aiConsentBodyBeforeElevenLabs),
+                  TextSpan(text: context.l10n.aiConsentElevenLabs, style: const TextStyle(fontWeight: FontWeight.w700)),
                   TextSpan(text: context.l10n.aiConsentBodyEnd),
                 ],
               ),

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10276,23 +10276,23 @@
   "@aiConsentTitle": {
     "description": "Locked first-run listening consent title"
   },
-  "aiConsentBodyIntro": "To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ",
+  "aiConsentBodyIntro": "When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella's secure backend to ",
   "@aiConsentBodyIntro": {
-    "description": "Locked consent body before the Deepgram processor name"
+    "description": "Locked consent body naming Ella routing and the data sent before the Deepgram processor name"
   },
   "aiConsentDeepgram": "Deepgram",
   "@aiConsentDeepgram": {
     "description": "Speech-to-text processor named in the locked consent disclosure"
   },
-  "aiConsentBodyMiddle": " (speech-to-text) and ",
+  "aiConsentBodyMiddle": " for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ",
   "@aiConsentBodyMiddle": {
     "description": "Locked consent body between processor names"
   },
-  "aiConsentAiPartners": "Google (Gemini), OpenAI, and Groq",
+  "aiConsentAiPartners": "Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs",
   "@aiConsentAiPartners": {
-    "description": "Summary and answer processors named in the locked consent disclosure"
+    "description": "Voice, summary, answer, and generated speech processors named in the locked consent disclosure"
   },
-  "aiConsentBodyEnd": " (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.",
+  "aiConsentBodyEnd": ". Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.",
   "@aiConsentBodyEnd": {
     "description": "Locked final portion of the listening consent body"
   },

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10284,15 +10284,23 @@
   "@aiConsentDeepgram": {
     "description": "Speech-to-text processor named in the locked consent disclosure"
   },
-  "aiConsentBodyMiddle": " for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ",
+  "aiConsentBodyMiddle": " for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ",
   "@aiConsentBodyMiddle": {
     "description": "Locked consent body between processor names"
   },
-  "aiConsentAiPartners": "Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs",
+  "aiConsentAiPartners": "OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)",
   "@aiConsentAiPartners": {
-    "description": "Voice, summary, answer, and generated speech processors named in the locked consent disclosure"
+    "description": "Text routing, summary, answer, and native voice processors named in the locked consent disclosure"
   },
-  "aiConsentBodyEnd": ". Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.",
+  "aiConsentBodyBeforeElevenLabs": ". OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ",
+  "@aiConsentBodyBeforeElevenLabs": {
+    "description": "Locked consent body explaining model routing and live voice before naming the TTS processor"
+  },
+  "aiConsentElevenLabs": "ElevenLabs",
+  "@aiConsentElevenLabs": {
+    "description": "Generated voice processor named in the locked consent disclosure"
+  },
+  "aiConsentBodyEnd": " and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.",
   "@aiConsentBodyEnd": {
     "description": "Locked final portion of the listening consent body"
   },

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -16140,19 +16140,31 @@ abstract class AppLocalizations {
   /// Locked consent body between processor names
   ///
   /// In en, this message translates to:
-  /// **' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to '**
+  /// **' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to '**
   String get aiConsentBodyMiddle;
 
-  /// Voice, summary, answer, and generated speech processors named in the locked consent disclosure
+  /// Text routing, summary, answer, and native voice processors named in the locked consent disclosure
   ///
   /// In en, this message translates to:
-  /// **'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs'**
+  /// **'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)'**
   String get aiConsentAiPartners;
+
+  /// Locked consent body explaining model routing and live voice before naming the TTS processor
+  ///
+  /// In en, this message translates to:
+  /// **'. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to '**
+  String get aiConsentBodyBeforeElevenLabs;
+
+  /// Generated voice processor named in the locked consent disclosure
+  ///
+  /// In en, this message translates to:
+  /// **'ElevenLabs'**
+  String get aiConsentElevenLabs;
 
   /// Locked final portion of the listening consent body
   ///
   /// In en, this message translates to:
-  /// **'. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.'**
+  /// **' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.'**
   String get aiConsentBodyEnd;
 
   /// Accept listening consent action

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -16125,10 +16125,10 @@ abstract class AppLocalizations {
   /// **'Ella listens to help remember.'**
   String get aiConsentTitle;
 
-  /// Locked consent body before the Deepgram processor name
+  /// Locked consent body naming Ella routing and the data sent before the Deepgram processor name
   ///
   /// In en, this message translates to:
-  /// **'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: '**
+  /// **'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to '**
   String get aiConsentBodyIntro;
 
   /// Speech-to-text processor named in the locked consent disclosure
@@ -16140,19 +16140,19 @@ abstract class AppLocalizations {
   /// Locked consent body between processor names
   ///
   /// In en, this message translates to:
-  /// **' (speech-to-text) and '**
+  /// **' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to '**
   String get aiConsentBodyMiddle;
 
-  /// Summary and answer processors named in the locked consent disclosure
+  /// Voice, summary, answer, and generated speech processors named in the locked consent disclosure
   ///
   /// In en, this message translates to:
-  /// **'Google (Gemini), OpenAI, and Groq'**
+  /// **'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs'**
   String get aiConsentAiPartners;
 
   /// Locked final portion of the listening consent body
   ///
   /// In en, this message translates to:
-  /// **' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.'**
+  /// **'. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.'**
   String get aiConsentBodyEnd;
 
   /// Accept listening consent action

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8601,14 +8601,21 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8594,20 +8594,21 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8689,14 +8689,21 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8682,20 +8682,21 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8705,14 +8705,21 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8698,20 +8698,21 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8645,20 +8645,21 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8652,14 +8652,21 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8634,20 +8634,21 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8641,14 +8641,21 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8716,20 +8716,21 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8723,14 +8723,21 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8707,20 +8707,21 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8714,14 +8714,21 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8654,14 +8654,21 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8647,20 +8647,21 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8664,20 +8664,21 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8671,14 +8671,21 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8656,14 +8656,21 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8649,20 +8649,21 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8655,14 +8655,21 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8648,20 +8648,21 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8730,14 +8730,21 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8723,20 +8723,21 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8637,14 +8637,21 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8630,20 +8630,21 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8694,14 +8694,21 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8687,20 +8687,21 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8662,20 +8662,21 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8669,14 +8669,21 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8699,20 +8699,21 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8706,14 +8706,21 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8523,14 +8523,21 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8516,20 +8516,21 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8525,14 +8525,21 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8518,20 +8518,21 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8662,14 +8662,21 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8655,20 +8655,21 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8674,14 +8674,21 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8667,20 +8667,21 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8680,14 +8680,21 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8673,20 +8673,21 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8682,14 +8682,21 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8675,20 +8675,21 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8652,14 +8652,21 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8645,20 +8645,21 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8668,20 +8668,21 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8675,14 +8675,21 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8657,14 +8657,21 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8650,20 +8650,21 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8695,14 +8695,21 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8688,20 +8688,21 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8682,14 +8682,21 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8675,20 +8675,21 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8647,14 +8647,21 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8640,20 +8640,21 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8655,20 +8655,21 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8662,14 +8662,21 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8619,14 +8619,21 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8612,20 +8612,21 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8663,20 +8663,21 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8670,14 +8670,21 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8669,14 +8669,21 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8662,20 +8662,21 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8659,14 +8659,21 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8652,20 +8652,21 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8506,20 +8506,21 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get aiConsentBodyIntro =>
-      'To turn speech into memories, audio from your device and necklace is sent securely to our processing partners: ';
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace is sent through Ella\'s secure backend to ';
 
   @override
   String get aiConsentDeepgram => 'Deepgram';
 
   @override
-  String get aiConsentBodyMiddle => ' (speech-to-text) and ';
+  String get aiConsentBodyMiddle =>
+      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, and Groq';
+  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      ' (to write summaries and answer you). Summaries are shared only with family members you choose. You can turn listening off any time in Settings.';
+      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8513,14 +8513,21 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get aiConsentBodyMiddle =>
-      ' for speech-to-text. Depending on the voice feature you choose, live audio and transcripts may also be sent to ';
+      ' for speech-to-text. To create summaries or answers, transcript and derived text may be sent to ';
 
   @override
-  String get aiConsentAiPartners => 'Google (Gemini), OpenAI, xAI (Grok), and ElevenLabs';
+  String get aiConsentAiPartners => 'OpenRouter, Google (Gemini), OpenAI, Groq, and xAI (Grok)';
+
+  @override
+  String get aiConsentBodyBeforeElevenLabs =>
+      '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentElevenLabs => 'ElevenLabs';
 
   @override
   String get aiConsentBodyEnd =>
-      '. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you; ElevenLabs receives response text and returns generated voice audio. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
+      ' and receives generated voice audio. Ella sends data only to the provider needed for the feature you choose. These processors use it to transcribe, answer, and speak to you. Summaries are shared only with family members you choose. You can choose Not now or turn listening off any time in Settings.';
 
   @override
   String get allowAndContinue => 'Allow and continue';

--- a/app/test/backend/audio_consent_guard_test.dart
+++ b/app/test/backend/audio_consent_guard_test.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:omi/backend/http/api/messages.dart';
 import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/elevenlabs_tts.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -16,5 +17,6 @@ void main() {
 
     await expectLater(transcribeVoiceMessage(File('unused.wav')), throwsStateError);
     await expectLater(syncLocalFiles([File('unused.wav')]), throwsStateError);
+    expect(await ElevenLabsTts.synthesize('This must stay on device.'), isNull);
   });
 }

--- a/app/test/backend/preferences_public_mode_test.dart
+++ b/app/test/backend/preferences_public_mode_test.dart
@@ -54,8 +54,30 @@ void main() {
     await preferences.saveString('aiConsentContractVersion', 'voice-ai-processors-v1');
     expect(preferences.aiConsentAccepted, isFalse);
 
-    preferences.acceptAiConsent(receiptId: 'current-receipt', uid: 'uid-a');
+    preferences.acceptAiConsent(
+      receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}current-receipt',
+      uid: 'uid-a',
+    );
     expect(preferences.aiConsentAccepted, isTrue);
     expect(preferences.hasAccountBoundAiConsent('uid-a'), isTrue);
+  });
+
+  test('receipt-less acceptance clears stale same-account authority', () async {
+    SharedPreferences.setMockInitialValues({
+      'aiConsentAccepted': true,
+      'aiConsentAcceptedAt': '2026-01-01T00:00:00Z',
+      'aiConsentContractVersion': 'voice-ai-processors-v1',
+      'aiConsentReceiptId': 'ios-private-cloud-sync:voice-ai-processors-v1:stale-receipt',
+      'aiConsentReceiptUid': 'uid-a',
+    });
+    await SharedPreferencesUtil.init();
+
+    final preferences = SharedPreferencesUtil();
+    preferences.acceptAiConsent();
+
+    expect(preferences.aiConsentAccepted, isTrue);
+    expect(preferences.aiConsentReceiptId, isEmpty);
+    expect(preferences.aiConsentReceiptUid, isEmpty);
+    expect(preferences.hasAccountBoundAiConsent('uid-a'), isFalse);
   });
 }

--- a/app/test/backend/preferences_public_mode_test.dart
+++ b/app/test/backend/preferences_public_mode_test.dart
@@ -30,9 +30,32 @@ void main() {
 
     expect(preferences.aiConsentAccepted, isTrue);
     expect(DateTime.tryParse(preferences.aiConsentAcceptedAt), isNotNull);
+    expect(preferences.aiConsentContractVersion, SharedPreferencesUtil.currentAiConsentContractVersion);
 
     preferences.declineAiConsent();
     expect(preferences.aiConsentAccepted, isFalse);
     expect(preferences.aiConsentAcceptedAt, isEmpty);
+    expect(preferences.aiConsentContractVersion, isEmpty);
+  });
+
+  test('legacy and stale processor consent receipts fail closed', () async {
+    SharedPreferences.setMockInitialValues({
+      'aiConsentAccepted': true,
+      'aiConsentAcceptedAt': '2026-01-01T00:00:00Z',
+      'aiConsentReceiptId': 'legacy-receipt',
+      'aiConsentReceiptUid': 'uid-a',
+    });
+    await SharedPreferencesUtil.init();
+
+    final preferences = SharedPreferencesUtil();
+    expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.hasAccountBoundAiConsent('uid-a'), isFalse);
+
+    await preferences.saveString('aiConsentContractVersion', 'voice-ai-processors-v1');
+    expect(preferences.aiConsentAccepted, isFalse);
+
+    preferences.acceptAiConsent(receiptId: 'current-receipt', uid: 'uid-a');
+    expect(preferences.aiConsentAccepted, isTrue);
+    expect(preferences.hasAccountBoundAiConsent('uid-a'), isTrue);
   });
 }

--- a/app/test/ella/services/ella_provisioning_service_test.dart
+++ b/app/test/ella/services/ella_provisioning_service_test.dart
@@ -120,7 +120,7 @@ void main() {
       'ellaSettingsVoiceModeDirty': true,
       'aiConsentAccepted': true,
       'aiConsentAcceptedAt': '2026-01-01T00:00:00Z',
-      'aiConsentReceiptId': 'consent-a',
+      'aiConsentReceiptId': '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}consent-a',
       'aiConsentReceiptUid': 'uid-a',
       'demoMode': true,
       'publicMode': true,
@@ -155,7 +155,7 @@ void main() {
       'ellaGatewayToken': 'secret',
       'ellaKey': 'legacy-key',
       'aiConsentAccepted': true,
-      'aiConsentReceiptId': 'consent-a',
+      'aiConsentReceiptId': '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}consent-a',
       'aiConsentReceiptUid': 'uid-a',
       'aiConsentContractVersion': SharedPreferencesUtil.currentAiConsentContractVersion,
     });

--- a/app/test/ella/services/ella_provisioning_service_test.dart
+++ b/app/test/ella/services/ella_provisioning_service_test.dart
@@ -147,7 +147,8 @@ void main() {
     expect(preferences.getStringList('cachedMessages'), isEmpty);
   });
 
-  test('same retained account preserves legacy preferences without making them provisioning authority', () async {
+  test('same retained account preserves current consent and legacy preferences without making them authority',
+      () async {
     SharedPreferences.setMockInitialValues({
       'ellaProvisioningAccountUid': 'uid-a',
       'ellaGatewayUrl': 'https://gateway.invalid',
@@ -156,6 +157,7 @@ void main() {
       'aiConsentAccepted': true,
       'aiConsentReceiptId': 'consent-a',
       'aiConsentReceiptUid': 'uid-a',
+      'aiConsentContractVersion': SharedPreferencesUtil.currentAiConsentContractVersion,
     });
     await SharedPreferencesUtil.init();
     final preferences = SharedPreferencesUtil();
@@ -354,11 +356,15 @@ void main() {
 
     final receiptId = await service.acknowledgePrivateCloudSync(uid: 'uid-a');
 
-    expect(receiptId, 'ios-private-cloud-sync:receipt-1');
+    expect(receiptId, 'ios-private-cloud-sync:voice-ai-processors-v2:receipt-1');
     expect(transport.values, [true]);
     expect(transport.getCalls, 1);
     expect(SharedPreferencesUtil().hasAccountBoundAiConsent('uid-a'), isTrue);
     expect(SharedPreferencesUtil().aiConsentReceiptId, receiptId);
+    expect(
+      SharedPreferencesUtil().aiConsentContractVersion,
+      SharedPreferencesUtil.currentAiConsentContractVersion,
+    );
   });
 
   test('AI consent stays disabled when private cloud sync cannot be confirmed', () async {

--- a/app/test/ella/services/v2v_client_test.dart
+++ b/app/test/ella/services/v2v_client_test.dart
@@ -1,7 +1,17 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/services/v2v_client.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
   group('V2VClient provider contract', () {
     test('normalizes legacy provider ids and recognizes canonical session providers', () {
       expect(V2VClient.normalizeProvider('gemini-live'), 'gemini-native-live');
@@ -83,6 +93,24 @@ void main() {
         V2VClient.safeErrorCode('{"detail":"Provider grok-voice is not configured (missing API key)"}'),
         'provider_not_configured',
       );
+    });
+
+    test('legacy consent receipt blocks before V2V provider or session requests', () async {
+      SharedPreferences.setMockInitialValues({
+        'aiConsentAccepted': true,
+        'aiConsentReceiptId': 'legacy-receipt',
+        'aiConsentReceiptUid': 'uid-a',
+        'uid': 'uid-a',
+      });
+      await SharedPreferencesUtil.init();
+      final client = V2VClient(onEvent: (_) {}, onConnectionChanged: (_) {});
+
+      final receipt = await client.connect(provider: 'grok-voice');
+
+      expect(receipt.connected, isFalse);
+      expect(receipt.stage, V2VConnectionStage.consent);
+      expect(receipt.errorCode, 'ai_consent_required');
+      await client.disconnect();
     });
   });
 

--- a/app/test/ella/widgets/ai_consent_sheet_test.dart
+++ b/app/test/ella/widgets/ai_consent_sheet_test.dart
@@ -29,9 +29,13 @@ void main() {
     expect(disclosure, contains("Ella's secure backend"));
     expect(disclosure, contains('live microphone audio'));
     expect(disclosure, contains('Deepgram'));
+    expect(disclosure, contains('OpenRouter'));
+    expect(disclosure, contains('selected model provider'));
     expect(disclosure, contains('Google (Gemini)'));
     expect(disclosure, contains('OpenAI'));
+    expect(disclosure, contains('Groq'));
     expect(disclosure, contains('xAI (Grok)'));
+    expect(disclosure, contains('OpenAI, Groq, and xAI (Grok)'));
     expect(disclosure, contains('ElevenLabs'));
     expect(disclosure, contains('response text'));
     expect(find.text('Not now'), findsOneWidget);
@@ -41,6 +45,8 @@ void main() {
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
 
+    await tester.ensureVisible(find.text('Allow and continue'));
+    await tester.pumpAndSettle();
     await tester.tap(find.text('Allow and continue'));
     await tester.pumpAndSettle();
 

--- a/app/test/ella/widgets/ai_consent_sheet_test.dart
+++ b/app/test/ella/widgets/ai_consent_sheet_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/widgets/ai_consent_sheet.dart';
+import 'package:omi/l10n/app_localizations.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  Widget buildApp() => const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: AiConsentSheet()),
+      );
+
+  testWidgets('names every voice processor and explains routed data before acceptance', (tester) async {
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    final disclosure =
+        tester.widgetList<RichText>(find.byType(RichText)).map((widget) => widget.text.toPlainText()).join(' ');
+    expect(disclosure, contains("Ella's secure backend"));
+    expect(disclosure, contains('live microphone audio'));
+    expect(disclosure, contains('Deepgram'));
+    expect(disclosure, contains('Google (Gemini)'));
+    expect(disclosure, contains('OpenAI'));
+    expect(disclosure, contains('xAI (Grok)'));
+    expect(disclosure, contains('ElevenLabs'));
+    expect(disclosure, contains('response text'));
+    expect(find.text('Not now'), findsOneWidget);
+  });
+
+  testWidgets('accept records the current processor contract', (tester) async {
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Allow and continue'));
+    await tester.pumpAndSettle();
+
+    final preferences = SharedPreferencesUtil();
+    expect(preferences.aiConsentAccepted, isTrue);
+    expect(preferences.aiConsentContractVersion, SharedPreferencesUtil.currentAiConsentContractVersion);
+  });
+
+  testWidgets('Not now revokes the current processor contract', (tester) async {
+    final preferences = SharedPreferencesUtil();
+    preferences.acceptAiConsent();
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.text('Not now'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Not now'));
+    await tester.pumpAndSettle();
+
+    expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.aiConsentContractVersion, isEmpty);
+  });
+}


### PR DESCRIPTION
Closes ellaaicare/ella-ai#1095.

## What changed
- introduces consent contract `voice-ai-processors-v2`; legacy or mismatched receipts fail closed
- versions account-bound receipt IDs passed to Hermes provisioning and requires the current versioned prefix for authority
- receipt-less or malformed acceptance clears any stale receipt ID/UID pair
- names Ella backend routing, Deepgram, OpenRouter, Google Gemini, OpenAI, direct Groq, xAI/Grok, and ElevenLabs before cloud processing
- distinguishes Deepgram microphone STT, OpenRouter transcript/derived-text routing, direct model providers, native live microphone providers, and ElevenLabs response-text TTS/generated audio
- keeps **Not now** available and blocks backend ElevenLabs TTS directly when current consent is absent

## User impact
Existing users with an older unversioned receipt must accept the updated disclosure before listening, V2V, chat, transcription, summary processing, or backend TTS can send data. Receipt-less local acceptance cannot revive stale account-bound authority. Declining leaves cloud paths disabled.

## Validation
- focused consent/provisioning/V2V/TTS/UI suite: 32 passed
- `./app/test.sh`: 18 capture + 3 transcript tests passed
- focused `flutter analyze --no-pub`: no issues
- prod-flavor iOS Simulator build succeeded for `com.ellaaicare.ella`

## Release boundary
No Firebase, auth, signing, provider, backend, or rollout configuration changed. Live `https://ella-ai-care.com/privacy` names Deepgram, Firebase/Gemini, direct Groq, xAI/Grok, and ElevenLabs but currently omits OpenRouter and OpenAI. The Infra/Vendor handoff requires those policy additions plus ASC App Privacy/App Review alignment before public submission. Internal TestFlight diagnosis of build 798 remains separate.