### PR TITLE
Discover delayed memory correction receipts on iOS

### DIFF
--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -280,6 +280,106 @@ class ConversationCorrectionReceipt {
       );
 }
 
+class ConversationReinterpretationReceiptReference {
+  const ConversationReinterpretationReceiptReference({
+    required this.conversationId,
+    required this.correctionId,
+    required this.status,
+  });
+
+  final String conversationId;
+  final String correctionId;
+  final String status;
+
+  static ConversationReinterpretationReceiptReference? tryParse(Object? value) {
+    if (value is! Map) return null;
+    final conversationId = value['conversation_id']?.toString().trim() ?? '';
+    final correctionId = value['correction_id']?.toString().trim() ?? '';
+    final status = value['status']?.toString().trim() ?? '';
+    if (conversationId.isEmpty || correctionId.isEmpty || status.isEmpty) return null;
+    return ConversationReinterpretationReceiptReference(
+      conversationId: conversationId,
+      correctionId: correctionId,
+      status: status,
+    );
+  }
+}
+
+class ConversationReinterpretationJob {
+  const ConversationReinterpretationJob({
+    required this.jobId,
+    required this.sessionId,
+    required this.conversationId,
+    required this.status,
+    required this.correctionIds,
+    required this.receipts,
+  });
+
+  final String jobId;
+  final String sessionId;
+  final String conversationId;
+  final String status;
+  final List<String> correctionIds;
+  final List<ConversationReinterpretationReceiptReference> receipts;
+
+  bool get isPending => const {'pending', 'running', 'retry'}.contains(status);
+  bool get isNoChange => status == 'no_change';
+  bool get isPendingReview => status == 'pending_review';
+  bool get isApplied => status == 'applied';
+
+  String? get appliedCorrectionId {
+    for (final receipt in receipts) {
+      if (receipt.status == 'applied' && receipt.conversationId == conversationId) {
+        return receipt.correctionId;
+      }
+    }
+    return correctionIds.isEmpty ? null : correctionIds.first;
+  }
+
+  static ConversationReinterpretationJob? tryParse(Object? value) {
+    if (value is! Map) return null;
+    final jobId = value['job_id']?.toString().trim() ?? '';
+    final sessionId = value['session_id']?.toString().trim() ?? '';
+    final conversationId = value['conversation_id']?.toString().trim() ?? '';
+    final status = value['status']?.toString().trim() ?? '';
+    if (jobId.isEmpty || sessionId.isEmpty || conversationId.isEmpty || status.isEmpty) return null;
+
+    final rawCorrectionIds = value['correction_ids'];
+    final correctionIds =
+        (rawCorrectionIds is List ? rawCorrectionIds : const []).map((item) => item.toString().trim()).where((id) {
+      return id.isNotEmpty;
+    }).toList(growable: false);
+    final rawReceipts = value['receipts'];
+    final receipts = (rawReceipts is List ? rawReceipts : const [])
+        .map(ConversationReinterpretationReceiptReference.tryParse)
+        .whereType<ConversationReinterpretationReceiptReference>()
+        .toList(growable: false);
+
+    return ConversationReinterpretationJob(
+      jobId: jobId,
+      sessionId: sessionId,
+      conversationId: conversationId,
+      status: status,
+      correctionIds: correctionIds,
+      receipts: receipts,
+    );
+  }
+}
+
+Future<ConversationReinterpretationJob?> getLatestConversationReinterpretation({required String conversationId}) async {
+  final encodedConversationId = Uri.encodeComponent(conversationId);
+  final response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/ella/conversations/$encodedConversationId/reinterpretations/latest',
+    headers: {},
+    method: 'GET',
+    body: '',
+  );
+  if (response == null || response.statusCode != 200) return null;
+  final decoded = jsonDecode(response.body);
+  if (decoded is! Map) return null;
+  return ConversationReinterpretationJob.tryParse(decoded['reinterpretation']);
+}
+
 Future<ConversationCorrectionReceipt?> getConversationCorrectionReceipt({
   required String conversationId,
   required String correctionId,

--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -311,6 +311,7 @@ class ConversationReinterpretationJob {
     required this.sessionId,
     required this.conversationId,
     required this.status,
+    this.outcome = '',
     required this.correctionIds,
     required this.receipts,
   });
@@ -319,6 +320,7 @@ class ConversationReinterpretationJob {
   final String sessionId;
   final String conversationId;
   final String status;
+  final String outcome;
   final List<String> correctionIds;
   final List<ConversationReinterpretationReceiptReference> receipts;
 
@@ -326,14 +328,15 @@ class ConversationReinterpretationJob {
   bool get isNoChange => status == 'no_change';
   bool get isPendingReview => status == 'pending_review';
   bool get isApplied => status == 'applied';
+  bool get hasTerminalAppliedCorrection => isApplied || (isPendingReview && outcome == 'applied_with_pending');
 
   String? get appliedCorrectionId {
-    for (final receipt in receipts) {
+    for (final receipt in receipts.reversed) {
       if (receipt.status == 'applied' && receipt.conversationId == conversationId) {
         return receipt.correctionId;
       }
     }
-    return correctionIds.isEmpty ? null : correctionIds.first;
+    return correctionIds.isEmpty ? null : correctionIds.last;
   }
 
   static ConversationReinterpretationJob? tryParse(Object? value) {
@@ -342,6 +345,7 @@ class ConversationReinterpretationJob {
     final sessionId = value['session_id']?.toString().trim() ?? '';
     final conversationId = value['conversation_id']?.toString().trim() ?? '';
     final status = value['status']?.toString().trim() ?? '';
+    final outcome = value['outcome']?.toString().trim() ?? '';
     if (jobId.isEmpty || sessionId.isEmpty || conversationId.isEmpty || status.isEmpty) return null;
 
     final rawCorrectionIds = value['correction_ids'];
@@ -360,6 +364,7 @@ class ConversationReinterpretationJob {
       sessionId: sessionId,
       conversationId: conversationId,
       status: status,
+      outcome: outcome,
       correctionIds: correctionIds,
       receipts: receipts,
     );

--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -41,10 +41,16 @@ import 'package:omi/utils/l10n_extensions.dart';
 /// Flow: Tap orb → always-listen via on-device speech recognition →
 /// auto-detect silence → send text to Ella chat → TTS → play audio → repeat.
 class EllaVoiceChatPage extends StatefulWidget {
-  const EllaVoiceChatPage({super.key, this.sessionScope, this.memoryTitle});
+  const EllaVoiceChatPage({
+    super.key,
+    this.sessionScope,
+    this.memoryTitle,
+    this.onMemorySessionEnded,
+  });
 
   final V2VSessionScope? sessionScope;
   final String? memoryTitle;
+  final ValueChanged<MemoryReceiptDiscoveryRequest>? onMemorySessionEnded;
 
   @visibleForTesting
   static bool shouldInjectVoiceTurns(V2VSessionScope? sessionScope) => sessionScope == null;
@@ -104,6 +110,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   int _memoryReceiptPollAttempts = 0;
   final MemoryReinterpretationReceiptDiscovery _memoryReceiptDiscovery = MemoryReinterpretationReceiptDiscovery();
   String? _memoryReceiptDiscoveryKey;
+  String? _memorySessionNotificationKey;
 
   /// Regex to strip emojis from text before sending to TTS
   static final _emojiRegex = RegExp(
@@ -222,6 +229,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
   @override
   void dispose() {
+    _notifyMemorySessionEnded(_activeSessionId);
     _voiceModeActive = false;
     _typewriterTimer?.cancel();
     _memoryReceiptPollTimer?.cancel();
@@ -634,6 +642,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
     _activeSessionId = receipt.sessionId;
     _memoryReceiptDiscoveryKey = null;
+    _memorySessionNotificationKey = null;
     _memoryReinterpretationEvent = null;
     _memoryReceiptPollTimer?.cancel();
     _activeV2VProvider = providerName;
@@ -659,10 +668,21 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   void _beginPostSessionReceiptDiscovery(String sessionId) {
     final scope = _sessionScope;
     if (scope == null || sessionId.isEmpty) return;
-    final discoveryKey = '${scope.conversationId}:$sessionId';
+    final request = MemoryReceiptDiscoveryRequest(conversationId: scope.conversationId, sessionId: sessionId);
+    _notifyMemorySessionEnded(sessionId);
+    final discoveryKey = request.key;
     if (_memoryReceiptDiscoveryKey == discoveryKey) return;
     _memoryReceiptDiscoveryKey = discoveryKey;
-    unawaited(_discoverPostSessionReceipt(scope.conversationId, sessionId, discoveryKey));
+    unawaited(_discoverPostSessionReceipt(request.conversationId, request.sessionId, discoveryKey));
+  }
+
+  void _notifyMemorySessionEnded(String sessionId) {
+    final scope = _sessionScope;
+    if (scope == null || sessionId.isEmpty) return;
+    final request = MemoryReceiptDiscoveryRequest(conversationId: scope.conversationId, sessionId: sessionId);
+    if (_memorySessionNotificationKey == request.key) return;
+    _memorySessionNotificationKey = request.key;
+    widget.onMemorySessionEnded?.call(request);
   }
 
   Future<void> _discoverPostSessionReceipt(String conversationId, String sessionId, String discoveryKey) async {

--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -22,6 +22,7 @@ import 'package:omi/ella/ella_theme.dart';
 import 'package:omi/ella/services/ella_ai_consent_service.dart';
 import 'package:omi/ella/services/elevenlabs_tts.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
+import 'package:omi/ella/services/memory_reinterpretation_receipt_service.dart';
 import 'package:omi/ella/services/v2v_client.dart';
 import 'package:omi/ella/widgets/ai_consent_sheet.dart';
 import 'package:omi/ella/widgets/ella_breathing_dot.dart';
@@ -101,6 +102,8 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   ConversationCorrectionReceipt? _memoryCorrectionReceipt;
   Timer? _memoryReceiptPollTimer;
   int _memoryReceiptPollAttempts = 0;
+  final MemoryReinterpretationReceiptDiscovery _memoryReceiptDiscovery = MemoryReinterpretationReceiptDiscovery();
+  String? _memoryReceiptDiscoveryKey;
 
   /// Regex to strip emojis from text before sending to TTS
   static final _emojiRegex = RegExp(
@@ -222,6 +225,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     _voiceModeActive = false;
     _typewriterTimer?.cancel();
     _memoryReceiptPollTimer?.cancel();
+    _memoryReceiptDiscoveryKey = null;
     _playerSub?.cancel();
     _audioPlayer.dispose();
     _transcriptScrollController.dispose();
@@ -563,6 +567,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       onConnectionChanged: (connected) {
         if (!mounted) return;
         if (!connected && _isV2VMode) {
+          final endedSessionId = _activeSessionId;
           debugPrint('[VoiceChat] V2V disconnected unexpectedly');
           setState(() {
             _orbState = VoiceOrbState.idle;
@@ -570,6 +575,8 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
             _isV2VMode = false;
             _voiceModeActive = false;
           });
+          _beginPostSessionReceiptDiscovery(endedSessionId);
+          _activeSessionId = '';
         }
       },
     );
@@ -626,9 +633,13 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     }
 
     _activeSessionId = receipt.sessionId;
+    _memoryReceiptDiscoveryKey = null;
+    _memoryReinterpretationEvent = null;
+    _memoryReceiptPollTimer?.cancel();
     _activeV2VProvider = providerName;
     _usingElevenLabsFallback = false;
     setState(() {
+      _memoryCorrectionReceipt = null;
       _orbState = VoiceOrbState.listening;
       _statusText = context.l10n.voiceV2vActive(providerName);
     });
@@ -636,11 +647,36 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
   Future<void> _stopV2V() async {
     debugPrint('[VoiceChat] Stopping V2V mode');
+    final endedSessionId = _activeSessionId;
     await _v2vClient?.disconnect();
     _v2vClient = null;
+    _beginPostSessionReceiptDiscovery(endedSessionId);
     _activeSessionId = '';
     _activeV2VProvider = '';
     _pauseVoiceMode();
+  }
+
+  void _beginPostSessionReceiptDiscovery(String sessionId) {
+    final scope = _sessionScope;
+    if (scope == null || sessionId.isEmpty) return;
+    final discoveryKey = '${scope.conversationId}:$sessionId';
+    if (_memoryReceiptDiscoveryKey == discoveryKey) return;
+    _memoryReceiptDiscoveryKey = discoveryKey;
+    unawaited(_discoverPostSessionReceipt(scope.conversationId, sessionId, discoveryKey));
+  }
+
+  Future<void> _discoverPostSessionReceipt(String conversationId, String sessionId, String discoveryKey) async {
+    final result = await _memoryReceiptDiscovery.discover(
+      conversationId: conversationId,
+      sessionId: sessionId,
+      shouldContinue: () => mounted && _memoryReceiptDiscoveryKey == discoveryKey,
+    );
+    if (!mounted || _memoryReceiptDiscoveryKey != discoveryKey) return;
+    debugPrint('[VoiceChat] Memory receipt discovery: ${result.state.name}');
+    final receipt = result.receipt;
+    if (receipt != null && receipt.conversationId == conversationId) {
+      setState(() => _memoryCorrectionReceipt = receipt);
+    }
   }
 
   void _onV2VEvent(V2VEvent event) {

--- a/app/lib/ella/services/memory_reinterpretation_receipt_service.dart
+++ b/app/lib/ella/services/memory_reinterpretation_receipt_service.dart
@@ -2,6 +2,15 @@ import 'package:omi/backend/http/api/conversations.dart';
 
 enum MemoryReceiptDiscoveryState { applied, noChange, pendingReview, failed, timeout, sessionMismatch, cancelled }
 
+class MemoryReceiptDiscoveryRequest {
+  const MemoryReceiptDiscoveryRequest({required this.conversationId, required this.sessionId});
+
+  final String conversationId;
+  final String sessionId;
+
+  String get key => '$conversationId:$sessionId';
+}
+
 class MemoryReceiptDiscoveryResult {
   const MemoryReceiptDiscoveryResult(this.state, {this.receipt});
 
@@ -15,12 +24,20 @@ typedef CorrectionReceiptFetcher = Future<ConversationCorrectionReceipt?> Functi
 typedef MemoryReceiptPollDelay = Future<void> Function(Duration duration);
 
 class MemoryReinterpretationReceiptDiscovery {
+  // Production waits 45 seconds before the worker is eligible. A 90-second
+  // window leaves another 45 seconds for worker/API latency and 24 seconds
+  // beyond the observed 66-second successful canary.
+  static const productionDebounce = Duration(seconds: 45);
+  static const defaultMaxWait = Duration(seconds: 90);
+  static const defaultPollInterval = Duration(seconds: 2);
+  static const defaultMaxAttempts = 46;
+
   MemoryReinterpretationReceiptDiscovery({
     LatestReinterpretationFetcher? fetchLatest,
     CorrectionReceiptFetcher? fetchReceipt,
     MemoryReceiptPollDelay? wait,
-    this.maxAttempts = 40,
-    this.pollInterval = const Duration(milliseconds: 750),
+    this.maxAttempts = defaultMaxAttempts,
+    this.pollInterval = defaultPollInterval,
   })  : _fetchLatest = fetchLatest ?? _getLatest,
         _fetchReceipt = fetchReceipt ?? _getReceipt,
         _wait = wait ?? ((duration) => Future<void>.delayed(duration));
@@ -57,22 +74,27 @@ class MemoryReinterpretationReceiptDiscovery {
         if (job.conversationId != conversationId || job.sessionId != sessionId) {
           sawSessionMismatch = true;
         } else {
-          if (job.isPendingReview) {
-            return const MemoryReceiptDiscoveryResult(MemoryReceiptDiscoveryState.pendingReview);
-          }
-
           final correctionId = job.appliedCorrectionId;
-          if (job.isApplied && correctionId != null) {
+          if (job.hasTerminalAppliedCorrection && correctionId != null) {
             final receipt = await _fetchReceipt(conversationId, correctionId);
             if (shouldContinue?.call() == false) {
               return const MemoryReceiptDiscoveryResult(MemoryReceiptDiscoveryState.cancelled);
             }
-            if (receipt != null &&
-                receipt.conversationId == conversationId &&
-                receipt.correctionId == correctionId &&
-                receipt.isApplied) {
-              return MemoryReceiptDiscoveryResult(MemoryReceiptDiscoveryState.applied, receipt: receipt);
+            if (receipt != null) {
+              if (receipt.conversationId != conversationId || receipt.correctionId != correctionId) {
+                return const MemoryReceiptDiscoveryResult(MemoryReceiptDiscoveryState.failed);
+              }
+              if (receipt.isApplied) {
+                return MemoryReceiptDiscoveryResult(MemoryReceiptDiscoveryState.applied, receipt: receipt);
+              }
+              if (!receipt.isPending) {
+                return const MemoryReceiptDiscoveryResult(MemoryReceiptDiscoveryState.failed);
+              }
             }
+          } else if (job.hasTerminalAppliedCorrection) {
+            return const MemoryReceiptDiscoveryResult(MemoryReceiptDiscoveryState.failed);
+          } else if (job.isPendingReview) {
+            return const MemoryReceiptDiscoveryResult(MemoryReceiptDiscoveryState.pendingReview);
           } else if (job.isNoChange) {
             return const MemoryReceiptDiscoveryResult(MemoryReceiptDiscoveryState.noChange);
           } else if (!job.isPending) {

--- a/app/lib/ella/services/memory_reinterpretation_receipt_service.dart
+++ b/app/lib/ella/services/memory_reinterpretation_receipt_service.dart
@@ -1,0 +1,93 @@
+import 'package:omi/backend/http/api/conversations.dart';
+
+enum MemoryReceiptDiscoveryState { applied, noChange, pendingReview, failed, timeout, sessionMismatch, cancelled }
+
+class MemoryReceiptDiscoveryResult {
+  const MemoryReceiptDiscoveryResult(this.state, {this.receipt});
+
+  final MemoryReceiptDiscoveryState state;
+  final ConversationCorrectionReceipt? receipt;
+}
+
+typedef LatestReinterpretationFetcher = Future<ConversationReinterpretationJob?> Function(String conversationId);
+typedef CorrectionReceiptFetcher = Future<ConversationCorrectionReceipt?> Function(
+    String conversationId, String correctionId);
+typedef MemoryReceiptPollDelay = Future<void> Function(Duration duration);
+
+class MemoryReinterpretationReceiptDiscovery {
+  MemoryReinterpretationReceiptDiscovery({
+    LatestReinterpretationFetcher? fetchLatest,
+    CorrectionReceiptFetcher? fetchReceipt,
+    MemoryReceiptPollDelay? wait,
+    this.maxAttempts = 40,
+    this.pollInterval = const Duration(milliseconds: 750),
+  })  : _fetchLatest = fetchLatest ?? _getLatest,
+        _fetchReceipt = fetchReceipt ?? _getReceipt,
+        _wait = wait ?? ((duration) => Future<void>.delayed(duration));
+
+  final LatestReinterpretationFetcher _fetchLatest;
+  final CorrectionReceiptFetcher _fetchReceipt;
+  final MemoryReceiptPollDelay _wait;
+  final int maxAttempts;
+  final Duration pollInterval;
+
+  static Future<ConversationReinterpretationJob?> _getLatest(String conversationId) =>
+      getLatestConversationReinterpretation(conversationId: conversationId);
+
+  static Future<ConversationCorrectionReceipt?> _getReceipt(String conversationId, String correctionId) =>
+      getConversationCorrectionReceipt(conversationId: conversationId, correctionId: correctionId);
+
+  Future<MemoryReceiptDiscoveryResult> discover({
+    required String conversationId,
+    required String sessionId,
+    bool Function()? shouldContinue,
+  }) async {
+    var sawSessionMismatch = false;
+    for (var attempt = 0; attempt < maxAttempts; attempt++) {
+      if (shouldContinue?.call() == false) {
+        return const MemoryReceiptDiscoveryResult(MemoryReceiptDiscoveryState.cancelled);
+      }
+
+      final job = await _fetchLatest(conversationId);
+      if (shouldContinue?.call() == false) {
+        return const MemoryReceiptDiscoveryResult(MemoryReceiptDiscoveryState.cancelled);
+      }
+
+      if (job != null) {
+        if (job.conversationId != conversationId || job.sessionId != sessionId) {
+          sawSessionMismatch = true;
+        } else {
+          if (job.isPendingReview) {
+            return const MemoryReceiptDiscoveryResult(MemoryReceiptDiscoveryState.pendingReview);
+          }
+
+          final correctionId = job.appliedCorrectionId;
+          if (job.isApplied && correctionId != null) {
+            final receipt = await _fetchReceipt(conversationId, correctionId);
+            if (shouldContinue?.call() == false) {
+              return const MemoryReceiptDiscoveryResult(MemoryReceiptDiscoveryState.cancelled);
+            }
+            if (receipt != null &&
+                receipt.conversationId == conversationId &&
+                receipt.correctionId == correctionId &&
+                receipt.isApplied) {
+              return MemoryReceiptDiscoveryResult(MemoryReceiptDiscoveryState.applied, receipt: receipt);
+            }
+          } else if (job.isNoChange) {
+            return const MemoryReceiptDiscoveryResult(MemoryReceiptDiscoveryState.noChange);
+          } else if (!job.isPending) {
+            return const MemoryReceiptDiscoveryResult(MemoryReceiptDiscoveryState.failed);
+          }
+        }
+      }
+
+      if (attempt + 1 < maxAttempts) {
+        await _wait(pollInterval);
+      }
+    }
+
+    return MemoryReceiptDiscoveryResult(
+      sawSessionMismatch ? MemoryReceiptDiscoveryState.sessionMismatch : MemoryReceiptDiscoveryState.timeout,
+    );
+  }
+}

--- a/app/lib/pages/conversation_detail/widgets.dart
+++ b/app/lib/pages/conversation_detail/widgets.dart
@@ -17,7 +17,9 @@ import 'package:omi/backend/schema/folder.dart';
 import 'package:omi/backend/schema/geolocation.dart';
 import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/ella/pages/ella_voice_chat_page.dart';
+import 'package:omi/ella/services/memory_reinterpretation_receipt_service.dart';
 import 'package:omi/ella/services/v2v_client.dart';
+import 'package:omi/ella/widgets/memory_correction_receipt.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/pages/apps/app_detail/app_detail.dart';
 import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
@@ -735,26 +737,50 @@ class _TalkAboutMemoryButton extends StatelessWidget {
 
   final ServerConversation conversation;
 
+  Future<void> _openMemoryTalk(BuildContext context) async {
+    MemoryReceiptDiscoveryRequest? endedSession;
+    final displayTitle = parseEllaDisplayValue(conversation.structured.title).text.trim();
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => EllaVoiceChatPage(
+          sessionScope: V2VSessionScope.memory(
+            conversationId: conversation.id,
+            expectedActiveSummaryVersionId: conversation.activeSummaryVersionId,
+          ),
+          memoryTitle: displayTitle,
+          onMemorySessionEnded: (request) => endedSession = request,
+        ),
+      ),
+    );
+
+    final request = endedSession;
+    if (!context.mounted || request == null) return;
+    final result = await MemoryReinterpretationReceiptDiscovery().discover(
+      conversationId: request.conversationId,
+      sessionId: request.sessionId,
+      shouldContinue: () => context.mounted,
+    );
+    if (!context.mounted || result.receipt == null) return;
+    final receipt = result.receipt!;
+    await showMemoryCorrectionReceiptSheet(
+      context,
+      receipt: receipt,
+      onUndo: () => undoConversationCorrection(
+        conversationId: receipt.conversationId,
+        correctionId: receipt.correctionId,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Material(
       color: Colors.transparent,
       child: InkWell(
         borderRadius: BorderRadius.circular(18),
-        onTap: () {
+        onTap: () async {
           HapticFeedback.lightImpact();
-          final displayTitle = parseEllaDisplayValue(conversation.structured.title).text.trim();
-          Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (_) => EllaVoiceChatPage(
-                sessionScope: V2VSessionScope.memory(
-                  conversationId: conversation.id,
-                  expectedActiveSummaryVersionId: conversation.activeSummaryVersionId,
-                ),
-                memoryTitle: displayTitle,
-              ),
-            ),
-          );
+          await _openMemoryTalk(context);
         },
         child: Ink(
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),

--- a/app/test/ella/services/memory_reinterpretation_receipt_service_test.dart
+++ b/app/test/ella/services/memory_reinterpretation_receipt_service_test.dart
@@ -10,31 +10,35 @@ const correctionId = 'correction-1';
 ConversationReinterpretationJob job({
   String status = 'applied',
   String currentSessionId = sessionId,
+  String outcome = '',
   List<String> correctionIds = const [correctionId],
+  List<ConversationReinterpretationReceiptReference>? receipts,
 }) =>
     ConversationReinterpretationJob(
       jobId: 'job-1',
       sessionId: currentSessionId,
       conversationId: conversationId,
       status: status,
+      outcome: outcome,
       correctionIds: correctionIds,
-      receipts: correctionIds
-          .map(
-            (id) => ConversationReinterpretationReceiptReference(
-              conversationId: conversationId,
-              correctionId: id,
-              status: 'applied',
-            ),
-          )
-          .toList(),
+      receipts: receipts ??
+          correctionIds
+              .map(
+                (id) => ConversationReinterpretationReceiptReference(
+                  conversationId: conversationId,
+                  correctionId: id,
+                  status: 'applied',
+                ),
+              )
+              .toList(),
     );
 
-ConversationCorrectionReceipt appliedReceipt() => const ConversationCorrectionReceipt(
-      correctionId: correctionId,
+ConversationCorrectionReceipt appliedReceipt({String id = correctionId}) => ConversationCorrectionReceipt(
+      correctionId: id,
       conversationId: conversationId,
       status: 'applied',
-      before: ConversationCorrectionSummary(title: 'Before'),
-      after: ConversationCorrectionSummary(title: 'After'),
+      before: const ConversationCorrectionSummary(title: 'Before'),
+      after: const ConversationCorrectionSummary(title: 'After'),
     );
 
 void main() {
@@ -44,6 +48,7 @@ void main() {
       'session_id': sessionId,
       'conversation_id': conversationId,
       'status': 'applied',
+      'outcome': 'applied',
       'correction_ids': [correctionId],
       'receipts': [
         {'conversation_id': conversationId, 'correction_id': correctionId, 'status': 'applied'},
@@ -52,6 +57,7 @@ void main() {
     });
 
     expect(parsed?.sessionId, sessionId);
+    expect(parsed?.outcome, 'applied');
     expect(parsed?.appliedCorrectionId, correctionId);
   });
 
@@ -83,6 +89,60 @@ void main() {
     expect(result.receipt?.after.title, 'After');
   });
 
+  test('discovers a receipt that becomes available after the observed 66-second completion', () async {
+    var elapsed = Duration.zero;
+    var polls = 0;
+    final discovery = MemoryReinterpretationReceiptDiscovery(
+      fetchLatest: (_) async {
+        polls++;
+        return elapsed < const Duration(seconds: 66) ? null : job();
+      },
+      fetchReceipt: (_, __) async => appliedReceipt(),
+      wait: (duration) async => elapsed += duration,
+    );
+
+    final result = await discovery.discover(conversationId: conversationId, sessionId: sessionId);
+
+    expect(result.state, MemoryReceiptDiscoveryState.applied);
+    expect(elapsed, const Duration(seconds: 66));
+    expect(elapsed, lessThan(MemoryReinterpretationReceiptDiscovery.defaultMaxWait));
+    expect(polls, 34);
+  });
+
+  test('surfaces the applied receipt from an applied-with-pending terminal job', () async {
+    final discovery = MemoryReinterpretationReceiptDiscovery(
+      fetchLatest: (_) async => job(status: 'pending_review', outcome: 'applied_with_pending'),
+      fetchReceipt: (_, __) async => appliedReceipt(),
+      wait: (_) async {},
+      maxAttempts: 1,
+    );
+
+    final result = await discovery.discover(conversationId: conversationId, sessionId: sessionId);
+
+    expect(result.state, MemoryReceiptDiscoveryState.applied);
+    expect(result.receipt?.correctionId, correctionId);
+  });
+
+  test('uses the latest applied correction when a job applied more than one correction', () async {
+    const latestCorrectionId = 'correction-2';
+    String? fetchedCorrectionId;
+    final discovery = MemoryReinterpretationReceiptDiscovery(
+      fetchLatest: (_) async => job(correctionIds: const [correctionId, latestCorrectionId]),
+      fetchReceipt: (_, requestedCorrectionId) async {
+        fetchedCorrectionId = requestedCorrectionId;
+        return appliedReceipt(id: requestedCorrectionId);
+      },
+      wait: (_) async {},
+      maxAttempts: 1,
+    );
+
+    final result = await discovery.discover(conversationId: conversationId, sessionId: sessionId);
+
+    expect(result.state, MemoryReceiptDiscoveryState.applied);
+    expect(fetchedCorrectionId, latestCorrectionId);
+    expect(result.receipt?.correctionId, latestCorrectionId);
+  });
+
   test('stops without fetching a receipt for no-change', () async {
     var receiptFetches = 0;
     final discovery = MemoryReinterpretationReceiptDiscovery(
@@ -104,7 +164,7 @@ void main() {
   test('returns pending-review when no applied correction exists', () async {
     var receiptFetches = 0;
     final discovery = MemoryReinterpretationReceiptDiscovery(
-      fetchLatest: (_) async => job(status: 'pending_review'),
+      fetchLatest: (_) async => job(status: 'pending_review', correctionIds: const [], receipts: const []),
       fetchReceipt: (_, __) async {
         receiptFetches++;
         return null;
@@ -136,6 +196,44 @@ void main() {
 
     expect(result.state, MemoryReceiptDiscoveryState.timeout);
     expect(polls, 3);
+  });
+
+  test('cancels without waiting when its owner stops the discovery', () async {
+    var active = true;
+    var waits = 0;
+    final discovery = MemoryReinterpretationReceiptDiscovery(
+      fetchLatest: (_) async {
+        active = false;
+        return null;
+      },
+      fetchReceipt: (_, __) async => null,
+      wait: (_) async => waits++,
+      maxAttempts: 3,
+    );
+
+    final result = await discovery.discover(
+      conversationId: conversationId,
+      sessionId: sessionId,
+      shouldContinue: () => active,
+    );
+
+    expect(result.state, MemoryReceiptDiscoveryState.cancelled);
+    expect(waits, 0);
+  });
+
+  test('maps conflict and dead-letter terminal jobs to failed', () async {
+    for (final status in const ['conflict', 'dead_letter']) {
+      final discovery = MemoryReinterpretationReceiptDiscovery(
+        fetchLatest: (_) async => job(status: status, correctionIds: const [], receipts: const []),
+        fetchReceipt: (_, __) async => null,
+        wait: (_) async {},
+        maxAttempts: 1,
+      );
+
+      final result = await discovery.discover(conversationId: conversationId, sessionId: sessionId);
+
+      expect(result.state, MemoryReceiptDiscoveryState.failed, reason: status);
+    }
   });
 
   test('rejects a stale cross-session result without fetching its receipt', () async {

--- a/app/test/ella/services/memory_reinterpretation_receipt_service_test.dart
+++ b/app/test/ella/services/memory_reinterpretation_receipt_service_test.dart
@@ -1,0 +1,159 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/http/api/conversations.dart';
+import 'package:omi/ella/services/memory_reinterpretation_receipt_service.dart';
+
+const conversationId = 'conversation-1';
+const sessionId = 'session-1';
+const correctionId = 'correction-1';
+
+ConversationReinterpretationJob job({
+  String status = 'applied',
+  String currentSessionId = sessionId,
+  List<String> correctionIds = const [correctionId],
+}) =>
+    ConversationReinterpretationJob(
+      jobId: 'job-1',
+      sessionId: currentSessionId,
+      conversationId: conversationId,
+      status: status,
+      correctionIds: correctionIds,
+      receipts: correctionIds
+          .map(
+            (id) => ConversationReinterpretationReceiptReference(
+              conversationId: conversationId,
+              correctionId: id,
+              status: 'applied',
+            ),
+          )
+          .toList(),
+    );
+
+ConversationCorrectionReceipt appliedReceipt() => const ConversationCorrectionReceipt(
+      correctionId: correctionId,
+      conversationId: conversationId,
+      status: 'applied',
+      before: ConversationCorrectionSummary(title: 'Before'),
+      after: ConversationCorrectionSummary(title: 'After'),
+    );
+
+void main() {
+  test('parses identifier and status fields from latest reinterpretation response', () {
+    final parsed = ConversationReinterpretationJob.tryParse({
+      'job_id': 'job-1',
+      'session_id': sessionId,
+      'conversation_id': conversationId,
+      'status': 'applied',
+      'correction_ids': [correctionId],
+      'receipts': [
+        {'conversation_id': conversationId, 'correction_id': correctionId, 'status': 'applied'},
+      ],
+      'proposal_plan': {'private': 'ignored'},
+    });
+
+    expect(parsed?.sessionId, sessionId);
+    expect(parsed?.appliedCorrectionId, correctionId);
+  });
+
+  test('ignores malformed optional correction collections', () {
+    final parsed = ConversationReinterpretationJob.tryParse({
+      'job_id': 'job-1',
+      'session_id': sessionId,
+      'conversation_id': conversationId,
+      'status': 'no_change',
+      'correction_ids': 'not-a-list',
+      'receipts': {'not': 'a-list'},
+    });
+
+    expect(parsed?.correctionIds, isEmpty);
+    expect(parsed?.receipts, isEmpty);
+  });
+
+  test('returns a matching authoritative applied receipt', () async {
+    final discovery = MemoryReinterpretationReceiptDiscovery(
+      fetchLatest: (_) async => job(),
+      fetchReceipt: (_, __) async => appliedReceipt(),
+      wait: (_) async {},
+      maxAttempts: 1,
+    );
+
+    final result = await discovery.discover(conversationId: conversationId, sessionId: sessionId);
+
+    expect(result.state, MemoryReceiptDiscoveryState.applied);
+    expect(result.receipt?.after.title, 'After');
+  });
+
+  test('stops without fetching a receipt for no-change', () async {
+    var receiptFetches = 0;
+    final discovery = MemoryReinterpretationReceiptDiscovery(
+      fetchLatest: (_) async => job(status: 'no_change', correctionIds: const []),
+      fetchReceipt: (_, __) async {
+        receiptFetches++;
+        return null;
+      },
+      wait: (_) async {},
+      maxAttempts: 1,
+    );
+
+    final result = await discovery.discover(conversationId: conversationId, sessionId: sessionId);
+
+    expect(result.state, MemoryReceiptDiscoveryState.noChange);
+    expect(receiptFetches, 0);
+  });
+
+  test('returns pending-review when no applied correction exists', () async {
+    var receiptFetches = 0;
+    final discovery = MemoryReinterpretationReceiptDiscovery(
+      fetchLatest: (_) async => job(status: 'pending_review'),
+      fetchReceipt: (_, __) async {
+        receiptFetches++;
+        return null;
+      },
+      wait: (_) async {},
+      maxAttempts: 1,
+    );
+
+    final result = await discovery.discover(conversationId: conversationId, sessionId: sessionId);
+
+    expect(result.state, MemoryReceiptDiscoveryState.pendingReview);
+    expect(result.receipt, isNull);
+    expect(receiptFetches, 0);
+  });
+
+  test('times out after a bounded number of pending polls', () async {
+    var polls = 0;
+    final discovery = MemoryReinterpretationReceiptDiscovery(
+      fetchLatest: (_) async {
+        polls++;
+        return job(status: 'running', correctionIds: const []);
+      },
+      fetchReceipt: (_, __) async => null,
+      wait: (_) async {},
+      maxAttempts: 3,
+    );
+
+    final result = await discovery.discover(conversationId: conversationId, sessionId: sessionId);
+
+    expect(result.state, MemoryReceiptDiscoveryState.timeout);
+    expect(polls, 3);
+  });
+
+  test('rejects a stale cross-session result without fetching its receipt', () async {
+    var receiptFetches = 0;
+    final discovery = MemoryReinterpretationReceiptDiscovery(
+      fetchLatest: (_) async => job(currentSessionId: 'previous-session'),
+      fetchReceipt: (_, __) async {
+        receiptFetches++;
+        return appliedReceipt();
+      },
+      wait: (_) async {},
+      maxAttempts: 2,
+    );
+
+    final result = await discovery.discover(conversationId: conversationId, sessionId: sessionId);
+
+    expect(result.state, MemoryReceiptDiscoveryState.sessionMismatch);
+    expect(result.receipt, isNull);
+    expect(receiptFetches, 0);
+  });
+}


### PR DESCRIPTION
## Summary

- keep the existing WebSocket reinterpretation event as the fast path
- discover delayed memory reinterpretation results after a scoped V2V session ends
- validate the exact conversation and session before surfacing the existing Review/Undo receipt UI
- handle applied, no-change, pending-review, failed, timeout, cancellation, and stale-session outcomes

## Why

The production worker can apply a memory correction after the V2V WebSocket has disconnected. Build 801 had no way to discover that delayed result, so an authoritative applied correction receipt could exist without exposing Review/Undo in the app.

## Validation

- `flutter test test/ella/services/memory_reinterpretation_receipt_service_test.dart test/ella/services/memory_correction_receipt_test.dart test/ella/services/v2v_client_test.dart` (26 passed)
- `flutter test` (183 passed)
- targeted `dart analyze` completed with no errors or warnings; 9 existing info-level findings remain in legacy code
- `git diff --check`

Linked work order: https://github.com/ellaaicare/ella-ai/issues/1101

No backend/proxy changes, build-number change, TestFlight upload, or App Store Connect mutation.
