### PR TITLE
Add isolated Honcho memory-scoped voice context

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -616,6 +616,108 @@ def update_conversation_if_active_summary_version(
     )
 
 
+def _ensure_voice_memory_summary_version_transaction(
+    transaction,
+    conversation_ref,
+    expected_active_summary_version_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Establish a durable active summary version before evaluating a voice CAS."""
+    snapshot = conversation_ref.get(transaction=transaction)
+    if not snapshot.exists:
+        return {'status': 'not_found'}
+
+    conversation = snapshot.to_dict() or {}
+    versions = conversation.get('summary_versions')
+    versions = copy.deepcopy(versions) if isinstance(versions, list) else []
+    active_version = _active_summary_version(conversation)
+    update_data: Dict[str, Any] = {}
+
+    if not active_version:
+        if not versions:
+            bootstrap_update = bootstrap_summary_versioning_update(conversation)
+            if bootstrap_update:
+                versions = bootstrap_update['summary_versions']
+                active_version = versions[0]
+                update_data.update(bootstrap_update)
+        else:
+            # Recover a missing active pointer from the newest durable version.
+            active_version = next(
+                (
+                    version
+                    for version in reversed(versions)
+                    if isinstance(version, dict) and str(version.get('id') or '').strip()
+                ),
+                None,
+            )
+            if active_version:
+                active_id = str(active_version['id'])
+                for version in versions:
+                    if isinstance(version, dict):
+                        version['is_active'] = str(version.get('id') or '') == active_id
+                update_data.update(
+                    {
+                        'summary_versions': versions,
+                        'active_summary_version_id': active_id,
+                    }
+                )
+
+    active_version_id = str((active_version or {}).get('id') or '').strip()
+    if not active_version_id:
+        return {'status': 'version_unavailable'}
+
+    if str(conversation.get('active_summary_version_id') or '').strip() != active_version_id:
+        update_data['active_summary_version_id'] = active_version_id
+    if update_data:
+        transaction.update(conversation_ref, update_data)
+        conversation.update(update_data)
+
+    expected_version_id = str(expected_active_summary_version_id or '').strip()
+    if expected_version_id and expected_version_id != active_version_id:
+        return {
+            'status': 'stale',
+            'active_summary_version_id': active_version_id,
+            'conversation': conversation,
+        }
+    return {
+        'status': 'ready',
+        'active_summary_version_id': active_version_id,
+        'conversation': conversation,
+    }
+
+
+@transactional
+def _ensure_voice_memory_summary_version(
+    transaction,
+    conversation_ref,
+    expected_active_summary_version_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    return _ensure_voice_memory_summary_version_transaction(
+        transaction,
+        conversation_ref,
+        expected_active_summary_version_id,
+    )
+
+
+def ensure_voice_memory_summary_version(
+    uid: str,
+    conversation_id: str,
+    expected_active_summary_version_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Load one user-owned memory and atomically establish its voice CAS version."""
+    conversation_ref = (
+        db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
+    )
+    result = _ensure_voice_memory_summary_version(
+        db.transaction(),
+        conversation_ref,
+        expected_active_summary_version_id,
+    )
+    conversation = result.get('conversation')
+    if isinstance(conversation, dict):
+        result = {**result, 'conversation': _prepare_conversation_for_read(conversation, uid)}
+    return result
+
+
 def create_audio_files_from_chunks(
     uid: str,
     conversation_id: str,

--- a/backend/ella/routers/canonical_events.py
+++ b/backend/ella/routers/canonical_events.py
@@ -83,6 +83,12 @@ def _should_replace_existing_event(item: dict[str, Any]) -> bool:
     return item.get("channel") == "omi" and metadata.get("adapter") == "omi-enriched-conversation"
 
 
+def _is_memory_scoped_event(item: dict[str, Any]) -> bool:
+    source_ref = item.get("source_ref") if isinstance(item.get("source_ref"), dict) else {}
+    metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+    return (source_ref.get("scope_kind") or metadata.get("scope_kind")) == "memory"
+
+
 def _derive_source_identity(
     *,
     uid: str,
@@ -339,7 +345,15 @@ class PostgresCanonicalEventStore(CanonicalEventStore):
         channels: Optional[list[str]],
     ) -> list[dict[str, Any]]:
         params: list[Any] = [uid]
-        filters = ["lower(uid) = lower($1)"]
+        filters = [
+            "lower(uid) = lower($1)",
+            (
+                "NOT ("
+                "COALESCE(source_ref ->> 'scope_kind', '') = 'memory' "
+                "OR COALESCE(metadata ->> 'scope_kind', '') = 'memory'"
+                ")"
+            ),
+        ]
         if since:
             params.append(since)
             filters.append(f"started_at >= ${len(params)}")
@@ -439,6 +453,8 @@ class InMemoryCanonicalEventStore(CanonicalEventStore):
             if since and event["started_at"] < since:
                 continue
             if channel_set and event["channel"] not in channel_set:
+                continue
+            if _is_memory_scoped_event(event):
                 continue
             events.append(event)
 

--- a/backend/ella/routers/canonical_events.py
+++ b/backend/ella/routers/canonical_events.py
@@ -346,7 +346,7 @@ class PostgresCanonicalEventStore(CanonicalEventStore):
     ) -> list[dict[str, Any]]:
         params: list[Any] = [uid]
         filters = [
-            "lower(uid) = lower($1)",
+            "uid = $1",
             (
                 "NOT ("
                 "COALESCE(source_ref ->> 'scope_kind', '') = 'memory' "
@@ -448,7 +448,7 @@ class InMemoryCanonicalEventStore(CanonicalEventStore):
         channel_set = set(channels or [])
         events = []
         for event in self._events.values():
-            if event["uid"].lower() != uid.lower():
+            if event["uid"] != uid:
                 continue
             if since and event["started_at"] < since:
                 continue

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -274,8 +274,17 @@ async def _resolve_voice_honcho_binding(uid: str, runtime: Any = None):
         return None, "honcho_profile_resolution_cached_unavailable"
 
     try:
+        transport_timeout = max(
+            0.01,
+            VOICE_HONCHO_PROFILE_RESOLUTION_TIMEOUT_SECONDS * 0.8,
+        )
         target, reason = await asyncio.wait_for(
-            asyncio.to_thread(resolve_voice_honcho_target, uid, runtime),
+            asyncio.to_thread(
+                resolve_voice_honcho_target,
+                uid,
+                runtime,
+                profile_map_timeout_seconds=transport_timeout,
+            ),
             timeout=VOICE_HONCHO_PROFILE_RESOLUTION_TIMEOUT_SECONDS,
         )
         if target:
@@ -2094,7 +2103,7 @@ async def _search_canonical_timeline(
             """
             SELECT channel, provider, role, text, started_at, session_id, metadata
             FROM canonical_events
-            WHERE lower(uid) = lower($1)
+            WHERE uid = $1
               AND text IS NOT NULL
               AND trim(text) != ''
               AND (
@@ -2242,7 +2251,7 @@ async def _fetch_recent_canonical_timeline(
             """
             SELECT channel, provider, role, text, started_at
             FROM canonical_events
-            WHERE lower(uid) = lower($1)
+            WHERE uid = $1
               AND text IS NOT NULL
               AND trim(text) != ''
               AND (

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -15,6 +15,7 @@ Provider types:
   v2v  — Voice-to-voice (WebSocket, bidirectional audio streaming via /session)
 """
 
+import asyncio
 import base64
 import hmac
 import json
@@ -25,7 +26,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
-from typing import List, Optional
+from typing import Any, List, Literal, Optional
 
 import asyncpg
 import httpx
@@ -37,6 +38,7 @@ from pydantic import BaseModel
 from database.conversations import _decrypt_conversation_data
 from ella.services.provisioning import ProvisioningError, rollout_enabled
 from ella.services.runtime_resolver import resolve_isolated_runtime, runtime_bindings_enabled
+from ella.services.voice_honcho import fetch_voice_honcho_context, search_voice_honcho
 from utils.ella.canonical_context import fetch_canonical_timeline
 from utils.other import endpoints as auth
 
@@ -104,6 +106,10 @@ class VoiceProxyPrincipal:
     provider: str
     voice_mode: str
     isolated_runtime: bool
+    scope_kind: Optional[str] = None
+    conversation_id: Optional[str] = None
+    active_summary_version_id: Optional[str] = None
+    can_reinterpret: bool = False
 
 
 def _voice_proxy_bearer(request: Request) -> str:
@@ -195,12 +201,38 @@ def authenticate_voice_proxy_request(request: Request, requested_uid: str) -> Vo
     ):
         raise HTTPException(status_code=401, detail={"code": "voice_session_invalid"})
 
+    scope_kind = claims.get("scope_kind")
+    scope_claim_keys = {
+        "scope_kind",
+        "conversation_id",
+        "active_summary_version_id",
+        "can_reinterpret",
+    }
+    if scope_kind is None:
+        if any(key in claims for key in scope_claim_keys):
+            raise HTTPException(status_code=401, detail={"code": "voice_session_invalid"})
+    elif (
+        scope_kind != "memory"
+        or not str(claims.get("conversation_id") or "").strip()
+        or not isinstance(claims.get("active_summary_version_id"), str)
+        or not isinstance(claims.get("can_reinterpret"), bool)
+    ):
+        raise HTTPException(status_code=401, detail={"code": "voice_session_invalid"})
+
     return VoiceProxyPrincipal(
         uid=subject,
         session_id=str(claims.get("jti") or ""),
         provider=str(claims.get("provider") or ""),
         voice_mode=str(claims.get("voice_mode") or ""),
         isolated_runtime=claims.get("isolated_runtime") is True,
+        scope_kind=scope_kind,
+        conversation_id=str(claims.get("conversation_id") or "").strip() or None,
+        active_summary_version_id=(
+            str(claims.get("active_summary_version_id"))
+            if scope_kind == "memory"
+            else None
+        ),
+        can_reinterpret=claims.get("can_reinterpret") is True,
     )
 
 
@@ -299,12 +331,21 @@ V2V_PROVIDERS = {
 # ============================================================================
 
 
+class VoiceSessionScope(BaseModel):
+    """Non-authoritative client scope; all memory content is resolved server-side."""
+
+    kind: Literal["memory"]
+    conversation_id: str
+    expected_active_summary_version_id: Optional[str] = None
+
+
 class VoiceSessionRequest(BaseModel):
     """Request for creating a V2V voice session."""
 
     uid: Optional[str] = None
     provider: str = "grok-voice"
     voice_mode: Optional[str] = None
+    session_scope: Optional[VoiceSessionScope] = None
 
 
 class VoiceSessionResponse(BaseModel):
@@ -316,6 +357,8 @@ class VoiceSessionResponse(BaseModel):
     audio_format: dict
     provider: str
     voice_mode: str
+    session_id: str
+    session_scope: Optional[dict] = None
 
 
 class VoiceConfigResponse(BaseModel):
@@ -328,6 +371,132 @@ class VoiceConfigResponse(BaseModel):
 
 
 DEFAULT_ELEVENLABS_VOICE_ID = "pFZP5JQG7iQjIQuC4Bku"
+
+
+def _iso_value(value: Any) -> str:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat()
+    return str(value or "")
+
+
+def _load_voice_memory_scope(uid: str, scope: VoiceSessionScope) -> Optional[dict[str, Any]]:
+    """Load one user-owned canonical memory without probing other users."""
+    from database import conversations as conversations_db
+    from database import users as users_db
+
+    conversation_id = str(scope.conversation_id or "").strip()
+    if not conversation_id:
+        return None
+    conversation = conversations_db.get_conversation(uid, conversation_id)
+    if not isinstance(conversation, dict):
+        return None
+
+    active_version_id = str(conversation.get("active_summary_version_id") or "")
+    expected_version_id = str(scope.expected_active_summary_version_id or "")
+    if expected_version_id and expected_version_id != active_version_id:
+        raise ValueError("voice_session_scope_stale")
+
+    structured = conversation.get("structured")
+    structured = structured if isinstance(structured, dict) else {}
+    person_ids: list[str] = []
+    for segment in conversation.get("transcript_segments") or []:
+        if not isinstance(segment, dict):
+            continue
+        person_id = str(segment.get("person_id") or "").strip()
+        if person_id and person_id not in person_ids:
+            person_ids.append(person_id)
+    people: list[str] = []
+    if person_ids:
+        try:
+            for person in users_db.get_people_by_ids(uid, person_ids):
+                if not isinstance(person, dict):
+                    continue
+                name = str(person.get("name") or "").strip()
+                if name and name not in people:
+                    people.append(name)
+        except Exception as exc:
+            logger.warning(
+                "[FLOW:VOICE-SCOPE] people lookup degraded uid=%s conversation=%s error=%s",
+                uid,
+                conversation_id,
+                type(exc).__name__,
+            )
+
+    occurred_at = (
+        conversation.get("started_at")
+        or conversation.get("created_at")
+        or conversation.get("finished_at")
+    )
+    title = str(structured.get("title") or "Untitled memory").strip()
+    overview = str(structured.get("overview") or "").strip()
+    topic_query = " ".join(
+        part
+        for part in (
+            title,
+            overview[:700],
+            " ".join(people[:12]),
+            _iso_value(occurred_at)[:10],
+        )
+        if part
+    )[:1200]
+
+    return {
+        "kind": "memory",
+        "conversation_id": conversation_id,
+        "active_summary_version_id": active_version_id,
+        "can_reinterpret": not bool(conversation.get("is_locked")),
+        "title": title[:300],
+        "overview": overview[:1600],
+        "emoji": str(structured.get("emoji") or "")[:16],
+        "category": str(structured.get("category") or "")[:80],
+        "people": people[:12],
+        "occurred_at": _iso_value(occurred_at),
+        "topic_query": topic_query,
+        "instruction": (
+            "This is a memory-scoped conversation. Help the user reminisce and "
+            "answer questions normally. Do not treat every statement as a correction. "
+            "Memory changes are considered asynchronously after the session."
+        ),
+    }
+
+
+async def _resolve_voice_memory_scope(uid: str, scope: VoiceSessionScope) -> dict[str, Any]:
+    try:
+        resolved = await asyncio.to_thread(_load_voice_memory_scope, uid, scope)
+    except ValueError as exc:
+        if str(exc) == "voice_session_scope_stale":
+            raise HTTPException(status_code=409, detail={"code": "voice_session_scope_stale"}) from exc
+        raise
+    except Exception as exc:
+        logger.warning(
+            "[FLOW:VOICE-SCOPE] lookup unavailable uid=%s conversation=%s error=%s",
+            uid,
+            scope.conversation_id,
+            type(exc).__name__,
+        )
+        raise HTTPException(status_code=503, detail={"code": "voice_session_scope_unavailable"}) from exc
+    if not resolved:
+        # Missing and non-owned IDs intentionally share one response.
+        raise HTTPException(status_code=404, detail={"code": "voice_session_scope_not_found"})
+    return resolved
+
+
+async def _resolve_principal_memory_scope(principal: VoiceProxyPrincipal) -> Optional[dict[str, Any]]:
+    if principal.scope_kind != "memory":
+        return None
+    resolved = await _resolve_voice_memory_scope(
+        principal.uid,
+        VoiceSessionScope(
+            kind="memory",
+            conversation_id=principal.conversation_id or "",
+            expected_active_summary_version_id=principal.active_summary_version_id,
+        ),
+    )
+    if resolved["can_reinterpret"] != principal.can_reinterpret:
+        raise HTTPException(status_code=409, detail={"code": "voice_session_scope_stale"})
+    return resolved
 
 
 class TtsRequest(BaseModel):
@@ -399,6 +568,8 @@ def create_session_token(
     voice_mode: str = "v3-rich",
     provider: str = "grok-voice",
     isolated_runtime: bool = False,
+    session_id: Optional[str] = None,
+    session_scope: Optional[dict[str, Any]] = None,
 ) -> str:
     """
     Create a JWT session token for V2V connection.
@@ -431,11 +602,20 @@ def create_session_token(
         "context_url": f"{ELLA_API_BASE}/v1/users/{uid}/context",
         "callback_url": f"{ELLA_API_BASE}/v1/ella/voice-session",
         "aud": VOICE_SESSION_AUDIENCE,
-        "jti": str(uuid.uuid4()),
+        "jti": session_id or str(uuid.uuid4()),
         "exp": datetime.utcnow() + timedelta(hours=SESSION_EXPIRY_HOURS),
         "iat": datetime.utcnow(),
         "iss": "omi-backend",
     }
+    if session_scope:
+        payload.update(
+            {
+                "scope_kind": session_scope["kind"],
+                "conversation_id": session_scope["conversation_id"],
+                "active_summary_version_id": session_scope["active_summary_version_id"],
+                "can_reinterpret": bool(session_scope["can_reinterpret"]),
+            }
+        )
 
     return jwt.encode(payload, ELLA_SESSION_SECRET, algorithm="HS256")
 
@@ -570,6 +750,7 @@ async def create_voice_session(
     uid = authenticated_uid
     provider = (body.provider if body else None) or provider or "grok-voice"
     voice_mode = (body.voice_mode if body else None) or voice_mode
+    requested_scope = body.session_scope if body else None
 
     runtime_bound = runtime_bindings_enabled(uid)
     voice_rollout_enabled = isolated_voice_routing_enabled(uid)
@@ -585,6 +766,14 @@ async def create_voice_session(
             # Runtime-bound users must never fall through to legacy voice while
             # their explicit isolated-voice rollout gate remains disabled.
             raise HTTPException(status_code=503, detail={"code": "isolated_voice_not_ready"})
+    if requested_scope and not isolated_runtime:
+        raise HTTPException(status_code=503, detail={"code": "isolated_voice_runtime_required"})
+
+    memory_scope = (
+        await _resolve_voice_memory_scope(uid, requested_scope)
+        if requested_scope
+        else None
+    )
 
     # Validate provider
     if provider not in V2V_PROVIDERS:
@@ -621,6 +810,7 @@ async def create_voice_session(
         logger.warning(f"[FLOW:VOICE-SESSION] name lookup failed for {uid}: {e}")
 
     try:
+        session_id = str(uuid.uuid4())
         token = create_session_token(
             uid=uid,
             firebase_uid=uid,
@@ -628,6 +818,8 @@ async def create_voice_session(
             voice_mode=resolved_mode,
             provider=provider,
             isolated_runtime=isolated_runtime,
+            session_id=session_id,
+            session_scope=memory_scope,
         )
 
         # Build endpoint URL with mode query param
@@ -653,6 +845,17 @@ async def create_voice_session(
             },
             provider=provider,
             voice_mode=resolved_mode,
+            session_id=session_id,
+            session_scope=(
+                {
+                    "kind": memory_scope["kind"],
+                    "conversation_id": memory_scope["conversation_id"],
+                    "active_summary_version_id": memory_scope["active_summary_version_id"],
+                    "can_reinterpret": memory_scope["can_reinterpret"],
+                }
+                if memory_scope
+                else None
+            ),
         )
 
     except HTTPException:
@@ -1038,6 +1241,7 @@ async def get_voice_context(request: Request):
     principal = authenticate_voice_proxy_request(request, uid)
     uid = principal.uid
     runtime = await _resolve_voice_runtime(principal)
+    memory_scope = await _resolve_principal_memory_scope(principal)
 
     budget = body.get("context_budget", 8000)
     memory_timeout_seconds = float(body.get("memory_timeout_seconds", 2.0))
@@ -1140,15 +1344,33 @@ async def get_voice_context(request: Request):
     recent_conversations = ""
     recent_timeline = ""
     memory_context = ""
+    honcho_context_result: dict[str, Any] = {
+        "available": False,
+        "reason": "isolated_runtime_required",
+        "context": "",
+    }
     try:
-        import asyncio as _aio
-
-        conv_task = _aio.create_task(_fetch_recent_conversations(uid, limit=8))
-        timeline_task = _aio.create_task(_fetch_recent_canonical_timeline(uid, limit=40, max_chars=9000))
+        conv_task = asyncio.create_task(_fetch_recent_conversations(uid, limit=8))
+        timeline_task = asyncio.create_task(_fetch_recent_canonical_timeline(uid, limit=40, max_chars=9000))
         if runtime:
-            mem_task = _aio.create_task(_aio.sleep(0, result=""))
+            mem_task = asyncio.create_task(asyncio.sleep(0, result=""))
+            honcho_query = (
+                memory_scope.get("topic_query")
+                if memory_scope
+                else (
+                    "Recent themes, personal facts, relationships, preferences, "
+                    "plans, and details useful for a supportive voice conversation."
+                )
+            )
+            honcho_task = asyncio.create_task(
+                fetch_voice_honcho_context(
+                    runtime,
+                    query=str(honcho_query or ""),
+                    top_k=16 if memory_scope else 12,
+                )
+            )
         else:
-            mem_task = _aio.create_task(
+            mem_task = asyncio.create_task(
                 _fetch_memory_context(
                     gateway_url,
                     gateway_token,
@@ -1156,10 +1378,17 @@ async def get_voice_context(request: Request):
                     timeout_seconds=memory_timeout_seconds,
                 )
             )
-        recent_conversations, recent_timeline, memory_context = await _aio.gather(
+            honcho_task = asyncio.create_task(asyncio.sleep(0, result=honcho_context_result))
+        (
+            recent_conversations,
+            recent_timeline,
+            memory_context,
+            honcho_context_result,
+        ) = await asyncio.gather(
             conv_task,
             timeline_task,
             mem_task,
+            honcho_task,
         )
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-CONTEXT] Parallel context fetch error: {e}")
@@ -1211,6 +1440,7 @@ async def get_voice_context(request: Request):
         f"[FLOW:VOICE-CONTEXT] uid={uid} user={row['name']} agent={agent_id} "
         f"files={len(files)} rules={len(dynamic_rules)} "
         f"convos={len(recent_conversations)} timeline={len(recent_timeline)} mem={len(memory_context)} "
+        f"honcho={honcho_context_result.get('reason')} "
         f"latency={_elapsed}ms",
         flush=True,
     )
@@ -1232,6 +1462,13 @@ async def get_voice_context(request: Request):
         "recent_timeline": recent_timeline,
         "recent_conversations": recent_conversations,
         "memory_context": memory_context,
+        "honcho_context": str(honcho_context_result.get("context") or ""),
+        "honcho_status": {
+            key: value
+            for key, value in honcho_context_result.items()
+            if key != "context"
+        },
+        "memory_scope": memory_scope,
         "shared_reports": shared_reports,
         "caregiver_notes": _extract_caregiver_section(user_profile),
         "dynamic_rules": dynamic_rules,
@@ -1502,10 +1739,10 @@ async def search_omi_conversations(request: Request):
 # Privacy policy: maps agent_role -> source -> access level
 # True = full access, False = no access, "own" = own data only, "full" = full
 SEARCH_POLICY = {
-    "user":      {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": "own"},
-    "caregiver": {"timeline": True, "workspace": True, "omi_full": False, "omi_meta": True, "memories": False, "voice": False, "scanner": "full"},
-    "scanner":   {"timeline": False, "workspace": False, "omi_full": False, "omi_meta": False, "memories": False, "voice": False, "scanner": False},
-    "voice":     {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "scanner": False},
+    "user":      {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "honcho": True, "scanner": "own"},
+    "caregiver": {"timeline": True, "workspace": True, "omi_full": False, "omi_meta": True, "memories": False, "voice": False, "honcho": False, "scanner": "full"},
+    "scanner":   {"timeline": False, "workspace": False, "omi_full": False, "omi_meta": False, "memories": False, "voice": False, "honcho": False, "scanner": False},
+    "voice":     {"timeline": True, "workspace": True, "omi_full": True, "omi_meta": True, "memories": True, "voice": True, "honcho": True, "scanner": False},
 }
 
 # Which source keys map to which request-level source names
@@ -1516,6 +1753,7 @@ _SOURCE_TO_POLICY_KEYS = {
     "omi":       ["omi_full", "omi_meta"],
     "memories":  ["memories"],
     "voice":     ["voice"],
+    "honcho":    ["honcho"],
     "scanner":   ["scanner"],
 }
 
@@ -2801,6 +3039,10 @@ async def unified_search(request: Request):
             tasks.append(_search_voice_logs(uid, agent_id, query, limit))
         task_source_names.append("voice")
 
+    if runtime and allowed.get("honcho"):
+        tasks.append(search_voice_honcho(runtime, query, limit))
+        task_source_names.append("honcho")
+
     scanner_access = allowed.get("scanner")
     if scanner_access:
         access_level = "full" if scanner_access == "full" else "own"
@@ -2808,7 +3050,16 @@ async def unified_search(request: Request):
         task_source_names.append("scanner")
 
     # Determine which sources were denied
-    all_source_names = {"voice_memory", "timeline", "workspace", "omi", "memories", "voice", "scanner"}
+    all_source_names = {
+        "voice_memory",
+        "timeline",
+        "workspace",
+        "omi",
+        "memories",
+        "voice",
+        "honcho",
+        "scanner",
+    }
     if requested_sources:
         requested_set = set(requested_sources)
     else:

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -396,6 +396,11 @@ MEMORY_SCOPED_VOICE_MODE_ALIASES = {
     "gemini-lite-live-v1": "v4",
     "gemini-full-live-v1": "v4",
 }
+MEMORY_SCOPED_VOICE_PROVIDERS = {
+    "grok-voice",
+    "gemini-live",
+    "gemini-native-live",
+}
 
 
 def _normalized_memory_scoped_voice_mode(value: str) -> str:
@@ -403,8 +408,18 @@ def _normalized_memory_scoped_voice_mode(value: str) -> str:
     return MEMORY_SCOPED_VOICE_MODE_ALIASES.get(candidate, candidate)
 
 
-def _memory_scoped_voice_mode_allowed(value: str) -> bool:
-    return _normalized_memory_scoped_voice_mode(value) == "v4"
+def _memory_scoped_voice_provider_mode_error(provider: str, voice_mode: str) -> Optional[str]:
+    provider = str(provider or "").strip().lower()
+    raw_mode = str(voice_mode or "").strip().lower()
+    if provider not in MEMORY_SCOPED_VOICE_PROVIDERS:
+        return "memory_scoped_voice_provider_unsupported"
+    if _normalized_memory_scoped_voice_mode(raw_mode) != "v4":
+        return "memory_scoped_voice_mode_required"
+    if provider == "grok-voice" and raw_mode != "v4":
+        return "memory_scoped_voice_provider_mode_mismatch"
+    if provider in {"gemini-live", "gemini-native-live"} and not raw_mode.startswith("gemini"):
+        return "memory_scoped_voice_provider_mode_mismatch"
+    return None
 
 
 # ============================================================================
@@ -688,8 +703,10 @@ def create_session_token(
     if not ELLA_SESSION_SECRET:
         raise HTTPException(status_code=500, detail="Session secret not configured")
 
-    if session_scope and not _memory_scoped_voice_mode_allowed(voice_mode):
-        raise ValueError("memory-scoped voice sessions require a V4-compatible mode")
+    if session_scope:
+        scope_pair_error = _memory_scoped_voice_provider_mode_error(provider, voice_mode)
+        if scope_pair_error:
+            raise ValueError(scope_pair_error)
 
     payload = {
         "sub": firebase_uid,
@@ -879,6 +896,17 @@ async def create_voice_session(
 
     provider_info = V2V_PROVIDERS[provider]
 
+    # Resolve and validate the complete scoped pair before memory lookup or
+    # provider setup. Unscoped sessions retain their existing behavior.
+    resolved_mode = voice_mode or provider_info["default_mode"]
+    if requested_scope:
+        scope_pair_error = _memory_scoped_voice_provider_mode_error(provider, resolved_mode)
+        if scope_pair_error:
+            raise HTTPException(
+                status_code=400,
+                detail={"code": scope_pair_error},
+            )
+
     # Check provider availability
     if not provider_info["key_check"]():
         raise HTTPException(
@@ -886,13 +914,6 @@ async def create_voice_session(
             detail=f"Provider {provider!r} is not configured (missing API key)",
         )
 
-    # Resolve voice mode
-    resolved_mode = voice_mode or provider_info["default_mode"]
-    if requested_scope and not _memory_scoped_voice_mode_allowed(resolved_mode):
-        raise HTTPException(
-            status_code=400,
-            detail={"code": "memory_scoped_voice_mode_required"},
-        )
     memory_scope = (
         await _resolve_voice_memory_scope(uid, requested_scope)
         if requested_scope

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -84,6 +84,12 @@ HERMES_PROVISION_API_TOKEN = os.getenv("ELLA_HERMES_PROVISION_API_TOKEN", "").st
 VOICE_PROXY_SERVICE_TOKEN = os.getenv("ELLA_VOICE_PROXY_SERVICE_TOKEN", "").strip()
 VOICE_PROXY_SERVICE_HEADER = "X-Ella-Voice-Proxy-Token"
 VOICE_SESSION_AUDIENCE = "ella-voice-proxy"
+VOICE_HONCHO_PROFILE_RESOLUTION_TIMEOUT_SECONDS = float(
+    os.getenv("ELLA_VOICE_HONCHO_PROFILE_RESOLUTION_TIMEOUT_SECONDS", "0.35")
+)
+VOICE_HONCHO_PROFILE_NEGATIVE_CACHE_TTL_SECONDS = float(
+    os.getenv("ELLA_VOICE_HONCHO_PROFILE_NEGATIVE_CACHE_TTL_SECONDS", "15")
+)
 ALLOW_LEGACY_VOICE_SESSION_TOKENS = os.getenv("ELLA_ALLOW_LEGACY_VOICE_SESSION_TOKENS", "true").strip().lower() in {
     "1",
     "true",
@@ -92,6 +98,7 @@ ALLOW_LEGACY_VOICE_SESSION_TOKENS = os.getenv("ELLA_ALLOW_LEGACY_VOICE_SESSION_T
 }
 DEFAULT_GATEWAY_URL = os.getenv("OPENCLAW_URL", "http://100.76.138.56:19001")
 OPENCLAW_GATEWAY_TOKEN = os.getenv("OPENCLAW_GATEWAY_TOKEN", "")
+_VOICE_HONCHO_PROFILE_NEGATIVE_CACHE: dict[str, float] = {}
 
 
 def isolated_voice_routing_enabled(uid: Optional[str] = None) -> bool:
@@ -259,9 +266,39 @@ async def _resolve_voice_runtime(principal: VoiceProxyPrincipal):
 
 async def _resolve_voice_honcho_binding(uid: str, runtime: Any = None):
     """Resolve Honcho without blocking the event loop or failing the voice path."""
+    if runtime is not None:
+        return resolve_voice_honcho_target(uid, runtime)
+
+    now = time.monotonic()
+    if _VOICE_HONCHO_PROFILE_NEGATIVE_CACHE.get(uid, 0) > now:
+        return None, "honcho_profile_resolution_cached_unavailable"
+
     try:
-        return await asyncio.to_thread(resolve_voice_honcho_target, uid, runtime)
+        target, reason = await asyncio.wait_for(
+            asyncio.to_thread(resolve_voice_honcho_target, uid, runtime),
+            timeout=VOICE_HONCHO_PROFILE_RESOLUTION_TIMEOUT_SECONDS,
+        )
+        if target:
+            _VOICE_HONCHO_PROFILE_NEGATIVE_CACHE.pop(uid, None)
+            return target, reason
+        _VOICE_HONCHO_PROFILE_NEGATIVE_CACHE[uid] = (
+            time.monotonic() + VOICE_HONCHO_PROFILE_NEGATIVE_CACHE_TTL_SECONDS
+        )
+        return None, reason
+    except asyncio.TimeoutError:
+        _VOICE_HONCHO_PROFILE_NEGATIVE_CACHE[uid] = (
+            time.monotonic() + VOICE_HONCHO_PROFILE_NEGATIVE_CACHE_TTL_SECONDS
+        )
+        logger.warning(
+            "[FLOW:VOICE-HONCHO] target resolution timed out uid=%s timeout=%.3fs",
+            uid,
+            VOICE_HONCHO_PROFILE_RESOLUTION_TIMEOUT_SECONDS,
+        )
+        return None, "honcho_profile_resolution_timeout"
     except Exception as exc:
+        _VOICE_HONCHO_PROFILE_NEGATIVE_CACHE[uid] = (
+            time.monotonic() + VOICE_HONCHO_PROFILE_NEGATIVE_CACHE_TTL_SECONDS
+        )
         logger.warning(
             "[FLOW:VOICE-HONCHO] target resolution degraded uid=%s error=%s",
             uid,
@@ -1386,7 +1423,15 @@ async def get_voice_context(request: Request):
     }
     try:
         conv_task = asyncio.create_task(_fetch_recent_conversations(uid, limit=8))
-        timeline_task = asyncio.create_task(_fetch_recent_canonical_timeline(uid, limit=40, max_chars=9000))
+        timeline_task = asyncio.create_task(
+            _fetch_recent_canonical_timeline(
+                uid,
+                limit=40,
+                max_chars=9000,
+                scope_kind=principal.scope_kind,
+                conversation_id=principal.conversation_id,
+            )
+        )
         if runtime:
             mem_task = asyncio.create_task(asyncio.sleep(0, result=""))
         else:
@@ -2025,7 +2070,14 @@ def _should_use_voice_memory_fast_path(query: str) -> bool:
     return not any(term in query_lower for term in detail_terms)
 
 
-async def _search_canonical_timeline(uid: str, query: str, limit: int) -> list:
+async def _search_canonical_timeline(
+    uid: str,
+    query: str,
+    limit: int,
+    *,
+    scope_kind: Optional[str] = None,
+    conversation_id: Optional[str] = None,
+) -> list:
     """Search the canonical cross-channel event ledger.
 
     This is the durable source for voice/app/iMessage/chat turns and should be
@@ -2045,10 +2097,26 @@ async def _search_canonical_timeline(uid: str, query: str, limit: int) -> list:
             WHERE lower(uid) = lower($1)
               AND text IS NOT NULL
               AND trim(text) != ''
+              AND (
+                    NOT (
+                        COALESCE(source_ref ->> 'scope_kind', '') = 'memory'
+                        OR COALESCE(metadata ->> 'scope_kind', '') = 'memory'
+                    )
+                    OR (
+                        $2 = 'memory'
+                        AND COALESCE(
+                            NULLIF(source_ref ->> 'conversation_id', ''),
+                            metadata ->> 'conversation_id',
+                            ''
+                        ) = $3
+                    )
+              )
             ORDER BY started_at DESC, id DESC
             LIMIT 300
             """,
             uid,
+            scope_kind or "",
+            conversation_id or "",
         )
         matches = []
         include_assistant = any(
@@ -2154,7 +2222,14 @@ async def _search_voice_memory_pack(uid: str, query: str, limit: int) -> list:
         return []
 
 
-async def _fetch_recent_canonical_timeline(uid: str, limit: int = 30, max_chars: int = 9000) -> str:
+async def _fetch_recent_canonical_timeline(
+    uid: str,
+    limit: int = 30,
+    max_chars: int = 9000,
+    *,
+    scope_kind: Optional[str] = None,
+    conversation_id: Optional[str] = None,
+) -> str:
     """Fetch the latest cross-channel turns for realtime voice startup context.
 
     This is not keyword search. Realtime voice providers need a hot chronological
@@ -2170,10 +2245,26 @@ async def _fetch_recent_canonical_timeline(uid: str, limit: int = 30, max_chars:
             WHERE lower(uid) = lower($1)
               AND text IS NOT NULL
               AND trim(text) != ''
+              AND (
+                    NOT (
+                        COALESCE(source_ref ->> 'scope_kind', '') = 'memory'
+                        OR COALESCE(metadata ->> 'scope_kind', '') = 'memory'
+                    )
+                    OR (
+                        $2 = 'memory'
+                        AND COALESCE(
+                            NULLIF(source_ref ->> 'conversation_id', ''),
+                            metadata ->> 'conversation_id',
+                            ''
+                        ) = $3
+                    )
+              )
             ORDER BY started_at DESC, id DESC
-            LIMIT $2
+            LIMIT $4
             """,
             uid,
+            scope_kind or "",
+            conversation_id or "",
             limit,
         )
     except Exception as e:
@@ -3050,7 +3141,15 @@ async def unified_search(request: Request):
         task_source_names.append("voice_memory")
 
     if allowed.get("timeline"):
-        tasks.append(_search_canonical_timeline(uid, query, limit))
+        tasks.append(
+            _search_canonical_timeline(
+                uid,
+                query,
+                limit,
+                scope_kind=principal.scope_kind,
+                conversation_id=principal.conversation_id,
+            )
+        )
         task_source_names.append("timeline")
 
     if allowed.get("workspace"):

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -389,6 +389,23 @@ V2V_PROVIDERS = {
     },
 }
 
+MEMORY_SCOPED_VOICE_MODE_ALIASES = {
+    "gemini-live": "v4",
+    "gemini-native-live-v1": "v4",
+    "gemini-zero-live-v1": "v4",
+    "gemini-lite-live-v1": "v4",
+    "gemini-full-live-v1": "v4",
+}
+
+
+def _normalized_memory_scoped_voice_mode(value: str) -> str:
+    candidate = str(value or "").strip().lower()
+    return MEMORY_SCOPED_VOICE_MODE_ALIASES.get(candidate, candidate)
+
+
+def _memory_scoped_voice_mode_allowed(value: str) -> bool:
+    return _normalized_memory_scoped_voice_mode(value) == "v4"
+
 
 # ============================================================================
 # Request/Response Models
@@ -671,6 +688,9 @@ def create_session_token(
     if not ELLA_SESSION_SECRET:
         raise HTTPException(status_code=500, detail="Session secret not configured")
 
+    if session_scope and not _memory_scoped_voice_mode_allowed(voice_mode):
+        raise ValueError("memory-scoped voice sessions require a V4-compatible mode")
+
     payload = {
         "sub": firebase_uid,
         "uid": uid,
@@ -849,12 +869,6 @@ async def create_voice_session(
             # Runtime-bound users must never fall through to legacy voice while
             # their explicit isolated-voice rollout gate remains disabled.
             raise HTTPException(status_code=503, detail={"code": "isolated_voice_not_ready"})
-    memory_scope = (
-        await _resolve_voice_memory_scope(uid, requested_scope)
-        if requested_scope
-        else None
-    )
-
     # Validate provider
     if provider not in V2V_PROVIDERS:
         valid = list(V2V_PROVIDERS.keys())
@@ -874,6 +888,16 @@ async def create_voice_session(
 
     # Resolve voice mode
     resolved_mode = voice_mode or provider_info["default_mode"]
+    if requested_scope and not _memory_scoped_voice_mode_allowed(resolved_mode):
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "memory_scoped_voice_mode_required"},
+        )
+    memory_scope = (
+        await _resolve_voice_memory_scope(uid, requested_scope)
+        if requested_scope
+        else None
+    )
 
     _start = time.time()
 

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -38,7 +38,11 @@ from pydantic import BaseModel
 from database.conversations import _decrypt_conversation_data
 from ella.services.provisioning import ProvisioningError, rollout_enabled
 from ella.services.runtime_resolver import resolve_isolated_runtime, runtime_bindings_enabled
-from ella.services.voice_honcho import fetch_voice_honcho_context, search_voice_honcho
+from ella.services.voice_honcho import (
+    fetch_voice_honcho_context,
+    resolve_voice_honcho_target,
+    search_voice_honcho,
+)
 from utils.ella.canonical_context import fetch_canonical_timeline
 from utils.other import endpoints as auth
 
@@ -215,6 +219,7 @@ def authenticate_voice_proxy_request(request: Request, requested_uid: str) -> Vo
         scope_kind != "memory"
         or not str(claims.get("conversation_id") or "").strip()
         or not isinstance(claims.get("active_summary_version_id"), str)
+        or not str(claims.get("active_summary_version_id") or "").strip()
         or not isinstance(claims.get("can_reinterpret"), bool)
     ):
         raise HTTPException(status_code=401, detail={"code": "voice_session_invalid"})
@@ -250,6 +255,19 @@ async def _resolve_voice_runtime(principal: VoiceProxyPrincipal):
         return await resolve_isolated_runtime(principal.uid)
     except ProvisioningError as exc:
         raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
+
+
+async def _resolve_voice_honcho_binding(uid: str, runtime: Any = None):
+    """Resolve Honcho without blocking the event loop or failing the voice path."""
+    try:
+        return await asyncio.to_thread(resolve_voice_honcho_target, uid, runtime)
+    except Exception as exc:
+        logger.warning(
+            "[FLOW:VOICE-HONCHO] target resolution degraded uid=%s error=%s",
+            uid,
+            type(exc).__name__,
+        )
+        return None, "honcho_profile_resolution_unavailable"
 
 
 def _hermes_workspace_headers(uid: str) -> dict[str, str]:
@@ -389,14 +407,25 @@ def _load_voice_memory_scope(uid: str, scope: VoiceSessionScope) -> Optional[dic
     conversation_id = str(scope.conversation_id or "").strip()
     if not conversation_id:
         return None
-    conversation = conversations_db.get_conversation(uid, conversation_id)
-    if not isinstance(conversation, dict):
+    version_result = conversations_db.ensure_voice_memory_summary_version(
+        uid,
+        conversation_id,
+        scope.expected_active_summary_version_id,
+    )
+    status = str(version_result.get("status") or "")
+    if status == "stale":
+        raise ValueError("voice_session_scope_stale")
+    if status == "version_unavailable":
+        raise ValueError("voice_session_scope_version_unavailable")
+    if status == "not_found":
         return None
+    conversation = version_result.get("conversation")
+    if not isinstance(conversation, dict):
+        raise RuntimeError("voice_session_scope_invalid_result")
 
     active_version_id = str(conversation.get("active_summary_version_id") or "")
-    expected_version_id = str(scope.expected_active_summary_version_id or "")
-    if expected_version_id and expected_version_id != active_version_id:
-        raise ValueError("voice_session_scope_stale")
+    if not active_version_id:
+        raise ValueError("voice_session_scope_version_unavailable")
 
     structured = conversation.get("structured")
     structured = structured if isinstance(structured, dict) else {}
@@ -468,6 +497,11 @@ async def _resolve_voice_memory_scope(uid: str, scope: VoiceSessionScope) -> dic
     except ValueError as exc:
         if str(exc) == "voice_session_scope_stale":
             raise HTTPException(status_code=409, detail={"code": "voice_session_scope_stale"}) from exc
+        if str(exc) == "voice_session_scope_version_unavailable":
+            raise HTTPException(
+                status_code=409,
+                detail={"code": "voice_session_scope_version_unavailable"},
+            ) from exc
         raise
     except Exception as exc:
         logger.warning(
@@ -608,11 +642,14 @@ def create_session_token(
         "iss": "omi-backend",
     }
     if session_scope:
+        active_summary_version_id = str(session_scope.get("active_summary_version_id") or "").strip()
+        if not active_summary_version_id:
+            raise ValueError("memory scope requires an active summary version")
         payload.update(
             {
                 "scope_kind": session_scope["kind"],
                 "conversation_id": session_scope["conversation_id"],
-                "active_summary_version_id": session_scope["active_summary_version_id"],
+                "active_summary_version_id": active_summary_version_id,
                 "can_reinterpret": bool(session_scope["can_reinterpret"]),
             }
         )
@@ -766,9 +803,6 @@ async def create_voice_session(
             # Runtime-bound users must never fall through to legacy voice while
             # their explicit isolated-voice rollout gate remains disabled.
             raise HTTPException(status_code=503, detail={"code": "isolated_voice_not_ready"})
-    if requested_scope and not isolated_runtime:
-        raise HTTPException(status_code=503, detail={"code": "isolated_voice_runtime_required"})
-
     memory_scope = (
         await _resolve_voice_memory_scope(uid, requested_scope)
         if requested_scope
@@ -1242,6 +1276,7 @@ async def get_voice_context(request: Request):
     uid = principal.uid
     runtime = await _resolve_voice_runtime(principal)
     memory_scope = await _resolve_principal_memory_scope(principal)
+    honcho_target, honcho_target_reason = await _resolve_voice_honcho_binding(uid, runtime)
 
     budget = body.get("context_budget", 8000)
     memory_timeout_seconds = float(body.get("memory_timeout_seconds", 2.0))
@@ -1346,7 +1381,7 @@ async def get_voice_context(request: Request):
     memory_context = ""
     honcho_context_result: dict[str, Any] = {
         "available": False,
-        "reason": "isolated_runtime_required",
+        "reason": honcho_target_reason or "missing_companion_honcho_target",
         "context": "",
     }
     try:
@@ -1354,21 +1389,6 @@ async def get_voice_context(request: Request):
         timeline_task = asyncio.create_task(_fetch_recent_canonical_timeline(uid, limit=40, max_chars=9000))
         if runtime:
             mem_task = asyncio.create_task(asyncio.sleep(0, result=""))
-            honcho_query = (
-                memory_scope.get("topic_query")
-                if memory_scope
-                else (
-                    "Recent themes, personal facts, relationships, preferences, "
-                    "plans, and details useful for a supportive voice conversation."
-                )
-            )
-            honcho_task = asyncio.create_task(
-                fetch_voice_honcho_context(
-                    runtime,
-                    query=str(honcho_query or ""),
-                    top_k=16 if memory_scope else 12,
-                )
-            )
         else:
             mem_task = asyncio.create_task(
                 _fetch_memory_context(
@@ -1378,6 +1398,23 @@ async def get_voice_context(request: Request):
                     timeout_seconds=memory_timeout_seconds,
                 )
             )
+        honcho_query = (
+            memory_scope.get("topic_query")
+            if memory_scope
+            else (
+                "Recent themes, personal facts, relationships, preferences, "
+                "plans, and details useful for a supportive voice conversation."
+            )
+        )
+        if honcho_target:
+            honcho_task = asyncio.create_task(
+                fetch_voice_honcho_context(
+                    honcho_target,
+                    query=str(honcho_query or ""),
+                    top_k=16 if memory_scope else 12,
+                )
+            )
+        else:
             honcho_task = asyncio.create_task(asyncio.sleep(0, result=honcho_context_result))
         (
             recent_conversations,
@@ -2930,13 +2967,21 @@ async def unified_search(request: Request):
         raise HTTPException(status_code=403, detail="agent_id does not belong to this uid")
 
     _start = time.time()
+    honcho_target = None
+    honcho_target_reason = ""
+    honcho_target_resolved = False
+    prefetched_voice_memory_results = None
 
     # Realtime voice needs a bounded fast path. If the compact Hermes memory
     # pack has a high-confidence answer, return it immediately and avoid
-    # waiting on slower Firestore/workspace/Honcho fallback searches.
+    # waiting on slower fallback searches. A mapped retained companion still
+    # fans out to Honcho so retained and isolated voice share durable memory.
     if not runtime and agent_role == "voice" and not requested_sources and _should_use_voice_memory_fast_path(query):
+        honcho_target, honcho_target_reason = await _resolve_voice_honcho_binding(uid, runtime)
+        honcho_target_resolved = True
         fast_results = await _search_voice_memory_pack(uid, query, limit)
-        if fast_results and fast_results[0].get("score", 0) >= 120:
+        prefetched_voice_memory_results = fast_results
+        if not honcho_target and fast_results and fast_results[0].get("score", 0) >= 120:
             _elapsed = int((time.time() - _start) * 1000)
             logger.info(
                 f"[FLOW:UNIFIED-SEARCH] uid={uid} role={agent_role} query=\"{query}\" "
@@ -2979,6 +3024,15 @@ async def unified_search(request: Request):
 
     # Determine allowed sources based on role
     allowed = _get_allowed_sources(agent_role, requested_sources)
+    if allowed.get("honcho"):
+        if not honcho_target_resolved:
+            honcho_target, honcho_target_reason = await _resolve_voice_honcho_binding(uid, runtime)
+        if not honcho_target:
+            logger.info(
+                "[FLOW:UNIFIED-SEARCH] Honcho profile unavailable uid=%s reason=%s",
+                uid,
+                honcho_target_reason,
+            )
 
     # Build task list for parallel fan-out
     tasks = []
@@ -2989,7 +3043,10 @@ async def unified_search(request: Request):
         or (not requested_sources and _should_use_voice_memory_fast_path(query))
     )
     if agent_role in {"voice", "user"} and include_voice_memory:
-        tasks.append(_search_voice_memory_pack(uid, query, limit))
+        if prefetched_voice_memory_results is None:
+            tasks.append(_search_voice_memory_pack(uid, query, limit))
+        else:
+            tasks.append(_aio.sleep(0, result=prefetched_voice_memory_results))
         task_source_names.append("voice_memory")
 
     if allowed.get("timeline"):
@@ -3039,8 +3096,8 @@ async def unified_search(request: Request):
             tasks.append(_search_voice_logs(uid, agent_id, query, limit))
         task_source_names.append("voice")
 
-    if runtime and allowed.get("honcho"):
-        tasks.append(search_voice_honcho(runtime, query, limit))
+    if honcho_target and allowed.get("honcho"):
+        tasks.append(search_voice_honcho(honcho_target, query, limit))
         task_source_names.append("honcho")
 
     scanner_access = allowed.get("scanner")

--- a/backend/ella/services/correction_honcho_contract.py
+++ b/backend/ella/services/correction_honcho_contract.py
@@ -223,45 +223,49 @@ def _profile_target_from_entry(entry: Any) -> dict[str, str] | None:
     }
 
 
-def _target_from_profile_map(uid: str) -> dict[str, str] | None:
-    uid_norm = str(uid or "").strip().lower()
-    candidates = []
-    inline = _safe_json_loads(HONCHO_PROFILE_MAP_JSON)
-    if inline is not None:
-        candidates.append(inline)
-    url_data = _safe_json_url(HONCHO_PROFILE_MAP_URL)
-    if url_data is not None:
-        candidates.append(url_data)
-    file_data = _safe_json_file(HONCHO_PROFILE_MAP_PATH)
-    if file_data is not None:
-        candidates.append(file_data)
-
-    for data in candidates:
-        if isinstance(data, dict):
-            for key in (uid, uid_norm):
-                if key in data:
-                    target = _profile_target_from_entry(data[key])
-                    if target:
-                        return {**target, "source": "profile_map"}
-            profiles = data.get("profiles") or data.get("users")
-            if isinstance(profiles, list):
-                data = profiles
-        if isinstance(data, list):
-            for entry in data:
-                if not isinstance(entry, dict):
-                    continue
-                entry_uid = str(entry.get("uid") or entry.get("profile_uid") or entry.get("profileUid") or "").lower()
-                if entry_uid != uid_norm:
-                    continue
-                target = _profile_target_from_entry(entry)
-                if target:
-                    return {**target, "source": "profile_map"}
+def _target_from_profile_map_data(uid: str, data: Any) -> dict[str, str] | None:
+    if isinstance(data, dict):
+        if uid in data:
+            target = _profile_target_from_entry(data[uid])
+            if target:
+                return {**target, "source": "profile_map"}
+        profiles = data.get("profiles") or data.get("users")
+        if isinstance(profiles, list):
+            data = profiles
+    if isinstance(data, list):
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            entry_uid = str(
+                entry.get("uid") or entry.get("profile_uid") or entry.get("profileUid") or ""
+            ).strip()
+            if entry_uid != uid:
+                continue
+            target = _profile_target_from_entry(entry)
+            if target:
+                return {**target, "source": "profile_map"}
     return None
 
 
+def _target_from_profile_map(uid: str) -> dict[str, str] | None:
+    uid = str(uid or "").strip()
+    # Evaluate local sources before the remote provisioning map. This avoids
+    # putting a network timeout on the voice startup path when a local exact-UID
+    # binding is already available.
+    for data in (
+        _safe_json_loads(HONCHO_PROFILE_MAP_JSON),
+        _safe_json_file(HONCHO_PROFILE_MAP_PATH),
+    ):
+        target = _target_from_profile_map_data(uid, data)
+        if target:
+            return target
+
+    return _target_from_profile_map_data(uid, _safe_json_url(HONCHO_PROFILE_MAP_URL))
+
+
 def _target_from_profile_config(uid: str) -> dict[str, str] | None:
-    uid_norm = str(uid or "").strip().lower()
-    if not HONCHO_PROFILE_UID or HONCHO_PROFILE_UID.strip().lower() != uid_norm:
+    uid = str(uid or "").strip()
+    if not HONCHO_PROFILE_UID or HONCHO_PROFILE_UID.strip() != uid:
         return None
     data = _safe_json_file(HONCHO_PROFILE_CONFIG_PATH)
     target = _profile_target_from_entry(data)

--- a/backend/ella/services/correction_honcho_contract.py
+++ b/backend/ella/services/correction_honcho_contract.py
@@ -259,14 +259,36 @@ def _target_from_profile_map(uid: str) -> dict[str, str] | None:
     return None
 
 
-def _target_from_profile_config(candidate: HonchoFactCandidate) -> dict[str, str] | None:
-    if HONCHO_PROFILE_UID and HONCHO_PROFILE_UID.lower() != candidate.uid.lower():
+def _target_from_profile_config(uid: str) -> dict[str, str] | None:
+    uid_norm = str(uid or "").strip().lower()
+    if not HONCHO_PROFILE_UID or HONCHO_PROFILE_UID.strip().lower() != uid_norm:
         return None
     data = _safe_json_file(HONCHO_PROFILE_CONFIG_PATH)
     target = _profile_target_from_entry(data)
     if target:
         return {**target, "source": "profile_config"}
     return None
+
+
+def resolve_companion_honcho_target(uid: str) -> tuple[dict[str, str] | None, str]:
+    """Resolve an exact user profile without correction-write global fallbacks."""
+    uid = str(uid or "").strip()
+    if not uid:
+        return None, "missing_companion_honcho_target"
+    target = _target_from_profile_map(uid) or _target_from_profile_config(uid)
+    if not target:
+        return None, "missing_companion_honcho_target"
+    return (
+        {
+            "workspace": target["workspace"],
+            "observer_peer_id": _honcho_resource_id(
+                target.get("observer_peer_id") or "ella-correction-observer"
+            ),
+            "observed_peer_id": target["observed_peer_id"],
+            "source": target.get("source") or "companion_profile",
+        },
+        "",
+    )
 
 
 def _resolve_native_honcho_target(
@@ -293,9 +315,9 @@ def _resolve_native_honcho_target(
             "",
         )
 
-    target = _target_from_profile_map(candidate.uid) or _target_from_profile_config(candidate)
+    target, _ = resolve_companion_honcho_target(candidate.uid)
     if target:
-        observer_peer_id = explicit_observer or target.get("observer_peer_id") or "ella-correction-observer"
+        observer_peer_id = explicit_observer or target["observer_peer_id"]
         return (
             {
                 "workspace": target["workspace"],

--- a/backend/ella/services/correction_honcho_contract.py
+++ b/backend/ella/services/correction_honcho_contract.py
@@ -167,7 +167,7 @@ def _safe_json_file(path: str) -> Any:
         return None
 
 
-def _safe_json_url(url: str) -> Any:
+def _safe_json_url(url: str, *, timeout_seconds: float = 5.0) -> Any:
     if not str(url or "").strip():
         return None
     now = time.monotonic()
@@ -181,7 +181,10 @@ def _safe_json_url(url: str) -> Any:
     if HONCHO_PROFILE_MAP_URL_TOKEN:
         headers["Authorization"] = f"Bearer {HONCHO_PROFILE_MAP_URL_TOKEN}"
     try:
-        with urlopen(Request(url, headers=headers), timeout=5) as response:
+        with urlopen(
+            Request(url, headers=headers),
+            timeout=max(0.01, float(timeout_seconds)),
+        ) as response:
             data = json.loads(response.read().decode("utf-8"))
     except (HTTPError, URLError, OSError, json.JSONDecodeError, TimeoutError):
         return None
@@ -247,11 +250,8 @@ def _target_from_profile_map_data(uid: str, data: Any) -> dict[str, str] | None:
     return None
 
 
-def _target_from_profile_map(uid: str) -> dict[str, str] | None:
+def _target_from_local_profile_map(uid: str) -> dict[str, str] | None:
     uid = str(uid or "").strip()
-    # Evaluate local sources before the remote provisioning map. This avoids
-    # putting a network timeout on the voice startup path when a local exact-UID
-    # binding is already available.
     for data in (
         _safe_json_loads(HONCHO_PROFILE_MAP_JSON),
         _safe_json_file(HONCHO_PROFILE_MAP_PATH),
@@ -259,8 +259,21 @@ def _target_from_profile_map(uid: str) -> dict[str, str] | None:
         target = _target_from_profile_map_data(uid, data)
         if target:
             return target
+    return None
 
-    return _target_from_profile_map_data(uid, _safe_json_url(HONCHO_PROFILE_MAP_URL))
+
+def _target_from_remote_profile_map(
+    uid: str,
+    *,
+    timeout_seconds: float = 5.0,
+) -> dict[str, str] | None:
+    return _target_from_profile_map_data(
+        str(uid or "").strip(),
+        _safe_json_url(
+            HONCHO_PROFILE_MAP_URL,
+            timeout_seconds=timeout_seconds,
+        ),
+    )
 
 
 def _target_from_profile_config(uid: str) -> dict[str, str] | None:
@@ -274,12 +287,24 @@ def _target_from_profile_config(uid: str) -> dict[str, str] | None:
     return None
 
 
-def resolve_companion_honcho_target(uid: str) -> tuple[dict[str, str] | None, str]:
+def resolve_companion_honcho_target(
+    uid: str,
+    *,
+    remote_timeout_seconds: float = 5.0,
+) -> tuple[dict[str, str] | None, str]:
     """Resolve an exact user profile without correction-write global fallbacks."""
     uid = str(uid or "").strip()
     if not uid:
         return None, "missing_companion_honcho_target"
-    target = _target_from_profile_map(uid) or _target_from_profile_config(uid)
+    # Every local exact-UID source must win before remote provisioning I/O.
+    target = (
+        _target_from_local_profile_map(uid)
+        or _target_from_profile_config(uid)
+        or _target_from_remote_profile_map(
+            uid,
+            timeout_seconds=remote_timeout_seconds,
+        )
+    )
     if not target:
         return None, "missing_companion_honcho_target"
     return (

--- a/backend/ella/services/voice_honcho.py
+++ b/backend/ella/services/voice_honcho.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import logging
 import os
 import time
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import quote
 
 import httpx
+
+from ella.services.correction_honcho_contract import resolve_companion_honcho_target
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +19,53 @@ HONCHO_BASE_URL = os.getenv("ELLA_VOICE_HONCHO_BASE_URL", "http://100.76.138.56:
 HONCHO_API_KEY = os.getenv("ELLA_VOICE_HONCHO_API_KEY", os.getenv("HONCHO_API_KEY", "")).strip()
 HONCHO_TIMEOUT_SECONDS = float(os.getenv("ELLA_VOICE_HONCHO_TIMEOUT_SECONDS", "1.5"))
 HONCHO_CONTEXT_MAX_CHARS = int(os.getenv("ELLA_VOICE_HONCHO_CONTEXT_MAX_CHARS", "2400"))
+
+
+@dataclass(frozen=True)
+class VoiceHonchoTarget:
+    uid: str
+    honcho_workspace: str
+    observer_peer: str
+    observed_peer: str
+    source: str
+
+
+def resolve_voice_honcho_target(uid: str, runtime: Any = None) -> tuple[VoiceHonchoTarget | None, str]:
+    """Prefer an isolated runtime receipt; otherwise require an exact UID profile."""
+    uid = str(uid or "").strip()
+    if runtime is not None:
+        runtime_uid = str(getattr(runtime, "uid", "") or "").strip()
+        if runtime_uid and runtime_uid != uid:
+            return None, "runtime_honcho_owner_mismatch"
+        workspace = str(getattr(runtime, "honcho_workspace", "") or "").strip()
+        observer = str(getattr(runtime, "observer_peer", "") or "").strip()
+        observed = str(getattr(runtime, "observed_peer", "") or "").strip()
+        if not all((workspace, observer, observed)):
+            return None, "runtime_honcho_binding_missing"
+        return (
+            VoiceHonchoTarget(
+                uid=uid,
+                honcho_workspace=workspace,
+                observer_peer=observer,
+                observed_peer=observed,
+                source="isolated_runtime_receipt",
+            ),
+            "",
+        )
+
+    target, reason = resolve_companion_honcho_target(uid)
+    if not target:
+        return None, reason
+    return (
+        VoiceHonchoTarget(
+            uid=uid,
+            honcho_workspace=target["workspace"],
+            observer_peer=target["observer_peer_id"],
+            observed_peer=target["observed_peer_id"],
+            source=str(target.get("source") or "companion_profile"),
+        ),
+        "",
+    )
 
 
 def _target(runtime: Any) -> tuple[str, str, str] | None:

--- a/backend/ella/services/voice_honcho.py
+++ b/backend/ella/services/voice_honcho.py
@@ -30,7 +30,12 @@ class VoiceHonchoTarget:
     source: str
 
 
-def resolve_voice_honcho_target(uid: str, runtime: Any = None) -> tuple[VoiceHonchoTarget | None, str]:
+def resolve_voice_honcho_target(
+    uid: str,
+    runtime: Any = None,
+    *,
+    profile_map_timeout_seconds: float | None = None,
+) -> tuple[VoiceHonchoTarget | None, str]:
     """Prefer an isolated runtime receipt; otherwise require an exact UID profile."""
     uid = str(uid or "").strip()
     if runtime is not None:
@@ -53,7 +58,13 @@ def resolve_voice_honcho_target(uid: str, runtime: Any = None) -> tuple[VoiceHon
             "",
         )
 
-    target, reason = resolve_companion_honcho_target(uid)
+    if profile_map_timeout_seconds is None:
+        target, reason = resolve_companion_honcho_target(uid)
+    else:
+        target, reason = resolve_companion_honcho_target(
+            uid,
+            remote_timeout_seconds=profile_map_timeout_seconds,
+        )
     if not target:
         return None, reason
     return (

--- a/backend/ella/services/voice_honcho.py
+++ b/backend/ella/services/voice_honcho.py
@@ -1,0 +1,184 @@
+"""Bounded, profile-isolated Honcho reads for realtime voice."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+HONCHO_BASE_URL = os.getenv("ELLA_VOICE_HONCHO_BASE_URL", "http://100.76.138.56:8320").rstrip("/")
+HONCHO_API_KEY = os.getenv("ELLA_VOICE_HONCHO_API_KEY", os.getenv("HONCHO_API_KEY", "")).strip()
+HONCHO_TIMEOUT_SECONDS = float(os.getenv("ELLA_VOICE_HONCHO_TIMEOUT_SECONDS", "1.5"))
+HONCHO_CONTEXT_MAX_CHARS = int(os.getenv("ELLA_VOICE_HONCHO_CONTEXT_MAX_CHARS", "2400"))
+
+
+def _target(runtime: Any) -> tuple[str, str, str] | None:
+    workspace = str(getattr(runtime, "honcho_workspace", "") or "").strip()
+    observer = str(getattr(runtime, "observer_peer", "") or "").strip()
+    observed = str(getattr(runtime, "observed_peer", "") or "").strip()
+    if not all((workspace, observer, observed)):
+        return None
+    return workspace, observer, observed
+
+
+def _headers() -> dict[str, str]:
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+    if HONCHO_API_KEY:
+        headers["Authorization"] = f"Bearer {HONCHO_API_KEY}"
+    return headers
+
+
+def _bounded_context(body: Any, max_chars: int) -> str:
+    if not isinstance(body, dict):
+        return ""
+    parts: list[str] = []
+    representation = str(body.get("representation") or "").strip()
+    if representation:
+        parts.append(representation)
+    peer_card = body.get("peer_card")
+    if isinstance(peer_card, list):
+        cards = [str(item).strip() for item in peer_card if str(item).strip()]
+        if cards:
+            parts.append("Known user facts:\n" + "\n".join(f"- {item}" for item in cards))
+    return "\n\n".join(parts)[: max(0, max_chars)].strip()
+
+
+async def fetch_voice_honcho_context(
+    runtime: Any,
+    *,
+    query: str,
+    top_k: int = 12,
+    max_chars: int = HONCHO_CONTEXT_MAX_CHARS,
+) -> dict[str, Any]:
+    """Return semantic Honcho context or a degraded result without raising."""
+    target = _target(runtime)
+    if target is None:
+        return {"available": False, "reason": "runtime_honcho_binding_missing", "context": ""}
+
+    workspace, observer, observed = target
+    started = time.monotonic()
+    try:
+        async with httpx.AsyncClient(timeout=HONCHO_TIMEOUT_SECONDS) as client:
+            response = await client.get(
+                f"{HONCHO_BASE_URL}/v3/workspaces/{quote(workspace, safe='')}"
+                f"/peers/{quote(observer, safe='')}/context",
+                headers=_headers(),
+                params={
+                    "target": observed,
+                    "search_query": query[:1200],
+                    "search_top_k": min(max(top_k, 1), 100),
+                    "include_most_frequent": "true",
+                    "max_conclusions": min(max(top_k, 1), 100),
+                },
+            )
+        if response.status_code != 200:
+            logger.warning(
+                "[FLOW:VOICE-HONCHO] context unavailable uid=%s status=%s",
+                getattr(runtime, "uid", ""),
+                response.status_code,
+            )
+            return {
+                "available": False,
+                "reason": f"honcho_http_{response.status_code}",
+                "context": "",
+            }
+        body = response.json()
+        if str(body.get("peer_id") or "") != observer or str(body.get("target_id") or "") != observed:
+            logger.warning(
+                "[FLOW:VOICE-HONCHO] context target mismatch uid=%s",
+                getattr(runtime, "uid", ""),
+            )
+            return {"available": False, "reason": "honcho_target_mismatch", "context": ""}
+        context = _bounded_context(body, max_chars)
+        return {
+            "available": bool(context),
+            "reason": "ok" if context else "honcho_context_empty",
+            "context": context,
+            "latency_ms": int((time.monotonic() - started) * 1000),
+            "source": "honcho",
+        }
+    except Exception as exc:
+        logger.warning(
+            "[FLOW:VOICE-HONCHO] context degraded uid=%s error=%s",
+            getattr(runtime, "uid", ""),
+            type(exc).__name__,
+        )
+        return {
+            "available": False,
+            "reason": "honcho_timeout" if isinstance(exc, httpx.TimeoutException) else "honcho_unavailable",
+            "context": "",
+            "latency_ms": int((time.monotonic() - started) * 1000),
+        }
+
+
+async def search_voice_honcho(runtime: Any, query: str, limit: int) -> list[dict[str, Any]]:
+    """Semantically search the exact receipt-bound Honcho peer pair."""
+    target = _target(runtime)
+    if target is None:
+        return []
+
+    workspace, observer, observed = target
+    started = time.monotonic()
+    try:
+        async with httpx.AsyncClient(timeout=HONCHO_TIMEOUT_SECONDS) as client:
+            response = await client.post(
+                f"{HONCHO_BASE_URL}/v3/workspaces/{quote(workspace, safe='')}/conclusions/query",
+                headers=_headers(),
+                json={
+                    "query": query[:1200],
+                    "top_k": min(max(limit, 1), 10),
+                    "filters": {"observer": observer, "observed": observed},
+                },
+            )
+        if response.status_code != 200:
+            logger.warning(
+                "[FLOW:VOICE-HONCHO] search unavailable uid=%s status=%s",
+                getattr(runtime, "uid", ""),
+                response.status_code,
+            )
+            return []
+        body = response.json()
+        if not isinstance(body, list):
+            return []
+        latency_ms = int((time.monotonic() - started) * 1000)
+        results: list[dict[str, Any]] = []
+        for item in body:
+            if not isinstance(item, dict):
+                continue
+            if (
+                str(item.get("observer_id") or item.get("observer") or "") != observer
+                or str(item.get("observed_id") or item.get("observed") or "") != observed
+            ):
+                continue
+            content = str(item.get("content") or "").strip()
+            if not content:
+                continue
+            created_at = str(item.get("created_at") or "")
+            results.append(
+                {
+                    "source": "honcho",
+                    "title": "Related user context",
+                    "content": content[:900],
+                    "timestamp": created_at,
+                    "score": 90,
+                    "metadata": {
+                        "provenance": "honcho_conclusion",
+                        "conclusion_id": str(item.get("id") or ""),
+                        "latency_ms": latency_ms,
+                    },
+                }
+            )
+        return results[:limit]
+    except Exception as exc:
+        logger.warning(
+            "[FLOW:VOICE-HONCHO] search degraded uid=%s error=%s",
+            getattr(runtime, "uid", ""),
+            type(exc).__name__,
+        )
+        return []

--- a/backend/tests/unit/test_canonical_voice_scope_isolation.py
+++ b/backend/tests/unit/test_canonical_voice_scope_isolation.py
@@ -1,9 +1,20 @@
 import asyncio
 
-from ella.routers.canonical_events import CanonicalEventIn, InMemoryCanonicalEventStore
+from ella.routers import canonical_events
+from ella.routers.canonical_events import (
+    CanonicalEventIn,
+    InMemoryCanonicalEventStore,
+    PostgresCanonicalEventStore,
+)
 
 
-def _event(event_id: str, text: str, *, conversation_id: str = "") -> CanonicalEventIn:
+def _event(
+    event_id: str,
+    text: str,
+    *,
+    uid: str = "uid-a",
+    conversation_id: str = "",
+) -> CanonicalEventIn:
     scope = (
         {
             "scope_kind": "memory",
@@ -14,8 +25,8 @@ def _event(event_id: str, text: str, *, conversation_id: str = "") -> CanonicalE
         else {}
     )
     return CanonicalEventIn(
-        uid="uid-a",
-        canonical_identity="uid-a",
+        uid=uid,
+        canonical_identity=uid,
         event_id=event_id,
         session_id="session-a",
         channel="ios_voice",
@@ -47,3 +58,58 @@ def test_public_canonical_timeline_excludes_memory_scoped_voice_events():
     timeline = asyncio.run(store.timeline(uid="uid-a", since=None, limit=50, channels=None))
 
     assert [event["event_id"] for event in timeline] == ["general"]
+
+
+def test_public_canonical_timeline_uses_exact_case_sensitive_uid():
+    store = InMemoryCanonicalEventStore()
+    asyncio.run(
+        store.write_batch(
+            [
+                _event("upper-general", "User A general turn", uid="UserA"),
+                _event("lower-general", "Lowercase user general turn", uid="usera"),
+                _event(
+                    "upper-scoped",
+                    "User A scoped turn",
+                    uid="UserA",
+                    conversation_id="shared-memory-id",
+                ),
+                _event(
+                    "lower-scoped",
+                    "Lowercase user scoped turn",
+                    uid="usera",
+                    conversation_id="shared-memory-id",
+                ),
+            ]
+        )
+    )
+
+    timeline = asyncio.run(store.timeline(uid="UserA", since=None, limit=50, channels=None))
+
+    assert [event["event_id"] for event in timeline] == ["upper-general"]
+
+
+def test_postgres_public_timeline_query_uses_exact_uid(monkeypatch):
+    queries = []
+
+    class Pool:
+        async def fetch(self, query, *args):
+            queries.append((query, args))
+            return []
+
+    async def get_pool():
+        return Pool()
+
+    monkeypatch.setattr(canonical_events, "_get_pool", get_pool)
+
+    timeline = asyncio.run(
+        PostgresCanonicalEventStore().timeline(
+            uid="UserA",
+            since=None,
+            limit=50,
+            channels=None,
+        )
+    )
+
+    assert timeline == []
+    assert "uid = $1" in queries[0][0]
+    assert "lower(uid)" not in queries[0][0]

--- a/backend/tests/unit/test_canonical_voice_scope_isolation.py
+++ b/backend/tests/unit/test_canonical_voice_scope_isolation.py
@@ -1,0 +1,49 @@
+import asyncio
+
+from ella.routers.canonical_events import CanonicalEventIn, InMemoryCanonicalEventStore
+
+
+def _event(event_id: str, text: str, *, conversation_id: str = "") -> CanonicalEventIn:
+    scope = (
+        {
+            "scope_kind": "memory",
+            "conversation_id": conversation_id,
+            "active_summary_version_id": "version-1",
+        }
+        if conversation_id
+        else {}
+    )
+    return CanonicalEventIn(
+        uid="uid-a",
+        canonical_identity="uid-a",
+        event_id=event_id,
+        session_id="session-a",
+        channel="ios_voice",
+        provider="grok-realtime",
+        role="user",
+        text=text,
+        started_at="2026-07-24T10:00:00Z",
+        scan_policy="none" if conversation_id else "immediate",
+        source_ref={
+            "source_identity": f"test:{event_id}",
+            **scope,
+        },
+        metadata=scope,
+    )
+
+
+def test_public_canonical_timeline_excludes_memory_scoped_voice_events():
+    store = InMemoryCanonicalEventStore()
+    asyncio.run(
+        store.write_batch(
+            [
+                _event("general", "General voice turn"),
+                _event("scoped-a", "Private memory A turn", conversation_id="memory-a"),
+                _event("scoped-b", "Private memory B turn", conversation_id="memory-b"),
+            ]
+        )
+    )
+
+    timeline = asyncio.run(store.timeline(uid="uid-a", since=None, limit=50, channels=None))
+
+    assert [event["event_id"] for event in timeline] == ["general"]

--- a/backend/tests/unit/test_conversation_voice_memory_scope.py
+++ b/backend/tests/unit/test_conversation_voice_memory_scope.py
@@ -1,0 +1,174 @@
+import copy
+import asyncio
+import os
+import sys
+import types
+
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("FIRESTORE_EMULATOR_HOST", "localhost:9999")
+os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "test-project")
+os.environ.setdefault("ENCRYPTION_SECRET", "test-encryption-secret-32-bytes-long")
+
+if "redis" not in sys.modules:
+    redis_stub = types.ModuleType("redis")
+    redis_stub.Redis = lambda *args, **kwargs: None
+    sys.modules["redis"] = redis_stub
+
+if "stripe" not in sys.modules:
+    stripe_stub = types.ModuleType("stripe")
+    stripe_stub.api_key = None
+    sys.modules["stripe"] = stripe_stub
+
+storage_stub = types.ModuleType("utils.other.storage")
+storage_stub.list_audio_chunks = lambda *args, **kwargs: []
+sys.modules.setdefault("utils.other.storage", storage_stub)
+sys.modules.setdefault("websockets", types.ModuleType("websockets"))
+
+from database import conversations as conversations_db
+from ella.routers import voice
+
+
+class _Snapshot:
+    def __init__(self, data):
+        self.exists = data is not None
+        self._data = data
+
+    def to_dict(self):
+        return copy.deepcopy(self._data)
+
+
+class _DocumentRef:
+    def __init__(self, data):
+        self.data = data
+
+    def get(self, transaction=None):
+        return _Snapshot(self.data)
+
+
+class _Transaction:
+    def __init__(self):
+        self.updates = []
+
+    def update(self, document_ref, update_data):
+        update_data = copy.deepcopy(update_data)
+        self.updates.append(update_data)
+        document_ref.data.update(update_data)
+
+
+def _legacy_conversation():
+    return {
+        "id": "memory-a",
+        "structured": {
+            "title": "Cafe visit",
+            "overview": "The user ordered coffee and waffles.",
+            "category": "other",
+        },
+    }
+
+
+def test_legacy_memory_atomically_bootstraps_a_durable_active_version():
+    reference = _DocumentRef(_legacy_conversation())
+    transaction = _Transaction()
+
+    result = conversations_db._ensure_voice_memory_summary_version_transaction(
+        transaction,
+        reference,
+    )
+
+    assert result["status"] == "ready"
+    assert result["active_summary_version_id"]
+    assert reference.data["active_summary_version_id"] == result["active_summary_version_id"]
+    assert reference.data["summary_versions"][0]["id"] == result["active_summary_version_id"]
+    assert transaction.updates == [
+        {
+            "summary_versions": reference.data["summary_versions"],
+            "active_summary_version_id": result["active_summary_version_id"],
+        }
+    ]
+
+
+def test_bootstrap_commits_before_client_cas_and_retry_observes_same_version():
+    reference = _DocumentRef(_legacy_conversation())
+    first = conversations_db._ensure_voice_memory_summary_version_transaction(
+        _Transaction(),
+        reference,
+        "client-prebootstrap-version",
+    )
+
+    assert first["status"] == "stale"
+    established_version = first["active_summary_version_id"]
+    assert reference.data["active_summary_version_id"] == established_version
+
+    retry = conversations_db._ensure_voice_memory_summary_version_transaction(
+        _Transaction(),
+        reference,
+        established_version,
+    )
+
+    assert retry["status"] == "ready"
+    assert retry["active_summary_version_id"] == established_version
+
+
+def test_unversionable_memory_returns_defined_nonwriteable_state():
+    reference = _DocumentRef({"id": "memory-empty", "structured": {}})
+    transaction = _Transaction()
+
+    result = conversations_db._ensure_voice_memory_summary_version_transaction(
+        transaction,
+        reference,
+    )
+
+    assert result == {"status": "version_unavailable"}
+    assert transaction.updates == []
+
+
+class _PathReference:
+    def __init__(self, path):
+        self.path = path
+
+    def collection(self, name):
+        return _PathReference((*self.path, name))
+
+    def document(self, name):
+        return _PathReference((*self.path, name))
+
+
+class _PathDatabase:
+    def collection(self, name):
+        return _PathReference((name,))
+
+    def transaction(self):
+        return object()
+
+
+def test_missing_and_nonowned_loader_queries_only_authenticated_user_subcollection(monkeypatch):
+    queried_paths = []
+
+    def missing(_transaction, conversation_ref, expected_version_id=None):
+        queried_paths.append((conversation_ref.path, expected_version_id))
+        return {"status": "not_found"}
+
+    monkeypatch.setattr(conversations_db, "db", _PathDatabase())
+    monkeypatch.setattr(conversations_db, "_ensure_voice_memory_summary_version", missing)
+
+    responses = []
+    for conversation_id in ("missing", "owned-by-user-b"):
+        with pytest.raises(HTTPException) as error:
+            asyncio.run(
+                voice._resolve_voice_memory_scope(
+                    "user-a",
+                    voice.VoiceSessionScope(kind="memory", conversation_id=conversation_id),
+                )
+            )
+        responses.append((error.value.status_code, error.value.detail))
+
+    assert responses == [
+        (404, {"code": "voice_session_scope_not_found"}),
+        (404, {"code": "voice_session_scope_not_found"}),
+    ]
+    assert queried_paths == [
+        (("users", "user-a", "conversations", "missing"), None),
+        (("users", "user-a", "conversations", "owned-by-user-b"), None),
+    ]

--- a/backend/tests/unit/test_conversation_voice_memory_scope.py
+++ b/backend/tests/unit/test_conversation_voice_memory_scope.py
@@ -89,26 +89,35 @@ def test_legacy_memory_atomically_bootstraps_a_durable_active_version():
     ]
 
 
-def test_bootstrap_commits_before_client_cas_and_retry_observes_same_version():
-    reference = _DocumentRef(_legacy_conversation())
-    first = conversations_db._ensure_voice_memory_summary_version_transaction(
-        _Transaction(),
-        reference,
+def test_transaction_retry_after_competing_bootstrap_observes_committed_version_without_second_write():
+    losing_reference = _DocumentRef(_legacy_conversation())
+    losing_transaction = _Transaction()
+    first_attempt = conversations_db._ensure_voice_memory_summary_version_transaction(
+        losing_transaction,
+        losing_reference,
         "client-prebootstrap-version",
     )
 
-    assert first["status"] == "stale"
-    established_version = first["active_summary_version_id"]
-    assert reference.data["active_summary_version_id"] == established_version
+    assert first_attempt["status"] == "stale"
+    assert len(losing_transaction.updates) == 1
+
+    # Simulate another transaction committing the same deterministic bootstrap
+    # while Firestore retries this callback from a fresh server snapshot.
+    winning_snapshot = _legacy_conversation()
+    winning_snapshot.update(copy.deepcopy(losing_transaction.updates[0]))
+    established_version = winning_snapshot["active_summary_version_id"]
+    retry_reference = _DocumentRef(winning_snapshot)
+    retry_transaction = _Transaction()
 
     retry = conversations_db._ensure_voice_memory_summary_version_transaction(
-        _Transaction(),
-        reference,
+        retry_transaction,
+        retry_reference,
         established_version,
     )
 
     assert retry["status"] == "ready"
     assert retry["active_summary_version_id"] == established_version
+    assert retry_transaction.updates == []
 
 
 def test_unversionable_memory_returns_defined_nonwriteable_state():

--- a/backend/tests/unit/test_ella_correction_honcho_contract.py
+++ b/backend/tests/unit/test_ella_correction_honcho_contract.py
@@ -599,6 +599,39 @@ def test_write_honcho_fact_candidate_native_honcho_profile_config_prefers_host_a
     }
 
 
+def test_companion_target_requires_exact_uid_and_ignores_global_write_override(monkeypatch, tmp_path):
+    config = tmp_path / "honcho.json"
+    config.write_text(
+        json.dumps(
+            {
+                "workspace": "workspace-a",
+                "peerName": "user-a",
+                "aiPeer": "ella-a",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(contract, "HONCHO_WORKSPACE", "shared-write-workspace")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_JSON", "")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_PATH", "")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_URL", "")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_CONFIG_PATH", str(config))
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_UID", "user-a")
+
+    target_a, reason_a = contract.resolve_companion_honcho_target("user-a")
+    target_b, reason_b = contract.resolve_companion_honcho_target("user-b")
+
+    assert reason_a == ""
+    assert target_a == {
+        "workspace": "workspace-a",
+        "observer_peer_id": "ella-a",
+        "observed_peer_id": "user-a",
+        "source": "profile_config",
+    }
+    assert target_b is None
+    assert reason_b == "missing_companion_honcho_target"
+
+
 def test_write_honcho_fact_candidate_native_honcho_explicit_workspace_can_set_observed_peer(monkeypatch):
     candidate = _candidate(active_summary_version_id="v1")
     fake_client, calls = _fake_sequence_client_factory(

--- a/backend/tests/unit/test_ella_correction_honcho_contract.py
+++ b/backend/tests/unit/test_ella_correction_honcho_contract.py
@@ -1,7 +1,10 @@
 import asyncio
 import json
-from datetime import datetime, timezone
 import sys
+import threading
+import time
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from unittest.mock import MagicMock
 
 sys.modules.setdefault("database._client", MagicMock(db=MagicMock()))
@@ -550,6 +553,89 @@ def test_companion_profile_map_checks_local_exact_uid_before_remote_source(monke
     assert target["observed_peer_id"] == "user-a"
 
 
+def test_companion_profile_config_checks_local_exact_uid_before_remote_source(monkeypatch, tmp_path):
+    profile_config = tmp_path / "honcho.json"
+    profile_config.write_text(
+        json.dumps(
+            {
+                "workspace": "workspace-config",
+                "peerName": "user-config",
+                "aiPeer": "ella-config",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_JSON", "")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_PATH", "")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_URL", "http://unavailable.test/profile-map")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_UID", "UserA")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_CONFIG_PATH", str(profile_config))
+    monkeypatch.setattr(
+        contract,
+        "_safe_json_url",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("remote map must stay lazy")
+        ),
+    )
+
+    target, reason = contract.resolve_companion_honcho_target("UserA")
+
+    assert reason == ""
+    assert target == {
+        "workspace": "workspace-config",
+        "observer_peer_id": "ella-config",
+        "observed_peer_id": "user-config",
+        "source": "profile_config",
+    }
+
+
+def test_remote_profile_loader_honors_transport_timeout(monkeypatch):
+    class SlowHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            time.sleep(0.25)
+            body = b'{"entries": {}}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            try:
+                self.wfile.write(body)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), SlowHandler)
+    server.daemon_threads = True
+    thread = threading.Thread(
+        target=server.serve_forever,
+        kwargs={"poll_interval": 0.01},
+        daemon=True,
+    )
+    thread.start()
+    monkeypatch.setattr(
+        contract,
+        "_PROFILE_MAP_URL_CACHE",
+        {"url": "", "fetched_at": 0.0, "data": None},
+    )
+
+    started = time.monotonic()
+    try:
+        result = contract._safe_json_url(
+            f"http://127.0.0.1:{server.server_port}/profile-map",
+            timeout_seconds=0.03,
+        )
+        elapsed = time.monotonic() - started
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=0.2)
+
+    assert result is None
+    assert elapsed < 0.15
+
+
 def test_write_honcho_fact_candidate_native_honcho_profile_map_url_targets_companion_scope(monkeypatch):
     candidate = _candidate(active_summary_version_id="v1")
     fake_client, calls = _fake_sequence_client_factory(
@@ -584,7 +670,7 @@ def test_write_honcho_fact_candidate_native_honcho_profile_map_url_targets_compa
     monkeypatch.setattr(
         contract,
         "_safe_json_url",
-        lambda url: {
+        lambda url, **kwargs: {
             "user-123": {
                 "workspace": "ella-omi-firebaseuid-a-canonical",
                 "observed_peer_id": "user-FirebaseUID-A",

--- a/backend/tests/unit/test_ella_correction_honcho_contract.py
+++ b/backend/tests/unit/test_ella_correction_honcho_contract.py
@@ -497,6 +497,59 @@ def test_write_honcho_fact_candidate_native_honcho_profile_map_targets_companion
     assert calls[4]["json"]["filters"] == {"observer_id": "ella", "observed_id": "plato"}
 
 
+def test_companion_profile_maps_treat_firebase_uids_as_case_sensitive(monkeypatch, tmp_path):
+    profile_config = tmp_path / "honcho.json"
+    profile_config.write_text(
+        json.dumps({"workspace": "wrong-workspace", "peerName": "wrong-peer"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        contract,
+        "HONCHO_PROFILE_MAP_JSON",
+        json.dumps(
+            {
+                "usera": {"workspace": "wrong-dict-workspace", "peerName": "wrong-dict-peer"},
+                "profiles": [
+                    {
+                        "uid": "usera",
+                        "workspace": "wrong-list-workspace",
+                        "peerName": "wrong-list-peer",
+                    }
+                ],
+            }
+        ),
+    )
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_PATH", "")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_URL", "")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_UID", "usera")
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_CONFIG_PATH", str(profile_config))
+
+    target, reason = contract.resolve_companion_honcho_target("UserA")
+
+    assert target is None
+    assert reason == "missing_companion_honcho_target"
+
+
+def test_companion_profile_map_checks_local_exact_uid_before_remote_source(monkeypatch):
+    monkeypatch.setattr(
+        contract,
+        "HONCHO_PROFILE_MAP_JSON",
+        json.dumps({"UserA": {"workspace": "workspace-a", "peerName": "user-a"}}),
+    )
+    monkeypatch.setattr(contract, "HONCHO_PROFILE_MAP_PATH", "")
+    monkeypatch.setattr(
+        contract,
+        "_safe_json_url",
+        lambda url: (_ for _ in ()).throw(AssertionError("remote map must stay lazy")),
+    )
+
+    target, reason = contract.resolve_companion_honcho_target("UserA")
+
+    assert reason == ""
+    assert target["workspace"] == "workspace-a"
+    assert target["observed_peer_id"] == "user-a"
+
+
 def test_write_honcho_fact_candidate_native_honcho_profile_map_url_targets_companion_scope(monkeypatch):
     candidate = _candidate(active_summary_version_id="v1")
     fake_client, calls = _fake_sequence_client_factory(

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -281,10 +281,14 @@ def test_memory_scoped_voice_session_rejects_legacy_mode_before_scope_resolution
     async def forbidden_scope_resolution(*args, **kwargs):
         raise AssertionError("legacy scoped mode must fail before memory resolution")
 
+    def forbidden_token_issuance(*args, **kwargs):
+        raise AssertionError("legacy scoped mode must fail before token issuance")
+
     monkeypatch.setattr(voice, "ELLA_SESSION_SECRET", "test-session-secret-at-least-32-bytes")
     monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
     monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
     monkeypatch.setattr(voice, "_resolve_voice_memory_scope", forbidden_scope_resolution)
+    monkeypatch.setattr(voice, "create_session_token", forbidden_token_issuance)
 
     with pytest.raises(HTTPException) as error:
         asyncio.run(
@@ -307,18 +311,190 @@ def test_memory_scoped_voice_session_rejects_legacy_mode_before_scope_resolution
 
 
 @pytest.mark.parametrize(
-    "mode",
+    ("provider", "mode"),
     [
-        "v4",
-        "gemini-live",
-        "gemini-native-live-v1",
-        "gemini-zero-live-v1",
-        "gemini-lite-live-v1",
-        "gemini-full-live-v1",
+        ("grok-voice", "v4"),
+        ("gemini-live", "gemini-live"),
+        ("gemini-native-live", "gemini-native-live-v1"),
+        ("gemini-live", "gemini-zero-live-v1"),
+        ("gemini-native-live", "gemini-lite-live-v1"),
+        ("gemini-native-live", "gemini-full-live-v1"),
     ],
 )
-def test_memory_scoped_voice_mode_allows_modern_proxy_aliases(mode):
-    assert voice._memory_scoped_voice_mode_allowed(mode) is True
+def test_memory_scoped_voice_provider_mode_allows_modern_proxy_pairs(provider, mode):
+    assert voice._memory_scoped_voice_provider_mode_error(provider, mode) is None
+
+
+@pytest.mark.parametrize(
+    ("provider", "mode", "expected_code"),
+    [
+        (
+            "openai-native-realtime",
+            None,
+            "memory_scoped_voice_provider_unsupported",
+        ),
+        (
+            "openai-native-realtime",
+            "v4",
+            "memory_scoped_voice_provider_unsupported",
+        ),
+        (
+            "grok-voice",
+            "gemini-live",
+            "memory_scoped_voice_provider_mode_mismatch",
+        ),
+        (
+            "gemini-live",
+            "v4",
+            "memory_scoped_voice_provider_mode_mismatch",
+        ),
+    ],
+)
+def test_memory_scoped_voice_session_rejects_unsupported_provider_mode_pair_before_scope_resolution(
+    monkeypatch,
+    provider,
+    mode,
+    expected_code,
+):
+    async def forbidden_scope_resolution(*args, **kwargs):
+        raise AssertionError("invalid scoped pair must fail before memory resolution")
+
+    def forbidden_token_issuance(*args, **kwargs):
+        raise AssertionError("invalid scoped pair must fail before token issuance")
+
+    monkeypatch.setattr(voice, "ELLA_SESSION_SECRET", "test-session-secret-at-least-32-bytes")
+    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "_resolve_voice_memory_scope", forbidden_scope_resolution)
+    monkeypatch.setattr(voice, "create_session_token", forbidden_token_issuance)
+
+    with pytest.raises(HTTPException) as error:
+        asyncio.run(
+            voice.create_voice_session(
+                body=voice.VoiceSessionRequest(
+                    uid="user-a",
+                    provider=provider,
+                    voice_mode=mode,
+                    session_scope=voice.VoiceSessionScope(
+                        kind="memory",
+                        conversation_id="memory-a",
+                    ),
+                ),
+                authenticated_uid="user-a",
+            )
+        )
+
+    assert error.value.status_code == 400
+    assert error.value.detail == {"code": expected_code}
+
+
+@pytest.mark.parametrize(
+    ("provider", "requested_mode", "expected_mode"),
+    [
+        ("grok-voice", None, "v4"),
+        ("grok-voice", "v4", "v4"),
+        ("gemini-live", None, "gemini-live"),
+        ("gemini-live", "gemini-zero-live-v1", "gemini-zero-live-v1"),
+        ("gemini-native-live", None, "gemini-native-live-v1"),
+        ("gemini-native-live", "gemini-full-live-v1", "gemini-full-live-v1"),
+    ],
+)
+def test_retained_memory_scoped_voice_session_accepts_supported_provider_mode_pair(
+    monkeypatch,
+    provider,
+    requested_mode,
+    expected_mode,
+):
+    async def resolve_scope(uid, scope):
+        assert uid == "user-a"
+        return {
+            "kind": "memory",
+            "conversation_id": scope.conversation_id,
+            "active_summary_version_id": "version-2",
+            "can_reinterpret": True,
+        }
+
+    class Pool:
+        async def fetchrow(self, *args):
+            return None
+
+    async def pool():
+        return Pool()
+
+    monkeypatch.setattr(voice, "ELLA_SESSION_SECRET", "test-session-secret-at-least-32-bytes")
+    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "_resolve_voice_memory_scope", resolve_scope)
+    monkeypatch.setattr(voice, "_get_pool", pool)
+
+    result = asyncio.run(
+        voice.create_voice_session(
+            body=voice.VoiceSessionRequest(
+                uid="user-a",
+                provider=provider,
+                voice_mode=requested_mode,
+                session_scope=voice.VoiceSessionScope(
+                    kind="memory",
+                    conversation_id="memory-a",
+                ),
+            ),
+            authenticated_uid="user-a",
+        )
+    )
+    claims = voice.jwt.decode(
+        result.session_token,
+        voice.ELLA_SESSION_SECRET,
+        algorithms=["HS256"],
+        issuer="omi-backend",
+        audience=voice.VOICE_SESSION_AUDIENCE,
+    )
+
+    assert result.provider == provider
+    assert result.voice_mode == expected_mode
+    assert claims["provider"] == provider
+    assert claims["voice_mode"] == expected_mode
+    assert claims["isolated_runtime"] is False
+
+
+@pytest.mark.parametrize(
+    ("provider", "mode"),
+    [
+        ("grok-voice", "v1"),
+        ("grok-voice", "gemini-live"),
+        ("gemini-live", "v4"),
+        ("openai-native-realtime", "v4"),
+    ],
+)
+def test_unscoped_voice_session_preserves_existing_provider_mode_behavior(
+    monkeypatch,
+    provider,
+    mode,
+):
+    class Pool:
+        async def fetchrow(self, *args):
+            return None
+
+    async def pool():
+        return Pool()
+
+    monkeypatch.setattr(voice, "ELLA_SESSION_SECRET", "test-session-secret-at-least-32-bytes")
+    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "_get_pool", pool)
+
+    result = asyncio.run(
+        voice.create_voice_session(
+            body=voice.VoiceSessionRequest(
+                uid="user-a",
+                provider=provider,
+                voice_mode=mode,
+            ),
+            authenticated_uid="user-a",
+        )
+    )
+
+    assert result.provider == provider
+    assert result.voice_mode == mode
 
 
 def test_unversionable_memory_scope_returns_defined_nonwriteable_state(monkeypatch):

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -273,6 +273,54 @@ def test_memory_scoped_voice_session_resolves_server_context_and_signs_ids(monke
     assert "overview" not in claims
 
 
+@pytest.mark.parametrize("legacy_mode", ["v1", "v2", "v3-fast"])
+def test_memory_scoped_voice_session_rejects_legacy_mode_before_scope_resolution(
+    monkeypatch,
+    legacy_mode,
+):
+    async def forbidden_scope_resolution(*args, **kwargs):
+        raise AssertionError("legacy scoped mode must fail before memory resolution")
+
+    monkeypatch.setattr(voice, "ELLA_SESSION_SECRET", "test-session-secret-at-least-32-bytes")
+    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "_resolve_voice_memory_scope", forbidden_scope_resolution)
+
+    with pytest.raises(HTTPException) as error:
+        asyncio.run(
+            voice.create_voice_session(
+                body=voice.VoiceSessionRequest(
+                    uid="user-a",
+                    provider="grok-voice",
+                    voice_mode=legacy_mode,
+                    session_scope=voice.VoiceSessionScope(
+                        kind="memory",
+                        conversation_id="memory-a",
+                    ),
+                ),
+                authenticated_uid="user-a",
+            )
+        )
+
+    assert error.value.status_code == 400
+    assert error.value.detail == {"code": "memory_scoped_voice_mode_required"}
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "v4",
+        "gemini-live",
+        "gemini-native-live-v1",
+        "gemini-zero-live-v1",
+        "gemini-lite-live-v1",
+        "gemini-full-live-v1",
+    ],
+)
+def test_memory_scoped_voice_mode_allows_modern_proxy_aliases(mode):
+    assert voice._memory_scoped_voice_mode_allowed(mode) is True
+
+
 def test_unversionable_memory_scope_returns_defined_nonwriteable_state(monkeypatch):
     def unavailable(uid, scope):
         raise ValueError("voice_session_scope_version_unavailable")

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -209,6 +209,90 @@ def test_voice_session_issues_isolated_token_for_enabled_uid_canary(monkeypatch)
     assert claims["isolated_runtime"] is True
 
 
+def test_memory_scoped_voice_session_resolves_server_context_and_signs_ids(monkeypatch):
+    async def ready_runtime(uid):
+        assert uid == "user-a"
+        return object()
+
+    async def resolve_scope(uid, scope):
+        assert uid == "user-a"
+        assert scope.conversation_id == "memory-a"
+        return {
+            "kind": "memory",
+            "conversation_id": "memory-a",
+            "active_summary_version_id": "version-2",
+            "can_reinterpret": True,
+            "title": "Private title",
+            "overview": "Private overview",
+        }
+
+    class Pool:
+        async def fetchrow(self, *args):
+            return {"name": "User A"}
+
+    async def pool():
+        return Pool()
+
+    monkeypatch.setattr(voice, "ELLA_SESSION_SECRET", "test-session-secret-at-least-32-bytes")
+    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: True)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: True)
+    monkeypatch.setattr(voice, "resolve_isolated_runtime", ready_runtime)
+    monkeypatch.setattr(voice, "_resolve_voice_memory_scope", resolve_scope)
+    monkeypatch.setattr(voice, "_get_pool", pool)
+
+    result = asyncio.run(
+        voice.create_voice_session(
+            body=voice.VoiceSessionRequest(
+                uid="user-a",
+                provider="grok-voice",
+                session_scope=voice.VoiceSessionScope(
+                    kind="memory",
+                    conversation_id="memory-a",
+                ),
+            ),
+            authenticated_uid="user-a",
+        )
+    )
+    claims = voice.jwt.decode(
+        result.session_token,
+        voice.ELLA_SESSION_SECRET,
+        algorithms=["HS256"],
+        issuer="omi-backend",
+        audience=voice.VOICE_SESSION_AUDIENCE,
+    )
+
+    assert result.session_id == claims["jti"]
+    assert result.session_scope == {
+        "kind": "memory",
+        "conversation_id": "memory-a",
+        "active_summary_version_id": "version-2",
+        "can_reinterpret": True,
+    }
+    assert claims["conversation_id"] == "memory-a"
+    assert "title" not in claims
+    assert "overview" not in claims
+
+
+def test_missing_and_nonowned_memory_scope_are_indistinguishable(monkeypatch):
+    monkeypatch.setattr(voice, "_load_voice_memory_scope", lambda uid, scope: None)
+
+    responses = []
+    for conversation_id in ("missing", "owned-by-another-user"):
+        with pytest.raises(HTTPException) as error:
+            asyncio.run(
+                voice._resolve_voice_memory_scope(
+                    "user-a",
+                    voice.VoiceSessionScope(kind="memory", conversation_id=conversation_id),
+                )
+            )
+        responses.append((error.value.status_code, error.value.detail))
+
+    assert responses == [
+        (404, {"code": "voice_session_scope_not_found"}),
+        (404, {"code": "voice_session_scope_not_found"}),
+    ]
+
+
 def test_voice_session_rejects_voice_canary_without_runtime_binding(monkeypatch):
     monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
     monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: uid == "user-a")

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -273,24 +273,22 @@ def test_memory_scoped_voice_session_resolves_server_context_and_signs_ids(monke
     assert "overview" not in claims
 
 
-def test_missing_and_nonowned_memory_scope_are_indistinguishable(monkeypatch):
-    monkeypatch.setattr(voice, "_load_voice_memory_scope", lambda uid, scope: None)
+def test_unversionable_memory_scope_returns_defined_nonwriteable_state(monkeypatch):
+    def unavailable(uid, scope):
+        raise ValueError("voice_session_scope_version_unavailable")
 
-    responses = []
-    for conversation_id in ("missing", "owned-by-another-user"):
-        with pytest.raises(HTTPException) as error:
-            asyncio.run(
-                voice._resolve_voice_memory_scope(
-                    "user-a",
-                    voice.VoiceSessionScope(kind="memory", conversation_id=conversation_id),
-                )
+    monkeypatch.setattr(voice, "_load_voice_memory_scope", unavailable)
+
+    with pytest.raises(HTTPException) as error:
+        asyncio.run(
+            voice._resolve_voice_memory_scope(
+                "user-a",
+                voice.VoiceSessionScope(kind="memory", conversation_id="memory-empty"),
             )
-        responses.append((error.value.status_code, error.value.detail))
+        )
 
-    assert responses == [
-        (404, {"code": "voice_session_scope_not_found"}),
-        (404, {"code": "voice_session_scope_not_found"}),
-    ]
+    assert error.value.status_code == 409
+    assert error.value.detail == {"code": "voice_session_scope_version_unavailable"}
 
 
 def test_voice_session_rejects_voice_canary_without_runtime_binding(monkeypatch):

--- a/backend/tests/unit/test_voice_honcho.py
+++ b/backend/tests/unit/test_voice_honcho.py
@@ -15,6 +15,56 @@ def _runtime():
     )
 
 
+def test_isolated_target_uses_runtime_receipt_without_profile_fallback(monkeypatch):
+    monkeypatch.setattr(
+        voice_honcho,
+        "resolve_companion_honcho_target",
+        lambda uid: (_ for _ in ()).throw(AssertionError("profile fallback must not run")),
+    )
+
+    target, reason = voice_honcho.resolve_voice_honcho_target("uid-a", _runtime())
+
+    assert reason == ""
+    assert target.uid == "uid-a"
+    assert target.honcho_workspace == "workspace-a"
+    assert target.observer_peer == "ella-a"
+    assert target.observed_peer == "user-a"
+    assert target.source == "isolated_runtime_receipt"
+
+
+def test_retained_target_uses_exact_uid_profile_and_does_not_reuse_cross_user(monkeypatch):
+    mappings = {
+        "uid-a": {
+            "workspace": "workspace-a",
+            "observer_peer_id": "ella-a",
+            "observed_peer_id": "user-a",
+            "source": "profile_map",
+        },
+        "uid-b": {
+            "workspace": "workspace-b",
+            "observer_peer_id": "ella-b",
+            "observed_peer_id": "user-b",
+            "source": "profile_map",
+        },
+    }
+    monkeypatch.setattr(
+        voice_honcho,
+        "resolve_companion_honcho_target",
+        lambda uid: (mappings.get(uid), "" if uid in mappings else "missing_companion_honcho_target"),
+    )
+
+    target_a, reason_a = voice_honcho.resolve_voice_honcho_target("uid-a")
+    target_b, reason_b = voice_honcho.resolve_voice_honcho_target("uid-b")
+    missing, missing_reason = voice_honcho.resolve_voice_honcho_target("uid-c")
+
+    assert reason_a == reason_b == ""
+    assert (target_a.honcho_workspace, target_a.observed_peer) == ("workspace-a", "user-a")
+    assert (target_b.honcho_workspace, target_b.observed_peer) == ("workspace-b", "user-b")
+    assert target_a != target_b
+    assert missing is None
+    assert missing_reason == "missing_companion_honcho_target"
+
+
 def test_context_uses_exact_receipt_target(monkeypatch):
     calls = []
 

--- a/backend/tests/unit/test_voice_honcho.py
+++ b/backend/tests/unit/test_voice_honcho.py
@@ -1,0 +1,154 @@
+import asyncio
+from types import SimpleNamespace
+
+import httpx
+
+from ella.services import voice_honcho
+
+
+def _runtime():
+    return SimpleNamespace(
+        uid="uid-a",
+        honcho_workspace="workspace-a",
+        observer_peer="ella-a",
+        observed_peer="user-a",
+    )
+
+
+def test_context_uses_exact_receipt_target(monkeypatch):
+    calls = []
+
+    class Response:
+        status_code = 200
+
+        def json(self):
+            return {
+                "peer_id": "ella-a",
+                "target_id": "user-a",
+                "representation": "User enjoys gardening.",
+                "peer_card": ["Prefers morning calls"],
+            }
+
+    class Client:
+        def __init__(self, *args, **kwargs):
+            calls.append(("timeout", kwargs.get("timeout")))
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, url, headers=None, params=None):
+            calls.append((url, headers, params))
+            return Response()
+
+    monkeypatch.setattr(voice_honcho, "HONCHO_BASE_URL", "http://honcho.test")
+    monkeypatch.setattr(voice_honcho, "HONCHO_API_KEY", "honcho-secret")
+    monkeypatch.setattr(voice_honcho.httpx, "AsyncClient", Client)
+
+    result = asyncio.run(
+        voice_honcho.fetch_voice_honcho_context(
+            _runtime(),
+            query="gardening and recent plans",
+            top_k=7,
+        )
+    )
+
+    assert result["available"] is True
+    assert "User enjoys gardening." in result["context"]
+    assert "Prefers morning calls" in result["context"]
+    assert calls[1] == (
+        "http://honcho.test/v3/workspaces/workspace-a/peers/ella-a/context",
+        {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": "Bearer honcho-secret",
+        },
+        {
+            "target": "user-a",
+            "search_query": "gardening and recent plans",
+            "search_top_k": 7,
+            "include_most_frequent": "true",
+            "max_conclusions": 7,
+        },
+    )
+
+
+def test_context_timeout_degrades_without_raising(monkeypatch):
+    class Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, *args, **kwargs):
+            raise httpx.ReadTimeout("slow")
+
+    monkeypatch.setattr(voice_honcho.httpx, "AsyncClient", Client)
+
+    result = asyncio.run(voice_honcho.fetch_voice_honcho_context(_runtime(), query="recent themes"))
+
+    assert result["available"] is False
+    assert result["reason"] == "honcho_timeout"
+    assert result["context"] == ""
+
+
+def test_semantic_search_filters_cross_target_rows(monkeypatch):
+    calls = []
+
+    class Response:
+        status_code = 200
+
+        def json(self):
+            return [
+                {
+                    "id": "good",
+                    "content": "User A discussed tomato plants.",
+                    "observer_id": "ella-a",
+                    "observed_id": "user-a",
+                    "created_at": "2026-07-24T12:00:00Z",
+                },
+                {
+                    "id": "wrong-user",
+                    "content": "Private User B fact.",
+                    "observer_id": "ella-b",
+                    "observed_id": "user-b",
+                    "created_at": "2026-07-24T12:01:00Z",
+                },
+            ]
+
+    class Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url, headers=None, json=None):
+            calls.append((url, json))
+            return Response()
+
+    monkeypatch.setattr(voice_honcho, "HONCHO_BASE_URL", "http://honcho.test")
+    monkeypatch.setattr(voice_honcho.httpx, "AsyncClient", Client)
+
+    results = asyncio.run(voice_honcho.search_voice_honcho(_runtime(), "tomato plants", 5))
+
+    assert [item["metadata"]["conclusion_id"] for item in results] == ["good"]
+    assert calls == [
+        (
+            "http://honcho.test/v3/workspaces/workspace-a/conclusions/query",
+            {
+                "query": "tomato plants",
+                "top_k": 5,
+                "filters": {"observer": "ella-a", "observed": "user-a"},
+            },
+        )
+    ]

--- a/backend/tests/unit/test_voice_proxy_auth.py
+++ b/backend/tests/unit/test_voice_proxy_auth.py
@@ -148,10 +148,52 @@ def test_voice_session_token_binds_memory_scope_without_memory_content():
     assert "title" not in claims
 
 
+def test_voice_session_token_rejects_empty_memory_version():
+    with pytest.raises(ValueError, match="active summary version"):
+        voice.create_session_token(
+            uid="uid-a",
+            firebase_uid="uid-a",
+            voice_mode="v4",
+            provider="grok-voice",
+            isolated_runtime=True,
+            session_scope={
+                "kind": "memory",
+                "conversation_id": "legacy-memory",
+                "active_summary_version_id": "",
+                "can_reinterpret": False,
+            },
+        )
+
+
 def test_voice_proxy_rejects_partial_scope_claims():
     token = _token(
         "uid-a",
         scope={"scope_kind": "memory", "conversation_id": "memory-a"},
+    )
+
+    with pytest.raises(HTTPException) as error:
+        voice.authenticate_voice_proxy_request(
+            _request(
+                {"uid": "uid-a"},
+                token=token,
+                service_token="test-proxy-secret",
+            ),
+            "uid-a",
+        )
+
+    assert error.value.status_code == 401
+    assert error.value.detail == {"code": "voice_session_invalid"}
+
+
+def test_voice_proxy_rejects_empty_memory_version_claim():
+    token = _token(
+        "uid-a",
+        scope={
+            "scope_kind": "memory",
+            "conversation_id": "memory-a",
+            "active_summary_version_id": "",
+            "can_reinterpret": False,
+        },
     )
 
     with pytest.raises(HTTPException) as error:
@@ -372,8 +414,12 @@ def test_isolated_context_uses_active_8210_agent_and_redacts_credentials(monkeyp
     async def empty(*args, **kwargs):
         return ""
 
-    async def honcho_context(runtime_arg, *, query, top_k):
-        assert runtime_arg is runtime
+    async def honcho_context(target, *, query, top_k):
+        assert target.uid == "uid-a"
+        assert target.honcho_workspace == "workspace-a"
+        assert target.observer_peer == "ella-a"
+        assert target.observed_peer == "user-a"
+        assert target.source == "isolated_runtime_receipt"
         assert "Recent themes" in query
         assert top_k == 12
         return {
@@ -412,6 +458,68 @@ def test_isolated_context_uses_active_8210_agent_and_redacts_credentials(monkeyp
     assert result["honcho_status"]["available"] is True
     assert requests[0][0] == "http://hermes-8210/workspace/ella-uid-a/files"
     assert requests[0][1]["X-Ella-Owner-Uid"] == "uid-a"
+
+
+def test_retained_context_loads_uid_mapped_honcho_without_runtime_receipt(monkeypatch):
+    target = SimpleNamespace(
+        uid="uid-a",
+        honcho_workspace="workspace-a",
+        observer_peer="ella-a",
+        observed_peer="user-a",
+        source="profile_map",
+    )
+
+    class Pool:
+        async def fetchrow(self, query, uid):
+            return {
+                "id": "db-user-a",
+                "name": "User A",
+                "conditions": [],
+                "medications": [],
+                "guardian_mode": "off",
+                "agents": {},
+            }
+
+        async def fetch(self, *args):
+            return []
+
+    async def empty(*args, **kwargs):
+        return ""
+
+    async def honcho_context(target_arg, *, query, top_k):
+        assert target_arg is target
+        return {
+            "available": True,
+            "reason": "ok",
+            "context": "Mapped retained context.",
+            "source": "honcho",
+        }
+
+    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "_get_pool", lambda: asyncio.sleep(0, result=Pool()))
+    monkeypatch.setattr(voice, "_fetch_recent_conversations", empty)
+    monkeypatch.setattr(voice, "_fetch_recent_canonical_timeline", empty)
+    monkeypatch.setattr(voice, "_fetch_memory_context", empty)
+    monkeypatch.setattr(
+        voice,
+        "resolve_voice_honcho_target",
+        lambda uid, runtime=None: (target, ""),
+    )
+    monkeypatch.setattr(voice, "fetch_voice_honcho_context", honcho_context)
+
+    result = asyncio.run(
+        voice.get_voice_context(
+            _request(
+                {"uid": "uid-a"},
+                token=_token("uid-a", isolated=False),
+                service_token="test-proxy-secret",
+            )
+        )
+    )
+
+    assert result["honcho_context"] == "Mapped retained context."
+    assert result["honcho_status"]["available"] is True
 
 
 def test_isolated_search_forces_receipt_agent_and_owner_header(monkeypatch):
@@ -468,8 +576,8 @@ def test_isolated_search_includes_receipt_bound_honcho_source(monkeypatch):
     async def resolve(uid):
         return runtime
 
-    async def honcho_search(runtime_arg, query, limit):
-        calls.append((runtime_arg, query, limit))
+    async def honcho_search(target, query, limit):
+        calls.append((target, query, limit))
         return [
             {
                 "source": "honcho",
@@ -502,7 +610,83 @@ def test_isolated_search_includes_receipt_bound_honcho_source(monkeypatch):
     assert result["sources_searched"] == ["honcho"]
     assert result["sources_denied"] == []
     assert result["results"][0]["content"] == "User A discussed tomato plants."
-    assert calls == [(runtime, "tomato plants", 5)]
+    target, query, limit = calls[0]
+    assert query == "tomato plants"
+    assert limit == 5
+    assert target.uid == "uid-a"
+    assert target.honcho_workspace == "workspace-a"
+    assert target.observer_peer == "ella-a"
+    assert target.observed_peer == "user-a"
+    assert target.source == "isolated_runtime_receipt"
+
+
+def test_retained_search_uses_uid_mapped_honcho_and_unmapped_user_fails_open(monkeypatch):
+    target = SimpleNamespace(
+        uid="uid-a",
+        honcho_workspace="workspace-a",
+        observer_peer="ella-a",
+        observed_peer="user-a",
+        source="profile_map",
+    )
+    calls = []
+
+    async def binding(uid, runtime=None):
+        if uid == "uid-a":
+            return target, ""
+        return None, "missing_companion_honcho_target"
+
+    async def honcho_search(target_arg, query, limit):
+        calls.append((target_arg, query, limit))
+        return [
+            {
+                "source": "honcho",
+                "title": "Related user context",
+                "content": "Mapped retained result.",
+                "score": 90,
+                "metadata": {"provenance": "honcho_conclusion"},
+            }
+        ]
+
+    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "_resolve_voice_honcho_binding", binding)
+    monkeypatch.setattr(voice, "search_voice_honcho", honcho_search)
+
+    mapped = asyncio.run(
+        voice.unified_search(
+            _request(
+                {
+                    "uid": "uid-a",
+                    "agent_id": "ella-uid-a",
+                    "query": "garden",
+                    "sources": ["honcho"],
+                },
+                token=_token("uid-a", isolated=False),
+                service_token="test-proxy-secret",
+            )
+        )
+    )
+    unmapped = asyncio.run(
+        voice.unified_search(
+            _request(
+                {
+                    "uid": "uid-b",
+                    "agent_id": "ella-uid-b",
+                    "query": "garden",
+                    "sources": ["honcho"],
+                },
+                token=_token("uid-b", isolated=False),
+                service_token="test-proxy-secret",
+            )
+        )
+    )
+
+    assert mapped["sources_searched"] == ["honcho"]
+    assert mapped["results"][0]["content"] == "Mapped retained result."
+    assert calls == [(target, "garden", 5)]
+    assert unmapped["results"] == []
+    assert unmapped["sources_searched"] == []
+    assert unmapped["sources_denied"] == ["honcho"]
 
 
 def test_isolated_workspace_search_uses_hermes_post_contract(monkeypatch):

--- a/backend/tests/unit/test_voice_proxy_auth.py
+++ b/backend/tests/unit/test_voice_proxy_auth.py
@@ -39,22 +39,31 @@ def _request(body: dict, *, token: str = "", service_token: str = "") -> Request
     )
 
 
-def _token(uid: str, *, isolated: bool = True, expired: bool = False) -> str:
+def _token(
+    uid: str,
+    *,
+    isolated: bool = True,
+    expired: bool = False,
+    scope: dict | None = None,
+) -> str:
     now = datetime.now(timezone.utc)
+    claims = {
+        "sub": uid,
+        "uid": uid,
+        "firebase_uid": uid,
+        "provider": "grok-voice",
+        "voice_mode": "v4",
+        "isolated_runtime": isolated,
+        "jti": f"session-{uid}",
+        "aud": voice.VOICE_SESSION_AUDIENCE,
+        "iss": "omi-backend",
+        "iat": now - timedelta(minutes=2),
+        "exp": now - timedelta(minutes=1) if expired else now + timedelta(minutes=10),
+    }
+    if scope:
+        claims.update(scope)
     return jwt.encode(
-        {
-            "sub": uid,
-            "uid": uid,
-            "firebase_uid": uid,
-            "provider": "grok-voice",
-            "voice_mode": "v4",
-            "isolated_runtime": isolated,
-            "jti": f"session-{uid}",
-            "aud": voice.VOICE_SESSION_AUDIENCE,
-            "iss": "omi-backend",
-            "iat": now - timedelta(minutes=2),
-            "exp": now - timedelta(minutes=1) if expired else now + timedelta(minutes=10),
-        },
+        claims,
         voice.ELLA_SESSION_SECRET,
         algorithm="HS256",
     )
@@ -105,6 +114,84 @@ def test_voice_session_token_has_firebase_subject_and_proxy_audience():
     assert claims["uid"] == "uid-a"
     assert claims["isolated_runtime"] is True
     assert claims["jti"]
+
+
+def test_voice_session_token_binds_memory_scope_without_memory_content():
+    encoded = voice.create_session_token(
+        uid="uid-a",
+        firebase_uid="uid-a",
+        voice_mode="v4",
+        provider="grok-voice",
+        isolated_runtime=True,
+        session_id="session-a",
+        session_scope={
+            "kind": "memory",
+            "conversation_id": "memory-a",
+            "active_summary_version_id": "version-3",
+            "can_reinterpret": True,
+            "title": "Must not enter token",
+        },
+    )
+    claims = jwt.decode(
+        encoded,
+        voice.ELLA_SESSION_SECRET,
+        algorithms=["HS256"],
+        issuer="omi-backend",
+        audience=voice.VOICE_SESSION_AUDIENCE,
+    )
+
+    assert claims["jti"] == "session-a"
+    assert claims["scope_kind"] == "memory"
+    assert claims["conversation_id"] == "memory-a"
+    assert claims["active_summary_version_id"] == "version-3"
+    assert claims["can_reinterpret"] is True
+    assert "title" not in claims
+
+
+def test_voice_proxy_rejects_partial_scope_claims():
+    token = _token(
+        "uid-a",
+        scope={"scope_kind": "memory", "conversation_id": "memory-a"},
+    )
+
+    with pytest.raises(HTTPException) as error:
+        voice.authenticate_voice_proxy_request(
+            _request(
+                {"uid": "uid-a"},
+                token=token,
+                service_token="test-proxy-secret",
+            ),
+            "uid-a",
+        )
+
+    assert error.value.status_code == 401
+    assert error.value.detail == {"code": "voice_session_invalid"}
+
+
+def test_voice_proxy_accepts_complete_memory_scope_claims():
+    token = _token(
+        "uid-a",
+        scope={
+            "scope_kind": "memory",
+            "conversation_id": "memory-a",
+            "active_summary_version_id": "version-3",
+            "can_reinterpret": False,
+        },
+    )
+
+    principal = voice.authenticate_voice_proxy_request(
+        _request(
+            {"uid": "uid-a"},
+            token=token,
+            service_token="test-proxy-secret",
+        ),
+        "uid-a",
+    )
+
+    assert principal.scope_kind == "memory"
+    assert principal.conversation_id == "memory-a"
+    assert principal.active_summary_version_id == "version-3"
+    assert principal.can_reinterpret is False
 
 
 @pytest.mark.parametrize("endpoint", ["context", "search", "tool"])
@@ -233,7 +320,14 @@ def test_voice_runtime_rechecks_rollout_gate_on_every_request(
 
 
 def test_isolated_context_uses_active_8210_agent_and_redacts_credentials(monkeypatch):
-    runtime = SimpleNamespace(agent_id="ella-uid-a", revision=7)
+    runtime = SimpleNamespace(
+        uid="uid-a",
+        agent_id="ella-uid-a",
+        revision=7,
+        honcho_workspace="workspace-a",
+        observer_peer="ella-a",
+        observed_peer="user-a",
+    )
     queries = []
     requests = []
 
@@ -278,12 +372,25 @@ def test_isolated_context_uses_active_8210_agent_and_redacts_credentials(monkeyp
     async def empty(*args, **kwargs):
         return ""
 
+    async def honcho_context(runtime_arg, *, query, top_k):
+        assert runtime_arg is runtime
+        assert "Recent themes" in query
+        assert top_k == 12
+        return {
+            "available": True,
+            "reason": "ok",
+            "context": "Honcho remembers the user's gardening plans.",
+            "latency_ms": 42,
+            "source": "honcho",
+        }
+
     monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: True)
     monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: True)
     monkeypatch.setattr(voice, "resolve_isolated_runtime", resolve)
     monkeypatch.setattr(voice, "_get_pool", lambda: asyncio.sleep(0, result=Pool()))
     monkeypatch.setattr(voice, "_fetch_recent_conversations", empty)
     monkeypatch.setattr(voice, "_fetch_recent_canonical_timeline", empty)
+    monkeypatch.setattr(voice, "fetch_voice_honcho_context", honcho_context)
     monkeypatch.setattr(voice.httpx, "AsyncClient", Client)
 
     result = asyncio.run(
@@ -301,6 +408,8 @@ def test_isolated_context_uses_active_8210_agent_and_redacts_credentials(monkeyp
     assert result["runtime"] == {"provider": "hermes", "agent_id": "ella-uid-a", "binding_revision": 7}
     assert "gateway_token" not in result
     assert "gateway_url" not in result
+    assert result["honcho_context"] == "Honcho remembers the user's gardening plans."
+    assert result["honcho_status"]["available"] is True
     assert requests[0][0] == "http://hermes-8210/workspace/ella-uid-a/files"
     assert requests[0][1]["X-Ella-Owner-Uid"] == "uid-a"
 
@@ -343,6 +452,57 @@ def test_isolated_search_forces_receipt_agent_and_owner_header(monkeypatch):
             },
         )
     ]
+
+
+def test_isolated_search_includes_receipt_bound_honcho_source(monkeypatch):
+    runtime = SimpleNamespace(
+        uid="uid-a",
+        agent_id="ella-uid-a",
+        revision=8,
+        honcho_workspace="workspace-a",
+        observer_peer="ella-a",
+        observed_peer="user-a",
+    )
+    calls = []
+
+    async def resolve(uid):
+        return runtime
+
+    async def honcho_search(runtime_arg, query, limit):
+        calls.append((runtime_arg, query, limit))
+        return [
+            {
+                "source": "honcho",
+                "title": "Related user context",
+                "content": "User A discussed tomato plants.",
+                "score": 90,
+                "metadata": {"provenance": "honcho_conclusion"},
+            }
+        ]
+
+    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: True)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: True)
+    monkeypatch.setattr(voice, "resolve_isolated_runtime", resolve)
+    monkeypatch.setattr(voice, "search_voice_honcho", honcho_search)
+
+    result = asyncio.run(
+        voice.unified_search(
+            _request(
+                {
+                    "uid": "uid-a",
+                    "query": "tomato plants",
+                    "sources": ["honcho"],
+                },
+                token=_token("uid-a"),
+                service_token="test-proxy-secret",
+            )
+        )
+    )
+
+    assert result["sources_searched"] == ["honcho"]
+    assert result["sources_denied"] == []
+    assert result["results"][0]["content"] == "User A discussed tomato plants."
+    assert calls == [(runtime, "tomato plants", 5)]
 
 
 def test_isolated_workspace_search_uses_hermes_post_contract(monkeypatch):

--- a/backend/tests/unit/test_voice_proxy_auth.py
+++ b/backend/tests/unit/test_voice_proxy_auth.py
@@ -1,8 +1,10 @@
 import asyncio
 import json
 import sys
+import threading
 import time
 from datetime import datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from types import ModuleType, SimpleNamespace
 
 import jwt
@@ -15,6 +17,7 @@ conversations_module._decrypt_conversation_data = lambda value, uid=None: value
 sys.modules.setdefault("database.conversations", conversations_module)
 
 from ella.routers import voice
+from ella.services import correction_honcho_contract as honcho_contract
 
 
 def _request(body: dict, *, token: str = "", service_token: str = "") -> Request:
@@ -505,7 +508,7 @@ def test_retained_context_loads_uid_mapped_honcho_without_runtime_receipt(monkey
     monkeypatch.setattr(
         voice,
         "resolve_voice_honcho_target",
-        lambda uid, runtime=None: (target, ""),
+        lambda uid, runtime=None, **kwargs: (target, ""),
     )
     monkeypatch.setattr(voice, "fetch_voice_honcho_context", honcho_context)
 
@@ -524,8 +527,6 @@ def test_retained_context_loads_uid_mapped_honcho_without_runtime_receipt(monkey
 
 
 def test_retained_context_profile_resolution_timeout_degrades_within_cap(monkeypatch):
-    to_thread_calls = []
-
     class Pool:
         async def fetchrow(self, query, uid):
             return {
@@ -543,20 +544,54 @@ def test_retained_context_profile_resolution_timeout_degrades_within_cap(monkeyp
     async def empty(*args, **kwargs):
         return ""
 
-    async def slow_to_thread(*args, **kwargs):
-        to_thread_calls.append(args)
-        await asyncio.sleep(0.25)
+    class SlowHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            time.sleep(0.25)
+            body = b'{"entries": {}}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            try:
+                self.wfile.write(body)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), SlowHandler)
+    server.daemon_threads = True
+    thread = threading.Thread(
+        target=server.serve_forever,
+        kwargs={"poll_interval": 0.01},
+        daemon=True,
+    )
+    thread.start()
 
     monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
     monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
-    monkeypatch.setattr(voice, "VOICE_HONCHO_PROFILE_RESOLUTION_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(voice, "VOICE_HONCHO_PROFILE_RESOLUTION_TIMEOUT_SECONDS", 0.05)
     monkeypatch.setattr(voice, "VOICE_HONCHO_PROFILE_NEGATIVE_CACHE_TTL_SECONDS", 30)
-    monkeypatch.setattr(voice.asyncio, "to_thread", slow_to_thread)
     monkeypatch.setattr(voice, "_get_pool", lambda: asyncio.sleep(0, result=Pool()))
     monkeypatch.setattr(voice, "_fetch_recent_conversations", empty)
     monkeypatch.setattr(voice, "_fetch_recent_canonical_timeline", empty)
     monkeypatch.setattr(voice, "_fetch_memory_context", empty)
     monkeypatch.setattr(voice, "_VOICE_HONCHO_PROFILE_NEGATIVE_CACHE", {})
+    monkeypatch.setattr(honcho_contract, "HONCHO_PROFILE_MAP_JSON", "")
+    monkeypatch.setattr(honcho_contract, "HONCHO_PROFILE_MAP_PATH", "")
+    monkeypatch.setattr(
+        honcho_contract,
+        "HONCHO_PROFILE_MAP_URL",
+        f"http://127.0.0.1:{server.server_port}/profile-map",
+    )
+    monkeypatch.setattr(honcho_contract, "HONCHO_PROFILE_UID", "")
+    monkeypatch.setattr(honcho_contract, "HONCHO_PROFILE_CONFIG_PATH", "")
+    monkeypatch.setattr(
+        honcho_contract,
+        "_PROFILE_MAP_URL_CACHE",
+        {"url": "", "fetched_at": 0.0, "data": None},
+    )
 
     async def load_context():
         started = time.monotonic()
@@ -569,15 +604,22 @@ def test_retained_context_profile_resolution_timeout_degrades_within_cap(monkeyp
         )
         return result, time.monotonic() - started
 
-    result, elapsed = asyncio.run(load_context())
-    cached_result, cached_elapsed = asyncio.run(load_context())
+    try:
+        result, elapsed = asyncio.run(load_context())
+        cached_result, cached_elapsed = asyncio.run(load_context())
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=0.2)
 
     assert elapsed < 0.15
     assert cached_elapsed < 0.15
     assert result["honcho_context"] == ""
-    assert result["honcho_status"]["reason"] == "honcho_profile_resolution_timeout"
+    assert result["honcho_status"]["reason"] in {
+        "honcho_profile_resolution_timeout",
+        "missing_companion_honcho_target",
+    }
     assert cached_result["honcho_status"]["reason"] == "honcho_profile_resolution_cached_unavailable"
-    assert len(to_thread_calls) == 1
     assert voice._VOICE_HONCHO_PROFILE_NEGATIVE_CACHE["uid-a"] > time.monotonic()
 
 
@@ -748,9 +790,10 @@ def test_retained_search_uses_uid_mapped_honcho_and_unmapped_user_fails_open(mon
     assert unmapped["sources_denied"] == ["honcho"]
 
 
-def test_canonical_startup_and_search_only_include_matching_signed_memory_scope(monkeypatch):
+def test_canonical_startup_and_search_require_exact_uid_and_matching_signed_memory_scope(monkeypatch):
     rows = [
         {
+            "uid": "UserA",
             "channel": "ios_voice",
             "provider": "grok-realtime",
             "role": "user",
@@ -761,6 +804,7 @@ def test_canonical_startup_and_search_only_include_matching_signed_memory_scope(
             "metadata": {},
         },
         {
+            "uid": "UserA",
             "channel": "ios_voice",
             "provider": "grok-realtime",
             "role": "user",
@@ -771,6 +815,7 @@ def test_canonical_startup_and_search_only_include_matching_signed_memory_scope(
             "metadata": {"scope_kind": "memory", "conversation_id": "memory-a"},
         },
         {
+            "uid": "UserA",
             "channel": "ios_voice",
             "provider": "grok-realtime",
             "role": "user",
@@ -780,6 +825,28 @@ def test_canonical_startup_and_search_only_include_matching_signed_memory_scope(
             "source_ref": {"scope_kind": "memory", "conversation_id": "memory-b"},
             "metadata": {"scope_kind": "memory", "conversation_id": "memory-b"},
         },
+        {
+            "uid": "usera",
+            "channel": "ios_voice",
+            "provider": "grok-realtime",
+            "role": "user",
+            "text": "Case-colliding general garden detail.",
+            "started_at": datetime(2026, 7, 24, 10, 3),
+            "session_id": "case-collision-general",
+            "source_ref": {},
+            "metadata": {},
+        },
+        {
+            "uid": "usera",
+            "channel": "ios_voice",
+            "provider": "grok-realtime",
+            "role": "user",
+            "text": "Case-colliding private garden detail.",
+            "started_at": datetime(2026, 7, 24, 10, 4),
+            "session_id": "case-collision-scoped",
+            "source_ref": {"scope_kind": "memory", "conversation_id": "memory-a"},
+            "metadata": {"scope_kind": "memory", "conversation_id": "memory-a"},
+        },
     ]
     queries = []
 
@@ -788,6 +855,8 @@ def test_canonical_startup_and_search_only_include_matching_signed_memory_scope(
             queries.append((query, uid, scope_kind, conversation_id, rest))
             visible = []
             for row in rows:
+                if row["uid"] != uid:
+                    continue
                 row_scope = row["source_ref"].get("scope_kind")
                 row_conversation = row["source_ref"].get("conversation_id")
                 if row_scope != "memory" or (
@@ -798,18 +867,18 @@ def test_canonical_startup_and_search_only_include_matching_signed_memory_scope(
 
     monkeypatch.setattr(voice, "_get_pool", lambda: asyncio.sleep(0, result=Pool()))
 
-    general_startup = asyncio.run(voice._fetch_recent_canonical_timeline("uid-a"))
+    general_startup = asyncio.run(voice._fetch_recent_canonical_timeline("UserA"))
     scoped_startup = asyncio.run(
         voice._fetch_recent_canonical_timeline(
-            "uid-a",
+            "UserA",
             scope_kind="memory",
             conversation_id="memory-a",
         )
     )
-    general_search = asyncio.run(voice._search_canonical_timeline("uid-a", "garden", 10))
+    general_search = asyncio.run(voice._search_canonical_timeline("UserA", "garden", 10))
     scoped_search = asyncio.run(
         voice._search_canonical_timeline(
-            "uid-a",
+            "UserA",
             "garden",
             10,
             scope_kind="memory",
@@ -820,15 +889,21 @@ def test_canonical_startup_and_search_only_include_matching_signed_memory_scope(
     assert "General garden plans." in general_startup
     assert "Memory A garden detail." not in general_startup
     assert "Memory B private garden detail." not in general_startup
+    assert "Case-colliding general garden detail." not in general_startup
+    assert "Case-colliding private garden detail." not in general_startup
     assert "General garden plans." in scoped_startup
     assert "Memory A garden detail." in scoped_startup
     assert "Memory B private garden detail." not in scoped_startup
+    assert "Case-colliding general garden detail." not in scoped_startup
+    assert "Case-colliding private garden detail." not in scoped_startup
     assert [result["content"] for result in general_search] == ["General garden plans."]
     assert {result["content"] for result in scoped_search} == {
         "General garden plans.",
         "Memory A garden detail.",
     }
     assert all("source_ref ->> 'scope_kind'" in query for query, *_ in queries)
+    assert all("WHERE uid = $1" in query for query, *_ in queries)
+    assert all("lower(uid)" not in query for query, *_ in queries)
 
 
 def test_isolated_workspace_search_uses_hermes_post_contract(monkeypatch):

--- a/backend/tests/unit/test_voice_proxy_auth.py
+++ b/backend/tests/unit/test_voice_proxy_auth.py
@@ -171,12 +171,58 @@ def test_voice_session_token_rejects_empty_memory_version():
 
 @pytest.mark.parametrize("legacy_mode", ["v1", "v2", "v3-fast"])
 def test_voice_session_token_rejects_legacy_memory_scope(legacy_mode):
-    with pytest.raises(ValueError, match="V4-compatible"):
+    with pytest.raises(ValueError, match="memory_scoped_voice_mode_required"):
         voice.create_session_token(
             uid="uid-a",
             firebase_uid="uid-a",
             voice_mode=legacy_mode,
             provider="grok-voice",
+            isolated_runtime=False,
+            session_scope={
+                "kind": "memory",
+                "conversation_id": "memory-a",
+                "active_summary_version_id": "version-3",
+                "can_reinterpret": False,
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    ("provider", "mode", "expected_code"),
+    [
+        (
+            "openai-native-realtime",
+            "openai-native-realtime-v1",
+            "memory_scoped_voice_provider_unsupported",
+        ),
+        (
+            "openai-native-realtime",
+            "v4",
+            "memory_scoped_voice_provider_unsupported",
+        ),
+        (
+            "grok-voice",
+            "gemini-live",
+            "memory_scoped_voice_provider_mode_mismatch",
+        ),
+        (
+            "gemini-live",
+            "v4",
+            "memory_scoped_voice_provider_mode_mismatch",
+        ),
+    ],
+)
+def test_voice_session_token_rejects_invalid_memory_scoped_provider_mode_pair(
+    provider,
+    mode,
+    expected_code,
+):
+    with pytest.raises(ValueError, match=expected_code):
+        voice.create_session_token(
+            uid="uid-a",
+            firebase_uid="uid-a",
+            voice_mode=mode,
+            provider=provider,
             isolated_runtime=False,
             session_scope={
                 "kind": "memory",

--- a/backend/tests/unit/test_voice_proxy_auth.py
+++ b/backend/tests/unit/test_voice_proxy_auth.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import sys
+import time
 from datetime import datetime, timedelta, timezone
 from types import ModuleType, SimpleNamespace
 
@@ -522,6 +523,64 @@ def test_retained_context_loads_uid_mapped_honcho_without_runtime_receipt(monkey
     assert result["honcho_status"]["available"] is True
 
 
+def test_retained_context_profile_resolution_timeout_degrades_within_cap(monkeypatch):
+    to_thread_calls = []
+
+    class Pool:
+        async def fetchrow(self, query, uid):
+            return {
+                "id": "db-user-a",
+                "name": "User A",
+                "conditions": [],
+                "medications": [],
+                "guardian_mode": "off",
+                "agents": {},
+            }
+
+        async def fetch(self, *args):
+            return []
+
+    async def empty(*args, **kwargs):
+        return ""
+
+    async def slow_to_thread(*args, **kwargs):
+        to_thread_calls.append(args)
+        await asyncio.sleep(0.25)
+
+    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "VOICE_HONCHO_PROFILE_RESOLUTION_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(voice, "VOICE_HONCHO_PROFILE_NEGATIVE_CACHE_TTL_SECONDS", 30)
+    monkeypatch.setattr(voice.asyncio, "to_thread", slow_to_thread)
+    monkeypatch.setattr(voice, "_get_pool", lambda: asyncio.sleep(0, result=Pool()))
+    monkeypatch.setattr(voice, "_fetch_recent_conversations", empty)
+    monkeypatch.setattr(voice, "_fetch_recent_canonical_timeline", empty)
+    monkeypatch.setattr(voice, "_fetch_memory_context", empty)
+    monkeypatch.setattr(voice, "_VOICE_HONCHO_PROFILE_NEGATIVE_CACHE", {})
+
+    async def load_context():
+        started = time.monotonic()
+        result = await voice.get_voice_context(
+            _request(
+                {"uid": "uid-a"},
+                token=_token("uid-a", isolated=False),
+                service_token="test-proxy-secret",
+            )
+        )
+        return result, time.monotonic() - started
+
+    result, elapsed = asyncio.run(load_context())
+    cached_result, cached_elapsed = asyncio.run(load_context())
+
+    assert elapsed < 0.15
+    assert cached_elapsed < 0.15
+    assert result["honcho_context"] == ""
+    assert result["honcho_status"]["reason"] == "honcho_profile_resolution_timeout"
+    assert cached_result["honcho_status"]["reason"] == "honcho_profile_resolution_cached_unavailable"
+    assert len(to_thread_calls) == 1
+    assert voice._VOICE_HONCHO_PROFILE_NEGATIVE_CACHE["uid-a"] > time.monotonic()
+
+
 def test_isolated_search_forces_receipt_agent_and_owner_header(monkeypatch):
     runtime = SimpleNamespace(agent_id="ella-uid-a", revision=8)
     calls = []
@@ -687,6 +746,89 @@ def test_retained_search_uses_uid_mapped_honcho_and_unmapped_user_fails_open(mon
     assert unmapped["results"] == []
     assert unmapped["sources_searched"] == []
     assert unmapped["sources_denied"] == ["honcho"]
+
+
+def test_canonical_startup_and_search_only_include_matching_signed_memory_scope(monkeypatch):
+    rows = [
+        {
+            "channel": "ios_voice",
+            "provider": "grok-realtime",
+            "role": "user",
+            "text": "General garden plans.",
+            "started_at": datetime(2026, 7, 24, 10, 0),
+            "session_id": "general-session",
+            "source_ref": {},
+            "metadata": {},
+        },
+        {
+            "channel": "ios_voice",
+            "provider": "grok-realtime",
+            "role": "user",
+            "text": "Memory A garden detail.",
+            "started_at": datetime(2026, 7, 24, 10, 1),
+            "session_id": "scoped-session",
+            "source_ref": {"scope_kind": "memory", "conversation_id": "memory-a"},
+            "metadata": {"scope_kind": "memory", "conversation_id": "memory-a"},
+        },
+        {
+            "channel": "ios_voice",
+            "provider": "grok-realtime",
+            "role": "user",
+            "text": "Memory B private garden detail.",
+            "started_at": datetime(2026, 7, 24, 10, 2),
+            "session_id": "other-scoped-session",
+            "source_ref": {"scope_kind": "memory", "conversation_id": "memory-b"},
+            "metadata": {"scope_kind": "memory", "conversation_id": "memory-b"},
+        },
+    ]
+    queries = []
+
+    class Pool:
+        async def fetch(self, query, uid, scope_kind, conversation_id, *rest):
+            queries.append((query, uid, scope_kind, conversation_id, rest))
+            visible = []
+            for row in rows:
+                row_scope = row["source_ref"].get("scope_kind")
+                row_conversation = row["source_ref"].get("conversation_id")
+                if row_scope != "memory" or (
+                    scope_kind == "memory" and row_conversation == conversation_id
+                ):
+                    visible.append(row)
+            return visible
+
+    monkeypatch.setattr(voice, "_get_pool", lambda: asyncio.sleep(0, result=Pool()))
+
+    general_startup = asyncio.run(voice._fetch_recent_canonical_timeline("uid-a"))
+    scoped_startup = asyncio.run(
+        voice._fetch_recent_canonical_timeline(
+            "uid-a",
+            scope_kind="memory",
+            conversation_id="memory-a",
+        )
+    )
+    general_search = asyncio.run(voice._search_canonical_timeline("uid-a", "garden", 10))
+    scoped_search = asyncio.run(
+        voice._search_canonical_timeline(
+            "uid-a",
+            "garden",
+            10,
+            scope_kind="memory",
+            conversation_id="memory-a",
+        )
+    )
+
+    assert "General garden plans." in general_startup
+    assert "Memory A garden detail." not in general_startup
+    assert "Memory B private garden detail." not in general_startup
+    assert "General garden plans." in scoped_startup
+    assert "Memory A garden detail." in scoped_startup
+    assert "Memory B private garden detail." not in scoped_startup
+    assert [result["content"] for result in general_search] == ["General garden plans."]
+    assert {result["content"] for result in scoped_search} == {
+        "General garden plans.",
+        "Memory A garden detail.",
+    }
+    assert all("source_ref ->> 'scope_kind'" in query for query, *_ in queries)
 
 
 def test_isolated_workspace_search_uses_hermes_post_contract(monkeypatch):

--- a/backend/tests/unit/test_voice_proxy_auth.py
+++ b/backend/tests/unit/test_voice_proxy_auth.py
@@ -169,6 +169,24 @@ def test_voice_session_token_rejects_empty_memory_version():
         )
 
 
+@pytest.mark.parametrize("legacy_mode", ["v1", "v2", "v3-fast"])
+def test_voice_session_token_rejects_legacy_memory_scope(legacy_mode):
+    with pytest.raises(ValueError, match="V4-compatible"):
+        voice.create_session_token(
+            uid="uid-a",
+            firebase_uid="uid-a",
+            voice_mode=legacy_mode,
+            provider="grok-voice",
+            isolated_runtime=False,
+            session_scope={
+                "kind": "memory",
+                "conversation_id": "memory-a",
+                "active_summary_version_id": "version-3",
+                "can_reinterpret": False,
+            },
+        )
+
+
 def test_voice_proxy_rejects_partial_scope_claims():
     token = _token(
         "uid-a",


### PR DESCRIPTION
## What changed

- Adds the typed `session_scope` contract for memory-scoped V2V sessions.
- Resolves canonical memory content and linked people server-side under the authenticated UID.
- Signs only scope identifiers, active version, and capability into the short-lived voice JWT.
- Revalidates scope ownership/version on voice context reads and makes missing/non-owned IDs indistinguishable.
- Adds receipt-bound Honcho startup context with a 1.5 second fail-open budget.
- Adds semantic Honcho results to authenticated unified voice search.

## Why

ella-ai#1101 requires the existing Grok/Gemini voice transport to open against one canonical memory without trusting client-authored context. Work order v2.1 also promotes Honcho to a required quality component while preserving graceful degradation.

The integration calls Honcho directly from the VPS using the exact isolated runtime receipt's workspace, observer peer, and observed peer. It does not depend on Hermes model/tool hops or Atlas's host container rollout in ella-ai#1103, and it never falls back to a shared Honcho profile.

## Impact and boundaries

- Memory title/overview/people never enter the JWT or voice URL.
- Scoped context is keyed to the canonical active summary version.
- Honcho timeout or outage returns the existing context pack instead of blocking voice.
- Legacy users without an isolated runtime receipt degrade without Honcho rather than using an unsafe shared target.
- This PR does not add the post-session reinterpretation outbox/worker and does not change iOS consent or UI.

## Validation

`87 passed` across:

- `test_voice_honcho.py`
- `test_voice_proxy_auth.py`
- `test_ella_runtime_route_isolation.py`
- `test_ella_provisioning_service.py`
- `test_ella_correction_honcho_contract.py`

Python compilation and `git diff --check` also pass. The only warnings are pre-existing `datetime.utcnow()` deprecations.

Tracks ellaaicare/ella-ai#1101.

Companion voice-proxy PR: ellaaicare/ella-ai#1105.
