### PR TITLE
Add memory-scoped V2V on iOS

### DIFF
--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -226,6 +226,92 @@ Future<bool> submitConversationCorrection({
   return response.statusCode == 200 || response.statusCode == 201 || response.statusCode == 202;
 }
 
+class ConversationCorrectionSummary {
+  const ConversationCorrectionSummary({this.title = '', this.overview = '', this.emoji = '', this.category = 'other'});
+
+  final String title;
+  final String overview;
+  final String emoji;
+  final String category;
+
+  factory ConversationCorrectionSummary.fromJson(Object? value) {
+    if (value is! Map) return const ConversationCorrectionSummary();
+    return ConversationCorrectionSummary(
+      title: value['title']?.toString() ?? '',
+      overview: value['overview']?.toString() ?? '',
+      emoji: value['emoji']?.toString() ?? '',
+      category: value['category']?.toString() ?? 'other',
+    );
+  }
+}
+
+class ConversationCorrectionReceipt {
+  const ConversationCorrectionReceipt({
+    required this.correctionId,
+    required this.conversationId,
+    required this.status,
+    required this.before,
+    required this.after,
+    this.appliedAt,
+    this.undoneAt,
+  });
+
+  final String correctionId;
+  final String conversationId;
+  final String status;
+  final ConversationCorrectionSummary before;
+  final ConversationCorrectionSummary after;
+  final DateTime? appliedAt;
+  final DateTime? undoneAt;
+
+  bool get isPending => const {'submitted', 'queued', 'processing', 'pending'}.contains(status);
+  bool get isApplied => status == 'applied' && undoneAt == null;
+  bool get isUndone => status == 'undone' || undoneAt != null;
+  bool get isFailed => !isPending && !isApplied && !isUndone;
+
+  factory ConversationCorrectionReceipt.fromJson(Map<String, dynamic> json) => ConversationCorrectionReceipt(
+        correctionId: json['correction_id']?.toString() ?? '',
+        conversationId: json['conversation_id']?.toString() ?? '',
+        status: json['status']?.toString() ?? 'unknown',
+        before: ConversationCorrectionSummary.fromJson(json['before']),
+        after: ConversationCorrectionSummary.fromJson(json['after']),
+        appliedAt: DateTime.tryParse(json['applied_at']?.toString() ?? '')?.toLocal(),
+        undoneAt: DateTime.tryParse(json['undone_at']?.toString() ?? '')?.toLocal(),
+      );
+}
+
+Future<ConversationCorrectionReceipt?> getConversationCorrectionReceipt({
+  required String conversationId,
+  required String correctionId,
+}) async {
+  final response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/ella/conversations/$conversationId/corrections/$correctionId',
+    headers: {},
+    method: 'GET',
+    body: '',
+  );
+  if (response == null || response.statusCode != 200) return null;
+  final decoded = jsonDecode(response.body);
+  if (decoded is! Map) return null;
+  return ConversationCorrectionReceipt.fromJson(Map<String, dynamic>.from(decoded));
+}
+
+Future<ConversationCorrectionReceipt?> undoConversationCorrection({
+  required String conversationId,
+  required String correctionId,
+}) async {
+  final response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/ella/conversations/$conversationId/corrections/$correctionId/undo',
+    headers: {},
+    method: 'POST',
+    body: jsonEncode({}),
+  );
+  if (response == null || response.statusCode != 200) return null;
+  final decoded = jsonDecode(response.body);
+  if (decoded is! Map) return null;
+  return ConversationCorrectionReceipt.fromJson(Map<String, dynamic>.from(decoded));
+}
+
 Future<bool> deleteConversationServer(String conversationId) async {
   var response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/conversations/$conversationId',

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -18,7 +18,7 @@ class SharedPreferencesUtil {
   static SharedPreferences? _preferences;
 
   static const bool isPublicBuild = bool.fromEnvironment('ELLA_PUBLIC_BUILD');
-  static const String currentAiConsentContractVersion = 'voice-ai-processors-v2';
+  static const String currentAiConsentContractVersion = 'voice-ai-processors-v3';
   static const String currentAiConsentReceiptPrefix = 'ios-private-cloud-sync:$currentAiConsentContractVersion:';
 
   factory SharedPreferencesUtil() {
@@ -210,16 +210,29 @@ class SharedPreferencesUtil {
 
   String get aiConsentContractVersion => getString('aiConsentContractVersion');
 
+  String get aiConsentDeferredVersion => getString('aiConsentDeferredVersion');
+
+  bool get isCurrentAiConsentDeferred => aiConsentDeferredVersion == currentAiConsentContractVersion;
+
   bool hasAccountBoundAiConsent(String uid) =>
       uid.isNotEmpty &&
       aiConsentAccepted &&
       aiConsentReceiptId.startsWith(currentAiConsentReceiptPrefix) &&
       aiConsentReceiptUid == uid;
 
+  bool hasPriorAccountBoundAiConsent(String uid) =>
+      uid.isNotEmpty &&
+      getBool('aiConsentAccepted', defaultValue: false) &&
+      aiConsentContractVersion.isNotEmpty &&
+      aiConsentContractVersion != currentAiConsentContractVersion &&
+      aiConsentReceiptId.isNotEmpty &&
+      aiConsentReceiptUid == uid;
+
   void acceptAiConsent({String receiptId = '', String uid = ''}) {
     aiConsentAccepted = true;
     aiConsentAcceptedAt = DateTime.now().toUtc().toIso8601String();
     saveString('aiConsentContractVersion', currentAiConsentContractVersion);
+    remove('aiConsentDeferredVersion');
     if (receiptId.startsWith(currentAiConsentReceiptPrefix) && uid.isNotEmpty) {
       saveString('aiConsentReceiptId', receiptId);
       saveString('aiConsentReceiptUid', uid);
@@ -229,12 +242,18 @@ class SharedPreferencesUtil {
     }
   }
 
+  void deferAiConsent() {
+    declineAiConsent();
+    saveString('aiConsentDeferredVersion', currentAiConsentContractVersion);
+  }
+
   void declineAiConsent() {
     aiConsentAccepted = false;
     remove('aiConsentAcceptedAt');
     remove('aiConsentReceiptId');
     remove('aiConsentReceiptUid');
     remove('aiConsentContractVersion');
+    remove('aiConsentDeferredVersion');
   }
 
   // Notification frequency (0-5): 0 = off, 5 = most frequent. Default is 0 (disabled)
@@ -605,6 +624,7 @@ class SharedPreferencesUtil {
       'aiConsentReceiptId',
       'aiConsentReceiptUid',
       'aiConsentContractVersion',
+      'aiConsentDeferredVersion',
     ]) {
       await remove(key);
     }

--- a/app/lib/backend/schema/conversation.dart
+++ b/app/lib/backend/schema/conversation.dart
@@ -193,6 +193,7 @@ class ServerConversation {
   final List<String> ellaTags;
   final Map<String, dynamic>? ellaSignal;
   final Map<String, dynamic>? enrichmentState;
+  final String? activeSummaryVersionId;
   final String? processingRetryEnrichmentVectorStatus;
   final String? processingError;
   final DateTime? processingErrorAt;
@@ -239,6 +240,7 @@ class ServerConversation {
     this.ellaTags = const [],
     this.ellaSignal,
     this.enrichmentState,
+    this.activeSummaryVersionId,
     this.processingRetryEnrichmentVectorStatus,
     this.processingError,
     this.processingErrorAt,
@@ -277,6 +279,7 @@ class ServerConversation {
       ellaTags: ((json['ella_tags'] ?? []) as List<dynamic>).map((tag) => tag.toString()).toList(),
       ellaSignal: json['ella_signal'] is Map ? Map<String, dynamic>.from(json['ella_signal']) : null,
       enrichmentState: json['enrichment_state'] is Map ? Map<String, dynamic>.from(json['enrichment_state']) : null,
+      activeSummaryVersionId: json['active_summary_version_id']?.toString(),
       processingRetryEnrichmentVectorStatus: json['processing_retry_enrichment_vector_status'],
       processingError: json['processing_error'],
       processingErrorAt:
@@ -311,6 +314,7 @@ class ServerConversation {
       'ella_tags': ellaTags,
       'ella_signal': ellaSignal,
       'enrichment_state': enrichmentState,
+      'active_summary_version_id': activeSummaryVersionId,
       'processing_retry_enrichment_vector_status': processingRetryEnrichmentVectorStatus,
       'processing_error': processingError,
       'processing_error_at': processingErrorAt?.toUtc().toIso8601String(),

--- a/app/lib/core/app_shell.dart
+++ b/app/lib/core/app_shell.dart
@@ -85,20 +85,12 @@ class _AppShellState extends State<AppShell> {
     } else if (uri.pathSegments.first == 'wrapped') {
       if (mounted) {
         PlatformManager.instance.mixpanel.track('Wrapped Opened From DeepLink');
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (context) => const Wrapped2025Page(),
-          ),
-        );
+        Navigator.of(context).push(MaterialPageRoute(builder: (context) => const Wrapped2025Page()));
       }
     } else if (uri.pathSegments.first == 'unlimited') {
       if (mounted) {
         PlatformManager.instance.mixpanel.track('Plans Opened From DeepLink');
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (context) => const UsagePage(showUpgradeDialog: true),
-          ),
-        );
+        Navigator.of(context).push(MaterialPageRoute(builder: (context) => const UsagePage(showUpgradeDialog: true)));
       }
     } else if (uri.host == 'todoist' && uri.pathSegments.isNotEmpty && uri.pathSegments.first == 'callback') {
       // Handle Todoist OAuth callback
@@ -174,7 +166,11 @@ class _AppShellState extends State<AppShell> {
   }
 
   Future<void> _handleOAuthCallback(
-      Uri uri, String errorDisplayName, String oauthLogName, Future<void> Function() onSuccess) async {
+    Uri uri,
+    String errorDisplayName,
+    String oauthLogName,
+    Future<void> Function() onSuccess,
+  ) async {
     final error = uri.queryParameters['error'];
     if (error != null) {
       Logger.debug('$oauthLogName OAuth error: $error');
@@ -372,6 +368,11 @@ class _AppShellState extends State<AppShell> {
       await preferences.prepareEllaProvisioningAccount(uid);
       if (!mounted || _consentPromptPresented) return;
       if (preferences.hasAccountBoundAiConsent(uid)) return;
+      if (preferences.hasPriorAccountBoundAiConsent(uid) || preferences.isCurrentAiConsentDeferred) {
+        // Existing users review a new processor contract on their next
+        // explicit voice action rather than at unrelated app startup.
+        return;
+      }
 
       // Legacy local consent is not sufficient for a newly isolated account.
       preferences.declineAiConsent();

--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:audio_session/audio_session.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -13,17 +14,22 @@ import 'package:speech_to_text/speech_to_text.dart';
 
 import 'package:uuid/uuid.dart';
 
+import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/services/ella_chat_service.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/ella/services/ella_ai_consent_service.dart';
 import 'package:omi/ella/services/elevenlabs_tts.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/ella/services/v2v_client.dart';
-import 'package:omi/ella/widgets/v2v_fallback_dialog.dart';
-import 'package:omi/ella/widgets/ella_voice_orb.dart';
+import 'package:omi/ella/widgets/ai_consent_sheet.dart';
 import 'package:omi/ella/widgets/ella_breathing_dot.dart';
+import 'package:omi/ella/widgets/ella_voice_orb.dart';
+import 'package:omi/ella/widgets/memory_correction_receipt.dart';
+import 'package:omi/ella/widgets/v2v_fallback_dialog.dart';
 import 'package:omi/providers/capture_provider.dart';
+import 'package:omi/providers/ella_provisioning_provider.dart';
 import 'package:omi/providers/home_provider.dart';
 import 'package:omi/providers/message_provider.dart';
 import 'package:omi/utils/enums.dart';
@@ -34,7 +40,17 @@ import 'package:omi/utils/l10n_extensions.dart';
 /// Flow: Tap orb → always-listen via on-device speech recognition →
 /// auto-detect silence → send text to Ella chat → TTS → play audio → repeat.
 class EllaVoiceChatPage extends StatefulWidget {
-  const EllaVoiceChatPage({super.key});
+  const EllaVoiceChatPage({super.key, this.sessionScope, this.memoryTitle});
+
+  final V2VSessionScope? sessionScope;
+  final String? memoryTitle;
+
+  @visibleForTesting
+  static bool shouldInjectVoiceTurns(V2VSessionScope? sessionScope) => sessionScope == null;
+
+  @visibleForTesting
+  static V2VSessionScope refreshedMemoryScope(V2VSessionScope current, String? activeSummaryVersionId) =>
+      current.withExpectedActiveSummaryVersionId(activeSummaryVersionId);
 
   @override
   State<EllaVoiceChatPage> createState() => _EllaVoiceChatPageState();
@@ -78,6 +94,13 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
   /// Track whether we've injected chat messages for the current V2V turn
   bool _v2vTurnInjected = false;
+  late V2VSessionScope? _sessionScope;
+  String _activeSessionId = '';
+  bool _consentPromptActive = false;
+  MemoryReinterpretationEvent? _memoryReinterpretationEvent;
+  ConversationCorrectionReceipt? _memoryCorrectionReceipt;
+  Timer? _memoryReceiptPollTimer;
+  int _memoryReceiptPollAttempts = 0;
 
   /// Regex to strip emojis from text before sending to TTS
   static final _emojiRegex = RegExp(
@@ -105,11 +128,12 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       );
 
   @override
-  bool get wantKeepAlive => true;
+  bool get wantKeepAlive => widget.sessionScope == null;
 
   @override
   void initState() {
     super.initState();
+    _sessionScope = widget.sessionScope;
     // Voice mode auto-starts when the Voice tab becomes active (see didChangeDependencies)
     _playerSub = _audioPlayer.playerStateStream.listen((state) {
       if (state.processingState == ProcessingState.completed && _orbState == VoiceOrbState.speaking) {
@@ -124,26 +148,28 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       }
     });
     _initSpeech();
+    if (widget.sessionScope != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Future.delayed(const Duration(milliseconds: 300), () {
+          if (mounted && !_voiceModeActive) _activateSelectedVoice();
+        });
+      });
+    }
   }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    if (widget.sessionScope != null) return;
     // Auto-start listening when user navigates TO the Voice tab (index 2)
     try {
       final homeProvider = Provider.of<HomeProvider>(context);
       final isOnVoiceTab = homeProvider.selectedIndex == 2;
       if (isOnVoiceTab && !_wasOnVoiceTab && !_voiceModeActive) {
         debugPrint('[VoiceChat] Voice tab became active, auto-starting');
-        _voiceModeActive = true;
-        final provider = _effectiveVoiceProvider;
         Future.delayed(const Duration(milliseconds: 300), () {
           if (mounted && _orbState == VoiceOrbState.idle) {
-            if (_isV2VProvider(provider)) {
-              _startV2V(provider);
-            } else {
-              _startListening();
-            }
+            _activateSelectedVoice();
           }
         });
       } else if (!isOnVoiceTab && _wasOnVoiceTab && _voiceModeActive) {
@@ -195,6 +221,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   void dispose() {
     _voiceModeActive = false;
     _typewriterTimer?.cancel();
+    _memoryReceiptPollTimer?.cancel();
     _playerSub?.cancel();
     _audioPlayer.dispose();
     _transcriptScrollController.dispose();
@@ -220,23 +247,63 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     });
   }
 
-  Future<void> _onOrbTap() async {
-    if (!SharedPreferencesUtil().aiConsentAccepted) return;
-    debugPrint(
-      '[VoiceChat] Orb tapped, state: $_orbState, voiceMode: $_voiceModeActive, v2v: $_isV2VMode',
+  Future<bool> _ensureVoiceConsent() async {
+    if (SharedPreferencesUtil().aiConsentAccepted) return true;
+    if (_consentPromptActive || !mounted) return false;
+
+    _consentPromptActive = true;
+    final uid = FirebaseAuth.instance.currentUser?.uid ?? '';
+    final accepted = await AiConsentSheet.show(
+      context,
+      onAccept: isHermesProvisioningGateEnabled
+          ? () async {
+              final receiptId = await EllaAiConsentService().acknowledgePrivateCloudSync(uid: uid);
+              if (receiptId == null) return false;
+              if (mounted) {
+                try {
+                  context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
+                } catch (_) {
+                  // The authenticated receipt remains persisted even if this
+                  // route is rendered outside the provisioning provider tree.
+                }
+              }
+              return true;
+            }
+          : null,
     );
+    _consentPromptActive = false;
+    return accepted == true && SharedPreferencesUtil().aiConsentAccepted;
+  }
+
+  Future<void> _activateSelectedVoice() async {
+    if (!await _ensureVoiceConsent() || !mounted) return;
+
+    final provider = _effectiveVoiceProvider;
+    if (_sessionScope != null && !V2VClient.isMemoryScopedProvider(provider)) {
+      setState(() {
+        _voiceModeActive = false;
+        _isV2VMode = false;
+        _orbState = VoiceOrbState.idle;
+        _statusText = context.l10n.memoryTalkProviderRequired;
+      });
+      return;
+    }
+
+    _voiceModeActive = true;
+    if (_isV2VProvider(provider)) {
+      await _startV2V(provider);
+    } else {
+      _isV2VMode = false;
+      await _startListening();
+    }
+  }
+
+  Future<void> _onOrbTap() async {
+    debugPrint('[VoiceChat] Orb tapped, state: $_orbState, voiceMode: $_voiceModeActive, v2v: $_isV2VMode');
     HapticFeedback.mediumImpact();
 
     if (!_voiceModeActive) {
-      // Resume voice mode — check if V2V provider is selected
-      _voiceModeActive = true;
-      final provider = _effectiveVoiceProvider;
-      if (_isV2VProvider(provider)) {
-        await _startV2V(provider);
-      } else {
-        _isV2VMode = false;
-        await _startListening();
-      }
+      await _activateSelectedVoice();
       return;
     }
 
@@ -310,16 +377,10 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
           context: context,
           builder: (ctx) => AlertDialog(
             backgroundColor: EllaColors.bgSecondary,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(EllaSizes.radiusLarge),
-            ),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(EllaSizes.radiusLarge)),
             title: const Text(
               'Microphone Access',
-              style: TextStyle(
-                fontSize: 22,
-                fontWeight: FontWeight.bold,
-                color: EllaColors.textPrimary,
-              ),
+              style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold, color: EllaColors.textPrimary),
             ),
             content: const Text(
               'Ella needs microphone access for voice chat. Please enable it in Settings.',
@@ -328,33 +389,22 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
             actions: [
               TextButton(
                 onPressed: () => Navigator.of(ctx).pop(),
-                child: const Text(
-                  'Cancel',
-                  style: TextStyle(
-                    fontSize: 18,
-                    color: EllaColors.textTertiary,
-                  ),
-                ),
+                child: const Text('Cancel', style: TextStyle(fontSize: 18, color: EllaColors.textTertiary)),
               ),
               TextButton(
                 onPressed: () {
                   Navigator.of(ctx).pop();
                   openAppSettings();
                 },
-                child: const Text(
-                  'Open Settings',
-                  style: TextStyle(fontSize: 18, color: EllaColors.primary),
-                ),
+                child: const Text('Open Settings', style: TextStyle(fontSize: 18, color: EllaColors.primary)),
               ),
             ],
           ),
         );
       } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Microphone permission is required for voice chat'),
-          ),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Microphone permission is required for voice chat')));
       }
       return;
     }
@@ -362,11 +412,9 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     final speechStatus = await Permission.speech.request();
     if (!speechStatus.isGranted) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Speech recognition permission is required'),
-        ),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Speech recognition permission is required')));
       return;
     }
 
@@ -374,21 +422,16 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       await _initSpeech();
       if (!_speechAvailable) {
         if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Speech recognition is not available on this device'),
-          ),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Speech recognition is not available on this device')));
         return;
       }
     }
 
     // Stop any existing mic recording from CaptureProvider
     if (mounted) {
-      final captureProvider = Provider.of<CaptureProvider>(
-        context,
-        listen: false,
-      );
+      final captureProvider = Provider.of<CaptureProvider>(context, listen: false);
       if (captureProvider.recordingState == RecordingState.record) {
         debugPrint('[VoiceChat] Pausing capture recording to free mic');
         await captureProvider.stopStreamRecording();
@@ -474,7 +517,20 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
   // --- V2V (Voice-to-Voice) WebSocket mode ---
 
-  Future<void> _startV2V(String provider) async {
+  Future<bool> _refreshMemoryScope() async {
+    final currentScope = _sessionScope;
+    if (currentScope == null) return false;
+    setState(() {
+      _orbState = VoiceOrbState.processing;
+      _statusText = context.l10n.memoryTalkStale;
+    });
+    final refreshed = await getConversationById(currentScope.conversationId);
+    if (!mounted || refreshed == null) return false;
+    _sessionScope = EllaVoiceChatPage.refreshedMemoryScope(currentScope, refreshed.activeSummaryVersionId);
+    return true;
+  }
+
+  Future<void> _startV2V(String provider, {bool allowScopeRefresh = true}) async {
     if (!SharedPreferencesUtil().aiConsentAccepted) return;
     provider = V2VClient.normalizeProvider(provider);
     final providerName = localizedV2VProviderName(context, provider);
@@ -484,10 +540,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
     // Stop any existing mic recording from CaptureProvider
     if (mounted) {
-      final captureProvider = Provider.of<CaptureProvider>(
-        context,
-        listen: false,
-      );
+      final captureProvider = Provider.of<CaptureProvider>(context, listen: false);
       if (captureProvider.recordingState == RecordingState.record) {
         debugPrint('[VoiceChat] Pausing capture recording for V2V');
         await captureProvider.stopStreamRecording();
@@ -521,7 +574,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       },
     );
 
-    final receipt = await _v2vClient!.connect(provider: provider);
+    final receipt = await _v2vClient!.connect(provider: provider, sessionScope: _sessionScope);
     if (!mounted) return;
 
     if (!receipt.connected) {
@@ -531,13 +584,21 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       _isV2VMode = false;
       _v2vClient = null;
       _voiceModeActive = false;
+      if (allowScopeRefresh && receipt.shouldRefreshMemoryScope && await _refreshMemoryScope()) {
+        if (!mounted) return;
+        _voiceModeActive = true;
+        await _startV2V(provider, allowScopeRefresh: false);
+        return;
+      }
       setState(() {
         _orbState = VoiceOrbState.idle;
-        _statusText = receipt.safeDetail;
+        _statusText = _sessionScope != null && receipt.errorCode == 'voice_session_scope_unavailable'
+            ? context.l10n.memoryTalkUnavailable
+            : receipt.safeDetail;
         _audioLevel = 0.0;
       });
 
-      final choice = await showV2VFallbackDialog(context, receipt);
+      final choice = await showV2VFallbackDialog(context, receipt, allowStandardFallback: _sessionScope == null);
       if (!mounted) return;
       switch (choice) {
         case V2VFailureChoice.retry:
@@ -545,6 +606,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
           await _startV2V(provider);
           break;
         case V2VFailureChoice.useElevenLabs:
+          if (_sessionScope != null) break;
           _usingElevenLabsFallback = true;
           _voiceModeActive = true;
           setState(() {
@@ -563,6 +625,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       return;
     }
 
+    _activeSessionId = receipt.sessionId;
     _activeV2VProvider = providerName;
     _usingElevenLabsFallback = false;
     setState(() {
@@ -575,6 +638,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     debugPrint('[VoiceChat] Stopping V2V mode');
     await _v2vClient?.disconnect();
     _v2vClient = null;
+    _activeSessionId = '';
     _activeV2VProvider = '';
     _pauseVoiceMode();
   }
@@ -605,7 +669,10 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
         break;
       case 'audio_done':
         // Inject into chat history once per turn (using final transcript)
-        if (!_v2vTurnInjected && _lastUserText.isNotEmpty && _lastEllaText.isNotEmpty) {
+        if (EllaVoiceChatPage.shouldInjectVoiceTurns(_sessionScope) &&
+            !_v2vTurnInjected &&
+            _lastUserText.isNotEmpty &&
+            _lastEllaText.isNotEmpty) {
           _injectVoiceMessages(_lastUserText, _lastEllaText);
           _v2vTurnInjected = true;
         }
@@ -644,6 +711,12 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
           _statusText = 'Generating response...';
         });
         break;
+      case 'memory_reinterpretation':
+        final memoryReinterpretation = event.memoryReinterpretation;
+        if (memoryReinterpretation != null) {
+          _handleMemoryReinterpretation(memoryReinterpretation);
+        }
+        break;
       case 'v2v_debug':
         // Debug info from V2V client — show on screen temporarily
         setState(() {
@@ -668,11 +741,62 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     }
   }
 
+  void _handleMemoryReinterpretation(MemoryReinterpretationEvent event) {
+    final scope = _sessionScope;
+    if (scope == null ||
+        event.conversationId != scope.conversationId ||
+        (_activeSessionId.isNotEmpty && event.sessionId != _activeSessionId)) {
+      return;
+    }
+    _memoryReinterpretationEvent = event;
+    _memoryReceiptPollAttempts = 0;
+    _memoryReceiptPollTimer?.cancel();
+    _pollMemoryCorrectionReceipt();
+  }
+
+  Future<void> _pollMemoryCorrectionReceipt() async {
+    final event = _memoryReinterpretationEvent;
+    if (event == null || !mounted) return;
+    _memoryReceiptPollAttempts++;
+
+    final receipt = await getConversationCorrectionReceipt(
+      conversationId: event.conversationId,
+      correctionId: event.correctionId,
+    );
+    if (!mounted || _memoryReinterpretationEvent != event) return;
+    if (receipt != null &&
+        receipt.conversationId == event.conversationId &&
+        receipt.correctionId == event.correctionId) {
+      setState(() => _memoryCorrectionReceipt = receipt);
+    }
+
+    if ((receipt == null || receipt.isPending) && _memoryReceiptPollAttempts < 40) {
+      _memoryReceiptPollTimer = Timer(event.pollAfter, _pollMemoryCorrectionReceipt);
+    }
+  }
+
+  Future<ConversationCorrectionReceipt?> _undoMemoryCorrection() async {
+    final receipt = _memoryCorrectionReceipt;
+    if (receipt == null || !receipt.isApplied) return null;
+    final updated = await undoConversationCorrection(
+      conversationId: receipt.conversationId,
+      correctionId: receipt.correctionId,
+    );
+    if (mounted && updated != null) {
+      setState(() => _memoryCorrectionReceipt = updated);
+    }
+    return updated;
+  }
+
+  void _reviewMemoryCorrection() {
+    final receipt = _memoryCorrectionReceipt;
+    if (receipt == null || !receipt.isApplied) return;
+    showMemoryCorrectionReceiptSheet(context, receipt: receipt, onUndo: _undoMemoryCorrection);
+  }
+
   void _onSpeechResult(SpeechRecognitionResult result) {
     if (!mounted) return;
-    debugPrint(
-      '[VoiceChat] Speech result: final=${result.finalResult}, text="${result.recognizedWords}"',
-    );
+    debugPrint('[VoiceChat] Speech result: final=${result.finalResult}, text="${result.recognizedWords}"');
 
     _currentWords = result.recognizedWords;
 
@@ -700,9 +824,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
     try {
       if (_speech.isListening) {
-        debugPrint(
-          '[VoiceChat] Stopping speech recognizer before response playback',
-        );
+        debugPrint('[VoiceChat] Stopping speech recognizer before response playback');
         await _speech.stop();
         // Let iOS release the recording session before we synthesize/play audio.
         await Future.delayed(const Duration(milliseconds: 150));
@@ -737,7 +859,9 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       }
 
       // Inject both messages into chat history so Chat tab shows them
-      _injectVoiceMessages(transcript, fullReply);
+      if (EllaVoiceChatPage.shouldInjectVoiceTurns(_sessionScope)) {
+        _injectVoiceMessages(transcript, fullReply);
+      }
 
       // Store full reply and start typewriter reveal
       _lastEllaText = fullReply;
@@ -749,9 +873,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       });
 
       // Strip emojis before TTS — prevents the TTS engine from reading emoji names aloud
-      final ttsText = _stripEmojis(
-        fullReply.length > 500 ? fullReply.substring(0, 500) : fullReply,
-      );
+      final ttsText = _stripEmojis(fullReply.length > 500 ? fullReply.substring(0, 500) : fullReply);
       debugPrint('[VoiceChat] Synthesizing TTS (${ttsText.length} chars)...');
       final audioPath = await ElevenLabsTts.synthesize(ttsText);
       debugPrint('[VoiceChat] TTS result: $audioPath');
@@ -778,9 +900,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
         await _audioPlayer.setFilePath(audioPath);
         await _audioPlayer.play();
       } catch (playbackError, playbackStack) {
-        debugPrint(
-          '[VoiceChat] File playback failed, using on-device TTS: $playbackError\n$playbackStack',
-        );
+        debugPrint('[VoiceChat] File playback failed, using on-device TTS: $playbackError\n$playbackStack');
         await ElevenLabsTts.speakOnDevice(ttsText);
         if (!mounted) return;
         if (_voiceModeActive) {
@@ -875,9 +995,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     _typewriterTimer?.cancel();
     _ellaDisplayText = '';
     int charIndex = 0;
-    _typewriterTimer = Timer.periodic(const Duration(milliseconds: 50), (
-      timer,
-    ) {
+    _typewriterTimer = Timer.periodic(const Duration(milliseconds: 50), (timer) {
       if (!mounted || charIndex >= fullText.length) {
         timer.cancel();
         if (mounted) {
@@ -914,15 +1032,11 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     return Scaffold(
       backgroundColor: EllaColors.bgPrimary,
       appBar: AppBar(
-        automaticallyImplyLeading: false,
+        automaticallyImplyLeading: widget.sessionScope != null,
         backgroundColor: EllaColors.bgPrimary,
-        title: const Text(
-          'Voice Chat',
-          style: TextStyle(
-            fontSize: 22,
-            fontWeight: FontWeight.w600,
-            color: EllaColors.textPrimary,
-          ),
+        title: Text(
+          context.l10n.voiceChatTitle,
+          style: const TextStyle(fontSize: 22, fontWeight: FontWeight.w600, color: EllaColors.textPrimary),
         ),
         elevation: 0,
         centerTitle: true,
@@ -931,13 +1045,36 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
+            if (_sessionScope != null && widget.memoryTitle?.trim().isNotEmpty == true) ...[
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 8, 24, 0),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                  decoration: BoxDecoration(
+                    color: EllaColors.card,
+                    borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+                    border: Border.all(color: EllaColors.cardDeep),
+                  ),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.auto_stories_outlined, size: 20, color: EllaColors.primary),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: Text(
+                          context.l10n.memoryTalkContext(widget.memoryTitle!.trim()),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: EllaTextStyles.caption.copyWith(fontWeight: FontWeight.w600),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
             const Spacer(flex: 2),
             Center(
-              child: EllaVoiceOrb(
-                state: _orbState,
-                audioLevel: _audioLevel,
-                onTap: _onOrbTap,
-              ),
+              child: EllaVoiceOrb(state: _orbState, audioLevel: _audioLevel, onTap: _onOrbTap),
             ),
             const SizedBox(height: 24),
             Center(
@@ -951,10 +1088,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    if (_orbState == VoiceOrbState.listening) ...[
-                      const EllaBreathingDot(),
-                      const SizedBox(width: 10),
-                    ],
+                    if (_orbState == VoiceOrbState.listening) ...[const EllaBreathingDot(), const SizedBox(width: 10)],
                     Text(
                       _orbState == VoiceOrbState.listening
                           ? _usingElevenLabsFallback
@@ -970,6 +1104,10 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
                 ),
               ),
             ),
+            if (_memoryCorrectionReceipt != null) ...[
+              const SizedBox(height: 12),
+              MemoryCorrectionReceiptChip(receipt: _memoryCorrectionReceipt!, onReview: _reviewMemoryCorrection),
+            ],
             const SizedBox(height: 16),
             SizedBox(
               height: 100,

--- a/app/lib/ella/services/v2v_client.dart
+++ b/app/lib/ella/services/v2v_client.dart
@@ -16,12 +16,115 @@ import 'package:omi/env/env.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 
+enum V2VSessionScopeKind { memory }
+
+@immutable
+class V2VSessionScope {
+  const V2VSessionScope.memory({required this.conversationId, this.expectedActiveSummaryVersionId})
+      : kind = V2VSessionScopeKind.memory;
+
+  final V2VSessionScopeKind kind;
+  final String conversationId;
+  final String? expectedActiveSummaryVersionId;
+
+  Map<String, dynamic> toJson() => {
+        'kind': kind.name,
+        'conversation_id': conversationId,
+        if (expectedActiveSummaryVersionId?.isNotEmpty == true)
+          'expected_active_summary_version_id': expectedActiveSummaryVersionId,
+      };
+
+  V2VSessionScope withExpectedActiveSummaryVersionId(String? value) =>
+      V2VSessionScope.memory(conversationId: conversationId, expectedActiveSummaryVersionId: value);
+}
+
+@immutable
+class V2VResolvedSessionScope {
+  const V2VResolvedSessionScope({
+    required this.kind,
+    required this.conversationId,
+    required this.activeSummaryVersionId,
+    required this.canReinterpret,
+  });
+
+  final V2VSessionScopeKind kind;
+  final String conversationId;
+  final String activeSummaryVersionId;
+  final bool canReinterpret;
+
+  static V2VResolvedSessionScope? tryParse(Object? value) {
+    if (value is! Map) return null;
+    final kind = value['kind']?.toString();
+    final conversationId = value['conversation_id']?.toString().trim() ?? '';
+    final activeSummaryVersionId = value['active_summary_version_id']?.toString().trim() ?? '';
+    final canReinterpret = value['can_reinterpret'];
+    if (kind != V2VSessionScopeKind.memory.name ||
+        conversationId.isEmpty ||
+        activeSummaryVersionId.isEmpty ||
+        canReinterpret is! bool) {
+      return null;
+    }
+    return V2VResolvedSessionScope(
+      kind: V2VSessionScopeKind.memory,
+      conversationId: conversationId,
+      activeSummaryVersionId: activeSummaryVersionId,
+      canReinterpret: canReinterpret,
+    );
+  }
+
+  bool matches(V2VSessionScope requested) => kind == requested.kind && conversationId == requested.conversationId;
+}
+
+@immutable
+class MemoryReinterpretationEvent {
+  const MemoryReinterpretationEvent({
+    required this.state,
+    required this.sessionId,
+    required this.conversationId,
+    required this.correctionId,
+    this.traceId = '',
+    this.status = '',
+    this.pollAfter = const Duration(milliseconds: 750),
+  });
+
+  final String state;
+  final String sessionId;
+  final String conversationId;
+  final String correctionId;
+  final String traceId;
+  final String status;
+  final Duration pollAfter;
+
+  static MemoryReinterpretationEvent? tryParse(Object? value) {
+    if (value is! Map) return null;
+    final state = value['state']?.toString().trim() ?? '';
+    final sessionId = value['session_id']?.toString().trim() ?? '';
+    final conversationId = value['conversation_id']?.toString().trim() ?? '';
+    final correctionId = value['correction_id']?.toString().trim() ?? '';
+    if (state.isEmpty || sessionId.isEmpty || conversationId.isEmpty || correctionId.isEmpty) {
+      return null;
+    }
+    final rawPollAfter = value['poll_after_ms'];
+    final pollAfterMs = rawPollAfter is num ? rawPollAfter.toInt().clamp(500, 5000) : 750;
+    return MemoryReinterpretationEvent(
+      state: state,
+      sessionId: sessionId,
+      conversationId: conversationId,
+      correctionId: correctionId,
+      traceId: value['trace_id']?.toString().trim() ?? '',
+      status: value['status']?.toString().trim() ?? '',
+      pollAfter: Duration(milliseconds: pollAfterMs),
+    );
+  }
+}
+
 /// JSON event from the V2V proxy WebSocket.
 class V2VEvent {
+  const V2VEvent({required this.type, this.text, this.memoryReinterpretation});
+
   final String type;
   final String? text;
-
-  V2VEvent({required this.type, this.text});
+  final MemoryReinterpretationEvent? memoryReinterpretation;
 }
 
 enum V2VConnectionStage { consent, identity, providerRegistry, session, audioSession, websocket, microphone, connected }
@@ -34,6 +137,8 @@ class V2VConnectionReceipt {
     required this.provider,
     required this.stage,
     this.voiceMode = '',
+    this.sessionId = '',
+    this.sessionScope,
     this.httpStatus,
     this.errorCode = '',
   });
@@ -41,15 +146,16 @@ class V2VConnectionReceipt {
   final bool connected;
   final String provider;
   final String voiceMode;
+  final String sessionId;
+  final V2VResolvedSessionScope? sessionScope;
   final V2VConnectionStage stage;
   final int? httpStatus;
   final String errorCode;
 
+  bool get shouldRefreshMemoryScope => stage == V2VConnectionStage.session && errorCode == 'voice_session_scope_stale';
+
   String get safeDetail {
-    final parts = <String>[
-      if (httpStatus != null) 'HTTP $httpStatus',
-      if (errorCode.isNotEmpty) errorCode,
-    ];
+    final parts = <String>[if (httpStatus != null) 'HTTP $httpStatus', if (errorCode.isNotEmpty) errorCode];
     return parts.isEmpty ? stage.name : parts.join(' · ');
   }
 
@@ -58,6 +164,9 @@ class V2VConnectionReceipt {
         'provider': provider,
         'voice_mode': voiceMode,
         'stage': stage.name,
+        if (sessionId.isNotEmpty) 'session_id': sessionId,
+        if (sessionScope != null) 'scope_kind': sessionScope!.kind.name,
+        if (sessionScope != null) 'scope_conversation_id': sessionScope!.conversationId,
         if (httpStatus != null) 'http_status': httpStatus,
         if (errorCode.isNotEmpty) 'error_code': errorCode,
       };
@@ -137,12 +246,19 @@ class V2VClient {
       normalizeProvider(provider) == 'grok-voice' ||
       normalizeProvider(provider) == 'gemini-native-live';
 
-  static String? sessionVoiceMode(String provider) => switch (normalizeProvider(provider)) {
+  static String? sessionVoiceMode(String provider, {bool memoryScoped = false}) =>
+      switch (normalizeProvider(provider)) {
+        'grok-voice' when memoryScoped => 'v4',
         'openclaw-direct' => 'openclaw-direct-v1',
         'openai-native-realtime' => 'openai-native-realtime-v1',
         'gemini-native-live' => 'gemini-native-live-v1',
         _ => null,
       };
+
+  static bool isMemoryScopedProvider(String provider) {
+    final normalized = normalizeProvider(provider);
+    return normalized == 'grok-voice' || normalized == 'gemini-native-live';
+  }
 
   static String providerDisplayName(String provider) => switch (normalizeProvider(provider)) {
         'grok-voice' => 'Grok Native Realtime',
@@ -162,14 +278,30 @@ class V2VClient {
     required String uid,
     required String provider,
     required bool includeUid,
+    V2VSessionScope? sessionScope,
   }) {
     final canonicalProvider = normalizeProvider(provider);
-    final voiceMode = sessionVoiceMode(canonicalProvider);
+    final voiceMode = sessionVoiceMode(canonicalProvider, memoryScoped: sessionScope != null);
     return {
       if (includeUid) 'uid': uid,
       'provider': canonicalProvider,
       if (voiceMode != null) 'voice_mode': voiceMode,
+      if (sessionScope != null) 'session_scope': sessionScope.toJson(),
     };
+  }
+
+  @visibleForTesting
+  static String sessionFailureCode({required int? statusCode, required String body, V2VSessionScope? sessionScope}) {
+    if (sessionScope != null && statusCode == 404) {
+      return 'voice_session_scope_unavailable';
+    }
+    final code = safeErrorCode(body, fallback: 'session_request_failed');
+    if (sessionScope != null &&
+        statusCode == 409 &&
+        (code == 'voice_session_scope_stale' || code == 'voice_session_scope_version_unavailable')) {
+      return 'voice_session_scope_stale';
+    }
+    return code;
   }
 
   @visibleForTesting
@@ -227,7 +359,7 @@ class V2VClient {
   }
 
   /// Start a V2V session: get session token, connect WebSocket, start audio.
-  Future<V2VConnectionReceipt> connect({required String provider}) async {
+  Future<V2VConnectionReceipt> connect({required String provider, V2VSessionScope? sessionScope}) async {
     provider = normalizeProvider(provider);
     if (_activeClient != null && _activeClient != this) {
       Logger.debug('[V2V] Closing existing active V2V client before provider=$provider connect');
@@ -242,33 +374,49 @@ class V2VClient {
     }
 
     if (!SharedPreferencesUtil().aiConsentAccepted) {
-      return _completeReceipt(V2VConnectionReceipt(
-        connected: false,
-        provider: provider,
-        stage: V2VConnectionStage.consent,
-        errorCode: 'ai_consent_required',
-      ));
+      return _completeReceipt(
+        V2VConnectionReceipt(
+          connected: false,
+          provider: provider,
+          stage: V2VConnectionStage.consent,
+          errorCode: 'ai_consent_required',
+        ),
+      );
     }
 
     if (!isSessionProvider(provider)) {
-      return _completeReceipt(V2VConnectionReceipt(
-        connected: false,
-        provider: provider,
-        stage: V2VConnectionStage.providerRegistry,
-        errorCode: 'unsupported_provider',
-      ));
+      return _completeReceipt(
+        V2VConnectionReceipt(
+          connected: false,
+          provider: provider,
+          stage: V2VConnectionStage.providerRegistry,
+          errorCode: 'unsupported_provider',
+        ),
+      );
+    }
+    if (sessionScope != null && !isMemoryScopedProvider(provider)) {
+      return _completeReceipt(
+        V2VConnectionReceipt(
+          connected: false,
+          provider: provider,
+          stage: V2VConnectionStage.providerRegistry,
+          errorCode: 'memory_scope_provider_unsupported',
+        ),
+      );
     }
 
     final uid = SharedPreferencesUtil().uid;
     if (uid.isEmpty) {
       Logger.debug('[V2V] No uid, cannot connect');
       if (_activeClient == this) _activeClient = null;
-      return _completeReceipt(V2VConnectionReceipt(
-        connected: false,
-        provider: provider,
-        stage: V2VConnectionStage.identity,
-        errorCode: 'missing_authenticated_identity',
-      ));
+      return _completeReceipt(
+        V2VConnectionReceipt(
+          connected: false,
+          provider: provider,
+          stage: V2VConnectionStage.identity,
+          errorCode: 'missing_authenticated_identity',
+        ),
+      );
     }
 
     final registryFailure = await _validateProviderRegistry(provider);
@@ -278,7 +426,7 @@ class V2VClient {
     }
 
     // 1. Get session token from backend
-    final sessionResult = await _createSession(uid, provider);
+    final sessionResult = await _createSession(uid, provider, sessionScope);
     final sessionData = sessionResult.data;
     if (sessionData == null) {
       if (_activeClient == this) _activeClient = null;
@@ -288,29 +436,50 @@ class V2VClient {
     final token = sessionData['session_token'] as String? ?? '';
     final endpoint = sessionData['voice_endpoint'] as String? ?? '';
     final confirmedProvider = normalizeProvider(sessionData['provider'] as String? ?? provider);
-    final confirmedVoiceMode = sessionData['voice_mode'] as String? ?? sessionVoiceMode(provider) ?? '';
+    final confirmedVoiceMode =
+        sessionData['voice_mode'] as String? ?? sessionVoiceMode(provider, memoryScoped: sessionScope != null) ?? '';
+    final sessionId = sessionData['session_id']?.toString().trim() ?? '';
+    final confirmedScope = V2VResolvedSessionScope.tryParse(sessionData['session_scope']);
     if (token.isEmpty || endpoint.isEmpty) {
       Logger.debug('[V2V] Invalid session data');
       if (_activeClient == this) _activeClient = null;
-      return _completeReceipt(V2VConnectionReceipt(
-        connected: false,
-        provider: provider,
-        voiceMode: confirmedVoiceMode,
-        stage: V2VConnectionStage.session,
-        httpStatus: 200,
-        errorCode: 'invalid_session_contract',
-      ));
+      return _completeReceipt(
+        V2VConnectionReceipt(
+          connected: false,
+          provider: provider,
+          voiceMode: confirmedVoiceMode,
+          stage: V2VConnectionStage.session,
+          httpStatus: 200,
+          errorCode: 'invalid_session_contract',
+        ),
+      );
     }
     if (confirmedProvider != provider) {
       if (_activeClient == this) _activeClient = null;
-      return _completeReceipt(V2VConnectionReceipt(
-        connected: false,
-        provider: provider,
-        voiceMode: confirmedVoiceMode,
-        stage: V2VConnectionStage.session,
-        httpStatus: 200,
-        errorCode: 'provider_mismatch',
-      ));
+      return _completeReceipt(
+        V2VConnectionReceipt(
+          connected: false,
+          provider: provider,
+          voiceMode: confirmedVoiceMode,
+          stage: V2VConnectionStage.session,
+          httpStatus: 200,
+          errorCode: 'provider_mismatch',
+        ),
+      );
+    }
+    if (sessionScope != null &&
+        (sessionId.isEmpty || confirmedScope == null || !confirmedScope.matches(sessionScope))) {
+      if (_activeClient == this) _activeClient = null;
+      return _completeReceipt(
+        V2VConnectionReceipt(
+          connected: false,
+          provider: provider,
+          voiceMode: confirmedVoiceMode,
+          stage: V2VConnectionStage.session,
+          httpStatus: 200,
+          errorCode: 'invalid_session_scope',
+        ),
+      );
     }
 
     // 2. Configure iOS audio session for playAndRecord with Bluetooth + speaker routing
@@ -319,13 +488,15 @@ class V2VClient {
     } catch (error) {
       Logger.error('[V2V] Audio session setup failed for provider=$provider');
       if (_activeClient == this) _activeClient = null;
-      return _completeReceipt(V2VConnectionReceipt(
-        connected: false,
-        provider: provider,
-        voiceMode: confirmedVoiceMode,
-        stage: V2VConnectionStage.audioSession,
-        errorCode: _safeExceptionCode(error, fallback: 'audio_session_failed'),
-      ));
+      return _completeReceipt(
+        V2VConnectionReceipt(
+          connected: false,
+          provider: provider,
+          voiceMode: confirmedVoiceMode,
+          stage: V2VConnectionStage.audioSession,
+          errorCode: _safeExceptionCode(error, fallback: 'audio_session_failed'),
+        ),
+      );
     }
 
     // 3. Connect WebSocket
@@ -333,10 +504,7 @@ class V2VClient {
     Logger.debug('[V2V] Connecting to WebSocket for provider=$provider...');
 
     try {
-      _channel = IOWebSocketChannel.connect(
-        Uri.parse(wsUrl),
-        pingInterval: const Duration(seconds: 30),
-      );
+      _channel = IOWebSocketChannel.connect(Uri.parse(wsUrl), pingInterval: const Duration(seconds: 30));
 
       await _channel!.ready.timeout(const Duration(seconds: 12));
 
@@ -362,33 +530,41 @@ class V2VClient {
       final micStarted = await _startMicStream();
       if (!micStarted || !_isConnected) {
         await disconnect();
-        return _completeReceipt(V2VConnectionReceipt(
-          connected: false,
-          provider: provider,
-          voiceMode: confirmedVoiceMode,
-          stage: micStarted ? V2VConnectionStage.websocket : V2VConnectionStage.microphone,
-          errorCode: micStarted ? 'websocket_closed' : 'microphone_unavailable',
-        ));
+        return _completeReceipt(
+          V2VConnectionReceipt(
+            connected: false,
+            provider: provider,
+            voiceMode: confirmedVoiceMode,
+            stage: micStarted ? V2VConnectionStage.websocket : V2VConnectionStage.microphone,
+            errorCode: micStarted ? 'websocket_closed' : 'microphone_unavailable',
+          ),
+        );
       }
       _connectionAnnounced = true;
       onConnectionChanged?.call(true);
 
-      return _completeReceipt(V2VConnectionReceipt(
-        connected: true,
-        provider: provider,
-        voiceMode: confirmedVoiceMode,
-        stage: V2VConnectionStage.connected,
-      ));
+      return _completeReceipt(
+        V2VConnectionReceipt(
+          connected: true,
+          provider: provider,
+          voiceMode: confirmedVoiceMode,
+          sessionId: sessionId,
+          sessionScope: confirmedScope,
+          stage: V2VConnectionStage.connected,
+        ),
+      );
     } catch (error) {
       Logger.error('[V2V] WebSocket handshake failed for provider=$provider');
       await disconnect();
-      return _completeReceipt(V2VConnectionReceipt(
-        connected: false,
-        provider: provider,
-        voiceMode: confirmedVoiceMode,
-        stage: V2VConnectionStage.websocket,
-        errorCode: _safeExceptionCode(error, fallback: 'websocket_handshake_failed'),
-      ));
+      return _completeReceipt(
+        V2VConnectionReceipt(
+          connected: false,
+          provider: provider,
+          voiceMode: confirmedVoiceMode,
+          stage: V2VConnectionStage.websocket,
+          errorCode: _safeExceptionCode(error, fallback: 'websocket_handshake_failed'),
+        ),
+      );
     }
   }
 
@@ -472,16 +648,18 @@ class V2VClient {
 
   Future<void> _configureAudioSession() async {
     final session = await AudioSession.instance;
-    await session.configure(AudioSessionConfiguration(
-      avAudioSessionCategory: AVAudioSessionCategory.playAndRecord,
-      avAudioSessionCategoryOptions: AVAudioSessionCategoryOptions.defaultToSpeaker |
-          AVAudioSessionCategoryOptions.allowBluetooth |
-          AVAudioSessionCategoryOptions.allowBluetoothA2dp |
-          AVAudioSessionCategoryOptions.allowAirPlay,
-      avAudioSessionMode: AVAudioSessionMode.defaultMode,
-      avAudioSessionRouteSharingPolicy: AVAudioSessionRouteSharingPolicy.defaultPolicy,
-      avAudioSessionSetActiveOptions: AVAudioSessionSetActiveOptions.none,
-    ));
+    await session.configure(
+      AudioSessionConfiguration(
+        avAudioSessionCategory: AVAudioSessionCategory.playAndRecord,
+        avAudioSessionCategoryOptions: AVAudioSessionCategoryOptions.defaultToSpeaker |
+            AVAudioSessionCategoryOptions.allowBluetooth |
+            AVAudioSessionCategoryOptions.allowBluetoothA2dp |
+            AVAudioSessionCategoryOptions.allowAirPlay,
+        avAudioSessionMode: AVAudioSessionMode.defaultMode,
+        avAudioSessionRouteSharingPolicy: AVAudioSessionRouteSharingPolicy.defaultPolicy,
+        avAudioSessionSetActiveOptions: AVAudioSessionSetActiveOptions.none,
+      ),
+    );
     await session.setActive(true);
     Logger.debug('[V2V] Audio session: playAndRecord + defaultToSpeaker + BT + AirPlay');
   }
@@ -520,14 +698,15 @@ class V2VClient {
     return null;
   }
 
-  Future<_V2VSessionResult> _createSession(String uid, String provider) async {
+  Future<_V2VSessionResult> _createSession(String uid, String provider, V2VSessionScope? sessionScope) async {
     try {
       provider = normalizeProvider(provider);
-      final voiceMode = sessionVoiceMode(provider);
+      final voiceMode = sessionVoiceMode(provider, memoryScoped: sessionScope != null);
       final requestBody = buildSessionRequestBody(
         uid: uid,
         provider: provider,
         includeUid: !isHermesProvisioningGateEnabled,
+        sessionScope: sessionScope,
       );
 
       final response = await makeApiCall(
@@ -549,7 +728,7 @@ class V2VClient {
             httpStatus: response?.statusCode,
             errorCode: response == null
                 ? 'session_request_failed'
-                : safeErrorCode(response.body, fallback: 'session_request_failed'),
+                : sessionFailureCode(statusCode: response.statusCode, body: response.body, sessionScope: sessionScope),
           ),
         );
       }
@@ -563,6 +742,8 @@ class V2VClient {
           provider: provider,
           voiceMode: data['voice_mode'] as String? ?? voiceMode ?? '',
           stage: V2VConnectionStage.session,
+          sessionId: data['session_id']?.toString() ?? '',
+          sessionScope: V2VResolvedSessionScope.tryParse(data['session_scope']),
           httpStatus: response.statusCode,
         ),
       );
@@ -572,7 +753,7 @@ class V2VClient {
         receipt: V2VConnectionReceipt(
           connected: false,
           provider: provider,
-          voiceMode: sessionVoiceMode(provider) ?? '',
+          voiceMode: sessionVoiceMode(provider, memoryScoped: sessionScope != null) ?? '',
           stage: V2VConnectionStage.session,
           errorCode: _safeExceptionCode(error, fallback: 'session_request_failed'),
         ),
@@ -708,14 +889,16 @@ class V2VClient {
         return false;
       }
 
-      final stream = await _recorder!.startStream(const RecordConfig(
-        encoder: AudioEncoder.pcm16bits,
-        sampleRate: 24000,
-        numChannels: 1,
-        autoGain: true,
-        echoCancel: true,
-        noiseSuppress: true,
-      ));
+      final stream = await _recorder!.startStream(
+        const RecordConfig(
+          encoder: AudioEncoder.pcm16bits,
+          sampleRate: 24000,
+          numChannels: 1,
+          autoGain: true,
+          echoCancel: true,
+          noiseSuppress: true,
+        ),
+      );
 
       _micChunksSent = 0;
       _micBytesSent = 0;
@@ -984,6 +1167,12 @@ class V2VClient {
           case 'function_calling':
           case 'function_executed':
             onEvent?.call(V2VEvent(type: type, text: text ?? json.toString()));
+            break;
+          case 'memory_reinterpretation':
+            final memoryReinterpretation = MemoryReinterpretationEvent.tryParse(json);
+            if (memoryReinterpretation != null) {
+              onEvent?.call(V2VEvent(type: type, memoryReinterpretation: memoryReinterpretation));
+            }
             break;
           case 'session_end':
             onEvent?.call(V2VEvent(type: 'session_end', text: text));

--- a/app/lib/ella/widgets/ai_consent_sheet.dart
+++ b/app/lib/ella/widgets/ai_consent_sheet.dart
@@ -63,10 +63,7 @@ class _AiConsentSheetState extends State<AiConsentSheet> {
 
   @override
   Widget build(BuildContext context) {
-    final bodyStyle = Theme.of(context).textTheme.bodyLarge?.copyWith(
-          color: EllaColors.textSecondary,
-          height: 1.5,
-        );
+    final bodyStyle = Theme.of(context).textTheme.bodyLarge?.copyWith(color: EllaColors.textSecondary, height: 1.5);
     return PopScope(
       canPop: false,
       child: SingleChildScrollView(
@@ -75,22 +72,29 @@ class _AiConsentSheetState extends State<AiConsentSheet> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              context.l10n.aiConsentTitle,
-              style: EllaTextStyles.display,
-            ),
+            Text(context.l10n.aiConsentTitle, style: EllaTextStyles.display),
             const SizedBox(height: 16),
             Text.rich(
               TextSpan(
                 style: bodyStyle,
                 children: [
                   TextSpan(text: context.l10n.aiConsentBodyIntro),
-                  TextSpan(text: context.l10n.aiConsentDeepgram, style: const TextStyle(fontWeight: FontWeight.w700)),
+                  TextSpan(
+                    text: context.l10n.aiConsentDeepgram,
+                    style: const TextStyle(fontWeight: FontWeight.w700),
+                  ),
                   TextSpan(text: context.l10n.aiConsentBodyMiddle),
-                  TextSpan(text: context.l10n.aiConsentAiPartners, style: const TextStyle(fontWeight: FontWeight.w700)),
+                  TextSpan(
+                    text: context.l10n.aiConsentAiPartners,
+                    style: const TextStyle(fontWeight: FontWeight.w700),
+                  ),
                   TextSpan(text: context.l10n.aiConsentBodyBeforeElevenLabs),
-                  TextSpan(text: context.l10n.aiConsentElevenLabs, style: const TextStyle(fontWeight: FontWeight.w700)),
+                  TextSpan(
+                    text: context.l10n.aiConsentElevenLabs,
+                    style: const TextStyle(fontWeight: FontWeight.w700),
+                  ),
                   TextSpan(text: context.l10n.aiConsentBodyEnd),
+                  TextSpan(text: context.l10n.aiConsentMemoryContext),
                 ],
               ),
             ),
@@ -108,10 +112,7 @@ class _AiConsentSheetState extends State<AiConsentSheet> {
             ),
             const SizedBox(height: 28),
             if (_hasError) ...[
-              Text(
-                context.l10n.somethingWentWrongTryAgain,
-                style: bodyStyle?.copyWith(color: EllaColors.error),
-              ),
+              Text(context.l10n.somethingWentWrongTryAgain, style: bodyStyle?.copyWith(color: EllaColors.error)),
               const SizedBox(height: 12),
             ],
             SizedBox(
@@ -140,7 +141,7 @@ class _AiConsentSheetState extends State<AiConsentSheet> {
                 onPressed: _isSubmitting
                     ? null
                     : () {
-                        SharedPreferencesUtil().declineAiConsent();
+                        SharedPreferencesUtil().deferAiConsent();
                         Navigator.of(context).pop(false);
                       },
                 child: Text(

--- a/app/lib/ella/widgets/memory_correction_receipt.dart
+++ b/app/lib/ella/widgets/memory_correction_receipt.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+
+import 'package:omi/backend/http/api/conversations.dart';
+import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+
+class MemoryCorrectionReceiptChip extends StatelessWidget {
+  const MemoryCorrectionReceiptChip({required this.receipt, required this.onReview, super.key});
+
+  final ConversationCorrectionReceipt receipt;
+  final VoidCallback onReview;
+
+  @override
+  Widget build(BuildContext context) {
+    final (icon, label) = switch (receipt) {
+      ConversationCorrectionReceipt(isPending: true) => (Icons.sync_rounded, context.l10n.memoryCorrectionPending),
+      ConversationCorrectionReceipt(isApplied: true) => (
+          Icons.check_circle_outline_rounded,
+          context.l10n.memoryCorrectionApplied,
+        ),
+      ConversationCorrectionReceipt(isUndone: true) => (Icons.undo_rounded, context.l10n.memoryCorrectionUndone),
+      _ => (Icons.error_outline_rounded, context.l10n.memoryCorrectionFailed),
+    };
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 24),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: EllaColors.card,
+        borderRadius: BorderRadius.circular(EllaSizes.radiusCircular),
+        border: Border.all(color: EllaColors.cardDeep),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (receipt.isPending)
+            const SizedBox(
+              width: 18,
+              height: 18,
+              child: CircularProgressIndicator(strokeWidth: 2, color: EllaColors.primary),
+            )
+          else
+            Icon(icon, size: 19, color: EllaColors.primary),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(label, style: EllaTextStyles.caption.copyWith(fontWeight: FontWeight.w600)),
+          ),
+          if (receipt.isApplied) ...[
+            const SizedBox(width: 8),
+            TextButton(onPressed: onReview, child: Text(context.l10n.memoryCorrectionReview)),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+Future<void> showMemoryCorrectionReceiptSheet(
+  BuildContext context, {
+  required ConversationCorrectionReceipt receipt,
+  required Future<ConversationCorrectionReceipt?> Function() onUndo,
+}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    builder: (_) => _MemoryCorrectionReceiptSheet(receipt: receipt, onUndo: onUndo),
+  );
+}
+
+class _MemoryCorrectionReceiptSheet extends StatefulWidget {
+  const _MemoryCorrectionReceiptSheet({required this.receipt, required this.onUndo});
+
+  final ConversationCorrectionReceipt receipt;
+  final Future<ConversationCorrectionReceipt?> Function() onUndo;
+
+  @override
+  State<_MemoryCorrectionReceiptSheet> createState() => _MemoryCorrectionReceiptSheetState();
+}
+
+class _MemoryCorrectionReceiptSheetState extends State<_MemoryCorrectionReceiptSheet> {
+  late ConversationCorrectionReceipt _receipt = widget.receipt;
+  bool _undoing = false;
+
+  Future<void> _undo() async {
+    if (_undoing) return;
+    setState(() => _undoing = true);
+    final updated = await widget.onUndo();
+    if (!mounted) return;
+    setState(() {
+      _undoing = false;
+      if (updated != null) _receipt = updated;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        color: EllaColors.bgPrimary,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+      ),
+      padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+      child: SafeArea(
+        top: false,
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Container(
+                  width: 44,
+                  height: 4,
+                  decoration: BoxDecoration(color: EllaColors.bgTertiary, borderRadius: BorderRadius.circular(999)),
+                ),
+              ),
+              const SizedBox(height: 20),
+              Text(context.l10n.memoryCorrectionReviewTitle, style: EllaTextStyles.display),
+              const SizedBox(height: 18),
+              _SummaryBlock(label: context.l10n.memoryCorrectionBefore, summary: _receipt.before),
+              const SizedBox(height: 14),
+              _SummaryBlock(label: context.l10n.memoryCorrectionAfter, summary: _receipt.after),
+              if (_receipt.isApplied) ...[
+                const SizedBox(height: 20),
+                SizedBox(
+                  width: double.infinity,
+                  child: OutlinedButton.icon(
+                    onPressed: _undoing ? null : _undo,
+                    icon: _undoing
+                        ? const SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2))
+                        : const Icon(Icons.undo_rounded),
+                    label: Text(context.l10n.memoryCorrectionUndo),
+                  ),
+                ),
+              ],
+              if (_receipt.isUndone) ...[
+                const SizedBox(height: 18),
+                Text(
+                  context.l10n.memoryCorrectionUndone,
+                  style: EllaTextStyles.body.copyWith(fontWeight: FontWeight.w600),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryBlock extends StatelessWidget {
+  const _SummaryBlock({required this.label, required this.summary});
+
+  final String label;
+  final ConversationCorrectionSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: EllaColors.card,
+        borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+        border: Border.all(color: EllaColors.cardDeep),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: EllaTextStyles.caption.copyWith(fontWeight: FontWeight.w700)),
+          if (summary.title.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Text(summary.title, style: EllaTextStyles.body.copyWith(fontWeight: FontWeight.w700)),
+          ],
+          if (summary.overview.isNotEmpty) ...[
+            const SizedBox(height: 6),
+            Text(summary.overview, style: EllaTextStyles.secondary),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/ella/widgets/v2v_fallback_dialog.dart
+++ b/app/lib/ella/widgets/v2v_fallback_dialog.dart
@@ -17,9 +17,10 @@ String localizedV2VProviderName(BuildContext context, String provider) {
 }
 
 class V2VFallbackDialog extends StatelessWidget {
-  const V2VFallbackDialog({required this.receipt, super.key});
+  const V2VFallbackDialog({required this.receipt, this.allowStandardFallback = true, super.key});
 
   final V2VConnectionReceipt receipt;
+  final bool allowStandardFallback;
 
   @override
   Widget build(BuildContext context) {
@@ -31,18 +32,18 @@ class V2VFallbackDialog extends StatelessWidget {
         style: EllaTextStyles.display.copyWith(fontSize: 22),
       ),
       content: Text(
-        context.l10n.voiceV2vUnavailableBody(receipt.stage.name, receipt.safeDetail),
+        allowStandardFallback
+            ? context.l10n.voiceV2vUnavailableBody(receipt.stage.name, receipt.safeDetail)
+            : context.l10n.memoryTalkUnavailable,
         style: EllaTextStyles.body,
       ),
       actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(V2VFailureChoice.stop),
-          child: Text(context.l10n.notNow),
-        ),
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(V2VFailureChoice.useElevenLabs),
-          child: Text(context.l10n.voiceUseElevenLabs),
-        ),
+        TextButton(onPressed: () => Navigator.of(context).pop(V2VFailureChoice.stop), child: Text(context.l10n.notNow)),
+        if (allowStandardFallback)
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(V2VFailureChoice.useElevenLabs),
+            child: Text(context.l10n.voiceUseElevenLabs),
+          ),
         FilledButton(
           onPressed: () => Navigator.of(context).pop(V2VFailureChoice.retry),
           child: Text(context.l10n.retry),
@@ -54,12 +55,13 @@ class V2VFallbackDialog extends StatelessWidget {
 
 Future<V2VFailureChoice> showV2VFallbackDialog(
   BuildContext context,
-  V2VConnectionReceipt receipt,
-) async {
+  V2VConnectionReceipt receipt, {
+  bool allowStandardFallback = true,
+}) async {
   return await showDialog<V2VFailureChoice>(
         context: context,
         barrierDismissible: false,
-        builder: (_) => V2VFallbackDialog(receipt: receipt),
+        builder: (_) => V2VFallbackDialog(receipt: receipt, allowStandardFallback: allowStandardFallback),
       ) ??
       V2VFailureChoice.stop;
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10172,6 +10172,67 @@
   "@voiceProviderOpenClawDirect": {
     "description": "OpenClaw direct provider label"
   },
+  "memoryTalkAction": "Talk about this",
+  "@memoryTalkAction": {
+    "description": "Action on a memory that opens a memory-scoped realtime voice session"
+  },
+  "memoryTalkContext": "Talking about: {title}",
+  "@memoryTalkContext": {
+    "description": "Presentation-only context header for a memory-scoped voice session",
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "memoryTalkUnavailable": "This memory is unavailable for voice right now. Refresh it and try again.",
+  "@memoryTalkUnavailable": {
+    "description": "Privacy-preserving missing or non-owned memory scope error"
+  },
+  "memoryTalkStale": "This memory changed. Ella is refreshing it before reconnecting.",
+  "@memoryTalkStale": {
+    "description": "Status shown while a stale memory scope is refreshed"
+  },
+  "memoryTalkProviderRequired": "Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.",
+  "@memoryTalkProviderRequired": {
+    "description": "Error shown when the selected voice provider cannot open memory-scoped V2V"
+  },
+  "memoryCorrectionPending": "Ella is updating this memory",
+  "@memoryCorrectionPending": {
+    "description": "Pending memory reinterpretation receipt status"
+  },
+  "memoryCorrectionApplied": "Memory updated",
+  "@memoryCorrectionApplied": {
+    "description": "Applied memory reinterpretation receipt status"
+  },
+  "memoryCorrectionFailed": "Ella couldn't update this memory",
+  "@memoryCorrectionFailed": {
+    "description": "Failed memory reinterpretation receipt status"
+  },
+  "memoryCorrectionReview": "Review",
+  "@memoryCorrectionReview": {
+    "description": "Action that opens a correction receipt"
+  },
+  "memoryCorrectionReviewTitle": "Memory update",
+  "@memoryCorrectionReviewTitle": {
+    "description": "Title for the correction receipt review sheet"
+  },
+  "memoryCorrectionBefore": "Before",
+  "@memoryCorrectionBefore": {
+    "description": "Label for the previous memory summary"
+  },
+  "memoryCorrectionAfter": "After",
+  "@memoryCorrectionAfter": {
+    "description": "Label for the updated memory summary"
+  },
+  "memoryCorrectionUndo": "Undo update",
+  "@memoryCorrectionUndo": {
+    "description": "Action that undoes an applied memory correction"
+  },
+  "memoryCorrectionUndone": "Memory update undone",
+  "@memoryCorrectionUndone": {
+    "description": "Status shown after a memory correction is undone"
+  },
   "ellaAddCaregiverErrorNameRequired": "Name is required",
   "ellaAddCaregiverErrorEmailRequired": "Email is required",
   "ellaAddCaregiverErrorEmailInvalid": "Please enter a valid email",
@@ -10295,6 +10356,10 @@
   "aiConsentBodyBeforeElevenLabs": ". OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ",
   "@aiConsentBodyBeforeElevenLabs": {
     "description": "Locked consent body explaining model routing and live voice before naming the TTS processor"
+  },
+  "aiConsentMemoryContext": " When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella's secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.",
+  "@aiConsentMemoryContext": {
+    "description": "Version 3 disclosure for selected stored memory context sent to a named realtime voice processor"
   },
   "aiConsentElevenLabs": "ElevenLabs",
   "@aiConsentElevenLabs": {

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -15789,6 +15789,90 @@ abstract class AppLocalizations {
   /// **'OpenClaw Direct'**
   String get voiceProviderOpenClawDirect;
 
+  /// Action on a memory that opens a memory-scoped realtime voice session
+  ///
+  /// In en, this message translates to:
+  /// **'Talk about this'**
+  String get memoryTalkAction;
+
+  /// Presentation-only context header for a memory-scoped voice session
+  ///
+  /// In en, this message translates to:
+  /// **'Talking about: {title}'**
+  String memoryTalkContext(String title);
+
+  /// Privacy-preserving missing or non-owned memory scope error
+  ///
+  /// In en, this message translates to:
+  /// **'This memory is unavailable for voice right now. Refresh it and try again.'**
+  String get memoryTalkUnavailable;
+
+  /// Status shown while a stale memory scope is refreshed
+  ///
+  /// In en, this message translates to:
+  /// **'This memory changed. Ella is refreshing it before reconnecting.'**
+  String get memoryTalkStale;
+
+  /// Error shown when the selected voice provider cannot open memory-scoped V2V
+  ///
+  /// In en, this message translates to:
+  /// **'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.'**
+  String get memoryTalkProviderRequired;
+
+  /// Pending memory reinterpretation receipt status
+  ///
+  /// In en, this message translates to:
+  /// **'Ella is updating this memory'**
+  String get memoryCorrectionPending;
+
+  /// Applied memory reinterpretation receipt status
+  ///
+  /// In en, this message translates to:
+  /// **'Memory updated'**
+  String get memoryCorrectionApplied;
+
+  /// Failed memory reinterpretation receipt status
+  ///
+  /// In en, this message translates to:
+  /// **'Ella couldn\'t update this memory'**
+  String get memoryCorrectionFailed;
+
+  /// Action that opens a correction receipt
+  ///
+  /// In en, this message translates to:
+  /// **'Review'**
+  String get memoryCorrectionReview;
+
+  /// Title for the correction receipt review sheet
+  ///
+  /// In en, this message translates to:
+  /// **'Memory update'**
+  String get memoryCorrectionReviewTitle;
+
+  /// Label for the previous memory summary
+  ///
+  /// In en, this message translates to:
+  /// **'Before'**
+  String get memoryCorrectionBefore;
+
+  /// Label for the updated memory summary
+  ///
+  /// In en, this message translates to:
+  /// **'After'**
+  String get memoryCorrectionAfter;
+
+  /// Action that undoes an applied memory correction
+  ///
+  /// In en, this message translates to:
+  /// **'Undo update'**
+  String get memoryCorrectionUndo;
+
+  /// Status shown after a memory correction is undone
+  ///
+  /// In en, this message translates to:
+  /// **'Memory update undone'**
+  String get memoryCorrectionUndone;
+
   /// No description provided for @ellaAddCaregiverErrorNameRequired.
   ///
   /// In en, this message translates to:
@@ -16154,6 +16238,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to '**
   String get aiConsentBodyBeforeElevenLabs;
+
+  /// Version 3 disclosure for selected stored memory context sent to a named realtime voice processor
+  ///
+  /// In en, this message translates to:
+  /// **' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.'**
+  String get aiConsentMemoryContext;
 
   /// Generated voice processor named in the locked consent disclosure
   ///

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8416,6 +8416,51 @@ class AppLocalizationsAr extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8609,6 +8654,10 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8504,6 +8504,51 @@ class AppLocalizationsBg extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8697,6 +8742,10 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8520,6 +8520,51 @@ class AppLocalizationsCa extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8713,6 +8758,10 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8467,6 +8467,51 @@ class AppLocalizationsCs extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8660,6 +8705,10 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8456,6 +8456,51 @@ class AppLocalizationsDa extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8649,6 +8694,10 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8538,6 +8538,51 @@ class AppLocalizationsDe extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8731,6 +8776,10 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8529,6 +8529,51 @@ class AppLocalizationsEl extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8722,6 +8767,10 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8469,6 +8469,51 @@ class AppLocalizationsEn extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8662,6 +8707,10 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8486,6 +8486,51 @@ class AppLocalizationsEs extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8679,6 +8724,10 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8471,6 +8471,51 @@ class AppLocalizationsEt extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8664,6 +8709,10 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8470,6 +8470,51 @@ class AppLocalizationsFi extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8663,6 +8708,10 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8545,6 +8545,51 @@ class AppLocalizationsFr extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8738,6 +8783,10 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8452,6 +8452,51 @@ class AppLocalizationsHi extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8645,6 +8690,10 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8509,6 +8509,51 @@ class AppLocalizationsHu extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8702,6 +8747,10 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8484,6 +8484,51 @@ class AppLocalizationsId extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8677,6 +8722,10 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8521,6 +8521,51 @@ class AppLocalizationsIt extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8714,6 +8759,10 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8338,6 +8338,51 @@ class AppLocalizationsJa extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8531,6 +8576,10 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8340,6 +8340,51 @@ class AppLocalizationsKo extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8533,6 +8578,10 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8477,6 +8477,51 @@ class AppLocalizationsLt extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8670,6 +8715,10 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8489,6 +8489,51 @@ class AppLocalizationsLv extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8682,6 +8727,10 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8495,6 +8495,51 @@ class AppLocalizationsMs extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8688,6 +8733,10 @@ class AppLocalizationsMs extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8497,6 +8497,51 @@ class AppLocalizationsNl extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8690,6 +8735,10 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8467,6 +8467,51 @@ class AppLocalizationsNo extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8660,6 +8705,10 @@ class AppLocalizationsNo extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8490,6 +8490,51 @@ class AppLocalizationsPl extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8683,6 +8728,10 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8472,6 +8472,51 @@ class AppLocalizationsPt extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8665,6 +8710,10 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8510,6 +8510,51 @@ class AppLocalizationsRo extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8703,6 +8748,10 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8497,6 +8497,51 @@ class AppLocalizationsRu extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8690,6 +8735,10 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8462,6 +8462,51 @@ class AppLocalizationsSk extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8655,6 +8700,10 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8477,6 +8477,51 @@ class AppLocalizationsSv extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8670,6 +8715,10 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8434,6 +8434,51 @@ class AppLocalizationsTh extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8627,6 +8672,10 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8485,6 +8485,51 @@ class AppLocalizationsTr extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8678,6 +8723,10 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8484,6 +8484,51 @@ class AppLocalizationsUk extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8677,6 +8722,10 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8474,6 +8474,51 @@ class AppLocalizationsVi extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8667,6 +8712,10 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8328,6 +8328,51 @@ class AppLocalizationsZh extends AppLocalizations {
   String get voiceProviderOpenClawDirect => 'OpenClaw Direct';
 
   @override
+  String get memoryTalkAction => 'Talk about this';
+
+  @override
+  String memoryTalkContext(String title) {
+    return 'Talking about: $title';
+  }
+
+  @override
+  String get memoryTalkUnavailable => 'This memory is unavailable for voice right now. Refresh it and try again.';
+
+  @override
+  String get memoryTalkStale => 'This memory changed. Ella is refreshing it before reconnecting.';
+
+  @override
+  String get memoryTalkProviderRequired =>
+      'Choose Grok Native Realtime or Gemini Native Live in Voice settings to talk about this memory.';
+
+  @override
+  String get memoryCorrectionPending => 'Ella is updating this memory';
+
+  @override
+  String get memoryCorrectionApplied => 'Memory updated';
+
+  @override
+  String get memoryCorrectionFailed => 'Ella couldn\'t update this memory';
+
+  @override
+  String get memoryCorrectionReview => 'Review';
+
+  @override
+  String get memoryCorrectionReviewTitle => 'Memory update';
+
+  @override
+  String get memoryCorrectionBefore => 'Before';
+
+  @override
+  String get memoryCorrectionAfter => 'After';
+
+  @override
+  String get memoryCorrectionUndo => 'Undo update';
+
+  @override
+  String get memoryCorrectionUndone => 'Memory update undone';
+
+  @override
   String get ellaAddCaregiverErrorNameRequired => 'Name is required';
 
   @override
@@ -8521,6 +8566,10 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get aiConsentBodyBeforeElevenLabs =>
       '. OpenRouter may route this text to the selected model provider. For live voice, microphone audio may be sent to Google (Gemini), OpenAI, or xAI (Grok). To speak a standard response, Ella sends response text to ';
+
+  @override
+  String get aiConsentMemoryContext =>
+      ' When you choose Talk about this, the selected stored memory, including related people, topics, and dates, is sent through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor.';
 
   @override
   String get aiConsentElevenLabs => 'ElevenLabs';

--- a/app/lib/pages/conversation_detail/widgets.dart
+++ b/app/lib/pages/conversation_detail/widgets.dart
@@ -16,6 +16,8 @@ import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/folder.dart';
 import 'package:omi/backend/schema/geolocation.dart';
 import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/ella/pages/ella_voice_chat_page.dart';
+import 'package:omi/ella/services/v2v_client.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/pages/apps/app_detail/app_detail.dart';
 import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
@@ -710,12 +712,72 @@ class AppResultDetailWidget extends StatelessWidget {
             ),
           if (content.isNotEmpty) ...[
             const SizedBox(height: 18),
-            _CorrectSummaryButton(
-              conversation: conversation,
-              appSummary: content,
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              children: [
+                _TalkAboutMemoryButton(conversation: conversation),
+                _CorrectSummaryButton(
+                  conversation: conversation,
+                  appSummary: content,
+                ),
+              ],
             ),
           ],
         ],
+      ),
+    );
+  }
+}
+
+class _TalkAboutMemoryButton extends StatelessWidget {
+  const _TalkAboutMemoryButton({required this.conversation});
+
+  final ServerConversation conversation;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(18),
+        onTap: () {
+          HapticFeedback.lightImpact();
+          final displayTitle = parseEllaDisplayValue(conversation.structured.title).text.trim();
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (_) => EllaVoiceChatPage(
+                sessionScope: V2VSessionScope.memory(
+                  conversationId: conversation.id,
+                  expectedActiveSummaryVersionId: conversation.activeSummaryVersionId,
+                ),
+                memoryTitle: displayTitle,
+              ),
+            ),
+          );
+        },
+        child: Ink(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          decoration: BoxDecoration(
+            color: EllaColors.primary,
+            borderRadius: BorderRadius.circular(18),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.graphic_eq_rounded, size: 18, color: EllaColors.paper),
+              const SizedBox(width: 8),
+              Text(
+                context.l10n.memoryTalkAction,
+                style: const TextStyle(
+                  color: EllaColors.paper,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/app/test/backend/preferences_public_mode_test.dart
+++ b/app/test/backend/preferences_public_mode_test.dart
@@ -62,6 +62,35 @@ void main() {
     expect(preferences.hasAccountBoundAiConsent('uid-a'), isTrue);
   });
 
+  test('existing v2 account defers v3 until an explicit voice action', () async {
+    SharedPreferences.setMockInitialValues({
+      'aiConsentAccepted': true,
+      'aiConsentAcceptedAt': '2026-01-01T00:00:00Z',
+      'aiConsentContractVersion': 'voice-ai-processors-v2',
+      'aiConsentReceiptId': 'ios-private-cloud-sync:voice-ai-processors-v2:receipt-a',
+      'aiConsentReceiptUid': 'uid-a',
+    });
+    await SharedPreferencesUtil.init();
+
+    final preferences = SharedPreferencesUtil();
+    expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.hasPriorAccountBoundAiConsent('uid-a'), isTrue);
+    expect(preferences.hasPriorAccountBoundAiConsent('uid-b'), isFalse);
+  });
+
+  test('deferred v3 remains inactive until acceptance and acceptance is one-time', () {
+    final preferences = SharedPreferencesUtil();
+
+    preferences.deferAiConsent();
+    expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.isCurrentAiConsentDeferred, isTrue);
+
+    preferences.acceptAiConsent();
+    expect(preferences.aiConsentAccepted, isTrue);
+    expect(preferences.isCurrentAiConsentDeferred, isFalse);
+    expect(preferences.aiConsentContractVersion, 'voice-ai-processors-v3');
+  });
+
   test('receipt-less acceptance clears stale same-account authority', () async {
     SharedPreferences.setMockInitialValues({
       'aiConsentAccepted': true,

--- a/app/test/backend/schema/conversation_test.dart
+++ b/app/test/backend/schema/conversation_test.dart
@@ -77,6 +77,28 @@ void main() {
     expect(conversation.toJson()['processing_error_at'], '2026-07-20T08:05:00.000Z');
   });
 
+  test('preserves the active summary version used by memory-scoped voice', () {
+    final conversation = ServerConversation.fromJson({
+      'id': 'memory-voice-conversation',
+      'created_at': '2026-07-24T08:00:00Z',
+      'structured': {
+        'title': 'Garden memory',
+        'overview': 'A quiet afternoon.',
+        'emoji': '',
+        'category': 'other',
+        'action_items': [],
+        'events': [],
+      },
+      'transcript_segments': [],
+      'apps_results': [],
+      'audio_files': [],
+      'active_summary_version_id': 'summary-v3',
+    });
+
+    expect(conversation.activeSummaryVersionId, 'summary-v3');
+    expect(conversation.toJson()['active_summary_version_id'], 'summary-v3');
+  });
+
   test('treats initial and recovery summary failures as retryable without exposing unrelated errors', () {
     for (final error in ['conversation_summary_failed', 'conversation_summary_recovery_failed']) {
       final conversation = ServerConversation(

--- a/app/test/ella/services/ella_provisioning_service_test.dart
+++ b/app/test/ella/services/ella_provisioning_service_test.dart
@@ -356,7 +356,7 @@ void main() {
 
     final receiptId = await service.acknowledgePrivateCloudSync(uid: 'uid-a');
 
-    expect(receiptId, 'ios-private-cloud-sync:voice-ai-processors-v2:receipt-1');
+    expect(receiptId, 'ios-private-cloud-sync:voice-ai-processors-v3:receipt-1');
     expect(transport.values, [true]);
     expect(transport.getCalls, 1);
     expect(SharedPreferencesUtil().hasAccountBoundAiConsent('uid-a'), isTrue);

--- a/app/test/ella/services/memory_correction_receipt_test.dart
+++ b/app/test/ella/services/memory_correction_receipt_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/http/api/conversations.dart';
+
+void main() {
+  test('parses authoritative applied and undone receipt states', () {
+    final applied = ConversationCorrectionReceipt.fromJson({
+      'correction_id': 'correction-1',
+      'conversation_id': 'conversation-1',
+      'status': 'applied',
+      'applied_at': '2026-07-24T12:00:00Z',
+      'before': {'title': 'Before title', 'overview': 'Before overview'},
+      'after': {'title': 'After title', 'overview': 'After overview'},
+    });
+
+    expect(applied.isApplied, isTrue);
+    expect(applied.isPending, isFalse);
+    expect(applied.before.title, 'Before title');
+    expect(applied.after.overview, 'After overview');
+
+    final undone = ConversationCorrectionReceipt.fromJson({
+      'correction_id': 'correction-1',
+      'conversation_id': 'conversation-1',
+      'status': 'applied',
+      'undone_at': '2026-07-24T12:05:00Z',
+      'before': {},
+      'after': {},
+    });
+    expect(undone.isUndone, isTrue);
+    expect(undone.isApplied, isFalse);
+  });
+}

--- a/app/test/ella/services/v2v_client_test.dart
+++ b/app/test/ella/services/v2v_client_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/pages/ella_voice_chat_page.dart';
 import 'package:omi/ella/services/v2v_client.dart';
 
 void main() {
@@ -28,40 +29,151 @@ void main() {
         'gemini-native-live',
       );
       expect(
-        V2VClient.resolveEffectiveProvider(
-          provisionedProvider: 'grok-voice',
-          selectedProvider: 'gemini-native-live',
-        ),
+        V2VClient.resolveEffectiveProvider(provisionedProvider: 'grok-voice', selectedProvider: 'gemini-native-live'),
         'grok-voice',
       );
     });
 
     test('authenticated session body preserves provider and mode while omitting uid', () {
+      expect(V2VClient.buildSessionRequestBody(uid: 'firebase-user-1', provider: 'gemini-live', includeUid: false), {
+        'provider': 'gemini-native-live',
+        'voice_mode': 'gemini-native-live-v1',
+      });
+    });
+
+    test('memory scope serializes identifiers only for Grok and Gemini and survives retry', () {
+      const scope = V2VSessionScope.memory(
+        conversationId: 'conversation-42',
+        expectedActiveSummaryVersionId: 'summary-v7',
+      );
+      for (final provider in ['grok-voice', 'gemini-native-live']) {
+        final firstAttempt = V2VClient.buildSessionRequestBody(
+          uid: 'firebase-user-1',
+          provider: provider,
+          includeUid: false,
+          sessionScope: scope,
+        );
+        final retryAttempt = V2VClient.buildSessionRequestBody(
+          uid: 'firebase-user-1',
+          provider: provider,
+          includeUid: false,
+          sessionScope: scope,
+        );
+
+        expect(retryAttempt, firstAttempt);
+        expect(firstAttempt['provider'], provider);
+        expect(firstAttempt['voice_mode'], provider == 'grok-voice' ? 'v4' : 'gemini-native-live-v1');
+        expect(firstAttempt['session_scope'], {
+          'kind': 'memory',
+          'conversation_id': 'conversation-42',
+          'expected_active_summary_version_id': 'summary-v7',
+        });
+        expect(firstAttempt, isNot(contains('uid')));
+        expect(firstAttempt, isNot(contains('title')));
+        expect(firstAttempt, isNot(contains('overview')));
+        expect(firstAttempt, isNot(contains('people')));
+        expect(firstAttempt, isNot(contains('transcript')));
+        expect(firstAttempt, isNot(contains('system_prompt')));
+      }
+    });
+
+    test('memory scope omits an unknown active version rather than inventing one', () {
+      const scope = V2VSessionScope.memory(conversationId: 'conversation-42');
+
       expect(
         V2VClient.buildSessionRequestBody(
           uid: 'firebase-user-1',
-          provider: 'gemini-live',
+          provider: 'grok-voice',
           includeUid: false,
-        ),
-        {
-          'provider': 'gemini-native-live',
-          'voice_mode': 'gemini-native-live-v1',
-        },
+          sessionScope: scope,
+        )['session_scope'],
+        {'kind': 'memory', 'conversation_id': 'conversation-42'},
+      );
+    });
+
+    test('accepts only a matching identifier-only resolved scope', () {
+      const requested = V2VSessionScope.memory(
+        conversationId: 'conversation-42',
+        expectedActiveSummaryVersionId: 'summary-v1',
+      );
+      final resolved = V2VResolvedSessionScope.tryParse({
+        'kind': 'memory',
+        'conversation_id': 'conversation-42',
+        'active_summary_version_id': 'summary-v2',
+        'can_reinterpret': true,
+        'overview': 'ignored by the client',
+      });
+
+      expect(resolved, isNotNull);
+      expect(resolved!.matches(requested), isTrue);
+      expect(resolved.activeSummaryVersionId, 'summary-v2');
+      expect(
+        V2VResolvedSessionScope.tryParse({
+          'kind': 'memory',
+          'conversation_id': 'another-conversation',
+          'active_summary_version_id': 'summary-v2',
+          'can_reinterpret': true,
+        })!
+            .matches(requested),
+        isFalse,
+      );
+    });
+
+    test('missing and non-owned scoped memories expose the same safe failure', () {
+      const scope = V2VSessionScope.memory(conversationId: 'conversation-42');
+
+      final missing = V2VClient.sessionFailureCode(
+        statusCode: 404,
+        body: '{"detail":{"code":"voice_session_scope_not_found"}}',
+        sessionScope: scope,
+      );
+      final nonOwned = V2VClient.sessionFailureCode(
+        statusCode: 404,
+        body: '{"detail":{"code":"different_internal_code"}}',
+        sessionScope: scope,
+      );
+
+      expect(missing, 'voice_session_scope_unavailable');
+      expect(nonOwned, missing);
+    });
+
+    test('stale scoped versions normalize to refresh behavior without dropping scope', () {
+      const scope = V2VSessionScope.memory(
+        conversationId: 'conversation-42',
+        expectedActiveSummaryVersionId: 'summary-v1',
+      );
+      final code = V2VClient.sessionFailureCode(
+        statusCode: 409,
+        body: '{"detail":{"code":"voice_session_scope_version_unavailable"}}',
+        sessionScope: scope,
+      );
+      final refreshed = EllaVoiceChatPage.refreshedMemoryScope(scope, 'summary-v2');
+
+      expect(code, 'voice_session_scope_stale');
+      expect(refreshed.conversationId, scope.conversationId);
+      expect(refreshed.expectedActiveSummaryVersionId, 'summary-v2');
+    });
+
+    test('only Grok and Gemini can carry memory scope', () {
+      expect(V2VClient.isMemoryScopedProvider('grok-voice'), isTrue);
+      expect(V2VClient.isMemoryScopedProvider('gemini-live'), isTrue);
+      expect(V2VClient.isMemoryScopedProvider('openai-native-realtime'), isFalse);
+      expect(V2VClient.isMemoryScopedProvider('elevenlabs'), isFalse);
+    });
+
+    test('scoped voice turns never append to general Chat', () {
+      expect(EllaVoiceChatPage.shouldInjectVoiceTurns(null), isTrue);
+      expect(
+        EllaVoiceChatPage.shouldInjectVoiceTurns(const V2VSessionScope.memory(conversationId: 'conversation-42')),
+        isFalse,
       );
     });
 
     test('legacy session body includes uid without changing canonical provider', () {
-      expect(
-        V2VClient.buildSessionRequestBody(
-          uid: 'legacy-user-1',
-          provider: 'grok-voice',
-          includeUid: true,
-        ),
-        {
-          'uid': 'legacy-user-1',
-          'provider': 'grok-voice',
-        },
-      );
+      expect(V2VClient.buildSessionRequestBody(uid: 'legacy-user-1', provider: 'grok-voice', includeUid: true), {
+        'uid': 'legacy-user-1',
+        'provider': 'grok-voice',
+      });
     });
 
     test('provider registry filters unavailable and non-V2V entries and deduplicates aliases', () {
@@ -78,10 +190,7 @@ void main() {
     });
 
     test('failure receipts extract bounded codes without retaining opaque tokens', () {
-      expect(
-        V2VClient.safeErrorCode('{"detail":{"code":"isolated_voice_not_ready"}}'),
-        'isolated_voice_not_ready',
-      );
+      expect(V2VClient.safeErrorCode('{"detail":{"code":"isolated_voice_not_ready"}}'), 'isolated_voice_not_ready');
       expect(
         V2VClient.safeErrorCode(
           '{"detail":"eyJhbGciOiJIUzI1NiJ9.payload.signature"}',
@@ -98,7 +207,8 @@ void main() {
     test('legacy consent receipt blocks before V2V provider or session requests', () async {
       SharedPreferences.setMockInitialValues({
         'aiConsentAccepted': true,
-        'aiConsentReceiptId': 'legacy-receipt',
+        'aiConsentContractVersion': 'voice-ai-processors-v2',
+        'aiConsentReceiptId': 'ios-private-cloud-sync:voice-ai-processors-v2:legacy-receipt',
         'aiConsentReceiptUid': 'uid-a',
         'uid': 'uid-a',
       });
@@ -110,6 +220,19 @@ void main() {
       expect(receipt.connected, isFalse);
       expect(receipt.stage, V2VConnectionStage.consent);
       expect(receipt.errorCode, 'ai_consent_required');
+      await client.disconnect();
+    });
+
+    test('accepted v3 consent passes the mic gate before identity validation', () async {
+      final preferences = SharedPreferencesUtil();
+      preferences.acceptAiConsent();
+      final client = V2VClient(onEvent: (_) {}, onConnectionChanged: (_) {});
+
+      final receipt = await client.connect(provider: 'grok-voice');
+
+      expect(receipt.connected, isFalse);
+      expect(receipt.stage, V2VConnectionStage.identity);
+      expect(receipt.errorCode, 'missing_authenticated_identity');
       await client.disconnect();
     });
   });
@@ -127,6 +250,26 @@ void main() {
       expect(V2VClient.treatsAsAudioDoneEvent('response.done'), isFalse);
       expect(V2VClient.treatsAsResponseCompleteEvent('response.done'), isTrue);
       expect(V2VClient.treatsAsResponseCompleteEvent('audio_done'), isFalse);
+    });
+
+    test('parses identifier-only memory reinterpretation events', () {
+      final event = MemoryReinterpretationEvent.tryParse({
+        'type': 'memory_reinterpretation',
+        'state': 'submitted',
+        'session_id': 'session-1',
+        'conversation_id': 'conversation-42',
+        'correction_id': 'correction-7',
+        'trace_id': 'trace-9',
+        'status': 'queued',
+        'poll_after_ms': 750,
+        'overview': 'must not be retained',
+      });
+
+      expect(event, isNotNull);
+      expect(event!.sessionId, 'session-1');
+      expect(event.conversationId, 'conversation-42');
+      expect(event.correctionId, 'correction-7');
+      expect(event.pollAfter, const Duration(milliseconds: 750));
     });
   });
 }

--- a/app/test/ella/widgets/ai_consent_sheet_test.dart
+++ b/app/test/ella/widgets/ai_consent_sheet_test.dart
@@ -38,6 +38,9 @@ void main() {
     expect(disclosure, contains('OpenAI, Groq, and xAI (Grok)'));
     expect(disclosure, contains('ElevenLabs'));
     expect(disclosure, contains('response text'));
+    expect(disclosure, contains('selected stored memory'));
+    expect(disclosure, contains('related people, topics, and dates'));
+    expect(disclosure, contains('Google (Gemini) or xAI (Grok) voice processor'));
     expect(find.text('Not now'), findsOneWidget);
   });
 
@@ -53,9 +56,10 @@ void main() {
     final preferences = SharedPreferencesUtil();
     expect(preferences.aiConsentAccepted, isTrue);
     expect(preferences.aiConsentContractVersion, SharedPreferencesUtil.currentAiConsentContractVersion);
+    expect(preferences.aiConsentDeferredVersion, isEmpty);
   });
 
-  testWidgets('Not now revokes the current processor contract', (tester) async {
+  testWidgets('Not now defers the current processor contract', (tester) async {
     final preferences = SharedPreferencesUtil();
     preferences.acceptAiConsent();
 
@@ -68,5 +72,6 @@ void main() {
 
     expect(preferences.aiConsentAccepted, isFalse);
     expect(preferences.aiConsentContractVersion, isEmpty);
+    expect(preferences.isCurrentAiConsentDeferred, isTrue);
   });
 }

--- a/app/test/ella/widgets/v2v_fallback_dialog_test.dart
+++ b/app/test/ella/widgets/v2v_fallback_dialog_test.dart
@@ -33,4 +33,24 @@ void main() {
     expect(find.text('Use ElevenLabs'), findsOneWidget);
     expect(find.text('Not now'), findsOneWidget);
   });
+
+  testWidgets('memory-scoped failures offer retry or stop without an unscoped fallback', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: V2VFallbackDialog(
+            receipt: receipt,
+            allowStandardFallback: false,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Use ElevenLabs'), findsNothing);
+    expect(find.text('Retry'), findsOneWidget);
+    expect(find.text('Not now'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary

Implements the strictly iOS work order for https://github.com/ellaaicare/ella-ai/issues/1101 after the typed memory-session foundation merged in https://github.com/ellaaicare/omi/pull/324.

- adds `Talk about this` on a memory and reuses the existing V2V orb, audio, mic-gating, reconnect, and provider flows
- sends only typed `session_scope` identifiers (`kind`, `conversation_id`, and optional expected active summary version)
- accepts only matching identifier-only scope receipts, refreshes stale versions once, and preserves Grok/Gemini scope across retries
- prevents memory-scoped turns from entering general Chat and disables unscoped ElevenLabs fallback
- adds the one-time `voice-ai-processors-v3` consent disclosure with an explicit Not now path and no mic activation before acceptance
- parses identifier-only reinterpretation events and keeps receipt/review/Undo UI dormant until a real backend event provides an authoritative receipt

No backend, proxy, Hermes, Honcho, n8n, Firebase, signing, deployment, or TestFlight changes are included.

## Validation

- `./test.sh`: passed (`capture_provider_test` 18/18, `transcript_test` 3/3)
- focused memory scope, consent, fallback, schema, provisioning, and receipt tests: 51/51
- `flutter test --no-pub`: 176/176
- targeted Flutter analyzers: no errors; only existing warning/info debt
- `git diff --check`: clean
- GitNexus index refreshed successfully

## Runtime gate

The receipt chip remains dormant until the real backend reinterpretation event/status path is available. This PR does not enable or deploy the backend outbox/worker and does not create a TestFlight build.
