### PR TITLE
D3: reusable safe memory voice modal

### DIFF
--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -29,6 +29,7 @@ import 'package:omi/ella/widgets/ella_breathing_dot.dart';
 import 'package:omi/ella/widgets/ella_voice_orb.dart';
 import 'package:omi/ella/widgets/memory_correction_receipt.dart';
 import 'package:omi/ella/widgets/v2v_fallback_dialog.dart';
+import 'package:omi/ella/widgets/voice_modal_scaffold.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/ella_provisioning_provider.dart';
 import 'package:omi/providers/home_provider.dart';
@@ -46,11 +47,13 @@ class EllaVoiceChatPage extends StatefulWidget {
     this.sessionScope,
     this.memoryTitle,
     this.onMemorySessionEnded,
+    this.modalPresentation = false,
   });
 
   final V2VSessionScope? sessionScope;
   final String? memoryTitle;
   final ValueChanged<MemoryReceiptDiscoveryRequest>? onMemorySessionEnded;
+  final bool modalPresentation;
 
   @visibleForTesting
   static bool shouldInjectVoiceTurns(V2VSessionScope? sessionScope) => sessionScope == null;
@@ -661,6 +664,31 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     _pauseVoiceMode();
   }
 
+  bool get _hasActiveVoiceSession =>
+      _voiceModeActive || _isV2VMode || _speech.isListening || _orbState != VoiceOrbState.idle;
+
+  Future<bool> _endModalVoiceSession() async {
+    if (_isV2VMode || _v2vClient != null) {
+      await _stopV2V();
+    } else {
+      _voiceModeActive = false;
+      _typewriterTimer?.cancel();
+      if (_speech.isListening) {
+        try {
+          await _speech.stop();
+        } catch (_) {}
+      }
+      try {
+        await _audioPlayer.stop();
+      } catch (_) {}
+      try {
+        await ElevenLabsTts.stopOnDevice();
+      } catch (_) {}
+      _pauseVoiceMode();
+    }
+    return !_hasActiveVoiceSession;
+  }
+
   void _notifyMemorySessionEnded(String sessionId) {
     final scope = _sessionScope;
     if (scope == null || sessionId.isEmpty) return;
@@ -1056,6 +1084,120 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   Widget build(BuildContext context) {
     super.build(context);
 
+    final body = SafeArea(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (_sessionScope != null && widget.memoryTitle?.trim().isNotEmpty == true) ...[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 8, 24, 0),
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                decoration: BoxDecoration(
+                  color: EllaColors.card,
+                  borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+                  border: Border.all(color: EllaColors.cardDeep),
+                ),
+                child: Row(
+                  children: [
+                    const Icon(Icons.auto_stories_outlined, size: 20, color: EllaColors.primary),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        context.l10n.memoryTalkContext(widget.memoryTitle!.trim()),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: EllaTextStyles.caption.copyWith(fontWeight: FontWeight.w600),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+          const Spacer(flex: 2),
+          Center(
+            child: EllaVoiceOrb(state: _orbState, audioLevel: _audioLevel, onTap: _onOrbTap),
+          ),
+          const SizedBox(height: 24),
+          Center(
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              decoration: BoxDecoration(
+                color: EllaColors.card,
+                borderRadius: BorderRadius.circular(EllaSizes.radiusCircular),
+                border: Border.all(color: EllaColors.cardDeep),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (_orbState == VoiceOrbState.listening) ...[const EllaBreathingDot(), const SizedBox(width: 10)],
+                  Text(
+                    _orbState == VoiceOrbState.listening
+                        ? _usingElevenLabsFallback
+                            ? context.l10n.voiceElevenLabsFallbackActive
+                            : _isV2VMode && _activeV2VProvider.isNotEmpty
+                                ? context.l10n.voiceV2vActive(_activeV2VProvider)
+                                : context.l10n.voiceListening
+                        : _statusText,
+                    style: EllaTextStyles.body.copyWith(fontWeight: FontWeight.w600),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (_memoryCorrectionReceipt != null) ...[
+            const SizedBox(height: 12),
+            MemoryCorrectionReceiptChip(receipt: _memoryCorrectionReceipt!, onReview: _reviewMemoryCorrection),
+          ],
+          const SizedBox(height: 16),
+          SizedBox(
+            height: 100,
+            width: double.infinity,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: _lastUserText.isEmpty && _ellaDisplayText.isEmpty && _currentWords.isEmpty
+                  ? const SizedBox.shrink()
+                  : SingleChildScrollView(
+                      controller: _transcriptScrollController,
+                      child: Column(
+                        children: [
+                          if (_lastUserText.isNotEmpty)
+                            Opacity(
+                              opacity: 0.6,
+                              child: Text(
+                                _lastUserText,
+                                style: EllaTextStyles.secondary,
+                                textAlign: TextAlign.center,
+                              ),
+                            ),
+                          if (_lastUserText.isNotEmpty && (_ellaDisplayText.isNotEmpty || _currentWords.isNotEmpty))
+                            const SizedBox(height: 8),
+                          if (_ellaDisplayText.isNotEmpty || _currentWords.isNotEmpty)
+                            Text(
+                              _ellaDisplayText.isNotEmpty ? _ellaDisplayText : _currentWords,
+                              style: EllaTextStyles.secondary.copyWith(color: EllaColors.ink),
+                              textAlign: TextAlign.center,
+                            ),
+                        ],
+                      ),
+                    ),
+            ),
+          ),
+          const Spacer(flex: 3),
+        ],
+      ),
+    );
+    if (widget.modalPresentation) {
+      return VoiceModalScaffold(
+        voiceActive: _hasActiveVoiceSession,
+        onEnd: _endModalVoiceSession,
+        title: context.l10n.voiceChatTitle,
+        child: body,
+      );
+    }
+
     return Scaffold(
       backgroundColor: EllaColors.bgPrimary,
       appBar: AppBar(
@@ -1068,111 +1210,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
         elevation: 0,
         centerTitle: true,
       ),
-      body: SafeArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            if (_sessionScope != null && widget.memoryTitle?.trim().isNotEmpty == true) ...[
-              Padding(
-                padding: const EdgeInsets.fromLTRB(24, 8, 24, 0),
-                child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-                  decoration: BoxDecoration(
-                    color: EllaColors.card,
-                    borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
-                    border: Border.all(color: EllaColors.cardDeep),
-                  ),
-                  child: Row(
-                    children: [
-                      const Icon(Icons.auto_stories_outlined, size: 20, color: EllaColors.primary),
-                      const SizedBox(width: 10),
-                      Expanded(
-                        child: Text(
-                          context.l10n.memoryTalkContext(widget.memoryTitle!.trim()),
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                          style: EllaTextStyles.caption.copyWith(fontWeight: FontWeight.w600),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ],
-            const Spacer(flex: 2),
-            Center(
-              child: EllaVoiceOrb(state: _orbState, audioLevel: _audioLevel, onTap: _onOrbTap),
-            ),
-            const SizedBox(height: 24),
-            Center(
-              child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-                decoration: BoxDecoration(
-                  color: EllaColors.card,
-                  borderRadius: BorderRadius.circular(EllaSizes.radiusCircular),
-                  border: Border.all(color: EllaColors.cardDeep),
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    if (_orbState == VoiceOrbState.listening) ...[const EllaBreathingDot(), const SizedBox(width: 10)],
-                    Text(
-                      _orbState == VoiceOrbState.listening
-                          ? _usingElevenLabsFallback
-                              ? context.l10n.voiceElevenLabsFallbackActive
-                              : _isV2VMode && _activeV2VProvider.isNotEmpty
-                                  ? context.l10n.voiceV2vActive(_activeV2VProvider)
-                                  : context.l10n.voiceListening
-                          : _statusText,
-                      style: EllaTextStyles.body.copyWith(fontWeight: FontWeight.w600),
-                      textAlign: TextAlign.center,
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            if (_memoryCorrectionReceipt != null) ...[
-              const SizedBox(height: 12),
-              MemoryCorrectionReceiptChip(receipt: _memoryCorrectionReceipt!, onReview: _reviewMemoryCorrection),
-            ],
-            const SizedBox(height: 16),
-            SizedBox(
-              height: 100,
-              width: double.infinity,
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 32),
-                child: _lastUserText.isEmpty && _ellaDisplayText.isEmpty && _currentWords.isEmpty
-                    ? const SizedBox.shrink()
-                    : SingleChildScrollView(
-                        controller: _transcriptScrollController,
-                        child: Column(
-                          children: [
-                            if (_lastUserText.isNotEmpty)
-                              Opacity(
-                                opacity: 0.6,
-                                child: Text(
-                                  _lastUserText,
-                                  style: EllaTextStyles.secondary,
-                                  textAlign: TextAlign.center,
-                                ),
-                              ),
-                            if (_lastUserText.isNotEmpty && (_ellaDisplayText.isNotEmpty || _currentWords.isNotEmpty))
-                              const SizedBox(height: 8),
-                            if (_ellaDisplayText.isNotEmpty || _currentWords.isNotEmpty)
-                              Text(
-                                _ellaDisplayText.isNotEmpty ? _ellaDisplayText : _currentWords,
-                                style: EllaTextStyles.secondary.copyWith(color: EllaColors.ink),
-                                textAlign: TextAlign.center,
-                              ),
-                          ],
-                        ),
-                      ),
-              ),
-            ),
-            const Spacer(flex: 3),
-          ],
-        ),
-      ),
+      body: body,
     );
   }
 }

--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -24,6 +24,7 @@ import 'package:omi/ella/services/elevenlabs_tts.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/ella/services/memory_reinterpretation_receipt_service.dart';
 import 'package:omi/ella/services/v2v_client.dart';
+import 'package:omi/ella/services/voice_session_startup_guard.dart';
 import 'package:omi/ella/widgets/ai_consent_sheet.dart';
 import 'package:omi/ella/widgets/ella_breathing_dot.dart';
 import 'package:omi/ella/widgets/ella_voice_orb.dart';
@@ -98,6 +99,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
   /// V2V client for WebSocket-based voice-to-voice mode
   V2VClient? _v2vClient;
+  final VoiceSessionStartupGuard _voiceStartupGuard = VoiceSessionStartupGuard();
   bool _isV2VMode = false;
   String _activeV2VProvider = '';
   bool _usingElevenLabsFallback = false;
@@ -231,6 +233,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   @override
   void dispose() {
     _notifyMemorySessionEnded(_activeSessionId);
+    _voiceStartupGuard.dispose();
     _voiceModeActive = false;
     _typewriterTimer?.cancel();
     _memoryReceiptPollTimer?.cancel();
@@ -240,8 +243,9 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     if (_speech.isListening) {
       _speech.stop();
     }
-    _v2vClient?.disconnect();
+    final client = _v2vClient;
     _v2vClient = null;
+    if (client != null) unawaited(client.disconnect());
     super.dispose();
   }
 
@@ -301,14 +305,33 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       return;
     }
 
-    _voiceModeActive = true;
     if (_isV2VProvider(provider)) {
-      await _startV2V(provider);
+      final startupGeneration = _beginV2VStartup(provider);
+      await _startV2V(provider, startupGeneration: startupGeneration);
     } else {
-      _isV2VMode = false;
+      setState(() {
+        _voiceModeActive = true;
+        _isV2VMode = false;
+      });
       await _startListening();
     }
   }
+
+  int _beginV2VStartup(String provider) {
+    final startupGeneration = _voiceStartupGuard.begin();
+    final providerName = localizedV2VProviderName(context, V2VClient.normalizeProvider(provider));
+    setState(() {
+      _voiceModeActive = true;
+      _isV2VMode = true;
+      _usingElevenLabsFallback = false;
+      _orbState = VoiceOrbState.processing;
+      _statusText = context.l10n.voiceV2vConnecting(providerName);
+      _audioLevel = 0.0;
+    });
+    return startupGeneration;
+  }
+
+  bool _isCurrentV2VStartup(int startupGeneration) => mounted && _voiceStartupGuard.isCurrent(startupGeneration);
 
   Future<void> _onOrbTap() async {
     debugPrint('[VoiceChat] Orb tapped, state: $_orbState, voiceMode: $_voiceModeActive, v2v: $_isV2VMode');
@@ -347,8 +370,9 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     }
   }
 
-  void _pauseVoiceMode() {
+  void _pauseVoiceMode({bool cancelStartup = true}) {
     debugPrint('[VoiceChat] Pausing voice mode');
+    if (cancelStartup) _voiceStartupGuard.cancel();
     _voiceModeActive = false;
     _isV2VMode = false;
     _typewriterTimer?.cancel();
@@ -529,34 +553,35 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
   // --- V2V (Voice-to-Voice) WebSocket mode ---
 
-  Future<bool> _refreshMemoryScope() async {
+  Future<bool> _refreshMemoryScope(int startupGeneration) async {
     final currentScope = _sessionScope;
-    if (currentScope == null) return false;
+    if (currentScope == null || !_isCurrentV2VStartup(startupGeneration)) return false;
     setState(() {
       _orbState = VoiceOrbState.processing;
       _statusText = context.l10n.memoryTalkStale;
     });
     final refreshed = await getConversationById(currentScope.conversationId);
-    if (!mounted || refreshed == null) return false;
+    if (!_isCurrentV2VStartup(startupGeneration) || refreshed == null) return false;
     _sessionScope = EllaVoiceChatPage.refreshedMemoryScope(currentScope, refreshed.activeSummaryVersionId);
     return true;
   }
 
-  Future<void> _startV2V(String provider, {bool allowScopeRefresh = true}) async {
-    if (!SharedPreferencesUtil().aiConsentAccepted) return;
+  Future<void> _startV2V(
+    String provider, {
+    required int startupGeneration,
+    bool allowScopeRefresh = true,
+  }) async {
+    if (!SharedPreferencesUtil().aiConsentAccepted || !_isCurrentV2VStartup(startupGeneration)) return;
     provider = V2VClient.normalizeProvider(provider);
     final providerName = localizedV2VProviderName(context, provider);
     debugPrint('[VoiceChat] Starting V2V mode with provider: $provider');
-    _isV2VMode = true;
-    _usingElevenLabsFallback = false;
 
     // Stop any existing mic recording from CaptureProvider
-    if (mounted) {
-      final captureProvider = Provider.of<CaptureProvider>(context, listen: false);
-      if (captureProvider.recordingState == RecordingState.record) {
-        debugPrint('[VoiceChat] Pausing capture recording for V2V');
-        await captureProvider.stopStreamRecording();
-      }
+    final captureProvider = Provider.of<CaptureProvider>(context, listen: false);
+    if (captureProvider.recordingState == RecordingState.record) {
+      debugPrint('[VoiceChat] Pausing capture recording for V2V');
+      await captureProvider.stopStreamRecording();
+      if (!_isCurrentV2VStartup(startupGeneration)) return;
     }
 
     setState(() {
@@ -569,14 +594,21 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     try {
       await _audioPlayer.stop();
     } catch (_) {}
+    if (!_isCurrentV2VStartup(startupGeneration)) return;
 
-    _v2vClient = V2VClient(
-      onEvent: _onV2VEvent,
+    late final V2VClient client;
+    client = V2VClient(
+      onEvent: (event) {
+        if (!_isCurrentV2VStartup(startupGeneration) || !identical(_v2vClient, client)) return;
+        _onV2VEvent(event);
+      },
       onConnectionChanged: (connected) {
-        if (!mounted) return;
+        if (!_isCurrentV2VStartup(startupGeneration) || !identical(_v2vClient, client)) return;
         if (!connected && _isV2VMode) {
           final endedSessionId = _activeSessionId;
           debugPrint('[VoiceChat] V2V disconnected unexpectedly');
+          _voiceStartupGuard.cancel();
+          _v2vClient = null;
           setState(() {
             _orbState = VoiceOrbState.idle;
             _statusText = 'Disconnected — Tap to Reconnect';
@@ -588,24 +620,39 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
         }
       },
     );
+    if (!_isCurrentV2VStartup(startupGeneration)) {
+      await client.disconnect();
+      return;
+    }
+    _v2vClient = client;
 
-    final receipt = await _v2vClient!.connect(provider: provider, sessionScope: _sessionScope);
-    if (!mounted) return;
+    final receipt = await client.connect(
+      provider: provider,
+      sessionScope: _sessionScope,
+      shouldContinue: () => _isCurrentV2VStartup(startupGeneration) && identical(_v2vClient, client),
+    );
+    if (!_isCurrentV2VStartup(startupGeneration) || !identical(_v2vClient, client)) {
+      await client.disconnect();
+      return;
+    }
 
     if (!receipt.connected) {
       debugPrint('[VoiceChat] V2V connect failed: ${receipt.toDebugFields()}');
-      await _v2vClient?.disconnect();
-      if (!mounted) return;
-      _isV2VMode = false;
       _v2vClient = null;
-      _voiceModeActive = false;
-      if (allowScopeRefresh && receipt.shouldRefreshMemoryScope && await _refreshMemoryScope()) {
-        if (!mounted) return;
-        _voiceModeActive = true;
-        await _startV2V(provider, allowScopeRefresh: false);
+      await client.disconnect();
+      if (!_isCurrentV2VStartup(startupGeneration)) return;
+      if (allowScopeRefresh && receipt.shouldRefreshMemoryScope && await _refreshMemoryScope(startupGeneration)) {
+        await _startV2V(
+          provider,
+          startupGeneration: startupGeneration,
+          allowScopeRefresh: false,
+        );
         return;
       }
+      _voiceStartupGuard.complete(startupGeneration);
       setState(() {
+        _isV2VMode = false;
+        _voiceModeActive = false;
         _orbState = VoiceOrbState.idle;
         _statusText = _sessionScope != null && receipt.errorCode == 'voice_session_scope_unavailable'
             ? context.l10n.memoryTalkUnavailable
@@ -613,23 +660,26 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
         _audioLevel = 0.0;
       });
 
+      if (!mounted) return;
       final choice = await showV2VFallbackDialog(context, receipt, allowStandardFallback: _sessionScope == null);
       if (!mounted) return;
       switch (choice) {
         case V2VFailureChoice.retry:
-          _voiceModeActive = true;
-          await _startV2V(provider);
+          final retryGeneration = _beginV2VStartup(provider);
+          await _startV2V(provider, startupGeneration: retryGeneration);
           break;
         case V2VFailureChoice.useElevenLabs:
           if (_sessionScope != null) break;
           _usingElevenLabsFallback = true;
-          _voiceModeActive = true;
           setState(() {
+            _voiceModeActive = true;
+            _isV2VMode = false;
             _statusText = context.l10n.voiceElevenLabsFallbackActive;
           });
           await _startListening();
           break;
         case V2VFailureChoice.stop:
+          _voiceStartupGuard.cancel();
           _usingElevenLabsFallback = false;
           _activeV2VProvider = '';
           setState(() {
@@ -640,6 +690,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       return;
     }
 
+    _voiceStartupGuard.complete(startupGeneration);
     _activeSessionId = receipt.sessionId;
     _memorySessionNotificationKey = null;
     _memoryReinterpretationEvent = null;
@@ -655,20 +706,28 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
   Future<void> _stopV2V() async {
     debugPrint('[VoiceChat] Stopping V2V mode');
+    _voiceStartupGuard.cancel();
     final endedSessionId = _activeSessionId;
-    await _v2vClient?.disconnect();
+    final client = _v2vClient;
     _v2vClient = null;
+    _voiceModeActive = false;
+    _isV2VMode = false;
+    if (client != null) await client.disconnect();
     _notifyMemorySessionEnded(endedSessionId);
     _activeSessionId = '';
     _activeV2VProvider = '';
-    _pauseVoiceMode();
+    _pauseVoiceMode(cancelStartup: false);
   }
 
   bool get _hasActiveVoiceSession =>
-      _voiceModeActive || _isV2VMode || _speech.isListening || _orbState != VoiceOrbState.idle;
+      _voiceStartupGuard.isStarting ||
+      _voiceModeActive ||
+      _isV2VMode ||
+      _speech.isListening ||
+      _orbState != VoiceOrbState.idle;
 
   Future<bool> _endModalVoiceSession() async {
-    if (_isV2VMode || _v2vClient != null) {
+    if (_voiceStartupGuard.isStarting || _isV2VMode || _v2vClient != null) {
       await _stopV2V();
     } else {
       _voiceModeActive = false;

--- a/app/lib/ella/services/v2v_client.dart
+++ b/app/lib/ella/services/v2v_client.dart
@@ -359,17 +359,47 @@ class V2VClient {
   }
 
   /// Start a V2V session: get session token, connect WebSocket, start audio.
-  Future<V2VConnectionReceipt> connect({required String provider, V2VSessionScope? sessionScope}) async {
+  Future<V2VConnectionReceipt> connect({
+    required String provider,
+    V2VSessionScope? sessionScope,
+    bool Function()? shouldContinue,
+  }) async {
     provider = normalizeProvider(provider);
+
+    Future<V2VConnectionReceipt?> cancelIfRequested(
+      V2VConnectionStage stage, {
+      String voiceMode = '',
+    }) async {
+      if (shouldContinue == null || shouldContinue()) return null;
+      Logger.debug('[V2V] Cancelling stale connect for provider=$provider stage=${stage.name}');
+      await disconnect();
+      return _completeReceipt(
+        V2VConnectionReceipt(
+          connected: false,
+          provider: provider,
+          voiceMode: voiceMode,
+          stage: stage,
+          errorCode: 'connection_cancelled',
+        ),
+      );
+    }
+
+    final initialCancellation = await cancelIfRequested(V2VConnectionStage.providerRegistry);
+    if (initialCancellation != null) return initialCancellation;
+
     if (_activeClient != null && _activeClient != this) {
       Logger.debug('[V2V] Closing existing active V2V client before provider=$provider connect');
       await _activeClient!.disconnect();
+      final cancellation = await cancelIfRequested(V2VConnectionStage.providerRegistry);
+      if (cancellation != null) return cancellation;
     }
     _activeClient = this;
 
     if (_isConnected || _channel != null || _recorder != null) {
       Logger.debug('[V2V] connect() called with existing session state, disconnecting first');
       await disconnect();
+      final cancellation = await cancelIfRequested(V2VConnectionStage.providerRegistry);
+      if (cancellation != null) return cancellation;
       _activeClient = this;
     }
 
@@ -420,6 +450,8 @@ class V2VClient {
     }
 
     final registryFailure = await _validateProviderRegistry(provider);
+    final registryCancellation = await cancelIfRequested(V2VConnectionStage.providerRegistry);
+    if (registryCancellation != null) return registryCancellation;
     if (registryFailure != null) {
       if (_activeClient == this) _activeClient = null;
       return _completeReceipt(registryFailure);
@@ -427,6 +459,11 @@ class V2VClient {
 
     // 1. Get session token from backend
     final sessionResult = await _createSession(uid, provider, sessionScope);
+    final sessionCancellation = await cancelIfRequested(
+      V2VConnectionStage.session,
+      voiceMode: sessionVoiceMode(provider, memoryScoped: sessionScope != null) ?? '',
+    );
+    if (sessionCancellation != null) return sessionCancellation;
     final sessionData = sessionResult.data;
     if (sessionData == null) {
       if (_activeClient == this) _activeClient = null;
@@ -485,6 +522,11 @@ class V2VClient {
     // 2. Configure iOS audio session for playAndRecord with Bluetooth + speaker routing
     try {
       await _configureAudioSession();
+      final cancellation = await cancelIfRequested(
+        V2VConnectionStage.audioSession,
+        voiceMode: confirmedVoiceMode,
+      );
+      if (cancellation != null) return cancellation;
     } catch (error) {
       Logger.error('[V2V] Audio session setup failed for provider=$provider');
       if (_activeClient == this) _activeClient = null;
@@ -507,6 +549,11 @@ class V2VClient {
       _channel = IOWebSocketChannel.connect(Uri.parse(wsUrl), pingInterval: const Duration(seconds: 30));
 
       await _channel!.ready.timeout(const Duration(seconds: 12));
+      final websocketCancellation = await cancelIfRequested(
+        V2VConnectionStage.websocket,
+        voiceMode: confirmedVoiceMode,
+      );
+      if (websocketCancellation != null) return websocketCancellation;
 
       // 3. Listen for messages from proxy
       _isConnected = true;
@@ -528,6 +575,11 @@ class V2VClient {
 
       // 4. Start recording mic audio and streaming to WebSocket
       final micStarted = await _startMicStream();
+      final microphoneCancellation = await cancelIfRequested(
+        V2VConnectionStage.microphone,
+        voiceMode: confirmedVoiceMode,
+      );
+      if (microphoneCancellation != null) return microphoneCancellation;
       if (!micStarted || !_isConnected) {
         await disconnect();
         return _completeReceipt(

--- a/app/lib/ella/services/voice_session_startup_guard.dart
+++ b/app/lib/ella/services/voice_session_startup_guard.dart
@@ -1,0 +1,30 @@
+class VoiceSessionStartupGuard {
+  int _generation = 0;
+  bool _disposed = false;
+  bool _starting = false;
+
+  bool get isStarting => _starting;
+
+  int begin() {
+    if (_disposed) throw StateError('Voice startup guard is disposed');
+    _starting = true;
+    return ++_generation;
+  }
+
+  bool isCurrent(int generation) => !_disposed && generation == _generation;
+
+  void complete(int generation) {
+    if (isCurrent(generation)) _starting = false;
+  }
+
+  void cancel() {
+    _generation += 1;
+    _starting = false;
+  }
+
+  void dispose() {
+    _disposed = true;
+    _generation += 1;
+    _starting = false;
+  }
+}

--- a/app/lib/ella/widgets/voice_modal_scaffold.dart
+++ b/app/lib/ella/widgets/voice_modal_scaffold.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+
+import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+
+class VoiceModalScaffold extends StatefulWidget {
+  const VoiceModalScaffold({
+    required this.voiceActive,
+    required this.onEnd,
+    required this.child,
+    required this.title,
+    super.key,
+  });
+
+  final bool voiceActive;
+  final Future<bool> Function() onEnd;
+  final Widget child;
+  final String title;
+
+  @override
+  State<VoiceModalScaffold> createState() => _VoiceModalScaffoldState();
+}
+
+class _VoiceModalScaffoldState extends State<VoiceModalScaffold> {
+  bool _ending = false;
+
+  Future<void> _close() async {
+    if (_ending) return;
+    if (widget.voiceActive) {
+      setState(() => _ending = true);
+      var ended = false;
+      try {
+        ended = await widget.onEnd();
+      } catch (_) {
+        ended = false;
+      }
+      if (!mounted) return;
+      if (!ended) {
+        setState(() => _ending = false);
+        return;
+      }
+    }
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: !widget.voiceActive && !_ending,
+      child: Scaffold(
+        key: const ValueKey('voice-modal-root'),
+        backgroundColor: EllaColors.bgPrimary,
+        appBar: AppBar(
+          automaticallyImplyLeading: false,
+          backgroundColor: EllaColors.bgPrimary,
+          elevation: 0,
+          centerTitle: true,
+          leadingWidth: widget.voiceActive ? 72 : 56,
+          leading: widget.voiceActive
+              ? TextButton(
+                  key: const ValueKey('voice-modal-end'),
+                  onPressed: _ending ? null : _close,
+                  child: _ending
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2, color: EllaColors.primary),
+                        )
+                      : Text(
+                          context.l10n.voiceModalEndAction,
+                          style: const TextStyle(color: EllaColors.primary, fontWeight: FontWeight.w700),
+                        ),
+                )
+              : IconButton(
+                  key: const ValueKey('voice-modal-close'),
+                  tooltip: context.l10n.close,
+                  onPressed: _close,
+                  icon: const Icon(Icons.close, color: EllaColors.textPrimary),
+                ),
+          title: Text(
+            widget.title,
+            style: const TextStyle(fontSize: 22, fontWeight: FontWeight.w600, color: EllaColors.textPrimary),
+          ),
+        ),
+        body: widget.child,
+      ),
+    );
+  }
+}

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10466,5 +10466,6 @@
   "todayMemoriesEmpty": "As Ella listens today, your memories will gather here. 🪽",
   "todayListeningLead": "Ella is listening — ",
   "todayListeningLink": "See what she hears ›",
-  "todayReadMore": "Read more"
+  "todayReadMore": "Read more",
+  "voiceModalEndAction": "End"
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -16508,6 +16508,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Read more'**
   String get todayReadMore;
+
+  /// No description provided for @voiceModalEndAction.
+  ///
+  /// In en, this message translates to:
+  /// **'End'**
+  String get voiceModalEndAction;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8797,4 +8797,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8885,4 +8885,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8901,4 +8901,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8848,4 +8848,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8837,4 +8837,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8919,4 +8919,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8910,4 +8910,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8850,4 +8850,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8867,4 +8867,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8852,4 +8852,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8851,4 +8851,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8926,4 +8926,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8833,4 +8833,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8890,4 +8890,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8865,4 +8865,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8902,4 +8902,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8719,4 +8719,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8721,4 +8721,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8858,4 +8858,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8870,4 +8870,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8876,4 +8876,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8878,4 +8878,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8848,4 +8848,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8871,4 +8871,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8853,4 +8853,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8891,4 +8891,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8878,4 +8878,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8843,4 +8843,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8858,4 +8858,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8815,4 +8815,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8866,4 +8866,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8865,4 +8865,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8855,4 +8855,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8709,4 +8709,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get todayReadMore => 'Read more';
+
+  @override
+  String get voiceModalEndAction => 'End';
 }

--- a/app/lib/pages/conversation_detail/widgets.dart
+++ b/app/lib/pages/conversation_detail/widgets.dart
@@ -751,6 +751,12 @@ class MemoryTalkButton extends StatefulWidget {
   final MemoryTalkRouteOpener? routeOpener;
   final MemoryReinterpretationReceiptDiscovery? receiptDiscovery;
 
+  @visibleForTesting
+  static V2VSessionScope sessionScopeFor(ServerConversation conversation) => V2VSessionScope.memory(
+        conversationId: conversation.id,
+        expectedActiveSummaryVersionId: conversation.activeSummaryVersionId,
+      );
+
   @override
   State<MemoryTalkButton> createState() => _MemoryTalkButtonState();
 }
@@ -794,15 +800,22 @@ class _MemoryTalkButtonState extends State<MemoryTalkButton> {
     ValueChanged<MemoryReceiptDiscoveryRequest> onMemorySessionEnded,
   ) {
     final displayTitle = parseEllaDisplayValue(conversation.structured.title).text.trim();
-    return Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (_) => EllaVoiceChatPage(
-          sessionScope: V2VSessionScope.memory(
-            conversationId: conversation.id,
-            expectedActiveSummaryVersionId: conversation.activeSummaryVersionId,
-          ),
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      isDismissible: false,
+      enableDrag: false,
+      useSafeArea: true,
+      backgroundColor: EllaColors.bgPrimary,
+      shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(28))),
+      clipBehavior: Clip.antiAlias,
+      builder: (_) => FractionallySizedBox(
+        heightFactor: 0.94,
+        child: EllaVoiceChatPage(
+          sessionScope: MemoryTalkButton.sessionScopeFor(conversation),
           memoryTitle: displayTitle,
           onMemorySessionEnded: onMemorySessionEnded,
+          modalPresentation: true,
         ),
       ),
     );

--- a/app/test/ella/services/v2v_client_test.dart
+++ b/app/test/ella/services/v2v_client_test.dart
@@ -235,6 +235,21 @@ void main() {
       expect(receipt.errorCode, 'missing_authenticated_identity');
       await client.disconnect();
     });
+
+    test('cancelled startup stops before provider or session work begins', () async {
+      final client = V2VClient(onEvent: (_) {}, onConnectionChanged: (_) {});
+
+      final receipt = await client.connect(
+        provider: 'grok-voice',
+        shouldContinue: () => false,
+      );
+
+      expect(receipt.connected, isFalse);
+      expect(receipt.stage, V2VConnectionStage.providerRegistry);
+      expect(receipt.errorCode, 'connection_cancelled');
+      expect(client.isConnected, isFalse);
+      await client.disconnect();
+    });
   });
 
   group('V2VClient proxy event mapping', () {

--- a/app/test/ella/services/voice_session_startup_guard_test.dart
+++ b/app/test/ella/services/voice_session_startup_guard_test.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/ella/services/voice_session_startup_guard.dart';
+
+void main() {
+  group('VoiceSessionStartupGuard', () {
+    test('End during delayed capture shutdown prevents connect and UI activation', () async {
+      final guard = VoiceSessionStartupGuard();
+      final captureStopped = Completer<void>();
+      final generation = guard.begin();
+      var connectCalls = 0;
+      var activationCalls = 0;
+
+      final startup = () async {
+        await captureStopped.future;
+        if (!guard.isCurrent(generation)) return;
+        connectCalls += 1;
+        if (!guard.isCurrent(generation)) return;
+        activationCalls += 1;
+      }();
+
+      expect(guard.isStarting, isTrue);
+      guard.cancel();
+      captureStopped.complete();
+      await startup;
+
+      expect(guard.isStarting, isFalse);
+      expect(connectCalls, 0);
+      expect(activationCalls, 0);
+    });
+
+    test('dispose during delayed connect disconnects the stale client and never activates UI', () async {
+      final guard = VoiceSessionStartupGuard();
+      final connectedClient = Completer<String>();
+      final generation = guard.begin();
+      var disconnectCalls = 0;
+      var activationCalls = 0;
+
+      final startup = () async {
+        await connectedClient.future;
+        if (!guard.isCurrent(generation)) {
+          disconnectCalls += 1;
+          return;
+        }
+        activationCalls += 1;
+      }();
+
+      guard.dispose();
+      connectedClient.complete('client');
+      await startup;
+
+      expect(disconnectCalls, 1);
+      expect(activationCalls, 0);
+    });
+
+    test('only the current generation can complete startup', () {
+      final guard = VoiceSessionStartupGuard();
+      final first = guard.begin();
+      final second = guard.begin();
+
+      guard.complete(first);
+      expect(guard.isStarting, isTrue);
+
+      guard.complete(second);
+      expect(guard.isStarting, isFalse);
+    });
+  });
+}

--- a/app/test/ella/widgets/voice_modal_scaffold_test.dart
+++ b/app/test/ella/widgets/voice_modal_scaffold_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -72,6 +74,40 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const ValueKey('voice-modal-root')), findsOneWidget);
+  });
+
+  testWidgets('startup blocks route back and End waits for delayed cancellation before closing', (tester) async {
+    final ended = Completer<bool>();
+    var endCalls = 0;
+    await tester.pumpWidget(
+      app(
+        voiceActive: true,
+        onEnd: () {
+          endCalls++;
+          return ended.future;
+        },
+      ),
+    );
+    await tester.tap(find.byKey(const ValueKey('open-voice-modal')));
+    await tester.pumpAndSettle();
+
+    await tester.binding.handlePopRoute();
+    await tester.pump();
+    expect(find.byKey(const ValueKey('voice-modal-root')), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('voice-modal-end')));
+    await tester.pump();
+    expect(endCalls, 1);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byKey(const ValueKey('voice-modal-root')), findsOneWidget);
+
+    await tester.binding.handlePopRoute();
+    await tester.pump();
+    expect(find.byKey(const ValueKey('voice-modal-root')), findsOneWidget);
+
+    ended.complete(true);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('voice-modal-root')), findsNothing);
   });
 
   testWidgets('inactive voice closes and returns without calling End', (tester) async {

--- a/app/test/ella/widgets/voice_modal_scaffold_test.dart
+++ b/app/test/ella/widgets/voice_modal_scaffold_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/ella/widgets/voice_modal_scaffold.dart';
+import 'package:omi/l10n/app_localizations.dart';
+
+Widget app({required bool voiceActive, required Future<bool> Function() onEnd}) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Builder(
+      builder: (context) => Scaffold(
+        body: TextButton(
+          key: const ValueKey('open-voice-modal'),
+          onPressed: () => showModalBottomSheet<void>(
+            context: context,
+            isScrollControlled: true,
+            isDismissible: false,
+            enableDrag: false,
+            builder: (_) => FractionallySizedBox(
+              heightFactor: 0.94,
+              child: VoiceModalScaffold(
+                voiceActive: voiceActive,
+                onEnd: onEnd,
+                title: 'Voice Chat',
+                child: const Center(child: Text('Talking about: A seeded memory')),
+              ),
+            ),
+          ),
+          child: const Text('Open voice'),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('active voice blocks back until explicit End and then returns', (tester) async {
+    var endCalls = 0;
+    await tester.pumpWidget(
+      app(
+        voiceActive: true,
+        onEnd: () async {
+          endCalls++;
+          return true;
+        },
+      ),
+    );
+    await tester.tap(find.byKey(const ValueKey('open-voice-modal')));
+    await tester.pumpAndSettle();
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('voice-modal-root')), findsOneWidget);
+    expect(endCalls, 0);
+
+    await tester.tap(find.byKey(const ValueKey('voice-modal-end')));
+    await tester.pumpAndSettle();
+
+    expect(endCalls, 1);
+    expect(find.byKey(const ValueKey('voice-modal-root')), findsNothing);
+    expect(find.byKey(const ValueKey('open-voice-modal')), findsOneWidget);
+  });
+
+  testWidgets('failed End keeps the active voice sheet visible', (tester) async {
+    await tester.pumpWidget(app(voiceActive: true, onEnd: () async => false));
+    await tester.tap(find.byKey(const ValueKey('open-voice-modal')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('voice-modal-end')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('voice-modal-root')), findsOneWidget);
+  });
+
+  testWidgets('inactive voice closes and returns without calling End', (tester) async {
+    var endCalls = 0;
+    await tester.pumpWidget(
+      app(
+        voiceActive: false,
+        onEnd: () async {
+          endCalls++;
+          return true;
+        },
+      ),
+    );
+    await tester.tap(find.byKey(const ValueKey('open-voice-modal')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('voice-modal-close')));
+    await tester.pumpAndSettle();
+
+    expect(endCalls, 0);
+    expect(find.byKey(const ValueKey('voice-modal-root')), findsNothing);
+    expect(find.byKey(const ValueKey('open-voice-modal')), findsOneWidget);
+  });
+}

--- a/app/test/pages/conversation_detail/memory_talk_receipt_lifecycle_test.dart
+++ b/app/test/pages/conversation_detail/memory_talk_receipt_lifecycle_test.dart
@@ -45,16 +45,16 @@ ConversationCorrectionReceipt appliedReceipt() => const ConversationCorrectionRe
       after: ConversationCorrectionSummary(title: 'After'),
     );
 
-class _FakeMemoryVoiceRoute extends StatefulWidget {
-  const _FakeMemoryVoiceRoute({required this.onSessionEnded});
+class _FakeMemoryVoiceSheet extends StatefulWidget {
+  const _FakeMemoryVoiceSheet({required this.onSessionEnded});
 
   final ValueChanged<MemoryReceiptDiscoveryRequest> onSessionEnded;
 
   @override
-  State<_FakeMemoryVoiceRoute> createState() => _FakeMemoryVoiceRouteState();
+  State<_FakeMemoryVoiceSheet> createState() => _FakeMemoryVoiceSheetState();
 }
 
-class _FakeMemoryVoiceRouteState extends State<_FakeMemoryVoiceRoute> {
+class _FakeMemoryVoiceSheetState extends State<_FakeMemoryVoiceSheet> {
   @override
   void dispose() {
     widget.onSessionEnded(
@@ -87,9 +87,14 @@ Widget app({
       body: MemoryTalkButton(
         conversation: memoryConversation(),
         receiptDiscovery: discovery,
-        routeOpener: (context, _, onSessionEnded) => Navigator.of(context).push(
-          MaterialPageRoute<void>(
-            builder: (_) => _FakeMemoryVoiceRoute(onSessionEnded: onSessionEnded),
+        routeOpener: (context, _, onSessionEnded) => showModalBottomSheet<void>(
+          context: context,
+          isScrollControlled: true,
+          isDismissible: false,
+          enableDrag: false,
+          builder: (_) => FractionallySizedBox(
+            heightFactor: 0.94,
+            child: _FakeMemoryVoiceSheet(onSessionEnded: onSessionEnded),
           ),
         ),
       ),
@@ -98,7 +103,21 @@ Widget app({
 }
 
 void main() {
-  testWidgets('discovers a delayed receipt after the memory voice route is popped', (tester) async {
+  test('memory modal keeps the exact conversation and summary version scope', () {
+    final conversation = ServerConversation(
+      id: conversationId,
+      createdAt: DateTime.utc(2026, 7, 24),
+      structured: Structured('A seeded memory', 'The selected memory overview'),
+      activeSummaryVersionId: 'summary-v4',
+    );
+
+    final scope = MemoryTalkButton.sessionScopeFor(conversation);
+
+    expect(scope.conversationId, conversationId);
+    expect(scope.expectedActiveSummaryVersionId, 'summary-v4');
+  });
+
+  testWidgets('discovers a delayed receipt after the memory voice sheet closes', (tester) async {
     final delayedJob = Completer<ConversationReinterpretationJob?>();
     final discovery = MemoryReinterpretationReceiptDiscovery(
       fetchLatest: (_) => delayedJob.future,
@@ -111,11 +130,11 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('memory-talk-$conversationId')));
     await tester.pumpAndSettle();
 
-    expect(find.byType(_FakeMemoryVoiceRoute), findsOneWidget);
+    expect(find.byType(_FakeMemoryVoiceSheet), findsOneWidget);
     await tester.tap(find.byKey(const ValueKey('end-memory-session')));
     await tester.pumpAndSettle();
 
-    expect(find.byType(_FakeMemoryVoiceRoute), findsNothing);
+    expect(find.byType(_FakeMemoryVoiceSheet), findsNothing);
     expect(find.byType(MemoryCorrectionReceiptChip), findsNothing);
 
     delayedJob.complete(appliedJob());


### PR DESCRIPTION
Implements the D3 iOS work order from ellaaicare/ella-ai#1109.

- presents `Talk about this` in a near-full-height bottom sheet
- hosts the existing `EllaVoiceChatPage` and V2V engine; no second transport or correction parser
- preserves exact conversation and active-summary-version scope
- disables backdrop/drag dismissal and blocks system back while mic/session/playback is active
- exposes explicit `End`; the sheet closes only after audio/session teardown succeeds
- preserves conversation-owned delayed receipt discovery after the sheet closes

Validation:
- focused modal/lifecycle/V2V/receipt tests: 35/35 passed
- full Flutter suite: 193/193 passed
- targeted `dart analyze`: no errors or warnings; existing info-level findings only
- `git diff --check`: clean

No backend, build number, TestFlight, or App Store Connect changes.

AgentStatus: ready-for-review