### PR TITLE
Add managed-cloud AI consent v6 on iOS

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -21,13 +21,19 @@ class SharedPreferencesUtil {
   static String _verifiedAiConsentReceiptId = '';
   static String _verifiedAiConsentPolicyVersion = '';
   static String _verifiedAiConsentProcessorSetHash = '';
+  static String _verifiedAiConsentProfileBindingId = '';
+  static String _verifiedAiConsentScopeVersion = '';
+  static String _verifiedAiConsentScopeHash = '';
   static DateTime? _verifiedAiConsentAt;
 
   static const bool isPublicBuild = bool.fromEnvironment('ELLA_PUBLIC_BUILD');
   static const bool isTodayDesignPreview = bool.fromEnvironment('ELLA_TODAY_DESIGN_PREVIEW');
-  static const String currentAiConsentContractVersion = 'ai-data-processors-v5';
+  static const String currentAiConsentContractVersion = 'ai-data-processors-v6';
   static const String currentAiConsentProcessorSetHash =
-      'sha256:9c2529babbd6241f20242cf0836baf7e1899d05bb3d945a0d38a357113d4cbc4';
+      'sha256:dd84e4a9da1166cff66e5de55c2570d0496a2c89d46ca431530e993758616296';
+  static const String currentAiConsentScopeVersion = 'managed-cloud-internal-pilot-v1';
+  static const String currentAiConsentScopeHash =
+      'sha256:727b1db818ce79090a02279f1cc6d15dfc3d65a58592b13fbed53ad048c38a30';
   static const String currentAiConsentReceiptPrefix = 'aicr_';
 
   factory SharedPreferencesUtil() {
@@ -70,6 +76,7 @@ class SharedPreferencesUtil {
   String? get verifiedPersonaId => getString('verifiedPersonaId');
 
   set verifiedPersonaId(String? value) {
+    if (value != verifiedPersonaId) clearAiConsentServerVerification();
     if (value != null) {
       _preferences?.setString('verifiedPersonaId', value);
     } else {
@@ -217,7 +224,11 @@ class SharedPreferencesUtil {
     if (!accepted ||
         uid.isEmpty ||
         !aiConsentReceiptId.startsWith(currentAiConsentReceiptPrefix) ||
-        aiConsentReceiptUid != uid) {
+        aiConsentReceiptUid != uid ||
+        aiConsentProfileBindingId.isEmpty ||
+        aiConsentScopeVersion != currentAiConsentScopeVersion ||
+        aiConsentScopeHash != currentAiConsentScopeHash ||
+        DateTime.tryParse(aiConsentServerDecidedAt) == null) {
       return false;
     }
     final verifiedAt = _verifiedAiConsentAt;
@@ -226,7 +237,10 @@ class SharedPreferencesUtil {
         _verifiedAiConsentUid == uid &&
         _verifiedAiConsentReceiptId == aiConsentReceiptId &&
         _verifiedAiConsentPolicyVersion == currentAiConsentContractVersion &&
-        _verifiedAiConsentProcessorSetHash == currentAiConsentProcessorSetHash;
+        _verifiedAiConsentProcessorSetHash == currentAiConsentProcessorSetHash &&
+        _verifiedAiConsentProfileBindingId == aiConsentProfileBindingId &&
+        _verifiedAiConsentScopeVersion == currentAiConsentScopeVersion &&
+        _verifiedAiConsentScopeHash == currentAiConsentScopeHash;
   }
 
   Duration? get aiConsentServerVerificationRemaining {
@@ -235,7 +249,10 @@ class SharedPreferencesUtil {
         _verifiedAiConsentUid != uid ||
         _verifiedAiConsentReceiptId != aiConsentReceiptId ||
         _verifiedAiConsentPolicyVersion != currentAiConsentContractVersion ||
-        _verifiedAiConsentProcessorSetHash != currentAiConsentProcessorSetHash) {
+        _verifiedAiConsentProcessorSetHash != currentAiConsentProcessorSetHash ||
+        _verifiedAiConsentProfileBindingId != aiConsentProfileBindingId ||
+        _verifiedAiConsentScopeVersion != currentAiConsentScopeVersion ||
+        _verifiedAiConsentScopeHash != currentAiConsentScopeHash) {
       return null;
     }
     final remaining = aiConsentServerVerificationTtl - DateTime.now().difference(verifiedAt);
@@ -258,6 +275,14 @@ class SharedPreferencesUtil {
 
   String get aiConsentLocale => getString('aiConsentLocale');
 
+  String get aiConsentProfileBindingId => getString('aiConsentProfileBindingId');
+
+  String get aiConsentScopeVersion => getString('aiConsentScopeVersion');
+
+  String get aiConsentScopeHash => getString('aiConsentScopeHash');
+
+  String get aiConsentServerDecidedAt => getString('aiConsentServerDecidedAt');
+
   String get aiConsentDeferredVersion => getString('aiConsentDeferredVersion');
 
   bool get isCurrentAiConsentDeferred => aiConsentDeferredVersion == currentAiConsentContractVersion;
@@ -266,7 +291,8 @@ class SharedPreferencesUtil {
       uid.isNotEmpty &&
       aiConsentAccepted &&
       aiConsentReceiptId.startsWith(currentAiConsentReceiptPrefix) &&
-      aiConsentReceiptUid == uid;
+      aiConsentReceiptUid == uid &&
+      aiConsentProfileBindingId.isNotEmpty;
 
   bool hasPriorAccountBoundAiConsent(String uid) =>
       uid.isNotEmpty &&
@@ -281,12 +307,18 @@ class SharedPreferencesUtil {
     required String receiptId,
     required String policyVersion,
     required String processorSetHash,
+    required String profileBindingId,
+    required String scopeVersion,
+    required String scopeHash,
     DateTime? verifiedAt,
   }) {
     if (uid.isEmpty ||
         !receiptId.startsWith(currentAiConsentReceiptPrefix) ||
         policyVersion != currentAiConsentContractVersion ||
-        processorSetHash != currentAiConsentProcessorSetHash) {
+        processorSetHash != currentAiConsentProcessorSetHash ||
+        profileBindingId.isEmpty ||
+        scopeVersion != currentAiConsentScopeVersion ||
+        scopeHash != currentAiConsentScopeHash) {
       clearAiConsentServerVerification();
       return;
     }
@@ -294,6 +326,9 @@ class SharedPreferencesUtil {
     _verifiedAiConsentReceiptId = receiptId;
     _verifiedAiConsentPolicyVersion = policyVersion;
     _verifiedAiConsentProcessorSetHash = processorSetHash;
+    _verifiedAiConsentProfileBindingId = profileBindingId;
+    _verifiedAiConsentScopeVersion = scopeVersion;
+    _verifiedAiConsentScopeHash = scopeHash;
     _verifiedAiConsentAt = verifiedAt ?? DateTime.now();
   }
 
@@ -302,6 +337,9 @@ class SharedPreferencesUtil {
     _verifiedAiConsentReceiptId = '';
     _verifiedAiConsentPolicyVersion = '';
     _verifiedAiConsentProcessorSetHash = '';
+    _verifiedAiConsentProfileBindingId = '';
+    _verifiedAiConsentScopeVersion = '';
+    _verifiedAiConsentScopeHash = '';
     _verifiedAiConsentAt = null;
   }
 
@@ -310,6 +348,8 @@ class SharedPreferencesUtil {
     String uid = '',
     String clientVersion = '',
     String locale = '',
+    String profileBindingId = '',
+    String serverDecidedAt = '',
   }) {
     aiConsentAccepted = true;
     aiConsentAcceptedAt = DateTime.now().toUtc().toIso8601String();
@@ -317,6 +357,10 @@ class SharedPreferencesUtil {
     saveString('aiConsentProcessorSetHash', currentAiConsentProcessorSetHash);
     saveString('aiConsentClientVersion', clientVersion);
     saveString('aiConsentLocale', locale);
+    saveString('aiConsentProfileBindingId', profileBindingId);
+    saveString('aiConsentScopeVersion', currentAiConsentScopeVersion);
+    saveString('aiConsentScopeHash', currentAiConsentScopeHash);
+    saveString('aiConsentServerDecidedAt', serverDecidedAt);
     remove('aiConsentDeferredVersion');
     if (receiptId.startsWith(currentAiConsentReceiptPrefix) && uid.isNotEmpty) {
       saveString('aiConsentReceiptId', receiptId);
@@ -342,6 +386,10 @@ class SharedPreferencesUtil {
     remove('aiConsentProcessorSetHash');
     remove('aiConsentClientVersion');
     remove('aiConsentLocale');
+    remove('aiConsentProfileBindingId');
+    remove('aiConsentScopeVersion');
+    remove('aiConsentScopeHash');
+    remove('aiConsentServerDecidedAt');
     remove('aiConsentDeferredVersion');
   }
 
@@ -718,6 +766,10 @@ class SharedPreferencesUtil {
       'aiConsentProcessorSetHash',
       'aiConsentClientVersion',
       'aiConsentLocale',
+      'aiConsentProfileBindingId',
+      'aiConsentScopeVersion',
+      'aiConsentScopeHash',
+      'aiConsentServerDecidedAt',
       'aiConsentDeferredVersion',
     ]) {
       await remove(key);

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -25,6 +25,7 @@ class SharedPreferencesUtil {
   static String _verifiedAiConsentScopeVersion = '';
   static String _verifiedAiConsentScopeHash = '';
   static DateTime? _verifiedAiConsentAt;
+  static int _aiConsentAuthorityGeneration = 0;
 
   static const bool isPublicBuild = bool.fromEnvironment('ELLA_PUBLIC_BUILD');
   static const bool isTodayDesignPreview = bool.fromEnvironment('ELLA_TODAY_DESIGN_PREVIEW');
@@ -51,11 +52,13 @@ class SharedPreferencesUtil {
   }
 
   set uid(String value) {
-    if (value != uid) clearAiConsentServerVerification();
+    if (value != uid) _invalidateAiConsentAuthority();
     saveString('uid', value);
   }
 
   String get uid => getString('uid');
+
+  int get aiConsentAuthorityGeneration => _aiConsentAuthorityGeneration;
 
   //-------------------------------- Device ----------------------------------//
 
@@ -76,7 +79,7 @@ class SharedPreferencesUtil {
   String? get verifiedPersonaId => getString('verifiedPersonaId');
 
   set verifiedPersonaId(String? value) {
-    if (value != verifiedPersonaId) clearAiConsentServerVerification();
+    if (value != verifiedPersonaId) _invalidateAiConsentAuthority();
     if (value != null) {
       _preferences?.setString('verifiedPersonaId', value);
     } else {
@@ -343,6 +346,11 @@ class SharedPreferencesUtil {
     _verifiedAiConsentAt = null;
   }
 
+  static void _invalidateAiConsentAuthority() {
+    _aiConsentAuthorityGeneration++;
+    clearAiConsentServerVerification();
+  }
+
   void acceptAiConsent({
     String receiptId = '',
     String uid = '',
@@ -351,6 +359,9 @@ class SharedPreferencesUtil {
     String profileBindingId = '',
     String serverDecidedAt = '',
   }) {
+    if (uid != aiConsentReceiptUid || profileBindingId != aiConsentProfileBindingId) {
+      _invalidateAiConsentAuthority();
+    }
     aiConsentAccepted = true;
     aiConsentAcceptedAt = DateTime.now().toUtc().toIso8601String();
     saveString('aiConsentContractVersion', currentAiConsentContractVersion);
@@ -377,7 +388,7 @@ class SharedPreferencesUtil {
   }
 
   void declineAiConsent() {
-    clearAiConsentServerVerification();
+    _invalidateAiConsentAuthority();
     aiConsentAccepted = false;
     remove('aiConsentAcceptedAt');
     remove('aiConsentReceiptId');
@@ -731,7 +742,7 @@ class SharedPreferencesUtil {
 
     if (previousUid == newUid) return;
 
-    clearAiConsentServerVerification();
+    _invalidateAiConsentAuthority();
 
     if (previousUid.isNotEmpty) {
       // Retained users keep compatibility preferences when returning to the

--- a/app/lib/ella/services/ai_consent_policy.dart
+++ b/app/lib/ella/services/ai_consent_policy.dart
@@ -10,12 +10,17 @@ class AiConsentProcessor {
   });
 
   factory AiConsentProcessor.fromJson(Map<String, dynamic> json) {
+    String readString(String key) {
+      final value = json[key];
+      return value is String ? value : '';
+    }
+
     return AiConsentProcessor(
-      id: json['id'] as String? ?? '',
-      name: json['legal_recipient'] as String? ?? '',
-      function: json['function'] as String? ?? '',
-      data: json['data'] as String? ?? '',
-      isThirdParty: json['third_party'] as bool? ?? true,
+      id: readString('id'),
+      name: readString('legal_recipient'),
+      function: readString('function'),
+      data: readString('data'),
+      isThirdParty: json['third_party'] is bool ? json['third_party'] as bool : true,
     );
   }
 
@@ -33,18 +38,30 @@ class AiConsentPolicy {
     required this.version,
     required this.processorSetHash,
     required this.canonicalProcessorSet,
+    required this.scopeVersion,
+    required this.scopeHash,
+    required this.canonicalScope,
     required this.processors,
   });
 
   factory AiConsentPolicy.fromJson(Map<String, dynamic> json) {
-    final processors = (json['processors'] as List<dynamic>? ?? const [])
+    String readString(String key) {
+      final value = json[key];
+      return value is String ? value : '';
+    }
+
+    final rawProcessors = json['processors'];
+    final processors = (rawProcessors is List<dynamic> ? rawProcessors : const <dynamic>[])
         .whereType<Map<String, dynamic>>()
         .map(AiConsentProcessor.fromJson)
         .toList(growable: false);
     return AiConsentPolicy(
-      version: json['version'] as String? ?? '',
-      processorSetHash: json['processor_set_hash'] as String? ?? '',
-      canonicalProcessorSet: json['canonical_processor_set'] as String? ?? '',
+      version: readString('version'),
+      processorSetHash: readString('processor_set_hash'),
+      canonicalProcessorSet: readString('canonical_processor_set'),
+      scopeVersion: readString('scope_version'),
+      scopeHash: readString('scope_hash'),
+      canonicalScope: readString('canonical_scope'),
       processors: processors,
     );
   }
@@ -52,12 +69,18 @@ class AiConsentPolicy {
   final String version;
   final String processorSetHash;
   final String canonicalProcessorSet;
+  final String scopeVersion;
+  final String scopeHash;
+  final String canonicalScope;
   final List<AiConsentProcessor> processors;
 
   bool get isBundledCurrent {
     if (version != bundled.version ||
         processorSetHash != bundled.processorSetHash ||
         canonicalProcessorSet != bundled.canonicalProcessorSet ||
+        scopeVersion != bundled.scopeVersion ||
+        scopeHash != bundled.scopeHash ||
+        canonicalScope != bundled.canonicalScope ||
         processors.length != bundled.processors.length) {
       return false;
     }
@@ -81,8 +104,15 @@ class AiConsentPolicy {
     processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
     canonicalProcessorSet: 'deepgram:stt|soniox:stt|speechmatics:stt|firebase:auth-infrastructure|'
         'hermes-self-hosted:agent-runtime|honcho-self-hosted:memory-context|ella-self-hosted-tts:tts|'
+        'nous-hermes-cloud:managed-agent-runtime|honcho-cloud:derived-memory-context|'
+        'openai-codex:managed-agent-model|photon:messaging-delivery|'
         'openrouter:model-routing|google-gemini:language-live-voice|openai:language-live-voice|'
         'groq:language|xai-grok:language-live-voice|inworld:tts|elevenlabs:tts-fallback',
+    scopeVersion: SharedPreferencesUtil.currentAiConsentScopeVersion,
+    scopeHash: SharedPreferencesUtil.currentAiConsentScopeHash,
+    canonicalScope: 'profile_binding=server-profile-v1|runtime_provider=hermes_cloud|'
+        'model_route=openai-codex/gpt-5.6-terra|memory_provider=honcho_cloud_profile_isolated|'
+        'photon_scope=shared_test_line_explicit_contact_v1;allow_all=false;caregiver=false;attachments=false',
     processors: [
       AiConsentProcessor(
         id: 'deepgram',
@@ -130,6 +160,31 @@ class AiConsentPolicy {
         isThirdParty: false,
       ),
       AiConsentProcessor(
+        id: 'nous-hermes-cloud',
+        name: 'Nous Research / Hermes Cloud',
+        function: 'Managed agent runtime',
+        data:
+            'Prompt policy, messages, transcripts, selected first-party context, session metadata, and model or tool usage',
+      ),
+      AiConsentProcessor(
+        id: 'honcho-cloud',
+        name: 'Honcho Cloud',
+        function: 'Profile-bound derived memory and context',
+        data: 'Consented derived memory, selected context, and memory relationships for the bound profile',
+      ),
+      AiConsentProcessor(
+        id: 'openai-codex',
+        name: 'OpenAI',
+        function: 'Managed agent model processing',
+        data: 'Model input and output through the approved OpenAI Codex OAuth route',
+      ),
+      AiConsentProcessor(
+        id: 'photon',
+        name: 'Photon',
+        function: 'Test/shared-line message delivery',
+        data: 'Message content and messaging identifiers for one explicitly allowed test contact',
+      ),
+      AiConsentProcessor(
         id: 'openrouter',
         name: 'OpenRouter',
         function: 'Model routing',
@@ -147,24 +202,14 @@ class AiConsentPolicy {
         function: 'Language processing and live voice',
         data: 'Text, selected context, or live microphone audio',
       ),
-      AiConsentProcessor(
-        id: 'groq',
-        name: 'Groq',
-        function: 'Language processing',
-        data: 'Text and selected context',
-      ),
+      AiConsentProcessor(id: 'groq', name: 'Groq', function: 'Language processing', data: 'Text and selected context'),
       AiConsentProcessor(
         id: 'xai-grok',
         name: 'xAI Grok',
         function: 'Language processing and live voice',
         data: 'Text, selected context, or live microphone audio',
       ),
-      AiConsentProcessor(
-        id: 'inworld',
-        name: 'Inworld AI',
-        function: 'Voice synthesis',
-        data: 'Response text',
-      ),
+      AiConsentProcessor(id: 'inworld', name: 'Inworld AI', function: 'Voice synthesis', data: 'Response text'),
       AiConsentProcessor(
         id: 'elevenlabs',
         name: 'ElevenLabs',

--- a/app/lib/ella/services/ella_ai_consent_service.dart
+++ b/app/lib/ella/services/ella_ai_consent_service.dart
@@ -29,6 +29,10 @@ class AiConsentStatus {
     required this.appVersion,
     required this.buildNumber,
     required this.locale,
+    required this.profileBindingId,
+    required this.scopeVersion,
+    required this.scopeHash,
+    required this.serverDecidedAt,
   });
 
   factory AiConsentStatus.fromJson(Map<String, dynamic> json) {
@@ -36,20 +40,29 @@ class AiConsentStatus {
         json['consent'] is Map<String, dynamic> ? json['consent'] as Map<String, dynamic> : const <String, dynamic>{};
     final receipt =
         json['receipt'] is Map<String, dynamic> ? json['receipt'] as Map<String, dynamic> : const <String, dynamic>{};
+    String readString(String key) {
+      final value = receipt[key] ?? consent[key];
+      return value is String ? value : '';
+    }
+
     final policy = json['policy'] is Map<String, dynamic>
         ? AiConsentPolicy.fromJson(json['policy'] as Map<String, dynamic>)
         : null;
     return AiConsentStatus(
-      subjectUid: json['subject_uid'] as String? ?? '',
-      authorized: json['authorized'] as bool? ?? false,
+      subjectUid: json['subject_uid'] is String ? json['subject_uid'] as String : '',
+      authorized: json['authorized'] is bool ? json['authorized'] as bool : false,
       policy: policy,
-      decision: receipt['decision'] as String? ?? consent['decision'] as String? ?? '',
-      receiptId: receipt['receipt_id'] as String? ?? consent['receipt_id'] as String? ?? '',
-      policyVersion: receipt['policy_version'] as String? ?? consent['policy_version'] as String? ?? '',
-      processorSetHash: receipt['processor_set_hash'] as String? ?? consent['processor_set_hash'] as String? ?? '',
-      appVersion: receipt['app_version'] as String? ?? consent['app_version'] as String? ?? '',
-      buildNumber: receipt['build_number'] as String? ?? consent['build_number'] as String? ?? '',
-      locale: receipt['locale'] as String? ?? consent['locale'] as String? ?? '',
+      decision: readString('decision'),
+      receiptId: readString('receipt_id'),
+      policyVersion: readString('policy_version'),
+      processorSetHash: readString('processor_set_hash'),
+      appVersion: readString('app_version'),
+      buildNumber: readString('build_number'),
+      locale: readString('locale'),
+      profileBindingId: readString('profile_binding_id'),
+      scopeVersion: readString('scope_version'),
+      scopeHash: readString('scope_hash'),
+      serverDecidedAt: DateTime.tryParse(readString('server_decided_at')),
     );
   }
 
@@ -63,8 +76,12 @@ class AiConsentStatus {
   final String appVersion;
   final String buildNumber;
   final String locale;
+  final String profileBindingId;
+  final String scopeVersion;
+  final String scopeHash;
+  final DateTime? serverDecidedAt;
 
-  bool isCurrentGrantFor(String uid) {
+  bool isCurrentGrantFor(String uid, {String? expectedProfileBindingId}) {
     return uid.isNotEmpty &&
         subjectUid == uid &&
         authorized &&
@@ -72,6 +89,11 @@ class AiConsentStatus {
         receiptId.startsWith(SharedPreferencesUtil.currentAiConsentReceiptPrefix) &&
         policyVersion == SharedPreferencesUtil.currentAiConsentContractVersion &&
         processorSetHash == SharedPreferencesUtil.currentAiConsentProcessorSetHash &&
+        profileBindingId.isNotEmpty &&
+        (expectedProfileBindingId == null || profileBindingId == expectedProfileBindingId) &&
+        scopeVersion == SharedPreferencesUtil.currentAiConsentScopeVersion &&
+        scopeHash == SharedPreferencesUtil.currentAiConsentScopeHash &&
+        serverDecidedAt != null &&
         (policy?.isBundledCurrent ?? false);
   }
 }
@@ -85,6 +107,8 @@ class AiConsentSubmission {
     required this.appVersion,
     required this.buildNumber,
     required this.locale,
+    required this.scopeVersion,
+    required this.scopeHash,
   });
 
   final AiConsentDecision decision;
@@ -94,6 +118,8 @@ class AiConsentSubmission {
   final String appVersion;
   final String buildNumber;
   final String locale;
+  final String scopeVersion;
+  final String scopeHash;
 
   Map<String, dynamic> toJson() => {
         'decision': decision.wireValue,
@@ -103,6 +129,8 @@ class AiConsentSubmission {
         'app_version': appVersion,
         'build_number': buildNumber,
         'locale': locale,
+        'scope_version': scopeVersion,
+        'scope_hash': scopeHash,
       };
 }
 
@@ -144,12 +172,7 @@ class EllaAiConsentHttpTransport implements EllaAiConsentTransport {
 
   @override
   Future<AiConsentStatus?> fetchStatus() async {
-    final response = await makeApiCall(
-      url: _endpoint,
-      headers: const {},
-      method: 'GET',
-      body: '',
-    );
+    final response = await makeApiCall(url: _endpoint, headers: const {}, method: 'GET', body: '');
     if (response?.statusCode != 200) return null;
     final body = _decodeMap(response!.body);
     return body == null ? null : AiConsentStatus.fromJson(body);
@@ -206,7 +229,11 @@ class EllaAiConsentService {
         SharedPreferencesUtil.clearAiConsentServerVerification();
         return false;
       }
-      if (!status.isCurrentGrantFor(uid)) {
+      final expectedProfileBindingId = _preferences.aiConsentProfileBindingId;
+      if (!status.isCurrentGrantFor(
+        uid,
+        expectedProfileBindingId: expectedProfileBindingId.isEmpty ? null : expectedProfileBindingId,
+      )) {
         if (status.subjectUid == uid && status.decision == AiConsentDecision.declined.wireValue) {
           _preferences.deferAiConsent();
         } else if (status.subjectUid == uid) {
@@ -250,10 +277,7 @@ class EllaAiConsentService {
         status.decision == AiConsentDecision.revoked.wireValue;
   }
 
-  Future<AiConsentStatus?> _submit({
-    required String uid,
-    required AiConsentDecision decision,
-  }) async {
+  Future<AiConsentStatus?> _submit({required String uid, required AiConsentDecision decision}) async {
     SharedPreferencesUtil.clearAiConsentServerVerification();
     if (uid.isEmpty || _preferences.uid != uid) return null;
     final policy = await _fetchAcceptedPolicy();
@@ -273,6 +297,8 @@ class EllaAiConsentService {
         appVersion: appVersion,
         buildNumber: buildNumber,
         locale: _localeFactory(),
+        scopeVersion: policy.scopeVersion,
+        scopeHash: policy.scopeHash,
       ),
     );
   }
@@ -289,12 +315,17 @@ class EllaAiConsentService {
       uid: uid,
       clientVersion: clientVersion,
       locale: status.locale,
+      profileBindingId: status.profileBindingId,
+      serverDecidedAt: status.serverDecidedAt!.toUtc().toIso8601String(),
     );
     _preferences.markAiConsentServerVerified(
       uid: uid,
       receiptId: status.receiptId,
       policyVersion: status.policyVersion,
       processorSetHash: status.processorSetHash,
+      profileBindingId: status.profileBindingId,
+      scopeVersion: status.scopeVersion,
+      scopeHash: status.scopeHash,
     );
   }
 }

--- a/app/lib/ella/services/ella_ai_consent_service.dart
+++ b/app/lib/ella/services/ella_ai_consent_service.dart
@@ -212,24 +212,27 @@ class EllaAiConsentService {
   final String Function() _localeFactory;
 
   Future<bool> refreshServerAuthority({required String uid}) async {
-    if (uid.isEmpty || _preferences.uid != uid) {
+    final authority = _captureAuthority(uid);
+    if (authority == null) {
       SharedPreferencesUtil.clearAiConsentServerVerification();
       return false;
     }
 
     try {
       final policy = await _fetchAcceptedPolicy();
-      if (policy == null) {
+      if (!_requireCurrentAuthority(authority) || policy == null) {
         SharedPreferencesUtil.clearAiConsentServerVerification();
         return false;
       }
 
       final status = await _transport.fetchStatus();
-      if (status == null || status.policy?.processorSetHash != policy.processorSetHash) {
+      if (!_requireCurrentAuthority(authority) ||
+          status == null ||
+          status.policy?.processorSetHash != policy.processorSetHash) {
         SharedPreferencesUtil.clearAiConsentServerVerification();
         return false;
       }
-      final expectedProfileBindingId = _preferences.aiConsentProfileBindingId;
+      final expectedProfileBindingId = authority.profileBindingId;
       if (!status.isCurrentGrantFor(
         uid,
         expectedProfileBindingId: expectedProfileBindingId.isEmpty ? null : expectedProfileBindingId,
@@ -244,8 +247,7 @@ class EllaAiConsentService {
         return false;
       }
 
-      _persistVerifiedGrant(uid, status);
-      return _preferences.aiConsentAccepted;
+      return _persistVerifiedGrant(authority, status) && _preferences.aiConsentAccepted;
     } catch (_) {
       SharedPreferencesUtil.clearAiConsentServerVerification();
       return false;
@@ -253,15 +255,22 @@ class EllaAiConsentService {
   }
 
   Future<String?> grantCurrentConsent({required String uid}) async {
-    final status = await _submit(uid: uid, decision: AiConsentDecision.granted);
-    if (status == null || !status.isCurrentGrantFor(uid)) return null;
-    _persistVerifiedGrant(uid, status);
+    final authority = _captureAuthority(uid);
+    if (authority == null) {
+      SharedPreferencesUtil.clearAiConsentServerVerification();
+      return null;
+    }
+    final status = await _submit(authority: authority, decision: AiConsentDecision.granted);
+    if (!_requireCurrentAuthority(authority) || status == null || !status.isCurrentGrantFor(uid)) return null;
+    if (!_persistVerifiedGrant(authority, status)) return null;
     return _preferences.aiConsentAccepted ? status.receiptId : null;
   }
 
   Future<bool> declineCurrentConsent({required String uid}) async {
     _preferences.deferAiConsent();
-    final status = await _submit(uid: uid, decision: AiConsentDecision.declined);
+    final authority = _captureAuthority(uid);
+    if (authority == null) return false;
+    final status = await _submit(authority: authority, decision: AiConsentDecision.declined);
     return status != null &&
         status.subjectUid == uid &&
         !status.authorized &&
@@ -270,25 +279,30 @@ class EllaAiConsentService {
 
   Future<bool> revokeCurrentConsent({required String uid}) async {
     _preferences.declineAiConsent();
-    final status = await _submit(uid: uid, decision: AiConsentDecision.revoked);
+    final authority = _captureAuthority(uid);
+    if (authority == null) return false;
+    final status = await _submit(authority: authority, decision: AiConsentDecision.revoked);
     return status != null &&
         status.subjectUid == uid &&
         !status.authorized &&
         status.decision == AiConsentDecision.revoked.wireValue;
   }
 
-  Future<AiConsentStatus?> _submit({required String uid, required AiConsentDecision decision}) async {
+  Future<AiConsentStatus?> _submit({
+    required _AiConsentAuthority authority,
+    required AiConsentDecision decision,
+  }) async {
     SharedPreferencesUtil.clearAiConsentServerVerification();
-    if (uid.isEmpty || _preferences.uid != uid) return null;
+    if (!_requireCurrentAuthority(authority)) return null;
     final policy = await _fetchAcceptedPolicy();
-    if (policy == null) return null;
+    if (!_requireCurrentAuthority(authority) || policy == null) return null;
 
     final fullVersion = _clientVersionFactory();
     final separator = fullVersion.lastIndexOf('+');
     final appVersion = separator > 0 ? fullVersion.substring(0, separator) : fullVersion;
     final buildNumber =
         separator > 0 && separator < fullVersion.length - 1 ? fullVersion.substring(separator + 1) : 'unknown';
-    return _transport.submit(
+    final status = await _transport.submit(
       AiConsentSubmission(
         decision: decision,
         policyVersion: policy.version,
@@ -301,6 +315,7 @@ class EllaAiConsentService {
         scopeHash: policy.scopeHash,
       ),
     );
+    return _requireCurrentAuthority(authority) ? status : null;
   }
 
   Future<AiConsentPolicy?> _fetchAcceptedPolicy() async {
@@ -308,18 +323,50 @@ class EllaAiConsentService {
     return policy?.isBundledCurrent == true ? policy : null;
   }
 
-  void _persistVerifiedGrant(String uid, AiConsentStatus status) {
+  _AiConsentAuthority? _captureAuthority(String uid) {
+    if (uid.isEmpty || _preferences.uid != uid) return null;
+    return _AiConsentAuthority(
+      generation: _preferences.aiConsentAuthorityGeneration,
+      uid: uid,
+      verifiedPersonaId: _preferences.verifiedPersonaId,
+      profileBindingId: _preferences.aiConsentProfileBindingId,
+    );
+  }
+
+  bool _isCurrentAuthority(_AiConsentAuthority authority) {
+    return _preferences.aiConsentAuthorityGeneration == authority.generation &&
+        _preferences.uid == authority.uid &&
+        _preferences.verifiedPersonaId == authority.verifiedPersonaId &&
+        _preferences.aiConsentProfileBindingId == authority.profileBindingId;
+  }
+
+  bool _requireCurrentAuthority(_AiConsentAuthority authority) {
+    if (_isCurrentAuthority(authority)) return true;
+    SharedPreferencesUtil.clearAiConsentServerVerification();
+    return false;
+  }
+
+  bool _persistVerifiedGrant(_AiConsentAuthority authority, AiConsentStatus status) {
+    if (!_requireCurrentAuthority(authority)) return false;
     final clientVersion = status.buildNumber.isEmpty ? status.appVersion : '${status.appVersion}+${status.buildNumber}';
     _preferences.acceptAiConsent(
       receiptId: status.receiptId,
-      uid: uid,
+      uid: authority.uid,
       clientVersion: clientVersion,
       locale: status.locale,
       profileBindingId: status.profileBindingId,
       serverDecidedAt: status.serverDecidedAt!.toUtc().toIso8601String(),
     );
+    final persistedAuthority = _captureAuthority(authority.uid);
+    if (persistedAuthority == null ||
+        persistedAuthority.verifiedPersonaId != authority.verifiedPersonaId ||
+        persistedAuthority.profileBindingId != status.profileBindingId ||
+        !_requireCurrentAuthority(persistedAuthority)) {
+      SharedPreferencesUtil.clearAiConsentServerVerification();
+      return false;
+    }
     _preferences.markAiConsentServerVerified(
-      uid: uid,
+      uid: authority.uid,
       receiptId: status.receiptId,
       policyVersion: status.policyVersion,
       processorSetHash: status.processorSetHash,
@@ -327,5 +374,20 @@ class EllaAiConsentService {
       scopeVersion: status.scopeVersion,
       scopeHash: status.scopeHash,
     );
+    return _requireCurrentAuthority(persistedAuthority);
   }
+}
+
+class _AiConsentAuthority {
+  const _AiConsentAuthority({
+    required this.generation,
+    required this.uid,
+    required this.verifiedPersonaId,
+    required this.profileBindingId,
+  });
+
+  final int generation;
+  final String uid;
+  final String? verifiedPersonaId;
+  final String profileBindingId;
 }

--- a/app/lib/ella/widgets/ai_consent_sheet.dart
+++ b/app/lib/ella/widgets/ai_consent_sheet.dart
@@ -9,13 +9,7 @@ import 'package:omi/utils/l10n_extensions.dart';
 class AiConsentSheet extends StatefulWidget {
   static final Uri privacyPolicyUri = Uri.parse('https://ella-ai-care.com/privacy');
 
-  const AiConsentSheet({
-    super.key,
-    this.onAccept,
-    this.onDecline,
-    this.onRequestDeletion,
-    this.reviewMode = false,
-  });
+  const AiConsentSheet({super.key, this.onAccept, this.onDecline, this.onRequestDeletion, this.reviewMode = false});
 
   final Future<bool> Function()? onAccept;
   final Future<bool> Function()? onDecline;
@@ -38,7 +32,7 @@ class AiConsentSheet extends StatefulWidget {
       backgroundColor: EllaColors.paper,
       shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(28))),
       builder: (_) => FractionallySizedBox(
-        heightFactor: reviewMode ? 0.78 : 0.68,
+        heightFactor: 0.92,
         child: AiConsentSheet(
           onAccept: onAccept,
           onDecline: onDecline,
@@ -107,6 +101,44 @@ class _AiConsentSheetState extends State<AiConsentSheet> {
     await widget.onRequestDeletion!.call();
   }
 
+  Widget _processorDisclosure({required IconData icon, required String title, required String body}) {
+    return Semantics(
+      container: true,
+      label: '$title. $body',
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(14),
+        decoration: BoxDecoration(
+          color: EllaColors.bgSecondary,
+          borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+          border: Border.all(color: EllaColors.cardEdge),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(icon, color: EllaColors.primary, size: 22),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(title, style: EllaTextStyles.body.copyWith(fontWeight: FontWeight.w700)),
+                  const SizedBox(height: 4),
+                  Text(
+                    body,
+                    style: Theme.of(
+                      context,
+                    ).textTheme.bodyMedium?.copyWith(color: EllaColors.textSecondary, height: 1.4),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final bodyStyle = Theme.of(context).textTheme.bodyLarge?.copyWith(color: EllaColors.textSecondary, height: 1.5);
@@ -123,6 +155,42 @@ class _AiConsentSheetState extends State<AiConsentSheet> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(context.l10n.aiConsentTitle, style: EllaTextStyles.display),
+                    const SizedBox(height: 16),
+                    Text(context.l10n.aiConsentManagedCloudIntro, style: bodyStyle),
+                    const SizedBox(height: 12),
+                    _processorDisclosure(
+                      icon: Icons.cloud_outlined,
+                      title: context.l10n.aiConsentHermesCloudTitle,
+                      body: context.l10n.aiConsentHermesCloudBody,
+                    ),
+                    const SizedBox(height: 10),
+                    _processorDisclosure(
+                      icon: Icons.auto_awesome_outlined,
+                      title: context.l10n.aiConsentOpenAiManagedTitle,
+                      body: context.l10n.aiConsentOpenAiManagedBody,
+                    ),
+                    const SizedBox(height: 10),
+                    _processorDisclosure(
+                      icon: Icons.psychology_alt_outlined,
+                      title: context.l10n.aiConsentHonchoCloudTitle,
+                      body: context.l10n.aiConsentHonchoCloudBody,
+                    ),
+                    const SizedBox(height: 10),
+                    _processorDisclosure(
+                      icon: Icons.message_outlined,
+                      title: context.l10n.aiConsentPhotonTitle,
+                      body: context.l10n.aiConsentPhotonBody,
+                    ),
+                    const SizedBox(height: 12),
+                    Container(
+                      width: double.infinity,
+                      padding: const EdgeInsets.all(14),
+                      decoration: BoxDecoration(
+                        color: EllaColors.primarySubtle,
+                        borderRadius: BorderRadius.circular(EllaSizes.radiusMedium),
+                      ),
+                      child: Text(context.l10n.aiConsentManagedCloudScope, style: bodyStyle),
+                    ),
                     const SizedBox(height: 16),
                     Text(context.l10n.aiConsentCompactSummary, style: bodyStyle),
                     const SizedBox(height: 12),
@@ -141,8 +209,10 @@ class _AiConsentSheetState extends State<AiConsentSheet> {
                     ),
                     if (_hasError) ...[
                       const SizedBox(height: 12),
-                      Text(context.l10n.somethingWentWrongTryAgain,
-                          style: bodyStyle?.copyWith(color: EllaColors.error)),
+                      Text(
+                        context.l10n.somethingWentWrongTryAgain,
+                        style: bodyStyle?.copyWith(color: EllaColors.error),
+                      ),
                     ],
                   ],
                 ),

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10333,7 +10333,7 @@
   "@necklaceResting": {
     "description": "Gentle device reconnection action shown on Today"
   },
-  "aiConsentTitle": "Ella listens to help remember.",
+  "aiConsentTitle": "Choose how Ella uses cloud AI",
   "@aiConsentTitle": {
     "description": "Locked first-run listening consent title"
   },
@@ -10469,18 +10469,58 @@
   "todayReadMore": "Read more",
   "voiceModalEndAction": "End",
   "ellaAuthDataDisclosure": "Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.",
-  "aiConsentCompactSummary": "Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella's self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella's self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.",
+  "aiConsentCompactSummary": "Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.",
   "aiConsentProcessorDetailsLink": "Full processor details in Privacy Policy",
-  "aiConsentNoSharingBeforeAllow": "Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.",
+  "aiConsentNoSharingBeforeAllow": "Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.",
   "aiConsentRevokeAction": "Revoke AI permission",
   "aiConsentDeleteDataAction": "Delete my account and data",
-  "aiConsentAllowedStatus": "Allowed for this account",
-  "aiConsentNotAllowedStatus": "Not allowed — AI sharing is off",
+  "aiConsentAllowedStatus": "Managed cloud AI allowed for this account and profile",
+  "aiConsentNotAllowedStatus": "Managed cloud AI sharing is off — v6 permission required",
   "aiConsentRevokeSyncFailed": "Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.",
   "aiConsentOffGateTitle": "AI sharing is off",
   "aiConsentOffGateBody": "Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.",
   "aiConsentReviewAction": "Review AI permission",
   "aiConsentActiveAudioStopped": "AI permission could not be verified. Recording and voice chat stopped.",
   "deleteAccountServerConfirmationFailed": "Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.",
-  "deleteAccountLocalCleanupFailed": "Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again."
+  "deleteAccountLocalCleanupFailed": "Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.",
+  "aiConsentManagedCloudIntro": "For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:",
+  "@aiConsentManagedCloudIntro": {
+    "description": "Introduces the named managed-cloud processors before first use"
+  },
+  "aiConsentHermesCloudTitle": "Nous Research / Hermes Cloud",
+  "@aiConsentHermesCloudTitle": {
+    "description": "Legal recipient and product name for the managed agent runtime"
+  },
+  "aiConsentHermesCloudBody": "Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.",
+  "@aiConsentHermesCloudBody": {
+    "description": "Data categories and purpose for Hermes Cloud"
+  },
+  "aiConsentOpenAiManagedTitle": "OpenAI",
+  "@aiConsentOpenAiManagedTitle": {
+    "description": "Legal recipient for the approved managed model route"
+  },
+  "aiConsentOpenAiManagedBody": "Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.",
+  "@aiConsentOpenAiManagedBody": {
+    "description": "Data categories and purpose for the managed OpenAI route"
+  },
+  "aiConsentHonchoCloudTitle": "Honcho Cloud",
+  "@aiConsentHonchoCloudTitle": {
+    "description": "Legal recipient and product name for managed derived memory"
+  },
+  "aiConsentHonchoCloudBody": "Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.",
+  "@aiConsentHonchoCloudBody": {
+    "description": "Data categories and purpose for Honcho Cloud"
+  },
+  "aiConsentPhotonTitle": "Photon",
+  "@aiConsentPhotonTitle": {
+    "description": "Legal recipient for the narrow messaging channel"
+  },
+  "aiConsentPhotonBody": "Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.",
+  "@aiConsentPhotonBody": {
+    "description": "Data categories and purpose for Photon"
+  },
+  "aiConsentManagedCloudScope": "This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.",
+  "@aiConsentManagedCloudScope": {
+    "description": "Explains the exact managed-cloud profile and messaging scope"
+  }
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -16604,6 +16604,66 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.'**
   String get deleteAccountLocalCleanupFailed;
+
+  /// Introduces the named managed-cloud processors before first use
+  ///
+  /// In en, this message translates to:
+  /// **'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:'**
+  String get aiConsentManagedCloudIntro;
+
+  /// Legal recipient and product name for the managed agent runtime
+  ///
+  /// In en, this message translates to:
+  /// **'Nous Research / Hermes Cloud'**
+  String get aiConsentHermesCloudTitle;
+
+  /// Data categories and purpose for Hermes Cloud
+  ///
+  /// In en, this message translates to:
+  /// **'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.'**
+  String get aiConsentHermesCloudBody;
+
+  /// Legal recipient for the approved managed model route
+  ///
+  /// In en, this message translates to:
+  /// **'OpenAI'**
+  String get aiConsentOpenAiManagedTitle;
+
+  /// Data categories and purpose for the managed OpenAI route
+  ///
+  /// In en, this message translates to:
+  /// **'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.'**
+  String get aiConsentOpenAiManagedBody;
+
+  /// Legal recipient and product name for managed derived memory
+  ///
+  /// In en, this message translates to:
+  /// **'Honcho Cloud'**
+  String get aiConsentHonchoCloudTitle;
+
+  /// Data categories and purpose for Honcho Cloud
+  ///
+  /// In en, this message translates to:
+  /// **'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.'**
+  String get aiConsentHonchoCloudBody;
+
+  /// Legal recipient for the narrow messaging channel
+  ///
+  /// In en, this message translates to:
+  /// **'Photon'**
+  String get aiConsentPhotonTitle;
+
+  /// Data categories and purpose for Photon
+  ///
+  /// In en, this message translates to:
+  /// **'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.'**
+  String get aiConsentPhotonBody;
+
+  /// Explains the exact managed-cloud profile and messaging scope
+  ///
+  /// In en, this message translates to:
+  /// **'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.'**
+  String get aiConsentManagedCloudScope;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8635,7 +8635,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8807,14 +8807,14 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8823,10 +8823,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8852,4 +8852,30 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8723,7 +8723,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8895,14 +8895,14 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8911,10 +8911,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8940,4 +8940,30 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8739,7 +8739,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8911,14 +8911,14 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8927,10 +8927,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8956,4 +8956,30 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8686,7 +8686,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8858,14 +8858,14 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8874,10 +8874,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8903,4 +8903,30 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8675,7 +8675,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8847,14 +8847,14 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8863,10 +8863,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8892,4 +8892,30 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8757,7 +8757,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8929,14 +8929,14 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8945,10 +8945,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8974,4 +8974,30 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8748,7 +8748,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8920,14 +8920,14 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8936,10 +8936,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8965,4 +8965,30 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8688,7 +8688,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8860,14 +8860,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8876,10 +8876,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8905,4 +8905,30 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8705,7 +8705,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8877,14 +8877,14 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8893,10 +8893,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8922,4 +8922,30 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8690,7 +8690,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8862,14 +8862,14 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8878,10 +8878,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8907,4 +8907,30 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8689,7 +8689,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8861,14 +8861,14 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8877,10 +8877,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8906,4 +8906,30 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8764,7 +8764,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8936,14 +8936,14 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8952,10 +8952,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8981,4 +8981,30 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8671,7 +8671,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8843,14 +8843,14 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8859,10 +8859,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8888,4 +8888,30 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8728,7 +8728,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8900,14 +8900,14 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8916,10 +8916,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8945,4 +8945,30 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8703,7 +8703,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8875,14 +8875,14 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8891,10 +8891,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8920,4 +8920,30 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8740,7 +8740,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8912,14 +8912,14 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8928,10 +8928,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8957,4 +8957,30 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8557,7 +8557,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8729,14 +8729,14 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8745,10 +8745,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8774,4 +8774,30 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8559,7 +8559,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8731,14 +8731,14 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8747,10 +8747,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8776,4 +8776,30 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8696,7 +8696,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8868,14 +8868,14 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8884,10 +8884,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8913,4 +8913,30 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8708,7 +8708,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8880,14 +8880,14 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8896,10 +8896,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8925,4 +8925,30 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8714,7 +8714,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8886,14 +8886,14 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8902,10 +8902,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8931,4 +8931,30 @@ class AppLocalizationsMs extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8716,7 +8716,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8888,14 +8888,14 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8904,10 +8904,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8933,4 +8933,30 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8686,7 +8686,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8858,14 +8858,14 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8874,10 +8874,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8903,4 +8903,30 @@ class AppLocalizationsNo extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8709,7 +8709,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8881,14 +8881,14 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8897,10 +8897,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8926,4 +8926,30 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8691,7 +8691,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8863,14 +8863,14 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8879,10 +8879,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8908,4 +8908,30 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8729,7 +8729,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8901,14 +8901,14 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8917,10 +8917,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8946,4 +8946,30 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8716,7 +8716,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8888,14 +8888,14 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8904,10 +8904,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8933,4 +8933,30 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8681,7 +8681,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8853,14 +8853,14 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8869,10 +8869,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8898,4 +8898,30 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8696,7 +8696,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8868,14 +8868,14 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8884,10 +8884,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8913,4 +8913,30 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8653,7 +8653,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8825,14 +8825,14 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8841,10 +8841,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8870,4 +8870,30 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8704,7 +8704,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8876,14 +8876,14 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8892,10 +8892,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8921,4 +8921,30 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8703,7 +8703,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8875,14 +8875,14 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8891,10 +8891,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8920,4 +8920,30 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8693,7 +8693,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8865,14 +8865,14 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8881,10 +8881,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8910,4 +8910,30 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8547,7 +8547,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get necklaceResting => 'Ella\'s necklace is resting — tap to reconnect';
 
   @override
-  String get aiConsentTitle => 'Ella listens to help remember.';
+  String get aiConsentTitle => 'Choose how Ella uses cloud AI';
 
   @override
   String get aiConsentBodyIntro =>
@@ -8719,14 +8719,14 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.';
+      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.';
+      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8735,10 +8735,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get aiConsentDeleteDataAction => 'Delete my account and data';
 
   @override
-  String get aiConsentAllowedStatus => 'Allowed for this account';
+  String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Not allowed — AI sharing is off';
+  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8764,4 +8764,30 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+  @override
+  String get aiConsentManagedCloudIntro =>
+      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+  @override
+  String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+  @override
+  String get aiConsentHermesCloudBody =>
+      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+  @override
+  String get aiConsentOpenAiManagedTitle => 'OpenAI';
+  @override
+  String get aiConsentOpenAiManagedBody =>
+      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+  @override
+  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  @override
+  String get aiConsentHonchoCloudBody =>
+      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+  @override
+  String get aiConsentPhotonTitle => 'Photon';
+  @override
+  String get aiConsentPhotonBody =>
+      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+  @override
+  String get aiConsentManagedCloudScope =>
+      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
 }

--- a/app/test/backend/preferences_public_mode_test.dart
+++ b/app/test/backend/preferences_public_mode_test.dart
@@ -32,6 +32,8 @@ void main() {
       uid: 'uid-a',
       clientVersion: '1.0.528+804',
       locale: 'en-US',
+      profileBindingId: 'profile-binding-a',
+      serverDecidedAt: '2026-07-27T00:00:00Z',
     );
 
     expect(preferences.aiConsentAccepted, isFalse);
@@ -43,6 +45,10 @@ void main() {
     expect(preferences.aiConsentProcessorSetHash, SharedPreferencesUtil.currentAiConsentProcessorSetHash);
     expect(preferences.aiConsentClientVersion, '1.0.528+804');
     expect(preferences.aiConsentLocale, 'en-US');
+    expect(preferences.aiConsentProfileBindingId, 'profile-binding-a');
+    expect(preferences.aiConsentScopeVersion, SharedPreferencesUtil.currentAiConsentScopeVersion);
+    expect(preferences.aiConsentScopeHash, SharedPreferencesUtil.currentAiConsentScopeHash);
+    expect(preferences.aiConsentServerDecidedAt, '2026-07-27T00:00:00Z');
 
     preferences.declineAiConsent();
     expect(preferences.aiConsentAccepted, isFalse);
@@ -71,18 +77,20 @@ void main() {
     preferences.acceptAiConsent(
       receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}current-receipt',
       uid: 'uid-a',
+      profileBindingId: 'profile-binding-a',
+      serverDecidedAt: '2026-07-27T00:00:00Z',
     );
     _markServerVerified(preferences, uid: 'uid-a', receiptId: 'aicr_current-receipt');
     expect(preferences.aiConsentAccepted, isTrue);
     expect(preferences.hasAccountBoundAiConsent('uid-a'), isTrue);
   });
 
-  test('existing v4 account requires v5 before any AI action', () async {
+  test('existing v5 account requires v6 before any managed-cloud AI action', () async {
     SharedPreferences.setMockInitialValues({
       'aiConsentAccepted': true,
       'aiConsentAcceptedAt': '2026-01-01T00:00:00Z',
-      'aiConsentContractVersion': 'ai-data-processors-v4',
-      'aiConsentReceiptId': 'ios-ai-consent:ai-data-processors-v4:receipt-a',
+      'aiConsentContractVersion': 'ai-data-processors-v5',
+      'aiConsentReceiptId': 'aicr_v5-receipt-a',
       'aiConsentReceiptUid': 'uid-a',
     });
     await SharedPreferencesUtil.init();
@@ -93,7 +101,7 @@ void main() {
     expect(preferences.hasPriorAccountBoundAiConsent('uid-b'), isFalse);
   });
 
-  test('deferred v5 remains inactive until a server-verified account grant', () {
+  test('deferred v6 remains inactive until a server-verified account and profile grant', () {
     final preferences = SharedPreferencesUtil();
     preferences.uid = 'uid-a';
 
@@ -104,12 +112,14 @@ void main() {
     preferences.acceptAiConsent(
       receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
       uid: 'uid-a',
+      profileBindingId: 'profile-binding-a',
+      serverDecidedAt: '2026-07-27T00:00:00Z',
     );
     expect(preferences.aiConsentAccepted, isFalse);
     _markServerVerified(preferences, uid: 'uid-a', receiptId: 'aicr_receipt-a');
     expect(preferences.aiConsentAccepted, isTrue);
     expect(preferences.isCurrentAiConsentDeferred, isFalse);
-    expect(preferences.aiConsentContractVersion, 'ai-data-processors-v5');
+    expect(preferences.aiConsentContractVersion, 'ai-data-processors-v6');
   });
 
   test('receipt-less acceptance clears stale authority and remains fail closed', () async {
@@ -137,6 +147,8 @@ void main() {
     preferences.acceptAiConsent(
       receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
       uid: 'uid-a',
+      profileBindingId: 'profile-binding-a',
+      serverDecidedAt: '2026-07-27T00:00:00Z',
     );
     _markServerVerified(preferences, uid: 'uid-a', receiptId: 'aicr_receipt-a');
     expect(preferences.aiConsentAccepted, isTrue);
@@ -155,6 +167,10 @@ void main() {
       'aiConsentProcessorSetHash': 'sha256:stale',
       'aiConsentReceiptId': '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
       'aiConsentReceiptUid': 'uid-a',
+      'aiConsentProfileBindingId': 'profile-binding-a',
+      'aiConsentScopeVersion': SharedPreferencesUtil.currentAiConsentScopeVersion,
+      'aiConsentScopeHash': SharedPreferencesUtil.currentAiConsentScopeHash,
+      'aiConsentServerDecidedAt': '2026-07-27T00:00:00Z',
     });
     await SharedPreferencesUtil.init();
 
@@ -164,13 +180,56 @@ void main() {
   test('expired server verification fails closed without deleting the cached receipt', () {
     final preferences = SharedPreferencesUtil();
     preferences.uid = 'uid-a';
-    preferences.acceptAiConsent(receiptId: 'aicr_receipt-a', uid: 'uid-a');
+    preferences.acceptAiConsent(
+      receiptId: 'aicr_receipt-a',
+      uid: 'uid-a',
+      profileBindingId: 'profile-binding-a',
+      serverDecidedAt: '2026-07-27T00:00:00Z',
+    );
     _markServerVerified(
       preferences,
       uid: 'uid-a',
       receiptId: 'aicr_receipt-a',
       verifiedAt: DateTime.now().subtract(SharedPreferencesUtil.aiConsentServerVerificationTtl),
     );
+
+    expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.aiConsentReceiptId, 'aicr_receipt-a');
+  });
+
+  test('provider, profile, or Photon scope drift fails closed without deleting the cached receipt', () async {
+    SharedPreferences.setMockInitialValues({
+      'uid': 'uid-a',
+      'aiConsentAccepted': true,
+      'aiConsentContractVersion': SharedPreferencesUtil.currentAiConsentContractVersion,
+      'aiConsentProcessorSetHash': SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+      'aiConsentReceiptId': 'aicr_receipt-a',
+      'aiConsentReceiptUid': 'uid-a',
+      'aiConsentProfileBindingId': 'profile-binding-a',
+      'aiConsentScopeVersion': SharedPreferencesUtil.currentAiConsentScopeVersion,
+      'aiConsentScopeHash': 'sha256:stale-scope',
+      'aiConsentServerDecidedAt': '2026-07-27T00:00:00Z',
+    });
+    await SharedPreferencesUtil.init();
+
+    expect(SharedPreferencesUtil().aiConsentAccepted, isFalse);
+    expect(SharedPreferencesUtil().aiConsentReceiptId, 'aicr_receipt-a');
+  });
+
+  test('profile selection change invalidates ephemeral authority until the server re-verifies it', () {
+    final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
+    preferences.verifiedPersonaId = 'persona-a';
+    preferences.acceptAiConsent(
+      receiptId: 'aicr_receipt-a',
+      uid: 'uid-a',
+      profileBindingId: 'profile-binding-a',
+      serverDecidedAt: '2026-07-27T00:00:00Z',
+    );
+    _markServerVerified(preferences, uid: 'uid-a', receiptId: 'aicr_receipt-a');
+    expect(preferences.aiConsentAccepted, isTrue);
+
+    preferences.verifiedPersonaId = 'persona-b';
 
     expect(preferences.aiConsentAccepted, isFalse);
     expect(preferences.aiConsentReceiptId, 'aicr_receipt-a');
@@ -188,6 +247,9 @@ void _markServerVerified(
     receiptId: receiptId,
     policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
     processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+    profileBindingId: 'profile-binding-a',
+    scopeVersion: SharedPreferencesUtil.currentAiConsentScopeVersion,
+    scopeHash: SharedPreferencesUtil.currentAiConsentScopeHash,
     verifiedAt: verifiedAt,
   );
 }

--- a/app/test/ella/services/ai_consent_active_session_lease_test.dart
+++ b/app/test/ella/services/ai_consent_active_session_lease_test.dart
@@ -14,12 +14,20 @@ void main() {
     await SharedPreferencesUtil.init();
     preferences = SharedPreferencesUtil();
     preferences.uid = 'uid-a';
-    preferences.acceptAiConsent(receiptId: 'aicr_receipt-a', uid: 'uid-a');
+    preferences.acceptAiConsent(
+      receiptId: 'aicr_receipt-a',
+      uid: 'uid-a',
+      profileBindingId: 'profile-binding-a',
+      serverDecidedAt: '2026-07-27T00:00:00Z',
+    );
     preferences.markAiConsentServerVerified(
       uid: 'uid-a',
       receiptId: 'aicr_receipt-a',
       policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
       processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+      profileBindingId: 'profile-binding-a',
+      scopeVersion: SharedPreferencesUtil.currentAiConsentScopeVersion,
+      scopeHash: SharedPreferencesUtil.currentAiConsentScopeHash,
     );
   });
 
@@ -36,6 +44,9 @@ void main() {
           receiptId: 'aicr_receipt-a',
           policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
           processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+          profileBindingId: 'profile-binding-a',
+          scopeVersion: SharedPreferencesUtil.currentAiConsentScopeVersion,
+          scopeHash: SharedPreferencesUtil.currentAiConsentScopeHash,
         );
         return true;
       },
@@ -45,10 +56,7 @@ void main() {
     );
 
     lease.start();
-    expect(
-      AiConsentActiveSessionLease.refreshInterval,
-      lessThan(SharedPreferencesUtil.aiConsentServerVerificationTtl),
-    );
+    expect(AiConsentActiveSessionLease.refreshInterval, lessThan(SharedPreferencesUtil.aiConsentServerVerificationTtl));
     await lease.refreshNow();
 
     expect(refreshCalls, 1);
@@ -59,10 +67,7 @@ void main() {
   });
 
   test('session opened near expiry refreshes immediately rather than waiting a fresh interval', () {
-    expect(
-      AiConsentActiveSessionLease.refreshDelayFor(const Duration(seconds: 30)),
-      Duration.zero,
-    );
+    expect(AiConsentActiveSessionLease.refreshDelayFor(const Duration(seconds: 30)), Duration.zero);
     expect(
       AiConsentActiveSessionLease.refreshDelayFor(SharedPreferencesUtil.aiConsentServerVerificationTtl),
       AiConsentActiveSessionLease.refreshInterval,

--- a/app/test/ella/services/ai_consent_policy_test.dart
+++ b/app/test/ella/services/ai_consent_policy_test.dart
@@ -7,15 +7,15 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/services/ai_consent_policy.dart';
 
 void main() {
-  test('v5 fallback manifest matches the accepted server processor contract', () {
+  test('v6 fallback manifest matches the accepted managed-cloud processor and scope contract', () {
     const policy = AiConsentPolicy.bundled;
     expect(policy.version, SharedPreferencesUtil.currentAiConsentContractVersion);
     expect(policy.processorSetHash, SharedPreferencesUtil.currentAiConsentProcessorSetHash);
     expect(policy.processorSetHash, startsWith('sha256:'));
-    expect(
-      policy.processorSetHash,
-      'sha256:${sha256.convert(utf8.encode(policy.canonicalProcessorSet))}',
-    );
+    expect(policy.processorSetHash, 'sha256:${sha256.convert(utf8.encode(policy.canonicalProcessorSet))}');
+    expect(policy.scopeVersion, SharedPreferencesUtil.currentAiConsentScopeVersion);
+    expect(policy.scopeHash, SharedPreferencesUtil.currentAiConsentScopeHash);
+    expect(policy.scopeHash, 'sha256:${sha256.convert(utf8.encode(policy.canonicalScope))}');
 
     final names = policy.processors.map((processor) => processor.name).toSet();
     expect(
@@ -28,6 +28,9 @@ void main() {
         'Ella self-hosted Hermes',
         'Ella self-hosted Honcho',
         'Ella self-hosted voice synthesis',
+        'Nous Research / Hermes Cloud',
+        'Honcho Cloud',
+        'Photon',
         'OpenRouter',
         'Google Gemini',
         'OpenAI',
@@ -39,6 +42,10 @@ void main() {
     );
     expect(policy.processors.every((processor) => processor.function.isNotEmpty), isTrue);
     expect(policy.processors.every((processor) => processor.data.isNotEmpty), isTrue);
+    expect(policy.canonicalScope, contains('openai-codex/gpt-5.6-terra'));
+    expect(policy.canonicalScope, contains('allow_all=false'));
+    expect(policy.canonicalScope, contains('caregiver=false'));
+    expect(policy.canonicalScope, contains('attachments=false'));
     expect(policy.isBundledCurrent, isTrue);
   });
 
@@ -47,7 +54,45 @@ void main() {
       'version': SharedPreferencesUtil.currentAiConsentContractVersion,
       'processor_set_hash': 'sha256:changed',
       'canonical_processor_set': AiConsentPolicy.bundled.canonicalProcessorSet,
+      'scope_version': AiConsentPolicy.bundled.scopeVersion,
+      'scope_hash': AiConsentPolicy.bundled.scopeHash,
+      'canonical_scope': AiConsentPolicy.bundled.canonicalScope,
       'processors': const [],
+    });
+
+    expect(policy.isBundledCurrent, isFalse);
+  });
+
+  test('a v5 policy cannot authorize the managed-cloud v6 scope', () {
+    final policy = AiConsentPolicy.fromJson({
+      'version': 'ai-data-processors-v5',
+      'processor_set_hash': 'sha256:9c2529babbd6241f20242cf0836baf7e1899d05bb3d945a0d38a357113d4cbc4',
+      'canonical_processor_set': AiConsentPolicy.bundled.canonicalProcessorSet,
+      'processors': const [],
+    });
+
+    expect(policy.isBundledCurrent, isFalse);
+  });
+
+  test('provider or Photon scope drift requires reconsent even when processors are unchanged', () {
+    final policy = AiConsentPolicy.fromJson({
+      'version': AiConsentPolicy.bundled.version,
+      'processor_set_hash': AiConsentPolicy.bundled.processorSetHash,
+      'canonical_processor_set': AiConsentPolicy.bundled.canonicalProcessorSet,
+      'scope_version': AiConsentPolicy.bundled.scopeVersion,
+      'scope_hash': 'sha256:changed',
+      'canonical_scope': AiConsentPolicy.bundled.canonicalScope,
+      'processors': AiConsentPolicy.bundled.processors
+          .map(
+            (processor) => {
+              'id': processor.id,
+              'legal_recipient': processor.name,
+              'function': processor.function,
+              'data': processor.data,
+              'third_party': processor.isThirdParty,
+            },
+          )
+          .toList(),
     });
 
     expect(policy.isBundledCurrent, isFalse);

--- a/app/test/ella/services/ella_chat_consent_test.dart
+++ b/app/test/ella/services/ella_chat_consent_test.dart
@@ -18,12 +18,17 @@ void main() {
     preferences.acceptAiConsent(
       receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
       uid: 'uid-a',
+      profileBindingId: 'profile-binding-a',
+      serverDecidedAt: '2026-07-27T00:00:00Z',
     );
     preferences.markAiConsentServerVerified(
       uid: 'uid-a',
       receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
       policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
       processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+      profileBindingId: 'profile-binding-a',
+      scopeVersion: SharedPreferencesUtil.currentAiConsentScopeVersion,
+      scopeHash: SharedPreferencesUtil.currentAiConsentScopeHash,
     );
     expect(preferences.aiConsentAccepted, isTrue);
     preferences.uid = 'uid-b';

--- a/app/test/ella/services/ella_provisioning_service_test.dart
+++ b/app/test/ella/services/ella_provisioning_service_test.dart
@@ -501,6 +501,85 @@ void main() {
     expect(preferences.aiConsentAccepted, isTrue);
   });
 
+  test('profile switch during delayed policy refresh cannot persist the stale grant', () async {
+    final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
+    preferences.verifiedPersonaId = 'persona-a';
+    final transport = _DeferredConsentPolicyTransport(statusResponse: _consentStatus());
+    final service = EllaAiConsentService(transport: transport);
+
+    final refresh = service.refreshServerAuthority(uid: 'uid-a');
+    await transport.policyStarted.future;
+    preferences.verifiedPersonaId = 'persona-b';
+    transport.completePolicy(AiConsentPolicy.bundled);
+
+    expect(await refresh, isFalse);
+    expect(transport.statusCalls, 0);
+    expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.aiConsentReceiptId, isEmpty);
+  });
+
+  test('account switch during delayed policy grant prevents submission and persistence', () async {
+    final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
+    preferences.verifiedPersonaId = 'persona-a';
+    final transport = _DeferredConsentPolicyTransport(submitResponse: _consentStatus());
+    final service = EllaAiConsentService(
+      transport: transport,
+      clientVersionFactory: () => '1.0.528+804',
+      localeFactory: () => 'en-US',
+    );
+
+    final grant = service.grantCurrentConsent(uid: 'uid-a');
+    await transport.policyStarted.future;
+    preferences.uid = 'uid-b';
+    transport.completePolicy(AiConsentPolicy.bundled);
+
+    expect(await grant, isNull);
+    expect(transport.submissions, isEmpty);
+    expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.aiConsentReceiptId, isEmpty);
+  });
+
+  test('account switch during delayed status refresh cannot persist the stale grant', () async {
+    final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
+    preferences.verifiedPersonaId = 'persona-a';
+    final transport = _DeferredConsentStatusTransport();
+    final service = EllaAiConsentService(transport: transport);
+
+    final refresh = service.refreshServerAuthority(uid: 'uid-a');
+    await transport.statusStarted.future;
+    preferences.uid = 'uid-b';
+    transport.complete(_consentStatus());
+
+    expect(await refresh, isFalse);
+    expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.aiConsentReceiptId, isEmpty);
+  });
+
+  test('profile switch during delayed grant submission cannot persist the stale receipt', () async {
+    final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
+    preferences.verifiedPersonaId = 'persona-a';
+    final transport = _DeferredConsentSubmitTransport();
+    final service = EllaAiConsentService(
+      transport: transport,
+      clientVersionFactory: () => '1.0.528+804',
+      localeFactory: () => 'en-US',
+    );
+
+    final grant = service.grantCurrentConsent(uid: 'uid-a');
+    await transport.submitStarted.future;
+    preferences.verifiedPersonaId = 'persona-b';
+    transport.complete(_consentStatus());
+
+    expect(await grant, isNull);
+    expect(transport.submissions, hasLength(1));
+    expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.aiConsentReceiptId, isEmpty);
+  });
+
   test('stale server status fails closed even if it claims authorization', () async {
     final preferences = SharedPreferencesUtil();
     preferences.uid = 'uid-a';
@@ -709,8 +788,40 @@ class _FakeConsentTransport implements EllaAiConsentTransport {
   }
 }
 
+class _DeferredConsentPolicyTransport implements EllaAiConsentTransport {
+  _DeferredConsentPolicyTransport({this.statusResponse, this.submitResponse});
+
+  final AiConsentStatus? statusResponse;
+  final AiConsentStatus? submitResponse;
+  final Completer<void> policyStarted = Completer<void>();
+  final Completer<AiConsentPolicy?> _policy = Completer<AiConsentPolicy?>();
+  final List<AiConsentSubmission> submissions = [];
+  int statusCalls = 0;
+
+  void completePolicy(AiConsentPolicy? policy) => _policy.complete(policy);
+
+  @override
+  Future<AiConsentPolicy?> fetchPolicy() {
+    policyStarted.complete();
+    return _policy.future;
+  }
+
+  @override
+  Future<AiConsentStatus?> fetchStatus() async {
+    statusCalls++;
+    return statusResponse;
+  }
+
+  @override
+  Future<AiConsentStatus?> submit(AiConsentSubmission submission) async {
+    submissions.add(submission);
+    return submitResponse;
+  }
+}
+
 class _DeferredConsentStatusTransport implements EllaAiConsentTransport {
   final Completer<AiConsentStatus?> _status = Completer<AiConsentStatus?>();
+  final Completer<void> statusStarted = Completer<void>();
 
   void complete(AiConsentStatus? status) => _status.complete(status);
 
@@ -718,11 +829,37 @@ class _DeferredConsentStatusTransport implements EllaAiConsentTransport {
   Future<AiConsentPolicy?> fetchPolicy() async => AiConsentPolicy.bundled;
 
   @override
-  Future<AiConsentStatus?> fetchStatus() => _status.future;
+  Future<AiConsentStatus?> fetchStatus() {
+    statusStarted.complete();
+    return _status.future;
+  }
 
   @override
   Future<AiConsentStatus?> submit(AiConsentSubmission submission) {
     throw StateError('submit should not be called');
+  }
+}
+
+class _DeferredConsentSubmitTransport implements EllaAiConsentTransport {
+  final Completer<AiConsentStatus?> _status = Completer<AiConsentStatus?>();
+  final Completer<void> submitStarted = Completer<void>();
+  final List<AiConsentSubmission> submissions = [];
+
+  void complete(AiConsentStatus? status) => _status.complete(status);
+
+  @override
+  Future<AiConsentPolicy?> fetchPolicy() async => AiConsentPolicy.bundled;
+
+  @override
+  Future<AiConsentStatus?> fetchStatus() {
+    throw StateError('status should not be called');
+  }
+
+  @override
+  Future<AiConsentStatus?> submit(AiConsentSubmission submission) {
+    submissions.add(submission);
+    submitStarted.complete();
+    return _status.future;
   }
 }
 

--- a/app/test/ella/services/ella_provisioning_service_test.dart
+++ b/app/test/ella/services/ella_provisioning_service_test.dart
@@ -148,37 +148,46 @@ void main() {
     expect(preferences.getStringList('cachedMessages'), isEmpty);
   });
 
-  test('same retained account preserves current consent and legacy preferences without making them authority',
-      () async {
-    SharedPreferences.setMockInitialValues({
-      'ellaProvisioningAccountUid': 'uid-a',
-      'ellaGatewayUrl': 'https://gateway.invalid',
-      'ellaGatewayToken': 'secret',
-      'ellaKey': 'legacy-key',
-      'aiConsentAccepted': true,
-      'aiConsentReceiptId': '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}consent-a',
-      'aiConsentReceiptUid': 'uid-a',
-      'aiConsentContractVersion': SharedPreferencesUtil.currentAiConsentContractVersion,
-      'aiConsentProcessorSetHash': SharedPreferencesUtil.currentAiConsentProcessorSetHash,
-      'uid': 'uid-a',
-    });
-    await SharedPreferencesUtil.init();
-    final preferences = SharedPreferencesUtil();
-    preferences.markAiConsentServerVerified(
-      uid: 'uid-a',
-      receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}consent-a',
-      policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
-      processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
-    );
+  test(
+    'same retained account preserves current consent and legacy preferences without making them authority',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        'ellaProvisioningAccountUid': 'uid-a',
+        'ellaGatewayUrl': 'https://gateway.invalid',
+        'ellaGatewayToken': 'secret',
+        'ellaKey': 'legacy-key',
+        'aiConsentAccepted': true,
+        'aiConsentReceiptId': '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}consent-a',
+        'aiConsentReceiptUid': 'uid-a',
+        'aiConsentContractVersion': SharedPreferencesUtil.currentAiConsentContractVersion,
+        'aiConsentProcessorSetHash': SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+        'aiConsentProfileBindingId': 'profile-binding-a',
+        'aiConsentScopeVersion': SharedPreferencesUtil.currentAiConsentScopeVersion,
+        'aiConsentScopeHash': SharedPreferencesUtil.currentAiConsentScopeHash,
+        'aiConsentServerDecidedAt': '2026-07-27T00:00:00Z',
+        'uid': 'uid-a',
+      });
+      await SharedPreferencesUtil.init();
+      final preferences = SharedPreferencesUtil();
+      preferences.markAiConsentServerVerified(
+        uid: 'uid-a',
+        receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}consent-a',
+        policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
+        processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+        profileBindingId: 'profile-binding-a',
+        scopeVersion: SharedPreferencesUtil.currentAiConsentScopeVersion,
+        scopeHash: SharedPreferencesUtil.currentAiConsentScopeHash,
+      );
 
-    await preferences.prepareEllaProvisioningAccount('uid-a');
+      await preferences.prepareEllaProvisioningAccount('uid-a');
 
-    expect(preferences.ellaGatewayUrl, 'https://gateway.invalid');
-    expect(preferences.ellaGatewayToken, 'secret');
-    expect(preferences.ellaKey, 'legacy-key');
-    expect(preferences.aiConsentAccepted, isTrue);
-    expect(preferences.hasAccountBoundAiConsent('uid-a'), isTrue);
-  });
+      expect(preferences.ellaGatewayUrl, 'https://gateway.invalid');
+      expect(preferences.ellaGatewayToken, 'secret');
+      expect(preferences.ellaKey, 'legacy-key');
+      expect(preferences.aiConsentAccepted, isTrue);
+      expect(preferences.hasAccountBoundAiConsent('uid-a'), isTrue);
+    },
+  );
 
   test('provider opens Home authority only for a complete ready receipt', () async {
     final transport = _FakeTransport(
@@ -356,12 +365,9 @@ void main() {
     provider.dispose();
   });
 
-  test('AI consent becomes authority only after an exact server v5 grant', () async {
+  test('AI consent becomes authority only after an exact server v6 managed-cloud grant', () async {
     SharedPreferencesUtil().uid = 'uid-a';
-    final transport = _FakeConsentTransport(
-      policy: AiConsentPolicy.bundled,
-      submitResponse: _consentStatus(),
-    );
+    final transport = _FakeConsentTransport(policy: AiConsentPolicy.bundled, submitResponse: _consentStatus());
     final service = EllaAiConsentService(
       transport: transport,
       requestIdFactory: () => 'request-0001',
@@ -383,16 +389,19 @@ void main() {
       'app_version': '1.0.528',
       'build_number': '804',
       'locale': 'en-US',
+      'scope_version': SharedPreferencesUtil.currentAiConsentScopeVersion,
+      'scope_hash': SharedPreferencesUtil.currentAiConsentScopeHash,
     });
     expect(SharedPreferencesUtil().hasAccountBoundAiConsent('uid-a'), isTrue);
     expect(SharedPreferencesUtil().aiConsentReceiptId, receiptId);
     expect(SharedPreferencesUtil().aiConsentProcessorSetHash, SharedPreferencesUtil.currentAiConsentProcessorSetHash);
     expect(SharedPreferencesUtil().aiConsentClientVersion, '1.0.528+804');
     expect(SharedPreferencesUtil().aiConsentLocale, 'en-US');
-    expect(
-      SharedPreferencesUtil().aiConsentContractVersion,
-      SharedPreferencesUtil.currentAiConsentContractVersion,
-    );
+    expect(SharedPreferencesUtil().aiConsentProfileBindingId, 'profile-binding-a');
+    expect(SharedPreferencesUtil().aiConsentScopeVersion, SharedPreferencesUtil.currentAiConsentScopeVersion);
+    expect(SharedPreferencesUtil().aiConsentScopeHash, SharedPreferencesUtil.currentAiConsentScopeHash);
+    expect(DateTime.tryParse(SharedPreferencesUtil().aiConsentServerDecidedAt), isNotNull);
+    expect(SharedPreferencesUtil().aiConsentContractVersion, SharedPreferencesUtil.currentAiConsentContractVersion);
   });
 
   test('AI consent stays disabled when the public policy is unavailable', () async {
@@ -413,13 +422,44 @@ void main() {
     expect(SharedPreferencesUtil().aiConsentReceiptId, isEmpty);
   });
 
+  test('decline submits only v6 consent metadata and grants no data authority', () async {
+    SharedPreferencesUtil().uid = 'uid-a';
+    final transport = _FakeConsentTransport(
+      policy: AiConsentPolicy.bundled,
+      submitResponse: _consentStatus(authorized: false, decision: 'declined'),
+    );
+    final service = EllaAiConsentService(
+      transport: transport,
+      requestIdFactory: () => 'request-decline',
+      clientVersionFactory: () => '1.0.528+804',
+      localeFactory: () => 'en-US',
+    );
+
+    final declined = await service.declineCurrentConsent(uid: 'uid-a');
+
+    expect(declined, isTrue);
+    expect(SharedPreferencesUtil().aiConsentAccepted, isFalse);
+    expect(transport.submissions, hasLength(1));
+    expect(transport.submissions.single.toJson(), {
+      'decision': 'declined',
+      'policy_version': SharedPreferencesUtil.currentAiConsentContractVersion,
+      'processor_set_hash': SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+      'request_id': 'request-decline',
+      'app_version': '1.0.528',
+      'build_number': '804',
+      'locale': 'en-US',
+      'scope_version': SharedPreferencesUtil.currentAiConsentScopeVersion,
+      'scope_hash': SharedPreferencesUtil.currentAiConsentScopeHash,
+    });
+    expect(transport.submissions.single.toJson().toString(), isNot(contains('message')));
+    expect(transport.submissions.single.toJson().toString(), isNot(contains('audio')));
+    expect(transport.submissions.single.toJson().toString(), isNot(contains('memory')));
+  });
+
   test('authenticated status refresh restores only an exact current server grant', () async {
     final preferences = SharedPreferencesUtil();
     preferences.uid = 'uid-a';
-    final transport = _FakeConsentTransport(
-      policy: AiConsentPolicy.bundled,
-      statusResponse: _consentStatus(),
-    );
+    final transport = _FakeConsentTransport(policy: AiConsentPolicy.bundled, statusResponse: _consentStatus());
     final service = EllaAiConsentService(transport: transport);
 
     final authorized = await service.refreshServerAuthority(uid: 'uid-a');
@@ -434,12 +474,20 @@ void main() {
   test('active authority remains valid while an early refresh is in flight', () async {
     final preferences = SharedPreferencesUtil();
     preferences.uid = 'uid-a';
-    preferences.acceptAiConsent(receiptId: 'aicr_server-receipt', uid: 'uid-a');
+    preferences.acceptAiConsent(
+      receiptId: 'aicr_server-receipt',
+      uid: 'uid-a',
+      profileBindingId: 'profile-binding-a',
+      serverDecidedAt: '2026-07-27T00:00:00Z',
+    );
     preferences.markAiConsentServerVerified(
       uid: 'uid-a',
       receiptId: 'aicr_server-receipt',
       policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
       processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+      profileBindingId: 'profile-binding-a',
+      scopeVersion: SharedPreferencesUtil.currentAiConsentScopeVersion,
+      scopeHash: SharedPreferencesUtil.currentAiConsentScopeHash,
     );
     final transport = _DeferredConsentStatusTransport();
     final service = EllaAiConsentService(transport: transport);
@@ -468,15 +516,92 @@ void main() {
     expect(preferences.aiConsentAccepted, isFalse);
   });
 
-  test('revocation stops local authority before an unreachable server update', () async {
+  test('profile binding change fails closed and requires reconsent', () async {
     final preferences = SharedPreferencesUtil();
     preferences.uid = 'uid-a';
-    preferences.acceptAiConsent(receiptId: 'aicr_receipt-a', uid: 'uid-a');
+    preferences.acceptAiConsent(
+      receiptId: 'aicr_receipt-a',
+      uid: 'uid-a',
+      profileBindingId: 'profile-binding-a',
+      serverDecidedAt: '2026-07-27T00:00:00Z',
+    );
     preferences.markAiConsentServerVerified(
       uid: 'uid-a',
       receiptId: 'aicr_receipt-a',
       policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
       processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+      profileBindingId: 'profile-binding-a',
+      scopeVersion: SharedPreferencesUtil.currentAiConsentScopeVersion,
+      scopeHash: SharedPreferencesUtil.currentAiConsentScopeHash,
+    );
+    final transport = _FakeConsentTransport(
+      policy: AiConsentPolicy.bundled,
+      statusResponse: _consentStatus(profileBindingId: 'profile-binding-b'),
+    );
+
+    final authorized = await EllaAiConsentService(transport: transport).refreshServerAuthority(uid: 'uid-a');
+
+    expect(authorized, isFalse);
+    expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.aiConsentReceiptId, isEmpty);
+  });
+
+  test('missing server decision timestamp never becomes v6 authority', () async {
+    final transport = _FakeConsentTransport(
+      policy: AiConsentPolicy.bundled,
+      submitResponse: _consentStatus(includeServerDecidedAt: false),
+    );
+    SharedPreferencesUtil().uid = 'uid-a';
+
+    final receiptId = await EllaAiConsentService(
+      transport: transport,
+      clientVersionFactory: () => '1.0.528+804',
+      localeFactory: () => 'en-US',
+    ).grantCurrentConsent(uid: 'uid-a');
+
+    expect(receiptId, isNull);
+    expect(SharedPreferencesUtil().aiConsentAccepted, isFalse);
+  });
+
+  test('malformed v6 server status parses safely and cannot become authority', () {
+    final status = AiConsentStatus.fromJson({
+      'subject_uid': 42,
+      'authorized': 'true',
+      'decision': <String, Object?>{},
+      'receipt_id': <String>['unexpected'],
+      'policy_version': SharedPreferencesUtil.currentAiConsentContractVersion,
+      'processor_set_hash': SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+      'profile_binding_id': true,
+      'scope_version': SharedPreferencesUtil.currentAiConsentScopeVersion,
+      'scope_hash': SharedPreferencesUtil.currentAiConsentScopeHash,
+      'server_decided_at': 'not-a-timestamp',
+      'policy': {'processors': 'unexpected'},
+    });
+
+    expect(status.authorized, isFalse);
+    expect(status.subjectUid, isEmpty);
+    expect(status.profileBindingId, isEmpty);
+    expect(status.serverDecidedAt, isNull);
+    expect(status.isCurrentGrantFor('uid-a'), isFalse);
+  });
+
+  test('revocation stops local authority before an unreachable server update', () async {
+    final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
+    preferences.acceptAiConsent(
+      receiptId: 'aicr_receipt-a',
+      uid: 'uid-a',
+      profileBindingId: 'profile-binding-a',
+      serverDecidedAt: '2026-07-27T00:00:00Z',
+    );
+    preferences.markAiConsentServerVerified(
+      uid: 'uid-a',
+      receiptId: 'aicr_receipt-a',
+      policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
+      processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+      profileBindingId: 'profile-binding-a',
+      scopeVersion: SharedPreferencesUtil.currentAiConsentScopeVersion,
+      scopeHash: SharedPreferencesUtil.currentAiConsentScopeHash,
     );
     expect(preferences.aiConsentAccepted, isTrue);
     final transport = _FakeConsentTransport(policy: null);
@@ -556,11 +681,7 @@ class _DeferredEnsureTransport implements EllaProvisioningTransport {
 }
 
 class _FakeConsentTransport implements EllaAiConsentTransport {
-  _FakeConsentTransport({
-    required this.policy,
-    this.statusResponse,
-    this.submitResponse,
-  });
+  _FakeConsentTransport({required this.policy, this.statusResponse, this.submitResponse});
 
   final AiConsentPolicy? policy;
   final AiConsentStatus? statusResponse;
@@ -609,6 +730,10 @@ AiConsentStatus _consentStatus({
   bool authorized = true,
   String decision = 'granted',
   String processorSetHash = SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+  String profileBindingId = 'profile-binding-a',
+  String scopeVersion = SharedPreferencesUtil.currentAiConsentScopeVersion,
+  String scopeHash = SharedPreferencesUtil.currentAiConsentScopeHash,
+  bool includeServerDecidedAt = true,
 }) {
   return AiConsentStatus(
     subjectUid: 'uid-a',
@@ -621,5 +746,9 @@ AiConsentStatus _consentStatus({
     appVersion: '1.0.528',
     buildNumber: '804',
     locale: 'en-US',
+    profileBindingId: profileBindingId,
+    scopeVersion: scopeVersion,
+    scopeHash: scopeHash,
+    serverDecidedAt: includeServerDecidedAt ? DateTime.parse('2026-07-27T00:00:00Z') : null,
   );
 }

--- a/app/test/ella/services/protected_egress_consent_test.dart
+++ b/app/test/ella/services/protected_egress_consent_test.dart
@@ -25,21 +25,57 @@ void main() {
     expect(await sendVoiceMessageStreamServer([file]).toList(), isEmpty);
     await expectLater(uploadFilesServer([file]), throwsStateError);
     expect(await sendStorageToBackend(file, '2026-07-27T00:00:00Z'), isEmpty);
+    expect(await updateUserGeolocation(geolocation: Geolocation(latitude: 1, longitude: 2)), isFalse);
     expect(
-      await updateUserGeolocation(
-        geolocation: Geolocation(latitude: 1, longitude: 2),
-      ),
-      isFalse,
-    );
-    expect(
-      await submitConversationCorrection(
-        conversationId: 'conversation-a',
-        correctionText: 'private correction',
-      ),
+      await submitConversationCorrection(conversationId: 'conversation-a', correctionText: 'private correction'),
       isFalse,
     );
     expect(await testConversationPrompt('private prompt', 'conversation-a'), isEmpty);
     expect(await retryConversationProcessing('conversation-a', 'request-a'), isNull);
     expect(await reProcessConversationServer('conversation-a'), isNull);
+  });
+
+  test('a cached v5 receipt sends no protected data under managed-cloud v6', () async {
+    SharedPreferences.setMockInitialValues({
+      'uid': 'uid-a',
+      'aiConsentAccepted': true,
+      'aiConsentContractVersion': 'ai-data-processors-v5',
+      'aiConsentProcessorSetHash': 'sha256:9c2529babbd6241f20242cf0836baf7e1899d05bb3d945a0d38a357113d4cbc4',
+      'aiConsentReceiptId': 'aicr_v5-receipt',
+      'aiConsentReceiptUid': 'uid-a',
+    });
+    await SharedPreferencesUtil.init();
+
+    expect(SharedPreferencesUtil().aiConsentAccepted, isFalse);
+    expect(await sendEllaMessageStream('must not leave device').toList(), isEmpty);
+    expect(await sendMessageStreamServer('must not leave device').toList(), isEmpty);
+  });
+
+  test('revocation immediately blocks protected text, audio, and location egress', () async {
+    final preferences = SharedPreferencesUtil();
+    preferences.uid = 'uid-a';
+    preferences.acceptAiConsent(
+      receiptId: 'aicr_receipt-a',
+      uid: 'uid-a',
+      profileBindingId: 'profile-binding-a',
+      serverDecidedAt: '2026-07-27T00:00:00Z',
+    );
+    preferences.markAiConsentServerVerified(
+      uid: 'uid-a',
+      receiptId: 'aicr_receipt-a',
+      policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
+      processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+      profileBindingId: 'profile-binding-a',
+      scopeVersion: SharedPreferencesUtil.currentAiConsentScopeVersion,
+      scopeHash: SharedPreferencesUtil.currentAiConsentScopeHash,
+    );
+    expect(preferences.aiConsentAccepted, isTrue);
+
+    preferences.declineAiConsent();
+
+    final file = File('${Directory.systemTemp.path}/revoked-v6-audio');
+    expect(await sendEllaMessageStream('must not leave device').toList(), isEmpty);
+    expect(await sendVoiceMessageStreamServer([file]).toList(), isEmpty);
+    expect(await updateUserGeolocation(geolocation: Geolocation(latitude: 1, longitude: 2)), isFalse);
   });
 }

--- a/app/test/ella/services/v2v_client_test.dart
+++ b/app/test/ella/services/v2v_client_test.dart
@@ -238,18 +238,23 @@ void main() {
       await client.disconnect();
     });
 
-    test('accepted server-verified v5 consent passes the mic gate before identity validation', () async {
+    test('accepted server-verified v6 consent passes the mic gate before identity validation', () async {
       final preferences = SharedPreferencesUtil();
       preferences.uid = 'uid-a';
       preferences.acceptAiConsent(
         receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
         uid: 'uid-a',
+        profileBindingId: 'profile-binding-a',
+        serverDecidedAt: '2026-07-27T00:00:00Z',
       );
       preferences.markAiConsentServerVerified(
         uid: 'uid-a',
         receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
         policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
         processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+        profileBindingId: 'profile-binding-a',
+        scopeVersion: SharedPreferencesUtil.currentAiConsentScopeVersion,
+        scopeHash: SharedPreferencesUtil.currentAiConsentScopeHash,
       );
       final client = V2VClient(onEvent: (_) {}, onConnectionChanged: (_) {});
 
@@ -264,10 +269,7 @@ void main() {
     test('cancelled startup stops before provider or session work begins', () async {
       final client = V2VClient(onEvent: (_) {}, onConnectionChanged: (_) {});
 
-      final receipt = await client.connect(
-        provider: 'grok-voice',
-        shouldContinue: () => false,
-      );
+      final receipt = await client.connect(provider: 'grok-voice', shouldContinue: () => false);
 
       expect(receipt.connected, isFalse);
       expect(receipt.stage, V2VConnectionStage.providerRegistry);

--- a/app/test/ella/widgets/ai_consent_sheet_test.dart
+++ b/app/test/ella/widgets/ai_consent_sheet_test.dart
@@ -25,12 +25,17 @@ void main() {
               preferences.acceptAiConsent(
                 receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
                 uid: 'uid-a',
+                profileBindingId: 'profile-binding-a',
+                serverDecidedAt: '2026-07-27T00:00:00Z',
               );
               preferences.markAiConsentServerVerified(
                 uid: 'uid-a',
                 receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
                 policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
                 processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+                profileBindingId: 'profile-binding-a',
+                scopeVersion: SharedPreferencesUtil.currentAiConsentScopeVersion,
+                scopeHash: SharedPreferencesUtil.currentAiConsentScopeHash,
               );
               return true;
             },
@@ -45,10 +50,7 @@ void main() {
         supportedLocales: AppLocalizations.supportedLocales,
         home: Builder(
           builder: (context) => Scaffold(
-            body: TextButton(
-              onPressed: () => AiConsentSheet.show(context),
-              child: const Text('Show consent'),
-            ),
+            body: TextButton(onPressed: () => AiConsentSheet.show(context), child: const Text('Show consent')),
           ),
         ),
       ),
@@ -58,26 +60,37 @@ void main() {
     await tester.pumpAndSettle();
 
     final screenHeight = tester.view.physicalSize.height / tester.view.devicePixelRatio;
-    expect(tester.getSize(find.byType(AiConsentSheet)).height, lessThanOrEqualTo(screenHeight * 0.7));
+    expect(tester.getSize(find.byType(AiConsentSheet)).height, lessThanOrEqualTo(screenHeight * 0.95));
     expect(find.text('Not now').hitTestable(), findsOneWidget);
   });
 
-  testWidgets('names every voice processor and explains routed data before acceptance', (tester) async {
+  testWidgets('names managed-cloud recipients, data, purpose, and narrow scope before acceptance', (tester) async {
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
 
     final disclosure =
         tester.widgetList<RichText>(find.byType(RichText)).map((widget) => widget.text.toPlainText()).join(' ');
     expect(disclosure, contains('secure backend'));
-    expect(disclosure, contains('live or stored microphone audio'));
+    expect(disclosure, contains('Nous Research / Hermes Cloud'));
+    expect(disclosure, contains('messages, voice or transcript text'));
+    expect(disclosure, contains('OpenAI'));
+    expect(disclosure, contains('OpenAI Codex OAuth route'));
+    expect(disclosure, contains('Honcho Cloud'));
+    expect(disclosure, contains('derived memory'));
+    expect(disclosure, contains('Photon'));
+    expect(disclosure, contains('messaging identifiers'));
+    expect(disclosure, contains('one explicitly allowed test contact'));
+    expect(disclosure, contains('no allow-all recipients'));
+    expect(disclosure, contains('caregiver delivery'));
+    expect(disclosure, contains('inbound attachments'));
+    expect(disclosure, contains('requires permission again'));
     expect(disclosure, contains('Deepgram'));
     expect(disclosure, contains('Soniox'));
     expect(disclosure, contains('Speechmatics'));
     expect(disclosure, contains('Google Firebase'));
     expect(disclosure, contains('self-hosted Hermes'));
-    expect(disclosure, contains('Honcho memory'));
+    expect(disclosure, contains('Ella self-hosted Hermes, Honcho'));
     expect(disclosure, contains('OpenRouter'));
-    expect(disclosure, contains('selected model provider'));
     expect(disclosure, contains('Google Gemini'));
     expect(disclosure, contains('OpenAI'));
     expect(disclosure, contains('Groq'));
@@ -86,9 +99,8 @@ void main() {
     expect(disclosure, contains('Inworld AI'));
     expect(disclosure, contains('Kokoro'));
     expect(disclosure, contains('Fish'));
-    expect(disclosure, contains('response text'));
     expect(disclosure, contains('selected memory context'));
-    expect(disclosure, contains('will not send audio, transcripts, messages, or memory context'));
+    expect(disclosure, contains('will not send audio, transcripts, messages, selected memory context'));
     expect(disclosure, contains('Full processor details in Privacy Policy'));
     expect(find.text('Not now'), findsOneWidget);
   });
@@ -115,12 +127,17 @@ void main() {
     preferences.acceptAiConsent(
       receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
       uid: 'uid-a',
+      profileBindingId: 'profile-binding-a',
+      serverDecidedAt: '2026-07-27T00:00:00Z',
     );
     preferences.markAiConsentServerVerified(
       uid: 'uid-a',
       receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
       policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
       processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+      profileBindingId: 'profile-binding-a',
+      scopeVersion: SharedPreferencesUtil.currentAiConsentScopeVersion,
+      scopeHash: SharedPreferencesUtil.currentAiConsentScopeHash,
     );
 
     await tester.pumpWidget(buildApp());
@@ -141,12 +158,17 @@ void main() {
     preferences.acceptAiConsent(
       receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
       uid: 'uid-a',
+      profileBindingId: 'profile-binding-a',
+      serverDecidedAt: '2026-07-27T00:00:00Z',
     );
     preferences.markAiConsentServerVerified(
       uid: 'uid-a',
       receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a',
       policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
       processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+      profileBindingId: 'profile-binding-a',
+      scopeVersion: SharedPreferencesUtil.currentAiConsentScopeVersion,
+      scopeHash: SharedPreferencesUtil.currentAiConsentScopeHash,
     );
     var revokeCalled = false;
 

--- a/docs/compliance/ella-managed-cloud-consent-v6.md
+++ b/docs/compliance/ella-managed-cloud-consent-v6.md
@@ -1,0 +1,148 @@
+# Ella Managed-Cloud Consent v6
+
+Status: draft for legal, backend, security, and App Review review. Do not publish
+or copy into App Store Connect until the deployed processor inventory and vendor
+terms are independently verified.
+
+Issue: https://github.com/ellaaicare/ella-ai/issues/1123
+
+## Exact client contract
+
+The iOS client accepts only all of the following values:
+
+- Policy version: `ai-data-processors-v6`
+- Processor-set hash:
+  `sha256:dd84e4a9da1166cff66e5de55c2570d0496a2c89d46ca431530e993758616296`
+- Scope version: `managed-cloud-internal-pilot-v1`
+- Scope hash:
+  `sha256:727b1db818ce79090a02279f1cc6d15dfc3d65a58592b13fbed53ad048c38a30`
+- Opaque server receipt prefix: `aicr_`
+- A non-empty opaque `profile_binding_id`
+- A parseable server-owned `server_decided_at`
+- The authenticated Firebase UID as `subject_uid`; the client never submits a UID
+
+The v6 policy response must add `scope_version`, `scope_hash`, and
+`canonical_scope` to the v5 policy response. Grant, decline, and revoke
+submissions add `scope_version` and `scope_hash`. Authenticated status and
+receipt responses add those fields plus `profile_binding_id` and
+`server_decided_at`.
+
+Any missing field, v5 response, changed processor hash, changed runtime/model/
+memory/Photon scope, changed profile binding, changed account, expired
+verification, revoked decision, or unavailable authority fails closed. A changed
+scope requires a new explicit grant; it is not a silent refresh.
+
+## Managed-cloud disclosure inventory
+
+| Legal recipient | Purpose | Data categories |
+| --- | --- | --- |
+| Nous Research / Hermes Cloud | Managed Ella agent runtime and session continuity | Prompt policy, messages, voice/transcript text, selected first-party context, session metadata, and model/tool usage |
+| OpenAI | Model processing through the approved `openai-codex/gpt-5.6-terra` OAuth-backed route | Model input and output required to generate the response |
+| Honcho Cloud | Profile-isolated derived memory and recall | Consented derived memory, selected context, and memory relationships for the bound profile |
+| Photon | Narrow test/shared-line iMessage delivery | Message content and messaging identifiers for one explicitly allowed test contact |
+
+The first-party Ella Cloudflare/Vultr control plane remains the authority for
+identity, consent, entitlement, canonical events, corrections, usage, and kill
+switches. It derives the profile binding and never returns vendor credentials to
+iOS.
+
+The bundled v6 manifest also retains every processor still routable under v5:
+Deepgram, Soniox, Speechmatics, Google Firebase, Ella self-hosted Hermes/Honcho/
+voice synthesis, OpenRouter, Google Gemini, OpenAI live voice, Groq, xAI Grok,
+Inworld AI, and ElevenLabs. A release inventory must remove any route that is no
+longer reachable rather than over-disclose it as active.
+
+Photon scope is restricted to the shared test line and an explicit single test
+contact. `allow_all`, caregiver delivery, and inbound attachments are false.
+Changing any of those values requires a new scope hash and re-consent.
+
+## Draft Privacy Policy addition
+
+> **Managed cloud AI and messaging.** If you explicitly choose Allow in the
+> Ella app, Ella may send the data needed for the feature you choose through
+> Ella's secure first-party control plane to named service providers. Nous
+> Research / Hermes Cloud may process messages, voice or transcript text,
+> selected Ella context, session metadata, prompt policy, and model/tool usage
+> to run the managed Ella agent. OpenAI may process model input and output
+> through Ella's approved OAuth-backed model route to generate responses.
+> Honcho Cloud may process consented derived memory and selected context for the
+> profile bound to your Ella account so Ella can recall relevant information;
+> Ella's canonical records remain in Ella's first-party system. Photon may
+> process iMessage content and the messaging identifiers required to deliver
+> messages for the explicitly enabled contact/channel scope.
+>
+> Ella does not send this content to those processors until you choose Allow.
+> Choosing Not now keeps the related cloud AI, memory, voice, and messaging
+> features off. You can review or revoke permission in Settings and request
+> account/data deletion. Permission is versioned for the disclosed processor
+> and routing scope; a material provider, model route, profile, or messaging
+> scope change requires permission again.
+
+Before publication, legal/vendor review must insert verified retention,
+deletion, export, data-location, subprocessors, and contact terms for Nous
+Research, OpenAI, Honcho Cloud, and Photon. Honcho's currently reported
+90-day content/log/backup posture is a launch question, not an approved final
+claim. The policy must also retain accurate disclosures for every active
+fallback processor.
+
+## Draft App Privacy changes
+
+These are proposed additions for the managed-cloud path, not a replacement for a
+full app-wide App Privacy audit:
+
+| Apple category | Linked to user | Tracking | Purpose |
+| --- | --- | --- | --- |
+| User Content - Emails or Text Messages | Yes | No | App Functionality |
+| User Content - Audio Data | Yes | No | App Functionality |
+| User Content - Other User Content | Yes | No | App Functionality |
+| Identifiers - User ID | Yes | No | App Functionality |
+| Usage Data - Product Interaction | Yes | No | App Functionality and service reliability |
+
+The App Privacy questionnaire must reflect retention and use across Ella's
+first-party control plane and all active processors. Do not mark data as
+"not collected" merely because a processor receives it transiently. Do not
+declare tracking unless the deployed SDK/vendor behavior meets Apple's tracking
+definition; verify rather than infer.
+
+## Draft App Review notes
+
+> Build: `[insert exact reviewed build]`
+>
+> Ella uses explicit first-use permission before sending personal content to
+> third-party AI or messaging processors. To review: sign in with the supplied
+> review account, choose Chat, Voice, recording, memory interaction, or the
+> managed messaging entry point, and the non-dismissible "Choose how Ella uses
+> cloud AI" sheet appears before the request starts. The sheet names Nous
+> Research / Hermes Cloud, OpenAI, Honcho Cloud, and Photon, explains the data
+> and purpose for each, identifies the restricted Photon scope, links the
+> Privacy Policy, and provides Allow and Not now. Not now sends no protected
+> payload and leaves those features off.
+>
+> Settings > Listening and consent shows whether an exact server-verified v6
+> receipt is active for the signed-in account/profile. Reviewers can revoke
+> permission or request account/data deletion there. Revocation stops active
+> audio/voice sessions and blocks subsequent protected requests. Material
+> provider, model, profile, or messaging-scope changes require consent again.
+>
+> The app calls only Ella's first-party API. Vendor credentials and raw profile
+> identifiers are never returned to iOS. Provide the exact backend revision,
+> consent policy/hash, health window, test account, and hardware-independent
+> steps in the final notes.
+
+Do not include credentials, personal contact identifiers, vendor secrets, or
+family-account data in App Review notes.
+
+## Release evidence still required
+
+- Reviewed backend v6 implementation and migration.
+- Deployed immutable backend revision with enforcement initially off.
+- Synthetic authenticated policy/grant/decline/revoke/profile/scope/delete
+  receipts and protected-route canaries.
+- First-use, Not now, allow, revoke, account/profile switch, and scope-change
+  screenshots from the exact candidate build.
+- Verified live Privacy Policy and App Privacy diff.
+- Stable reviewer access and backend health receipt covering the review window.
+- Independent legal/security review of vendor retention, deletion, location,
+  subprocessors, and contractual terms.
+
+No real managed-cloud or Photon content is authorized by v5.


### PR DESCRIPTION
## Summary

Implements the iOS half of managed-cloud consent v6 for
https://github.com/ellaaicare/ella-ai/issues/1123 on the reviewed Phase A
consent-v5 lineage.

- presents a first-use, non-dismissible disclosure before protected egress that
  names Nous Research / Hermes Cloud, OpenAI, Honcho Cloud, and Photon and
  explains each recipient's data categories and purpose
- retains visible `Allow and continue` and `Not now` paths; decline sends only
  consent metadata and grants no protected-data authority
- accepts only the exact server-authoritative v6 processor/scope receipt,
  including authenticated UID, opaque receipt, profile binding, server
  timestamp, processor hash, and managed provider/model/memory/Photon scope
- refresh and grant flows snapshot a monotonic authority generation plus exact
  UID, persona, and profile binding before network awaits; any account/profile
  race clears server verification and cannot persist a stale grant
- fails closed for v5, malformed/unavailable/revoked authority, account or
  profile changes, and provider/model/messaging-scope drift
- preserves active-session refresh/revoke and completed deletion-receipt
  behavior from consent v5
- adds draft Privacy Policy, App Privacy, and App Review text for independent
  legal/security/release review

Exact client contract:

- policy: `ai-data-processors-v6`
- processor hash:
  `sha256:dd84e4a9da1166cff66e5de55c2570d0496a2c89d46ca431530e993758616296`
- scope: `managed-cloud-internal-pilot-v1`
- scope hash:
  `sha256:727b1db818ce79090a02279f1cc6d15dfc3d65a58592b13fbed53ad048c38a30`

## Validation

- focused consent/provisioning/egress/V2V/UI tests: 75/75
- full `flutter test`: 242/242
- `app/test.sh`: 21/21
- targeted `flutter analyze`: no issues
- `git diff --check`: clean
- processor and scope SHA-256 values independently asserted from their
  canonical strings
- diff from the blocked head is limited to consent preferences, consent
  service, and focused provisioning tests

## Release Gate

This PR is source/tests/documentation only. It does not change the build number,
Firebase, signing, backend, production, TestFlight, App Store Connect, vendor
state, or real user data.

Managed-cloud and Photon real-data egress remains blocked until the separately
reviewed backend v6 implementation is merged, deployed, and proven with
synthetic authenticated receipts. The compliance copy is a draft and must not
be published until processor inventory, retention, deletion, data-location,
subprocessor, and contractual details are verified.
