### PR TITLE
Add server-authoritative AI processing consent

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -53,6 +53,14 @@ FIREBASE_API_KEY=
 FIREBASE_AUTH_DOMAIN=
 FIREBASE_PROJECT_ID=
 
+# Versioned third-party AI processing consent. Deploy the receipt API first,
+# canary exact Firebase UIDs, then enable globally only after iOS uses server
+# receipts. Internal Guardian TTS requires a separate service token once any
+# consent enforcement gate is active.
+ELLA_AI_CONSENT_ENFORCEMENT_ENABLED=false
+ELLA_AI_CONSENT_ENFORCEMENT_UIDS=
+ELLA_INTERNAL_VOICE_TTS_TOKEN=
+
 # Ella isolated Hermes onboarding. Keep both flags false until the provisioning
 # schema is migrated and a synthetic two-user 8210 canary passes.
 ELLA_HERMES_PROVISIONING_ENABLED=false

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -56,7 +56,8 @@ FIREBASE_PROJECT_ID=
 # Versioned third-party AI processing consent. Deploy the receipt API first,
 # canary exact Firebase UIDs, then enable globally only after iOS uses server
 # receipts. Internal Guardian TTS requires a separate service token once any
-# consent enforcement gate is active.
+# consent enforcement gate is active. UID canary clients must authenticate
+# direct TTS; global enforcement rejects legacy unattributed TTS requests.
 ELLA_AI_CONSENT_ENFORCEMENT_ENABLED=false
 ELLA_AI_CONSENT_ENFORCEMENT_UIDS=
 ELLA_INTERNAL_VOICE_TTS_TOKEN=

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -412,7 +412,15 @@ def delete_user_data(uid: str):
     if not user_ref.get().exists:
         return {'status': 'error', 'message': 'User not found'}
 
-    subcollections_to_delete = ['conversations', 'messages', 'chat_sessions', 'people', 'memories', 'files']
+    subcollections_to_delete = [
+        'conversations',
+        'messages',
+        'chat_sessions',
+        'people',
+        'memories',
+        'files',
+        'ai_consent_receipts',
+    ]
     batch_size = 450
 
     for cname in subcollections_to_delete:

--- a/backend/ella/README.md
+++ b/backend/ella/README.md
@@ -292,7 +292,9 @@ immutable receipt subcollection; callers cannot submit or select another UID.
 - `GET /v1/users/ai-consent/receipts/{receipt_id}` verifies a receipt only
   within the authenticated user's path.
 - Account/data deletion remains `DELETE /v1/users/delete-account`; deletion
-  also removes the user's consent receipt subcollection.
+  also removes the user's consent receipt subcollection and returns a
+  non-identifying synchronous completion receipt with request ID and server
+  completion time.
 
 Exact-policy grants are required at the Ella chat stream, Hermes onboarding
 ensure, voice-session issuance, necklace/web transcription sockets, direct TTS,

--- a/backend/ella/README.md
+++ b/backend/ella/README.md
@@ -273,6 +273,51 @@ Enable provisioning first for two synthetic Firebase users; enable runtime dispa
 
 The ensure job also creates or repairs the UID-scoped OMI Firestore identity. Missing cloud-sync and raw-recording permissions are initialized to `false`; iOS must enable the appropriate setting only after the account-bound consent flow completes.
 
+### AI processing consent
+
+`/v1/users/ai-consent` is the server authority for the versioned AI/data-sharing
+policy. The current `ai-data-processors-v5` manifest includes Soniox and
+Speechmatics STT, Inworld TTS, and Ella's self-hosted Kokoro/Fish TTS in
+addition to the model, memory, infrastructure, and fallback recipients. The
+authenticated Firebase UID selects both the current state and the
+immutable receipt subcollection; callers cannot submit or select another UID.
+
+- `GET /v1/users/ai-consent/policy` returns the required legal-recipient
+  manifest, policy version, and processor-set hash.
+- `GET /v1/users/ai-consent` returns the current decision and whether the exact
+  current policy authorizes protected routes.
+- `POST /v1/users/ai-consent` records `granted`, `declined`, or `revoked` with a
+  caller request ID, app/build, locale, and server timestamp. The same request
+  ID is idempotent; reuse with different metadata fails with `409`.
+- `GET /v1/users/ai-consent/receipts/{receipt_id}` verifies a receipt only
+  within the authenticated user's path.
+- Account/data deletion remains `DELETE /v1/users/delete-account`; deletion
+  also removes the user's consent receipt subcollection.
+
+Exact-policy grants are required at the Ella chat stream, Hermes onboarding
+ensure, voice-session issuance, necklace/web transcription sockets, direct TTS,
+and legacy message/audio/file upload routes. Read-only status/history and
+first-party canonical storage remain available so decline/revoke does not
+silently retransmit data.
+
+Rollout is fail-safe and non-breaking:
+
+1. Deploy the receipt API with `ELLA_AI_CONSENT_ENFORCEMENT_ENABLED=false`.
+2. Update iOS to replace the legacy private-cloud boolean/client UUID with the
+   authenticated receipt API.
+3. Set `ELLA_INTERNAL_VOICE_TTS_TOKEN` on both the OMI backend and internal
+   Guardian caller. Never expose it to iOS. Guardian also sends the target UID
+   in `X-Ella-Subject-Uid`; the backend rechecks that user's current receipt,
+   so the service token is not a consent bypass.
+4. Add synthetic Firebase UIDs to `ELLA_AI_CONSENT_ENFORCEMENT_UIDS` and prove
+   grant, stale-policy, decline, revoke, chat, voice, STT, and Guardian TTS.
+5. Enable `ELLA_AI_CONSENT_ENFORCEMENT_ENABLED=true` only after the live
+   privacy policy and App Store metadata match the server manifest.
+
+Changing the canonical processor set or its legal recipients requires a new
+policy version/hash. Do not reuse a prior hash or silently map an undisclosed
+fallback provider.
+
 Upstream-managed patch points are tracked in `docs/POST_MERGE_PATCHES.md`. Review that file after every Basehardware upstream sync.
 
 ---

--- a/backend/ella/README.md
+++ b/backend/ella/README.md
@@ -298,9 +298,14 @@ immutable receipt subcollection; callers cannot submit or select another UID.
 
 Exact-policy grants are required at the Ella chat stream, Hermes onboarding
 ensure, voice-session issuance, necklace/web transcription sockets, direct TTS,
-and legacy message/audio/file upload routes. Read-only status/history and
-first-party canonical storage remain available so decline/revoke does not
-silently retransmit data.
+legacy message/audio/file upload routes, shared conversation processing,
+stored-audio transcription, Guardian consolidation, and legacy callback TTS.
+Signed voice-proxy requests recheck current consent on every request so a token
+issued before revocation cannot continue sending audio. The consent authority
+router remains registered when `ELLA_ENABLED=false`; a rollback cannot leave
+generic OMI route gates active without grant/revoke endpoints. Read-only
+status/history and first-party canonical storage remain available so
+decline/revoke does not silently retransmit data.
 
 Rollout is fail-safe and non-breaking:
 
@@ -313,6 +318,9 @@ Rollout is fail-safe and non-breaking:
    so the service token is not a consent bypass.
 4. Add synthetic Firebase UIDs to `ELLA_AI_CONSENT_ENFORCEMENT_UIDS` and prove
    grant, stale-policy, decline, revoke, chat, voice, STT, and Guardian TTS.
+   Canary clients must authenticate direct TTS calls. Legacy anonymous TTS has
+   no trustworthy UID and remains a migration bridge during UID-only canaries;
+   global enforcement rejects those unattributed calls.
 5. Enable `ELLA_AI_CONSENT_ENFORCEMENT_ENABLED=true` only after the live
    privacy policy and App Store metadata match the server manifest.
 

--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -405,15 +405,6 @@ def _register_routers(app) -> None:
     except ImportError as e:
         print(f"  ⚠️ Ella settings not available: {e}", flush=True)
 
-    # Authenticated, versioned third-party AI processing consent
-    try:
-        from ella.routers.ai_consent import router as ai_consent_router
-
-        app.include_router(ai_consent_router, tags=["AI Consent"])
-        print("  🌐 /v1/users/ai-consent* - Versioned AI processing consent", flush=True)
-    except ImportError as e:
-        print(f"  ⚠️ AI consent endpoints not available: {e}", flush=True)
-
     # Authenticated, idempotent per-user Hermes onboarding
     try:
         app.include_router(onboarding_router, tags=["Ella Onboarding"])

--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -405,6 +405,15 @@ def _register_routers(app) -> None:
     except ImportError as e:
         print(f"  ⚠️ Ella settings not available: {e}", flush=True)
 
+    # Authenticated, versioned third-party AI processing consent
+    try:
+        from ella.routers.ai_consent import router as ai_consent_router
+
+        app.include_router(ai_consent_router, tags=["AI Consent"])
+        print("  🌐 /v1/users/ai-consent* - Versioned AI processing consent", flush=True)
+    except ImportError as e:
+        print(f"  ⚠️ AI consent endpoints not available: {e}", flush=True)
+
     # Authenticated, idempotent per-user Hermes onboarding
     try:
         app.include_router(onboarding_router, tags=["Ella Onboarding"])

--- a/backend/ella/routers/ai_consent.py
+++ b/backend/ella/routers/ai_consent.py
@@ -1,0 +1,78 @@
+"""Authenticated AI/data-sharing consent API."""
+
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from ella.services.ai_consent import (
+    AiConsentService,
+    ConsentIdempotencyConflict,
+    ConsentPolicyMismatch,
+    ConsentSubmission,
+    get_ai_consent_service,
+)
+from utils.other import endpoints as auth
+
+router = APIRouter(tags=["AI Consent"])
+
+
+class AiConsentSubmissionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    decision: Literal["granted", "declined", "revoked"]
+    policy_version: str = Field(min_length=1, max_length=80)
+    processor_set_hash: str = Field(min_length=1, max_length=100)
+    request_id: str = Field(min_length=8, max_length=128)
+    app_version: str = Field(min_length=1, max_length=80)
+    build_number: str = Field(min_length=1, max_length=40)
+    locale: str = Field(min_length=2, max_length=40)
+
+
+@router.get("/v1/users/ai-consent/policy")
+def get_ai_consent_policy():
+    """Public metadata so disclosure can occur before Firebase sign-in."""
+    return AiConsentService.policy()
+
+
+@router.get("/v1/users/ai-consent")
+def get_ai_consent_status(uid: str = Depends(auth.get_current_user_uid)):
+    return get_ai_consent_service().status(uid)
+
+
+@router.get("/v1/users/ai-consent/receipts/{receipt_id}")
+def get_ai_consent_receipt(receipt_id: str, uid: str = Depends(auth.get_current_user_uid)):
+    receipt = get_ai_consent_service().receipt(uid, receipt_id)
+    if receipt is None:
+        raise HTTPException(status_code=404, detail={"code": "ai_consent_receipt_not_found"})
+    return {"receipt": receipt}
+
+
+@router.post("/v1/users/ai-consent")
+def submit_ai_consent(
+    request: AiConsentSubmissionRequest,
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    try:
+        return get_ai_consent_service().submit(
+            uid,
+            ConsentSubmission(
+                decision=request.decision,
+                policy_version=request.policy_version,
+                processor_set_hash=request.processor_set_hash,
+                request_id=request.request_id,
+                app_version=request.app_version,
+                build_number=request.build_number,
+                locale=request.locale,
+            ),
+        )
+    except ConsentPolicyMismatch as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "ai_consent_policy_mismatch",
+                "required_policy": AiConsentService.policy(),
+            },
+        ) from exc
+    except ConsentIdempotencyConflict as exc:
+        raise HTTPException(status_code=409, detail={"code": "ai_consent_idempotency_conflict"}) from exc

