### PR TITLE
Preserve delayed memory receipts after leaving Voice Chat

### DIFF
--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -108,8 +108,6 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   ConversationCorrectionReceipt? _memoryCorrectionReceipt;
   Timer? _memoryReceiptPollTimer;
   int _memoryReceiptPollAttempts = 0;
-  final MemoryReinterpretationReceiptDiscovery _memoryReceiptDiscovery = MemoryReinterpretationReceiptDiscovery();
-  String? _memoryReceiptDiscoveryKey;
   String? _memorySessionNotificationKey;
 
   /// Regex to strip emojis from text before sending to TTS
@@ -233,7 +231,6 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     _voiceModeActive = false;
     _typewriterTimer?.cancel();
     _memoryReceiptPollTimer?.cancel();
-    _memoryReceiptDiscoveryKey = null;
     _playerSub?.cancel();
     _audioPlayer.dispose();
     _transcriptScrollController.dispose();
@@ -583,7 +580,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
             _isV2VMode = false;
             _voiceModeActive = false;
           });
-          _beginPostSessionReceiptDiscovery(endedSessionId);
+          _notifyMemorySessionEnded(endedSessionId);
           _activeSessionId = '';
         }
       },
@@ -641,7 +638,6 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     }
 
     _activeSessionId = receipt.sessionId;
-    _memoryReceiptDiscoveryKey = null;
     _memorySessionNotificationKey = null;
     _memoryReinterpretationEvent = null;
     _memoryReceiptPollTimer?.cancel();
@@ -659,21 +655,10 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     final endedSessionId = _activeSessionId;
     await _v2vClient?.disconnect();
     _v2vClient = null;
-    _beginPostSessionReceiptDiscovery(endedSessionId);
+    _notifyMemorySessionEnded(endedSessionId);
     _activeSessionId = '';
     _activeV2VProvider = '';
     _pauseVoiceMode();
