### PR TITLE
Add production correction receipt and undo API

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -562,6 +562,60 @@ def update_conversation(uid: str, conversation_id: str, update_data: dict):
     doc_ref.update(prepared_data)
 
 
+def _update_conversation_if_active_summary_version_transaction(
+    transaction,
+    conversation_ref,
+    uid: str,
+    expected_active_summary_version_id: Optional[str],
+    update_data: dict,
+) -> bool:
+    snapshot = conversation_ref.get(transaction=transaction)
+    if not snapshot.exists:
+        return False
+    conversation = snapshot.to_dict() or {}
+    if str(conversation.get('active_summary_version_id') or '') != str(expected_active_summary_version_id or ''):
+        return False
+    doc_level = conversation.get('data_protection_level', 'standard')
+    prepared_data = _prepare_conversation_for_write(update_data, uid, doc_level)
+    transaction.update(conversation_ref, prepared_data)
+    return True
+
+
+@transactional
+def _update_conversation_if_active_summary_version(
+    transaction,
+    conversation_ref,
+    uid: str,
+    expected_active_summary_version_id: Optional[str],
+    update_data: dict,
+) -> bool:
+    return _update_conversation_if_active_summary_version_transaction(
+        transaction,
+        conversation_ref,
+        uid,
+        expected_active_summary_version_id,
+        update_data,
+    )
+
+
+def update_conversation_if_active_summary_version(
+    uid: str,
+    conversation_id: str,
+    expected_active_summary_version_id: Optional[str],
+    update_data: dict,
+) -> bool:
+    conversation_ref = (
+        db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
+    )
+    return _update_conversation_if_active_summary_version(
+        db.transaction(),
+        conversation_ref,
+        uid,
+        expected_active_summary_version_id,
+        update_data,
+    )
+
+
 def create_audio_files_from_chunks(
     uid: str,
     conversation_id: str,

--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -34,6 +34,7 @@ from ella.services.summary_recovery import (
     recover_failed_conversation_summary,
     summary_provider_config_for_uid,
 )
+from ella.services.summary_writeback import ConcurrentConversationSummaryChangeError
 from ella.services import proposal_ingest
 from models.conversation import Conversation, ConversationStatus
 from utils.other import endpoints as auth
@@ -125,6 +126,30 @@ class ConversationCorrectionResponse(BaseModel):
     status: str
     queued: bool
     proposal_id: Optional[str] = None
+
+
+class CorrectionSummarySnapshot(BaseModel):
+    title: str = ""
+    overview: str = ""
+    emoji: str = ""
+    category: str = "other"
+
+
+class ConversationCorrectionReceiptResponse(BaseModel):
+    correction_id: str
+    conversation_id: str
+    status: str
+    applied_at: Optional[datetime] = None
+    undone_at: Optional[datetime] = None
+    before_version_id: Optional[str] = None
+    after_version_id: Optional[str] = None
+    active_version_id: Optional[str] = None
+    undo_version_id: Optional[str] = None
+    before: CorrectionSummarySnapshot
+    after: CorrectionSummarySnapshot
+    propagation_status: str = "known"
+    propagation_applied_count: Optional[int] = 0
+    propagation_reverted_count: Optional[int] = 0
 
 
 class ConversationProcessingRetryOutcome(str, Enum):
@@ -415,6 +440,280 @@ def _audit_ref(uid: str, conversation_id: str, correction_id: str):
         .collection("corrections")
         .document(correction_id)
     )
