### PR TITLE
Fix Guardian history wake acknowledgement noise

### DIFF
--- a/app/lib/ella/models/guardian_alert.dart
+++ b/app/lib/ella/models/guardian_alert.dart
@@ -14,6 +14,7 @@ class GuardianAlertRecord {
     this.queueItemId,
     this.ttsProvider,
     this.why,
+    this.ackOnly = false,
     this.isTest = false,
     this.fromLocalDebugLog = false,
   });
@@ -32,10 +33,14 @@ class GuardianAlertRecord {
   final String? queueItemId;
   final String? ttsProvider;
   final String? why;
+  final bool ackOnly;
   final bool isTest;
   final bool fromLocalDebugLog;
 
+  bool get isSystemWakeAcknowledgement => triggerType.trim().toLowerCase() == 'wake_word_ack' || ackOnly;
+
   factory GuardianAlertRecord.fromJson(Map<String, dynamic> json) {
+    final metadata = _nestedMap(json['metadata']);
     final id = _firstString(json, const [
       'id',
       'alert_id',
@@ -76,8 +81,8 @@ class GuardianAlertRecord {
       queueItemId: _nullableFirstString(json, const ['queue_item_id', 'guardian_queue_item_id']),
       ttsProvider: _nullableFirstString(json, const ['tts_provider', 'provider']),
       why: _nullableFirstString(json, const ['why', 'trigger_explanation', 'triggerExplanation']),
-      isTest:
-          json['is_test'] == true ||
+      ackOnly: _isTrue(json['ack_only']) || _isTrue(metadata['ack_only']),
+      isTest: json['is_test'] == true ||
           json['dry_run'] == true ||
           _isTestTarget(_firstString(json, const ['delivery_target', 'target'])),
     );
@@ -87,6 +92,7 @@ class GuardianAlertRecord {
     final extra = json['extra'];
     final fields = <String, dynamic>{...json};
     if (extra is Map<String, dynamic>) fields.addAll(extra);
+    final metadata = _nestedMap(fields['metadata']);
 
     final type = _firstString(fields, const ['type', 'event_type']);
     final message = _firstString(fields, const ['message']);
@@ -115,6 +121,7 @@ class GuardianAlertRecord {
       queueItemId: _nullableFirstString(fields, const ['queue_item_id', 'guardian_queue_item_id']),
       ttsProvider: _nullableFirstString(fields, const ['tts_provider', 'provider']),
       why: _nullableFirstString(fields, const ['why', 'trigger_explanation', 'triggerExplanation']),
+      ackOnly: _isTrue(fields['ack_only']) || _isTrue(metadata['ack_only']),
       isTest: fields['is_test'] == true || fields['dry_run'] == true || _isTestTarget(target),
       fromLocalDebugLog: true,
     );
@@ -184,3 +191,11 @@ bool _isTestTarget(String value) {
   final normalized = value.toLowerCase();
   return normalized.contains('test') || normalized.contains('dry-run') || normalized.contains('dry_run');
 }
+
+Map<String, dynamic> _nestedMap(dynamic value) {
+  if (value is Map<String, dynamic>) return value;
+  if (value is Map) return value.map((key, item) => MapEntry(key.toString(), item));
+  return const {};
+}
+
+bool _isTrue(dynamic value) => value == true || (value is String && value.trim().toLowerCase() == 'true');

--- a/app/lib/ella/pages/guardian_alert_history_page.dart
+++ b/app/lib/ella/pages/guardian_alert_history_page.dart
@@ -49,7 +49,8 @@ class _GuardianAlertHistoryPageState extends State<GuardianAlertHistoryPage> {
           if (snapshot.hasError || snapshot.data == null) {
             return _WhisperEmptyState(onRefresh: _refresh);
           }
-          final records = snapshot.data!.records;
+          final records =
+              snapshot.data!.records.where((record) => !record.isSystemWakeAcknowledgement).toList(growable: false);
           if (records.isEmpty) return _WhisperEmptyState(onRefresh: _refresh);
           final grouped = _groupByDay(records);
           return RefreshIndicator(
@@ -236,8 +237,8 @@ Map<String, List<GuardianAlertRecord>> _groupByDay(List<GuardianAlertRecord> rec
     final label = day == today
         ? 'TODAY'
         : day == today.subtract(const Duration(days: 1))
-        ? 'YESTERDAY'
-        : DateFormat('EEEE · MMMM d').format(day).toUpperCase();
+            ? 'YESTERDAY'
+            : DateFormat('EEEE · MMMM d').format(day).toUpperCase();
     result.putIfAbsent(label, () => []).add(record);
   }
   return result;

--- a/app/lib/ella/services/guardian_alert_history_api.dart
+++ b/app/lib/ella/services/guardian_alert_history_api.dart
@@ -9,11 +9,7 @@ import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 
 class GuardianAlertHistoryResult {
-  const GuardianAlertHistoryResult({
-    required this.records,
-    required this.source,
-    this.error,
-  });
+  const GuardianAlertHistoryResult({required this.records, required this.source, this.error});
 
   final List<GuardianAlertRecord> records;
   final GuardianAlertHistorySource source;
@@ -30,7 +26,10 @@ class GuardianAlertHistoryApi {
   static Future<GuardianAlertHistoryResult> fetch({int limit = 50}) async {
     if (SharedPreferencesUtil().demoMode) {
       return GuardianAlertHistoryResult(
-        records: DemoFixtures.whispers().take(limit).toList(),
+        records: DemoFixtures.whispers()
+            .where((record) => !record.isSystemWakeAcknowledgement)
+            .take(limit)
+            .toList(growable: false),
         source: GuardianAlertHistorySource.backend,
       );
     }
@@ -75,7 +74,8 @@ class GuardianAlertHistoryApi {
 
   static List<GuardianAlertRecord> parseBackendRecords(dynamic decoded) {
     final items = _extractRecordList(decoded);
-    final records = items.map(GuardianAlertRecord.fromJson).toList();
+    final records =
+        items.map(GuardianAlertRecord.fromJson).where((record) => !record.isSystemWakeAcknowledgement).toList();
     records.sort(_newestFirst);
     return records;
   }
@@ -93,7 +93,9 @@ class GuardianAlertHistoryApi {
           final decoded = jsonDecode(trimmed);
           if (decoded is! Map<String, dynamic>) continue;
           if (!GuardianAlertRecord.isGuardianDebugLog(decoded)) continue;
-          records.add(GuardianAlertRecord.fromDebugLog(decoded));
+          final record = GuardianAlertRecord.fromDebugLog(decoded);
+          if (record.isSystemWakeAcknowledgement) continue;
+          records.add(record);
         }
         if (records.length >= limit) break;
       }

--- a/app/test/ella/services/guardian_alert_history_api_test.dart
+++ b/app/test/ella/services/guardian_alert_history_api_test.dart
@@ -66,5 +66,36 @@ void main() {
       expect(record.fromLocalDebugLog, isTrue);
       expect(record.createdAt, DateTime.parse('2026-05-15T20:05:00.000Z'));
     });
+
+    test('excludes wake acknowledgement pulses while retaining genuine wake-word whispers', () {
+      final records = GuardianAlertHistoryApi.parseBackendRecords({
+        'alerts': [
+          {
+            'id': 'trigger-ack',
+            'alert_text': 'wake_ack',
+            'trigger_type': 'wake_word_ack',
+            'metadata': {'ack_only': false},
+            'created_at': '2026-05-15T20:07:00Z',
+          },
+          {
+            'id': 'metadata-ack',
+            'alert_text': 'Acknowledged',
+            'trigger_type': 'wake_word',
+            'metadata': {'ack_only': true},
+            'created_at': '2026-05-15T20:06:00Z',
+          },
+          {
+            'id': 'real-wake',
+            'alert_text': 'I found your glasses.',
+            'trigger_type': 'wake_word',
+            'metadata': {'ack_only': false},
+            'created_at': '2026-05-15T20:05:00Z',
+          },
+        ],
+      });
+
+      expect(records.map((record) => record.id), ['real-wake']);
+      expect(records.single.isSystemWakeAcknowledgement, isFalse);
+    });
   });
 }

--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -745,6 +745,8 @@ async def _guardian_alert_history(uid: str, limit: int) -> dict[str, Any]:
                 ) AS trace_id
             FROM guardian_queue
             WHERE LOWER(uid) = LOWER($1)
+              AND COALESCE(trigger_type, '') <> 'wake_word_ack'
+              AND COALESCE(metadata->>'ack_only', '') <> 'true'
             ORDER BY created_at DESC
             LIMIT $2
         ),
@@ -799,7 +801,9 @@ async def _guardian_alert_history(uid: str, limit: int) -> dict[str, Any]:
         safe_limit,
     )
 
-    alerts = [_normalize_guardian_alert_row(dict(row), timezone_name or "") for row in rows]
+    alerts = [
+        _normalize_guardian_alert_row(dict(row), timezone_name or "") for row in rows if not _is_wake_ack_row(dict(row))
+    ]
     return {
         "ok": True,
         "uid": uid,
@@ -830,6 +834,13 @@ def _queue_priority_rank(priority: Optional[str]) -> int:
 
 def _queue_trace_id(row: dict[str, Any]) -> str:
     return _trace_id_from_metadata(_coerce_metadata_dict(row.get("metadata")), str(row.get("id") or ""))
+
+
+def _is_wake_ack_row(row: dict[str, Any]) -> bool:
+    metadata = _coerce_metadata_dict(row.get("metadata"))
+    trigger = str(row.get("trigger_type") or metadata.get("trigger_type") or "").strip().lower()
+    ack_only = metadata.get("ack_only")
+    return trigger == "wake_word_ack" or ack_only is True or str(ack_only or "").strip().lower() == "true"
 
 
 def _normalize_for_echo_match(text: str) -> str:

--- a/backend/tests/unit/test_ella_guardian_delivery.py
+++ b/backend/tests/unit/test_ella_guardian_delivery.py
@@ -117,8 +117,9 @@ class _FakeAlertPool:
         self.fetchrow_args.append(args)
         return {"timezone": self.timezone_name}
 
-    async def fetch(self, _query, *args):
+    async def fetch(self, query, *args):
         self.fetch_args.append(args)
+        self.fetch_query = query
         return self.rows
 
 
@@ -458,6 +459,70 @@ def test_guardian_alert_history_normalizes_queue_event_delivery_rows(monkeypatch
     assert alert["test"] is True
     assert alert["created_time"]["timezone"] == "America/Los_Angeles"
     assert pool.fetch_args[0] == ("uid-1", 50)
+    assert "COALESCE(trigger_type, '') <> 'wake_word_ack'" in pool.fetch_query
+    assert "COALESCE(metadata->>'ack_only', '') <> 'true'" in pool.fetch_query
+
+
+def test_guardian_alerts_endpoint_excludes_ack_only_rows_but_keeps_real_wake_words(monkeypatch):
+    created = datetime(2026, 5, 15, 20, 0, tzinfo=timezone.utc)
+    pool = _FakeAlertPool(
+        [
+            {
+                "id": "guardian_ack_trigger",
+                "uid": "auth-uid",
+                "url": "https://example.test/wake-ack.mp3",
+                "priority": "normal",
+                "message": "wake_ack",
+                "trigger_type": "wake_word_ack",
+                "metadata": {"trace_id": "trace-ack-trigger"},
+                "created_at": created,
+                "consumed_at": None,
+                "trace_id": "trace-ack-trigger",
+                "events": [],
+                "deliveries": [],
+            },
+            {
+                "id": "guardian_ack_metadata",
+                "uid": "auth-uid",
+                "url": "https://example.test/wake-ack.mp3",
+                "priority": "normal",
+                "message": "Acknowledged",
+                "trigger_type": "wake_word",
+                "metadata": {"trace_id": "trace-ack-metadata", "ack_only": True},
+                "created_at": created,
+                "consumed_at": None,
+                "trace_id": "trace-ack-metadata",
+                "events": [],
+                "deliveries": [],
+            },
+            {
+                "id": "guardian_real_wake",
+                "uid": "auth-uid",
+                "url": "https://example.test/full-response.mp3",
+                "priority": "normal",
+                "message": "I found your glasses.",
+                "trigger_type": "wake_word",
+                "metadata": {"trace_id": "trace-real-wake", "ack_only": False},
+                "created_at": created,
+                "consumed_at": None,
+                "trace_id": "trace-real-wake",
+                "events": [],
+                "deliveries": [],
+            },
+        ]
+    )
+    monkeypatch.setattr(guardian, "_pool", pool)
+
+    app = FastAPI()
+    app.include_router(guardian.alerts_router)
+    app.dependency_overrides[guardian.auth.get_current_user_uid] = lambda: "auth-uid"
+
+    response = TestClient(app).get("/v1/ella/guardian-alerts?limit=50")
+
+    assert response.status_code == 200
+    assert [alert["queue_item_id"] for alert in response.json()["alerts"]] == ["guardian_real_wake"]
+    assert "COALESCE(trigger_type, '') <> 'wake_word_ack'" in pool.fetch_query
+    assert "COALESCE(metadata->>'ack_only', '') <> 'true'" in pool.fetch_query
 
 
 def test_guardian_alerts_endpoint_uses_authenticated_uid_not_query_uid(monkeypatch):


### PR DESCRIPTION
## Summary
- exclude `wake_word_ack` and `metadata.ack_only=true` rows in the Guardian alert-history SQL CTE
- retain genuine `wake_word` and `wake_word_user_support` entries
- add backend normalization plus iOS API/model/page defense-in-depth for rolled-back servers and local debug logs
- add endpoint and iOS parser regressions

## Validation
- `python3 -m pytest -q tests/unit/test_ella_guardian_delivery.py` — 15 passed
- `backend/test.sh` — passed
- `app/test.sh` — capture provider 18 passed; transcript 3 passed
- `flutter test test/ella/services/guardian_alert_history_api_test.dart` — 3 passed
- `git diff --check`

Fixes ellaaicare/ella-ai#1100