### PR TITLE
chore(ios): stage Ella Care TestFlight build 800

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.526+799
+version: 1.0.527+800
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- bump Ella Care from `1.0.526+799` to `1.0.527+800`
- stage the release branch after merged wake-ack Guardian history filtering (#319 / ella-ai#1100)
- intentionally exclude draft Talking to Memories PR #314 because its authenticated live correction/undo, exact-head screenshot, design, and code-review gates are not complete

## Validation
- `flutter test`: 162/162 passed
- `app/test.sh`: 18/18 capture + 3/3 transcript passed
- Task A implementation validation on PR #319: Guardian endpoint 15/15, backend standard suite, Guardian parser 3/3
- `git diff --check`

Release metadata only. No Firebase, auth, signing, backend URL, or feature configuration changes.
