### PR TITLE
Harden explicit AI consent and processor disclosure

### DIFF
--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -167,6 +167,7 @@ Future<ConversationProcessingRetryResult?> retryConversationProcessing(
   String requestId, {
   String? correctionText,
 }) async {
+  if (!SharedPreferencesUtil().aiConsentAccepted) return null;
   final normalizedCorrection = correctionText?.trim();
   final response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/conversations/$conversationId/processing-retries',
@@ -186,6 +187,7 @@ Future<ConversationProcessingRetryResult?> retryConversationProcessing(
 }
 
 Future<ServerConversation?> reProcessConversationServer(String conversationId, {String? appId}) async {
+  if (!SharedPreferencesUtil().aiConsentAccepted) return null;
   var response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/conversations/$conversationId/reprocess${appId != null ? '?app_id=$appId' : ''}',
     headers: {},
@@ -207,6 +209,7 @@ Future<bool> submitConversationCorrection({
   String? summaryOverview,
   String? appSummary,
 }) async {
+  if (!SharedPreferencesUtil().aiConsentAccepted) return false;
   var response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/ella/conversations/$conversationId/corrections',
     headers: {},
@@ -664,6 +667,7 @@ Future<bool> deleteConversationActionItem(String conversationId, ActionItem item
 
 //this is expected to return complete memories
 Future<List<ServerConversation>> sendStorageToBackend(File file, String sdCardDateTimeString) async {
+  if (!SharedPreferencesUtil().aiConsentAccepted) return [];
   try {
     var response = await makeMultipartApiCall(
       url: '${Env.apiBaseUrl}sdcard_memory?date_time=$sdCardDateTimeString',
@@ -744,6 +748,7 @@ Future<(List<ServerConversation>, int, int)> searchConversationsServer(
 }
 
 Future<String> testConversationPrompt(String prompt, String conversationId) async {
+  if (!SharedPreferencesUtil().aiConsentAccepted) return '';
   var response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/conversations/$conversationId/test-prompt',
     headers: {},

--- a/app/lib/backend/http/api/messages.dart
+++ b/app/lib/backend/http/api/messages.dart
@@ -104,6 +104,7 @@ Stream<ServerMessageChunk> sendMessageStreamServer(
   String? appId,
   List<String>? filesId,
 }) async* {
+  if (!SharedPreferencesUtil().aiConsentAccepted) return;
   var url = '${Env.apiBaseUrl}v2/messages?app_id=$appId';
   if (appId == null || appId.isEmpty || appId == 'null' || appId == 'no_selected') {
     url = '${Env.apiBaseUrl}v2/messages';
@@ -134,6 +135,7 @@ Stream<ServerMessageChunk> sendEllaMessageStream(
   String? clientMessageId,
   DateTime? clientSentAt,
 }) async* {
+  if (!SharedPreferencesUtil().aiConsentAccepted) return;
   var url = '${Env.apiBaseUrl}v1/ella/chat/stream';
   var uid = SharedPreferencesUtil().uid;
   var messageId = "1000";
@@ -184,6 +186,7 @@ Stream<ServerMessageChunk> sendVoiceMessageStreamServer(
   List<File> files, {
   String? language,
 }) async* {
+  if (!SharedPreferencesUtil().aiConsentAccepted) return;
   var messageId = "1000"; // Default new message
 
   await for (var line in makeMultipartStreamingApiCall(
@@ -205,6 +208,9 @@ Future<List<MessageFile>?> uploadFilesServer(
   List<File> files, {
   String? appId,
 }) async {
+  if (!SharedPreferencesUtil().aiConsentAccepted) {
+    throw StateError('AI consent is required before file upload');
+  }
   var url = '${Env.apiBaseUrl}v2/files?app_id=$appId';
   if (appId == null || appId.isEmpty || appId == 'null' || appId == 'no_selected') {
     url = '${Env.apiBaseUrl}v2/files';

--- a/app/lib/backend/http/api/users.dart
+++ b/app/lib/backend/http/api/users.dart
@@ -91,16 +91,61 @@ Future webhooksStatus() async {
   return null;
 }
 
-Future<bool> deleteAccount() async {
+class AccountDeletionReceipt {
+  const AccountDeletionReceipt({
+    required this.requestId,
+    required this.serverCompletedAt,
+  });
+
+  final String requestId;
+  final DateTime serverCompletedAt;
+
+  static AccountDeletionReceipt? tryParseResponse({
+    required int statusCode,
+    required String body,
+  }) {
+    if (statusCode != 200) return null;
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is! Map<String, dynamic>) return null;
+      if (decoded['status'] != 'ok') return null;
+      final receipt = decoded['deletion_receipt'];
+      if (receipt is! Map<String, dynamic> ||
+          receipt['status'] != 'completed' ||
+          receipt['scope'] != 'account_and_user_data') {
+        return null;
+      }
+
+      final requestId = receipt['request_id']?.toString() ?? '';
+      final completedAtValue = receipt['server_completed_at'];
+      final completedAt = completedAtValue is String ? DateTime.tryParse(completedAtValue) : null;
+      if (!RegExp(r'^aidel_[A-Za-z0-9_-]{16,128}$').hasMatch(requestId) || completedAt == null) {
+        return null;
+      }
+      return AccountDeletionReceipt(
+        requestId: requestId,
+        serverCompletedAt: completedAt.toUtc(),
+      );
+    } on FormatException {
+      return null;
+    }
+  }
+}
+
+Future<AccountDeletionReceipt?> deleteAccount() async {
   var response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/users/delete-account',
     headers: {},
     method: 'DELETE',
     body: '',
   );
-  if (response == null) return false;
-  Logger.debug('deleteAccount response: ${response.body}');
-  return response.statusCode == 200;
+  if (response == null) return null;
+  final receipt = AccountDeletionReceipt.tryParseResponse(
+    statusCode: response.statusCode,
+    body: response.body,
+  );
+  Logger.debug('deleteAccount completed with verified receipt: ${receipt != null}');
+  return receipt;
 }
 
 Future<bool> setRecordingPermission(bool value) async {

--- a/app/lib/backend/http/api/users.dart
+++ b/app/lib/backend/http/api/users.dart
@@ -14,6 +14,7 @@ import 'package:omi/models/user_usage.dart';
 import 'package:omi/utils/logger.dart';
 
 Future<bool> updateUserGeolocation({required Geolocation geolocation}) async {
+  if (!SharedPreferencesUtil().aiConsentAccepted) return false;
   var response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/users/geolocation',
     headers: {},

--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -93,11 +93,12 @@ Future<http.Response?> makeApiCall({
   required String method,
   Duration? timeout,
   int? retries,
+  bool? requireAuthCheck,
 }) async {
   try {
-    final bool requireAuthCheck = _isRequiredAuthCheck(url);
+    final shouldCheckAuth = requireAuthCheck ?? _isRequiredAuthCheck(url);
     Map<String, String> builtHeaders = await buildHeaders(
-      requireAuthCheck: requireAuthCheck,
+      requireAuthCheck: shouldCheckAuth,
       fromHeaders: headers,
     );
 
@@ -111,12 +112,12 @@ Future<http.Response?> makeApiCall({
       retries: effectiveRetries,
     );
 
-    if (requireAuthCheck && response.statusCode == 401) {
+    if (shouldCheckAuth && response.statusCode == 401) {
       Logger.log('Token expired on 1st attempt');
       SharedPreferencesUtil().authToken = await AuthService.instance.getIdToken() ?? '';
       if (SharedPreferencesUtil().authToken.isNotEmpty) {
         builtHeaders = await buildHeaders(
-          requireAuthCheck: requireAuthCheck,
+          requireAuthCheck: shouldCheckAuth,
           fromHeaders: headers,
         );
         response = await HttpPoolManager.instance.send(

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -19,8 +19,12 @@ class SharedPreferencesUtil {
 
   static const bool isPublicBuild = bool.fromEnvironment('ELLA_PUBLIC_BUILD');
   static const bool isTodayDesignPreview = bool.fromEnvironment('ELLA_TODAY_DESIGN_PREVIEW');
-  static const String currentAiConsentContractVersion = 'voice-ai-processors-v3';
-  static const String currentAiConsentReceiptPrefix = 'ios-private-cloud-sync:$currentAiConsentContractVersion:';
+  static const bool _requiresAccountBoundAiConsent =
+      bool.fromEnvironment('ELLA_HERMES_PROVISIONING_GATE', defaultValue: true);
+  static const String currentAiConsentContractVersion = 'ai-data-processors-v4';
+  static const String currentAiConsentProcessorSetHash =
+      'sha256:bd055957a43a28cf8d47d1daf2e161fa36b29bfc48842b322e87087ac5ae2261';
+  static const String currentAiConsentReceiptPrefix = 'ios-ai-consent:$currentAiConsentContractVersion:';
 
   factory SharedPreferencesUtil() {
     return _instance;
@@ -198,8 +202,13 @@ class SharedPreferencesUtil {
 
   set aiConsentAccepted(bool value) => saveBool('aiConsentAccepted', value);
 
-  bool get aiConsentAccepted =>
-      getBool('aiConsentAccepted', defaultValue: false) && aiConsentContractVersion == currentAiConsentContractVersion;
+  bool get aiConsentAccepted {
+    final accepted = getBool('aiConsentAccepted', defaultValue: false) &&
+        aiConsentContractVersion == currentAiConsentContractVersion &&
+        aiConsentProcessorSetHash == currentAiConsentProcessorSetHash;
+    if (!accepted || !_requiresAccountBoundAiConsent) return accepted;
+    return uid.isNotEmpty && aiConsentReceiptId.startsWith(currentAiConsentReceiptPrefix) && aiConsentReceiptUid == uid;
+  }
 
   set aiConsentAcceptedAt(String value) => saveString('aiConsentAcceptedAt', value);
 
@@ -210,6 +219,12 @@ class SharedPreferencesUtil {
   String get aiConsentReceiptUid => getString('aiConsentReceiptUid');
 
   String get aiConsentContractVersion => getString('aiConsentContractVersion');
+
+  String get aiConsentProcessorSetHash => getString('aiConsentProcessorSetHash');
+
+  String get aiConsentClientVersion => getString('aiConsentClientVersion');
+
+  String get aiConsentLocale => getString('aiConsentLocale');
 
   String get aiConsentDeferredVersion => getString('aiConsentDeferredVersion');
 
@@ -229,10 +244,18 @@ class SharedPreferencesUtil {
       aiConsentReceiptId.isNotEmpty &&
       aiConsentReceiptUid == uid;
 
-  void acceptAiConsent({String receiptId = '', String uid = ''}) {
+  void acceptAiConsent({
+    String receiptId = '',
+    String uid = '',
+    String clientVersion = '',
+    String locale = '',
+  }) {
     aiConsentAccepted = true;
     aiConsentAcceptedAt = DateTime.now().toUtc().toIso8601String();
     saveString('aiConsentContractVersion', currentAiConsentContractVersion);
+    saveString('aiConsentProcessorSetHash', currentAiConsentProcessorSetHash);
+    saveString('aiConsentClientVersion', clientVersion);
+    saveString('aiConsentLocale', locale);
     remove('aiConsentDeferredVersion');
     if (receiptId.startsWith(currentAiConsentReceiptPrefix) && uid.isNotEmpty) {
       saveString('aiConsentReceiptId', receiptId);
@@ -254,6 +277,9 @@ class SharedPreferencesUtil {
     remove('aiConsentReceiptId');
     remove('aiConsentReceiptUid');
     remove('aiConsentContractVersion');
+    remove('aiConsentProcessorSetHash');
+    remove('aiConsentClientVersion');
+    remove('aiConsentLocale');
     remove('aiConsentDeferredVersion');
   }
 
@@ -625,6 +651,9 @@ class SharedPreferencesUtil {
       'aiConsentReceiptId',
       'aiConsentReceiptUid',
       'aiConsentContractVersion',
+      'aiConsentProcessorSetHash',
+      'aiConsentClientVersion',
+      'aiConsentLocale',
       'aiConsentDeferredVersion',
     ]) {
       await remove(key);

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -229,6 +229,19 @@ class SharedPreferencesUtil {
         _verifiedAiConsentProcessorSetHash == currentAiConsentProcessorSetHash;
   }
 
+  Duration? get aiConsentServerVerificationRemaining {
+    final verifiedAt = _verifiedAiConsentAt;
+    if (verifiedAt == null ||
+        _verifiedAiConsentUid != uid ||
+        _verifiedAiConsentReceiptId != aiConsentReceiptId ||
+        _verifiedAiConsentPolicyVersion != currentAiConsentContractVersion ||
+        _verifiedAiConsentProcessorSetHash != currentAiConsentProcessorSetHash) {
+      return null;
+    }
+    final remaining = aiConsentServerVerificationTtl - DateTime.now().difference(verifiedAt);
+    return remaining.isNegative ? Duration.zero : remaining;
+  }
+
   set aiConsentAcceptedAt(String value) => saveString('aiConsentAcceptedAt', value);
 
   String get aiConsentAcceptedAt => getString('aiConsentAcceptedAt');

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -16,15 +16,19 @@ import 'package:omi/utils/logger.dart';
 class SharedPreferencesUtil {
   static final SharedPreferencesUtil _instance = SharedPreferencesUtil._internal();
   static SharedPreferences? _preferences;
+  static const Duration aiConsentServerVerificationTtl = Duration(minutes: 5);
+  static String _verifiedAiConsentUid = '';
+  static String _verifiedAiConsentReceiptId = '';
+  static String _verifiedAiConsentPolicyVersion = '';
+  static String _verifiedAiConsentProcessorSetHash = '';
+  static DateTime? _verifiedAiConsentAt;
 
   static const bool isPublicBuild = bool.fromEnvironment('ELLA_PUBLIC_BUILD');
   static const bool isTodayDesignPreview = bool.fromEnvironment('ELLA_TODAY_DESIGN_PREVIEW');
-  static const bool _requiresAccountBoundAiConsent =
-      bool.fromEnvironment('ELLA_HERMES_PROVISIONING_GATE', defaultValue: true);
-  static const String currentAiConsentContractVersion = 'ai-data-processors-v4';
+  static const String currentAiConsentContractVersion = 'ai-data-processors-v5';
   static const String currentAiConsentProcessorSetHash =
-      'sha256:bd055957a43a28cf8d47d1daf2e161fa36b29bfc48842b322e87087ac5ae2261';
-  static const String currentAiConsentReceiptPrefix = 'ios-ai-consent:$currentAiConsentContractVersion:';
+      'sha256:9c2529babbd6241f20242cf0836baf7e1899d05bb3d945a0d38a357113d4cbc4';
+  static const String currentAiConsentReceiptPrefix = 'aicr_';
 
   factory SharedPreferencesUtil() {
     return _instance;
@@ -37,9 +41,13 @@ class SharedPreferencesUtil {
 
   static Future<void> init() async {
     _preferences = await SharedPreferences.getInstance();
+    clearAiConsentServerVerification();
   }
 
-  set uid(String value) => saveString('uid', value);
+  set uid(String value) {
+    if (value != uid) clearAiConsentServerVerification();
+    saveString('uid', value);
+  }
 
   String get uid => getString('uid');
 
@@ -206,8 +214,19 @@ class SharedPreferencesUtil {
     final accepted = getBool('aiConsentAccepted', defaultValue: false) &&
         aiConsentContractVersion == currentAiConsentContractVersion &&
         aiConsentProcessorSetHash == currentAiConsentProcessorSetHash;
-    if (!accepted || !_requiresAccountBoundAiConsent) return accepted;
-    return uid.isNotEmpty && aiConsentReceiptId.startsWith(currentAiConsentReceiptPrefix) && aiConsentReceiptUid == uid;
+    if (!accepted ||
+        uid.isEmpty ||
+        !aiConsentReceiptId.startsWith(currentAiConsentReceiptPrefix) ||
+        aiConsentReceiptUid != uid) {
+      return false;
+    }
+    final verifiedAt = _verifiedAiConsentAt;
+    return verifiedAt != null &&
+        DateTime.now().difference(verifiedAt) <= aiConsentServerVerificationTtl &&
+        _verifiedAiConsentUid == uid &&
+        _verifiedAiConsentReceiptId == aiConsentReceiptId &&
+        _verifiedAiConsentPolicyVersion == currentAiConsentContractVersion &&
+        _verifiedAiConsentProcessorSetHash == currentAiConsentProcessorSetHash;
   }
 
   set aiConsentAcceptedAt(String value) => saveString('aiConsentAcceptedAt', value);
@@ -244,6 +263,35 @@ class SharedPreferencesUtil {
       aiConsentReceiptId.isNotEmpty &&
       aiConsentReceiptUid == uid;
 
+  void markAiConsentServerVerified({
+    required String uid,
+    required String receiptId,
+    required String policyVersion,
+    required String processorSetHash,
+    DateTime? verifiedAt,
+  }) {
+    if (uid.isEmpty ||
+        !receiptId.startsWith(currentAiConsentReceiptPrefix) ||
+        policyVersion != currentAiConsentContractVersion ||
+        processorSetHash != currentAiConsentProcessorSetHash) {
+      clearAiConsentServerVerification();
+      return;
+    }
+    _verifiedAiConsentUid = uid;
+    _verifiedAiConsentReceiptId = receiptId;
+    _verifiedAiConsentPolicyVersion = policyVersion;
+    _verifiedAiConsentProcessorSetHash = processorSetHash;
+    _verifiedAiConsentAt = verifiedAt ?? DateTime.now();
+  }
+
+  static void clearAiConsentServerVerification() {
+    _verifiedAiConsentUid = '';
+    _verifiedAiConsentReceiptId = '';
+    _verifiedAiConsentPolicyVersion = '';
+    _verifiedAiConsentProcessorSetHash = '';
+    _verifiedAiConsentAt = null;
+  }
+
   void acceptAiConsent({
     String receiptId = '',
     String uid = '',
@@ -272,6 +320,7 @@ class SharedPreferencesUtil {
   }
 
   void declineAiConsent() {
+    clearAiConsentServerVerification();
     aiConsentAccepted = false;
     remove('aiConsentAcceptedAt');
     remove('aiConsentReceiptId');
@@ -620,6 +669,8 @@ class SharedPreferencesUtil {
     final previousUid = getString('ellaProvisioningAccountUid');
 
     if (previousUid == newUid) return;
+
+    clearAiConsentServerVerification();
 
     if (previousUid.isNotEmpty) {
       // Retained users keep compatibility preferences when returning to the

--- a/app/lib/ella/pages/ella_provisioning_gate_page.dart
+++ b/app/lib/ella/pages/ella_provisioning_gate_page.dart
@@ -7,7 +7,9 @@ import 'package:provider/provider.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/ella/services/ella_ai_consent_service.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
+import 'package:omi/ella/widgets/ai_consent_sheet.dart';
 import 'package:omi/providers/ella_provisioning_provider.dart';
 import 'package:omi/utils/auth_utils.dart';
 import 'package:omi/utils/l10n_extensions.dart';
@@ -24,6 +26,8 @@ class EllaProvisioningGatePage extends StatefulWidget {
 }
 
 class _EllaProvisioningGatePageState extends State<EllaProvisioningGatePage> with WidgetsBindingObserver {
+  bool _consentDeferred = false;
+
   @override
   void initState() {
     super.initState();
@@ -33,9 +37,36 @@ class _EllaProvisioningGatePageState extends State<EllaProvisioningGatePage> wit
     }
   }
 
-  Future<void> _start() async {
+  Future<void> _start({bool forceConsentPrompt = false}) async {
     final user = FirebaseAuth.instance.currentUser;
     if (user == null || !mounted) return;
+
+    final preferences = SharedPreferencesUtil();
+    preferences.uid = user.uid;
+    await preferences.prepareEllaProvisioningAccount(user.uid);
+    if (!mounted) return;
+
+    final consentService = EllaAiConsentService();
+    var hasConsent = await consentService.refreshServerAuthority(uid: user.uid);
+    if (!mounted) return;
+    if (!hasConsent) {
+      if (preferences.isCurrentAiConsentDeferred && !forceConsentPrompt) {
+        setState(() => _consentDeferred = true);
+        return;
+      }
+      final accepted = await AiConsentSheet.show(
+        context,
+        onAccept: () async => (await consentService.grantCurrentConsent(uid: user.uid)) != null,
+        onDecline: () => consentService.declineCurrentConsent(uid: user.uid),
+      );
+      if (!mounted) return;
+      hasConsent = accepted == true && preferences.aiConsentAccepted;
+      if (!hasConsent) {
+        setState(() => _consentDeferred = true);
+        return;
+      }
+    }
+    setState(() => _consentDeferred = false);
 
     String timezone;
     try {
@@ -44,8 +75,6 @@ class _EllaProvisioningGatePageState extends State<EllaProvisioningGatePage> wit
       timezone = DateTime.now().timeZoneName;
     }
     if (!mounted) return;
-
-    final preferences = SharedPreferencesUtil();
 
     await context.read<EllaProvisioningProvider>().start(
           uid: user.uid,
@@ -77,6 +106,50 @@ class _EllaProvisioningGatePageState extends State<EllaProvisioningGatePage> wit
 
   @override
   Widget build(BuildContext context) {
+    if (_consentDeferred) {
+      return Scaffold(
+        backgroundColor: EllaColors.paper,
+        body: SafeArea(
+          child: Center(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(EllaSizes.screenPadding),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 480),
+                child: Container(
+                  padding: const EdgeInsets.all(28),
+                  decoration: BoxDecoration(
+                    color: EllaColors.card,
+                    borderRadius: BorderRadius.circular(EllaSizes.cardRadius),
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(Icons.lock_outline_rounded, color: EllaColors.tealDeep, size: 44),
+                      const SizedBox(height: 20),
+                      Text(context.l10n.aiConsentOffGateTitle,
+                          style: EllaTextStyles.display, textAlign: TextAlign.center),
+                      const SizedBox(height: 12),
+                      Text(context.l10n.aiConsentOffGateBody,
+                          style: EllaTextStyles.secondary, textAlign: TextAlign.center),
+                      const SizedBox(height: 24),
+                      SizedBox(
+                        width: double.infinity,
+                        child: FilledButton(
+                          onPressed: () => _start(forceConsentPrompt: true),
+                          child: Text(context.l10n.aiConsentReviewAction),
+                        ),
+                      ),
+                      TextButton(onPressed: _signOut, child: Text(context.l10n.signOut)),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
     return Consumer<EllaProvisioningProvider>(
       builder: (context, provider, _) {
         if (provider.isOperational) {

--- a/app/lib/ella/pages/ella_settings_page.dart
+++ b/app/lib/ella/pages/ella_settings_page.dart
@@ -25,6 +25,7 @@ import 'package:omi/ella/services/guardian_mode_api.dart' as guardian_api;
 import 'package:omi/ella/widgets/ella_settings_row.dart';
 import 'package:omi/ella/widgets/ai_consent_sheet.dart';
 import 'package:omi/pages/capture/connect.dart';
+import 'package:omi/pages/settings/delete_account.dart';
 import 'package:omi/pages/settings/settings_drawer.dart';
 import 'package:omi/providers/device_provider.dart';
 import 'package:omi/providers/capture_provider.dart';
@@ -173,8 +174,10 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
 
   Future<void> _openListeningConsent() async {
     final uid = FirebaseAuth.instance.currentUser?.uid ?? '';
+    var revokeSynced = true;
     final accepted = await AiConsentSheet.show(
       context,
+      reviewMode: true,
       onAccept: isHermesProvisioningGateEnabled
           ? () async {
               final receiptId = await EllaAiConsentService().acknowledgePrivateCloudSync(uid: uid);
@@ -183,6 +186,12 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
               return true;
             }
           : null,
+      onDecline: () async {
+        revokeSynced = await EllaAiConsentService().revokePrivateCloudSync();
+      },
+      onRequestDeletion: () async {
+        await Navigator.of(context).push(MaterialPageRoute(builder: (_) => const DeleteAccount()));
+      },
     );
     if (!mounted) return;
     final captureProvider = context.read<CaptureProvider>();
@@ -191,6 +200,13 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
     } else {
       await captureProvider.stopStreamDeviceRecording();
       await captureProvider.stopStreamRecording();
+    }
+    if (!mounted) return;
+    setState(() {});
+    if (!revokeSynced) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(context.l10n.aiConsentRevokeSyncFailed)),
+      );
     }
   }
 
@@ -310,7 +326,16 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
 
             // CAPTURE section
             _buildSectionHeader(context.l10n.ellaCaptureSection),
-            EllaSettingsRow(icon: Icons.hearing, title: context.l10n.listeningAndConsent, onTap: _openListeningConsent),
+            EllaSettingsRow(
+              icon: Icons.hearing,
+              title: context.l10n.listeningAndConsent,
+              subtitle: SharedPreferencesUtil().hasAccountBoundAiConsent(
+                FirebaseAuth.instance.currentUser?.uid ?? '',
+              )
+                  ? context.l10n.aiConsentAllowedStatus
+                  : context.l10n.aiConsentNotAllowedStatus,
+              onTap: _openListeningConsent,
+            ),
             const SizedBox(height: 8),
             EllaSettingsRow(
               icon: Icons.record_voice_over_rounded,

--- a/app/lib/ella/pages/ella_settings_page.dart
+++ b/app/lib/ella/pages/ella_settings_page.dart
@@ -20,7 +20,6 @@ import 'package:omi/ella/pages/guardian_alert_history_page.dart';
 import 'package:omi/ella/pages/guardian_mode_page.dart';
 import 'package:omi/ella/services/caregiver_api.dart' as caregiver_api;
 import 'package:omi/ella/services/ella_ai_consent_service.dart';
-import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/ella/services/guardian_mode_api.dart' as guardian_api;
 import 'package:omi/ella/widgets/ella_settings_row.dart';
 import 'package:omi/ella/widgets/ai_consent_sheet.dart';
@@ -174,20 +173,22 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
 
   Future<void> _openListeningConsent() async {
     final uid = FirebaseAuth.instance.currentUser?.uid ?? '';
+    final consentService = EllaAiConsentService();
+    await consentService.refreshServerAuthority(uid: uid);
+    if (!mounted) return;
     var revokeSynced = true;
     final accepted = await AiConsentSheet.show(
       context,
       reviewMode: true,
-      onAccept: isHermesProvisioningGateEnabled
-          ? () async {
-              final receiptId = await EllaAiConsentService().acknowledgePrivateCloudSync(uid: uid);
-              if (receiptId == null) return false;
-              if (mounted) context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
-              return true;
-            }
-          : null,
+      onAccept: () async {
+        final receiptId = await consentService.grantCurrentConsent(uid: uid);
+        if (receiptId == null) return false;
+        if (mounted) context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
+        return true;
+      },
       onDecline: () async {
-        revokeSynced = await EllaAiConsentService().revokePrivateCloudSync();
+        revokeSynced = await consentService.revokeCurrentConsent(uid: uid);
+        return revokeSynced;
       },
       onRequestDeletion: () async {
         await Navigator.of(context).push(MaterialPageRoute(builder: (_) => const DeleteAccount()));

--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:audio_session/audio_session.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -19,20 +18,18 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/services/ella_chat_service.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/ella/ella_theme.dart';
-import 'package:omi/ella/services/ella_ai_consent_service.dart';
+import 'package:omi/ella/services/ai_consent_coordinator.dart';
 import 'package:omi/ella/services/elevenlabs_tts.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/ella/services/memory_reinterpretation_receipt_service.dart';
 import 'package:omi/ella/services/v2v_client.dart';
 import 'package:omi/ella/services/voice_session_startup_guard.dart';
-import 'package:omi/ella/widgets/ai_consent_sheet.dart';
 import 'package:omi/ella/widgets/ella_breathing_dot.dart';
 import 'package:omi/ella/widgets/ella_voice_orb.dart';
 import 'package:omi/ella/widgets/memory_correction_receipt.dart';
 import 'package:omi/ella/widgets/v2v_fallback_dialog.dart';
 import 'package:omi/ella/widgets/voice_modal_scaffold.dart';
 import 'package:omi/providers/capture_provider.dart';
-import 'package:omi/providers/ella_provisioning_provider.dart';
 import 'package:omi/providers/home_provider.dart';
 import 'package:omi/providers/message_provider.dart';
 import 'package:omi/utils/enums.dart';
@@ -264,31 +261,14 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   }
 
   Future<bool> _ensureVoiceConsent() async {
-    if (SharedPreferencesUtil().aiConsentAccepted) return true;
     if (_consentPromptActive || !mounted) return false;
 
     _consentPromptActive = true;
-    final uid = FirebaseAuth.instance.currentUser?.uid ?? '';
-    final accepted = await AiConsentSheet.show(
-      context,
-      onAccept: isHermesProvisioningGateEnabled
-          ? () async {
-              final receiptId = await EllaAiConsentService().acknowledgePrivateCloudSync(uid: uid);
-              if (receiptId == null) return false;
-              if (mounted) {
-                try {
-                  context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
-                } catch (_) {
-                  // The authenticated receipt remains persisted even if this
-                  // route is rendered outside the provisioning provider tree.
-                }
-              }
-              return true;
-            }
-          : null,
-    );
-    _consentPromptActive = false;
-    return accepted == true && SharedPreferencesUtil().aiConsentAccepted;
+    try {
+      return await AiConsentCoordinator.ensure(context);
+    } finally {
+      _consentPromptActive = false;
+    }
   }
 
   Future<void> _activateSelectedVoice() async {

--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -18,6 +18,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/services/ella_chat_service.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/ella/services/ai_consent_active_session_lease.dart';
 import 'package:omi/ella/services/ai_consent_coordinator.dart';
 import 'package:omi/ella/services/elevenlabs_tts.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
@@ -96,6 +97,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
 
   /// V2V client for WebSocket-based voice-to-voice mode
   V2VClient? _v2vClient;
+  AiConsentActiveSessionLease? _standardVoiceConsentLease;
   final VoiceSessionStartupGuard _voiceStartupGuard = VoiceSessionStartupGuard();
   bool _isV2VMode = false;
   String _activeV2VProvider = '';
@@ -243,6 +245,8 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     final client = _v2vClient;
     _v2vClient = null;
     if (client != null) unawaited(client.disconnect());
+    _standardVoiceConsentLease?.stop();
+    _standardVoiceConsentLease = null;
     super.dispose();
   }
 
@@ -289,6 +293,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       final startupGeneration = _beginV2VStartup(provider);
       await _startV2V(provider, startupGeneration: startupGeneration);
     } else {
+      _startStandardVoiceConsentLease();
       setState(() {
         _voiceModeActive = true;
         _isV2VMode = false;
@@ -298,6 +303,8 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
   }
 
   int _beginV2VStartup(String provider) {
+    _standardVoiceConsentLease?.stop();
+    _standardVoiceConsentLease = null;
     final startupGeneration = _voiceStartupGuard.begin();
     final providerName = localizedV2VProviderName(context, V2VClient.normalizeProvider(provider));
     setState(() {
@@ -355,6 +362,8 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     if (cancelStartup) _voiceStartupGuard.cancel();
     _voiceModeActive = false;
     _isV2VMode = false;
+    _standardVoiceConsentLease?.stop();
+    _standardVoiceConsentLease = null;
     _typewriterTimer?.cancel();
     if (_speech.isListening) {
       _speech.stop();
@@ -363,6 +372,33 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     setState(() {
       _orbState = VoiceOrbState.idle;
       _statusText = 'Paused — Tap to Resume';
+      _audioLevel = 0.0;
+    });
+  }
+
+  void _startStandardVoiceConsentLease() {
+    _standardVoiceConsentLease?.stop();
+    _standardVoiceConsentLease = AiConsentActiveSessionLease(
+      uid: SharedPreferencesUtil().uid,
+      onAuthorityLost: _handleStandardVoiceConsentAuthorityLost,
+    )..start();
+  }
+
+  Future<void> _handleStandardVoiceConsentAuthorityLost() async {
+    _standardVoiceConsentLease = null;
+    _voiceModeActive = false;
+    _isV2VMode = false;
+    if (_speech.isListening) {
+      await _speech.stop();
+    }
+    try {
+      await _audioPlayer.stop();
+      await ElevenLabsTts.stopOnDevice();
+    } catch (_) {}
+    if (!mounted) return;
+    setState(() {
+      _orbState = VoiceOrbState.idle;
+      _statusText = context.l10n.aiConsentActiveAudioStopped;
       _audioLevel = 0.0;
     });
   }
@@ -651,6 +687,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
         case V2VFailureChoice.useElevenLabs:
           if (_sessionScope != null) break;
           _usingElevenLabsFallback = true;
+          _startStandardVoiceConsentLease();
           setState(() {
             _voiceModeActive = true;
             _isV2VMode = false;
@@ -824,6 +861,21 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
         debugPrint('[VoiceChat] V2V error: ${event.text}');
         setState(() {
           _statusText = 'Error: ${event.text ?? "unknown"}';
+        });
+        break;
+      case 'consent_authority_lost':
+        final endedSessionId = _activeSessionId;
+        _voiceStartupGuard.cancel();
+        _v2vClient = null;
+        _voiceModeActive = false;
+        _isV2VMode = false;
+        _activeSessionId = '';
+        _activeV2VProvider = '';
+        _notifyMemorySessionEnded(endedSessionId);
+        setState(() {
+          _orbState = VoiceOrbState.idle;
+          _statusText = context.l10n.aiConsentActiveAudioStopped;
+          _audioLevel = 0.0;
         });
         break;
       case 'session_end':

--- a/app/lib/ella/services/ai_consent_active_session_lease.dart
+++ b/app/lib/ella/services/ai_consent_active_session_lease.dart
@@ -1,0 +1,113 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ella_ai_consent_service.dart';
+import 'package:omi/utils/debug_log_manager.dart';
+import 'package:omi/utils/logger.dart';
+
+class AiConsentAuthorityLostException implements Exception {
+  const AiConsentAuthorityLostException();
+
+  @override
+  String toString() => 'AI processing permission could not be verified';
+}
+
+/// Keeps server-authoritative AI consent fresh while personal data is actively
+/// being streamed. Refreshing one minute before the five-minute TTL leaves room
+/// for the bounded backend request without extending stale authority.
+class AiConsentActiveSessionLease {
+  AiConsentActiveSessionLease({
+    required this.uid,
+    required FutureOr<void> Function() onAuthorityLost,
+    Future<bool> Function(String uid)? refreshAuthority,
+    SharedPreferencesUtil? preferences,
+  })  : _onAuthorityLost = onAuthorityLost,
+        _refreshAuthority = refreshAuthority ?? ((uid) => EllaAiConsentService().refreshServerAuthority(uid: uid)),
+        _preferences = preferences ?? SharedPreferencesUtil();
+
+  static const Duration refreshInterval = Duration(minutes: 4);
+  static const Duration refreshLeadTime = Duration(minutes: 1);
+
+  final String uid;
+  final FutureOr<void> Function() _onAuthorityLost;
+  final Future<bool> Function(String uid) _refreshAuthority;
+  final SharedPreferencesUtil _preferences;
+
+  Timer? _refreshTimer;
+  bool _active = false;
+  bool _refreshing = false;
+  bool _authorityLossReported = false;
+
+  bool get isActive => _active;
+
+  void start() {
+    if (_active) return;
+    _active = true;
+    if (uid.isEmpty || _preferences.uid != uid || !_preferences.aiConsentAccepted) {
+      unawaited(_loseAuthority('invalid_start_authority'));
+      return;
+    }
+    _scheduleRefresh();
+  }
+
+  void stop() {
+    _active = false;
+    _refreshTimer?.cancel();
+    _refreshTimer = null;
+  }
+
+  @visibleForTesting
+  Future<void> refreshNow() => _refresh();
+
+  @visibleForTesting
+  static Duration refreshDelayFor(Duration? remaining) {
+    if (remaining == null || remaining <= refreshLeadTime) return Duration.zero;
+    final beforeExpiry = remaining - refreshLeadTime;
+    return beforeExpiry < refreshInterval ? beforeExpiry : refreshInterval;
+  }
+
+  void _scheduleRefresh() {
+    if (!_active) return;
+    _refreshTimer?.cancel();
+    final delay = refreshDelayFor(_preferences.aiConsentServerVerificationRemaining);
+    _refreshTimer = Timer(delay, () {
+      unawaited(_refresh());
+    });
+  }
+
+  Future<void> _refresh() async {
+    if (!_active || _refreshing) return;
+    _refreshing = true;
+    _refreshTimer?.cancel();
+    _refreshTimer = null;
+
+    var authorized = false;
+    try {
+      authorized = await _refreshAuthority(uid);
+    } catch (error) {
+      Logger.debug('[AIConsent] Active-session authority refresh failed: ${error.runtimeType}');
+    } finally {
+      _refreshing = false;
+    }
+
+    if (!_active) return;
+    if (!authorized || _preferences.uid != uid || !_preferences.aiConsentAccepted) {
+      await _loseAuthority('refresh_denied_or_unavailable');
+      return;
+    }
+
+    unawaited(DebugLogManager.logEvent('ai_consent_active_session_refreshed', {'uid_matches': true}));
+    _scheduleRefresh();
+  }
+
+  Future<void> _loseAuthority(String reason) async {
+    SharedPreferencesUtil.clearAiConsentServerVerification();
+    stop();
+    if (_authorityLossReported) return;
+    _authorityLossReported = true;
+    unawaited(DebugLogManager.logWarning('ai_consent_active_session_stopped', {'reason': reason}));
+    await _onAuthorityLost();
+  }
+}

--- a/app/lib/ella/services/ai_consent_coordinator.dart
+++ b/app/lib/ella/services/ai_consent_coordinator.dart
@@ -5,7 +5,6 @@ import 'package:provider/provider.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/services/ella_ai_consent_service.dart';
-import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/ella/widgets/ai_consent_sheet.dart';
 import 'package:omi/providers/ella_provisioning_provider.dart';
 
@@ -51,8 +50,13 @@ class AiConsentActionGate {
 class AiConsentCoordinator {
   static final AiConsentActionGate _gate = AiConsentActionGate();
 
-  static Future<bool> ensure(BuildContext context) {
+  static Future<bool> ensure(BuildContext context) async {
     final preferences = SharedPreferencesUtil();
+    if (preferences.aiConsentAccepted) return true;
+    final uid = FirebaseAuth.instance.currentUser?.uid ?? '';
+    if (uid.isEmpty) return false;
+    if (await EllaAiConsentService().refreshServerAuthority(uid: uid)) return true;
+
     return _gate.ensure(
       hasConsent: () => preferences.aiConsentAccepted,
       requestConsent: () => _request(context),
@@ -61,25 +65,25 @@ class AiConsentCoordinator {
 
   static Future<bool> _request(BuildContext context) async {
     final uid = FirebaseAuth.instance.currentUser?.uid ?? '';
-    if (isHermesProvisioningGateEnabled && uid.isEmpty) return false;
+    if (uid.isEmpty) return false;
+    final service = EllaAiConsentService();
 
     final accepted = await AiConsentSheet.show(
       context,
-      onAccept: isHermesProvisioningGateEnabled
-          ? () async {
-              final receiptId = await EllaAiConsentService().acknowledgePrivateCloudSync(uid: uid);
-              if (receiptId == null) return false;
-              if (context.mounted) {
-                try {
-                  context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
-                } catch (_) {
-                  // The authenticated receipt is already persisted when this
-                  // action is rendered outside the provisioning provider tree.
-                }
-              }
-              return true;
-            }
-          : null,
+      onAccept: () async {
+        final receiptId = await service.grantCurrentConsent(uid: uid);
+        if (receiptId == null) return false;
+        if (context.mounted) {
+          try {
+            context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
+          } catch (_) {
+            // The authenticated receipt is already persisted when this
+            // action is rendered outside the provisioning provider tree.
+          }
+        }
+        return true;
+      },
+      onDecline: () => service.declineCurrentConsent(uid: uid),
     );
     return accepted == true && SharedPreferencesUtil().aiConsentAccepted;
   }

--- a/app/lib/ella/services/ai_consent_policy.dart
+++ b/app/lib/ella/services/ai_consent_policy.dart
@@ -2,71 +2,175 @@ import 'package:omi/backend/preferences.dart';
 
 class AiConsentProcessor {
   const AiConsentProcessor({
+    required this.id,
     required this.name,
     required this.function,
     required this.data,
     this.isThirdParty = true,
   });
 
+  factory AiConsentProcessor.fromJson(Map<String, dynamic> json) {
+    return AiConsentProcessor(
+      id: json['id'] as String? ?? '',
+      name: json['legal_recipient'] as String? ?? '',
+      function: json['function'] as String? ?? '',
+      data: json['data'] as String? ?? '',
+      isThirdParty: json['third_party'] as bool? ?? true,
+    );
+  }
+
+  final String id;
   final String name;
   final String function;
   final String data;
   final bool isThirdParty;
+
+  bool get isValid => id.isNotEmpty && name.isNotEmpty && function.isNotEmpty && data.isNotEmpty;
 }
 
 class AiConsentPolicy {
-  const AiConsentPolicy._();
+  const AiConsentPolicy({
+    required this.version,
+    required this.processorSetHash,
+    required this.canonicalProcessorSet,
+    required this.processors,
+  });
 
-  static const version = SharedPreferencesUtil.currentAiConsentContractVersion;
-  static const processorSetHash = SharedPreferencesUtil.currentAiConsentProcessorSetHash;
-  static const canonicalProcessorSet = 'deepgram:stt|firebase:auth-infrastructure|hermes-self-hosted:agent-runtime|'
-      'honcho-self-hosted:memory-context|openrouter:model-routing|google-gemini:language-live-voice|'
-      'openai:language-live-voice|groq:language|xai-grok:language-live-voice|elevenlabs:tts-fallback';
+  factory AiConsentPolicy.fromJson(Map<String, dynamic> json) {
+    final processors = (json['processors'] as List<dynamic>? ?? const [])
+        .whereType<Map<String, dynamic>>()
+        .map(AiConsentProcessor.fromJson)
+        .toList(growable: false);
+    return AiConsentPolicy(
+      version: json['version'] as String? ?? '',
+      processorSetHash: json['processor_set_hash'] as String? ?? '',
+      canonicalProcessorSet: json['canonical_processor_set'] as String? ?? '',
+      processors: processors,
+    );
+  }
 
-  static const processors = <AiConsentProcessor>[
-    AiConsentProcessor(name: 'Deepgram', function: 'Speech transcription', data: 'Live or stored microphone audio'),
-    AiConsentProcessor(
-      name: 'Google Firebase',
-      function: 'Authentication and service infrastructure',
-      data: 'Account and service metadata',
-    ),
-    AiConsentProcessor(
-      name: 'Ella self-hosted Hermes',
-      function: 'Agent reasoning',
-      data: 'Messages, transcripts, and selected memory context',
-      isThirdParty: false,
-    ),
-    AiConsentProcessor(
-      name: 'Ella self-hosted Honcho',
-      function: 'Memory context',
-      data: 'Derived text and selected memory relationships',
-      isThirdParty: false,
-    ),
-    AiConsentProcessor(
-      name: 'OpenRouter',
-      function: 'Model routing',
-      data: 'Messages, transcripts, and selected memory context',
-    ),
-    AiConsentProcessor(
-      name: 'Google Gemini',
-      function: 'Language processing and live voice',
-      data: 'Text, selected context, or live microphone audio',
-    ),
-    AiConsentProcessor(
-      name: 'OpenAI',
-      function: 'Language processing and live voice',
-      data: 'Text, selected context, or live microphone audio',
-    ),
-    AiConsentProcessor(name: 'Groq', function: 'Language processing', data: 'Text and selected context'),
-    AiConsentProcessor(
-      name: 'xAI Grok',
-      function: 'Language processing and live voice',
-      data: 'Text, selected context, or live microphone audio',
-    ),
-    AiConsentProcessor(
-      name: 'ElevenLabs',
-      function: 'Fallback voice synthesis',
-      data: 'Response text',
-    ),
-  ];
+  final String version;
+  final String processorSetHash;
+  final String canonicalProcessorSet;
+  final List<AiConsentProcessor> processors;
+
+  bool get isBundledCurrent {
+    if (version != bundled.version ||
+        processorSetHash != bundled.processorSetHash ||
+        canonicalProcessorSet != bundled.canonicalProcessorSet ||
+        processors.length != bundled.processors.length) {
+      return false;
+    }
+    for (var index = 0; index < processors.length; index++) {
+      final processor = processors[index];
+      final expected = bundled.processors[index];
+      if (!processor.isValid ||
+          processor.id != expected.id ||
+          processor.name != expected.name ||
+          processor.function != expected.function ||
+          processor.data != expected.data ||
+          processor.isThirdParty != expected.isThirdParty) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static const bundled = AiConsentPolicy(
+    version: SharedPreferencesUtil.currentAiConsentContractVersion,
+    processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+    canonicalProcessorSet: 'deepgram:stt|soniox:stt|speechmatics:stt|firebase:auth-infrastructure|'
+        'hermes-self-hosted:agent-runtime|honcho-self-hosted:memory-context|ella-self-hosted-tts:tts|'
+        'openrouter:model-routing|google-gemini:language-live-voice|openai:language-live-voice|'
+        'groq:language|xai-grok:language-live-voice|inworld:tts|elevenlabs:tts-fallback',
+    processors: [
+      AiConsentProcessor(
+        id: 'deepgram',
+        name: 'Deepgram',
+        function: 'Speech transcription',
+        data: 'Live or stored microphone audio',
+      ),
+      AiConsentProcessor(
+        id: 'soniox',
+        name: 'Soniox',
+        function: 'Speech transcription',
+        data: 'Live or stored microphone audio',
+      ),
+      AiConsentProcessor(
+        id: 'speechmatics',
+        name: 'Speechmatics',
+        function: 'Speech transcription',
+        data: 'Live or stored microphone audio',
+      ),
+      AiConsentProcessor(
+        id: 'firebase',
+        name: 'Google Firebase',
+        function: 'Authentication and service infrastructure',
+        data: 'Account and service metadata',
+      ),
+      AiConsentProcessor(
+        id: 'hermes-self-hosted',
+        name: 'Ella self-hosted Hermes',
+        function: 'Agent reasoning',
+        data: 'Messages, transcripts, and selected memory context',
+        isThirdParty: false,
+      ),
+      AiConsentProcessor(
+        id: 'honcho-self-hosted',
+        name: 'Ella self-hosted Honcho',
+        function: 'Memory context',
+        data: 'Derived text and selected memory relationships',
+        isThirdParty: false,
+      ),
+      AiConsentProcessor(
+        id: 'ella-self-hosted-tts',
+        name: 'Ella self-hosted voice synthesis',
+        function: 'Voice synthesis',
+        data: 'Response text',
+        isThirdParty: false,
+      ),
+      AiConsentProcessor(
+        id: 'openrouter',
+        name: 'OpenRouter',
+        function: 'Model routing',
+        data: 'Messages, transcripts, and selected memory context',
+      ),
+      AiConsentProcessor(
+        id: 'google-gemini',
+        name: 'Google Gemini',
+        function: 'Language processing and live voice',
+        data: 'Text, selected context, or live microphone audio',
+      ),
+      AiConsentProcessor(
+        id: 'openai',
+        name: 'OpenAI',
+        function: 'Language processing and live voice',
+        data: 'Text, selected context, or live microphone audio',
+      ),
+      AiConsentProcessor(
+        id: 'groq',
+        name: 'Groq',
+        function: 'Language processing',
+        data: 'Text and selected context',
+      ),
+      AiConsentProcessor(
+        id: 'xai-grok',
+        name: 'xAI Grok',
+        function: 'Language processing and live voice',
+        data: 'Text, selected context, or live microphone audio',
+      ),
+      AiConsentProcessor(
+        id: 'inworld',
+        name: 'Inworld AI',
+        function: 'Voice synthesis',
+        data: 'Response text',
+      ),
+      AiConsentProcessor(
+        id: 'elevenlabs',
+        name: 'ElevenLabs',
+        function: 'Fallback voice synthesis',
+        data: 'Response text',
+      ),
+    ],
+  );
 }

--- a/app/lib/ella/services/ai_consent_policy.dart
+++ b/app/lib/ella/services/ai_consent_policy.dart
@@ -1,0 +1,72 @@
+import 'package:omi/backend/preferences.dart';
+
+class AiConsentProcessor {
+  const AiConsentProcessor({
+    required this.name,
+    required this.function,
+    required this.data,
+    this.isThirdParty = true,
+  });
+
+  final String name;
+  final String function;
+  final String data;
+  final bool isThirdParty;
+}
+
+class AiConsentPolicy {
+  const AiConsentPolicy._();
+
+  static const version = SharedPreferencesUtil.currentAiConsentContractVersion;
+  static const processorSetHash = SharedPreferencesUtil.currentAiConsentProcessorSetHash;
+  static const canonicalProcessorSet = 'deepgram:stt|firebase:auth-infrastructure|hermes-self-hosted:agent-runtime|'
+      'honcho-self-hosted:memory-context|openrouter:model-routing|google-gemini:language-live-voice|'
+      'openai:language-live-voice|groq:language|xai-grok:language-live-voice|elevenlabs:tts-fallback';
+
+  static const processors = <AiConsentProcessor>[
+    AiConsentProcessor(name: 'Deepgram', function: 'Speech transcription', data: 'Live or stored microphone audio'),
+    AiConsentProcessor(
+      name: 'Google Firebase',
+      function: 'Authentication and service infrastructure',
+      data: 'Account and service metadata',
+    ),
+    AiConsentProcessor(
+      name: 'Ella self-hosted Hermes',
+      function: 'Agent reasoning',
+      data: 'Messages, transcripts, and selected memory context',
+      isThirdParty: false,
+    ),
+    AiConsentProcessor(
+      name: 'Ella self-hosted Honcho',
+      function: 'Memory context',
+      data: 'Derived text and selected memory relationships',
+      isThirdParty: false,
+    ),
+    AiConsentProcessor(
+      name: 'OpenRouter',
+      function: 'Model routing',
+      data: 'Messages, transcripts, and selected memory context',
+    ),
+    AiConsentProcessor(
+      name: 'Google Gemini',
+      function: 'Language processing and live voice',
+      data: 'Text, selected context, or live microphone audio',
+    ),
+    AiConsentProcessor(
+      name: 'OpenAI',
+      function: 'Language processing and live voice',
+      data: 'Text, selected context, or live microphone audio',
+    ),
+    AiConsentProcessor(name: 'Groq', function: 'Language processing', data: 'Text and selected context'),
+    AiConsentProcessor(
+      name: 'xAI Grok',
+      function: 'Language processing and live voice',
+      data: 'Text, selected context, or live microphone audio',
+    ),
+    AiConsentProcessor(
+      name: 'ElevenLabs',
+      function: 'Fallback voice synthesis',
+      data: 'Response text',
+    ),
+  ];
+}

--- a/app/lib/ella/services/ella_ai_consent_service.dart
+++ b/app/lib/ella/services/ella_ai_consent_service.dart
@@ -1,67 +1,285 @@
+import 'dart:convert';
 import 'dart:ui';
 
 import 'package:uuid/uuid.dart';
 
-import 'package:omi/backend/http/api/users.dart' as users_api;
+import 'package:omi/backend/http/shared.dart';
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ai_consent_policy.dart';
+import 'package:omi/env/env.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 
-abstract class EllaAiConsentTransport {
-  Future<bool> setPrivateCloudSync(bool value);
+enum AiConsentDecision {
+  granted,
+  declined,
+  revoked;
 
-  Future<bool> getPrivateCloudSyncEnabled();
+  String get wireValue => name;
+}
+
+class AiConsentStatus {
+  const AiConsentStatus({
+    required this.subjectUid,
+    required this.authorized,
+    required this.policy,
+    required this.decision,
+    required this.receiptId,
+    required this.policyVersion,
+    required this.processorSetHash,
+    required this.appVersion,
+    required this.buildNumber,
+    required this.locale,
+  });
+
+  factory AiConsentStatus.fromJson(Map<String, dynamic> json) {
+    final consent =
+        json['consent'] is Map<String, dynamic> ? json['consent'] as Map<String, dynamic> : const <String, dynamic>{};
+    final receipt =
+        json['receipt'] is Map<String, dynamic> ? json['receipt'] as Map<String, dynamic> : const <String, dynamic>{};
+    final policy = json['policy'] is Map<String, dynamic>
+        ? AiConsentPolicy.fromJson(json['policy'] as Map<String, dynamic>)
+        : null;
+    return AiConsentStatus(
+      subjectUid: json['subject_uid'] as String? ?? '',
+      authorized: json['authorized'] as bool? ?? false,
+      policy: policy,
+      decision: receipt['decision'] as String? ?? consent['decision'] as String? ?? '',
+      receiptId: receipt['receipt_id'] as String? ?? consent['receipt_id'] as String? ?? '',
+      policyVersion: receipt['policy_version'] as String? ?? consent['policy_version'] as String? ?? '',
+      processorSetHash: receipt['processor_set_hash'] as String? ?? consent['processor_set_hash'] as String? ?? '',
+      appVersion: receipt['app_version'] as String? ?? consent['app_version'] as String? ?? '',
+      buildNumber: receipt['build_number'] as String? ?? consent['build_number'] as String? ?? '',
+      locale: receipt['locale'] as String? ?? consent['locale'] as String? ?? '',
+    );
+  }
+
+  final String subjectUid;
+  final bool authorized;
+  final AiConsentPolicy? policy;
+  final String decision;
+  final String receiptId;
+  final String policyVersion;
+  final String processorSetHash;
+  final String appVersion;
+  final String buildNumber;
+  final String locale;
+
+  bool isCurrentGrantFor(String uid) {
+    return uid.isNotEmpty &&
+        subjectUid == uid &&
+        authorized &&
+        decision == AiConsentDecision.granted.wireValue &&
+        receiptId.startsWith(SharedPreferencesUtil.currentAiConsentReceiptPrefix) &&
+        policyVersion == SharedPreferencesUtil.currentAiConsentContractVersion &&
+        processorSetHash == SharedPreferencesUtil.currentAiConsentProcessorSetHash &&
+        (policy?.isBundledCurrent ?? false);
+  }
+}
+
+class AiConsentSubmission {
+  const AiConsentSubmission({
+    required this.decision,
+    required this.policyVersion,
+    required this.processorSetHash,
+    required this.requestId,
+    required this.appVersion,
+    required this.buildNumber,
+    required this.locale,
+  });
+
+  final AiConsentDecision decision;
+  final String policyVersion;
+  final String processorSetHash;
+  final String requestId;
+  final String appVersion;
+  final String buildNumber;
+  final String locale;
+
+  Map<String, dynamic> toJson() => {
+        'decision': decision.wireValue,
+        'policy_version': policyVersion,
+        'processor_set_hash': processorSetHash,
+        'request_id': requestId,
+        'app_version': appVersion,
+        'build_number': buildNumber,
+        'locale': locale,
+      };
+}
+
+abstract class EllaAiConsentTransport {
+  Future<AiConsentPolicy?> fetchPolicy();
+
+  Future<AiConsentStatus?> fetchStatus();
+
+  Future<AiConsentStatus?> submit(AiConsentSubmission submission);
 }
 
 class EllaAiConsentHttpTransport implements EllaAiConsentTransport {
   const EllaAiConsentHttpTransport();
 
-  @override
-  Future<bool> setPrivateCloudSync(bool value) => users_api.setPrivateCloudSyncEnabled(value);
+  static String get _endpoint => '${Env.apiBaseUrl}v1/users/ai-consent';
+
+  static Map<String, dynamic>? _decodeMap(String body) {
+    try {
+      final decoded = jsonDecode(body);
+      return decoded is Map<String, dynamic> ? decoded : null;
+    } on FormatException {
+      return null;
+    }
+  }
 
   @override
-  Future<bool> getPrivateCloudSyncEnabled() => users_api.getPrivateCloudSyncEnabled();
+  Future<AiConsentPolicy?> fetchPolicy() async {
+    final response = await makeApiCall(
+      url: '$_endpoint/policy',
+      headers: const {},
+      method: 'GET',
+      body: '',
+      requireAuthCheck: false,
+    );
+    if (response?.statusCode != 200) return null;
+    final body = _decodeMap(response!.body);
+    return body == null ? null : AiConsentPolicy.fromJson(body);
+  }
+
+  @override
+  Future<AiConsentStatus?> fetchStatus() async {
+    final response = await makeApiCall(
+      url: _endpoint,
+      headers: const {},
+      method: 'GET',
+      body: '',
+    );
+    if (response?.statusCode != 200) return null;
+    final body = _decodeMap(response!.body);
+    return body == null ? null : AiConsentStatus.fromJson(body);
+  }
+
+  @override
+  Future<AiConsentStatus?> submit(AiConsentSubmission submission) async {
+    final response = await makeApiCall(
+      url: _endpoint,
+      headers: const {},
+      method: 'POST',
+      body: jsonEncode(submission.toJson()),
+    );
+    if (response?.statusCode != 200) return null;
+    final body = _decodeMap(response!.body);
+    return body == null ? null : AiConsentStatus.fromJson(body);
+  }
 }
 
 class EllaAiConsentService {
   EllaAiConsentService({
     EllaAiConsentTransport? transport,
     SharedPreferencesUtil? preferences,
-    String Function()? receiptIdFactory,
+    String Function()? requestIdFactory,
     String Function()? clientVersionFactory,
     String Function()? localeFactory,
   })  : _transport = transport ?? const EllaAiConsentHttpTransport(),
         _preferences = preferences ?? SharedPreferencesUtil(),
-        _receiptIdFactory = receiptIdFactory ?? (() => const Uuid().v4()),
+        _requestIdFactory = requestIdFactory ?? (() => const Uuid().v4()),
         _clientVersionFactory = clientVersionFactory ?? (() => PlatformManager.instance.appVersion),
         _localeFactory = localeFactory ?? (() => PlatformDispatcher.instance.locale.toLanguageTag());
 
   final EllaAiConsentTransport _transport;
   final SharedPreferencesUtil _preferences;
-  final String Function() _receiptIdFactory;
+  final String Function() _requestIdFactory;
   final String Function() _clientVersionFactory;
   final String Function() _localeFactory;
 
-  Future<String?> acknowledgePrivateCloudSync({required String uid}) async {
-    if (uid.isEmpty) return null;
+  Future<bool> refreshServerAuthority({required String uid}) async {
+    SharedPreferencesUtil.clearAiConsentServerVerification();
+    if (uid.isEmpty || _preferences.uid != uid) return false;
 
-    final updated = await _transport.setPrivateCloudSync(true);
-    if (!updated) return null;
+    final policy = await _fetchAcceptedPolicy();
+    if (policy == null) return false;
 
-    final confirmed = await _transport.getPrivateCloudSyncEnabled();
-    if (!confirmed) return null;
+    final status = await _transport.fetchStatus();
+    if (status == null || status.policy?.processorSetHash != policy.processorSetHash) return false;
+    if (!status.isCurrentGrantFor(uid)) {
+      if (status.subjectUid == uid && status.decision == AiConsentDecision.declined.wireValue) {
+        _preferences.deferAiConsent();
+      } else if (status.subjectUid == uid) {
+        _preferences.declineAiConsent();
+      }
+      return false;
+    }
 
-    final receiptId = '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}${_receiptIdFactory()}';
-    _preferences.acceptAiConsent(
-      receiptId: receiptId,
-      uid: uid,
-      clientVersion: _clientVersionFactory(),
-      locale: _localeFactory(),
-    );
-    return receiptId;
+    _persistVerifiedGrant(uid, status);
+    return _preferences.aiConsentAccepted;
   }
 
-  Future<bool> revokePrivateCloudSync() async {
+  Future<String?> grantCurrentConsent({required String uid}) async {
+    final status = await _submit(uid: uid, decision: AiConsentDecision.granted);
+    if (status == null || !status.isCurrentGrantFor(uid)) return null;
+    _persistVerifiedGrant(uid, status);
+    return _preferences.aiConsentAccepted ? status.receiptId : null;
+  }
+
+  Future<bool> declineCurrentConsent({required String uid}) async {
+    _preferences.deferAiConsent();
+    final status = await _submit(uid: uid, decision: AiConsentDecision.declined);
+    return status != null &&
+        status.subjectUid == uid &&
+        !status.authorized &&
+        status.decision == AiConsentDecision.declined.wireValue;
+  }
+
+  Future<bool> revokeCurrentConsent({required String uid}) async {
     _preferences.declineAiConsent();
-    return _transport.setPrivateCloudSync(false);
+    final status = await _submit(uid: uid, decision: AiConsentDecision.revoked);
+    return status != null &&
+        status.subjectUid == uid &&
+        !status.authorized &&
+        status.decision == AiConsentDecision.revoked.wireValue;
+  }
+
+  Future<AiConsentStatus?> _submit({
+    required String uid,
+    required AiConsentDecision decision,
+  }) async {
+    SharedPreferencesUtil.clearAiConsentServerVerification();
+    if (uid.isEmpty || _preferences.uid != uid) return null;
+    final policy = await _fetchAcceptedPolicy();
+    if (policy == null) return null;
+
+    final fullVersion = _clientVersionFactory();
+    final separator = fullVersion.lastIndexOf('+');
+    final appVersion = separator > 0 ? fullVersion.substring(0, separator) : fullVersion;
+    final buildNumber =
+        separator > 0 && separator < fullVersion.length - 1 ? fullVersion.substring(separator + 1) : 'unknown';
+    return _transport.submit(
+      AiConsentSubmission(
+        decision: decision,
+        policyVersion: policy.version,
+        processorSetHash: policy.processorSetHash,
+        requestId: _requestIdFactory(),
+        appVersion: appVersion,
+        buildNumber: buildNumber,
+        locale: _localeFactory(),
+      ),
+    );
+  }
+
+  Future<AiConsentPolicy?> _fetchAcceptedPolicy() async {
+    final policy = await _transport.fetchPolicy();
+    return policy?.isBundledCurrent == true ? policy : null;
+  }
+
+  void _persistVerifiedGrant(String uid, AiConsentStatus status) {
+    final clientVersion = status.buildNumber.isEmpty ? status.appVersion : '${status.appVersion}+${status.buildNumber}';
+    _preferences.acceptAiConsent(
+      receiptId: status.receiptId,
+      uid: uid,
+      clientVersion: clientVersion,
+      locale: status.locale,
+    );
+    _preferences.markAiConsentServerVerified(
+      uid: uid,
+      receiptId: status.receiptId,
+      policyVersion: status.policyVersion,
+      processorSetHash: status.processorSetHash,
+    );
   }
 }

--- a/app/lib/ella/services/ella_ai_consent_service.dart
+++ b/app/lib/ella/services/ella_ai_consent_service.dart
@@ -189,25 +189,40 @@ class EllaAiConsentService {
   final String Function() _localeFactory;
 
   Future<bool> refreshServerAuthority({required String uid}) async {
-    SharedPreferencesUtil.clearAiConsentServerVerification();
-    if (uid.isEmpty || _preferences.uid != uid) return false;
-
-    final policy = await _fetchAcceptedPolicy();
-    if (policy == null) return false;
-
-    final status = await _transport.fetchStatus();
-    if (status == null || status.policy?.processorSetHash != policy.processorSetHash) return false;
-    if (!status.isCurrentGrantFor(uid)) {
-      if (status.subjectUid == uid && status.decision == AiConsentDecision.declined.wireValue) {
-        _preferences.deferAiConsent();
-      } else if (status.subjectUid == uid) {
-        _preferences.declineAiConsent();
-      }
+    if (uid.isEmpty || _preferences.uid != uid) {
+      SharedPreferencesUtil.clearAiConsentServerVerification();
       return false;
     }
 
-    _persistVerifiedGrant(uid, status);
-    return _preferences.aiConsentAccepted;
+    try {
+      final policy = await _fetchAcceptedPolicy();
+      if (policy == null) {
+        SharedPreferencesUtil.clearAiConsentServerVerification();
+        return false;
+      }
+
+      final status = await _transport.fetchStatus();
+      if (status == null || status.policy?.processorSetHash != policy.processorSetHash) {
+        SharedPreferencesUtil.clearAiConsentServerVerification();
+        return false;
+      }
+      if (!status.isCurrentGrantFor(uid)) {
+        if (status.subjectUid == uid && status.decision == AiConsentDecision.declined.wireValue) {
+          _preferences.deferAiConsent();
+        } else if (status.subjectUid == uid) {
+          _preferences.declineAiConsent();
+        } else {
+          SharedPreferencesUtil.clearAiConsentServerVerification();
+        }
+        return false;
+      }
+
+      _persistVerifiedGrant(uid, status);
+      return _preferences.aiConsentAccepted;
+    } catch (_) {
+      SharedPreferencesUtil.clearAiConsentServerVerification();
+      return false;
+    }
   }
 
   Future<String?> grantCurrentConsent({required String uid}) async {

--- a/app/lib/ella/services/ella_ai_consent_service.dart
+++ b/app/lib/ella/services/ella_ai_consent_service.dart
@@ -1,7 +1,10 @@
+import 'dart:ui';
+
 import 'package:uuid/uuid.dart';
 
 import 'package:omi/backend/http/api/users.dart' as users_api;
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/utils/platform/platform_manager.dart';
 
 abstract class EllaAiConsentTransport {
   Future<bool> setPrivateCloudSync(bool value);
@@ -24,13 +27,19 @@ class EllaAiConsentService {
     EllaAiConsentTransport? transport,
     SharedPreferencesUtil? preferences,
     String Function()? receiptIdFactory,
+    String Function()? clientVersionFactory,
+    String Function()? localeFactory,
   })  : _transport = transport ?? const EllaAiConsentHttpTransport(),
         _preferences = preferences ?? SharedPreferencesUtil(),
-        _receiptIdFactory = receiptIdFactory ?? (() => const Uuid().v4());
+        _receiptIdFactory = receiptIdFactory ?? (() => const Uuid().v4()),
+        _clientVersionFactory = clientVersionFactory ?? (() => PlatformManager.instance.appVersion),
+        _localeFactory = localeFactory ?? (() => PlatformDispatcher.instance.locale.toLanguageTag());
 
   final EllaAiConsentTransport _transport;
   final SharedPreferencesUtil _preferences;
   final String Function() _receiptIdFactory;
+  final String Function() _clientVersionFactory;
+  final String Function() _localeFactory;
 
   Future<String?> acknowledgePrivateCloudSync({required String uid}) async {
     if (uid.isEmpty) return null;
@@ -42,7 +51,17 @@ class EllaAiConsentService {
     if (!confirmed) return null;
 
     final receiptId = '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}${_receiptIdFactory()}';
-    _preferences.acceptAiConsent(receiptId: receiptId, uid: uid);
+    _preferences.acceptAiConsent(
+      receiptId: receiptId,
+      uid: uid,
+      clientVersion: _clientVersionFactory(),
+      locale: _localeFactory(),
+    );
     return receiptId;
+  }
+
+  Future<bool> revokePrivateCloudSync() async {
+    _preferences.declineAiConsent();
+    return _transport.setPrivateCloudSync(false);
   }
 }

--- a/app/lib/ella/services/v2v_client.dart
+++ b/app/lib/ella/services/v2v_client.dart
@@ -11,6 +11,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 
 import 'package:omi/backend/http/shared.dart';
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ai_consent_active_session_lease.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/utils/debug_log_manager.dart';
@@ -197,6 +198,7 @@ class V2VClient {
   AudioRecorder? _recorder;
   StreamSubscription? _micSub;
   StreamSubscription? _wsSub;
+  AiConsentActiveSessionLease? _aiConsentLease;
   bool _isConnected = false;
   bool _connectionAnnounced = false;
   bool _isPlaying = false;
@@ -592,6 +594,13 @@ class V2VClient {
           ),
         );
       }
+      _aiConsentLease = AiConsentActiveSessionLease(
+        uid: uid,
+        onAuthorityLost: () async {
+          onEvent?.call(const V2VEvent(type: 'consent_authority_lost'));
+          await disconnect();
+        },
+      )..start();
       _connectionAnnounced = true;
       onConnectionChanged?.call(true);
 
@@ -622,6 +631,9 @@ class V2VClient {
 
   /// Disconnect and clean up all resources.
   Future<void> disconnect() async {
+    final consentLease = _aiConsentLease;
+    _aiConsentLease = null;
+    consentLease?.stop();
     final shouldAnnounceDisconnect = _connectionAnnounced;
     _isConnected = false;
     _connectionAnnounced = false;

--- a/app/lib/ella/widgets/ai_consent_sheet.dart
+++ b/app/lib/ella/widgets/ai_consent_sheet.dart
@@ -18,14 +18,14 @@ class AiConsentSheet extends StatefulWidget {
   });
 
   final Future<bool> Function()? onAccept;
-  final Future<void> Function()? onDecline;
+  final Future<bool> Function()? onDecline;
   final Future<void> Function()? onRequestDeletion;
   final bool reviewMode;
 
   static Future<bool?> show(
     BuildContext context, {
     Future<bool> Function()? onAccept,
-    Future<void> Function()? onDecline,
+    Future<bool> Function()? onDecline,
     Future<void> Function()? onRequestDeletion,
     bool reviewMode = false,
   }) {
@@ -65,10 +65,9 @@ class _AiConsentSheetState extends State<AiConsentSheet> {
     });
 
     try {
-      final accepted = await (widget.onAccept?.call() ?? Future<bool>.value(true));
+      final accepted = await (widget.onAccept?.call() ?? Future<bool>.value(false));
       if (!mounted) return;
       if (accepted) {
-        if (widget.onAccept == null) SharedPreferencesUtil().acceptAiConsent();
         Navigator.of(context).pop(true);
         return;
       }

--- a/app/lib/ella/widgets/ai_consent_sheet.dart
+++ b/app/lib/ella/widgets/ai_consent_sheet.dart
@@ -9,11 +9,26 @@ import 'package:omi/utils/l10n_extensions.dart';
 class AiConsentSheet extends StatefulWidget {
   static final Uri privacyPolicyUri = Uri.parse('https://ella-ai-care.com/privacy');
 
-  const AiConsentSheet({super.key, this.onAccept});
+  const AiConsentSheet({
+    super.key,
+    this.onAccept,
+    this.onDecline,
+    this.onRequestDeletion,
+    this.reviewMode = false,
+  });
 
   final Future<bool> Function()? onAccept;
+  final Future<void> Function()? onDecline;
+  final Future<void> Function()? onRequestDeletion;
+  final bool reviewMode;
 
-  static Future<bool?> show(BuildContext context, {Future<bool> Function()? onAccept}) {
+  static Future<bool?> show(
+    BuildContext context, {
+    Future<bool> Function()? onAccept,
+    Future<void> Function()? onDecline,
+    Future<void> Function()? onRequestDeletion,
+    bool reviewMode = false,
+  }) {
     return showModalBottomSheet<bool>(
       context: context,
       isDismissible: false,
@@ -22,7 +37,15 @@ class AiConsentSheet extends StatefulWidget {
       useSafeArea: true,
       backgroundColor: EllaColors.paper,
       shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(28))),
-      builder: (_) => FractionallySizedBox(heightFactor: 0.68, child: AiConsentSheet(onAccept: onAccept)),
+      builder: (_) => FractionallySizedBox(
+        heightFactor: reviewMode ? 0.78 : 0.68,
+        child: AiConsentSheet(
+          onAccept: onAccept,
+          onDecline: onDecline,
+          onRequestDeletion: onRequestDeletion,
+          reviewMode: reviewMode,
+        ),
+      ),
     );
   }
 
@@ -61,6 +84,30 @@ class _AiConsentSheetState extends State<AiConsentSheet> {
     }
   }
 
+  Future<void> _decline() async {
+    if (_isSubmitting) return;
+    setState(() => _isSubmitting = true);
+
+    final preferences = SharedPreferencesUtil();
+    if (widget.reviewMode) {
+      preferences.declineAiConsent();
+    } else {
+      preferences.deferAiConsent();
+    }
+
+    try {
+      await widget.onDecline?.call();
+    } finally {
+      if (mounted) Navigator.of(context).pop(false);
+    }
+  }
+
+  Future<void> _requestDeletion() async {
+    if (_isSubmitting || widget.onRequestDeletion == null) return;
+    Navigator.of(context).pop(false);
+    await widget.onRequestDeletion!.call();
+  }
+
   @override
   Widget build(BuildContext context) {
     final bodyStyle = Theme.of(context).textTheme.bodyLarge?.copyWith(color: EllaColors.textSecondary, height: 1.5);
@@ -79,6 +126,8 @@ class _AiConsentSheetState extends State<AiConsentSheet> {
                     Text(context.l10n.aiConsentTitle, style: EllaTextStyles.display),
                     const SizedBox(height: 16),
                     Text(context.l10n.aiConsentCompactSummary, style: bodyStyle),
+                    const SizedBox(height: 12),
+                    Text(context.l10n.aiConsentNoSharingBeforeAllow, style: bodyStyle),
                     const SizedBox(height: 14),
                     Text.rich(
                       TextSpan(
@@ -127,14 +176,9 @@ class _AiConsentSheetState extends State<AiConsentSheet> {
                     width: double.infinity,
                     height: 50,
                     child: TextButton(
-                      onPressed: _isSubmitting
-                          ? null
-                          : () {
-                              SharedPreferencesUtil().deferAiConsent();
-                              Navigator.of(context).pop(false);
-                            },
+                      onPressed: _isSubmitting ? null : _decline,
                       child: Text(
-                        context.l10n.notNow,
+                        widget.reviewMode ? context.l10n.aiConsentRevokeAction : context.l10n.notNow,
                         style: const TextStyle(
                           fontSize: 17,
                           color: EllaColors.inkSoft,
@@ -144,6 +188,14 @@ class _AiConsentSheetState extends State<AiConsentSheet> {
                       ),
                     ),
                   ),
+                  if (widget.reviewMode && widget.onRequestDeletion != null)
+                    TextButton(
+                      onPressed: _isSubmitting ? null : _requestDeletion,
+                      child: Text(
+                        context.l10n.aiConsentDeleteDataAction,
+                        style: const TextStyle(fontSize: 16, color: EllaColors.error),
+                      ),
+                    ),
                 ],
               ),
             ),

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10479,5 +10479,8 @@
   "aiConsentRevokeSyncFailed": "Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.",
   "aiConsentOffGateTitle": "AI sharing is off",
   "aiConsentOffGateBody": "Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.",
-  "aiConsentReviewAction": "Review AI permission"
+  "aiConsentReviewAction": "Review AI permission",
+  "aiConsentActiveAudioStopped": "AI permission could not be verified. Recording and voice chat stopped.",
+  "deleteAccountServerConfirmationFailed": "Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.",
+  "deleteAccountLocalCleanupFailed": "Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again."
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10468,6 +10468,13 @@
   "todayListeningLink": "See what she hears ›",
   "todayReadMore": "Read more",
   "voiceModalEndAction": "End",
-  "aiConsentCompactSummary": "When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella's secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella's secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.",
-  "aiConsentProcessorDetailsLink": "Full processor details in Privacy Policy"
+  "ellaAuthDataDisclosure": "Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.",
+  "aiConsentCompactSummary": "Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella's self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella's own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.",
+  "aiConsentProcessorDetailsLink": "Full processor details in Privacy Policy",
+  "aiConsentNoSharingBeforeAllow": "Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.",
+  "aiConsentRevokeAction": "Revoke AI permission",
+  "aiConsentDeleteDataAction": "Delete my account and data",
+  "aiConsentAllowedStatus": "Allowed for this account",
+  "aiConsentNotAllowedStatus": "Not allowed — AI sharing is off",
+  "aiConsentRevokeSyncFailed": "Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device."
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10469,12 +10469,15 @@
   "todayReadMore": "Read more",
   "voiceModalEndAction": "End",
   "ellaAuthDataDisclosure": "Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.",
-  "aiConsentCompactSummary": "Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella's self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella's own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.",
+  "aiConsentCompactSummary": "Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella's self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella's self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.",
   "aiConsentProcessorDetailsLink": "Full processor details in Privacy Policy",
   "aiConsentNoSharingBeforeAllow": "Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.",
   "aiConsentRevokeAction": "Revoke AI permission",
   "aiConsentDeleteDataAction": "Delete my account and data",
   "aiConsentAllowedStatus": "Allowed for this account",
   "aiConsentNotAllowedStatus": "Not allowed — AI sharing is off",
-  "aiConsentRevokeSyncFailed": "Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device."
+  "aiConsentRevokeSyncFailed": "Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.",
+  "aiConsentOffGateTitle": "AI sharing is off",
+  "aiConsentOffGateBody": "Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.",
+  "aiConsentReviewAction": "Review AI permission"
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -16586,6 +16586,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Review AI permission'**
   String get aiConsentReviewAction;
+
+  /// No description provided for @aiConsentActiveAudioStopped.
+  ///
+  /// In en, this message translates to:
+  /// **'AI permission could not be verified. Recording and voice chat stopped.'**
+  String get aiConsentActiveAudioStopped;
+
+  /// No description provided for @deleteAccountServerConfirmationFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.'**
+  String get deleteAccountServerConfirmationFailed;
+
+  /// No description provided for @deleteAccountLocalCleanupFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.'**
+  String get deleteAccountLocalCleanupFailed;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -16515,10 +16515,16 @@ abstract class AppLocalizations {
   /// **'End'**
   String get voiceModalEndAction;
 
+  /// No description provided for @ellaAuthDataDisclosure.
+  ///
+  /// In en, this message translates to:
+  /// **'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.'**
+  String get ellaAuthDataDisclosure;
+
   /// No description provided for @aiConsentCompactSummary.
   ///
   /// In en, this message translates to:
-  /// **'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.'**
+  /// **'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.'**
   String get aiConsentCompactSummary;
 
   /// No description provided for @aiConsentProcessorDetailsLink.
@@ -16526,6 +16532,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Full processor details in Privacy Policy'**
   String get aiConsentProcessorDetailsLink;
+
+  /// No description provided for @aiConsentNoSharingBeforeAllow.
+  ///
+  /// In en, this message translates to:
+  /// **'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.'**
+  String get aiConsentNoSharingBeforeAllow;
+
+  /// No description provided for @aiConsentRevokeAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Revoke AI permission'**
+  String get aiConsentRevokeAction;
+
+  /// No description provided for @aiConsentDeleteDataAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete my account and data'**
+  String get aiConsentDeleteDataAction;
+
+  /// No description provided for @aiConsentAllowedStatus.
+  ///
+  /// In en, this message translates to:
+  /// **'Allowed for this account'**
+  String get aiConsentAllowedStatus;
+
+  /// No description provided for @aiConsentNotAllowedStatus.
+  ///
+  /// In en, this message translates to:
+  /// **'Not allowed — AI sharing is off'**
+  String get aiConsentNotAllowedStatus;
+
+  /// No description provided for @aiConsentRevokeSyncFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.'**
+  String get aiConsentRevokeSyncFailed;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -16524,7 +16524,7 @@ abstract class AppLocalizations {
   /// No description provided for @aiConsentCompactSummary.
   ///
   /// In en, this message translates to:
-  /// **'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.'**
+  /// **'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.'**
   String get aiConsentCompactSummary;
 
   /// No description provided for @aiConsentProcessorDetailsLink.
@@ -16568,6 +16568,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.'**
   String get aiConsentRevokeSyncFailed;
+
+  /// No description provided for @aiConsentOffGateTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'AI sharing is off'**
+  String get aiConsentOffGateTitle;
+
+  /// No description provided for @aiConsentOffGateBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.'**
+  String get aiConsentOffGateBody;
+
+  /// No description provided for @aiConsentReviewAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Review AI permission'**
+  String get aiConsentReviewAction;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8807,7 +8807,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8831,4 +8831,14 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8841,4 +8841,15 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8802,9 +8802,33 @@ class AppLocalizationsAr extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8890,9 +8890,33 @@ class AppLocalizationsBg extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8895,7 +8895,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8919,4 +8919,14 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8929,4 +8929,15 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8945,4 +8945,15 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8911,7 +8911,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8935,4 +8935,14 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8906,9 +8906,33 @@ class AppLocalizationsCa extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8853,9 +8853,33 @@ class AppLocalizationsCs extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8892,4 +8892,15 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8858,7 +8858,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8882,4 +8882,14 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8842,9 +8842,33 @@ class AppLocalizationsDa extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8881,4 +8881,15 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8847,7 +8847,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8871,4 +8871,14 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8929,7 +8929,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8953,4 +8953,14 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8963,4 +8963,15 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8924,9 +8924,33 @@ class AppLocalizationsDe extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8920,7 +8920,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8944,4 +8944,14 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8954,4 +8954,15 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8915,9 +8915,33 @@ class AppLocalizationsEl extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8855,9 +8855,33 @@ class AppLocalizationsEn extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8894,4 +8894,15 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8860,7 +8860,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8884,4 +8884,14 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8872,9 +8872,33 @@ class AppLocalizationsEs extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8911,4 +8911,15 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8877,7 +8877,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8901,4 +8901,14 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8896,4 +8896,15 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8862,7 +8862,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8886,4 +8886,14 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8857,9 +8857,33 @@ class AppLocalizationsEt extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8895,4 +8895,15 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8856,9 +8856,33 @@ class AppLocalizationsFi extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8861,7 +8861,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8885,4 +8885,14 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8970,4 +8970,15 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8936,7 +8936,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8960,4 +8960,14 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8931,9 +8931,33 @@ class AppLocalizationsFr extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8838,9 +8838,33 @@ class AppLocalizationsHi extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8843,7 +8843,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8867,4 +8867,14 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8877,4 +8877,15 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8900,7 +8900,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8924,4 +8924,14 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8895,9 +8895,33 @@ class AppLocalizationsHu extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8934,4 +8934,15 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8870,9 +8870,33 @@ class AppLocalizationsId extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8909,4 +8909,15 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8875,7 +8875,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8899,4 +8899,14 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8946,4 +8946,15 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8907,9 +8907,33 @@ class AppLocalizationsIt extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8912,7 +8912,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8936,4 +8936,14 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8763,4 +8763,15 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8724,9 +8724,33 @@ class AppLocalizationsJa extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8729,7 +8729,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8753,4 +8753,14 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8765,4 +8765,15 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8726,9 +8726,33 @@ class AppLocalizationsKo extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8731,7 +8731,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8755,4 +8755,14 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8902,4 +8902,15 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8868,7 +8868,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8892,4 +8892,14 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8863,9 +8863,33 @@ class AppLocalizationsLt extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8875,9 +8875,33 @@ class AppLocalizationsLv extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8914,4 +8914,15 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8880,7 +8880,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8904,4 +8904,14 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8881,9 +8881,33 @@ class AppLocalizationsMs extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8886,7 +8886,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8910,4 +8910,14 @@ class AppLocalizationsMs extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8920,4 +8920,15 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8883,9 +8883,33 @@ class AppLocalizationsNl extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8888,7 +8888,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8912,4 +8912,14 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8922,4 +8922,15 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8853,9 +8853,33 @@ class AppLocalizationsNo extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8858,7 +8858,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8882,4 +8882,14 @@ class AppLocalizationsNo extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8892,4 +8892,15 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8876,9 +8876,33 @@ class AppLocalizationsPl extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8881,7 +8881,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8905,4 +8905,14 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8915,4 +8915,15 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8858,9 +8858,33 @@ class AppLocalizationsPt extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8897,4 +8897,15 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8863,7 +8863,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8887,4 +8887,14 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8896,9 +8896,33 @@ class AppLocalizationsRo extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8901,7 +8901,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8925,4 +8925,14 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8935,4 +8935,15 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8888,7 +8888,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8912,4 +8912,14 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8883,9 +8883,33 @@ class AppLocalizationsRu extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8922,4 +8922,15 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8853,7 +8853,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8877,4 +8877,14 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8848,9 +8848,33 @@ class AppLocalizationsSk extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8887,4 +8887,15 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8868,7 +8868,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8892,4 +8892,14 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8863,9 +8863,33 @@ class AppLocalizationsSv extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8902,4 +8902,15 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8820,9 +8820,33 @@ class AppLocalizationsTh extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8825,7 +8825,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8849,4 +8849,14 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8859,4 +8859,15 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8910,4 +8910,15 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8871,9 +8871,33 @@ class AppLocalizationsTr extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8876,7 +8876,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8900,4 +8900,14 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8909,4 +8909,15 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8875,7 +8875,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8899,4 +8899,14 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8870,9 +8870,33 @@ class AppLocalizationsUk extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8860,9 +8860,33 @@ class AppLocalizationsVi extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8865,7 +8865,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8889,4 +8889,14 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8899,4 +8899,15 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8714,9 +8714,33 @@ class AppLocalizationsZh extends AppLocalizations {
   String get voiceModalEndAction => 'End';
 
   @override
+  String get ellaAuthDataDisclosure =>
+      'Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.';
+
+  @override
   String get aiConsentCompactSummary =>
-      'When you enable listening or voice, live microphone audio from your iPhone or necklace goes through Ella\'s secure backend to Deepgram for speech-to-text. To create summaries or answers, transcript and derived text may go to OpenRouter, Google (Gemini), OpenAI, Groq, or xAI (Grok); OpenRouter may route text to the selected model provider. Live voice may send microphone audio to Google (Gemini), OpenAI, or xAI (Grok), while standard spoken replies send response text to ElevenLabs. Talk about this sends the selected stored memory, including related people, topics, and dates, through Ella\'s secure backend to the selected Google (Gemini) or xAI (Grok) voice processor; Ella sends data only to the provider needed for the feature you choose, and summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
+
+  @override
+  String get aiConsentNoSharingBeforeAllow =>
+      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+
+  @override
+  String get aiConsentRevokeAction => 'Revoke AI permission';
+
+  @override
+  String get aiConsentDeleteDataAction => 'Delete my account and data';
+
+  @override
+  String get aiConsentAllowedStatus => 'Allowed for this account';
+
+  @override
+  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+
+  @override
+  String get aiConsentRevokeSyncFailed =>
+      'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8719,7 +8719,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription sends live or stored microphone audio to Deepgram. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s own voice service and may send response text to ElevenLabs as a fallback. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
@@ -8743,4 +8743,14 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get aiConsentRevokeSyncFailed =>
       'Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.';
+
+  @override
+  String get aiConsentOffGateTitle => 'AI sharing is off';
+
+  @override
+  String get aiConsentOffGateBody =>
+      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+
+  @override
+  String get aiConsentReviewAction => 'Review AI permission';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8753,4 +8753,15 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
+
+  @override
+  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+
+  @override
+  String get deleteAccountServerConfirmationFailed =>
+      'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.';
+
+  @override
+  String get deleteAccountLocalCleanupFailed =>
+      'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
 }

--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -13,7 +13,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/app.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/message.dart';
-import 'package:omi/gen/assets.gen.dart';
+import 'package:omi/ella/services/ai_consent_coordinator.dart';
 import 'package:omi/pages/apps/widgets/capability_apps_page.dart';
 import 'package:omi/pages/chat/widgets/ai_message.dart';
 import 'package:omi/pages/chat/widgets/user_message.dart';
@@ -685,8 +685,8 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
     );
   }
 
-  _sendMessageUtil(String text) {
-    if (!SharedPreferencesUtil().aiConsentAccepted) return;
+  Future<void> _sendMessageUtil(String text) async {
+    if (!await AiConsentCoordinator.ensure(context) || !mounted) return;
     String? currentContext = _selectedContext;
     setState(() {
       _selectedContext = null;
@@ -933,8 +933,8 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                   ),
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-                  child: Text(
-                    context.l10n.syncingMessages,
+                    child: Text(
+                      context.l10n.syncingMessages,
                       style: const TextStyle(color: EllaColors.textSecondary, fontSize: 12),
                     ),
                   ),

--- a/app/lib/pages/onboarding/ella/ella_onboarding.dart
+++ b/app/lib/pages/onboarding/ella/ella_onboarding.dart
@@ -31,7 +31,10 @@ class EllaOnboarding extends StatefulWidget {
     required bool hasPriorAccountConsent,
     required bool deferredCurrentConsent,
   }) =>
-      !hasCurrentConsent && !hasPriorAccountConsent && !deferredCurrentConsent;
+      !hasCurrentConsent && !deferredCurrentConsent;
+
+  @visibleForTesting
+  static bool shouldStartProvisioning({required bool hasCurrentConsent}) => hasCurrentConsent;
 
   @override
   State<EllaOnboarding> createState() => _EllaOnboardingState();
@@ -65,7 +68,6 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
 
   Future<void> _onSignedIn() async {
     setState(() => _isSignedIn = true);
-    if (isHermesProvisioningGateEnabled) unawaited(_startHermesProvisioning());
   }
 
   Future<void> _startHermesProvisioning() async {
@@ -131,7 +133,12 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
     SharedPreferencesUtil().onboardingCompleted = true;
     if (AuthService.instance.isSignedIn()) {
       updateUserOnboardingState(completed: true);
-      if (isHermesProvisioningGateEnabled) unawaited(_startHermesProvisioning());
+      final hasCurrentConsent =
+          isHermesProvisioningGateEnabled ? preferences.hasAccountBoundAiConsent(uid) : preferences.aiConsentAccepted;
+      if (isHermesProvisioningGateEnabled &&
+          EllaOnboarding.shouldStartProvisioning(hasCurrentConsent: hasCurrentConsent)) {
+        unawaited(_startHermesProvisioning());
+      }
     }
     _routeToAuthenticatedHome();
   }

--- a/app/lib/pages/onboarding/ella/ella_onboarding.dart
+++ b/app/lib/pages/onboarding/ella/ella_onboarding.dart
@@ -109,23 +109,26 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
       await preferences.prepareEllaProvisioningAccount(uid);
     }
     if (!mounted) return;
+    final consentService = EllaAiConsentService();
+    if (uid.isNotEmpty && !preferences.aiConsentAccepted) {
+      await consentService.refreshServerAuthority(uid: uid);
+    }
+    if (!mounted) return;
     final shouldPresentVoiceConsent = EllaOnboarding.shouldPresentVoiceConsent(
-      hasCurrentConsent:
-          isHermesProvisioningGateEnabled ? preferences.hasAccountBoundAiConsent(uid) : preferences.aiConsentAccepted,
+      hasCurrentConsent: preferences.hasAccountBoundAiConsent(uid),
       hasPriorAccountConsent: uid.isNotEmpty && preferences.hasPriorAccountBoundAiConsent(uid),
       deferredCurrentConsent: preferences.isCurrentAiConsentDeferred,
     );
     if (shouldPresentVoiceConsent && mounted) {
       await AiConsentSheet.show(
         context,
-        onAccept: isHermesProvisioningGateEnabled
-            ? () async {
-                final receiptId = await EllaAiConsentService().acknowledgePrivateCloudSync(uid: uid);
-                if (receiptId == null) return false;
-                if (mounted) context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
-                return true;
-              }
-            : null,
+        onAccept: () async {
+          final receiptId = await consentService.grantCurrentConsent(uid: uid);
+          if (receiptId == null) return false;
+          if (mounted) context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
+          return true;
+        },
+        onDecline: () => consentService.declineCurrentConsent(uid: uid),
       );
     }
     if (!mounted) return;
@@ -133,8 +136,7 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
     SharedPreferencesUtil().onboardingCompleted = true;
     if (AuthService.instance.isSignedIn()) {
       updateUserOnboardingState(completed: true);
-      final hasCurrentConsent =
-          isHermesProvisioningGateEnabled ? preferences.hasAccountBoundAiConsent(uid) : preferences.aiConsentAccepted;
+      final hasCurrentConsent = preferences.hasAccountBoundAiConsent(uid);
       if (isHermesProvisioningGateEnabled &&
           EllaOnboarding.shouldStartProvisioning(hasCurrentConsent: hasCurrentConsent)) {
         unawaited(_startHermesProvisioning());

--- a/app/lib/pages/settings/delete_account.dart
+++ b/app/lib/pages/settings/delete_account.dart
@@ -12,8 +12,27 @@ import 'package:omi/utils/other/temp.dart';
 import 'package:omi/utils/wal_file_manager.dart';
 import 'package:omi/widgets/dialog.dart';
 
+typedef DeleteAccountRequest = Future<AccountDeletionReceipt?> Function();
+
 class DeleteAccount extends StatefulWidget {
-  const DeleteAccount({super.key});
+  const DeleteAccount({
+    super.key,
+    this.deleteAccountRequest,
+    this.signOut,
+    this.clearWal,
+    this.clearPreferences,
+    this.onDeletionComplete,
+    this.onDeleteConfirmed,
+    this.onDeleteSucceeded,
+  });
+
+  final DeleteAccountRequest? deleteAccountRequest;
+  final Future<void> Function()? signOut;
+  final Future<void> Function()? clearWal;
+  final VoidCallback? clearPreferences;
+  final VoidCallback? onDeletionComplete;
+  final VoidCallback? onDeleteConfirmed;
+  final VoidCallback? onDeleteSucceeded;
 
   @override
   State<DeleteAccount> createState() => _DeleteAccountState();
@@ -33,16 +52,57 @@ class _DeleteAccountState extends State<DeleteAccount> {
     setState(() {
       isDeleteing = true;
     });
-    MixpanelManager().deleteAccountConfirmed();
-    MixpanelManager().deleteUser();
-    await deleteAccount();
-    await FirebaseAuth.instance.signOut();
-    await WalFileManager.clearAll();
-    SharedPreferencesUtil().clear();
+    (widget.onDeleteConfirmed ?? MixpanelManager().deleteAccountConfirmed).call();
+
+    AccountDeletionReceipt? receipt;
+    try {
+      receipt = await (widget.deleteAccountRequest ?? deleteAccount).call();
+    } catch (_) {
+      _showDeletionError();
+      return;
+    }
+    if (receipt == null) {
+      _showDeletionError();
+      return;
+    }
+
+    try {
+      (widget.onDeleteSucceeded ?? MixpanelManager().deleteUser).call();
+      await (widget.signOut ?? FirebaseAuth.instance.signOut).call();
+      await (widget.clearWal ?? WalFileManager.clearAll).call();
+      if (widget.clearPreferences != null) {
+        widget.clearPreferences!.call();
+      } else {
+        await SharedPreferencesUtil().clear();
+      }
+      if (!mounted) return;
+      setState(() {
+        isDeleteing = false;
+      });
+      if (widget.onDeletionComplete != null) {
+        widget.onDeletionComplete!.call();
+      } else {
+        routeToPage(context, const AppShell(), replace: true);
+      }
+    } catch (_) {
+      _showDeletionError(localCleanupFailed: true);
+    }
+  }
+
+  void _showDeletionError({bool localCleanupFailed = false}) {
+    if (!mounted) return;
     setState(() {
       isDeleteing = false;
     });
-    routeToPage(context, const AppShell(), replace: true);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          localCleanupFailed
+              ? context.l10n.deleteAccountLocalCleanupFailed
+              : context.l10n.deleteAccountServerConfirmationFailed,
+        ),
+      ),
+    );
   }
 
   @override
@@ -55,7 +115,7 @@ class _DeleteAccountState extends State<DeleteAccount> {
           backgroundColor: Theme.of(context).colorScheme.primary,
           title: Text(context.l10n.deleteAccountTitle),
         ),
-        body: Padding(
+        body: SingleChildScrollView(
           padding: const EdgeInsets.symmetric(horizontal: 10),
           child: Column(
             children: [
@@ -94,7 +154,7 @@ class _DeleteAccountState extends State<DeleteAccount> {
                 leading: const Icon(Icons.upload_file_outlined),
                 title: Text(context.l10n.exportBeforeDelete),
               ),
-              const Spacer(),
+              const SizedBox(height: 30),
               Row(
                 children: [
                   Checkbox(
@@ -105,8 +165,7 @@ class _DeleteAccountState extends State<DeleteAccount> {
                       }
                     },
                   ),
-                  SizedBox(
-                    width: MediaQuery.of(context).size.width * 0.80,
+                  Expanded(
                     child: Text(context.l10n.deleteAccountCheckbox),
                   ),
                 ],

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -21,6 +21,7 @@ import 'package:omi/backend/schema/message.dart';
 import 'package:omi/backend/schema/person.dart';
 import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/ella/services/ai_consent_active_session_lease.dart';
 import 'package:omi/ella/services/ai_consent_coordinator.dart';
 import 'package:omi/models/custom_stt_config.dart';
 import 'package:omi/providers/calendar_provider.dart';
@@ -1362,6 +1363,10 @@ class CaptureProvider extends ChangeNotifier
     }
 
     notifyListeners();
+    if (!SharedPreferencesUtil().aiConsentAccepted) {
+      _keepAliveTimer?.cancel();
+      return;
+    }
     _startKeepAliveServices();
   }
 
@@ -1405,6 +1410,20 @@ class CaptureProvider extends ChangeNotifier
   void onError(Object err) {
     _transcriptionServiceStatuses = [];
     _transcriptServiceReady = false;
+
+    if (err is AiConsentAuthorityLostException) {
+      _keepAliveTimer?.cancel();
+      _shouldAutoResumeAfterWake = false;
+      ServiceManager.instance().mic.stop();
+      if (recordingState == RecordingState.systemAudioRecord && PlatformService.isDesktop) {
+        ServiceManager.instance().systemAudio.stopAndClearCallbacks();
+      }
+      unawaited(_closeBleStream());
+      updateRecordingState(RecordingState.stop);
+      AppSnackbar.showSnackbarError(MyApp.navigatorKey.currentContext?.l10n.aiConsentActiveAudioStopped ??
+          'AI permission could not be verified. Recording stopped.');
+      return;
+    }
 
     if (err.toString().contains('Failed to find any displays or windows to capture')) {
       if (recordingState == RecordingState.systemAudioRecord) {

--- a/app/lib/providers/message_provider.dart
+++ b/app/lib/providers/message_provider.dart
@@ -20,6 +20,7 @@ import 'package:omi/backend/schema/app.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/ella/demo/demo_fixtures.dart';
+import 'package:omi/ella/services/ai_consent_coordinator.dart';
 import 'package:omi/providers/app_provider.dart';
 import 'package:omi/main.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
@@ -66,6 +67,12 @@ class MessageProvider extends ChangeNotifier {
 
   void updateAppProvider(AppProvider p) {
     appProvider = p;
+  }
+
+  Future<bool> _ensureAiConsent() async {
+    if (SharedPreferencesUtil().aiConsentAccepted) return true;
+    final context = MyApp.navigatorKey.currentContext;
+    return context != null && await AiConsentCoordinator.ensure(context);
   }
 
   void reset() {
@@ -368,7 +375,7 @@ class MessageProvider extends ChangeNotifier {
   }
 
   Future<List<MessageFile>?> uploadFiles(List<File> files, String? appId) async {
-    if (!SharedPreferencesUtil().aiConsentAccepted) return null;
+    if (!await _ensureAiConsent()) return null;
     if (files.isNotEmpty) {
       setMultiUploadingFileStatus(files.map((e) => e.path).toList(), true);
       var res = await uploadFilesServer(files, appId: appId);
@@ -536,7 +543,7 @@ class MessageProvider extends ChangeNotifier {
 
   Future sendVoiceMessageStreamToServer(List<List<int>> audioBytes,
       {Function? onFirstChunkRecived, BleAudioCodec? codec}) async {
-    if (!SharedPreferencesUtil().aiConsentAccepted) return;
+    if (!await _ensureAiConsent()) return;
     var file = await FileUtils.saveAudioBytesToTempFile(
       audioBytes,
       DateTime.now().millisecondsSinceEpoch ~/ 1000 - (audioBytes.length / 100).ceil(),
@@ -630,7 +637,7 @@ class MessageProvider extends ChangeNotifier {
   }
 
   Future sendMessageStreamToServer(String text) async {
-    if (!SharedPreferencesUtil().aiConsentAccepted) return;
+    if (!await _ensureAiConsent()) return;
     if (SharedPreferencesUtil().demoMode) {
       messages = DemoFixtures.chatMessages();
       setSendingMessage(false);

--- a/app/lib/providers/voice_recorder_provider.dart
+++ b/app/lib/providers/voice_recorder_provider.dart
@@ -8,6 +8,7 @@ import 'package:permission_handler/permission_handler.dart';
 
 import 'package:omi/backend/http/api/messages.dart';
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ai_consent_active_session_lease.dart';
 import 'package:omi/main.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
@@ -28,6 +29,7 @@ class VoiceRecorderProvider extends ChangeNotifier {
   List<List<int>> _audioChunks = [];
   String _transcript = '';
   bool _isProcessing = false;
+  AiConsentActiveSessionLease? _aiConsentLease;
 
   // Audio visualization
   final List<double> _audioLevels = List.generate(20, (_) => 0.1);
@@ -80,76 +82,100 @@ class VoiceRecorderProvider extends ChangeNotifier {
       }
     });
 
-    await ServiceManager.instance().mic.start(
-      onByteReceived: (bytes) {
-        if (_state == VoiceRecorderState.recording) {
-          _audioChunks.add(bytes.toList());
+    _aiConsentLease?.stop();
+    _aiConsentLease = AiConsentActiveSessionLease(
+      uid: SharedPreferencesUtil().uid,
+      onAuthorityLost: _handleConsentAuthorityLost,
+    )..start();
 
-          // Update audio visualization based on actual audio levels
-          if (bytes.isNotEmpty) {
-            // Calculate RMS (Root Mean Square) for PCM16 audio data
-            double rms = 0;
+    try {
+      await ServiceManager.instance().mic.start(
+        onByteReceived: (bytes) {
+          if (_state == VoiceRecorderState.recording) {
+            _audioChunks.add(bytes.toList());
 
-            // Process bytes as 16-bit samples (2 bytes per sample)
-            for (int i = 0; i < bytes.length - 1; i += 2) {
-              // Convert two bytes to a 16-bit signed integer
-              // PCM16 is little-endian: LSB first, then MSB
-              int sample = bytes[i] | (bytes[i + 1] << 8);
+            // Update audio visualization based on actual audio levels
+            if (bytes.isNotEmpty) {
+              // Calculate RMS (Root Mean Square) for PCM16 audio data
+              double rms = 0;
 
-              // Convert to signed value (if high bit is set)
-              if (sample > 32767) {
-                sample = sample - 65536;
+              // Process bytes as 16-bit samples (2 bytes per sample)
+              for (int i = 0; i < bytes.length - 1; i += 2) {
+                // Convert two bytes to a 16-bit signed integer
+                // PCM16 is little-endian: LSB first, then MSB
+                int sample = bytes[i] | (bytes[i + 1] << 8);
+
+                // Convert to signed value (if high bit is set)
+                if (sample > 32767) {
+                  sample = sample - 65536;
+                }
+
+                // Square the sample and add to sum
+                rms += sample * sample;
               }
 
-              // Square the sample and add to sum
-              rms += sample * sample;
+              // Calculate RMS and normalize to 0.0-1.0 range
+              // 32768 is max absolute value for 16-bit audio
+              int sampleCount = bytes.length ~/ 2;
+              if (sampleCount > 0) {
+                rms = math.sqrt(rms / sampleCount) / 32768.0;
+              } else {
+                rms = 0;
+              }
+
+              // Apply non-linear scaling to make quiet sounds more visible
+              // and loud sounds more dramatic
+              final level = math.pow(rms, 0.4).toDouble().clamp(0.1, 1.0);
+
+              // Shift all values left
+              for (int i = 0; i < _audioLevels.length - 1; i++) {
+                _audioLevels[i] = _audioLevels[i + 1];
+              }
+
+              // Add new level at the end
+              _audioLevels[_audioLevels.length - 1] = level;
             }
-
-            // Calculate RMS and normalize to 0.0-1.0 range
-            // 32768 is max absolute value for 16-bit audio
-            int sampleCount = bytes.length ~/ 2;
-            if (sampleCount > 0) {
-              rms = math.sqrt(rms / sampleCount) / 32768.0;
-            } else {
-              rms = 0;
-            }
-
-            // Apply non-linear scaling to make quiet sounds more visible
-            // and loud sounds more dramatic
-            final level = math.pow(rms, 0.4).toDouble().clamp(0.1, 1.0);
-
-            // Shift all values left
-            for (int i = 0; i < _audioLevels.length - 1; i++) {
-              _audioLevels[i] = _audioLevels[i + 1];
-            }
-
-            // Add new level at the end
-            _audioLevels[_audioLevels.length - 1] = level;
           }
-        }
-      },
-      onRecording: () {
-        Logger.debug('VoiceRecorderProvider: Recording started');
-        _state = VoiceRecorderState.recording;
-        _audioChunks = [];
-        // Reset audio levels
-        for (int i = 0; i < _audioLevels.length; i++) {
-          _audioLevels[i] = 0.1;
-        }
-        notifyListeners();
-      },
-      onStop: () {
-        Logger.debug('VoiceRecorderProvider: Recording stopped');
-      },
-      onInitializing: () {
-        Logger.debug('VoiceRecorderProvider: Initializing');
-      },
-    );
+        },
+        onRecording: () {
+          Logger.debug('VoiceRecorderProvider: Recording started');
+          _state = VoiceRecorderState.recording;
+          _audioChunks = [];
+          // Reset audio levels
+          for (int i = 0; i < _audioLevels.length; i++) {
+            _audioLevels[i] = 0.1;
+          }
+          notifyListeners();
+        },
+        onStop: () {
+          Logger.debug('VoiceRecorderProvider: Recording stopped');
+        },
+        onInitializing: () {
+          Logger.debug('VoiceRecorderProvider: Initializing');
+        },
+      );
+    } catch (_) {
+      _aiConsentLease?.stop();
+      _aiConsentLease = null;
+      rethrow;
+    }
   }
 
   void stopRecording() {
+    _aiConsentLease?.stop();
+    _aiConsentLease = null;
     _waveformTimer?.cancel();
     ServiceManager.instance().mic.stop();
+  }
+
+  Future<void> _handleConsentAuthorityLost() async {
+    stopRecording();
+    _state = VoiceRecorderState.transcribeFailed;
+    _audioChunks = [];
+    _isProcessing = false;
+    notifyListeners();
+    AppSnackbar.showSnackbarError(MyApp.navigatorKey.currentContext?.l10n.aiConsentActiveAudioStopped ??
+        'AI permission could not be verified. Recording stopped.');
   }
 
   Future<void> processRecording() async {
@@ -251,6 +277,8 @@ class VoiceRecorderProvider extends ChangeNotifier {
 
   @override
   void dispose() {
+    _aiConsentLease?.stop();
+    _aiConsentLease = null;
     _waveformTimer?.cancel();
     if (_state == VoiceRecorderState.recording) {
       ServiceManager.instance().mic.stop();

--- a/app/lib/services/sockets/transcription_service.dart
+++ b/app/lib/services/sockets/transcription_service.dart
@@ -2,16 +2,14 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/material.dart';
-
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/message_event.dart';
 import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/ella/services/ai_consent_active_session_lease.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/models/custom_stt_config.dart';
 import 'package:omi/models/stt_provider.dart';
-import 'package:omi/services/notifications.dart';
 import 'package:omi/services/sockets/on_device_apple_provider.dart';
 import 'package:omi/services/sockets/on_device_whisper_provider.dart';
 import 'package:omi/services/sockets/pure_socket.dart';
@@ -64,6 +62,7 @@ enum SocketServiceState {
 class TranscriptSegmentSocketService implements IPureSocketListener {
   late IPureSocket _socket;
   final Map<Object, ITransctiptSegmentSocketServiceListener> _listeners = {};
+  AiConsentActiveSessionLease? _aiConsentLease;
 
   /// Access to the underlying socket (for composite service creation)
   IPureSocket get socket => _socket;
@@ -152,10 +151,25 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
         'codec': codec.toString(),
         'language': language,
       });
+      return;
     }
+    final uid = SharedPreferencesUtil().uid;
+    _aiConsentLease = AiConsentActiveSessionLease(
+      uid: uid,
+      onAuthorityLost: () async {
+        final listeners = _listeners.values.toList(growable: false);
+        for (final listener in listeners) {
+          listener.onError(const AiConsentAuthorityLostException());
+        }
+        await stop(reason: 'AI consent authority lost');
+      },
+    )..start();
   }
 
   Future stop({String? reason}) async {
+    final consentLease = _aiConsentLease;
+    _aiConsentLease = null;
+    consentLease?.stop();
     await _socket.stop();
     _listeners.clear();
 
@@ -179,6 +193,9 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
 
   @override
   void onClosed([int? closeCode]) {
+    final consentLease = _aiConsentLease;
+    _aiConsentLease = null;
+    consentLease?.stop();
     _listeners.forEach((k, v) {
       v.onClosed(closeCode);
     });
@@ -189,6 +206,9 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
 
   @override
   void onError(Object err, StackTrace trace) {
+    final consentLease = _aiConsentLease;
+    _aiConsentLease = null;
+    consentLease?.stop();
     _listeners.forEach((k, v) {
       v.onError(err);
     });

--- a/app/lib/widgets/consent_bottom_sheet.dart
+++ b/app/lib/widgets/consent_bottom_sheet.dart
@@ -87,7 +87,7 @@ class ConsentBottomSheet extends StatelessWidget {
 
                 // Main message
                 Text(
-                  context.l10n.consentDataMessage,
+                  context.l10n.ellaAuthDataDisclosure,
                   style: const TextStyle(
                     color: EllaColors.textPrimary,
                     fontSize: 16,

--- a/app/test/backend/preferences_public_mode_test.dart
+++ b/app/test/backend/preferences_public_mode_test.dart
@@ -23,7 +23,7 @@ void main() {
     expect(preferences.publicMode, isFalse);
   });
 
-  test('accepting AI consent persists acceptance and a timestamp', () {
+  test('persisted AI consent is not authority until the server grant is verified', () {
     final preferences = SharedPreferencesUtil();
     preferences.uid = 'uid-a';
 
@@ -33,6 +33,9 @@ void main() {
       clientVersion: '1.0.528+804',
       locale: 'en-US',
     );
+
+    expect(preferences.aiConsentAccepted, isFalse);
+    _markServerVerified(preferences, uid: 'uid-a', receiptId: 'aicr_receipt-a');
 
     expect(preferences.aiConsentAccepted, isTrue);
     expect(DateTime.tryParse(preferences.aiConsentAcceptedAt), isNotNull);
@@ -69,16 +72,17 @@ void main() {
       receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}current-receipt',
       uid: 'uid-a',
     );
+    _markServerVerified(preferences, uid: 'uid-a', receiptId: 'aicr_current-receipt');
     expect(preferences.aiConsentAccepted, isTrue);
     expect(preferences.hasAccountBoundAiConsent('uid-a'), isTrue);
   });
 
-  test('existing v3 account requires v4 before any AI action', () async {
+  test('existing v4 account requires v5 before any AI action', () async {
     SharedPreferences.setMockInitialValues({
       'aiConsentAccepted': true,
       'aiConsentAcceptedAt': '2026-01-01T00:00:00Z',
-      'aiConsentContractVersion': 'voice-ai-processors-v3',
-      'aiConsentReceiptId': 'ios-private-cloud-sync:voice-ai-processors-v3:receipt-a',
+      'aiConsentContractVersion': 'ai-data-processors-v4',
+      'aiConsentReceiptId': 'ios-ai-consent:ai-data-processors-v4:receipt-a',
       'aiConsentReceiptUid': 'uid-a',
     });
     await SharedPreferencesUtil.init();
@@ -89,7 +93,7 @@ void main() {
     expect(preferences.hasPriorAccountBoundAiConsent('uid-b'), isFalse);
   });
 
-  test('deferred v4 remains inactive until account-bound acceptance', () {
+  test('deferred v5 remains inactive until a server-verified account grant', () {
     final preferences = SharedPreferencesUtil();
     preferences.uid = 'uid-a';
 
@@ -101,9 +105,11 @@ void main() {
       receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
       uid: 'uid-a',
     );
+    expect(preferences.aiConsentAccepted, isFalse);
+    _markServerVerified(preferences, uid: 'uid-a', receiptId: 'aicr_receipt-a');
     expect(preferences.aiConsentAccepted, isTrue);
     expect(preferences.isCurrentAiConsentDeferred, isFalse);
-    expect(preferences.aiConsentContractVersion, 'ai-data-processors-v4');
+    expect(preferences.aiConsentContractVersion, 'ai-data-processors-v5');
   });
 
   test('receipt-less acceptance clears stale authority and remains fail closed', () async {
@@ -132,6 +138,7 @@ void main() {
       receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
       uid: 'uid-a',
     );
+    _markServerVerified(preferences, uid: 'uid-a', receiptId: 'aicr_receipt-a');
     expect(preferences.aiConsentAccepted, isTrue);
 
     preferences.uid = 'uid-b';
@@ -153,4 +160,34 @@ void main() {
 
     expect(SharedPreferencesUtil().aiConsentAccepted, isFalse);
   });
+
+  test('expired server verification fails closed without deleting the cached receipt', () {
+    final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
+    preferences.acceptAiConsent(receiptId: 'aicr_receipt-a', uid: 'uid-a');
+    _markServerVerified(
+      preferences,
+      uid: 'uid-a',
+      receiptId: 'aicr_receipt-a',
+      verifiedAt: DateTime.now().subtract(SharedPreferencesUtil.aiConsentServerVerificationTtl),
+    );
+
+    expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.aiConsentReceiptId, 'aicr_receipt-a');
+  });
+}
+
+void _markServerVerified(
+  SharedPreferencesUtil preferences, {
+  required String uid,
+  required String receiptId,
+  DateTime? verifiedAt,
+}) {
+  preferences.markAiConsentServerVerified(
+    uid: uid,
+    receiptId: receiptId,
+    policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
+    processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+    verifiedAt: verifiedAt,
+  );
 }

--- a/app/test/backend/preferences_public_mode_test.dart
+++ b/app/test/backend/preferences_public_mode_test.dart
@@ -25,17 +25,27 @@ void main() {
 
   test('accepting AI consent persists acceptance and a timestamp', () {
     final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
 
-    preferences.acceptAiConsent();
+    preferences.acceptAiConsent(
+      receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
+      uid: 'uid-a',
+      clientVersion: '1.0.528+804',
+      locale: 'en-US',
+    );
 
     expect(preferences.aiConsentAccepted, isTrue);
     expect(DateTime.tryParse(preferences.aiConsentAcceptedAt), isNotNull);
     expect(preferences.aiConsentContractVersion, SharedPreferencesUtil.currentAiConsentContractVersion);
+    expect(preferences.aiConsentProcessorSetHash, SharedPreferencesUtil.currentAiConsentProcessorSetHash);
+    expect(preferences.aiConsentClientVersion, '1.0.528+804');
+    expect(preferences.aiConsentLocale, 'en-US');
 
     preferences.declineAiConsent();
     expect(preferences.aiConsentAccepted, isFalse);
     expect(preferences.aiConsentAcceptedAt, isEmpty);
     expect(preferences.aiConsentContractVersion, isEmpty);
+    expect(preferences.aiConsentProcessorSetHash, isEmpty);
   });
 
   test('legacy and stale processor consent receipts fail closed', () async {
@@ -48,6 +58,7 @@ void main() {
     await SharedPreferencesUtil.init();
 
     final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
     expect(preferences.aiConsentAccepted, isFalse);
     expect(preferences.hasAccountBoundAiConsent('uid-a'), isFalse);
 
@@ -62,12 +73,12 @@ void main() {
     expect(preferences.hasAccountBoundAiConsent('uid-a'), isTrue);
   });
 
-  test('existing v2 account defers v3 until an explicit voice action', () async {
+  test('existing v3 account requires v4 before any AI action', () async {
     SharedPreferences.setMockInitialValues({
       'aiConsentAccepted': true,
       'aiConsentAcceptedAt': '2026-01-01T00:00:00Z',
-      'aiConsentContractVersion': 'voice-ai-processors-v2',
-      'aiConsentReceiptId': 'ios-private-cloud-sync:voice-ai-processors-v2:receipt-a',
+      'aiConsentContractVersion': 'voice-ai-processors-v3',
+      'aiConsentReceiptId': 'ios-private-cloud-sync:voice-ai-processors-v3:receipt-a',
       'aiConsentReceiptUid': 'uid-a',
     });
     await SharedPreferencesUtil.init();
@@ -78,20 +89,24 @@ void main() {
     expect(preferences.hasPriorAccountBoundAiConsent('uid-b'), isFalse);
   });
 
-  test('deferred v3 remains inactive until acceptance and acceptance is one-time', () {
+  test('deferred v4 remains inactive until account-bound acceptance', () {
     final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
 
     preferences.deferAiConsent();
     expect(preferences.aiConsentAccepted, isFalse);
     expect(preferences.isCurrentAiConsentDeferred, isTrue);
 
-    preferences.acceptAiConsent();
+    preferences.acceptAiConsent(
+      receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
+      uid: 'uid-a',
+    );
     expect(preferences.aiConsentAccepted, isTrue);
     expect(preferences.isCurrentAiConsentDeferred, isFalse);
-    expect(preferences.aiConsentContractVersion, 'voice-ai-processors-v3');
+    expect(preferences.aiConsentContractVersion, 'ai-data-processors-v4');
   });
 
-  test('receipt-less acceptance clears stale same-account authority', () async {
+  test('receipt-less acceptance clears stale authority and remains fail closed', () async {
     SharedPreferences.setMockInitialValues({
       'aiConsentAccepted': true,
       'aiConsentAcceptedAt': '2026-01-01T00:00:00Z',
@@ -104,9 +119,38 @@ void main() {
     final preferences = SharedPreferencesUtil();
     preferences.acceptAiConsent();
 
-    expect(preferences.aiConsentAccepted, isTrue);
+    expect(preferences.aiConsentAccepted, isFalse);
     expect(preferences.aiConsentReceiptId, isEmpty);
     expect(preferences.aiConsentReceiptUid, isEmpty);
     expect(preferences.hasAccountBoundAiConsent('uid-a'), isFalse);
+  });
+
+  test('account switch invalidates otherwise current processor consent', () {
+    final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
+    preferences.acceptAiConsent(
+      receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
+      uid: 'uid-a',
+    );
+    expect(preferences.aiConsentAccepted, isTrue);
+
+    preferences.uid = 'uid-b';
+
+    expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.hasAccountBoundAiConsent('uid-b'), isFalse);
+  });
+
+  test('processor hash change fails closed even when version and receipt look current', () async {
+    SharedPreferences.setMockInitialValues({
+      'uid': 'uid-a',
+      'aiConsentAccepted': true,
+      'aiConsentContractVersion': SharedPreferencesUtil.currentAiConsentContractVersion,
+      'aiConsentProcessorSetHash': 'sha256:stale',
+      'aiConsentReceiptId': '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
+      'aiConsentReceiptUid': 'uid-a',
+    });
+    await SharedPreferencesUtil.init();
+
+    expect(SharedPreferencesUtil().aiConsentAccepted, isFalse);
   });
 }

--- a/app/test/ella/services/ai_consent_active_session_lease_test.dart
+++ b/app/test/ella/services/ai_consent_active_session_lease_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ai_consent_active_session_lease.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SharedPreferencesUtil preferences;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
+    preferences.acceptAiConsent(receiptId: 'aicr_receipt-a', uid: 'uid-a');
+    preferences.markAiConsentServerVerified(
+      uid: 'uid-a',
+      receiptId: 'aicr_receipt-a',
+      policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
+      processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+    );
+  });
+
+  test('active session refreshes before TTL and continues with renewed server authority', () async {
+    var refreshCalls = 0;
+    var authorityLossCalls = 0;
+    final lease = AiConsentActiveSessionLease(
+      uid: 'uid-a',
+      preferences: preferences,
+      refreshAuthority: (uid) async {
+        refreshCalls++;
+        preferences.markAiConsentServerVerified(
+          uid: uid,
+          receiptId: 'aicr_receipt-a',
+          policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
+          processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+        );
+        return true;
+      },
+      onAuthorityLost: () {
+        authorityLossCalls++;
+      },
+    );
+
+    lease.start();
+    expect(
+      AiConsentActiveSessionLease.refreshInterval,
+      lessThan(SharedPreferencesUtil.aiConsentServerVerificationTtl),
+    );
+    await lease.refreshNow();
+
+    expect(refreshCalls, 1);
+    expect(authorityLossCalls, 0);
+    expect(lease.isActive, isTrue);
+    expect(preferences.aiConsentAccepted, isTrue);
+    lease.stop();
+  });
+
+  test('session opened near expiry refreshes immediately rather than waiting a fresh interval', () {
+    expect(
+      AiConsentActiveSessionLease.refreshDelayFor(const Duration(seconds: 30)),
+      Duration.zero,
+    );
+    expect(
+      AiConsentActiveSessionLease.refreshDelayFor(SharedPreferencesUtil.aiConsentServerVerificationTtl),
+      AiConsentActiveSessionLease.refreshInterval,
+    );
+  });
+
+  test('server revocation stops active session visibly and fails closed', () async {
+    var authorityLossCalls = 0;
+    final lease = AiConsentActiveSessionLease(
+      uid: 'uid-a',
+      preferences: preferences,
+      refreshAuthority: (_) async {
+        preferences.declineAiConsent();
+        return false;
+      },
+      onAuthorityLost: () {
+        authorityLossCalls++;
+      },
+    )..start();
+
+    await lease.refreshNow();
+    await lease.refreshNow();
+
+    expect(authorityLossCalls, 1);
+    expect(lease.isActive, isFalse);
+    expect(preferences.aiConsentAccepted, isFalse);
+  });
+
+  test('unavailable consent authority stops active session without extending cached grant', () async {
+    var authorityLossCalls = 0;
+    final lease = AiConsentActiveSessionLease(
+      uid: 'uid-a',
+      preferences: preferences,
+      refreshAuthority: (_) async => false,
+      onAuthorityLost: () {
+        authorityLossCalls++;
+      },
+    )..start();
+
+    await lease.refreshNow();
+
+    expect(authorityLossCalls, 1);
+    expect(lease.isActive, isFalse);
+    expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.aiConsentReceiptId, 'aicr_receipt-a');
+  });
+}

--- a/app/test/ella/services/ai_consent_policy_test.dart
+++ b/app/test/ella/services/ai_consent_policy_test.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ai_consent_policy.dart';
+
+void main() {
+  test('v4 processor manifest is versioned and covers every live recipient function', () {
+    expect(AiConsentPolicy.version, SharedPreferencesUtil.currentAiConsentContractVersion);
+    expect(AiConsentPolicy.processorSetHash, SharedPreferencesUtil.currentAiConsentProcessorSetHash);
+    expect(AiConsentPolicy.processorSetHash, startsWith('sha256:'));
+    expect(
+      AiConsentPolicy.processorSetHash,
+      'sha256:${sha256.convert(utf8.encode(AiConsentPolicy.canonicalProcessorSet))}',
+    );
+
+    final names = AiConsentPolicy.processors.map((processor) => processor.name).toSet();
+    expect(
+      names,
+      containsAll({
+        'Deepgram',
+        'Google Firebase',
+        'Ella self-hosted Hermes',
+        'Ella self-hosted Honcho',
+        'OpenRouter',
+        'Google Gemini',
+        'OpenAI',
+        'Groq',
+        'xAI Grok',
+        'ElevenLabs',
+      }),
+    );
+    expect(AiConsentPolicy.processors.every((processor) => processor.function.isNotEmpty), isTrue);
+    expect(AiConsentPolicy.processors.every((processor) => processor.data.isNotEmpty), isTrue);
+  });
+}

--- a/app/test/ella/services/ai_consent_policy_test.dart
+++ b/app/test/ella/services/ai_consent_policy_test.dart
@@ -7,32 +7,49 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/services/ai_consent_policy.dart';
 
 void main() {
-  test('v4 processor manifest is versioned and covers every live recipient function', () {
-    expect(AiConsentPolicy.version, SharedPreferencesUtil.currentAiConsentContractVersion);
-    expect(AiConsentPolicy.processorSetHash, SharedPreferencesUtil.currentAiConsentProcessorSetHash);
-    expect(AiConsentPolicy.processorSetHash, startsWith('sha256:'));
+  test('v5 fallback manifest matches the accepted server processor contract', () {
+    const policy = AiConsentPolicy.bundled;
+    expect(policy.version, SharedPreferencesUtil.currentAiConsentContractVersion);
+    expect(policy.processorSetHash, SharedPreferencesUtil.currentAiConsentProcessorSetHash);
+    expect(policy.processorSetHash, startsWith('sha256:'));
     expect(
-      AiConsentPolicy.processorSetHash,
-      'sha256:${sha256.convert(utf8.encode(AiConsentPolicy.canonicalProcessorSet))}',
+      policy.processorSetHash,
+      'sha256:${sha256.convert(utf8.encode(policy.canonicalProcessorSet))}',
     );
 
-    final names = AiConsentPolicy.processors.map((processor) => processor.name).toSet();
+    final names = policy.processors.map((processor) => processor.name).toSet();
     expect(
       names,
       containsAll({
         'Deepgram',
+        'Soniox',
+        'Speechmatics',
         'Google Firebase',
         'Ella self-hosted Hermes',
         'Ella self-hosted Honcho',
+        'Ella self-hosted voice synthesis',
         'OpenRouter',
         'Google Gemini',
         'OpenAI',
         'Groq',
         'xAI Grok',
+        'Inworld AI',
         'ElevenLabs',
       }),
     );
-    expect(AiConsentPolicy.processors.every((processor) => processor.function.isNotEmpty), isTrue);
-    expect(AiConsentPolicy.processors.every((processor) => processor.data.isNotEmpty), isTrue);
+    expect(policy.processors.every((processor) => processor.function.isNotEmpty), isTrue);
+    expect(policy.processors.every((processor) => processor.data.isNotEmpty), isTrue);
+    expect(policy.isBundledCurrent, isTrue);
+  });
+
+  test('a server policy with a changed processor set is display-only and never authority', () {
+    final policy = AiConsentPolicy.fromJson({
+      'version': SharedPreferencesUtil.currentAiConsentContractVersion,
+      'processor_set_hash': 'sha256:changed',
+      'canonical_processor_set': AiConsentPolicy.bundled.canonicalProcessorSet,
+      'processors': const [],
+    });
+
+    expect(policy.isBundledCurrent, isFalse);
   });
 }

--- a/app/test/ella/services/ella_chat_consent_test.dart
+++ b/app/test/ella/services/ella_chat_consent_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ella_chat_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('chat sends no protected text without current account processor consent', () async {
+    final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
+    preferences.acceptAiConsent(
+      receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
+      uid: 'uid-a',
+    );
+    preferences.uid = 'uid-b';
+
+    final chunks = await sendEllaChatStream('private message').toList();
+
+    expect(chunks, isEmpty);
+  });
+}

--- a/app/test/ella/services/ella_chat_consent_test.dart
+++ b/app/test/ella/services/ella_chat_consent_test.dart
@@ -19,6 +19,13 @@ void main() {
       receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
       uid: 'uid-a',
     );
+    preferences.markAiConsentServerVerified(
+      uid: 'uid-a',
+      receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
+      policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
+      processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+    );
+    expect(preferences.aiConsentAccepted, isTrue);
     preferences.uid = 'uid-b';
 
     final chunks = await sendEllaChatStream('private message').toList();

--- a/app/test/ella/services/ella_provisioning_service_test.dart
+++ b/app/test/ella/services/ella_provisioning_service_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ai_consent_policy.dart';
 import 'package:omi/ella/services/ella_ai_consent_service.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
 import 'package:omi/providers/ella_provisioning_provider.dart';
@@ -163,6 +164,12 @@ void main() {
     });
     await SharedPreferencesUtil.init();
     final preferences = SharedPreferencesUtil();
+    preferences.markAiConsentServerVerified(
+      uid: 'uid-a',
+      receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}consent-a',
+      policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
+      processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+    );
 
     await preferences.prepareEllaProvisioningAccount('uid-a');
 
@@ -349,21 +356,34 @@ void main() {
     provider.dispose();
   });
 
-  test('AI consent becomes account-bound only after private cloud sync acknowledgement', () async {
+  test('AI consent becomes authority only after an exact server v5 grant', () async {
     SharedPreferencesUtil().uid = 'uid-a';
-    final transport = _FakeConsentTransport(updateResult: true, confirmedEnabled: true);
+    final transport = _FakeConsentTransport(
+      policy: AiConsentPolicy.bundled,
+      submitResponse: _consentStatus(),
+    );
     final service = EllaAiConsentService(
       transport: transport,
-      receiptIdFactory: () => 'receipt-1',
+      requestIdFactory: () => 'request-0001',
       clientVersionFactory: () => '1.0.528+804',
       localeFactory: () => 'en-US',
     );
 
-    final receiptId = await service.acknowledgePrivateCloudSync(uid: 'uid-a');
+    final receiptId = await service.grantCurrentConsent(uid: 'uid-a');
 
-    expect(receiptId, '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-1');
-    expect(transport.values, [true]);
-    expect(transport.getCalls, 1);
+    expect(receiptId, 'aicr_server-receipt');
+    expect(transport.policyCalls, 1);
+    expect(transport.statusCalls, 0);
+    expect(transport.submissions, hasLength(1));
+    expect(transport.submissions.single.toJson(), {
+      'decision': 'granted',
+      'policy_version': SharedPreferencesUtil.currentAiConsentContractVersion,
+      'processor_set_hash': SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+      'request_id': 'request-0001',
+      'app_version': '1.0.528',
+      'build_number': '804',
+      'locale': 'en-US',
+    });
     expect(SharedPreferencesUtil().hasAccountBoundAiConsent('uid-a'), isTrue);
     expect(SharedPreferencesUtil().aiConsentReceiptId, receiptId);
     expect(SharedPreferencesUtil().aiConsentProcessorSetHash, SharedPreferencesUtil.currentAiConsentProcessorSetHash);
@@ -375,43 +395,82 @@ void main() {
     );
   });
 
-  test('AI consent stays disabled when private cloud sync cannot be confirmed', () async {
-    final transport = _FakeConsentTransport(updateResult: true, confirmedEnabled: false);
+  test('AI consent stays disabled when the public policy is unavailable', () async {
+    SharedPreferencesUtil().uid = 'uid-a';
+    final transport = _FakeConsentTransport(policy: null);
     final service = EllaAiConsentService(
       transport: transport,
-      receiptIdFactory: () => 'receipt-1',
+      requestIdFactory: () => 'request-0001',
       clientVersionFactory: () => '1.0.528+804',
       localeFactory: () => 'en-US',
     );
 
-    final receiptId = await service.acknowledgePrivateCloudSync(uid: 'uid-a');
+    final receiptId = await service.grantCurrentConsent(uid: 'uid-a');
 
     expect(receiptId, isNull);
+    expect(transport.submissions, isEmpty);
     expect(SharedPreferencesUtil().aiConsentAccepted, isFalse);
     expect(SharedPreferencesUtil().aiConsentReceiptId, isEmpty);
   });
 
-  test('revocation stops local authority before requesting the server update', () async {
+  test('authenticated status refresh restores only an exact current server grant', () async {
     final preferences = SharedPreferencesUtil();
     preferences.uid = 'uid-a';
-    preferences.acceptAiConsent(
-      receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
-      uid: 'uid-a',
+    final transport = _FakeConsentTransport(
+      policy: AiConsentPolicy.bundled,
+      statusResponse: _consentStatus(),
     );
-    final transport = _FakeConsentTransport(updateResult: false, confirmedEnabled: true);
+    final service = EllaAiConsentService(transport: transport);
+
+    final authorized = await service.refreshServerAuthority(uid: 'uid-a');
+
+    expect(authorized, isTrue);
+    expect(preferences.aiConsentAccepted, isTrue);
+    expect(preferences.aiConsentReceiptId, 'aicr_server-receipt');
+    expect(transport.policyCalls, 1);
+    expect(transport.statusCalls, 1);
+  });
+
+  test('stale server status fails closed even if it claims authorization', () async {
+    final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
+    final transport = _FakeConsentTransport(
+      policy: AiConsentPolicy.bundled,
+      statusResponse: _consentStatus(processorSetHash: 'sha256:stale'),
+    );
+    final service = EllaAiConsentService(transport: transport);
+
+    final authorized = await service.refreshServerAuthority(uid: 'uid-a');
+
+    expect(authorized, isFalse);
+    expect(preferences.aiConsentAccepted, isFalse);
+  });
+
+  test('revocation stops local authority before an unreachable server update', () async {
+    final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
+    preferences.acceptAiConsent(receiptId: 'aicr_receipt-a', uid: 'uid-a');
+    preferences.markAiConsentServerVerified(
+      uid: 'uid-a',
+      receiptId: 'aicr_receipt-a',
+      policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
+      processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+    );
+    expect(preferences.aiConsentAccepted, isTrue);
+    final transport = _FakeConsentTransport(policy: null);
     final service = EllaAiConsentService(
       transport: transport,
-      receiptIdFactory: () => 'unused',
+      requestIdFactory: () => 'request-revoke',
       clientVersionFactory: () => '1.0.528+804',
       localeFactory: () => 'en-US',
     );
 
-    final synced = await service.revokePrivateCloudSync();
+    final synced = await service.revokeCurrentConsent(uid: 'uid-a');
 
     expect(synced, isFalse);
     expect(preferences.aiConsentAccepted, isFalse);
     expect(preferences.aiConsentReceiptId, isEmpty);
-    expect(transport.values, [false]);
+    expect(transport.submissions, isEmpty);
   });
 }
 
@@ -475,22 +534,53 @@ class _DeferredEnsureTransport implements EllaProvisioningTransport {
 }
 
 class _FakeConsentTransport implements EllaAiConsentTransport {
-  _FakeConsentTransport({required this.updateResult, required this.confirmedEnabled});
+  _FakeConsentTransport({
+    required this.policy,
+    this.statusResponse,
+    this.submitResponse,
+  });
 
-  final bool updateResult;
-  final bool confirmedEnabled;
-  final List<bool> values = [];
-  int getCalls = 0;
+  final AiConsentPolicy? policy;
+  final AiConsentStatus? statusResponse;
+  final AiConsentStatus? submitResponse;
+  final List<AiConsentSubmission> submissions = [];
+  int policyCalls = 0;
+  int statusCalls = 0;
 
   @override
-  Future<bool> setPrivateCloudSync(bool value) async {
-    values.add(value);
-    return updateResult;
+  Future<AiConsentPolicy?> fetchPolicy() async {
+    policyCalls++;
+    return policy;
   }
 
   @override
-  Future<bool> getPrivateCloudSyncEnabled() async {
-    getCalls++;
-    return confirmedEnabled;
+  Future<AiConsentStatus?> fetchStatus() async {
+    statusCalls++;
+    return statusResponse;
   }
+
+  @override
+  Future<AiConsentStatus?> submit(AiConsentSubmission submission) async {
+    submissions.add(submission);
+    return submitResponse;
+  }
+}
+
+AiConsentStatus _consentStatus({
+  bool authorized = true,
+  String decision = 'granted',
+  String processorSetHash = SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+}) {
+  return AiConsentStatus(
+    subjectUid: 'uid-a',
+    authorized: authorized,
+    policy: AiConsentPolicy.bundled,
+    decision: decision,
+    receiptId: 'aicr_server-receipt',
+    policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
+    processorSetHash: processorSetHash,
+    appVersion: '1.0.528',
+    buildNumber: '804',
+    locale: 'en-US',
+  );
 }

--- a/app/test/ella/services/ella_provisioning_service_test.dart
+++ b/app/test/ella/services/ella_provisioning_service_test.dart
@@ -431,6 +431,28 @@ void main() {
     expect(transport.statusCalls, 1);
   });
 
+  test('active authority remains valid while an early refresh is in flight', () async {
+    final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
+    preferences.acceptAiConsent(receiptId: 'aicr_server-receipt', uid: 'uid-a');
+    preferences.markAiConsentServerVerified(
+      uid: 'uid-a',
+      receiptId: 'aicr_server-receipt',
+      policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
+      processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+    );
+    final transport = _DeferredConsentStatusTransport();
+    final service = EllaAiConsentService(transport: transport);
+
+    final refresh = service.refreshServerAuthority(uid: 'uid-a');
+    await Future<void>.delayed(Duration.zero);
+
+    expect(preferences.aiConsentAccepted, isTrue);
+    transport.complete(_consentStatus());
+    expect(await refresh, isTrue);
+    expect(preferences.aiConsentAccepted, isTrue);
+  });
+
   test('stale server status fails closed even if it claims authorization', () async {
     final preferences = SharedPreferencesUtil();
     preferences.uid = 'uid-a';
@@ -563,6 +585,23 @@ class _FakeConsentTransport implements EllaAiConsentTransport {
   Future<AiConsentStatus?> submit(AiConsentSubmission submission) async {
     submissions.add(submission);
     return submitResponse;
+  }
+}
+
+class _DeferredConsentStatusTransport implements EllaAiConsentTransport {
+  final Completer<AiConsentStatus?> _status = Completer<AiConsentStatus?>();
+
+  void complete(AiConsentStatus? status) => _status.complete(status);
+
+  @override
+  Future<AiConsentPolicy?> fetchPolicy() async => AiConsentPolicy.bundled;
+
+  @override
+  Future<AiConsentStatus?> fetchStatus() => _status.future;
+
+  @override
+  Future<AiConsentStatus?> submit(AiConsentSubmission submission) {
+    throw StateError('submit should not be called');
   }
 }
 

--- a/app/test/ella/services/ella_provisioning_service_test.dart
+++ b/app/test/ella/services/ella_provisioning_service_test.dart
@@ -158,6 +158,8 @@ void main() {
       'aiConsentReceiptId': '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}consent-a',
       'aiConsentReceiptUid': 'uid-a',
       'aiConsentContractVersion': SharedPreferencesUtil.currentAiConsentContractVersion,
+      'aiConsentProcessorSetHash': SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+      'uid': 'uid-a',
     });
     await SharedPreferencesUtil.init();
     final preferences = SharedPreferencesUtil();
@@ -348,19 +350,25 @@ void main() {
   });
 
   test('AI consent becomes account-bound only after private cloud sync acknowledgement', () async {
+    SharedPreferencesUtil().uid = 'uid-a';
     final transport = _FakeConsentTransport(updateResult: true, confirmedEnabled: true);
     final service = EllaAiConsentService(
       transport: transport,
       receiptIdFactory: () => 'receipt-1',
+      clientVersionFactory: () => '1.0.528+804',
+      localeFactory: () => 'en-US',
     );
 
     final receiptId = await service.acknowledgePrivateCloudSync(uid: 'uid-a');
 
-    expect(receiptId, 'ios-private-cloud-sync:voice-ai-processors-v3:receipt-1');
+    expect(receiptId, '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-1');
     expect(transport.values, [true]);
     expect(transport.getCalls, 1);
     expect(SharedPreferencesUtil().hasAccountBoundAiConsent('uid-a'), isTrue);
     expect(SharedPreferencesUtil().aiConsentReceiptId, receiptId);
+    expect(SharedPreferencesUtil().aiConsentProcessorSetHash, SharedPreferencesUtil.currentAiConsentProcessorSetHash);
+    expect(SharedPreferencesUtil().aiConsentClientVersion, '1.0.528+804');
+    expect(SharedPreferencesUtil().aiConsentLocale, 'en-US');
     expect(
       SharedPreferencesUtil().aiConsentContractVersion,
       SharedPreferencesUtil.currentAiConsentContractVersion,
@@ -372,6 +380,8 @@ void main() {
     final service = EllaAiConsentService(
       transport: transport,
       receiptIdFactory: () => 'receipt-1',
+      clientVersionFactory: () => '1.0.528+804',
+      localeFactory: () => 'en-US',
     );
 
     final receiptId = await service.acknowledgePrivateCloudSync(uid: 'uid-a');
@@ -379,6 +389,29 @@ void main() {
     expect(receiptId, isNull);
     expect(SharedPreferencesUtil().aiConsentAccepted, isFalse);
     expect(SharedPreferencesUtil().aiConsentReceiptId, isEmpty);
+  });
+
+  test('revocation stops local authority before requesting the server update', () async {
+    final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
+    preferences.acceptAiConsent(
+      receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
+      uid: 'uid-a',
+    );
+    final transport = _FakeConsentTransport(updateResult: false, confirmedEnabled: true);
+    final service = EllaAiConsentService(
+      transport: transport,
+      receiptIdFactory: () => 'unused',
+      clientVersionFactory: () => '1.0.528+804',
+      localeFactory: () => 'en-US',
+    );
+
+    final synced = await service.revokePrivateCloudSync();
+
+    expect(synced, isFalse);
+    expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.aiConsentReceiptId, isEmpty);
+    expect(transport.values, [false]);
   });
 }
 

--- a/app/test/ella/services/protected_egress_consent_test.dart
+++ b/app/test/ella/services/protected_egress_consent_test.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/http/api/conversations.dart';
+import 'package:omi/backend/http/api/messages.dart';
+import 'package:omi/backend/http/api/users.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/geolocation.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('protected API boundaries fail closed without current server consent', () async {
+    final file = File('${Directory.systemTemp.path}/ai-consent-protected-payload');
+
+    expect(await sendMessageStreamServer('private chat').toList(), isEmpty);
+    expect(await sendEllaMessageStream('private Ella chat').toList(), isEmpty);
+    expect(await sendVoiceMessageStreamServer([file]).toList(), isEmpty);
+    await expectLater(uploadFilesServer([file]), throwsStateError);
+    expect(await sendStorageToBackend(file, '2026-07-27T00:00:00Z'), isEmpty);
+    expect(
+      await updateUserGeolocation(
+        geolocation: Geolocation(latitude: 1, longitude: 2),
+      ),
+      isFalse,
+    );
+    expect(
+      await submitConversationCorrection(
+        conversationId: 'conversation-a',
+        correctionText: 'private correction',
+      ),
+      isFalse,
+    );
+    expect(await testConversationPrompt('private prompt', 'conversation-a'), isEmpty);
+    expect(await retryConversationProcessing('conversation-a', 'request-a'), isNull);
+    expect(await reProcessConversationServer('conversation-a'), isNull);
+  });
+}

--- a/app/test/ella/services/v2v_client_test.dart
+++ b/app/test/ella/services/v2v_client_test.dart
@@ -238,16 +238,20 @@ void main() {
       await client.disconnect();
     });
 
-    test('accepted v3 consent passes the mic gate before identity validation', () async {
+    test('accepted account-bound v4 consent passes the mic gate before identity validation', () async {
       final preferences = SharedPreferencesUtil();
-      preferences.acceptAiConsent();
+      preferences.uid = 'uid-a';
+      preferences.acceptAiConsent(
+        receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
+        uid: 'uid-a',
+      );
       final client = V2VClient(onEvent: (_) {}, onConnectionChanged: (_) {});
 
       final receipt = await client.connect(provider: 'grok-voice');
 
       expect(receipt.connected, isFalse);
-      expect(receipt.stage, V2VConnectionStage.identity);
-      expect(receipt.errorCode, 'missing_authenticated_identity');
+      expect(receipt.stage, isNot(V2VConnectionStage.consent));
+      expect(receipt.errorCode, isNot('ai_consent_required'));
       await client.disconnect();
     });
 

--- a/app/test/ella/services/v2v_client_test.dart
+++ b/app/test/ella/services/v2v_client_test.dart
@@ -238,12 +238,18 @@ void main() {
       await client.disconnect();
     });
 
-    test('accepted account-bound v4 consent passes the mic gate before identity validation', () async {
+    test('accepted server-verified v5 consent passes the mic gate before identity validation', () async {
       final preferences = SharedPreferencesUtil();
       preferences.uid = 'uid-a';
       preferences.acceptAiConsent(
         receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
         uid: 'uid-a',
+      );
+      preferences.markAiConsentServerVerified(
+        uid: 'uid-a',
+        receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
+        policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
+        processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
       );
       final client = V2VClient(onEvent: (_) {}, onConnectionChanged: (_) {});
 

--- a/app/test/ella/widgets/ai_consent_sheet_test.dart
+++ b/app/test/ella/widgets/ai_consent_sheet_test.dart
@@ -26,6 +26,12 @@ void main() {
                 receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
                 uid: 'uid-a',
               );
+              preferences.markAiConsentServerVerified(
+                uid: 'uid-a',
+                receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
+                policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
+                processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+              );
               return true;
             },
           ),
@@ -65,6 +71,8 @@ void main() {
     expect(disclosure, contains('secure backend'));
     expect(disclosure, contains('live or stored microphone audio'));
     expect(disclosure, contains('Deepgram'));
+    expect(disclosure, contains('Soniox'));
+    expect(disclosure, contains('Speechmatics'));
     expect(disclosure, contains('Google Firebase'));
     expect(disclosure, contains('self-hosted Hermes'));
     expect(disclosure, contains('Honcho memory'));
@@ -75,6 +83,9 @@ void main() {
     expect(disclosure, contains('Groq'));
     expect(disclosure, contains('xAI Grok'));
     expect(disclosure, contains('ElevenLabs'));
+    expect(disclosure, contains('Inworld AI'));
+    expect(disclosure, contains('Kokoro'));
+    expect(disclosure, contains('Fish'));
     expect(disclosure, contains('response text'));
     expect(disclosure, contains('selected memory context'));
     expect(disclosure, contains('will not send audio, transcripts, messages, or memory context'));
@@ -105,6 +116,12 @@ void main() {
       receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
       uid: 'uid-a',
     );
+    preferences.markAiConsentServerVerified(
+      uid: 'uid-a',
+      receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
+      policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
+      processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+    );
 
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
@@ -124,6 +141,12 @@ void main() {
     preferences.acceptAiConsent(
       receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
       uid: 'uid-a',
+    );
+    preferences.markAiConsentServerVerified(
+      uid: 'uid-a',
+      receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
+      policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
+      processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
     );
     var revokeCalled = false;
 

--- a/app/test/ella/widgets/ai_consent_sheet_test.dart
+++ b/app/test/ella/widgets/ai_consent_sheet_test.dart
@@ -14,10 +14,22 @@ void main() {
     await SharedPreferencesUtil.init();
   });
 
-  Widget buildApp() => const MaterialApp(
+  Widget buildApp() => MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: Scaffold(body: AiConsentSheet()),
+        home: Scaffold(
+          body: AiConsentSheet(
+            onAccept: () async {
+              final preferences = SharedPreferencesUtil();
+              preferences.uid = 'uid-a';
+              preferences.acceptAiConsent(
+                receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
+                uid: 'uid-a',
+              );
+              return true;
+            },
+          ),
+        ),
       );
 
   testWidgets('presents as a bounded sheet with Not now always visible', (tester) async {
@@ -50,20 +62,22 @@ void main() {
 
     final disclosure =
         tester.widgetList<RichText>(find.byType(RichText)).map((widget) => widget.text.toPlainText()).join(' ');
-    expect(disclosure, contains("Ella's secure backend"));
-    expect(disclosure, contains('live microphone audio'));
+    expect(disclosure, contains('secure backend'));
+    expect(disclosure, contains('live or stored microphone audio'));
     expect(disclosure, contains('Deepgram'));
+    expect(disclosure, contains('Google Firebase'));
+    expect(disclosure, contains('self-hosted Hermes'));
+    expect(disclosure, contains('Honcho memory'));
     expect(disclosure, contains('OpenRouter'));
     expect(disclosure, contains('selected model provider'));
-    expect(disclosure, contains('Google (Gemini)'));
+    expect(disclosure, contains('Google Gemini'));
     expect(disclosure, contains('OpenAI'));
     expect(disclosure, contains('Groq'));
-    expect(disclosure, contains('xAI (Grok)'));
+    expect(disclosure, contains('xAI Grok'));
     expect(disclosure, contains('ElevenLabs'));
     expect(disclosure, contains('response text'));
-    expect(disclosure, contains('selected stored memory'));
-    expect(disclosure, contains('related people, topics, and dates'));
-    expect(disclosure, contains('Google (Gemini) or xAI (Grok) voice processor'));
+    expect(disclosure, contains('selected memory context'));
+    expect(disclosure, contains('will not send audio, transcripts, messages, or memory context'));
     expect(disclosure, contains('Full processor details in Privacy Policy'));
     expect(find.text('Not now'), findsOneWidget);
   });
@@ -80,12 +94,17 @@ void main() {
     final preferences = SharedPreferencesUtil();
     expect(preferences.aiConsentAccepted, isTrue);
     expect(preferences.aiConsentContractVersion, SharedPreferencesUtil.currentAiConsentContractVersion);
+    expect(preferences.aiConsentProcessorSetHash, SharedPreferencesUtil.currentAiConsentProcessorSetHash);
     expect(preferences.aiConsentDeferredVersion, isEmpty);
   });
 
   testWidgets('Not now defers the current processor contract', (tester) async {
     final preferences = SharedPreferencesUtil();
-    preferences.acceptAiConsent();
+    preferences.uid = 'uid-a';
+    preferences.acceptAiConsent(
+      receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
+      uid: 'uid-a',
+    );
 
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
@@ -97,5 +116,47 @@ void main() {
     expect(preferences.aiConsentAccepted, isFalse);
     expect(preferences.aiConsentContractVersion, isEmpty);
     expect(preferences.isCurrentAiConsentDeferred, isTrue);
+  });
+
+  testWidgets('review mode exposes revoke and deletion actions', (tester) async {
+    final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
+    preferences.acceptAiConsent(
+      receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
+      uid: 'uid-a',
+    );
+    var revokeCalled = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              onPressed: () => AiConsentSheet.show(
+                context,
+                reviewMode: true,
+                onDecline: () async => revokeCalled = true,
+                onRequestDeletion: () async {},
+              ),
+              child: const Text('Review consent'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Review consent'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Revoke AI permission'), findsOneWidget);
+    expect(find.text('Delete my account and data'), findsOneWidget);
+
+    await tester.tap(find.text('Revoke AI permission'));
+    await tester.pumpAndSettle();
+
+    expect(revokeCalled, isTrue);
+    expect(preferences.aiConsentAccepted, isFalse);
   });
 }

--- a/app/test/pages/onboarding/ella/ella_onboarding_consent_test.dart
+++ b/app/test/pages/onboarding/ella/ella_onboarding_consent_test.dart
@@ -26,14 +26,14 @@ void main() {
       );
     });
 
-    test('existing user with a stale contract waits for explicit voice use', () {
+    test('material processor change requests renewed consent during onboarding', () {
       expect(
         EllaOnboarding.shouldPresentVoiceConsent(
           hasCurrentConsent: false,
           hasPriorAccountConsent: true,
           deferredCurrentConsent: false,
         ),
-        isFalse,
+        isTrue,
       );
     });
 
@@ -46,6 +46,11 @@ void main() {
         ),
         isFalse,
       );
+    });
+
+    test('provisioning remains stopped until current consent exists', () {
+      expect(EllaOnboarding.shouldStartProvisioning(hasCurrentConsent: false), isFalse);
+      expect(EllaOnboarding.shouldStartProvisioning(hasCurrentConsent: true), isTrue);
     });
   });
 }

--- a/app/test/pages/settings/delete_account_receipt_test.dart
+++ b/app/test/pages/settings/delete_account_receipt_test.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/http/api/users.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/settings/delete_account.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('completed deletion receipt parses only from the exact backend contract', () {
+    final receipt = AccountDeletionReceipt.tryParseResponse(
+      statusCode: 200,
+      body: '''
+        {
+          "status": "ok",
+          "deletion_receipt": {
+            "request_id": "aidel_0123456789abcdef0123456789abcdef",
+            "status": "completed",
+            "scope": "account_and_user_data",
+            "server_completed_at": "2026-07-26T20:15:00+00:00"
+          }
+        }
+      ''',
+    );
+
+    expect(receipt?.requestId, 'aidel_0123456789abcdef0123456789abcdef');
+    expect(receipt?.serverCompletedAt, DateTime.utc(2026, 7, 26, 20, 15));
+  });
+
+  test('non-200 and malformed deletion responses are not authoritative', () {
+    expect(
+      AccountDeletionReceipt.tryParseResponse(
+        statusCode: 500,
+        body: '{"deletion_receipt":{"status":"completed"}}',
+      ),
+      isNull,
+    );
+    for (final body in [
+      'not-json',
+      '{"status":"ok"}',
+      '{"status":"failed","deletion_receipt":{"request_id":"aidel_0123456789abcdef0123456789abcdef","status":"completed","scope":"account_and_user_data","server_completed_at":"2026-07-26T20:15:00Z"}}',
+      '{"status":"ok","deletion_receipt":{"request_id":"aidel_short","status":"completed","scope":"account_and_user_data","server_completed_at":"2026-07-26T20:15:00Z"}}',
+      '{"status":"ok","deletion_receipt":{"request_id":"aidel_0123456789abcdef0123456789abcdef","status":"pending","scope":"account_and_user_data","server_completed_at":"2026-07-26T20:15:00Z"}}',
+      '{"status":"ok","deletion_receipt":{"request_id":"aidel_0123456789abcdef0123456789abcdef","status":"completed","scope":"some_data","server_completed_at":"2026-07-26T20:15:00Z"}}',
+      '{"status":"ok","deletion_receipt":{"request_id":"aidel_0123456789abcdef0123456789abcdef","status":"completed","scope":"account_and_user_data","server_completed_at":"invalid"}}',
+      '{"status":"ok","deletion_receipt":{"request_id":"aidel_0123456789abcdef0123456789abcdef","status":"completed","scope":"account_and_user_data","server_completed_at":1234}}',
+    ]) {
+      expect(AccountDeletionReceipt.tryParseResponse(statusCode: 200, body: body), isNull);
+    }
+  });
+
+  testWidgets('failed deletion preserves auth and local data and shows retry copy', (tester) async {
+    var signOutCalls = 0;
+    var clearWalCalls = 0;
+    var clearPreferencesCalls = 0;
+    await _pumpDeleteAccount(
+      tester,
+      request: () async => null,
+      signOut: () async {
+        signOutCalls++;
+      },
+      clearWal: () async {
+        clearWalCalls++;
+      },
+      clearPreferences: () {
+        clearPreferencesCalls++;
+      },
+    );
+
+    await _confirmDeletion(tester);
+
+    expect(signOutCalls, 0);
+    expect(clearWalCalls, 0);
+    expect(clearPreferencesCalls, 0);
+    expect(
+      find.text(
+          'Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('verified completed receipt permits sign-out and local clearing', (tester) async {
+    var signOutCalls = 0;
+    var clearWalCalls = 0;
+    var clearPreferencesCalls = 0;
+    var completionCalls = 0;
+    await _pumpDeleteAccount(
+      tester,
+      request: () async => AccountDeletionReceipt(
+        requestId: 'aidel_0123456789abcdef0123456789abcdef',
+        serverCompletedAt: DateTime.utc(2026, 7, 26, 20, 15),
+      ),
+      signOut: () async {
+        signOutCalls++;
+      },
+      clearWal: () async {
+        clearWalCalls++;
+      },
+      clearPreferences: () {
+        clearPreferencesCalls++;
+      },
+      onDeletionComplete: () {
+        completionCalls++;
+      },
+    );
+
+    await _confirmDeletion(tester);
+
+    expect(signOutCalls, 1);
+    expect(clearWalCalls, 1);
+    expect(clearPreferencesCalls, 1);
+    expect(completionCalls, 1);
+  });
+}
+
+Future<void> _pumpDeleteAccount(
+  WidgetTester tester, {
+  required DeleteAccountRequest request,
+  required Future<void> Function() signOut,
+  required Future<void> Function() clearWal,
+  required VoidCallback clearPreferences,
+  VoidCallback? onDeletionComplete,
+}) async {
+  await tester.binding.setSurfaceSize(const Size(430, 932));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: DeleteAccount(
+        deleteAccountRequest: request,
+        signOut: signOut,
+        clearWal: clearWal,
+        clearPreferences: clearPreferences,
+        onDeletionComplete: onDeletionComplete,
+        onDeleteConfirmed: () {},
+        onDeleteSucceeded: () {},
+      ),
+    ),
+  );
+}
+
+Future<void> _confirmDeletion(WidgetTester tester) async {
+  await tester.tap(find.byType(Checkbox));
+  await tester.pump();
+  await tester.tap(find.byType(ElevatedButton));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Delete Now'));
+  await tester.pumpAndSettle();
+}


### PR DESCRIPTION
## Scope

Implements the iOS-only compliance slice for https://github.com/ellaaicare/ella-ai/issues/1123 from approved Phase A source `e4095cd40bc46eeb796bf68a55023aab5ef2def4` (`testflight/phase-a-804`).

- enforces the server-authoritative, account-bound `ai-data-processors-v5` consent contract and deterministic processor-set hash across chat, transcription, standard voice, local recording, and V2V;
- refreshes active protected audio sessions before the five-minute authority TTL (one-minute lead, four-minute maximum cadence) without interrupting successful sessions;
- fails closed and visibly stops capture/playback/V2V when consent is revoked or server authority cannot be refreshed;
- preserves the explicit, versioned processor disclosure and visible `Not now` path;
- requires the exact completed backend deletion receipt (`status=completed`, `scope=account_and_user_data`, opaque `aidel_...` request id, valid completion timestamp) before Firebase sign-out or local data clearing;
- preserves authentication and local data, with safe retry copy, on null, non-200, malformed, or incomplete deletion responses.

No backend/proxy, Firebase/signing, build number, App Store Connect, TestFlight, or production changes are included.

## Validation

- cross-TTL/deletion focused regression set: 27/27
- focused consent and protected-egress suite: 74/74
- full `flutter test`: 228/228
- `./test.sh`: 21/21 (18 + 3)
- targeted `flutter analyze --no-fatal-infos`: no errors or warnings; 17 pre-existing info-only deprecation/style notices
- repository-wide analyzer baseline: 1,679 existing issues outside this change's scope
- `dart format` and `git diff --check`: clean
- approved Phase A source remains an ancestor; no version/signing/Firebase/project-file drift

## Release gate

Backend deletion-receipt support is merged at `6622a9cfcca91261f2172418783da86ce088720f`, but production deployment and authenticated smoke evidence remain required before any release build. The live privacy policy, App Privacy answers, and App Review notes must also be reconciled to the exact active processor routes before submission.

This PR is ready for independent code re-review only. It must not be shipped until those release gates are recorded.