-  }
-
-  void _beginPostSessionReceiptDiscovery(String sessionId) {
-    final scope = _sessionScope;
-    if (scope == null || sessionId.isEmpty) return;
-    final request = MemoryReceiptDiscoveryRequest(conversationId: scope.conversationId, sessionId: sessionId);
-    _notifyMemorySessionEnded(sessionId);
-    final discoveryKey = request.key;
-    if (_memoryReceiptDiscoveryKey == discoveryKey) return;
-    _memoryReceiptDiscoveryKey = discoveryKey;
-    unawaited(_discoverPostSessionReceipt(request.conversationId, request.sessionId, discoveryKey));
   }
 
   void _notifyMemorySessionEnded(String sessionId) {
@@ -683,20 +668,6 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     if (_memorySessionNotificationKey == request.key) return;
     _memorySessionNotificationKey = request.key;
     widget.onMemorySessionEnded?.call(request);
-  }
-
-  Future<void> _discoverPostSessionReceipt(String conversationId, String sessionId, String discoveryKey) async {
-    final result = await _memoryReceiptDiscovery.discover(
-      conversationId: conversationId,
-      sessionId: sessionId,
-      shouldContinue: () => mounted && _memoryReceiptDiscoveryKey == discoveryKey,
-    );
-    if (!mounted || _memoryReceiptDiscoveryKey != discoveryKey) return;
-    debugPrint('[VoiceChat] Memory receipt discovery: ${result.state.name}');
-    final receipt = result.receipt;
-    if (receipt != null && receipt.conversationId == conversationId) {
-      setState(() => _memoryCorrectionReceipt = receipt);
-    }
   }
 
   void _onV2VEvent(V2VEvent event) {

--- a/app/lib/pages/conversation_detail/widgets.dart
+++ b/app/lib/pages/conversation_detail/widgets.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -718,7 +720,7 @@ class AppResultDetailWidget extends StatelessWidget {
               spacing: 10,
               runSpacing: 10,
               children: [
-                _TalkAboutMemoryButton(conversation: conversation),
+                MemoryTalkButton(conversation: conversation),
                 _CorrectSummaryButton(
                   conversation: conversation,
                   appSummary: content,
@@ -732,15 +734,68 @@ class AppResultDetailWidget extends StatelessWidget {
   }
 }
 
-class _TalkAboutMemoryButton extends StatelessWidget {
-  const _TalkAboutMemoryButton({required this.conversation});
+typedef MemoryTalkRouteOpener = Future<void> Function(
+  BuildContext context,
+  ServerConversation conversation,
+  ValueChanged<MemoryReceiptDiscoveryRequest> onMemorySessionEnded,
+);
+
+class MemoryTalkButton extends StatefulWidget {
+  const MemoryTalkButton({
+    required this.conversation,
+    this.routeOpener,
+    this.receiptDiscovery,
+    super.key,
+  });
 
   final ServerConversation conversation;
+  final MemoryTalkRouteOpener? routeOpener;
+  final MemoryReinterpretationReceiptDiscovery? receiptDiscovery;
 
-  Future<void> _openMemoryTalk(BuildContext context) async {
-    MemoryReceiptDiscoveryRequest? endedSession;
+  @override
+  State<MemoryTalkButton> createState() => _MemoryTalkButtonState();
+}
+
+class _MemoryTalkButtonState extends State<MemoryTalkButton> {
+  late MemoryReinterpretationReceiptDiscovery _receiptDiscovery;
+  String? _activeDiscoveryKey;
+  MemoryReceiptDiscoveryResult? _discoveryResult;
+  ConversationCorrectionReceipt? _receipt;
+
+  ServerConversation get conversation => widget.conversation;
+
+  @override
+  void initState() {
+    super.initState();
+    _receiptDiscovery = widget.receiptDiscovery ?? MemoryReinterpretationReceiptDiscovery();
+  }
+
+  @override
+  void didUpdateWidget(covariant MemoryTalkButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.receiptDiscovery != widget.receiptDiscovery) {
+      _receiptDiscovery = widget.receiptDiscovery ?? MemoryReinterpretationReceiptDiscovery();
+    }
+    if (oldWidget.conversation.id != conversation.id) {
+      _activeDiscoveryKey = null;
+      _discoveryResult = null;
+      _receipt = null;
+    }
+  }
+
+  @override
+  void dispose() {
+    _activeDiscoveryKey = null;
+    super.dispose();
+  }
+
+  Future<void> _openDefaultVoiceRoute(
+    BuildContext context,
+    ServerConversation conversation,
+    ValueChanged<MemoryReceiptDiscoveryRequest> onMemorySessionEnded,
+  ) {
     final displayTitle = parseEllaDisplayValue(conversation.structured.title).text.trim();
-    await Navigator.of(context).push(
+    return Navigator.of(context).push(
       MaterialPageRoute(
         builder: (_) => EllaVoiceChatPage(
           sessionScope: V2VSessionScope.memory(
@@ -748,63 +803,107 @@ class _TalkAboutMemoryButton extends StatelessWidget {
             expectedActiveSummaryVersionId: conversation.activeSummaryVersionId,
           ),
           memoryTitle: displayTitle,
-          onMemorySessionEnded: (request) => endedSession = request,
+          onMemorySessionEnded: onMemorySessionEnded,
         ),
-      ),
-    );
-
-    final request = endedSession;
-    if (!context.mounted || request == null) return;
-    final result = await MemoryReinterpretationReceiptDiscovery().discover(
-      conversationId: request.conversationId,
-      sessionId: request.sessionId,
-      shouldContinue: () => context.mounted,
-    );
-    if (!context.mounted || result.receipt == null) return;
-    final receipt = result.receipt!;
-    await showMemoryCorrectionReceiptSheet(
-      context,
-      receipt: receipt,
-      onUndo: () => undoConversationCorrection(
-        conversationId: receipt.conversationId,
-        correctionId: receipt.correctionId,
       ),
     );
   }
 
+  Future<void> _openMemoryTalk() async {
+    final openRoute = widget.routeOpener ?? _openDefaultVoiceRoute;
+    await openRoute(context, conversation, _handleMemorySessionEnded);
+  }
+
+  void _handleMemorySessionEnded(MemoryReceiptDiscoveryRequest request) {
+    if (request.conversationId != conversation.id || request.sessionId.isEmpty) return;
+    if (_activeDiscoveryKey == request.key) return;
+    _activeDiscoveryKey = request.key;
+    _discoveryResult = null;
+    unawaited(_discoverReceipt(request));
+  }
+
+  Future<void> _discoverReceipt(MemoryReceiptDiscoveryRequest request) async {
+    final discoveryKey = request.key;
+    final result = await _receiptDiscovery.discover(
+      conversationId: request.conversationId,
+      sessionId: request.sessionId,
+      shouldContinue: () => mounted && _activeDiscoveryKey == discoveryKey,
+    );
+    if (!mounted || _activeDiscoveryKey != discoveryKey) return;
+    setState(() {
+      _discoveryResult = result;
+      if (result.receipt != null && result.receipt!.conversationId == conversation.id) {
+        _receipt = result.receipt;
+      }
+    });
+  }
+
+  Future<ConversationCorrectionReceipt?> _undoMemoryCorrection() async {
+    final receipt = _receipt;
+    if (receipt == null || !receipt.isApplied) return null;
+    final updated = await undoConversationCorrection(
+      conversationId: receipt.conversationId,
+      correctionId: receipt.correctionId,
+    );
+    if (mounted && updated != null && _receipt?.correctionId == receipt.correctionId) {
+      setState(() => _receipt = updated);
+    }
+    return updated;
+  }
+
+  void _reviewMemoryCorrection() {
+    final receipt = _receipt;
+    if (receipt == null || !receipt.isApplied) return;
+    showMemoryCorrectionReceiptSheet(context, receipt: receipt, onUndo: _undoMemoryCorrection);
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(18),
-        onTap: () async {
-          HapticFeedback.lightImpact();
-          await _openMemoryTalk(context);
-        },
-        child: Ink(
-          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-          decoration: BoxDecoration(
-            color: EllaColors.primary,
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Material(
+          color: Colors.transparent,
+          child: InkWell(
+            key: ValueKey('memory-talk-${conversation.id}'),
             borderRadius: BorderRadius.circular(18),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(Icons.graphic_eq_rounded, size: 18, color: EllaColors.paper),
-              const SizedBox(width: 8),
-              Text(
-                context.l10n.memoryTalkAction,
-                style: const TextStyle(
-                  color: EllaColors.paper,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w700,
-                ),
+            onTap: () async {
+              HapticFeedback.lightImpact();
+              await _openMemoryTalk();
+            },
+            child: Ink(
+              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+              decoration: BoxDecoration(
+                color: EllaColors.primary,
+                borderRadius: BorderRadius.circular(18),
               ),
-            ],
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.graphic_eq_rounded, size: 18, color: EllaColors.paper),
+                  const SizedBox(width: 8),
+                  Text(
+                    context.l10n.memoryTalkAction,
+                    style: const TextStyle(
+                      color: EllaColors.paper,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+            ),
           ),
         ),
-      ),
+        if (_discoveryResult?.receipt != null && _receipt != null) ...[
+          const SizedBox(height: 10),
+          MemoryCorrectionReceiptChip(
+            key: ValueKey('memory-receipt-${conversation.id}'),
+            receipt: _receipt!,
+            onReview: _reviewMemoryCorrection,
+          ),
+        ],
+      ],
     );
   }
 }

--- a/app/test/pages/conversation_detail/memory_talk_receipt_lifecycle_test.dart
+++ b/app/test/pages/conversation_detail/memory_talk_receipt_lifecycle_test.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/http/api/conversations.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/ella/services/memory_reinterpretation_receipt_service.dart';
+import 'package:omi/ella/widgets/memory_correction_receipt.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/conversation_detail/widgets.dart';
+
+const conversationId = 'conversation-1';
+const sessionId = 'session-1';
+const correctionId = 'correction-1';
+
+ServerConversation memoryConversation() => ServerConversation(
+      id: conversationId,
+      createdAt: DateTime.utc(2026, 7, 24),
+      structured: Structured('A seeded memory', 'The selected memory overview'),
+    );
+
+ConversationReinterpretationJob appliedJob() => const ConversationReinterpretationJob(
+      jobId: 'job-1',
+      sessionId: sessionId,
+      conversationId: conversationId,
+      status: 'applied',
+      outcome: 'applied',
+      correctionIds: [correctionId],
+      receipts: [
+        ConversationReinterpretationReceiptReference(
+          conversationId: conversationId,
+          correctionId: correctionId,
+          status: 'applied',
+        ),
+      ],
+    );
+
+ConversationCorrectionReceipt appliedReceipt() => const ConversationCorrectionReceipt(
+      correctionId: correctionId,
+      conversationId: conversationId,
+      status: 'applied',
+      before: ConversationCorrectionSummary(title: 'Before'),
+      after: ConversationCorrectionSummary(title: 'After'),
+    );
+
+class _FakeMemoryVoiceRoute extends StatefulWidget {
+  const _FakeMemoryVoiceRoute({required this.onSessionEnded});
+
+  final ValueChanged<MemoryReceiptDiscoveryRequest> onSessionEnded;
+
+  @override
+  State<_FakeMemoryVoiceRoute> createState() => _FakeMemoryVoiceRouteState();
+}
+
+class _FakeMemoryVoiceRouteState extends State<_FakeMemoryVoiceRoute> {
+  @override
+  void dispose() {
+    widget.onSessionEnded(
+      const MemoryReceiptDiscoveryRequest(conversationId: conversationId, sessionId: sessionId),
+    );
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: ElevatedButton(
+          key: const ValueKey('end-memory-session'),
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('End session'),
+        ),
+      ),
+    );
+  }
+}
+
+Widget app({
+  required MemoryReinterpretationReceiptDiscovery discovery,
+}) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: MemoryTalkButton(
+        conversation: memoryConversation(),
+        receiptDiscovery: discovery,
+        routeOpener: (context, _, onSessionEnded) => Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            builder: (_) => _FakeMemoryVoiceRoute(onSessionEnded: onSessionEnded),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('discovers a delayed receipt after the memory voice route is popped', (tester) async {
+    final delayedJob = Completer<ConversationReinterpretationJob?>();
+    final discovery = MemoryReinterpretationReceiptDiscovery(
+      fetchLatest: (_) => delayedJob.future,
+      fetchReceipt: (_, __) async => appliedReceipt(),
+      wait: (_) async {},
+      maxAttempts: 1,
+    );
+
+    await tester.pumpWidget(app(discovery: discovery));
+    await tester.tap(find.byKey(const ValueKey('memory-talk-$conversationId')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(_FakeMemoryVoiceRoute), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('end-memory-session')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(_FakeMemoryVoiceRoute), findsNothing);
+    expect(find.byType(MemoryCorrectionReceiptChip), findsNothing);
+
+    delayedJob.complete(appliedJob());
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MemoryCorrectionReceiptChip), findsOneWidget);
+    expect(find.text('Memory updated'), findsOneWidget);
+    expect(find.text('Review'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/ellaaicare/omi/pull/327, which was merged at `919b519cbe30319d15741d62d3579443030a9d34` before the route-lifetime blocker had lifecycle coverage.

- move post-session discovery/result/receipt ownership from disposable `EllaVoiceChatPage` state to the longer-lived conversation detail widget
- have Voice Chat emit only the exact ended conversation/session identifiers while retaining its WebSocket fast path
- keep the authoritative applied receipt on the conversation UI and reuse the existing Review/Undo sheet
- reject mismatched conversations and cancel superseded/disposed discovery by exact request key
- add a widget regression that ends a scoped session from route `dispose()`, pops Voice Chat, completes the backend result later, and proves the conversation UI renders `Memory updated` and `Review`

Tracks https://github.com/ellaaicare/ella-ai/issues/1101.

## Validation

- focused lifecycle + receipt discovery: 13/13 passed
- full Flutter suite: 189/189 passed
- targeted `flutter analyze --no-fatal-infos`: no errors or warnings; 26 existing info-level findings in legacy code
- `git diff --check`: clean
- GitNexus refreshed successfully at this head

No backend/proxy changes, build-number change, TestFlight upload, App Store Connect action, or production mutation.

AgentStatus: ready-for-review
Agent: Sophia
Caller: Henry
