### PR TITLE
D1: compact versioned voice consent

### DIFF
--- a/app/lib/core/app_shell.dart
+++ b/app/lib/core/app_shell.dart
@@ -3,14 +3,10 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import 'package:app_links/app_links.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:provider/provider.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/desktop/desktop_app.dart';
-import 'package:omi/ella/widgets/ai_consent_sheet.dart';
-import 'package:omi/ella/services/ella_ai_consent_service.dart';
-import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/mobile/mobile_app.dart';
 import 'package:omi/pages/apps/app_detail/app_detail.dart';
 import 'package:omi/pages/settings/asana_settings_page.dart';
@@ -19,9 +15,6 @@ import 'package:omi/pages/settings/usage_page.dart';
 import 'package:omi/pages/settings/wrapped_2025_page.dart';
 import 'package:omi/providers/app_provider.dart';
 import 'package:omi/providers/auth_provider.dart';
-import 'package:omi/providers/capture_provider.dart';
-import 'package:omi/providers/device_provider.dart';
-import 'package:omi/providers/ella_provisioning_provider.dart';
 import 'package:omi/providers/home_provider.dart';
 import 'package:omi/providers/integration_provider.dart';
 import 'package:omi/providers/message_provider.dart';
@@ -49,9 +42,6 @@ class AppShell extends StatefulWidget {
 class _AppShellState extends State<AppShell> {
   late AppLinks _appLinks;
   StreamSubscription<Uri>? _linkSubscription;
-  AuthenticationProvider? _authProvider;
-  bool _wasSignedIn = false;
-  bool _consentPromptPresented = false;
 
   Future<void> initDeepLinks() async {
     _appLinks = AppLinks();
@@ -302,35 +292,10 @@ class _AppShellState extends State<AppShell> {
     WidgetsBinding.instance.addPostFrameCallback((_) => _initializeProviders());
   }
 
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    final authProvider = context.read<AuthenticationProvider>();
-    if (identical(_authProvider, authProvider)) return;
-    _authProvider?.removeListener(_onAuthChanged);
-    _authProvider = authProvider;
-    _wasSignedIn = authProvider.isSignedIn();
-    authProvider.addListener(_onAuthChanged);
-  }
-
-  void _onAuthChanged() {
-    final isSignedIn = _authProvider?.isSignedIn() ?? false;
-    if (isSignedIn && !_wasSignedIn) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) _showConsentIfNeeded();
-      });
-    } else if (!isSignedIn) {
-      _consentPromptPresented = false;
-    }
-    _wasSignedIn = isSignedIn;
-  }
-
   Future<void> _initializeProviders() async {
     if (!mounted) return;
     final isSignedIn = context.read<AuthenticationProvider>().isSignedIn();
     if (isSignedIn) {
-      await _showConsentIfNeeded();
-      if (!mounted) return;
       context.read<HomeProvider>().setupHasSpeakerProfile();
       context.read<HomeProvider>().setupUserPrimaryLanguage();
       context.read<UserProvider>().initialize();
@@ -358,54 +323,8 @@ class _AppShellState extends State<AppShell> {
     PlatformManager.instance.intercom.setUserAttributes();
   }
 
-  Future<void> _showConsentIfNeeded() async {
-    if (_consentPromptPresented) return;
-
-    final preferences = SharedPreferencesUtil();
-    final uid = FirebaseAuth.instance.currentUser?.uid ?? '';
-    if (isHermesProvisioningGateEnabled) {
-      if (uid.isEmpty) return;
-      await preferences.prepareEllaProvisioningAccount(uid);
-      if (!mounted || _consentPromptPresented) return;
-      if (preferences.hasAccountBoundAiConsent(uid)) return;
-      if (preferences.hasPriorAccountBoundAiConsent(uid) || preferences.isCurrentAiConsentDeferred) {
-        // Existing users review a new processor contract on their next
-        // explicit voice action rather than at unrelated app startup.
-        return;
-      }
-
-      // Legacy local consent is not sufficient for a newly isolated account.
-      preferences.declineAiConsent();
-    } else if (preferences.aiConsentAccepted) {
-      return;
-    }
-
-    _consentPromptPresented = true;
-    final accepted = await AiConsentSheet.show(
-      context,
-      onAccept: isHermesProvisioningGateEnabled
-          ? () async {
-              final receiptId = await EllaAiConsentService().acknowledgePrivateCloudSync(uid: uid);
-              if (receiptId == null) return false;
-              if (mounted) context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
-              return true;
-            }
-          : null,
-    );
-    if (accepted == true && mounted) {
-      final captureProvider = context.read<CaptureProvider>();
-      final device = context.read<DeviceProvider>().connectedDevice;
-      await captureProvider.streamDeviceRecording(device: device);
-    } else if (accepted == false && mounted && isHermesProvisioningGateEnabled) {
-      final captureProvider = context.read<CaptureProvider>();
-      await captureProvider.stopStreamDeviceRecording();
-      await captureProvider.stopStreamRecording();
-    }
-  }
-
   @override
   void dispose() {
-    _authProvider?.removeListener(_onAuthChanged);
     _linkSubscription?.cancel();
     super.dispose();
   }

--- a/app/lib/desktop/pages/conversations/widgets/desktop_recording_widget.dart
+++ b/app/lib/desktop/pages/conversations/widgets/desktop_recording_widget.dart
@@ -85,8 +85,8 @@ class _DesktopRecordingWidgetState extends State<DesktopRecordingWidget> {
       // If we have an onStartRecording callback and not currently recording, use navigation
       if (widget.onStartRecording != null && recordingState != RecordingState.systemAudioRecord && !provider.isPaused) {
         // Start recording and then navigate
-        await provider.streamSystemAudioRecording();
-        widget.onStartRecording!();
+        final started = await provider.streamSystemAudioRecording();
+        if (started) widget.onStartRecording!();
       } else {
         // Handle recording controls (for when already on recording page)
         if (recordingState == RecordingState.systemAudioRecord) {
@@ -181,9 +181,7 @@ class _DesktopRecordingWidgetState extends State<DesktopRecordingWidget> {
               ),
               const SizedBox(height: 6),
               SelectableText(
-                isInitializing
-                    ? context.l10n.preparingSystemAudioCapture
-                    : context.l10n.clickTheButtonToCaptureAudio,
+                isInitializing ? context.l10n.preparingSystemAudioCapture : context.l10n.clickTheButtonToCaptureAudio,
                 style: const TextStyle(
                   fontSize: 15,
                   color: ResponsiveHelper.textTertiary,
@@ -293,7 +291,9 @@ class _DesktopRecordingWidgetState extends State<DesktopRecordingWidget> {
                                       ? '${latestTranscript.substring(0, 60)}...'
                                       : latestTranscript)
                                   : (isPaused ? context.l10n.tapPlayToResume : context.l10n.listeningForAudio))
-                              : (isInitializing ? context.l10n.preparingAudioCapture : context.l10n.clickToBeginRecording),
+                              : (isInitializing
+                                  ? context.l10n.preparingAudioCapture
+                                  : context.l10n.clickToBeginRecording),
                       style: TextStyle(
                         fontSize: 14,
                         color: isRecordingOrPaused ? ResponsiveHelper.textSecondary : ResponsiveHelper.textTertiary,
@@ -574,7 +574,8 @@ class _DesktopRecordingWidgetState extends State<DesktopRecordingWidget> {
         final segment = entry.value;
         final isLatest = index == displaySegments.length - 1;
 
-        String speakerName = segment.isUser ? context.l10n.you : context.l10n.speakerWithId(segment.speakerId.toString());
+        String speakerName =
+            segment.isUser ? context.l10n.you : context.l10n.speakerWithId(segment.speakerId.toString());
         if (segment.personId != null && !segment.isUser) {
           final person = people.firstWhereOrNull((p) => p.id == segment.personId);
           if (person != null) {

--- a/app/lib/ella/services/ai_consent_coordinator.dart
+++ b/app/lib/ella/services/ai_consent_coordinator.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ella_ai_consent_service.dart';
+import 'package:omi/ella/services/ella_provisioning_service.dart';
+import 'package:omi/ella/widgets/ai_consent_sheet.dart';
+import 'package:omi/providers/ella_provisioning_provider.dart';
+
+typedef AiConsentPrompt = Future<bool> Function();
+typedef AiConsentProtectedAction = Future<void> Function();
+
+class AiConsentActionGate {
+  Future<bool>? _activeRequest;
+
+  Future<bool> ensure({
+    required bool Function() hasConsent,
+    required AiConsentPrompt requestConsent,
+  }) async {
+    if (hasConsent()) return true;
+
+    final activeRequest = _activeRequest;
+    if (activeRequest != null) {
+      return await activeRequest && hasConsent();
+    }
+
+    late final Future<bool> trackedRequest;
+    trackedRequest = requestConsent().whenComplete(() {
+      if (identical(_activeRequest, trackedRequest)) {
+        _activeRequest = null;
+      }
+    });
+    _activeRequest = trackedRequest;
+
+    return await trackedRequest && hasConsent();
+  }
+
+  Future<bool> run({
+    required bool Function() hasConsent,
+    required AiConsentPrompt requestConsent,
+    required AiConsentProtectedAction action,
+  }) async {
+    if (!await ensure(hasConsent: hasConsent, requestConsent: requestConsent)) return false;
+    await action();
+    return true;
+  }
+}
+
+class AiConsentCoordinator {
+  static final AiConsentActionGate _gate = AiConsentActionGate();
+
+  static Future<bool> ensure(BuildContext context) {
+    final preferences = SharedPreferencesUtil();
+    return _gate.ensure(
+      hasConsent: () => preferences.aiConsentAccepted,
+      requestConsent: () => _request(context),
+    );
+  }
+
+  static Future<bool> _request(BuildContext context) async {
+    final uid = FirebaseAuth.instance.currentUser?.uid ?? '';
+    if (isHermesProvisioningGateEnabled && uid.isEmpty) return false;
+
+    final accepted = await AiConsentSheet.show(
+      context,
+      onAccept: isHermesProvisioningGateEnabled
+          ? () async {
+              final receiptId = await EllaAiConsentService().acknowledgePrivateCloudSync(uid: uid);
+              if (receiptId == null) return false;
+              if (context.mounted) {
+                try {
+                  context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
+                } catch (_) {
+                  // The authenticated receipt is already persisted when this
+                  // action is rendered outside the provisioning provider tree.
+                }
+              }
+              return true;
+            }
+          : null,
+    );
+    return accepted == true && SharedPreferencesUtil().aiConsentAccepted;
+  }
+}

--- a/app/lib/ella/widgets/ai_consent_sheet.dart
+++ b/app/lib/ella/widgets/ai_consent_sheet.dart
@@ -22,7 +22,7 @@ class AiConsentSheet extends StatefulWidget {
       useSafeArea: true,
       backgroundColor: EllaColors.paper,
       shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(28))),
-      builder: (_) => AiConsentSheet(onAccept: onAccept),
+      builder: (_) => FractionallySizedBox(heightFactor: 0.68, child: AiConsentSheet(onAccept: onAccept)),
     );
   }
 
@@ -66,93 +66,85 @@ class _AiConsentSheetState extends State<AiConsentSheet> {
     final bodyStyle = Theme.of(context).textTheme.bodyLarge?.copyWith(color: EllaColors.textSecondary, height: 1.5);
     return PopScope(
       canPop: false,
-      child: SingleChildScrollView(
-        padding: EdgeInsets.fromLTRB(24, 16, 24, 44 + MediaQuery.paddingOf(context).bottom),
+      child: Padding(
+        padding: EdgeInsets.only(bottom: 12 + MediaQuery.paddingOf(context).bottom),
         child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(context.l10n.aiConsentTitle, style: EllaTextStyles.display),
-            const SizedBox(height: 16),
-            Text.rich(
-              TextSpan(
-                style: bodyStyle,
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(24, 16, 24, 12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(context.l10n.aiConsentTitle, style: EllaTextStyles.display),
+                    const SizedBox(height: 16),
+                    Text(context.l10n.aiConsentCompactSummary, style: bodyStyle),
+                    const SizedBox(height: 14),
+                    Text.rich(
+                      TextSpan(
+                        text: context.l10n.aiConsentProcessorDetailsLink,
+                        style: bodyStyle?.copyWith(
+                          color: EllaColors.primary,
+                          decoration: TextDecoration.underline,
+                          decorationColor: EllaColors.primary,
+                        ),
+                        recognizer: TapGestureRecognizer()..onTap = () => launchUrl(AiConsentSheet.privacyPolicyUri),
+                      ),
+                    ),
+                    if (_hasError) ...[
+                      const SizedBox(height: 12),
+                      Text(context.l10n.somethingWentWrongTryAgain,
+                          style: bodyStyle?.copyWith(color: EllaColors.error)),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Column(
                 children: [
-                  TextSpan(text: context.l10n.aiConsentBodyIntro),
-                  TextSpan(
-                    text: context.l10n.aiConsentDeepgram,
-                    style: const TextStyle(fontWeight: FontWeight.w700),
+                  SizedBox(
+                    width: double.infinity,
+                    height: 56,
+                    child: FilledButton(
+                      onPressed: _isSubmitting ? null : _accept,
+                      style: FilledButton.styleFrom(
+                        backgroundColor: EllaColors.tealDeep,
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(EllaSizes.cardRadius)),
+                      ),
+                      child: _isSubmitting
+                          ? const SizedBox(
+                              width: 22,
+                              height: 22,
+                              child: CircularProgressIndicator(strokeWidth: 2, color: EllaColors.paper),
+                            )
+                          : Text(context.l10n.allowAndContinue, style: const TextStyle(fontSize: 17)),
+                    ),
                   ),
-                  TextSpan(text: context.l10n.aiConsentBodyMiddle),
-                  TextSpan(
-                    text: context.l10n.aiConsentAiPartners,
-                    style: const TextStyle(fontWeight: FontWeight.w700),
+                  const SizedBox(height: 4),
+                  SizedBox(
+                    width: double.infinity,
+                    height: 50,
+                    child: TextButton(
+                      onPressed: _isSubmitting
+                          ? null
+                          : () {
+                              SharedPreferencesUtil().deferAiConsent();
+                              Navigator.of(context).pop(false);
+                            },
+                      child: Text(
+                        context.l10n.notNow,
+                        style: const TextStyle(
+                          fontSize: 17,
+                          color: EllaColors.inkSoft,
+                          decoration: TextDecoration.underline,
+                          decorationColor: EllaColors.inkSoft,
+                        ),
+                      ),
+                    ),
                   ),
-                  TextSpan(text: context.l10n.aiConsentBodyBeforeElevenLabs),
-                  TextSpan(
-                    text: context.l10n.aiConsentElevenLabs,
-                    style: const TextStyle(fontWeight: FontWeight.w700),
-                  ),
-                  TextSpan(text: context.l10n.aiConsentBodyEnd),
-                  TextSpan(text: context.l10n.aiConsentMemoryContext),
                 ],
-              ),
-            ),
-            const SizedBox(height: 14),
-            Text.rich(
-              TextSpan(
-                text: context.l10n.privacyPolicy,
-                style: bodyStyle?.copyWith(
-                  color: EllaColors.primary,
-                  decoration: TextDecoration.underline,
-                  decorationColor: EllaColors.primary,
-                ),
-                recognizer: TapGestureRecognizer()..onTap = () => launchUrl(AiConsentSheet.privacyPolicyUri),
-              ),
-            ),
-            const SizedBox(height: 28),
-            if (_hasError) ...[
-              Text(context.l10n.somethingWentWrongTryAgain, style: bodyStyle?.copyWith(color: EllaColors.error)),
-              const SizedBox(height: 12),
-            ],
-            SizedBox(
-              width: double.infinity,
-              height: 56,
-              child: FilledButton(
-                onPressed: _isSubmitting ? null : _accept,
-                style: FilledButton.styleFrom(
-                  backgroundColor: EllaColors.tealDeep,
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(EllaSizes.cardRadius)),
-                ),
-                child: _isSubmitting
-                    ? const SizedBox(
-                        width: 22,
-                        height: 22,
-                        child: CircularProgressIndicator(strokeWidth: 2, color: EllaColors.paper),
-                      )
-                    : Text(context.l10n.allowAndContinue, style: const TextStyle(fontSize: 17)),
-              ),
-            ),
-            const SizedBox(height: 10),
-            SizedBox(
-              width: double.infinity,
-              height: 50,
-              child: TextButton(
-                onPressed: _isSubmitting
-                    ? null
-                    : () {
-                        SharedPreferencesUtil().deferAiConsent();
-                        Navigator.of(context).pop(false);
-                      },
-                child: Text(
-                  context.l10n.notNow,
-                  style: const TextStyle(
-                    fontSize: 17,
-                    color: EllaColors.inkSoft,
-                    decoration: TextDecoration.underline,
-                    decorationColor: EllaColors.inkSoft,
-                  ),
-                ),
               ),
             ),
           ],

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10466,5 +10466,7 @@
   "todayMemoriesEmpty": "As Ella listens today, your memories will gather here. 🪽",
   "todayListeningLead": "Ella is listening — ",
   "todayListeningLink": "See what she hears ›",
-  "todayReadMore": "Read more"
+  "todayReadMore": "Read more",
+  "aiConsentCompactSummary": "When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella's secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella's secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.",
+  "aiConsentProcessorDetailsLink": "Full processor details in Privacy Policy"
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -16508,6 +16508,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Read more'**
   String get todayReadMore;
+
+  /// No description provided for @aiConsentCompactSummary.
+  ///
+  /// In en, this message translates to:
+  /// **'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.'**
+  String get aiConsentCompactSummary;
+
+  /// No description provided for @aiConsentProcessorDetailsLink.
+  ///
+  /// In en, this message translates to:
+  /// **'Full processor details in Privacy Policy'**
+  String get aiConsentProcessorDetailsLink;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8797,4 +8797,11 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8885,4 +8885,11 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8901,4 +8901,11 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8848,4 +8848,11 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8837,4 +8837,11 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8919,4 +8919,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8910,4 +8910,11 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8850,4 +8850,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8867,4 +8867,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8852,4 +8852,11 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8851,4 +8851,11 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8926,4 +8926,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8833,4 +8833,11 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8890,4 +8890,11 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8865,4 +8865,11 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8902,4 +8902,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8719,4 +8719,11 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8721,4 +8721,11 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8858,4 +8858,11 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8870,4 +8870,11 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8876,4 +8876,11 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8878,4 +8878,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8848,4 +8848,11 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8871,4 +8871,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8853,4 +8853,11 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8891,4 +8891,11 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8878,4 +8878,11 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8843,4 +8843,11 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8858,4 +8858,11 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8815,4 +8815,11 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8866,4 +8866,11 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8865,4 +8865,11 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8855,4 +8855,11 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8709,4 +8709,11 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get aiConsentCompactSummary =>
+      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+
+  @override
+  String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 }

--- a/app/lib/pages/onboarding/ella/ella_onboarding.dart
+++ b/app/lib/pages/onboarding/ella/ella_onboarding.dart
@@ -9,7 +9,9 @@ import 'package:provider/provider.dart';
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/ella/services/ella_ai_consent_service.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
+import 'package:omi/ella/widgets/ai_consent_sheet.dart';
 import 'package:omi/pages/home/page.dart';
 import 'package:omi/pages/onboarding/auth.dart';
 import 'package:omi/pages/onboarding/ella/ella_connect.dart';
@@ -23,6 +25,14 @@ import 'package:omi/utils/platform/platform_manager.dart';
 class EllaOnboarding extends StatefulWidget {
   const EllaOnboarding({super.key});
 
+  @visibleForTesting
+  static bool shouldPresentVoiceConsent({
+    required bool hasCurrentConsent,
+    required bool hasPriorAccountConsent,
+    required bool deferredCurrentConsent,
+  }) =>
+      !hasCurrentConsent && !hasPriorAccountConsent && !deferredCurrentConsent;
+
   @override
   State<EllaOnboarding> createState() => _EllaOnboardingState();
 }
@@ -31,6 +41,7 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
   final PageController _pageController = PageController();
   int _currentPage = 0;
   bool _isSignedIn = false;
+  bool _isCompletingOnboarding = false;
 
   @override
   void initState() {
@@ -86,7 +97,37 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
     setState(() => _currentPage = page);
   }
 
-  void _completeOnboarding() {
+  Future<void> _completeOnboarding() async {
+    if (_isCompletingOnboarding) return;
+    setState(() => _isCompletingOnboarding = true);
+
+    final preferences = SharedPreferencesUtil();
+    final uid = FirebaseAuth.instance.currentUser?.uid ?? '';
+    if (isHermesProvisioningGateEnabled && uid.isNotEmpty) {
+      await preferences.prepareEllaProvisioningAccount(uid);
+    }
+    if (!mounted) return;
+    final shouldPresentVoiceConsent = EllaOnboarding.shouldPresentVoiceConsent(
+      hasCurrentConsent:
+          isHermesProvisioningGateEnabled ? preferences.hasAccountBoundAiConsent(uid) : preferences.aiConsentAccepted,
+      hasPriorAccountConsent: uid.isNotEmpty && preferences.hasPriorAccountBoundAiConsent(uid),
+      deferredCurrentConsent: preferences.isCurrentAiConsentDeferred,
+    );
+    if (shouldPresentVoiceConsent && mounted) {
+      await AiConsentSheet.show(
+        context,
+        onAccept: isHermesProvisioningGateEnabled
+            ? () async {
+                final receiptId = await EllaAiConsentService().acknowledgePrivateCloudSync(uid: uid);
+                if (receiptId == null) return false;
+                if (mounted) context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
+                return true;
+              }
+            : null,
+      );
+    }
+    if (!mounted) return;
+
     SharedPreferencesUtil().onboardingCompleted = true;
     if (AuthService.instance.isSignedIn()) {
       updateUserOnboardingState(completed: true);

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -10,7 +9,6 @@ import 'package:collection/collection.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:flutter_provider_utilities/flutter_provider_utilities.dart';
 import 'package:geolocator/geolocator.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import 'package:omi/backend/http/api/conversations.dart';
@@ -23,8 +21,8 @@ import 'package:omi/backend/schema/message.dart';
 import 'package:omi/backend/schema/person.dart';
 import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/ella/services/ai_consent_coordinator.dart';
 import 'package:omi/models/custom_stt_config.dart';
-import 'package:omi/models/stt_provider.dart';
 import 'package:omi/providers/calendar_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/providers/message_provider.dart';
@@ -40,7 +38,6 @@ import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/enums.dart';
 import 'package:omi/utils/image/image_utils.dart';
 import 'package:omi/utils/l10n_extensions.dart';
-import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 import 'package:omi/main.dart';
@@ -124,6 +121,7 @@ class CaptureProvider extends ChangeNotifier
 
   List<int> _systemAudioBuffer = [];
   bool _systemAudioCaching = true;
+  Future<bool>? _systemAudioStartFuture;
 
   bool _isLoadingInProgressConversation = false;
 
@@ -1036,11 +1034,29 @@ class CaptureProvider extends ChangeNotifier
     await _socket?.stop(reason: 'stop stream device recording');
   }
 
-  Future<void> streamSystemAudioRecording() async {
-    if (!SharedPreferencesUtil().aiConsentAccepted) return;
+  Future<bool> streamSystemAudioRecording() {
+    final activeStart = _systemAudioStartFuture;
+    if (activeStart != null) return activeStart;
+
+    late final Future<bool> trackedStart;
+    trackedStart = _streamSystemAudioRecording().whenComplete(() {
+      if (identical(_systemAudioStartFuture, trackedStart)) {
+        _systemAudioStartFuture = null;
+      }
+    });
+    _systemAudioStartFuture = trackedStart;
+    return trackedStart;
+  }
+
+  Future<bool> _streamSystemAudioRecording() async {
     if (!PlatformService.isDesktop) {
       notifyError('System audio recording is only available on macOS and Windows.');
-      return;
+      return false;
+    }
+
+    if (!SharedPreferencesUtil().aiConsentAccepted) {
+      final context = MyApp.navigatorKey.currentContext;
+      if (context == null || !await AiConsentCoordinator.ensure(context)) return false;
     }
 
     // User wants to record - enable auto-resume after wake
@@ -1058,8 +1074,10 @@ class CaptureProvider extends ChangeNotifier
     bool permissionsGranted = await _checkAndRequestSystemAudioPermissions();
     if (permissionsGranted) {
       await _startSystemAudioCapture();
+      return recordingState == RecordingState.systemAudioRecord;
     } else {
       updateRecordingState(RecordingState.stop);
+      return false;
     }
   }
 

--- a/app/test/ella/services/ai_consent_coordinator_test.dart
+++ b/app/test/ella/services/ai_consent_coordinator_test.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/ella/services/ai_consent_coordinator.dart';
+
+void main() {
+  group('AiConsentActionGate', () {
+    test('prompts once, accepts, and starts the protected action', () async {
+      final gate = AiConsentActionGate();
+      var hasConsent = false;
+      var promptCount = 0;
+      var startCount = 0;
+
+      final started = await gate.run(
+        hasConsent: () => hasConsent,
+        requestConsent: () async {
+          promptCount += 1;
+          hasConsent = true;
+          return true;
+        },
+        action: () async => startCount += 1,
+      );
+
+      expect(started, isTrue);
+      expect(promptCount, 1);
+      expect(startCount, 1);
+    });
+
+    test('decline leaves the protected audio action stopped', () async {
+      final gate = AiConsentActionGate();
+      var startCount = 0;
+
+      final started = await gate.run(
+        hasConsent: () => false,
+        requestConsent: () async => false,
+        action: () async => startCount += 1,
+      );
+
+      expect(started, isFalse);
+      expect(startCount, 0);
+    });
+
+    test('coalesces simultaneous consent requests', () async {
+      final gate = AiConsentActionGate();
+      final promptCompleter = Completer<bool>();
+      var hasConsent = false;
+      var promptCount = 0;
+
+      Future<bool> requestConsent() {
+        promptCount += 1;
+        return promptCompleter.future;
+      }
+
+      final first = gate.ensure(hasConsent: () => hasConsent, requestConsent: requestConsent);
+      final second = gate.ensure(hasConsent: () => hasConsent, requestConsent: requestConsent);
+      expect(promptCount, 1);
+
+      hasConsent = true;
+      promptCompleter.complete(true);
+
+      expect(await first, isTrue);
+      expect(await second, isTrue);
+    });
+  });
+}

--- a/app/test/ella/services/v2v_client_test.dart
+++ b/app/test/ella/services/v2v_client_test.dart
@@ -223,6 +223,21 @@ void main() {
       await client.disconnect();
     });
 
+    test('declined current consent blocks before V2V identity or session requests', () async {
+      final preferences = SharedPreferencesUtil();
+      preferences.uid = 'uid-a';
+      preferences.deferAiConsent();
+      final client = V2VClient(onEvent: (_) {}, onConnectionChanged: (_) {});
+
+      final receipt = await client.connect(provider: 'grok-voice');
+
+      expect(receipt.connected, isFalse);
+      expect(receipt.stage, V2VConnectionStage.consent);
+      expect(receipt.errorCode, 'ai_consent_required');
+      expect(client.isConnected, isFalse);
+      await client.disconnect();
+    });
+
     test('accepted v3 consent passes the mic gate before identity validation', () async {
       final preferences = SharedPreferencesUtil();
       preferences.acceptAiConsent();

--- a/app/test/ella/widgets/ai_consent_sheet_test.dart
+++ b/app/test/ella/widgets/ai_consent_sheet_test.dart
@@ -20,6 +20,30 @@ void main() {
         home: Scaffold(body: AiConsentSheet()),
       );
 
+  testWidgets('presents as a bounded sheet with Not now always visible', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              onPressed: () => AiConsentSheet.show(context),
+              child: const Text('Show consent'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Show consent'));
+    await tester.pumpAndSettle();
+
+    final screenHeight = tester.view.physicalSize.height / tester.view.devicePixelRatio;
+    expect(tester.getSize(find.byType(AiConsentSheet)).height, lessThanOrEqualTo(screenHeight * 0.7));
+    expect(find.text('Not now').hitTestable(), findsOneWidget);
+  });
+
   testWidgets('names every voice processor and explains routed data before acceptance', (tester) async {
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
@@ -35,12 +59,12 @@ void main() {
     expect(disclosure, contains('OpenAI'));
     expect(disclosure, contains('Groq'));
     expect(disclosure, contains('xAI (Grok)'));
-    expect(disclosure, contains('OpenAI, Groq, and xAI (Grok)'));
     expect(disclosure, contains('ElevenLabs'));
     expect(disclosure, contains('response text'));
     expect(disclosure, contains('selected stored memory'));
     expect(disclosure, contains('related people, topics, and dates'));
     expect(disclosure, contains('Google (Gemini) or xAI (Grok) voice processor'));
+    expect(disclosure, contains('Full processor details in Privacy Policy'));
     expect(find.text('Not now'), findsOneWidget);
   });
 

--- a/app/test/pages/onboarding/ella/ella_onboarding_consent_test.dart
+++ b/app/test/pages/onboarding/ella/ella_onboarding_consent_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/pages/onboarding/ella/ella_onboarding.dart';
+
+void main() {
+  group('Ella onboarding voice consent policy', () {
+    test('new user sees the current voice consent during onboarding', () {
+      expect(
+        EllaOnboarding.shouldPresentVoiceConsent(
+          hasCurrentConsent: false,
+          hasPriorAccountConsent: false,
+          deferredCurrentConsent: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('accepted current contract is never requested again', () {
+      expect(
+        EllaOnboarding.shouldPresentVoiceConsent(
+          hasCurrentConsent: true,
+          hasPriorAccountConsent: false,
+          deferredCurrentConsent: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('existing user with a stale contract waits for explicit voice use', () {
+      expect(
+        EllaOnboarding.shouldPresentVoiceConsent(
+          hasCurrentConsent: false,
+          hasPriorAccountConsent: true,
+          deferredCurrentConsent: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('Not now is remembered for the current onboarding flow', () {
+      expect(
+        EllaOnboarding.shouldPresentVoiceConsent(
+          hasCurrentConsent: false,
+          hasPriorAccountConsent: false,
+          deferredCurrentConsent: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Implements the D1 iOS work order from ellaaicare/ella-ai#1109.

- presents `voice-ai-processors-v3` as a compact bounded sheet with a four-sentence complete provider/data disclosure
- keeps `Not now` persistently visible and keeps microphone/V2V startup fail-closed
- moves first-time consent into onboarding
- defers existing users with stale consent to their next explicit voice action
- preserves authenticated account-bound receipt persistence

Validation:
- focused consent/onboarding/V2V tests: 33/33 passed
- full Flutter suite: 195/195 passed
- targeted `dart analyze`: no issues
- `git diff --check`: clean

No backend, build number, TestFlight, or App Store Connect changes.

AgentStatus: ready-for-review