### PR TITLE
fix(ios): resolve prod env deterministically in release builds

### DIFF
--- a/app/ios/build-and-upload.sh
+++ b/app/ios/build-and-upload.sh
@@ -155,6 +155,13 @@ EOF
 fi
 $FLUTTER pub get
 $DART run build_runner build --delete-conflicting-outputs
+# Envied's worker may not resolve annotation dotfile paths from APP_DIR.
+# Regenerate only the selected flavor with an absolute path before packaging.
+$DART run build_runner build \
+  --delete-conflicting-outputs \
+  --build-filter="lib/env/${FLAVOR}_env.g.dart" \
+  --define="envied_generator:envied=path=$APP_DIR/.${FLAVOR}.env" \
+  --define="envied_generator:envied=override=true"
 
 if [ "$FLAVOR" = "prod" ] && grep -q "static final String? apiBaseUrl = null;" lib/env/prod_env.g.dart; then
   echo "ERROR: ProdEnv.apiBaseUrl is null after build_runner; refusing to ship a backend-disconnected prod app."


### PR DESCRIPTION
## Summary
- force Envied to regenerate only the selected flavor with an absolute env path
- preserve the existing release guard against a null production API URL
- make headless SSH builds use the same backend wiring as GUI builds

## Validation
- `bash -n app/ios/build-and-upload.sh`
- normal build_runner pass followed by filtered production Envied generation
- verified generated `ProdEnv.apiBaseUrl` is non-null and sourced from the absolute `.prod.env` path

Found while staging TestFlight build 799. The previous preflight safely stopped before archive/upload.