### PR TITLE
fix(guardian): hide wake acknowledgements from production history

### DIFF
--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -740,6 +740,8 @@ async def _guardian_alert_history(uid: str, limit: int) -> dict[str, Any]:
                 ) AS trace_id
             FROM guardian_queue
             WHERE LOWER(uid) = LOWER($1)
+              AND COALESCE(trigger_type, '') <> 'wake_word_ack'
+              AND COALESCE(metadata->>'ack_only', '') <> 'true'
             ORDER BY created_at DESC
             LIMIT $2
         ),
@@ -794,7 +796,9 @@ async def _guardian_alert_history(uid: str, limit: int) -> dict[str, Any]:
         safe_limit,
     )
 
-    alerts = [_normalize_guardian_alert_row(dict(row), timezone_name or "") for row in rows]
+    alerts = [
+        _normalize_guardian_alert_row(dict(row), timezone_name or "") for row in rows if not _is_wake_ack_row(dict(row))
+    ]
     return {
         "ok": True,
         "uid": uid,
@@ -825,6 +829,13 @@ def _queue_priority_rank(priority: Optional[str]) -> int:
 
 def _queue_trace_id(row: dict[str, Any]) -> str:
     return _trace_id_from_metadata(_coerce_metadata_dict(row.get("metadata")), str(row.get("id") or ""))
+
+
+def _is_wake_ack_row(row: dict[str, Any]) -> bool:
+    metadata = _coerce_metadata_dict(row.get("metadata"))
+    trigger = str(row.get("trigger_type") or metadata.get("trigger_type") or "").strip().lower()
+    ack_only = metadata.get("ack_only")
+    return trigger == "wake_word_ack" or ack_only is True or str(ack_only or "").strip().lower() == "true"
 
 
 def _normalize_for_echo_match(text: str) -> str:

--- a/backend/tests/unit/test_ella_guardian_delivery.py
+++ b/backend/tests/unit/test_ella_guardian_delivery.py
@@ -39,6 +39,10 @@ ella_app_settings_module.build_effective_voice_settings = lambda _uid, voice: {
 }
 sys.modules["ella.services.app_settings"] = ella_app_settings_module
 
+runtime_resolver_module = types.ModuleType("ella.services.runtime_resolver")
+runtime_resolver_module.runtime_bindings_enabled = lambda _uid: False
+sys.modules["ella.services.runtime_resolver"] = runtime_resolver_module
+
 sys.modules.setdefault("ella.routers", types.ModuleType("ella.routers"))
 resolve_module = types.ModuleType("ella.routers.resolve")
 resolve_module.resolve_user_routing = None
@@ -117,8 +121,9 @@ class _FakeAlertPool:
         self.fetchrow_args.append(args)
         return {"timezone": self.timezone_name}
 
-    async def fetch(self, _query, *args):
+    async def fetch(self, query, *args):
         self.fetch_args.append(args)
+        self.fetch_query = query
         return self.rows
 
 
@@ -455,6 +460,70 @@ def test_guardian_alert_history_normalizes_queue_event_delivery_rows(monkeypatch
     assert alert["test"] is True
     assert alert["created_time"]["timezone"] == "America/Los_Angeles"
     assert pool.fetch_args[0] == ("uid-1", 50)
+    assert "COALESCE(trigger_type, '') <> 'wake_word_ack'" in pool.fetch_query
+    assert "COALESCE(metadata->>'ack_only', '') <> 'true'" in pool.fetch_query
+
+
+def test_guardian_alerts_endpoint_excludes_ack_only_rows_but_keeps_real_wake_words(monkeypatch):
+    created = datetime(2026, 5, 15, 20, 0, tzinfo=timezone.utc)
+    pool = _FakeAlertPool(
+        [
+            {
+                "id": "guardian_ack_trigger",
+                "uid": "auth-uid",
+                "url": "https://example.test/wake-ack.mp3",
+                "priority": "normal",
+                "message": "wake_ack",
+                "trigger_type": "wake_word_ack",
+                "metadata": {"trace_id": "trace-ack-trigger"},
+                "created_at": created,
+                "consumed_at": None,
+                "trace_id": "trace-ack-trigger",
+                "events": [],
+                "deliveries": [],
+            },
+            {
+                "id": "guardian_ack_metadata",
+                "uid": "auth-uid",
+                "url": "https://example.test/wake-ack.mp3",
+                "priority": "normal",
+                "message": "Acknowledged",
+                "trigger_type": "wake_word",
+                "metadata": {"trace_id": "trace-ack-metadata", "ack_only": True},
+                "created_at": created,
+                "consumed_at": None,
+                "trace_id": "trace-ack-metadata",
+                "events": [],
+                "deliveries": [],
+            },
+            {
+                "id": "guardian_real_wake",
+                "uid": "auth-uid",
+                "url": "https://example.test/full-response.mp3",
+                "priority": "normal",
+                "message": "I found your glasses.",
+                "trigger_type": "wake_word",
+                "metadata": {"trace_id": "trace-real-wake", "ack_only": False},
+                "created_at": created,
+                "consumed_at": None,
+                "trace_id": "trace-real-wake",
+                "events": [],
+                "deliveries": [],
+            },
+        ]
+    )
+    monkeypatch.setattr(guardian, "_pool", pool)
+
+    app = FastAPI()
+    app.include_router(guardian.alerts_router)
+    app.dependency_overrides[guardian.auth.get_current_user_uid] = lambda: "auth-uid"
+
+    response = TestClient(app).get("/v1/ella/guardian-alerts?limit=50")
+
+    assert response.status_code == 200
+    assert [alert["queue_item_id"] for alert in response.json()["alerts"]] == ["guardian_real_wake"]
+    assert "COALESCE(trigger_type, '') <> 'wake_word_ack'" in pool.fetch_query
+    assert "COALESCE(metadata->>'ack_only', '') <> 'true'" in pool.fetch_query
 
 
 def test_guardian_alerts_endpoint_uses_authenticated_uid_not_query_uid(monkeypatch):


### PR DESCRIPTION
## Summary
- carry the reviewed backend half of #319 onto current `main`
- exclude `wake_word_ack` and `metadata.ack_only=true` from Guardian history
- preserve genuine wake-word and user-support entries
- retain normalization defense for case/string variants
- repair the mainline Guardian test harness with a fail-closed isolated-runtime stub

## Why a separate PR
#319 targets `feature/phase-a-testflight`. That branch differs from production main across 41 backend files, including isolation/runtime services, so deploying the full Phase A backend would be unsafe. This PR is the narrow production release artifact.

## Validation
- `python3 -m pytest -q backend/tests/unit/test_ella_guardian_delivery.py`: 15 passed
- `black --check` on both changed Python files: clean
- `python3 -m compileall -q backend/ella/routers/guardian.py`
- `git diff --check`

Backend portion of ellaaicare/ella-ai#1100.