+
+
+def _summary_version(conversation: dict[str, Any], version_id: Optional[str]) -> Optional[dict[str, Any]]:
+    if not version_id:
+        return None
+    for version in conversation.get("summary_versions") or []:
+        if isinstance(version, dict) and str(version.get("id") or "") == str(version_id):
+            return version
+    return None
+
+
+def _summary_version_by_kind_and_base(
+    conversation: dict[str, Any],
+    *,
+    kind: str,
+    based_on_version_id: str,
+) -> Optional[dict[str, Any]]:
+    return next(
+        (
+            version
+            for version in reversed(conversation.get("summary_versions") or [])
+            if isinstance(version, dict)
+            and str(version.get("kind") or "") == kind
+            and str(version.get("based_on_version_id") or "") == based_on_version_id
+        ),
+        None,
+    )
+
+
+def _require_unlocked_conversation(conversation: dict[str, Any]) -> None:
+    if conversation.get("is_locked", False):
+        raise HTTPException(status_code=402, detail="Conversation locked")
+
+
+def _correction_summary_versions(
+    conversation: dict[str, Any],
+    correction_id: str,
+) -> tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+    corrected = next(
+        (
+            version
+            for version in reversed(conversation.get("summary_versions") or [])
+            if isinstance(version, dict) and str(version.get("correction_id") or "") == correction_id
+        ),
+        None,
+    )
+    before = _summary_version(conversation, corrected.get("based_on_version_id") if corrected else None)
+    return before, corrected
+
+
+def _snapshot(version: Optional[dict[str, Any]]) -> CorrectionSummarySnapshot:
+    value = version or {}
+    return CorrectionSummarySnapshot(
+        title=str(value.get("title") or ""),
+        overview=str(value.get("overview") or ""),
+        emoji=str(value.get("emoji") or ""),
+        category=str(value.get("category") or "other"),
+    )
+
+
+def _correction_propagation_counts(
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+) -> tuple[Optional[int], Optional[int], str]:
+    applied = 0
+    reverted = 0
+    try:
+        snapshots = _audit_ref(uid, conversation_id, correction_id).collection("propagation_runs").stream()
+        for snapshot in snapshots:
+            run = snapshot.to_dict() or {}
+            applied += int(run.get("auto_applied_count") or 0)
+            reverted += int(run.get("reverted_count") or 0)
+    except Exception:
+        logger.exception(
+            "Failed to read correction propagation counts",
+            extra={"uid": uid, "conversation_id": conversation_id, "correction_id": correction_id},
+        )
+        return None, None, "unknown"
+    return applied, reverted, "known"
+
+
+def _correction_receipt(
+    *,
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+    conversation: Optional[dict[str, Any]] = None,
+) -> ConversationCorrectionReceiptResponse:
+    conversation = conversation or conversations_db.get_conversation(uid, conversation_id)
+    if conversation is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    _require_unlocked_conversation(conversation)
+    audit_snapshot = _audit_ref(uid, conversation_id, correction_id).get()
+    audit = audit_snapshot.to_dict() if getattr(audit_snapshot, "exists", False) else {}
+    before, corrected = _correction_summary_versions(conversation, correction_id)
+    if not audit and corrected is None:
+        raise HTTPException(status_code=404, detail="Correction not found")
+    raw_state = conversation.get("correction_state")
+    state = (
+        raw_state if isinstance(raw_state, dict) and str(raw_state.get("correction_id") or "") == correction_id else {}
+    )
+    status_value = str(audit.get("status") or state.get("status") or "pending")
+    applied_count, reverted_count, propagation_status = _correction_propagation_counts(
+        uid,
+        conversation_id,
+        correction_id,
+    )
+    corrected_id = str(corrected.get("id") or "") if corrected else ""
+    undo_version = (
+        _summary_version_by_kind_and_base(
+            conversation,
+            kind="correction_undo",
+            based_on_version_id=corrected_id,
+        )
+        if corrected_id
+        else None
+    )
+    return ConversationCorrectionReceiptResponse(
+        correction_id=correction_id,
+        conversation_id=conversation_id,
+        status=status_value,
+        applied_at=audit.get("applied_at"),
+        undone_at=audit.get("undone_at"),
+        before_version_id=(str(before.get("id") or "") or None) if before else None,
+        after_version_id=corrected_id or None,
+        active_version_id=str(conversation.get("active_summary_version_id") or "") or None,
+        undo_version_id=(str(undo_version.get("id") or "") or None) if undo_version else None,
+        before=_snapshot(before),
+        after=_snapshot(corrected),
+        propagation_status=propagation_status,
+        propagation_applied_count=applied_count,
+        propagation_reverted_count=reverted_count,
+    )
+
+
+def _prepare_applied_propagation_rollbacks(
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+) -> list[dict[str, Any]]:
+    try:
+        snapshots = list(_audit_ref(uid, conversation_id, correction_id).collection("propagation_runs").stream())
+    except Exception as exc:
+        logger.exception(
+            "Failed to preflight correction propagation rollback",
+            extra={"uid": uid, "conversation_id": conversation_id, "correction_id": correction_id},
+        )
+        raise HTTPException(status_code=503, detail="Propagation rollback state is unavailable") from exc
+
+    plan: list[dict[str, Any]] = []
+    seen_related_ids: set[str] = set()
+    for snapshot in snapshots:
+        run = snapshot.to_dict() or {}
+        auto_applied_count = int(run.get("auto_applied_count") or 0)
+        if auto_applied_count <= 0:
+            continue
+        decisions = run.get("decisions") if isinstance(run.get("decisions"), list) else []
+        applicable_indexes = [
+            index
+            for index, decision in enumerate(decisions)
+            if isinstance(decision, dict) and decision.get("action") in {"applied", "auto_applied"}
+        ]
+        if len(applicable_indexes) != auto_applied_count:
+            raise HTTPException(status_code=409, detail="Propagation rollback data is incomplete")
+        for decision_index in applicable_indexes:
+            decision = decisions[decision_index]
+            rollback = decision.get("rollback_ref") if isinstance(decision.get("rollback_ref"), dict) else {}
+            structured = rollback.get("structured") if isinstance(rollback.get("structured"), dict) else None
+            related_id = str(decision.get("conversation_id") or "")
+            applied_version_id = str(decision.get("applied_summary_version_id") or "")
+            if not related_id or structured is None or not applied_version_id:
+                raise HTTPException(status_code=409, detail="Propagation rollback data is incomplete")
+            if related_id in seen_related_ids:
+                raise HTTPException(status_code=409, detail="Propagation rollback contains duplicate targets")
+            seen_related_ids.add(related_id)
+
+            related = conversations_db.get_conversation(uid, related_id)
+            if related is None:
+                raise HTTPException(status_code=409, detail="Propagation rollback target is missing")
+            _require_unlocked_conversation(related)
+
+            reverted_version_id = str(decision.get("reverted_summary_version_id") or "")
+            discovered_undo = _summary_version_by_kind_and_base(
+                related,
+                kind="correction_propagation_undo",
+                based_on_version_id=applied_version_id,
+            )
+            if not reverted_version_id and discovered_undo is not None:
+                reverted_version_id = str(discovered_undo.get("id") or "")
+
+            current_version_id = str(related.get("active_summary_version_id") or "")
+            expected_version_id = reverted_version_id or applied_version_id
+            if current_version_id != expected_version_id:
+                raise HTTPException(status_code=409, detail="A newer related memory update must be undone first")
+
+            plan.append(
+                {
+                    "snapshot": snapshot,
+                    "run": run,
+                    "decisions": decisions,
+                    "decision_index": decision_index,
+                    "related_id": related_id,
+                    "structured": structured,
+                    "applied_version_id": applied_version_id,
+                    "reverted_version_id": reverted_version_id,
+                    "completed": bool(reverted_version_id),
+                }
+            )
+    return plan
+
+
+def _persist_propagation_rollback_progress(item: dict[str, Any]) -> None:
+    decisions = item["decisions"]
+    decision = decisions[item["decision_index"]]
+    decision["reverted_summary_version_id"] = item["reverted_version_id"]
+    decision["rollback_status"] = "reverted"
+    decision["reverted_at"] = item["reverted_at"]
+    reverted_count = sum(
+        1
+        for value in decisions
+        if isinstance(value, dict)
+        and value.get("action") in {"applied", "auto_applied"}
+        and value.get("reverted_summary_version_id")
+    )
+    auto_applied_count = int(item["run"].get("auto_applied_count") or 0)
+    payload: dict[str, Any] = {
+        "decisions": decisions,
+        "reverted_count": reverted_count,
+    }
+    if reverted_count == auto_applied_count:
+        payload["reverted_at"] = item["reverted_at"]
+    item["snapshot"].reference.set(payload, merge=True)
+
+
+async def _revert_applied_propagations(
+    uid: str,
+    conversation_id: str,
+    correction_id: str,
+    *,
+    rollback_plan: Optional[list[dict[str, Any]]] = None,
+) -> int:
+    plan = rollback_plan
+    if plan is None:
+        plan = _prepare_applied_propagation_rollbacks(uid, conversation_id, correction_id)
+    reverted = 0
+    for item in plan:
+        if not item["completed"]:
+            try:
+                result = await apply_summary_update(
+                    uid=uid,
+                    conversation_id=item["related_id"],
+                    trace_id=f"correction-propagation-undo:{conversation_id}:{correction_id}:{item['related_id']}",
+                    active_summary_version_id=item["applied_version_id"],
+                    summary=item["structured"],
+                    summary_kind="correction_propagation_undo",
+                    summary_source="observer",
+                    require_based_on_match=True,
+                    preserve_generated_results=True,
+                )
+            except ConcurrentConversationSummaryChangeError as exc:
+                raise HTTPException(
+                    status_code=409,
+                    detail="A newer related memory update must be undone first",
+                ) from exc
+            reverted_version_id = str(result.get("active_summary_version_id") or "")
+            if not reverted_version_id:
+                raise HTTPException(status_code=500, detail="Propagation rollback version was not recorded")
+            item["reverted_version_id"] = reverted_version_id
+            item["completed"] = True
+        item["reverted_at"] = _now_iso()
+        _persist_propagation_rollback_progress(item)
+        reverted += 1
+    return reverted
 
 
 def _persist_correction_audit(
@@ -851,6 +1150,7 @@ async def _run_direct_correction_apply(
             correction_id,
             {
                 "status": "applied",
+                "applied_at": applied_at,
                 "updated_at": applied_at,
                 "direct_apply_result": apply_result,
                 "direct_apply_summary": corrected_summary,
@@ -1363,6 +1663,168 @@ async def submit_conversation_correction_ella(
     uid: str = Depends(auth.get_current_user_uid),
 ) -> ConversationCorrectionResponse:
     return await _submit_conversation_correction(conversation_id, request, background_tasks, uid)
+
+
+@router.get(
+    "/v1/ella/conversations/{conversation_id}/corrections/{correction_id}",
+    response_model=ConversationCorrectionReceiptResponse,
+)
+def get_conversation_correction_receipt(
+    conversation_id: str,
+    correction_id: str,
+    uid: str = Depends(auth.get_current_user_uid),
+) -> ConversationCorrectionReceiptResponse:
+    return _correction_receipt(
+        uid=uid,
+        conversation_id=conversation_id,
+        correction_id=correction_id,
+    )
+
+
+@router.post(
+    "/v1/ella/conversations/{conversation_id}/corrections/{correction_id}/undo",
+    response_model=ConversationCorrectionReceiptResponse,
+)
+async def undo_conversation_correction(
+    conversation_id: str,
+    correction_id: str,
+    uid: str = Depends(auth.get_current_user_uid),
+) -> ConversationCorrectionReceiptResponse:
+    conversation = conversations_db.get_conversation(uid, conversation_id)
+    if conversation is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    _require_unlocked_conversation(conversation)
+    before, corrected = _correction_summary_versions(conversation, correction_id)
+    if before is None or corrected is None:
+        raise HTTPException(status_code=404, detail="Applied correction not found")
+
+    audit_snapshot = _audit_ref(uid, conversation_id, correction_id).get()
+    audit = audit_snapshot.to_dict() if getattr(audit_snapshot, "exists", False) else {}
+    if audit.get("status") == "undone":
+        return _correction_receipt(
+            uid=uid,
+            conversation_id=conversation_id,
+            correction_id=correction_id,
+            conversation=conversation,
+        )
+    corrected_version_id = str(corrected.get("id") or "")
+    undo_version = _summary_version_by_kind_and_base(
+        conversation,
+        kind="correction_undo",
+        based_on_version_id=corrected_version_id,
+    )
+    undo_version_id = str(undo_version.get("id") or "") if undo_version else ""
+    active_version_id = str(conversation.get("active_summary_version_id") or "")
+    source_already_reverted = bool(undo_version_id and active_version_id == undo_version_id)
+    if active_version_id != corrected_version_id and not source_already_reverted:
+        raise HTTPException(status_code=409, detail="A newer memory update must be undone first")
+
+    rollback_plan = _prepare_applied_propagation_rollbacks(uid, conversation_id, correction_id)
+    trace_id = f"correction-undo:{conversation_id}:{correction_id}"
+    prepared_at = _now_iso()
+    _persist_correction_audit(
+        uid,
+        conversation_id,
+        correction_id,
+        {
+            "undo_operation": {
+                "status": "prepared",
+                "expected_source_version_id": corrected_version_id,
+                "related_target_count": len(rollback_plan),
+                "prepared_at": prepared_at,
+            },
+            "updated_at": prepared_at,
+        },
+    )
+    reverted_count = await _revert_applied_propagations(
+        uid,
+        conversation_id,
+        correction_id,
+        rollback_plan=rollback_plan,
+    )
+    propagation_reverted_at = _now_iso()
+    _persist_correction_audit(
+        uid,
+        conversation_id,
+        correction_id,
+        {
+            "undo_operation": {
+                "status": "propagation_reverted",
+                "expected_source_version_id": corrected_version_id,
+                "related_target_count": len(rollback_plan),
+                "propagation_reverted_count": reverted_count,
+                "updated_at": propagation_reverted_at,
+            },
+            "updated_at": propagation_reverted_at,
+        },
+    )
+    if not source_already_reverted:
+        try:
+            apply_result = await apply_summary_update(
+                uid=uid,
+                conversation_id=conversation_id,
+                trace_id=trace_id,
+                active_summary_version_id=corrected_version_id,
+                summary={
+                    "title": before.get("title"),
+                    "overview": before.get("overview"),
+                    "emoji": before.get("emoji"),
+                    "category": before.get("category"),
+                },
+                summary_kind="correction_undo",
+                summary_source="ios",
+                require_based_on_match=True,
+                preserve_generated_results=True,
+            )
+        except ConcurrentConversationSummaryChangeError as exc:
+            raise HTTPException(status_code=409, detail="A newer memory update must be undone first") from exc
+        undo_version_id = str(apply_result.get("active_summary_version_id") or "")
+        if not undo_version_id:
+            raise HTTPException(status_code=500, detail="Correction undo version was not recorded")
+    undone_at = _now_iso()
+    _persist_correction_audit(
+        uid,
+        conversation_id,
+        correction_id,
+        {
+            "status": "undone",
+            "undone_at": undone_at,
+            "updated_at": undone_at,
+            "propagation_reverted_count": reverted_count,
+            "undo_version_id": undo_version_id,
+            "undo_operation": {
+                "status": "completed",
+                "expected_source_version_id": corrected_version_id,
+                "undo_version_id": undo_version_id,
+                "related_target_count": len(rollback_plan),
+                "propagation_reverted_count": reverted_count,
+                "completed_at": undone_at,
+            },
+        },
+    )
+    latest = conversations_db.get_conversation(uid, conversation_id) or conversation
+    conversations_db.update_conversation(
+        uid,
+        conversation_id,
+        {
+            "correction_state": {
+                "correction_id": correction_id,
+                "status": "undone",
+                "pending": False,
+                "source": (conversation.get("correction_state") or {}).get("source"),
+                "submitted_at": (conversation.get("correction_state") or {}).get("submitted_at"),
+                "updated_at": datetime.now(timezone.utc),
+                "active_summary_version_id": undo_version_id,
+            }
+        },
+    )
+    latest = conversations_db.get_conversation(uid, conversation_id) or latest
+    return _correction_receipt(
+        uid=uid,
+        conversation_id=conversation_id,
+        correction_id=correction_id,
+        conversation=latest,
+    )
 
 
 @router.post(

--- a/backend/ella/services/correction_propagation.py
+++ b/backend/ella/services/correction_propagation.py
@@ -15,7 +15,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from database._client import db
 from ella.services import proposal_ingest
@@ -69,7 +69,14 @@ class CorrectionPropagationDecision(BaseModel):
     idempotency_key: str = ""
     proposal_id: str = ""
     active_summary_version_id: str = ""
+    applied_summary_version_id: str = ""
     rollback_ref: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _require_applied_version_for_rollback(self):
+        if self.action in {"applied", "auto_applied"} and not self.applied_summary_version_id:
+            raise ValueError("applied_summary_version_id is required for applied propagation decisions")
+        return self
 
 
 class CorrectionPropagationRun(BaseModel):
@@ -187,10 +194,17 @@ def _conversation_id(conversation: dict[str, Any]) -> str:
 
 
 def _source_ref(conversation: dict[str, Any]) -> dict[str, Any]:
+    structured = conversation.get("structured") if isinstance(conversation.get("structured"), dict) else {}
     return {
         "conversation_id": _conversation_id(conversation),
         "active_summary_version_id": _active_summary_version(conversation),
         "created_at": _conversation_time(conversation).isoformat(),
+        "structured": {
+            "title": str(structured.get("title") or ""),
+            "overview": str(structured.get("overview") or ""),
+            "emoji": str(structured.get("emoji") or ""),
+            "category": str(structured.get("category") or "other"),
+        },
     }
 
 

--- a/backend/ella/services/summary_writeback.py
+++ b/backend/ella/services/summary_writeback.py
@@ -196,7 +196,17 @@ async def write_conversation_summary(
             'active_summary_version_id': version_update['active_summary_version_id'],
         }
 
-    conversations_db.update_conversation(uid, conversation_id, update_data)
+    if require_based_on_match:
+        updated = conversations_db.update_conversation_if_active_summary_version(
+            uid,
+            conversation_id,
+            based_on_version_id,
+            update_data,
+        )
+        if not updated:
+            raise ConcurrentConversationSummaryChangeError('active_summary_version_changed')
+    else:
+        conversations_db.update_conversation(uid, conversation_id, update_data)
     canonical_base = dict(conversation)
     canonical_conversation = {
         **canonical_base,

--- a/backend/tests/unit/test_conversation_summary_cas.py
+++ b/backend/tests/unit/test_conversation_summary_cas.py
@@ -1,0 +1,76 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _load_conversations_module(monkeypatch):
+    import utils
+    import utils.other
+
+    monkeypatch.setitem(sys.modules, "database._client", MagicMock(db=MagicMock()))
+    monkeypatch.setitem(sys.modules, "database.users", MagicMock())
+    monkeypatch.setitem(sys.modules, "database.redis_db", MagicMock())
+    monkeypatch.setitem(sys.modules, "utils.encryption", MagicMock())
+    monkeypatch.setitem(sys.modules, "utils.other.hume", MagicMock())
+    monkeypatch.setitem(sys.modules, "utils.other.storage", MagicMock(list_audio_chunks=MagicMock()))
+
+    path = Path(__file__).resolve().parents[2] / "database" / "conversations.py"
+    spec = importlib.util.spec_from_file_location("database.conversations_cas_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_active_summary_version_compare_and_set_is_atomic_and_fail_closed(monkeypatch):
+    conversations = _load_conversations_module(monkeypatch)
+
+    class ConversationRef:
+        def __init__(self, active_version):
+            self.active_version = active_version
+
+        def get(self, transaction=None):
+            return SimpleNamespace(
+                exists=True,
+                to_dict=lambda: {
+                    "active_summary_version_id": self.active_version,
+                    "data_protection_level": "standard",
+                },
+            )
+
+    class Transaction:
+        def __init__(self):
+            self.updates = []
+
+        def update(self, ref, payload):
+            self.updates.append((ref, payload))
+
+    matching_ref = ConversationRef("expected-v1")
+    matching_transaction = Transaction()
+    assert (
+        conversations._update_conversation_if_active_summary_version_transaction(
+            matching_transaction,
+            matching_ref,
+            "uid-1",
+            "expected-v1",
+            {"active_summary_version_id": "undo-v2"},
+        )
+        is True
+    )
+    assert matching_transaction.updates == [(matching_ref, {"active_summary_version_id": "undo-v2"})]
+
+    stale_ref = ConversationRef("newer-v2")
+    stale_transaction = Transaction()
+    assert (
+        conversations._update_conversation_if_active_summary_version_transaction(
+            stale_transaction,
+            stale_ref,
+            "uid-1",
+            "expected-v1",
+            {"active_summary_version_id": "undo-v2"},
+        )
+        is False
+    )
+    assert stale_transaction.updates == []

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -223,6 +223,580 @@ def test_submit_correction_uses_authenticated_uid_for_ownership(monkeypatch):
     assert calls == [("authenticated-user", "conv-123")]
 
 
+def test_correction_receipt_exposes_old_and_new_summary_and_real_propagation_count(monkeypatch):
+    conversation = {
+        "summary_versions": [
+            {
+                "id": "before-v1",
+                "title": "Coffee with Margaret",
+                "overview": "Margaret came by.",
+                "emoji": "☕",
+                "category": "other",
+            },
+            {
+                "id": "after-v2",
+                "based_on_version_id": "before-v1",
+                "correction_id": "corr-1",
+                "title": "Coffee with Rose",
+                "overview": "Rose came by.",
+                "emoji": "☕",
+                "category": "other",
+            },
+        ],
+        "active_summary_version_id": "after-v2",
+        "correction_state": {"correction_id": "corr-1", "status": "applied"},
+    }
+
+    class AuditRef:
+        def get(self):
+            return SimpleNamespace(
+                exists=True,
+                to_dict=lambda: {"status": "applied", "applied_at": "2026-07-23T17:00:00+00:00"},
+            )
+
+    monkeypatch.setattr(corrections.conversations_db, "get_conversation", lambda uid, conversation_id: conversation)
+    monkeypatch.setattr(corrections, "_audit_ref", lambda uid, conversation_id, correction_id: AuditRef())
+    monkeypatch.setattr(
+        corrections, "_correction_propagation_counts", lambda uid, conversation_id, correction_id: (1, 0, "known")
+    )
+
+    receipt = corrections._correction_receipt(
+        uid="uid-1",
+        conversation_id="conv-1",
+        correction_id="corr-1",
+    )
+
+    assert receipt.before.title == "Coffee with Margaret"
+    assert receipt.after.title == "Coffee with Rose"
+    assert receipt.before_version_id == "before-v1"
+    assert receipt.after_version_id == "after-v2"
+    assert receipt.active_version_id == "after-v2"
+    assert receipt.undo_version_id is None
+    assert receipt.propagation_status == "known"
+    assert receipt.propagation_applied_count == 1
+    assert receipt.propagation_reverted_count == 0
+
+
+def test_undo_restores_source_summary_and_reverts_actual_propagations(monkeypatch):
+    conversation = {
+        "summary_versions": [
+            {
+                "id": "before-v1",
+                "title": "Coffee with Margaret",
+                "overview": "Margaret came by.",
+                "emoji": "☕",
+                "category": "other",
+            },
+            {
+                "id": "after-v2",
+                "based_on_version_id": "before-v1",
+                "correction_id": "corr-1",
+                "title": "Coffee with Rose",
+                "overview": "Rose came by.",
+                "emoji": "☕",
+                "category": "other",
+            },
+        ],
+        "active_summary_version_id": "after-v2",
+        "correction_state": {"correction_id": "corr-1", "status": "applied", "source": "ios"},
+    }
+    applied = {}
+    audits = []
+    updates = []
+
+    class AuditRef:
+        def get(self):
+            return SimpleNamespace(exists=True, to_dict=lambda: {"status": "applied"})
+
+    async def fake_apply(**kwargs):
+        applied.update(kwargs)
+        return {"status": "ok", "active_summary_version_id": "undo-v3"}
+
+    expected = corrections.ConversationCorrectionReceiptResponse(
+        correction_id="corr-1",
+        conversation_id="conv-1",
+        status="undone",
+        before=corrections.CorrectionSummarySnapshot(title="Coffee with Margaret"),
+        after=corrections.CorrectionSummarySnapshot(title="Coffee with Rose"),
+        propagation_applied_count=1,
+        propagation_reverted_count=1,
+    )
+
+    monkeypatch.setattr(corrections.conversations_db, "get_conversation", lambda uid, conversation_id: conversation)
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "update_conversation",
+        lambda uid, conversation_id, update: updates.append(update),
+    )
+    monkeypatch.setattr(corrections, "_audit_ref", lambda uid, conversation_id, correction_id: AuditRef())
+    monkeypatch.setattr(corrections, "apply_summary_update", fake_apply)
+    monkeypatch.setattr(corrections, "_prepare_applied_propagation_rollbacks", lambda uid, cid, correction_id: [])
+
+    async def fake_revert(uid, cid, correction_id, *, rollback_plan=None):
+        assert rollback_plan == []
+        return 1
+
+    monkeypatch.setattr(corrections, "_revert_applied_propagations", fake_revert)
+    monkeypatch.setattr(
+        corrections,
+        "_persist_correction_audit",
+        lambda uid, conversation_id, correction_id, payload: audits.append(payload),
+    )
+    monkeypatch.setattr(corrections, "_correction_receipt", lambda **kwargs: expected)
+
+    receipt = asyncio.run(
+        corrections.undo_conversation_correction(
+            "conv-1",
+            "corr-1",
+            uid="uid-1",
+        )
+    )
+
+    assert applied["summary"]["title"] == "Coffee with Margaret"
+    assert applied["active_summary_version_id"] == "after-v2"
+    assert applied["require_based_on_match"] is True
+    assert audits[-1]["status"] == "undone"
+    assert audits[-1]["propagation_reverted_count"] == 1
+    assert updates[-1]["correction_state"]["status"] == "undone"
+    assert receipt.status == "undone"
+
+
+def test_propagation_undo_restores_each_related_summary_from_rollback_snapshot(monkeypatch):
+    applies = []
+    run_updates = []
+    related = {
+        "active_summary_version_id": "related-v2",
+        "summary_versions": [
+            {"id": "related-v1", "kind": "observer_enriched", "is_active": False},
+            {"id": "related-v2", "kind": "correction_propagation", "is_active": True},
+        ],
+    }
+
+    class RunReference:
+        def set(self, payload, merge=False):
+            run_updates.append((payload, merge))
+
+    class RunSnapshot:
+        reference = RunReference()
+
+        def to_dict(self):
+            return {
+                "auto_applied_count": 1,
+                "decisions": [
+                    {
+                        "action": "auto_applied",
+                        "conversation_id": "related-1",
+                        "applied_summary_version_id": "related-v2",
+                        "rollback_ref": {
+                            "active_summary_version_id": "related-v1",
+                            "structured": {
+                                "title": "Coffee with Margaret",
+                                "overview": "Margaret came by.",
+                                "emoji": "☕",
+                                "category": "other",
+                            },
+                        },
+                    }
+                ],
+            }
+
+    class RunCollection:
+        def stream(self):
+            return [RunSnapshot()]
+
+    class AuditRef:
+        def collection(self, name):
+            assert name == "propagation_runs"
+            return RunCollection()
+
+    monkeypatch.setattr(corrections, "_audit_ref", lambda uid, conversation_id, correction_id: AuditRef())
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: related,
+    )
+
+    async def fake_apply(**kwargs):
+        applies.append(kwargs)
+        return {"status": "ok", "active_summary_version_id": "related-undo-v3"}
+
+    monkeypatch.setattr(corrections, "apply_summary_update", fake_apply)
+
+    plan = corrections._prepare_applied_propagation_rollbacks("uid-1", "conv-1", "corr-1")
+    reverted = asyncio.run(
+        corrections._revert_applied_propagations(
+            "uid-1",
+            "conv-1",
+            "corr-1",
+            rollback_plan=plan,
+        )
+    )
+
+    assert reverted == 1
+    assert applies[0]["conversation_id"] == "related-1"
+    assert applies[0]["active_summary_version_id"] == "related-v2"
+    assert applies[0]["summary"]["title"] == "Coffee with Margaret"
+    assert applies[0]["summary_kind"] == "correction_propagation_undo"
+    assert applies[0]["require_based_on_match"] is True
+    assert run_updates[0][0]["reverted_count"] == 1
+    assert run_updates[0][0]["decisions"][0]["reverted_summary_version_id"] == "related-undo-v3"
+    assert run_updates[0][1] is True
+
+
+def test_correction_receipt_exposes_unknown_propagation_state_and_ignores_other_correction_state(monkeypatch):
+    conversation = {
+        "summary_versions": [
+            {"id": "before-v1", "title": "Before"},
+            {
+                "id": "after-v2",
+                "based_on_version_id": "before-v1",
+                "correction_id": "corr-1",
+                "title": "After",
+            },
+        ],
+        "active_summary_version_id": "after-v2",
+        "correction_state": {"correction_id": "different-correction", "status": "undone"},
+    }
+
+    class AuditRef:
+        def get(self):
+            return SimpleNamespace(exists=True, to_dict=lambda: {"applied_at": "2026-07-23T17:00:00+00:00"})
+
+    monkeypatch.setattr(corrections.conversations_db, "get_conversation", lambda uid, conversation_id: conversation)
+    monkeypatch.setattr(corrections, "_audit_ref", lambda uid, conversation_id, correction_id: AuditRef())
+    monkeypatch.setattr(
+        corrections,
+        "_correction_propagation_counts",
+        lambda uid, conversation_id, correction_id: (None, None, "unknown"),
+    )
+
+    receipt = corrections._correction_receipt(
+        uid="uid-1",
+        conversation_id="conv-1",
+        correction_id="corr-1",
+    )
+
+    assert receipt.status == "pending"
+    assert receipt.propagation_status == "unknown"
+    assert receipt.propagation_applied_count is None
+    assert receipt.propagation_reverted_count is None
+
+
+def test_receipt_and_undo_reject_locked_conversation_before_audit_access(monkeypatch):
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: {"is_locked": True},
+    )
+    monkeypatch.setattr(
+        corrections,
+        "_audit_ref",
+        lambda *args: pytest.fail("locked conversations must not expose correction audit data"),
+    )
+
+    with pytest.raises(HTTPException) as receipt_error:
+        corrections._correction_receipt(
+            uid="uid-1",
+            conversation_id="conv-locked",
+            correction_id="corr-1",
+        )
+    with pytest.raises(HTTPException) as undo_error:
+        asyncio.run(
+            corrections.undo_conversation_correction(
+                "conv-locked",
+                "corr-1",
+                uid="uid-1",
+            )
+        )
+
+    assert receipt_error.value.status_code == 402
+    assert undo_error.value.status_code == 402
+
+
+def test_propagation_undo_preflight_rejects_stale_related_version_before_any_write(monkeypatch):
+    run = {
+        "auto_applied_count": 1,
+        "decisions": [
+            {
+                "action": "auto_applied",
+                "conversation_id": "related-1",
+                "applied_summary_version_id": "related-v2",
+                "rollback_ref": {
+                    "active_summary_version_id": "related-v1",
+                    "structured": {"title": "Before", "overview": "Before", "category": "other"},
+                },
+            }
+        ],
+    }
+
+    class RunSnapshot:
+        reference = SimpleNamespace(set=lambda *args, **kwargs: pytest.fail("preflight must not write"))
+
+        def to_dict(self):
+            return run
+
+    class AuditRef:
+        def collection(self, name):
+            return SimpleNamespace(stream=lambda: [RunSnapshot()])
+
+    monkeypatch.setattr(corrections, "_audit_ref", lambda uid, conversation_id, correction_id: AuditRef())
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: {"active_summary_version_id": "newer-v3"},
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        corrections._prepare_applied_propagation_rollbacks("uid-1", "source-1", "corr-1")
+
+    assert excinfo.value.status_code == 409
+    assert "newer related memory" in excinfo.value.detail
+
+
+def test_undo_preflights_stale_related_target_before_source_or_audit_mutation(monkeypatch):
+    source = {
+        "summary_versions": [
+            {"id": "before-v1", "title": "Before"},
+            {
+                "id": "after-v2",
+                "based_on_version_id": "before-v1",
+                "correction_id": "corr-1",
+                "title": "After",
+            },
+        ],
+        "active_summary_version_id": "after-v2",
+    }
+    run = {
+        "auto_applied_count": 1,
+        "decisions": [
+            {
+                "action": "auto_applied",
+                "conversation_id": "related-1",
+                "applied_summary_version_id": "related-v2",
+                "rollback_ref": {
+                    "active_summary_version_id": "related-v1",
+                    "structured": {"title": "Before", "overview": "Before", "category": "other"},
+                },
+            }
+        ],
+    }
+
+    class RunSnapshot:
+        reference = SimpleNamespace(set=lambda *args, **kwargs: pytest.fail("preflight must not write"))
+
+        def to_dict(self):
+            return run
+
+    class AuditRef:
+        def get(self):
+            return SimpleNamespace(exists=True, to_dict=lambda: {"status": "applied"})
+
+        def collection(self, name):
+            return SimpleNamespace(stream=lambda: [RunSnapshot()])
+
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: (
+            source if conversation_id == "source-1" else {"active_summary_version_id": "newer-v3"}
+        ),
+    )
+    monkeypatch.setattr(corrections, "_audit_ref", lambda uid, conversation_id, correction_id: AuditRef())
+    monkeypatch.setattr(
+        corrections,
+        "_persist_correction_audit",
+        lambda *args, **kwargs: pytest.fail("failed preflight must not mutate the audit"),
+    )
+
+    async def fail_apply(**kwargs):
+        pytest.fail("failed preflight must not mutate the source")
+
+    monkeypatch.setattr(corrections, "apply_summary_update", fail_apply)
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(
+            corrections.undo_conversation_correction(
+                "source-1",
+                "corr-1",
+                uid="uid-1",
+            )
+        )
+
+    assert excinfo.value.status_code == 409
+
+
+def test_propagation_undo_resumes_after_one_of_multiple_writes_fails(monkeypatch):
+    run = {
+        "auto_applied_count": 2,
+        "decisions": [
+            {
+                "action": "auto_applied",
+                "conversation_id": "related-1",
+                "applied_summary_version_id": "related-1-v2",
+                "rollback_ref": {
+                    "active_summary_version_id": "related-1-v1",
+                    "structured": {"title": "Related one before", "overview": "Before", "category": "other"},
+                },
+            },
+            {
+                "action": "auto_applied",
+                "conversation_id": "related-2",
+                "applied_summary_version_id": "related-2-v2",
+                "rollback_ref": {
+                    "active_summary_version_id": "related-2-v1",
+                    "structured": {"title": "Related two before", "overview": "Before", "category": "other"},
+                },
+            },
+        ],
+    }
+    related = {
+        "related-1": {
+            "active_summary_version_id": "related-1-v2",
+            "summary_versions": [{"id": "related-1-v2", "kind": "correction_propagation"}],
+        },
+        "related-2": {
+            "active_summary_version_id": "related-2-v2",
+            "summary_versions": [{"id": "related-2-v2", "kind": "correction_propagation"}],
+        },
+    }
+    run_writes = []
+
+    class RunReference:
+        def set(self, payload, merge=False):
+            assert merge is True
+            run.update(payload)
+            run_writes.append(payload)
+
+    class RunSnapshot:
+        reference = RunReference()
+
+        def to_dict(self):
+            return run
+
+    class AuditRef:
+        def collection(self, name):
+            return SimpleNamespace(stream=lambda: [RunSnapshot()])
+
+    monkeypatch.setattr(corrections, "_audit_ref", lambda uid, conversation_id, correction_id: AuditRef())
+    monkeypatch.setattr(
+        corrections.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: related[conversation_id],
+    )
+    calls = []
+    fail_second = {"enabled": True}
+
+    async def fake_apply(**kwargs):
+        related_id = kwargs["conversation_id"]
+        calls.append(related_id)
+        if related_id == "related-2" and fail_second["enabled"]:
+            raise RuntimeError("simulated second write failure")
+        undo_id = f"{related_id}-undo"
+        related[related_id]["active_summary_version_id"] = undo_id
+        related[related_id]["summary_versions"].append(
+            {
+                "id": undo_id,
+                "kind": "correction_propagation_undo",
+                "based_on_version_id": kwargs["active_summary_version_id"],
+            }
+        )
+        return {"status": "ok", "active_summary_version_id": undo_id}
+
+    monkeypatch.setattr(corrections, "apply_summary_update", fake_apply)
+
+    first_plan = corrections._prepare_applied_propagation_rollbacks("uid-1", "source-1", "corr-1")
+    with pytest.raises(RuntimeError, match="second write failure"):
+        asyncio.run(
+            corrections._revert_applied_propagations(
+                "uid-1",
+                "source-1",
+                "corr-1",
+                rollback_plan=first_plan,
+            )
+        )
+
+    assert run["decisions"][0]["reverted_summary_version_id"] == "related-1-undo"
+    assert "reverted_summary_version_id" not in run["decisions"][1]
+    assert run["reverted_count"] == 1
+
+    fail_second["enabled"] = False
+    retry_plan = corrections._prepare_applied_propagation_rollbacks("uid-1", "source-1", "corr-1")
+    reverted = asyncio.run(
+        corrections._revert_applied_propagations(
+            "uid-1",
+            "source-1",
+            "corr-1",
+            rollback_plan=retry_plan,
+        )
+    )
+
+    assert reverted == 2
+    assert calls.count("related-1") == 1
+    assert calls.count("related-2") == 2
+    assert run["reverted_count"] == 2
+    assert run["decisions"][1]["reverted_summary_version_id"] == "related-2-undo"
+    assert len(run_writes) == 3
+
+
+def test_repeated_undo_returns_same_recorded_undo_version_without_writing(monkeypatch):
+    conversation = {
+        "summary_versions": [
+            {"id": "before-v1", "title": "Before"},
+            {
+                "id": "after-v2",
+                "based_on_version_id": "before-v1",
+                "correction_id": "corr-1",
+                "title": "After",
+            },
+            {
+                "id": "undo-v3",
+                "based_on_version_id": "after-v2",
+                "kind": "correction_undo",
+                "title": "Before",
+            },
+        ],
+        "active_summary_version_id": "undo-v3",
+        "correction_state": {"correction_id": "corr-1", "status": "undone"},
+    }
+
+    class AuditRef:
+        def get(self):
+            return SimpleNamespace(
+                exists=True,
+                to_dict=lambda: {
+                    "status": "undone",
+                    "applied_at": "2026-07-23T17:00:00+00:00",
+                    "undone_at": "2026-07-23T18:00:00+00:00",
+                    "undo_version_id": "undo-v3",
+                },
+            )
+
+        def collection(self, name):
+            return SimpleNamespace(stream=lambda: [])
+
+    monkeypatch.setattr(corrections.conversations_db, "get_conversation", lambda uid, conversation_id: conversation)
+    monkeypatch.setattr(corrections, "_audit_ref", lambda uid, conversation_id, correction_id: AuditRef())
+    monkeypatch.setattr(
+        corrections,
+        "apply_summary_update",
+        lambda **kwargs: pytest.fail("repeated undo must not append another version"),
+    )
+
+    receipt = asyncio.run(
+        corrections.undo_conversation_correction(
+            "conv-1",
+            "corr-1",
+            uid="uid-1",
+        )
+    )
+
+    assert receipt.status == "undone"
+    assert receipt.before_version_id == "before-v1"
+    assert receipt.after_version_id == "after-v2"
+    assert receipt.active_version_id == "undo-v3"
+    assert receipt.undo_version_id == "undo-v3"
+
+
 def test_submit_correction_rejects_locked_conversation(monkeypatch):
     monkeypatch.setattr(
         corrections.conversations_db,
@@ -416,6 +990,7 @@ def test_submit_correction_directly_applies_when_model_path_succeeds(monkeypatch
     assert submitted["active_summary_version_id"] == "legacy-v1"
     assert submitted["corrected"]["overview"].startswith("[Ella] ")
     assert audits[-1]["status"] == "applied"
+    assert audits[-1]["applied_at"] == audits[-1]["updated_at"]
     assert audits[-1]["direct_apply_result"]["active_summary_version_id"] == "corrected-v1"
     assert events[-1]["stage"] == "direct_apply_succeeded"
     assert conversation_updates[0]["correction_state"]["status"] == "submitted"
@@ -2220,6 +2795,103 @@ def test_recovery_writeback_fails_closed_when_active_summary_changed(monkeypatch
                 category="other",
                 based_on_version_id="generic-v1",
                 require_based_on_match=True,
+            )
+        )
+
+
+def test_strict_summary_writeback_uses_atomic_active_version_compare_and_set(monkeypatch):
+    conversation = {
+        **_retry_conversation(status="completed", request_id=None),
+        "active_summary_version_id": "generic-v1",
+        "summary_versions": [{"id": "generic-v1", "kind": "generic", "is_active": True}],
+    }
+    cas_calls = []
+    monkeypatch.setattr(summary_writeback.conversations_db, "get_conversation", lambda uid, cid: conversation)
+    monkeypatch.setattr(
+        summary_writeback.conversations_db,
+        "build_summary_version_update",
+        lambda *args, **kwargs: {
+            "summary_versions": [
+                {"id": "generic-v1", "kind": "generic", "is_active": False},
+                {"id": "undo-v2", "kind": "correction_undo", "is_active": True},
+            ],
+            "active_summary_version_id": "undo-v2",
+        },
+    )
+    monkeypatch.setattr(
+        summary_writeback.conversations_db,
+        "update_conversation_if_active_summary_version",
+        lambda uid, cid, expected, update: cas_calls.append((uid, cid, expected, update)) or True,
+    )
+    monkeypatch.setattr(
+        summary_writeback.conversations_db,
+        "update_conversation",
+        lambda *args: pytest.fail("strict write must use the transactional compare-and-set helper"),
+    )
+
+    result = asyncio.run(
+        summary_writeback.write_conversation_summary(
+            uid="user-1",
+            conversation_id="conversation-1",
+            title="Restored",
+            overview="[Ella] Restored the prior conversation summary without changing newer memory.",
+            category="other",
+            summary_kind="correction_undo",
+            based_on_version_id="generic-v1",
+            require_based_on_match=True,
+            canonical_writer=lambda *args, **kwargs: {"ok": True},
+        )
+    )
+
+    assert result["active_summary_version_id"] == "undo-v2"
+    assert cas_calls[0][0:3] == ("user-1", "conversation-1", "generic-v1")
+    assert cas_calls[0][3]["active_summary_version_id"] == "undo-v2"
+
+
+def test_strict_summary_writeback_fails_when_atomic_compare_and_set_loses_race(monkeypatch):
+    conversation = {
+        **_retry_conversation(status="completed", request_id=None),
+        "active_summary_version_id": "generic-v1",
+        "summary_versions": [{"id": "generic-v1", "kind": "generic", "is_active": True}],
+    }
+    monkeypatch.setattr(summary_writeback.conversations_db, "get_conversation", lambda uid, cid: conversation)
+    monkeypatch.setattr(
+        summary_writeback.conversations_db,
+        "build_summary_version_update",
+        lambda *args, **kwargs: {
+            "summary_versions": [
+                {"id": "generic-v1", "kind": "generic", "is_active": False},
+                {"id": "undo-v2", "kind": "correction_undo", "is_active": True},
+            ],
+            "active_summary_version_id": "undo-v2",
+        },
+    )
+    monkeypatch.setattr(
+        summary_writeback.conversations_db,
+        "update_conversation_if_active_summary_version",
+        lambda uid, cid, expected, update: False,
+    )
+    monkeypatch.setattr(
+        summary_writeback.conversations_db,
+        "update_conversation",
+        lambda *args: pytest.fail("lost CAS must not fall back to an unconditional write"),
+    )
+
+    with pytest.raises(
+        summary_writeback.ConcurrentConversationSummaryChangeError,
+        match="active_summary_version_changed",
+    ):
+        asyncio.run(
+            summary_writeback.write_conversation_summary(
+                uid="user-1",
+                conversation_id="conversation-1",
+                title="Restored",
+                overview="[Ella] Restored the prior conversation summary without changing newer memory.",
+                category="other",
+                summary_kind="correction_undo",
+                based_on_version_id="generic-v1",
+                require_based_on_match=True,
+                canonical_writer=lambda *args, **kwargs: {"ok": True},
             )
         )
 

--- a/backend/tests/unit/test_ella_correction_propagation.py
+++ b/backend/tests/unit/test_ella_correction_propagation.py
@@ -2,8 +2,10 @@ from datetime import datetime, timezone
 import sys
 from unittest.mock import MagicMock
 
+import pytest
+
 sys.modules.setdefault("database._client", MagicMock(db=MagicMock()))
-from ella.services.correction_propagation import run_correction_propagation
+from ella.services.correction_propagation import CorrectionPropagationDecision, run_correction_propagation
 
 
 def _conversation(conversation_id: str, uid: str, title: str, overview: str, text: str, hour: int = 9):
@@ -131,3 +133,18 @@ def test_correction_propagation_skips_active_version_incompatible_candidate():
     assert run.proposal_count == 0
     assert run.decisions[0].action == "skip"
     assert "active_summary_version_incompatible" in run.decisions[0].skipped_reasons
+
+
+def test_applied_propagation_decision_requires_created_summary_version_id():
+    with pytest.raises(ValueError, match="applied_summary_version_id"):
+        CorrectionPropagationDecision(
+            action="auto_applied",
+            conversation_id="related-1",
+        )
+
+    decision = CorrectionPropagationDecision(
+        action="auto_applied",
+        conversation_id="related-1",
+        applied_summary_version_id="related-v2",
+    )
+    assert decision.applied_summary_version_id == "related-v2"


### PR DESCRIPTION
## Summary
- port the reviewed backend prerequisite from ellaaicare/omi#322 onto production `main`
- expose authenticated correction receipt GET with explicit before/after/active/undo version IDs
- add idempotent Undo with locked-conversation guards, preflighted propagation rollback, transactional active-version CAS, and resumable per-target progress
- preserve `main`'s per-user isolated Hermes runtime selection

## Why a separate PR
ellaaicare/omi#322 intentionally targets `feature/phase-a-testflight`; that branch is not an approved VPS source. This is the narrow production-main artifact following the same release pattern as ellaaicare/omi#320. No iOS/UI files are included.

## Integrity review
The initial #322 head was blocked for partial Undo, stale related-memory overwrite, incomplete version receipts, false status reporting, correction-state mismatch, and lock bypass. Exact repaired head `d18d65bb2ac80b84609348f6daf0745286188f6f` addresses every finding. All five review threads are resolved.

This port retains the two `main`-only isolated-runtime changes in `corrections.py` and their test while applying the exact seven-file #322 backend/test delta.

## Validation
- focused correction/propagation/CAS suite on `main`: **63 passed**
- `./backend/test.sh`: passed
- `python3 -m py_compile` changed runtime modules: passed
- `git diff --check`: clean
- Black was already clean on exact repaired #322 head; this host's production-main Python environment does not have the Black module installed

## Release gate
After independent review and merge, package an immutable release from current live revision `5c9e9815b490d706a2b1fb78b3af2cabf03e317f`. Do not deploy `feature/phase-a-testflight`, do not patch live files in place, and do not merge ellaaicare/omi#314 until authenticated endpoint smoke plus dedicated non-family `pending -> applied -> undo` proof passes for ellaaicare/ella-ai#1086.