--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -45,6 +45,7 @@ from database._client import db
 from models.conversation import CategoryEnum
 from database.ella_contacts import create_contact, delete_contact, get_contact, get_contacts, update_contact
 from ella.config import ELLA_CONFIG
+from ella.services.ai_consent import assert_current_ai_consent
 from ella.services.runtime_resolver import resolve_isolated_runtime, runtime_bindings_enabled
 from ella.services.summary_sanitizer import SummarySanitizationError
 from ella.services.summary_writeback import (
@@ -616,6 +617,7 @@ async def ella_notification(request: NotificationRequest):
     Flow:
         Letta agent tool call -> n8n webhook -> this endpoint -> TTS -> GCS -> FCM -> iOS
     """
+    assert_current_ai_consent(request.uid)
     logger.info(f"[Ella] Notification: uid={request.uid}, urgency={request.urgency}, audio={request.generate_audio}")
 
     audio_url = request.audio_url

--- a/backend/ella/routers/chat.py
+++ b/backend/ella/routers/chat.py
@@ -37,6 +37,7 @@ from ella.routers.canonical_events import CanonicalEventIn, PostgresCanonicalEve
 from ella.routers.resolve import resolve_user_routing
 from ella.routers.trace import RouteTrace, record_trace
 from ella.services.hermes_session import canonical_omi_session_key, safe_session_component
+from ella.services.ai_consent import require_current_ai_consent
 from ella.services.provisioning import ProvisioningError
 from ella.services.runtime_resolver import IsolatedRuntime, resolve_isolated_runtime, runtime_bindings_enabled
 from utils.ella.canonical_context import (
@@ -896,7 +897,7 @@ async def _stream_hermes_chat(
 async def ella_chat_stream(
     request: EllaChatRequest,
     raw_request: Request,
-    authenticated_uid: str = Depends(auth.get_current_user_uid),
+    authenticated_uid: str = Depends(require_current_ai_consent),
     x_ella_debug_level: str = Header(None, alias="X-Ella-Debug-Level"),
     x_ella_client_type: str = Header(None, alias="X-Ella-Client-Type"),
     x_ella_client_version: str = Header(None, alias="X-Ella-Client-Version"),

--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -24,6 +24,7 @@ from ella.config import ELLA_CONFIG
 from ella.routers.canonical_events import CanonicalEventIn, PostgresCanonicalEventStore
 from ella.services.correction_propagation import propagation_run_to_dict, run_correction_propagation
 from ella.services.hermes_session import canonical_omi_session_key, safe_session_component
+from ella.services.ai_consent import require_current_ai_consent
 from ella.services.summary_recovery import (
     SummaryProviderConfig,
     apply_summary_update,
@@ -1794,7 +1795,7 @@ async def submit_conversation_correction_ella(
     conversation_id: str,
     request: ConversationCorrectionRequest,
     background_tasks: BackgroundTasks,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(require_current_ai_consent),
 ) -> ConversationCorrectionResponse:
     return await _submit_conversation_correction(conversation_id, request, background_tasks, uid)
 
@@ -1970,6 +1971,6 @@ async def submit_conversation_correction(
     conversation_id: str,
     request: ConversationCorrectionRequest,
     background_tasks: BackgroundTasks,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(require_current_ai_consent),
 ) -> ConversationCorrectionResponse:
     return await _submit_conversation_correction(conversation_id, request, background_tasks, uid)

--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -67,6 +67,7 @@ N8N_GUARDIAN_DELIVER_WEBHOOK = os.getenv(
 )
 ELLA_API_BASE = os.getenv("ELLA_API_BASE", "https://api.ella-ai-care.com")
 ELLA_INTERNAL_VOICE_TTS_URL = os.getenv("ELLA_INTERNAL_VOICE_TTS_URL", "http://127.0.0.1:8000/v1/voice/tts")
+ELLA_INTERNAL_VOICE_TTS_TOKEN = os.getenv("ELLA_INTERNAL_VOICE_TTS_TOKEN", "")
 
 # Consolidate queue when this many non-debug items are pending
 CONSOLIDATION_THRESHOLD = int(os.getenv("CONSOLIDATION_THRESHOLD", "3"))
@@ -1636,10 +1637,14 @@ async def synthesize_audio(
         for candidate in provider_candidates:
             provider = candidate
             try:
+                headers = {"X-TTS-Provider": candidate}
+                if ELLA_INTERNAL_VOICE_TTS_TOKEN:
+                    headers["X-Ella-Internal-Token"] = ELLA_INTERNAL_VOICE_TTS_TOKEN
+                    headers["X-Ella-Subject-Uid"] = req.uid
                 response = await client.post(
                     ELLA_INTERNAL_VOICE_TTS_URL,
                     json=payload,
-                    headers={"X-TTS-Provider": candidate},
+                    headers=headers,
                     timeout=30.0,
                 )
             except httpx.TimeoutException:

--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -32,6 +32,7 @@ from pydantic import BaseModel, Field
 from ella.routers.resolve import resolve_user_routing
 from database import app_settings as app_settings_db
 from ella.services.app_settings import TTS_PROVIDERS, build_effective_voice_settings
+from ella.services.ai_consent import assert_current_ai_consent
 from ella.services.runtime_resolver import runtime_bindings_enabled
 from ella.services.escalation_policy import (
     CaregiverPolicyContext,
@@ -1113,6 +1114,8 @@ async def _consolidate_queue(
         str  — consolidated spoken message to enqueue (plain text, no SSML)
         None — all items are resolved/irrelevant, nothing to say
     """
+    assert_current_ai_consent(uid)
+
     pending_text = "\n".join(
         f"- [{i+1}] ({item.get('trigger_type', '?')} at {item.get('created_at', '?')}): {item.get('message', '')}"
         for i, item in enumerate(pending)

--- a/backend/ella/routers/onboarding.py
+++ b/backend/ella/routers/onboarding.py
@@ -24,6 +24,7 @@ from ella.services.provisioning import (
     retained_compatibility_receipt,
 )
 from ella.services.runtime_resolver import runtime_bindings_enabled
+from ella.services.ai_consent import require_current_ai_consent
 from utils.other import endpoints as auth
 
 logger = logging.getLogger("ella.onboarding")
@@ -100,7 +101,7 @@ def _payload_dict(payload: OnboardingEnsureRequest) -> dict[str, Any]:
     return payload.dict()
 
 
-@router.post("/ensure")
+@router.post("/ensure", dependencies=[Depends(require_current_ai_consent)])
 async def ensure_onboarding(
     payload: OnboardingEnsureRequest,
     background_tasks: BackgroundTasks,

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -38,6 +38,7 @@ from pydantic import BaseModel, Field
 from database import voice_canary as voice_canary_db
 from database.conversations import _decrypt_conversation_data
 from ella.services.ai_consent import (
+    assert_current_ai_consent,
     require_current_ai_consent,
     require_current_ai_consent_or_internal_tts,
     resolve_processor,
@@ -206,6 +207,7 @@ def authenticate_voice_proxy_request(request: Request, requested_uid: str) -> Vo
         subject = str(claims.get("uid") or "").strip()
         if not subject or str(requested_uid or "").strip() != subject:
             raise HTTPException(status_code=403, detail={"code": "voice_session_ownership_mismatch"})
+        assert_current_ai_consent(subject)
         return VoiceProxyPrincipal(
             uid=subject,
             session_id=str(claims.get("jti") or ""),
@@ -255,6 +257,7 @@ def authenticate_voice_proxy_request(request: Request, requested_uid: str) -> Vo
     ):
         raise HTTPException(status_code=401, detail={"code": "voice_session_invalid"})
 
+    assert_current_ai_consent(subject)
     return VoiceProxyPrincipal(
         uid=subject,
         session_id=str(claims.get("jti") or ""),

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -37,6 +37,11 @@ from pydantic import BaseModel, Field
 
 from database import voice_canary as voice_canary_db
 from database.conversations import _decrypt_conversation_data
+from ella.services.ai_consent import (
+    require_current_ai_consent,
+    require_current_ai_consent_or_internal_tts,
+    resolve_processor,
+)
 from ella.services.provisioning import ProvisioningError, rollout_enabled
 from ella.services.runtime_resolver import resolve_isolated_runtime, runtime_bindings_enabled
 from ella.services.voice_canary_alerts import (
@@ -911,7 +916,7 @@ async def create_voice_session(
     uid: Optional[str] = None,
     provider: Optional[str] = None,
     voice_mode: Optional[str] = None,
-    authenticated_uid: str = Depends(auth.get_current_user_uid),
+    authenticated_uid: str = Depends(require_current_ai_consent),
 ):
     """
     Create a voice session token for connecting to V2V service.
@@ -968,6 +973,8 @@ async def create_voice_session(
             status_code=400,
             detail=f"Unknown V2V provider: {provider!r}. Valid: {valid}",
         )
+    if resolve_processor(provider) is None:
+        raise HTTPException(status_code=503, detail={"code": "ai_processor_not_disclosed"})
 
     provider_info = V2V_PROVIDERS[provider]
     provider_model = str(provider_info.get("model") or "")
@@ -1213,7 +1220,7 @@ async def get_voice_config():
     return VoiceConfigResponse(sample_rate=24000, channels=1, encoding="pcm_int16", byte_order="little_endian")
 
 
-@router.post("/tts")
+@router.post("/tts", dependencies=[Depends(require_current_ai_consent_or_internal_tts)])
 async def synthesize_speech(
     request: TtsRequest,
     x_tts_provider: Optional[str] = Header(default=None, alias="X-TTS-Provider"),
@@ -1238,6 +1245,11 @@ async def synthesize_speech(
     provider = (x_tts_provider or "elevenlabs").lower()
     text = request.text[:500]  # Cap at 500 chars
     print(f"[FLOW:VOICE-TTS] header=X-TTS-Provider raw={x_tts_provider!r} resolved={provider}", flush=True)
+    if resolve_processor(provider) is None:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "ai_processor_not_disclosed", "provider": provider},
+        )
 
     # --- V2V providers — redirect to session flow ---
     if provider in V2V_PROVIDERS:

--- a/backend/ella/services/ai_consent.py
+++ b/backend/ella/services/ai_consent.py
@@ -170,6 +170,14 @@ class ConsentIdempotencyConflict(ValueError):
     pass
 
 
+_firestore_db: Any = None
+
+
+def configure_firestore_db(firestore_db: Any) -> None:
+    global _firestore_db
+    _firestore_db = firestore_db
+
+
 class ConsentRepository(Protocol):
     def get_state(self, uid: str) -> Optional[dict[str, Any]]: ...
 
@@ -248,20 +256,20 @@ def _record_firestore_receipt(
 
 class FirestoreConsentRepository:
     @staticmethod
-    def _db():
-        from database._client import db
-
-        return db
+    def _configured_db():
+        if _firestore_db is None:
+            raise RuntimeError("AI consent Firestore client is not configured")
+        return _firestore_db
 
     def get_state(self, uid: str) -> Optional[dict[str, Any]]:
-        db = self._db()
+        db = self._configured_db()
         snapshot = db.collection("users").document(uid).get()
         if not snapshot.exists:
             return None
         return dict((snapshot.to_dict() or {}).get("ai_consent") or {}) or None
 
     def get_receipt(self, uid: str, receipt_id: str) -> Optional[dict[str, Any]]:
-        db = self._db()
+        db = self._configured_db()
         snapshot = db.collection("users").document(uid).collection("ai_consent_receipts").document(receipt_id).get()
         return snapshot.to_dict() if snapshot.exists else None
 
@@ -272,7 +280,7 @@ class FirestoreConsentRepository:
         receipt: dict[str, Any],
         request_fingerprint: str,
     ) -> tuple[dict[str, Any], dict[str, Any], bool]:
-        db = self._db()
+        db = self._configured_db()
         user_ref = db.collection("users").document(uid)
         receipt_ref = user_ref.collection("ai_consent_receipts").document(receipt_id)
         return _record_firestore_receipt(
@@ -453,8 +461,8 @@ def ai_consent_enforcement_required(uid: str) -> bool:
     return os.getenv("ELLA_AI_CONSENT_ENFORCEMENT_ENABLED", "false").lower() == "true" or uid in _uid_allowlist()
 
 
-def ai_consent_enforcement_active() -> bool:
-    return os.getenv("ELLA_AI_CONSENT_ENFORCEMENT_ENABLED", "false").lower() == "true" or bool(_uid_allowlist())
+def ai_consent_global_enforcement_enabled() -> bool:
+    return os.getenv("ELLA_AI_CONSENT_ENFORCEMENT_ENABLED", "false").lower() == "true"
 
 
 def assert_current_ai_consent(uid: str) -> str:
@@ -498,8 +506,11 @@ def require_current_ai_consent_or_internal_tts(
         return assert_current_ai_consent(subject_uid)
     if authorization:
         return assert_current_ai_consent(auth.get_current_user_uid(authorization))
-    if ai_consent_enforcement_active():
+    if ai_consent_global_enforcement_enabled():
         raise HTTPException(status_code=401, detail={"code": "authorization_required"})
+    # A legacy anonymous request has no trustworthy subject to compare with the
+    # UID canary. Canary clients must send Firebase auth; global enforcement
+    # removes this migration bridge for every caller.
     return "migration-bypass"
 
 

--- a/backend/ella/services/ai_consent.py
+++ b/backend/ella/services/ai_consent.py
@@ -6,6 +6,7 @@ import hashlib
 import hmac
 import json
 import os
+import secrets
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Literal, Optional, Protocol
@@ -146,6 +147,19 @@ ACCOUNT_DELETION_CONTRACT = {
     "path": "/v1/users/delete-account",
     "scope": "account_and_user_data",
 }
+
+
+def build_account_deletion_receipt(
+    *,
+    now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+) -> dict[str, str]:
+    """Return a non-identifying receipt for a completed synchronous deletion."""
+    return {
+        "request_id": f"aidel_{secrets.token_hex(16)}",
+        "status": "completed",
+        "scope": ACCOUNT_DELETION_CONTRACT["scope"],
+        "server_completed_at": now().astimezone(timezone.utc).isoformat(),
+    }
 
 
 class ConsentPolicyMismatch(ValueError):

--- a/backend/ella/services/ai_consent.py
+++ b/backend/ella/services/ai_consent.py
@@ -1,0 +1,497 @@
+"""Server-authoritative consent for third-party AI processing."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Literal, Optional, Protocol
+
+from fastapi import Depends, Header, HTTPException
+from google.cloud.firestore_v1 import transactional
+
+from utils.other import endpoints as auth
+
+ConsentDecision = Literal["granted", "declined", "revoked"]
+
+CURRENT_POLICY_VERSION = "ai-data-processors-v5"
+CANONICAL_PROCESSOR_SET = (
+    "deepgram:stt|soniox:stt|speechmatics:stt|firebase:auth-infrastructure|"
+    "hermes-self-hosted:agent-runtime|honcho-self-hosted:memory-context|ella-self-hosted-tts:tts|"
+    "openrouter:model-routing|google-gemini:language-live-voice|openai:language-live-voice|"
+    "groq:language|xai-grok:language-live-voice|inworld:tts|elevenlabs:tts-fallback"
+)
+CURRENT_PROCESSOR_SET_HASH = f"sha256:{hashlib.sha256(CANONICAL_PROCESSOR_SET.encode()).hexdigest()}"
+
+PROCESSORS: tuple[dict[str, Any], ...] = (
+    {
+        "id": "deepgram",
+        "legal_recipient": "Deepgram",
+        "function": "Speech transcription",
+        "data": "Live or stored microphone audio",
+        "provider_aliases": ["deepgram", "deepgram-streaming"],
+        "third_party": True,
+    },
+    {
+        "id": "soniox",
+        "legal_recipient": "Soniox",
+        "function": "Speech transcription",
+        "data": "Live or stored microphone audio",
+        "provider_aliases": ["soniox", "soniox-streaming"],
+        "third_party": True,
+    },
+    {
+        "id": "speechmatics",
+        "legal_recipient": "Speechmatics",
+        "function": "Speech transcription",
+        "data": "Live or stored microphone audio",
+        "provider_aliases": ["speechmatics", "speechmatics-streaming"],
+        "third_party": True,
+    },
+    {
+        "id": "firebase",
+        "legal_recipient": "Google Firebase",
+        "function": "Authentication and service infrastructure",
+        "data": "Account and service metadata",
+        "provider_aliases": ["firebase", "google-firebase"],
+        "third_party": True,
+    },
+    {
+        "id": "hermes-self-hosted",
+        "legal_recipient": "Ella self-hosted Hermes",
+        "function": "Agent reasoning",
+        "data": "Messages, transcripts, and selected memory context",
+        "provider_aliases": ["hermes", "hermes-self-hosted", "hermes-retained", "hermes-isolated"],
+        "third_party": False,
+    },
+    {
+        "id": "honcho-self-hosted",
+        "legal_recipient": "Ella self-hosted Honcho",
+        "function": "Memory context",
+        "data": "Derived text and selected memory relationships",
+        "provider_aliases": ["honcho", "honcho-self-hosted"],
+        "third_party": False,
+    },
+    {
+        "id": "ella-self-hosted-tts",
+        "legal_recipient": "Ella self-hosted voice synthesis",
+        "function": "Voice synthesis",
+        "data": "Response text",
+        "provider_aliases": ["fish-audio", "fish-audio-s1", "fish-audio-s2", "kokoro"],
+        "third_party": False,
+    },
+    {
+        "id": "openrouter",
+        "legal_recipient": "OpenRouter",
+        "function": "Model routing",
+        "data": "Messages, transcripts, and selected memory context",
+        "provider_aliases": ["openrouter"],
+        "third_party": True,
+    },
+    {
+        "id": "google-gemini",
+        "legal_recipient": "Google Gemini",
+        "function": "Language processing and live voice",
+        "data": "Text, selected context, or live microphone audio",
+        "provider_aliases": ["gemini", "gemini-live", "gemini-native-live", "google-gemini"],
+        "third_party": True,
+    },
+    {
+        "id": "openai",
+        "legal_recipient": "OpenAI",
+        "function": "Language processing and live voice",
+        "data": "Text, selected context, or live microphone audio",
+        "provider_aliases": ["openai", "openai-native-realtime"],
+        "third_party": True,
+    },
+    {
+        "id": "groq",
+        "legal_recipient": "Groq",
+        "function": "Language processing",
+        "data": "Text and selected context",
+        "provider_aliases": ["groq"],
+        "third_party": True,
+    },
+    {
+        "id": "xai-grok",
+        "legal_recipient": "xAI Grok",
+        "function": "Language processing and live voice",
+        "data": "Text, selected context, or live microphone audio",
+        "provider_aliases": ["grok", "grok-voice", "xai", "xai-grok", "xai-tts"],
+        "third_party": True,
+    },
+    {
+        "id": "inworld",
+        "legal_recipient": "Inworld AI",
+        "function": "Voice synthesis",
+        "data": "Response text",
+        "provider_aliases": ["inworld"],
+        "third_party": True,
+    },
+    {
+        "id": "elevenlabs",
+        "legal_recipient": "ElevenLabs",
+        "function": "Fallback voice synthesis",
+        "data": "Response text",
+        "provider_aliases": ["elevenlabs"],
+        "third_party": True,
+    },
+)
+
+ACCOUNT_DELETION_CONTRACT = {
+    "method": "DELETE",
+    "path": "/v1/users/delete-account",
+    "scope": "account_and_user_data",
+}
+
+
+class ConsentPolicyMismatch(ValueError):
+    pass
+
+
+class ConsentIdempotencyConflict(ValueError):
+    pass
+
+
+class ConsentRepository(Protocol):
+    def get_state(self, uid: str) -> Optional[dict[str, Any]]: ...
+
+    def get_receipt(self, uid: str, receipt_id: str) -> Optional[dict[str, Any]]: ...
+
+    def record(
+        self,
+        uid: str,
+        receipt_id: str,
+        receipt: dict[str, Any],
+        request_fingerprint: str,
+    ) -> tuple[dict[str, Any], dict[str, Any], bool]: ...
+
+
+def _receipt_fingerprint(receipt: dict[str, Any]) -> str:
+    material = {
+        key: receipt.get(key)
+        for key in (
+            "decision",
+            "policy_version",
+            "processor_set_hash",
+            "request_id",
+            "app_version",
+            "build_number",
+            "locale",
+        )
+    }
+    encoded = json.dumps(material, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+@transactional
+def _record_firestore_receipt(
+    transaction,
+    user_ref,
+    receipt_ref,
+    receipt: dict[str, Any],
+    request_fingerprint: str,
+) -> tuple[dict[str, Any], dict[str, Any], bool]:
+    existing_snapshot = receipt_ref.get(transaction=transaction)
+    user_snapshot = user_ref.get(transaction=transaction)
+    user_data = user_snapshot.to_dict() if user_snapshot.exists else {}
+
+    if existing_snapshot.exists:
+        existing = existing_snapshot.to_dict()
+        if existing.get("request_fingerprint") != request_fingerprint:
+            raise ConsentIdempotencyConflict("request_id was already used with different consent metadata")
+        return existing, dict(user_data.get("ai_consent") or {}), False
+
+    state = {
+        key: receipt.get(key)
+        for key in (
+            "receipt_id",
+            "decision",
+            "policy_version",
+            "processor_set_hash",
+            "server_decided_at",
+            "app_version",
+            "build_number",
+            "locale",
+        )
+    }
+    stored_receipt = {**receipt, "request_fingerprint": request_fingerprint}
+    transaction.set(receipt_ref, stored_receipt)
+    transaction.set(
+        user_ref,
+        {
+            "ai_consent": state,
+            # Compatibility only. The versioned receipt is the authority.
+            "private_cloud_sync_enabled": receipt["decision"] == "granted",
+        },
+        merge=True,
+    )
+    return stored_receipt, state, True
+
+
+class FirestoreConsentRepository:
+    @staticmethod
+    def _db():
+        from database._client import db
+
+        return db
+
+    def get_state(self, uid: str) -> Optional[dict[str, Any]]:
+        db = self._db()
+        snapshot = db.collection("users").document(uid).get()
+        if not snapshot.exists:
+            return None
+        return dict((snapshot.to_dict() or {}).get("ai_consent") or {}) or None
+
+    def get_receipt(self, uid: str, receipt_id: str) -> Optional[dict[str, Any]]:
+        db = self._db()
+        snapshot = db.collection("users").document(uid).collection("ai_consent_receipts").document(receipt_id).get()
+        return snapshot.to_dict() if snapshot.exists else None
+
+    def record(
+        self,
+        uid: str,
+        receipt_id: str,
+        receipt: dict[str, Any],
+        request_fingerprint: str,
+    ) -> tuple[dict[str, Any], dict[str, Any], bool]:
+        db = self._db()
+        user_ref = db.collection("users").document(uid)
+        receipt_ref = user_ref.collection("ai_consent_receipts").document(receipt_id)
+        return _record_firestore_receipt(
+            db.transaction(),
+            user_ref,
+            receipt_ref,
+            receipt,
+            request_fingerprint,
+        )
+
+
+class InMemoryConsentRepository:
+    """Test repository with the same user-scoped idempotency behavior."""
+
+    def __init__(self) -> None:
+        self.states: dict[str, dict[str, Any]] = {}
+        self.receipts: dict[tuple[str, str], dict[str, Any]] = {}
+
+    def get_state(self, uid: str) -> Optional[dict[str, Any]]:
+        state = self.states.get(uid)
+        return dict(state) if state else None
+
+    def get_receipt(self, uid: str, receipt_id: str) -> Optional[dict[str, Any]]:
+        receipt = self.receipts.get((uid, receipt_id))
+        return dict(receipt) if receipt else None
+
+    def record(
+        self,
+        uid: str,
+        receipt_id: str,
+        receipt: dict[str, Any],
+        request_fingerprint: str,
+    ) -> tuple[dict[str, Any], dict[str, Any], bool]:
+        key = (uid, receipt_id)
+        existing = self.receipts.get(key)
+        if existing:
+            if existing.get("request_fingerprint") != request_fingerprint:
+                raise ConsentIdempotencyConflict("request_id was already used with different consent metadata")
+            return dict(existing), dict(self.states.get(uid) or {}), False
+
+        stored = {**receipt, "request_fingerprint": request_fingerprint}
+        state = {
+            key: receipt.get(key)
+            for key in (
+                "receipt_id",
+                "decision",
+                "policy_version",
+                "processor_set_hash",
+                "server_decided_at",
+                "app_version",
+                "build_number",
+                "locale",
+            )
+        }
+        self.receipts[(uid, receipt_id)] = stored
+        self.states[uid] = state
+        return dict(stored), dict(state), True
+
+
+@dataclass(frozen=True)
+class ConsentSubmission:
+    decision: ConsentDecision
+    policy_version: str
+    processor_set_hash: str
+    request_id: str
+    app_version: str
+    build_number: str
+    locale: str
+
+
+class AiConsentService:
+    def __init__(
+        self,
+        repository: ConsentRepository,
+        *,
+        now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+    ) -> None:
+        self.repository = repository
+        self.now = now
+
+    @staticmethod
+    def policy() -> dict[str, Any]:
+        return {
+            "version": CURRENT_POLICY_VERSION,
+            "processor_set_hash": CURRENT_PROCESSOR_SET_HASH,
+            "canonical_processor_set": CANONICAL_PROCESSOR_SET,
+            "processors": [dict(processor) for processor in PROCESSORS],
+        }
+
+    def status(self, uid: str) -> dict[str, Any]:
+        state = self.repository.get_state(uid)
+        return _status_payload(uid, state)
+
+    def receipt(self, uid: str, receipt_id: str) -> Optional[dict[str, Any]]:
+        receipt = self.repository.get_receipt(uid, receipt_id)
+        if not receipt:
+            return None
+        return _public_receipt(receipt)
+
+    def submit(self, uid: str, submission: ConsentSubmission) -> dict[str, Any]:
+        if submission.decision == "granted" and (
+            submission.policy_version != CURRENT_POLICY_VERSION
+            or submission.processor_set_hash != CURRENT_PROCESSOR_SET_HASH
+        ):
+            raise ConsentPolicyMismatch("grant does not match the server-required processor policy")
+
+        receipt_id = "aicr_" + hashlib.sha256(f"{uid}:{submission.request_id}".encode()).hexdigest()[:32]
+        receipt = {
+            "receipt_id": receipt_id,
+            "subject_uid": uid,
+            "decision": submission.decision,
+            "policy_version": submission.policy_version,
+            "processor_set_hash": submission.processor_set_hash,
+            "request_id": submission.request_id,
+            "server_decided_at": self.now().astimezone(timezone.utc).isoformat(),
+            "app_version": submission.app_version,
+            "build_number": submission.build_number,
+            "locale": submission.locale,
+        }
+        fingerprint = _receipt_fingerprint(receipt)
+        stored_receipt, state, created = self.repository.record(uid, receipt_id, receipt, fingerprint)
+        payload = _status_payload(uid, state)
+        payload["receipt"] = _public_receipt(stored_receipt)
+        payload["receipt_created"] = created
+        return payload
+
+
+def _public_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: receipt.get(key)
+        for key in (
+            "receipt_id",
+            "subject_uid",
+            "decision",
+            "policy_version",
+            "processor_set_hash",
+            "server_decided_at",
+            "app_version",
+            "build_number",
+            "locale",
+        )
+    }
+
+
+def _is_current_grant(state: Optional[dict[str, Any]]) -> bool:
+    return bool(
+        state
+        and state.get("decision") == "granted"
+        and state.get("policy_version") == CURRENT_POLICY_VERSION
+        and state.get("processor_set_hash") == CURRENT_PROCESSOR_SET_HASH
+        and state.get("receipt_id")
+    )
+
+
+def _status_payload(uid: str, state: Optional[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "subject_uid": uid,
+        "authorized": _is_current_grant(state),
+        "enforcement_required": ai_consent_enforcement_required(uid),
+        "policy": AiConsentService.policy(),
+        "consent": dict(state) if state else {"decision": "not_recorded", "receipt_id": None},
+        "account_deletion": {**ACCOUNT_DELETION_CONTRACT, "status": "not_requested"},
+    }
+
+
+_repository: ConsentRepository = FirestoreConsentRepository()
+
+
+def get_ai_consent_service() -> AiConsentService:
+    return AiConsentService(_repository)
+
+
+def _uid_allowlist() -> set[str]:
+    return {uid.strip() for uid in os.getenv("ELLA_AI_CONSENT_ENFORCEMENT_UIDS", "").split(",") if uid.strip()}
+
+
+def ai_consent_enforcement_required(uid: str) -> bool:
+    return os.getenv("ELLA_AI_CONSENT_ENFORCEMENT_ENABLED", "false").lower() == "true" or uid in _uid_allowlist()
+
+
+def ai_consent_enforcement_active() -> bool:
+    return os.getenv("ELLA_AI_CONSENT_ENFORCEMENT_ENABLED", "false").lower() == "true" or bool(_uid_allowlist())
+
+
+def assert_current_ai_consent(uid: str) -> str:
+    if not ai_consent_enforcement_required(uid):
+        return uid
+    status = get_ai_consent_service().status(uid)
+    if status["authorized"]:
+        return uid
+    consent = status["consent"]
+    raise HTTPException(
+        status_code=403,
+        detail={
+            "code": "ai_consent_required",
+            "decision": consent.get("decision", "not_recorded"),
+            "required_policy_version": CURRENT_POLICY_VERSION,
+            "required_processor_set_hash": CURRENT_PROCESSOR_SET_HASH,
+        },
+    )
+
+
+def require_current_ai_consent(
+    authenticated_uid: str = Depends(auth.get_current_user_uid),
+) -> str:
+    return assert_current_ai_consent(authenticated_uid)
+
+
+def require_current_ai_consent_or_internal_tts(
+    authorization: Optional[str] = Header(default=None),
+    x_internal_token: Optional[str] = Header(default=None, alias="X-Ella-Internal-Token"),
+    x_subject_uid: Optional[str] = Header(default=None, alias="X-Ella-Subject-Uid"),
+) -> str:
+    configured_internal_token = os.getenv("ELLA_INTERNAL_VOICE_TTS_TOKEN", "")
+    if (
+        configured_internal_token
+        and x_internal_token
+        and hmac.compare_digest(configured_internal_token, x_internal_token)
+    ):
+        subject_uid = (x_subject_uid or "").strip()
+        if not subject_uid:
+            raise HTTPException(status_code=400, detail={"code": "ai_consent_subject_required"})
+        return assert_current_ai_consent(subject_uid)
+    if authorization:
+        return assert_current_ai_consent(auth.get_current_user_uid(authorization))
+    if ai_consent_enforcement_active():
+        raise HTTPException(status_code=401, detail={"code": "authorization_required"})
+    return "migration-bypass"
+
+
+def resolve_processor(provider_alias: str) -> Optional[dict[str, Any]]:
+    normalized = provider_alias.strip().lower()
+    for processor in PROCESSORS:
+        if normalized in processor["provider_aliases"]:
+            return dict(processor)
+    return None

--- a/backend/main.py
+++ b/backend/main.py
@@ -46,6 +46,8 @@ from routers import (
 
 from utils.other.timeout import TimeoutMiddleware
 from utils.observability import log_langsmith_status
+from ella.routers import ai_consent
+from ella.services.ai_consent import configure_firestore_db as configure_ai_consent_firestore_db
 
 # Log LangSmith tracing status at startup
 log_langsmith_status()
@@ -75,6 +77,10 @@ app.add_middleware(
     max_age=3600,
 )
 
+# Consent authority stays available even when ELLA_ENABLED=false so rollback
+# cannot leave protected generic OMI routes without grant/revoke endpoints.
+configure_ai_consent_firestore_db(firestore_db)
+app.include_router(ai_consent.router)
 app.include_router(transcribe.router)
 app.include_router(conversations.router)
 app.include_router(action_items.router)

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -36,6 +36,7 @@ from utils.llm.persona import initial_persona_chat_message
 from utils.llm.chat import initial_chat_message
 from utils.llm.goals import extract_and_update_goal_progress
 from utils.other import endpoints as auth, storage
+from ella.services.ai_consent import require_current_ai_consent
 from utils.other.chat_file import FileChatTool
 from utils.retrieval.graph import execute_graph_chat, execute_graph_chat_stream, execute_persona_chat_stream
 from utils.retrieval.agentic import execute_agentic_chat, execute_agentic_chat_stream
@@ -62,7 +63,12 @@ def acquire_chat_session(uid: str, app_id: Optional[str] = None):
     return chat_session
 
 
-@router.post('/v2/messages', tags=['chat'], response_model=ResponseMessage)
+@router.post(
+    '/v2/messages',
+    tags=['chat'],
+    response_model=ResponseMessage,
+    dependencies=[Depends(require_current_ai_consent)],
+)
 def send_message(
     data: SendMessageRequest,
     plugin_id: Optional[str] = None,
@@ -276,7 +282,12 @@ def initial_message_util(uid: str, app_id: Optional[str] = None):
     return ai_message
 
 
-@router.post('/v2/initial-message', tags=['chat'], response_model=Message)
+@router.post(
+    '/v2/initial-message',
+    tags=['chat'],
+    response_model=Message,
+    dependencies=[Depends(require_current_ai_consent)],
+)
 def create_initial_message(
     app_id: Optional[str] = None, plugin_id: Optional[str] = None, uid: str = Depends(auth.get_current_user_uid)
 ):
@@ -312,7 +323,7 @@ def get_messages(
     return messages
 
 
-@router.post("/v2/voice-messages")
+@router.post("/v2/voice-messages", dependencies=[Depends(require_current_ai_consent)])
 async def create_voice_message_stream(
     files: List[UploadFile] = File(...),
     language: Optional[str] = Form(None),
@@ -337,7 +348,7 @@ async def create_voice_message_stream(
     return StreamingResponse(generate_stream(), media_type="text/event-stream")
 
 
-@router.post("/v2/voice-message/transcribe")
+@router.post("/v2/voice-message/transcribe", dependencies=[Depends(require_current_ai_consent)])
 async def transcribe_voice_message(
     files: List[UploadFile] = File(...),
     language: Optional[str] = Form(None),
@@ -432,7 +443,12 @@ async def transcribe_voice_message(
     return response
 
 
-@router.post('/v2/files', response_model=List[FileChat], tags=['chat'])
+@router.post(
+    '/v2/files',
+    response_model=List[FileChat],
+    tags=['chat'],
+    dependencies=[Depends(require_current_ai_consent)],
+)
 def upload_file_chat(files: List[UploadFile] = File(...), uid: str = Depends(auth.get_current_user_uid)):
     thumbs_name = []
     files_chat = []
@@ -485,7 +501,12 @@ def upload_file_chat(files: List[UploadFile] = File(...), uid: str = Depends(aut
 # CLEANUP: Remove after new app goes to prod ----------------------------------------------------------
 
 
-@router.post('/v1/files', response_model=List[FileChat], tags=['chat'])
+@router.post(
+    '/v1/files',
+    response_model=List[FileChat],
+    tags=['chat'],
+    dependencies=[Depends(require_current_ai_consent)],
+)
 def upload_file_chat(files: List[UploadFile] = File(...), uid: str = Depends(auth.get_current_user_uid)):
     thumbs_name = []
     files_chat = []
@@ -579,7 +600,12 @@ def clear_chat_messages(
     return initial_message_util(uid, compat_app_id)
 
 
-@router.post('/v1/initial-message', tags=['chat'], response_model=Message)
+@router.post(
+    '/v1/initial-message',
+    tags=['chat'],
+    response_model=Message,
+    dependencies=[Depends(require_current_ai_consent)],
+)
 def create_initial_message(
     plugin_id: Optional[str] = None, app_id: Optional[str] = None, uid: str = Depends(auth.get_current_user_uid)
 ):

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -36,7 +36,7 @@ from utils.llm.persona import initial_persona_chat_message
 from utils.llm.chat import initial_chat_message
 from utils.llm.goals import extract_and_update_goal_progress
 from utils.other import endpoints as auth, storage
-from ella.services.ai_consent import require_current_ai_consent
+from ella.services.ai_consent import assert_current_ai_consent, require_current_ai_consent
 from utils.other.chat_file import FileChatTool
 from utils.retrieval.graph import execute_graph_chat, execute_graph_chat_stream, execute_persona_chat_stream
 from utils.retrieval.agentic import execute_agentic_chat, execute_agentic_chat_stream
@@ -243,6 +243,7 @@ def clear_chat_messages(
 
 
 def initial_message_util(uid: str, app_id: Optional[str] = None):
+    assert_current_ai_consent(uid)
     print('initial_message_util', app_id)
 
     # init chat session

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -34,6 +34,7 @@ from utils.conversations.search import search_conversations
 from utils.llm.conversation_processing import generate_summary_with_prompt
 from utils.speaker_identification import extract_speaker_samples
 from utils.other import endpoints as auth
+from ella.services.ai_consent import require_current_ai_consent
 from utils.other.storage import get_conversation_recording_if_exists
 from utils.app_integrations import trigger_external_integrations
 from utils.conversations.location import get_google_maps_location
@@ -56,7 +57,12 @@ class ProcessConversationRequest(BaseModel):
     calendar_meeting_context: Optional[CalendarMeetingContext] = None
 
 
-@router.post("/v1/conversations", response_model=CreateConversationResponse, tags=['conversations'])
+@router.post(
+    "/v1/conversations",
+    response_model=CreateConversationResponse,
+    tags=['conversations'],
+    dependencies=[Depends(require_current_ai_consent)],
+)
 def process_in_progress_conversation(
     request: ProcessConversationRequest = None, uid: str = Depends(auth.get_current_user_uid)
 ):
@@ -86,7 +92,12 @@ def process_in_progress_conversation(
     return CreateConversationResponse(conversation=conversation, messages=messages)
 
 
-@router.post('/v1/conversations/{conversation_id}/reprocess', response_model=Conversation, tags=['conversations'])
+@router.post(
+    '/v1/conversations/{conversation_id}/reprocess',
+    response_model=Conversation,
+    tags=['conversations'],
+    dependencies=[Depends(require_current_ai_consent)],
+)
 def reprocess_conversation(
     conversation_id: str,
     language_code: Optional[str] = None,
@@ -671,7 +682,12 @@ def get_conversation_suggested_apps(conversation_id: str, uid: str = Depends(aut
     return {"suggested_apps": [app.dict() for app in suggested_apps], "conversation_id": conversation_id}
 
 
-@router.post("/v1/conversations/{conversation_id}/test-prompt", response_model=dict, tags=['conversations'])
+@router.post(
+    "/v1/conversations/{conversation_id}/test-prompt",
+    response_model=dict,
+    tags=['conversations'],
+    dependencies=[Depends(require_current_ai_consent)],
+)
 def test_prompt(conversation_id: str, request: TestPromptRequest, uid: str = Depends(auth.get_current_user_uid)):
     conversation_data = _get_valid_conversation_by_id(uid, conversation_id)
     conversation = Conversation(**conversation_data)
@@ -692,7 +708,12 @@ def test_prompt(conversation_id: str, request: TestPromptRequest, uid: str = Dep
 # *********************************************
 
 
-@router.post('/v1/conversations/merge', response_model=MergeConversationsResponse, tags=['conversations'])
+@router.post(
+    '/v1/conversations/merge',
+    response_model=MergeConversationsResponse,
+    tags=['conversations'],
+    dependencies=[Depends(require_current_ai_consent)],
+)
 async def merge_conversations(
     request: MergeConversationsRequest,
     background_tasks: BackgroundTasks,

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -20,6 +20,7 @@ from database.conversations import get_closest_conversation_to_timestamps, updat
 from models.conversation import CreateConversation, ConversationSource, Conversation
 from models.transcript_segment import TranscriptSegment
 from utils.conversations.process_conversation import process_conversation
+from ella.services.ai_consent import assert_current_ai_consent, require_current_ai_consent
 from utils.other import endpoints as auth
 from utils.other.storage import (
     get_syncing_file_temporal_signed_url,
@@ -615,6 +616,7 @@ def _reprocess_conversation_after_update(uid: str, conversation_id: str, languag
 
 
 def process_segment(path: str, uid: str, response: dict, source: ConversationSource = ConversationSource.omi):
+    assert_current_ai_consent(uid)
     url = get_syncing_file_temporal_signed_url(path)
 
     def delete_file():
@@ -699,7 +701,7 @@ def _cleanup_files(file_paths):
 
 
 @router.post("/v1/sync-local-files")
-async def sync_local_files(files: List[UploadFile] = File(...), uid: str = Depends(auth.get_current_user_uid)):
+async def sync_local_files(files: List[UploadFile] = File(...), uid: str = Depends(require_current_ai_consent)):
     # Improve a version without timestamp, to consider uploads from the stored in v2 device bytes.
     # Detect source from filenames
     source = ConversationSource.omi

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -102,6 +102,7 @@ from ella.routers.auto_provision import (
     get_agent_cluster,
     listen_runtime_gate,
 )
+from ella.services.ai_consent import assert_current_ai_consent, require_current_ai_consent, resolve_processor
 
 from utils.aac import AACDecoder
 from utils.audio import AudioRingBuffer
@@ -395,6 +396,10 @@ async def _stream_handler(
     if not stt_service or not stt_language:
         _latency_log("stt_provider_unsupported", requested_language=language)
         await websocket.close(code=1008, reason=f"The language is not supported, {language}")
+        return
+    if resolve_processor(_stt_service_value(stt_service) or "") is None:
+        _latency_log("stt_provider_not_disclosed", provider=_stt_service_value(stt_service))
+        await websocket.close(code=1011, reason="STT processor disclosure is incomplete")
         return
 
     # Translation language (disabled in single language mode)
@@ -2519,7 +2524,7 @@ async def _listen(
 @router.websocket("/v4/listen")
 async def listen_handler(
     websocket: WebSocket,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(require_current_ai_consent),
     language: str = 'en',
     sample_rate: int = 8000,
     codec: str = 'pcm8',
@@ -2633,6 +2638,20 @@ async def web_listen_handler(
         print(f"web_listen_handler: auth error {e}")
         await websocket.send_json({"type": "auth_response", "success": False})
         await websocket.close(code=1008, reason="Auth error")
+        return
+
+    try:
+        assert_current_ai_consent(uid)
+    except HTTPException as exc:
+        detail = exc.detail if isinstance(exc.detail, dict) else {}
+        await websocket.send_json(
+            {
+                "type": "auth_response",
+                "success": False,
+                "error": detail.get("code", "ai_consent_required"),
+            }
+        )
+        await websocket.close(code=1008, reason="AI consent required")
         return
 
     runtime_gate = await listen_runtime_gate(uid, user_db.is_exists_user)

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -56,6 +56,7 @@ from utils.llm.followup import followup_question_prompt
 from utils.notifications import send_notification, send_training_data_submitted_notification
 from utils.llm.external_integrations import generate_comprehensive_daily_summary
 from models.notification_message import NotificationMessage
+from ella.services.ai_consent import build_account_deletion_receipt
 from utils.other import endpoints as auth
 from utils.other.storage import (
     delete_all_conversation_recordings,
@@ -97,7 +98,11 @@ def delete_account(uid: str = Depends(auth.get_current_user_uid)):
         delete_user_data(uid)
         # delete user from firebase auth
         auth.delete_account(uid)
-        return {'status': 'ok', 'message': 'Account deleted successfully'}
+        return {
+            'status': 'ok',
+            'message': 'Account deleted successfully',
+            'deletion_receipt': build_account_deletion_receipt(),
+        }
     except Exception as e:
         print('delete_account', str(e))
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/tests/unit/test_ella_ai_consent.py
+++ b/backend/tests/unit/test_ella_ai_consent.py
@@ -1,0 +1,378 @@
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from ella.routers import ai_consent
+from ella.services import ai_consent as consent
+
+
+def _submission(
+    *,
+    decision="granted",
+    request_id="request-0001",
+    policy_version=consent.CURRENT_POLICY_VERSION,
+    processor_set_hash=consent.CURRENT_PROCESSOR_SET_HASH,
+):
+    return consent.ConsentSubmission(
+        decision=decision,
+        policy_version=policy_version,
+        processor_set_hash=processor_set_hash,
+        request_id=request_id,
+        app_version="1.0.0",
+        build_number="804",
+        locale="en-US",
+    )
+
+
+def _service(repository=None):
+    return consent.AiConsentService(
+        repository or consent.InMemoryConsentRepository(),
+        now=lambda: datetime(2026, 7, 26, 23, 45, tzinfo=timezone.utc),
+    )
+
+
+def test_policy_covers_current_chat_voice_stt_and_tts_surface():
+    policy = consent.AiConsentService.policy()
+
+    assert policy["version"] == "ai-data-processors-v5"
+    assert policy["processor_set_hash"] == "sha256:9c2529babbd6241f20242cf0836baf7e1899d05bb3d945a0d38a357113d4cbc4"
+    assert (
+        "|".join(
+            [
+                "deepgram:stt",
+                "soniox:stt",
+                "speechmatics:stt",
+                "firebase:auth-infrastructure",
+                "hermes-self-hosted:agent-runtime",
+                "honcho-self-hosted:memory-context",
+                "ella-self-hosted-tts:tts",
+                "openrouter:model-routing",
+                "google-gemini:language-live-voice",
+                "openai:language-live-voice",
+                "groq:language",
+                "xai-grok:language-live-voice",
+                "inworld:tts",
+                "elevenlabs:tts-fallback",
+            ]
+        )
+        == policy["canonical_processor_set"]
+    )
+
+
+def test_missing_consent_is_fail_closed_when_enforcement_is_enabled(monkeypatch):
+    repository = consent.InMemoryConsentRepository()
+    monkeypatch.setattr(consent, "_repository", repository)
+    monkeypatch.setenv("ELLA_AI_CONSENT_ENFORCEMENT_ENABLED", "true")
+
+    with pytest.raises(HTTPException) as error:
+        consent.assert_current_ai_consent("user-a")
+
+    assert error.value.status_code == 403
+    assert error.value.detail["code"] == "ai_consent_required"
+    assert error.value.detail["decision"] == "not_recorded"
+
+
+def test_exact_policy_grant_is_server_timestamped_and_authorizes(monkeypatch):
+    repository = consent.InMemoryConsentRepository()
+    service = _service(repository)
+    monkeypatch.setenv("ELLA_AI_CONSENT_ENFORCEMENT_UIDS", "user-a")
+
+    result = service.submit("user-a", _submission())
+
+    assert result["authorized"] is True
+    assert result["receipt_created"] is True
+    assert result["receipt"]["receipt_id"].startswith("aicr_")
+    assert "user-a" not in result["receipt"]["receipt_id"]
+    assert result["receipt"]["subject_uid"] == "user-a"
+    assert result["receipt"]["server_decided_at"] == "2026-07-26T23:45:00+00:00"
+    assert result["receipt"]["build_number"] == "804"
+    assert result["enforcement_required"] is True
+
+
+def test_same_request_retry_dedupes_and_payload_change_conflicts():
+    service = _service()
+
+    first = service.submit("user-a", _submission())
+    replay = service.submit("user-a", _submission())
+
+    assert replay["receipt_created"] is False
+    assert replay["receipt"]["receipt_id"] == first["receipt"]["receipt_id"]
+
+    with pytest.raises(consent.ConsentIdempotencyConflict):
+        service.submit("user-a", _submission(decision="revoked"))
+
+
+def test_firestore_transaction_writes_immutable_receipt_and_current_pointer():
+    class Snapshot:
+        def __init__(self, exists, data=None):
+            self.exists = exists
+            self._data = data or {}
+
+        def to_dict(self):
+            return dict(self._data)
+
+    class Ref:
+        def __init__(self, snapshot):
+            self.snapshot = snapshot
+
+        def get(self, transaction):
+            assert transaction is transaction_instance
+            return self.snapshot
+
+    class Transaction:
+        def __init__(self):
+            self.writes = []
+
+        def set(self, ref, data, merge=False):
+            self.writes.append((ref, data, merge))
+
+    transaction_instance = Transaction()
+    user_ref = Ref(Snapshot(True, {"existing": "preserved"}))
+    receipt_ref = Ref(Snapshot(False))
+    receipt = {
+        "receipt_id": "aicr_receipt",
+        "decision": "granted",
+        "policy_version": consent.CURRENT_POLICY_VERSION,
+        "processor_set_hash": consent.CURRENT_PROCESSOR_SET_HASH,
+        "server_decided_at": "2026-07-26T23:45:00+00:00",
+        "app_version": "1.0.0",
+        "build_number": "804",
+        "locale": "en-US",
+    }
+
+    stored, state, created = consent._record_firestore_receipt.to_wrap(
+        transaction_instance,
+        user_ref,
+        receipt_ref,
+        receipt,
+        "fingerprint",
+    )
+
+    assert created is True
+    assert stored["request_fingerprint"] == "fingerprint"
+    assert state["receipt_id"] == "aicr_receipt"
+    assert transaction_instance.writes[0][0] is receipt_ref
+    assert transaction_instance.writes[1] == (
+        user_ref,
+        {
+            "ai_consent": state,
+            "private_cloud_sync_enabled": True,
+        },
+        True,
+    )
+
+
+def test_firestore_transaction_replay_does_not_rewrite_current_state():
+    class Snapshot:
+        def __init__(self, data):
+            self.exists = True
+            self._data = data
+
+        def to_dict(self):
+            return dict(self._data)
+
+    class Ref:
+        def __init__(self, data):
+            self.snapshot = Snapshot(data)
+
+        def get(self, transaction):
+            return self.snapshot
+
+    class Transaction:
+        def set(self, *_args, **_kwargs):
+            raise AssertionError("idempotent replay must not write")
+
+    current_state = {"decision": "revoked", "receipt_id": "aicr_newer"}
+    stored, state, created = consent._record_firestore_receipt.to_wrap(
+        Transaction(),
+        Ref({"ai_consent": current_state}),
+        Ref({"request_fingerprint": "same", "receipt_id": "aicr_original"}),
+        {"decision": "granted"},
+        "same",
+    )
+
+    assert created is False
+    assert stored["receipt_id"] == "aicr_original"
+    assert state == current_state
+
+
+def test_stale_grant_is_rejected_but_stale_decline_is_recorded():
+    service = _service()
+
+    with pytest.raises(consent.ConsentPolicyMismatch):
+        service.submit(
+            "user-a",
+            _submission(
+                policy_version="ai-data-processors-v3",
+                processor_set_hash="sha256:stale",
+            ),
+        )
+
+    declined = service.submit(
+        "user-a",
+        _submission(
+            decision="declined",
+            request_id="request-decline",
+            policy_version="ai-data-processors-v3",
+            processor_set_hash="sha256:stale",
+        ),
+    )
+    assert declined["authorized"] is False
+    assert declined["consent"]["decision"] == "declined"
+
+
+def test_revoke_supersedes_prior_grant():
+    service = _service()
+    service.submit("user-a", _submission())
+
+    revoked = service.submit(
+        "user-a",
+        _submission(decision="revoked", request_id="request-revoke"),
+    )
+
+    assert revoked["authorized"] is False
+    assert revoked["consent"]["decision"] == "revoked"
+    assert revoked["account_deletion"]["path"] == "/v1/users/delete-account"
+
+
+def test_receipts_are_user_scoped():
+    repository = consent.InMemoryConsentRepository()
+    service = _service(repository)
+    result = service.submit("user-a", _submission())
+    receipt_id = result["receipt"]["receipt_id"]
+
+    assert service.receipt("user-a", receipt_id)["subject_uid"] == "user-a"
+    assert service.receipt("user-b", receipt_id) is None
+
+
+def test_enforcement_defaults_off_and_supports_uid_canary(monkeypatch):
+    monkeypatch.delenv("ELLA_AI_CONSENT_ENFORCEMENT_ENABLED", raising=False)
+    monkeypatch.delenv("ELLA_AI_CONSENT_ENFORCEMENT_UIDS", raising=False)
+    assert consent.ai_consent_enforcement_required("user-a") is False
+
+    monkeypatch.setenv("ELLA_AI_CONSENT_ENFORCEMENT_UIDS", "user-a,user-b")
+    assert consent.ai_consent_enforcement_required("user-a") is True
+    assert consent.ai_consent_enforcement_required("user-c") is False
+
+
+def test_tts_gate_accepts_configured_internal_service_token(monkeypatch):
+    repository = consent.InMemoryConsentRepository()
+    service = _service(repository)
+    service.submit("user-a", _submission())
+    monkeypatch.setattr(consent, "_repository", repository)
+    monkeypatch.setenv("ELLA_AI_CONSENT_ENFORCEMENT_ENABLED", "true")
+    monkeypatch.setenv("ELLA_INTERNAL_VOICE_TTS_TOKEN", "internal-secret")
+
+    assert (
+        consent.require_current_ai_consent_or_internal_tts(
+            authorization=None,
+            x_internal_token="internal-secret",
+            x_subject_uid="user-a",
+        )
+        == "user-a"
+    )
+
+
+def test_tts_internal_service_token_cannot_bypass_subject_consent(monkeypatch):
+    monkeypatch.setenv("ELLA_AI_CONSENT_ENFORCEMENT_ENABLED", "true")
+    monkeypatch.setenv("ELLA_INTERNAL_VOICE_TTS_TOKEN", "internal-secret")
+
+    with pytest.raises(HTTPException) as missing_subject:
+        consent.require_current_ai_consent_or_internal_tts(
+            authorization=None,
+            x_internal_token="internal-secret",
+            x_subject_uid=None,
+        )
+    assert missing_subject.value.detail == {"code": "ai_consent_subject_required"}
+
+    repository = consent.InMemoryConsentRepository()
+    monkeypatch.setattr(consent, "_repository", repository)
+    with pytest.raises(HTTPException) as missing_consent:
+        consent.require_current_ai_consent_or_internal_tts(
+            authorization=None,
+            x_internal_token="internal-secret",
+            x_subject_uid="user-a",
+        )
+    assert missing_consent.value.detail["code"] == "ai_consent_required"
+
+
+def test_tts_gate_rejects_unauthenticated_public_request_when_enforcement_is_active(monkeypatch):
+    monkeypatch.setenv("ELLA_AI_CONSENT_ENFORCEMENT_UIDS", "user-a")
+    monkeypatch.delenv("ELLA_INTERNAL_VOICE_TTS_TOKEN", raising=False)
+
+    with pytest.raises(HTTPException) as error:
+        consent.require_current_ai_consent_or_internal_tts(
+            authorization=None,
+            x_internal_token=None,
+            x_subject_uid=None,
+        )
+
+    assert error.value.status_code == 401
+    assert error.value.detail == {"code": "authorization_required"}
+
+
+def test_provider_aliases_resolve_to_disclosed_legal_recipient():
+    assert consent.resolve_processor("soniox")["legal_recipient"] == "Soniox"
+    assert consent.resolve_processor("speechmatics")["legal_recipient"] == "Speechmatics"
+    assert consent.resolve_processor("kokoro")["third_party"] is False
+    assert consent.resolve_processor("inworld")["legal_recipient"] == "Inworld AI"
+    assert consent.resolve_processor("gemini-native-live")["legal_recipient"] == "Google Gemini"
+    assert consent.resolve_processor("grok-voice")["legal_recipient"] == "xAI Grok"
+    assert consent.resolve_processor("unknown") is None
+
+
+def test_router_returns_conflict_for_stale_grant(monkeypatch):
+    service = _service()
+    monkeypatch.setattr(ai_consent, "get_ai_consent_service", lambda: service)
+    request = ai_consent.AiConsentSubmissionRequest(
+        decision="granted",
+        policy_version="ai-data-processors-v3",
+        processor_set_hash="sha256:stale",
+        request_id="request-stale",
+        app_version="1.0.0",
+        build_number="804",
+        locale="en-US",
+    )
+
+    with pytest.raises(HTTPException) as error:
+        ai_consent.submit_ai_consent(request, uid="user-a")
+
+    assert error.value.status_code == 409
+    assert error.value.detail["code"] == "ai_consent_policy_mismatch"
+
+
+def test_submission_rejects_device_identifiers_and_unknown_metadata():
+    with pytest.raises(ValidationError):
+        ai_consent.AiConsentSubmissionRequest(
+            decision="granted",
+            policy_version=consent.CURRENT_POLICY_VERSION,
+            processor_set_hash=consent.CURRENT_PROCESSOR_SET_HASH,
+            request_id="request-device",
+            app_version="1.0.0",
+            build_number="804",
+            locale="en-US",
+            device_id="do-not-store-this",
+        )
+
+
+def test_policy_is_public_but_status_and_receipts_require_firebase_auth(monkeypatch):
+    service = _service()
+    monkeypatch.setattr(ai_consent, "get_ai_consent_service", lambda: service)
+    app = FastAPI()
+    app.include_router(ai_consent.router)
+    client = TestClient(app)
+
+    policy_response = client.get("/v1/users/ai-consent/policy")
+    assert policy_response.status_code == 200
+    assert policy_response.json()["version"] == consent.CURRENT_POLICY_VERSION
+
+    assert client.get("/v1/users/ai-consent").status_code == 401
+    assert client.get("/v1/users/ai-consent/receipts/aicr_unknown").status_code == 401
+
+    app.dependency_overrides[consent.auth.get_current_user_uid] = lambda: "user-a"
+    status_response = client.get("/v1/users/ai-consent")
+    assert status_response.status_code == 200
+    assert status_response.json()["subject_uid"] == "user-a"

--- a/backend/tests/unit/test_ella_ai_consent.py
+++ b/backend/tests/unit/test_ella_ai_consent.py
@@ -238,6 +238,19 @@ def test_revoke_supersedes_prior_grant():
     assert revoked["account_deletion"]["path"] == "/v1/users/delete-account"
 
 
+def test_account_deletion_receipt_is_opaque_and_completed():
+    receipt = consent.build_account_deletion_receipt(
+        now=lambda: datetime(2026, 7, 26, 20, 15, tzinfo=timezone.utc)
+    )
+
+    assert receipt["request_id"].startswith("aidel_")
+    assert len(receipt["request_id"]) == len("aidel_") + 32
+    assert receipt["status"] == "completed"
+    assert receipt["scope"] == "account_and_user_data"
+    assert receipt["server_completed_at"] == "2026-07-26T20:15:00+00:00"
+    assert "uid" not in receipt
+
+
 def test_receipts_are_user_scoped():
     repository = consent.InMemoryConsentRepository()
     service = _service(repository)

--- a/backend/tests/unit/test_ella_ai_consent.py
+++ b/backend/tests/unit/test_ella_ai_consent.py
@@ -238,6 +238,26 @@ def test_revoke_supersedes_prior_grant():
     assert revoked["account_deletion"]["path"] == "/v1/users/delete-account"
 
 
+@pytest.mark.parametrize("decision", ["declined", "revoked"])
+def test_decline_and_revoke_block_central_target_uid_egress(monkeypatch, decision):
+    repository = consent.InMemoryConsentRepository()
+    service = _service(repository)
+    service.submit("user-a", _submission())
+    service.submit(
+        "user-a",
+        _submission(decision=decision, request_id=f"request-{decision}"),
+    )
+    monkeypatch.setattr(consent, "_repository", repository)
+    monkeypatch.setenv("ELLA_AI_CONSENT_ENFORCEMENT_UIDS", "user-a")
+
+    with pytest.raises(HTTPException) as error:
+        consent.assert_current_ai_consent("user-a")
+
+    assert error.value.status_code == 403
+    assert error.value.detail["code"] == "ai_consent_required"
+    assert error.value.detail["decision"] == decision
+
+
 def test_account_deletion_receipt_is_opaque_and_completed():
     receipt = consent.build_account_deletion_receipt(
         now=lambda: datetime(2026, 7, 26, 20, 15, tzinfo=timezone.utc)
@@ -312,8 +332,23 @@ def test_tts_internal_service_token_cannot_bypass_subject_consent(monkeypatch):
     assert missing_consent.value.detail["code"] == "ai_consent_required"
 
 
-def test_tts_gate_rejects_unauthenticated_public_request_when_enforcement_is_active(monkeypatch):
+def test_tts_uid_canary_does_not_break_unattributed_legacy_callers(monkeypatch):
     monkeypatch.setenv("ELLA_AI_CONSENT_ENFORCEMENT_UIDS", "user-a")
+    monkeypatch.delenv("ELLA_AI_CONSENT_ENFORCEMENT_ENABLED", raising=False)
+    monkeypatch.delenv("ELLA_INTERNAL_VOICE_TTS_TOKEN", raising=False)
+
+    result = consent.require_current_ai_consent_or_internal_tts(
+        authorization=None,
+        x_internal_token=None,
+        x_subject_uid=None,
+    )
+
+    assert result == "migration-bypass"
+
+
+def test_tts_global_enforcement_rejects_unattributed_legacy_callers(monkeypatch):
+    monkeypatch.setenv("ELLA_AI_CONSENT_ENFORCEMENT_ENABLED", "true")
+    monkeypatch.delenv("ELLA_AI_CONSENT_ENFORCEMENT_UIDS", raising=False)
     monkeypatch.delenv("ELLA_INTERNAL_VOICE_TTS_TOKEN", raising=False)
 
     with pytest.raises(HTTPException) as error:
@@ -325,6 +360,23 @@ def test_tts_gate_rejects_unauthenticated_public_request_when_enforcement_is_act
 
     assert error.value.status_code == 401
     assert error.value.detail == {"code": "authorization_required"}
+
+
+def test_tts_authenticated_canary_subject_must_have_current_consent(monkeypatch):
+    repository = consent.InMemoryConsentRepository()
+    monkeypatch.setattr(consent, "_repository", repository)
+    monkeypatch.setattr(consent.auth, "get_current_user_uid", lambda _authorization: "user-a")
+    monkeypatch.setenv("ELLA_AI_CONSENT_ENFORCEMENT_UIDS", "user-a")
+
+    with pytest.raises(HTTPException) as error:
+        consent.require_current_ai_consent_or_internal_tts(
+            authorization="Bearer firebase-token",
+            x_internal_token=None,
+            x_subject_uid=None,
+        )
+
+    assert error.value.status_code == 403
+    assert error.value.detail["code"] == "ai_consent_required"
 
 
 def test_provider_aliases_resolve_to_disclosed_legal_recipient():

--- a/backend/tests/unit/test_ella_ai_consent_route_gates.py
+++ b/backend/tests/unit/test_ella_ai_consent_route_gates.py
@@ -1,0 +1,129 @@
+import ast
+from pathlib import Path
+
+BACKEND = Path(__file__).resolve().parents[2]
+
+
+def _gated_route_paths(source_path: Path, dependency_name: str) -> set[str]:
+    tree = ast.parse(source_path.read_text())
+    gated_paths = set()
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        signature_uses_dependency = dependency_name in ast.unparse(node.args)
+        for decorator in node.decorator_list:
+            if not isinstance(decorator, ast.Call) or not decorator.args:
+                continue
+            path_arg = decorator.args[0]
+            if not isinstance(path_arg, ast.Constant) or not isinstance(path_arg.value, str):
+                continue
+            dependencies = next(
+                (keyword.value for keyword in decorator.keywords if keyword.arg == "dependencies"),
+                None,
+            )
+            decorator_uses_dependency = dependencies is not None and dependency_name in ast.unparse(dependencies)
+            if signature_uses_dependency or decorator_uses_dependency:
+                gated_paths.add(path_arg.value)
+
+    return gated_paths
+
+
+def test_authenticated_ai_egress_routes_share_the_consent_gate():
+    assert "/chat/stream" in _gated_route_paths(
+        BACKEND / "ella" / "routers" / "chat.py",
+        "require_current_ai_consent",
+    )
+    assert "/ensure" in _gated_route_paths(
+        BACKEND / "ella" / "routers" / "onboarding.py",
+        "require_current_ai_consent",
+    )
+    assert "/session" in _gated_route_paths(
+        BACKEND / "ella" / "routers" / "voice.py",
+        "require_current_ai_consent",
+    )
+    assert "/v4/listen" in _gated_route_paths(
+        BACKEND / "routers" / "transcribe.py",
+        "require_current_ai_consent",
+    )
+
+
+def test_first_message_websocket_auth_checks_consent_before_streaming():
+    source = (BACKEND / "routers" / "transcribe.py").read_text()
+
+    auth_position = source.index("uid = auth.get_current_user_uid_from_ws_message(first_message)")
+    consent_position = source.index("assert_current_ai_consent(uid)", auth_position)
+    stream_position = source.index("await _stream_handler(", consent_position)
+
+    assert auth_position < consent_position < stream_position
+    assert '"error": detail.get("code", "ai_consent_required")' in source
+
+
+def test_tts_route_uses_authenticated_or_internal_service_gate():
+    voice_source_path = BACKEND / "ella" / "routers" / "voice.py"
+    assert "/tts" in _gated_route_paths(
+        voice_source_path,
+        "require_current_ai_consent_or_internal_tts",
+    )
+    voice_source = voice_source_path.read_text()
+    assert "if resolve_processor(provider) is None:" in voice_source
+    guardian_source = (BACKEND / "ella" / "routers" / "guardian.py").read_text()
+    assert 'headers["X-Ella-Subject-Uid"] = req.uid' in guardian_source
+
+
+def test_selected_stt_provider_must_map_to_disclosed_recipient():
+    source = (BACKEND / "routers" / "transcribe.py").read_text()
+
+    selection_position = source.index("selected_stt_service = stt_service")
+    disclosure_position = source.index(
+        'if resolve_processor(_stt_service_value(stt_service) or "") is None:',
+        selection_position,
+    )
+    provider_connect_position = source.index("# DEEPGRAM", disclosure_position)
+
+    assert selection_position < disclosure_position < provider_connect_position
+
+
+def test_legacy_payload_routes_cannot_bypass_consent_gate():
+    protected_paths = {
+        "/v2/messages",
+        "/v2/initial-message",
+        "/v2/voice-messages",
+        "/v2/voice-message/transcribe",
+        "/v2/files",
+        "/v1/files",
+        "/v1/initial-message",
+    }
+    gated_paths = _gated_route_paths(
+        BACKEND / "routers" / "chat.py",
+        "require_current_ai_consent",
+    )
+
+    assert protected_paths <= gated_paths
+
+
+def test_stored_transcript_processing_routes_require_current_consent():
+    protected_paths = {
+        "/v1/conversations",
+        "/v1/conversations/{conversation_id}/reprocess",
+        "/v1/conversations/{conversation_id}/test-prompt",
+        "/v1/conversations/merge",
+    }
+    gated_paths = _gated_route_paths(
+        BACKEND / "routers" / "conversations.py",
+        "require_current_ai_consent",
+    )
+
+    assert protected_paths <= gated_paths
+
+
+def test_correction_submit_is_gated_but_receipt_and_undo_remain_available():
+    gated_paths = _gated_route_paths(
+        BACKEND / "ella" / "routers" / "corrections.py",
+        "require_current_ai_consent",
+    )
+
+    assert "/v1/ella/conversations/{conversation_id}/corrections" in gated_paths
+    assert "/v1/conversations/{conversation_id}/corrections" in gated_paths
+    assert "/v1/ella/conversations/{conversation_id}/corrections/{correction_id}" not in gated_paths
+    assert "/v1/ella/conversations/{conversation_id}/corrections/{correction_id}/undo" not in gated_paths

--- a/backend/tests/unit/test_ella_ai_consent_route_gates.py
+++ b/backend/tests/unit/test_ella_ai_consent_route_gates.py
@@ -29,6 +29,17 @@ def _gated_route_paths(source_path: Path, dependency_name: str) -> set[str]:
     return gated_paths
 
 
+def _function_source(source_path: Path, function_name: str) -> str:
+    source = source_path.read_text()
+    tree = ast.parse(source)
+    function = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name
+    )
+    return ast.get_source_segment(source, function)
+
+
 def test_authenticated_ai_egress_routes_share_the_consent_gate():
     assert "/chat/stream" in _gated_route_paths(
         BACKEND / "ella" / "routers" / "chat.py",
@@ -115,6 +126,49 @@ def test_stored_transcript_processing_routes_require_current_consent():
     )
 
     assert protected_paths <= gated_paths
+
+
+def test_shared_conversation_processor_gates_target_uid_before_model_work():
+    source_path = BACKEND / "utils" / "conversations" / "process_conversation.py"
+    source = _function_source(source_path, "process_conversation")
+
+    assert source.index("assert_current_ai_consent(uid)") < source.index("_get_structured(")
+    for caller in ("integration.py", "workflow.py", "developer.py"):
+        assert "process_conversation(" in (BACKEND / "routers" / caller).read_text()
+
+
+def test_stored_sync_gates_target_uid_before_deepgram_and_processing():
+    source_path = BACKEND / "routers" / "sync.py"
+    process_segment_source = _function_source(source_path, "process_segment")
+
+    assert process_segment_source.index("assert_current_ai_consent(uid)") < process_segment_source.index(
+        "deepgram_prerecorded("
+    )
+    assert "/v1/sync-local-files" in _gated_route_paths(source_path, "require_current_ai_consent")
+
+
+def test_legacy_initial_message_helper_gates_every_model_call_path():
+    source = _function_source(BACKEND / "routers" / "chat.py", "initial_message_util")
+
+    assert source.index("assert_current_ai_consent(uid)") < source.index("initial_chat_message(")
+
+
+def test_guardian_model_and_legacy_callback_tts_gate_target_uid():
+    consolidate_source = _function_source(BACKEND / "ella" / "routers" / "guardian.py", "_consolidate_queue")
+    notification_source = _function_source(BACKEND / "ella" / "routers" / "callbacks.py", "ella_notification")
+
+    assert consolidate_source.index("assert_current_ai_consent(uid)") < consolidate_source.index("httpx.AsyncClient(")
+    assert notification_source.index("assert_current_ai_consent(request.uid)") < notification_source.index(
+        "_generate_tts_audio("
+    )
+
+
+def test_consent_authority_router_is_registered_outside_ella_feature_switch():
+    main_source = (BACKEND / "main.py").read_text()
+    ella_init_source = (BACKEND / "ella" / "__init__.py").read_text()
+
+    assert "app.include_router(ai_consent.router)" in main_source
+    assert "ai_consent_router" not in ella_init_source
 
 
 def test_correction_submit_is_gated_but_receipt_and_undo_remain_available():

--- a/backend/tests/unit/test_ella_guardian_delivery.py
+++ b/backend/tests/unit/test_ella_guardian_delivery.py
@@ -39,6 +39,10 @@ ella_app_settings_module.build_effective_voice_settings = lambda _uid, voice: {
 }
 sys.modules["ella.services.app_settings"] = ella_app_settings_module
 
+ai_consent_module = types.ModuleType("ella.services.ai_consent")
+ai_consent_module.assert_current_ai_consent = lambda uid: uid
+sys.modules["ella.services.ai_consent"] = ai_consent_module
+
 runtime_resolver_module = types.ModuleType("ella.services.runtime_resolver")
 runtime_resolver_module.runtime_bindings_enabled = lambda _uid: False
 sys.modules["ella.services.runtime_resolver"] = runtime_resolver_module
@@ -559,3 +563,26 @@ def test_guardian_alerts_endpoint_uses_authenticated_uid_not_query_uid(monkeypat
     assert body["uid"] == "auth-uid"
     assert body["alerts"][0]["queue_item_id"] == "guardian_auth"
     assert pool.fetch_args[0] == ("auth-uid", 50)
+
+
+def test_guardian_consolidation_stops_before_provider_after_revoke(monkeypatch):
+    def reject(uid):
+        assert uid == "auth-uid"
+        raise HTTPException(status_code=403, detail={"code": "ai_consent_required", "decision": "revoked"})
+
+    monkeypatch.setattr(guardian, "assert_current_ai_consent", reject)
+    monkeypatch.setattr(guardian.httpx, "AsyncClient", _FakeAsyncClient)
+    _FakeAsyncClient.posts.clear()
+
+    with pytest.raises(HTTPException) as error:
+        asyncio.run(
+            guardian._consolidate_queue(
+                uid="auth-uid",
+                pending=[{"trigger_type": "wake_word", "created_at": "now", "message": "Private alert"}],
+                recently_consumed=[],
+                chat_turns=[{"role": "user", "content": "Private context"}],
+            )
+        )
+
+    assert error.value.detail["decision"] == "revoked"
+    assert _FakeAsyncClient.posts == []

--- a/backend/tests/unit/test_voice_proxy_auth.py
+++ b/backend/tests/unit/test_voice_proxy_auth.py
@@ -309,6 +309,30 @@ def test_voice_proxy_accepts_complete_memory_scope_claims():
     assert principal.can_reinterpret is False
 
 
+def test_voice_proxy_rechecks_current_consent_after_token_issuance(monkeypatch):
+    def reject_revoked(uid):
+        assert uid == "uid-a"
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "ai_consent_required", "decision": "revoked"},
+        )
+
+    monkeypatch.setattr(voice, "assert_current_ai_consent", reject_revoked)
+
+    with pytest.raises(HTTPException) as error:
+        voice.authenticate_voice_proxy_request(
+            _request(
+                {"uid": "uid-a"},
+                token=_token("uid-a"),
+                service_token="test-proxy-secret",
+            ),
+            "uid-a",
+        )
+
+    assert error.value.status_code == 403
+    assert error.value.detail == {"code": "ai_consent_required", "decision": "revoked"}
+
+
 @pytest.mark.parametrize("endpoint", ["context", "search", "tool"])
 def test_two_uid_request_is_denied_before_any_data_lookup(endpoint):
     bodies = {

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -61,6 +61,7 @@ from utils.notifications import send_notification
 from utils.other.hume import get_hume, HumeJobCallbackModel, HumeJobModelPredictionResponseModel
 from utils.retrieval.rag import retrieve_rag_conversation_context
 from utils.webhooks import conversation_created_webhook
+from ella.services.ai_consent import assert_current_ai_consent
 
 # ====== ELLA POST-PROCESS HOOK IMPORT ======
 try:
@@ -561,6 +562,8 @@ def process_conversation(
     is_reprocess: bool = False,
     app_id: Optional[str] = None,
 ) -> Conversation:
+    assert_current_ai_consent(uid)
+
     # Fetch meeting context from Firestore if meeting_id is associated with this conversation
     if hasattr(conversation, 'id') and conversation.id:
         meeting_id = redis_db.get_conversation_meeting_id(conversation.id)


### PR DESCRIPTION
## Scope

Backend slice for ellaaicare/ella-ai#1123. This does not close the parent release gate.

- adds authenticated UID-scoped AI consent policy/status/grant/decline/revoke and receipt APIs
- stores immutable opaque receipts and enforces exact current policy/hash
- gates provisioning, chat, voice session/TTS, live and stored transcription, correction, upload, and conversation-processing egress paths
- binds internal Guardian TTS authorization to the target user receipt
- returns a non-identifying completion receipt from synchronous account deletion
- leaves rollout enforcement default-off with a UID canary allowlist

## Processor inventory correction

The repo-supported production surface is broader than iOS PR #334 v4: Soniox is the current default STT, Speechmatics remains routable, and Inworld plus Ella self-hosted Kokoro/Fish TTS are supported. This PR therefore publishes `ai-data-processors-v5` with processor hash `sha256:9c2529babbd6241f20242cf0836baf7e1899d05bb3d945a0d38a357113d4cbc4`. The client must consume the server policy and fail closed; it must not treat a bundled manifest or `ELLA_HERMES_PROVISIONING_GATE` as consent authority.

## Validation

- consent and route-gate unit suite: 25 passed
- broader consent/onboarding/listen/chat/Guardian/voice/STT focused suite: 78 passed
- correction suite: 59 passed
- conversation processing suite: 30 passed
- voice canary suite: 5 passed
- `py_compile`: passed for modified Python modules
- `git diff --check`: passed
- optional Black module unavailable in this worktree environment
- GitNexus repository analysis attempted twice; native parser workers repeatedly idle-timed out and the generated cache was excluded

## Rollout gate

No deployment or production configuration change is included. Deploy API with enforcement off, integrate/update iOS #334, run a synthetic UID canary, update Privacy Policy/App Privacy/Review Notes to the exact v5 inventory, then consider global enforcement. No TestFlight or App Store action until the parent release gate is cleared.