### PR TITLE
Enforce managed-cloud consent v6

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -2,17 +2,18 @@ name: Hermes Cloud Runtime Tests
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - "backend/database/ella_provisioning.py"
       - "backend/database/voice_canary.py"
       - "backend/ella/routers/canonical_events.py"
+      - "backend/ella/routers/ai_consent.py"
       - "backend/ella/routers/chat.py"
       - "backend/ella/routers/onboarding.py"
       - "backend/ella/routers/photon.py"
       - "backend/ella/routers/resolve.py"
       - "backend/ella/routers/voice.py"
       - "backend/ella/services/hermes_cloud.py"
+      - "backend/ella/services/ai_consent.py"
       - "backend/ella/services/hermes_cloud_policy.py"
       - "backend/ella/services/hermes_cloud_photon.py"
       - "backend/ella/services/hermes_cloud_runtime.py"
@@ -23,6 +24,8 @@ on:
       - "backend/scripts/hermes_cloud_pool_admin.py"
       - "backend/scripts/hermes_cloud_shadow.py"
       - "backend/tests/unit/test_ella_provisioning_repository.py"
+      - "backend/tests/unit/test_ella_ai_consent.py"
+      - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
       - "backend/tests/unit/test_ella_runtime_route_isolation.py"
       - "backend/tests/unit/test_hermes_cloud_*.py"
       - "backend/tests/unit/test_voice_proxy_auth.py"
@@ -33,12 +36,14 @@ on:
       - "backend/database/ella_provisioning.py"
       - "backend/database/voice_canary.py"
       - "backend/ella/routers/canonical_events.py"
+      - "backend/ella/routers/ai_consent.py"
       - "backend/ella/routers/chat.py"
       - "backend/ella/routers/onboarding.py"
       - "backend/ella/routers/photon.py"
       - "backend/ella/routers/resolve.py"
       - "backend/ella/routers/voice.py"
       - "backend/ella/services/hermes_cloud.py"
+      - "backend/ella/services/ai_consent.py"
       - "backend/ella/services/hermes_cloud_policy.py"
       - "backend/ella/services/hermes_cloud_photon.py"
       - "backend/ella/services/hermes_cloud_runtime.py"
@@ -49,6 +54,8 @@ on:
       - "backend/scripts/hermes_cloud_pool_admin.py"
       - "backend/scripts/hermes_cloud_shadow.py"
       - "backend/tests/unit/test_ella_provisioning_repository.py"
+      - "backend/tests/unit/test_ella_ai_consent.py"
+      - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
       - "backend/tests/unit/test_ella_runtime_route_isolation.py"
       - "backend/tests/unit/test_hermes_cloud_*.py"
       - "backend/tests/unit/test_voice_proxy_auth.py"
@@ -60,6 +67,8 @@ jobs:
     env:
       ELLA_VOICE_CANARY_ENFORCEMENT_ENABLED: "false"
       FIRESTORE_EMULATOR_HOST: localhost:9999
+      GCLOUD_PROJECT: omi-ci
+      GOOGLE_CLOUD_PROJECT: omi-ci
       ENCRYPTION_SECRET: omi_ci_hermes_cloud_test_only
     defaults:
       run:
@@ -91,6 +100,8 @@ jobs:
           python -m py_compile
           database/ella_provisioning.py
           database/voice_canary.py
+          ella/routers/ai_consent.py
+          ella/services/ai_consent.py
           ella/services/hermes_cloud.py
           ella/services/hermes_cloud_photon.py
           ella/services/hermes_cloud_policy.py
@@ -105,6 +116,8 @@ jobs:
       - name: Run Hermes Cloud and isolation failure-path tests
         run: >-
           pytest
+          tests/unit/test_ella_ai_consent.py
+          tests/unit/test_ella_ai_consent_route_gates.py
           tests/unit/test_hermes_cloud_migration.py
           tests/unit/test_hermes_cloud_policy.py
           tests/unit/test_hermes_cloud_photon.py

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -61,6 +61,16 @@ FIREBASE_PROJECT_ID=
 ELLA_AI_CONSENT_ENFORCEMENT_ENABLED=false
 ELLA_AI_CONSENT_ENFORCEMENT_UIDS=
 ELLA_INTERNAL_VOICE_TTS_TOKEN=
+# Managed-cloud v6 remains independently fail-closed. Keep real data disabled
+# until the exact policy/scope receipt is deployed and synthetic canaries pass.
+ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED=false
+ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED_UIDS=
+ELLA_HERMES_CLOUD_SYNTHETIC_ONLY=true
+ELLA_HERMES_CLOUD_SYNTHETIC_UIDS=
+ELLA_HERMES_CLOUD_CONSENT_POLICY_VERSION=
+ELLA_HERMES_CLOUD_CONSENT_PROCESSOR_SET_HASH=
+ELLA_HERMES_CLOUD_CONSENT_SCOPE_VERSION=
+ELLA_HERMES_CLOUD_CONSENT_SCOPE_HASH=
 
 # Ella isolated Hermes onboarding. Keep both flags false until the provisioning
 # schema is migrated and a synthetic two-user 8210 canary passes.

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -1423,6 +1423,28 @@ class EllaProvisioningRepository:
             raise RuntimePoolClaimError("photon_binding_not_ready")
         return dict(row)
 
+    async def get_photon_message_by_inbound(
+        self,
+        *,
+        photon_binding_id: str,
+        inbound_provider_message_key: str,
+        inbound_payload_sha256: str,
+    ) -> Optional[dict[str, Any]]:
+        row = await self.pool.fetchrow(
+            """
+            SELECT *
+            FROM ella_photon_message_receipts
+            WHERE photon_binding_id = $1
+              AND inbound_provider_message_key = $2
+            """,
+            uuid.UUID(str(photon_binding_id)),
+            inbound_provider_message_key,
+        )
+        result = _row_dict(row)
+        if result and str(result.get("inbound_payload_sha256") or "") != inbound_payload_sha256:
+            raise RuntimePoolClaimError("photon_duplicate_payload_conflict")
+        return result
+
     async def claim_photon_message(
         self,
         *,
@@ -1430,10 +1452,13 @@ class EllaProvisioningRepository:
         inbound_provider_message_key: str,
         inbound_payload_sha256: str,
         command_tier_version: str,
+        consent_grant_epoch: str,
         lease_seconds: int,
     ) -> dict[str, Any]:
         if not 30 <= lease_seconds <= 900:
             raise RuntimePoolClaimError("photon_receipt_lease_invalid")
+        if not 16 <= len(consent_grant_epoch) <= 96:
+            raise RuntimePoolClaimError("photon_consent_grant_epoch_invalid")
         binding_uuid = uuid.UUID(str(photon_binding_id))
         new_lease_token = uuid.uuid4()
         async with self.pool.acquire() as connection:
@@ -1443,11 +1468,11 @@ class EllaProvisioningRepository:
                     INSERT INTO ella_photon_message_receipts (
                         id, photon_binding_id, inbound_provider_message_key,
                         inbound_payload_sha256, status, command_tier_version,
-                        lease_token, lease_expires_at
+                        consent_grant_epoch, lease_token, lease_expires_at
                     )
                     VALUES (
-                        $1, $2, $3, $4, 'claimed', $5, $6,
-                        CURRENT_TIMESTAMP + ($7 * INTERVAL '1 second')
+                        $1, $2, $3, $4, 'claimed', $5, $6, $7,
+                        CURRENT_TIMESTAMP + ($8 * INTERVAL '1 second')
                     )
                     ON CONFLICT (
                         photon_binding_id, inbound_provider_message_key
@@ -1459,6 +1484,7 @@ class EllaProvisioningRepository:
                     inbound_provider_message_key,
                     inbound_payload_sha256,
                     command_tier_version,
+                    consent_grant_epoch,
                     new_lease_token,
                     lease_seconds,
                 )
@@ -1485,6 +1511,27 @@ class EllaProvisioningRepository:
                     raise RuntimePoolClaimError("photon_duplicate_payload_conflict")
 
                 status = str(result.get("status") or "")
+                if str(result.get("consent_grant_epoch") or "") != consent_grant_epoch:
+                    if status in {"claimed", "running", "awaiting_delivery"}:
+                        quarantined = await connection.fetchrow(
+                            """
+                            UPDATE ella_photon_message_receipts
+                            SET status = 'uncertain',
+                                reconciliation_status = 'manual_required',
+                                error_code = 'managed_cloud_consent_grant_changed',
+                                lease_token = NULL,
+                                lease_expires_at = NULL,
+                                updated_at = CURRENT_TIMESTAMP
+                            WHERE id = $1
+                              AND status IN ('claimed', 'running', 'awaiting_delivery')
+                            RETURNING *
+                            """,
+                            result["id"],
+                        )
+                        result = dict(quarantined)
+                    result.update(inserted=False, reclaimed=False, acquired=False)
+                    return result
+
                 lease_expires_at = result.get("lease_expires_at")
                 stale = status in {"claimed", "running"} and (
                     not isinstance(lease_expires_at, datetime) or lease_expires_at <= datetime.now(timezone.utc)

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -1749,6 +1749,30 @@ class EllaProvisioningRepository:
             uuid.UUID(str(lease_token)),
         )
 
+    async def quarantine_photon_delivery_for_consent(
+        self,
+        *,
+        receipt_id: str,
+        error_code: str,
+    ) -> dict[str, Any]:
+        row = await self.pool.fetchrow(
+            """
+            UPDATE ella_photon_message_receipts
+            SET status = 'uncertain',
+                error_code = $2,
+                reconciliation_status = 'manual_required',
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = $1
+              AND status = 'awaiting_delivery'
+            RETURNING *
+            """,
+            uuid.UUID(str(receipt_id)),
+            error_code[:120],
+        )
+        if not row:
+            raise RuntimePoolClaimError("photon_consent_quarantine_conflict")
+        return dict(row)
+
     async def acknowledge_photon_delivery(
         self,
         *,

--- a/backend/ella/README.md
+++ b/backend/ella/README.md
@@ -283,12 +283,14 @@ authenticated Firebase UID selects both the current state and the
 immutable receipt subcollection; callers cannot submit or select another UID.
 
 - `GET /v1/users/ai-consent/policy` returns the required legal-recipient
-  manifest, policy version, and processor-set hash.
+  manifest, policy version, processor-set hash, and managed-cloud scope
+  version/hash.
 - `GET /v1/users/ai-consent` returns the current decision and whether the exact
   current policy authorizes protected routes.
 - `POST /v1/users/ai-consent` records `granted`, `declined`, or `revoked` with a
-  caller request ID, app/build, locale, and server timestamp. The same request
-  ID is idempotent; reuse with different metadata fails with `409`.
+  caller request ID, app/build, locale, exact scope, server-derived opaque
+  account/profile binding, and server timestamp. The same request ID is
+  idempotent; reuse with different metadata fails with `409`.
 - `GET /v1/users/ai-consent/receipts/{receipt_id}` verifies a receipt only
   within the authenticated user's path.
 - Account/data deletion remains `DELETE /v1/users/delete-account`; deletion
@@ -327,6 +329,15 @@ Rollout is fail-safe and non-breaking:
 Changing the canonical processor set or its legal recipients requires a new
 policy version/hash. Do not reuse a prior hash or silently map an undisclosed
 fallback provider.
+
+Managed Hermes Cloud real-data egress has a second default-off gate:
+`ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED=false` plus an optional exact UID canary
+list. Real egress also requires exact deployed v6 policy and scope env values.
+The backend rechecks the current account/profile-bound receipt immediately
+before Honcho Cloud profile creation, Hermes Cloud/OpenAI model calls, and
+Photon outbound handoff. A v5, missing, declined, revoked, deleted, malformed,
+or route/profile-drifted receipt fails closed. Synthetic/content-free preflight
+continues under `ELLA_HERMES_CLOUD_SYNTHETIC_ONLY=true`.
 
 Upstream-managed patch points are tracked in `docs/POST_MERGE_PATCHES.md`. Review that file after every Basehardware upstream sync.
 

--- a/backend/ella/routers/ai_consent.py
+++ b/backend/ella/routers/ai_consent.py
@@ -27,6 +27,8 @@ class AiConsentSubmissionRequest(BaseModel):
     app_version: str = Field(min_length=1, max_length=80)
     build_number: str = Field(min_length=1, max_length=40)
     locale: str = Field(min_length=2, max_length=40)
+    scope_version: str = Field(default="", max_length=100)
+    scope_hash: str = Field(default="", max_length=100)
 
 
 @router.get("/v1/users/ai-consent/policy")
@@ -64,6 +66,8 @@ def submit_ai_consent(
                 app_version=request.app_version,
                 build_number=request.build_number,
                 locale=request.locale,
+                scope_version=request.scope_version,
+                scope_hash=request.scope_hash,
             ),
         )
     except ConsentPolicyMismatch as exc:

--- a/backend/ella/services/ai_consent.py
+++ b/backend/ella/services/ai_consent.py
@@ -663,7 +663,7 @@ def assert_managed_cloud_consent(
     memory_provider: str,
     photon_scope: str,
 ) -> str:
-    """Authorize one exact managed-cloud egress contract for one account/profile."""
+    """Return the immutable receipt id authorizing one exact egress contract."""
     if not managed_cloud_real_data_enabled(account_uid):
         raise ManagedCloudConsentError("managed_cloud_real_data_disabled")
     if (
@@ -691,7 +691,10 @@ def assert_managed_cloud_consent(
         or not _valid_server_timestamp(state.get("server_decided_at"))
     ):
         raise ManagedCloudConsentError("managed_cloud_consent_stale")
-    return account_uid
+    receipt_id = str(state.get("receipt_id") or "")
+    if not receipt_id:
+        raise ManagedCloudConsentError("managed_cloud_consent_stale")
+    return receipt_id
 
 
 def assert_current_ai_consent(uid: str) -> str:

--- a/backend/ella/services/ai_consent.py
+++ b/backend/ella/services/ai_consent.py
@@ -18,14 +18,27 @@ from utils.other import endpoints as auth
 
 ConsentDecision = Literal["granted", "declined", "revoked"]
 
-CURRENT_POLICY_VERSION = "ai-data-processors-v5"
+CURRENT_POLICY_VERSION = "ai-data-processors-v6"
 CANONICAL_PROCESSOR_SET = (
     "deepgram:stt|soniox:stt|speechmatics:stt|firebase:auth-infrastructure|"
     "hermes-self-hosted:agent-runtime|honcho-self-hosted:memory-context|ella-self-hosted-tts:tts|"
+    "nous-hermes-cloud:managed-agent-runtime|honcho-cloud:derived-memory-context|"
+    "openai-codex:managed-agent-model|photon:messaging-delivery|"
     "openrouter:model-routing|google-gemini:language-live-voice|openai:language-live-voice|"
     "groq:language|xai-grok:language-live-voice|inworld:tts|elevenlabs:tts-fallback"
 )
 CURRENT_PROCESSOR_SET_HASH = f"sha256:{hashlib.sha256(CANONICAL_PROCESSOR_SET.encode()).hexdigest()}"
+CURRENT_SCOPE_VERSION = "managed-cloud-internal-pilot-v1"
+CANONICAL_SCOPE = (
+    "profile_binding=server-profile-v1|runtime_provider=hermes_cloud|"
+    "model_route=openai-codex/gpt-5.6-terra|memory_provider=honcho_cloud_profile_isolated|"
+    "photon_scope=shared_test_line_explicit_contact_v1;allow_all=false;caregiver=false;attachments=false"
+)
+CURRENT_SCOPE_HASH = f"sha256:{hashlib.sha256(CANONICAL_SCOPE.encode()).hexdigest()}"
+MANAGED_CLOUD_RUNTIME_PROVIDER = "hermes_cloud"
+MANAGED_CLOUD_MODEL_ROUTE = "openai-codex/gpt-5.6-terra"
+MANAGED_CLOUD_MEMORY_PROVIDER = "honcho_cloud_profile_isolated"
+MANAGED_CLOUD_PHOTON_SCOPE = "shared_test_line_explicit_contact_v1;allow_all=false;caregiver=false;attachments=false"
 
 PROCESSORS: tuple[dict[str, Any], ...] = (
     {
@@ -83,6 +96,41 @@ PROCESSORS: tuple[dict[str, Any], ...] = (
         "data": "Response text",
         "provider_aliases": ["fish-audio", "fish-audio-s1", "fish-audio-s2", "kokoro"],
         "third_party": False,
+    },
+    {
+        "id": "nous-hermes-cloud",
+        "legal_recipient": "Nous Research / Hermes Cloud",
+        "function": "Managed agent runtime",
+        "data": (
+            "Prompt policy, messages, transcripts, selected first-party context, "
+            "session metadata, and model or tool usage"
+        ),
+        "provider_aliases": ["hermes-cloud", "hermes_cloud", "nous-hermes-cloud"],
+        "third_party": True,
+    },
+    {
+        "id": "honcho-cloud",
+        "legal_recipient": "Honcho Cloud",
+        "function": "Profile-bound derived memory and context",
+        "data": ("Consented derived memory, selected context, and memory relationships " "for the bound profile"),
+        "provider_aliases": ["honcho-cloud", "honcho_cloud", "honcho_cloud_profile_isolated"],
+        "third_party": True,
+    },
+    {
+        "id": "openai-codex",
+        "legal_recipient": "OpenAI",
+        "function": "Managed agent model processing",
+        "data": "Model input and output through the approved OpenAI Codex OAuth route",
+        "provider_aliases": ["openai-codex", "openai-codex/gpt-5.6-terra"],
+        "third_party": True,
+    },
+    {
+        "id": "photon",
+        "legal_recipient": "Photon",
+        "function": "Test/shared-line message delivery",
+        "data": "Message content and messaging identifiers for one explicitly allowed test contact",
+        "provider_aliases": ["photon", "hermes-cloud-photon"],
+        "third_party": True,
     },
     {
         "id": "openrouter",
@@ -170,6 +218,34 @@ class ConsentIdempotencyConflict(ValueError):
     pass
 
 
+class ManagedCloudConsentError(ValueError):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+def _valid_server_timestamp(value: Any) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    try:
+        decided_at = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return decided_at.tzinfo is not None
+
+
+def derive_profile_binding_id(*, account_uid: str, profile_uid: str) -> str:
+    """Derive an opaque, stable binding from server-owned account/profile authority."""
+    account_uid = str(account_uid or "").strip()
+    profile_uid = str(profile_uid or "").strip()
+    if not account_uid or not profile_uid:
+        raise ManagedCloudConsentError("managed_cloud_profile_binding_missing")
+    digest = hashlib.sha256(
+        f"ella-managed-cloud-profile-v1\x1f{account_uid}\x1f{profile_uid}".encode("utf-8")
+    ).hexdigest()
+    return f"aipb_{digest[:32]}"
+
+
 _firestore_db: Any = None
 
 
@@ -199,6 +275,8 @@ def _receipt_fingerprint(receipt: dict[str, Any]) -> str:
             "decision",
             "policy_version",
             "processor_set_hash",
+            "scope_version",
+            "scope_hash",
             "request_id",
             "app_version",
             "build_number",
@@ -234,6 +312,10 @@ def _record_firestore_receipt(
             "decision",
             "policy_version",
             "processor_set_hash",
+            "processor_ids",
+            "profile_binding_id",
+            "scope_version",
+            "scope_hash",
             "server_decided_at",
             "app_version",
             "build_number",
@@ -329,6 +411,10 @@ class InMemoryConsentRepository:
                 "decision",
                 "policy_version",
                 "processor_set_hash",
+                "processor_ids",
+                "profile_binding_id",
+                "scope_version",
+                "scope_hash",
                 "server_decided_at",
                 "app_version",
                 "build_number",
@@ -349,6 +435,8 @@ class ConsentSubmission:
     app_version: str
     build_number: str
     locale: str
+    scope_version: str = ""
+    scope_hash: str = ""
 
 
 class AiConsentService:
@@ -367,12 +455,17 @@ class AiConsentService:
             "version": CURRENT_POLICY_VERSION,
             "processor_set_hash": CURRENT_PROCESSOR_SET_HASH,
             "canonical_processor_set": CANONICAL_PROCESSOR_SET,
+            "scope_version": CURRENT_SCOPE_VERSION,
+            "scope_hash": CURRENT_SCOPE_HASH,
+            "canonical_scope": CANONICAL_SCOPE,
             "processors": [dict(processor) for processor in PROCESSORS],
         }
 
     def status(self, uid: str) -> dict[str, Any]:
         state = self.repository.get_state(uid)
-        return _status_payload(uid, state)
+        receipt_id = str((state or {}).get("receipt_id") or "")
+        receipt = self.repository.get_receipt(uid, receipt_id) if receipt_id else None
+        return _status_payload(uid, state, receipt)
 
     def receipt(self, uid: str, receipt_id: str) -> Optional[dict[str, Any]]:
         receipt = self.repository.get_receipt(uid, receipt_id)
@@ -384,16 +477,23 @@ class AiConsentService:
         if submission.decision == "granted" and (
             submission.policy_version != CURRENT_POLICY_VERSION
             or submission.processor_set_hash != CURRENT_PROCESSOR_SET_HASH
+            or submission.scope_version != CURRENT_SCOPE_VERSION
+            or submission.scope_hash != CURRENT_SCOPE_HASH
         ):
             raise ConsentPolicyMismatch("grant does not match the server-required processor policy")
 
         receipt_id = "aicr_" + hashlib.sha256(f"{uid}:{submission.request_id}".encode()).hexdigest()[:32]
+        profile_binding_id = derive_profile_binding_id(account_uid=uid, profile_uid=uid)
         receipt = {
             "receipt_id": receipt_id,
             "subject_uid": uid,
             "decision": submission.decision,
             "policy_version": submission.policy_version,
             "processor_set_hash": submission.processor_set_hash,
+            "processor_ids": [str(processor["id"]) for processor in PROCESSORS],
+            "profile_binding_id": profile_binding_id,
+            "scope_version": submission.scope_version,
+            "scope_hash": submission.scope_hash,
             "request_id": submission.request_id,
             "server_decided_at": self.now().astimezone(timezone.utc).isoformat(),
             "app_version": submission.app_version,
@@ -402,7 +502,7 @@ class AiConsentService:
         }
         fingerprint = _receipt_fingerprint(receipt)
         stored_receipt, state, created = self.repository.record(uid, receipt_id, receipt, fingerprint)
-        payload = _status_payload(uid, state)
+        payload = _status_payload(uid, state, stored_receipt)
         payload["receipt"] = _public_receipt(stored_receipt)
         payload["receipt_created"] = created
         return payload
@@ -417,6 +517,10 @@ def _public_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
             "decision",
             "policy_version",
             "processor_set_hash",
+            "processor_ids",
+            "profile_binding_id",
+            "scope_version",
+            "scope_hash",
             "server_decided_at",
             "app_version",
             "build_number",
@@ -425,20 +529,51 @@ def _public_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _is_current_grant(state: Optional[dict[str, Any]]) -> bool:
+def _is_current_grant(
+    uid: str,
+    state: Optional[dict[str, Any]],
+    receipt: Optional[dict[str, Any]],
+) -> bool:
+    expected_processor_ids = [str(processor["id"]) for processor in PROCESSORS]
+    exact_fields = (
+        "receipt_id",
+        "decision",
+        "policy_version",
+        "processor_set_hash",
+        "processor_ids",
+        "profile_binding_id",
+        "scope_version",
+        "scope_hash",
+        "server_decided_at",
+        "app_version",
+        "build_number",
+        "locale",
+    )
     return bool(
         state
+        and receipt
+        and receipt.get("subject_uid") == uid
+        and all(receipt.get(field) == state.get(field) for field in exact_fields)
         and state.get("decision") == "granted"
         and state.get("policy_version") == CURRENT_POLICY_VERSION
         and state.get("processor_set_hash") == CURRENT_PROCESSOR_SET_HASH
+        and state.get("processor_ids") == expected_processor_ids
+        and state.get("profile_binding_id")
+        and state.get("scope_version") == CURRENT_SCOPE_VERSION
+        and state.get("scope_hash") == CURRENT_SCOPE_HASH
+        and _valid_server_timestamp(state.get("server_decided_at"))
         and state.get("receipt_id")
     )
 
 
-def _status_payload(uid: str, state: Optional[dict[str, Any]]) -> dict[str, Any]:
+def _status_payload(
+    uid: str,
+    state: Optional[dict[str, Any]],
+    receipt: Optional[dict[str, Any]],
+) -> dict[str, Any]:
     return {
         "subject_uid": uid,
-        "authorized": _is_current_grant(state),
+        "authorized": _is_current_grant(uid, state, receipt),
         "enforcement_required": ai_consent_enforcement_required(uid),
         "policy": AiConsentService.policy(),
         "consent": dict(state) if state else {"decision": "not_recorded", "receipt_id": None},
@@ -463,6 +598,56 @@ def ai_consent_enforcement_required(uid: str) -> bool:
 
 def ai_consent_global_enforcement_enabled() -> bool:
     return os.getenv("ELLA_AI_CONSENT_ENFORCEMENT_ENABLED", "false").lower() == "true"
+
+
+def managed_cloud_real_data_enabled(uid: str) -> bool:
+    enabled = os.getenv("ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED", "false").strip().lower() == "true"
+    enabled_uids = {
+        value.strip()
+        for value in os.getenv("ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED_UIDS", "").split(",")
+        if value.strip()
+    }
+    return enabled or uid in enabled_uids
+
+
+def assert_managed_cloud_consent(
+    account_uid: str,
+    *,
+    profile_uid: str,
+    runtime_provider: str,
+    model_route: str,
+    memory_provider: str,
+    photon_scope: str,
+) -> str:
+    """Authorize one exact managed-cloud egress contract for one account/profile."""
+    if not managed_cloud_real_data_enabled(account_uid):
+        raise ManagedCloudConsentError("managed_cloud_real_data_disabled")
+    if (
+        runtime_provider != MANAGED_CLOUD_RUNTIME_PROVIDER
+        or model_route != MANAGED_CLOUD_MODEL_ROUTE
+        or memory_provider != MANAGED_CLOUD_MEMORY_PROVIDER
+        or photon_scope != MANAGED_CLOUD_PHOTON_SCOPE
+    ):
+        raise ManagedCloudConsentError("managed_cloud_consent_scope_drift")
+
+    expected_profile_binding_id = derive_profile_binding_id(
+        account_uid=account_uid,
+        profile_uid=profile_uid,
+    )
+    status = get_ai_consent_service().status(account_uid)
+    state = dict(status.get("consent") or {})
+    if status.get("authorized") is not True or state.get("decision") != "granted":
+        raise ManagedCloudConsentError("managed_cloud_consent_required")
+    if (
+        state.get("policy_version") != CURRENT_POLICY_VERSION
+        or state.get("processor_set_hash") != CURRENT_PROCESSOR_SET_HASH
+        or state.get("scope_version") != CURRENT_SCOPE_VERSION
+        or state.get("scope_hash") != CURRENT_SCOPE_HASH
+        or state.get("profile_binding_id") != expected_profile_binding_id
+        or not _valid_server_timestamp(state.get("server_decided_at"))
+    ):
+        raise ManagedCloudConsentError("managed_cloud_consent_stale")
+    return account_uid
 
 
 def assert_current_ai_consent(uid: str) -> str:

--- a/backend/ella/services/ai_consent.py
+++ b/backend/ella/services/ai_consent.py
@@ -7,6 +7,7 @@ import hmac
 import json
 import os
 import secrets
+import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Literal, Optional, Protocol
@@ -259,6 +260,11 @@ class ConsentRepository(Protocol):
 
     def get_receipt(self, uid: str, receipt_id: str) -> Optional[dict[str, Any]]: ...
 
+    def get_current(
+        self,
+        uid: str,
+    ) -> tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]: ...
+
     def record(
         self,
         uid: str,
@@ -336,6 +342,23 @@ def _record_firestore_receipt(
     return stored_receipt, state, True
 
 
+@transactional
+def _read_firestore_current_receipt(
+    transaction,
+    user_ref,
+) -> tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+    user_snapshot = user_ref.get(transaction=transaction)
+    if not user_snapshot.exists:
+        return None, None
+    state = dict((user_snapshot.to_dict() or {}).get("ai_consent") or {}) or None
+    receipt_id = str((state or {}).get("receipt_id") or "")
+    if not receipt_id:
+        return state, None
+    receipt_snapshot = user_ref.collection("ai_consent_receipts").document(receipt_id).get(transaction=transaction)
+    receipt = receipt_snapshot.to_dict() if receipt_snapshot.exists else None
+    return state, receipt
+
+
 class FirestoreConsentRepository:
     @staticmethod
     def _configured_db():
@@ -354,6 +377,14 @@ class FirestoreConsentRepository:
         db = self._configured_db()
         snapshot = db.collection("users").document(uid).collection("ai_consent_receipts").document(receipt_id).get()
         return snapshot.to_dict() if snapshot.exists else None
+
+    def get_current(
+        self,
+        uid: str,
+    ) -> tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+        db = self._configured_db()
+        user_ref = db.collection("users").document(uid)
+        return _read_firestore_current_receipt(db.transaction(), user_ref)
 
     def record(
         self,
@@ -380,14 +411,28 @@ class InMemoryConsentRepository:
     def __init__(self) -> None:
         self.states: dict[str, dict[str, Any]] = {}
         self.receipts: dict[tuple[str, str], dict[str, Any]] = {}
+        self._lock = threading.RLock()
 
     def get_state(self, uid: str) -> Optional[dict[str, Any]]:
-        state = self.states.get(uid)
-        return dict(state) if state else None
+        with self._lock:
+            state = self.states.get(uid)
+            return dict(state) if state else None
 
     def get_receipt(self, uid: str, receipt_id: str) -> Optional[dict[str, Any]]:
-        receipt = self.receipts.get((uid, receipt_id))
-        return dict(receipt) if receipt else None
+        with self._lock:
+            receipt = self.receipts.get((uid, receipt_id))
+            return dict(receipt) if receipt else None
+
+    def get_current(
+        self,
+        uid: str,
+    ) -> tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+        with self._lock:
+            state = self.states.get(uid)
+            state_copy = dict(state) if state else None
+            receipt_id = str((state_copy or {}).get("receipt_id") or "")
+            receipt = self.receipts.get((uid, receipt_id)) if receipt_id else None
+            return state_copy, dict(receipt) if receipt else None
 
     def record(
         self,
@@ -396,34 +441,35 @@ class InMemoryConsentRepository:
         receipt: dict[str, Any],
         request_fingerprint: str,
     ) -> tuple[dict[str, Any], dict[str, Any], bool]:
-        key = (uid, receipt_id)
-        existing = self.receipts.get(key)
-        if existing:
-            if existing.get("request_fingerprint") != request_fingerprint:
-                raise ConsentIdempotencyConflict("request_id was already used with different consent metadata")
-            return dict(existing), dict(self.states.get(uid) or {}), False
+        with self._lock:
+            key = (uid, receipt_id)
+            existing = self.receipts.get(key)
+            if existing:
+                if existing.get("request_fingerprint") != request_fingerprint:
+                    raise ConsentIdempotencyConflict("request_id was already used with different consent metadata")
+                return dict(existing), dict(self.states.get(uid) or {}), False
 
-        stored = {**receipt, "request_fingerprint": request_fingerprint}
-        state = {
-            key: receipt.get(key)
-            for key in (
-                "receipt_id",
-                "decision",
-                "policy_version",
-                "processor_set_hash",
-                "processor_ids",
-                "profile_binding_id",
-                "scope_version",
-                "scope_hash",
-                "server_decided_at",
-                "app_version",
-                "build_number",
-                "locale",
-            )
-        }
-        self.receipts[(uid, receipt_id)] = stored
-        self.states[uid] = state
-        return dict(stored), dict(state), True
+            stored = {**receipt, "request_fingerprint": request_fingerprint}
+            state = {
+                key: receipt.get(key)
+                for key in (
+                    "receipt_id",
+                    "decision",
+                    "policy_version",
+                    "processor_set_hash",
+                    "processor_ids",
+                    "profile_binding_id",
+                    "scope_version",
+                    "scope_hash",
+                    "server_decided_at",
+                    "app_version",
+                    "build_number",
+                    "locale",
+                )
+            }
+            self.receipts[(uid, receipt_id)] = stored
+            self.states[uid] = state
+            return dict(stored), dict(state), True
 
 
 @dataclass(frozen=True)
@@ -462,9 +508,7 @@ class AiConsentService:
         }
 
     def status(self, uid: str) -> dict[str, Any]:
-        state = self.repository.get_state(uid)
-        receipt_id = str((state or {}).get("receipt_id") or "")
-        receipt = self.repository.get_receipt(uid, receipt_id) if receipt_id else None
+        state, receipt = self.repository.get_current(uid)
         return _status_payload(uid, state, receipt)
 
     def receipt(self, uid: str, receipt_id: str) -> Optional[dict[str, Any]]:

--- a/backend/ella/services/hermes_cloud_photon.py
+++ b/backend/ella/services/hermes_cloud_photon.py
@@ -14,7 +14,14 @@ from typing import Any, Awaitable, Callable, Optional
 from database.ella_provisioning import EllaProvisioningRepository, RuntimePoolClaimError
 from ella.routers.canonical_events import CanonicalEventStore
 from ella.services.hermes_cloud import HermesCloudClient
-from ella.services.hermes_cloud_policy import cloud_synthetic_only
+from ella.services.ai_consent import (
+    MANAGED_CLOUD_MEMORY_PROVIDER,
+    MANAGED_CLOUD_PHOTON_SCOPE,
+)
+from ella.services.hermes_cloud_policy import (
+    assert_cloud_identity_gate,
+    cloud_synthetic_only,
+)
 from ella.services.hermes_cloud_runtime import (
     HermesCloudRuntimeService,
     HermesCloudTurnRequest,
@@ -35,6 +42,7 @@ MANAGED_CLOUD_CONSENT_ERROR_CODES = {
     "managed_cloud_consent_required",
     "managed_cloud_consent_stale",
     "managed_cloud_consent_scope_drift",
+    "managed_cloud_consent_grant_changed",
     "hermes_cloud_consent_policy_not_deployed",
 }
 
@@ -399,26 +407,65 @@ class HermesCloudPhotonAdapter:
     async def _replay_with_consent(
         self,
         *,
-        runtime: IsolatedRuntime,
+        binding: dict[str, Any],
         receipt: dict[str, Any],
     ) -> PhotonAdapterResult:
-        if str(receipt.get("status") or "") == "awaiting_delivery":
-            try:
-                assert_runtime_managed_consent(runtime)
-            except ProvisioningError as exc:
-                if exc.code in MANAGED_CLOUD_CONSENT_ERROR_CODES:
-                    try:
-                        await self.repository.quarantine_photon_delivery_for_consent(
-                            receipt_id=str(receipt["id"]),
-                            error_code=exc.code,
-                        )
-                    except RuntimePoolClaimError as conflict:
-                        raise ProvisioningError(
-                            conflict.code,
-                            retryable=False,
-                        ) from conflict
-                raise
-        return await self._replay(receipt)
+        if str(receipt.get("status") or "") != "awaiting_delivery":
+            return await self._replay(receipt)
+        try:
+            self._assert_receipt_grant_epoch(
+                binding=binding,
+                receipt=receipt,
+            )
+            replay = await self._replay(receipt)
+            # Canonical reconstruction is asynchronous. Recheck after it so a
+            # revoke/regrant during the read cannot release the old payload.
+            self._assert_receipt_grant_epoch(
+                binding=binding,
+                receipt=receipt,
+            )
+            return replay
+        except ProvisioningError as exc:
+            if exc.code in MANAGED_CLOUD_CONSENT_ERROR_CODES:
+                try:
+                    await self.repository.quarantine_photon_delivery_for_consent(
+                        receipt_id=str(receipt["id"]),
+                        error_code=exc.code,
+                    )
+                except RuntimePoolClaimError as conflict:
+                    raise ProvisioningError(
+                        conflict.code,
+                        retryable=False,
+                    ) from conflict
+            raise
+
+    def _assert_receipt_grant_epoch(
+        self,
+        *,
+        binding: dict[str, Any],
+        receipt: dict[str, Any],
+    ) -> str:
+        expected_model = str(receipt.get("expected_model") or binding.get("expected_model") or "")
+        expected_epoch = str(receipt.get("consent_grant_epoch") or "")
+        if not expected_model or not expected_epoch:
+            raise ProvisioningError(
+                "managed_cloud_consent_grant_changed",
+                retryable=False,
+            )
+        current_epoch = assert_cloud_identity_gate(
+            self.config.internal_owner_uid,
+            profile_uid=self.config.internal_owner_uid,
+            runtime_provider=str(binding.get("provider") or ""),
+            model_route=f"openai-codex/{expected_model}",
+            memory_provider=MANAGED_CLOUD_MEMORY_PROVIDER,
+            photon_scope=MANAGED_CLOUD_PHOTON_SCOPE,
+        )
+        if not hmac.compare_digest(expected_epoch, current_epoch):
+            raise ProvisioningError(
+                "managed_cloud_consent_grant_changed",
+                retryable=False,
+            )
+        return current_epoch
 
     async def handle_inbound(
         self,
@@ -440,7 +487,6 @@ class HermesCloudPhotonAdapter:
             line_identity=request.line_identity,
             contact_identity=request.contact_identity,
         )
-        runtime = await self._runtime(binding)
         preflight_receipt = self._assert_live_preflight(
             binding=binding,
             connection_id=request.connection_id,
@@ -459,18 +505,35 @@ class HermesCloudPhotonAdapter:
             ).encode("utf-8")
         ).hexdigest()
         try:
+            existing = await self.repository.get_photon_message_by_inbound(
+                photon_binding_id=str(binding["photon_binding_id"]),
+                inbound_provider_message_key=inbound_provider_key,
+                inbound_payload_sha256=payload_sha256,
+            )
+        except RuntimePoolClaimError as exc:
+            raise ProvisioningError(exc.code, retryable=False) from exc
+        if existing and str(existing.get("status") or "") not in {"claimed", "running"}:
+            return await self._replay_with_consent(
+                binding=binding,
+                receipt=existing,
+            )
+
+        runtime = await self._runtime(binding)
+        consent_grant_epoch = assert_runtime_managed_consent(runtime)
+        try:
             receipt = await self.repository.claim_photon_message(
                 photon_binding_id=str(binding["photon_binding_id"]),
                 inbound_provider_message_key=inbound_provider_key,
                 inbound_payload_sha256=payload_sha256,
                 command_tier_version=self.config.command_tier_version,
+                consent_grant_epoch=consent_grant_epoch,
                 lease_seconds=self.config.receipt_lease_seconds,
             )
         except RuntimePoolClaimError as exc:
             raise ProvisioningError(exc.code, retryable=False) from exc
         if not receipt.get("acquired"):
             return await self._replay_with_consent(
-                runtime=runtime,
+                binding=binding,
                 receipt=receipt,
             )
 
@@ -507,6 +570,7 @@ class HermesCloudPhotonAdapter:
                     "photon_receipt_id": receipt_id,
                     "content_free_identifiers": True,
                 },
+                consent_grant_epoch=consent_grant_epoch,
             )
             if not provider_started:
                 await self.repository.mark_photon_provider_started(
@@ -527,7 +591,12 @@ class HermesCloudPhotonAdapter:
                 "runtime_interaction_id": result.runtime_interaction_id,
                 "content_free": True,
             }
-            assert_runtime_managed_consent(runtime)
+            current_grant_epoch = assert_runtime_managed_consent(runtime)
+            if not hmac.compare_digest(consent_grant_epoch, current_grant_epoch):
+                raise ProvisioningError(
+                    "managed_cloud_consent_grant_changed",
+                    retryable=False,
+                )
             completed = await self.repository.complete_photon_message(
                 receipt_id=receipt_id,
                 lease_token=lease_token,
@@ -552,7 +621,10 @@ class HermesCloudPhotonAdapter:
             )
             # The sidecar response is the Photon egress boundary. A revocation
             # after model completion must prevent delivery of the stored text.
-            assert_runtime_managed_consent(runtime)
+            self._assert_receipt_grant_epoch(
+                binding=refreshed_binding,
+                receipt=completed,
+            )
             return PhotonAdapterResult(
                 receipt_id=receipt_id,
                 status="awaiting_delivery",

--- a/backend/ella/services/hermes_cloud_photon.py
+++ b/backend/ella/services/hermes_cloud_photon.py
@@ -30,6 +30,13 @@ PHOTON_ALLOWED_TOOLS = ("honcho_context", "honcho_reasoning", "honcho_search")
 GIT_SHA_RE = re.compile(r"^[a-f0-9]{40}$")
 SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 TRUE_VALUES = {"1", "true", "yes", "on"}
+MANAGED_CLOUD_CONSENT_ERROR_CODES = {
+    "managed_cloud_real_data_disabled",
+    "managed_cloud_consent_required",
+    "managed_cloud_consent_stale",
+    "managed_cloud_consent_scope_drift",
+    "hermes_cloud_consent_policy_not_deployed",
+}
 
 
 def _utcnow() -> datetime:
@@ -389,6 +396,30 @@ class HermesCloudPhotonAdapter:
             canonical_outbound_event_id=canonical_outbound_event_id,
         )
 
+    async def _replay_with_consent(
+        self,
+        *,
+        runtime: IsolatedRuntime,
+        receipt: dict[str, Any],
+    ) -> PhotonAdapterResult:
+        if str(receipt.get("status") or "") == "awaiting_delivery":
+            try:
+                assert_runtime_managed_consent(runtime)
+            except ProvisioningError as exc:
+                if exc.code in MANAGED_CLOUD_CONSENT_ERROR_CODES:
+                    try:
+                        await self.repository.quarantine_photon_delivery_for_consent(
+                            receipt_id=str(receipt["id"]),
+                            error_code=exc.code,
+                        )
+                    except RuntimePoolClaimError as conflict:
+                        raise ProvisioningError(
+                            conflict.code,
+                            retryable=False,
+                        ) from conflict
+                raise
+        return await self._replay(receipt)
+
     async def handle_inbound(
         self,
         request: PhotonInboundEnvelope,
@@ -438,14 +469,17 @@ class HermesCloudPhotonAdapter:
         except RuntimePoolClaimError as exc:
             raise ProvisioningError(exc.code, retryable=False) from exc
         if not receipt.get("acquired"):
-            assert_runtime_managed_consent(runtime)
-            return await self._replay(receipt)
+            return await self._replay_with_consent(
+                runtime=runtime,
+                receipt=receipt,
+            )
 
         receipt_id = str(receipt["id"])
         lease_token = str(receipt.get("lease_token") or "")
         if not lease_token:
             raise ProvisioningError("photon_message_claim_conflict", retryable=True)
         provider_started = bool(receipt.get("provider_started"))
+        completed_for_delivery = False
         try:
             await self.repository.reserve_photon_quota(
                 receipt_id=receipt_id,
@@ -507,6 +541,7 @@ class HermesCloudPhotonAdapter:
                 preflight_receipt=preflight_receipt,
                 writeback_receipt=writeback_receipt,
             )
+            completed_for_delivery = True
             refreshed_binding = await self._binding(
                 line_identity=request.line_identity,
                 contact_identity=request.contact_identity,
@@ -537,13 +572,19 @@ class HermesCloudPhotonAdapter:
             )
             raise ProvisioningError(exc.code, retryable=not provider_started) from exc
         except ProvisioningError as exc:
-            await self.repository.fail_photon_message(
-                receipt_id=receipt_id,
-                lease_token=lease_token,
-                error_code=exc.code,
-                uncertain=provider_started,
-                provider_started=provider_started,
-            )
+            if completed_for_delivery and exc.code in MANAGED_CLOUD_CONSENT_ERROR_CODES:
+                await self.repository.quarantine_photon_delivery_for_consent(
+                    receipt_id=receipt_id,
+                    error_code=exc.code,
+                )
+            else:
+                await self.repository.fail_photon_message(
+                    receipt_id=receipt_id,
+                    lease_token=lease_token,
+                    error_code=exc.code,
+                    uncertain=provider_started,
+                    provider_started=provider_started,
+                )
             raise
         except Exception as exc:
             await self.repository.fail_photon_message(

--- a/backend/ella/services/hermes_cloud_photon.py
+++ b/backend/ella/services/hermes_cloud_photon.py
@@ -18,6 +18,7 @@ from ella.services.hermes_cloud_policy import cloud_synthetic_only
 from ella.services.hermes_cloud_runtime import (
     HermesCloudRuntimeService,
     HermesCloudTurnRequest,
+    assert_runtime_managed_consent,
 )
 from ella.services.runtime_errors import ProvisioningError
 from ella.services.runtime_resolver import IsolatedRuntime, resolve_isolated_runtime
@@ -437,6 +438,7 @@ class HermesCloudPhotonAdapter:
         except RuntimePoolClaimError as exc:
             raise ProvisioningError(exc.code, retryable=False) from exc
         if not receipt.get("acquired"):
+            assert_runtime_managed_consent(runtime)
             return await self._replay(receipt)
 
         receipt_id = str(receipt["id"])
@@ -491,6 +493,7 @@ class HermesCloudPhotonAdapter:
                 "runtime_interaction_id": result.runtime_interaction_id,
                 "content_free": True,
             }
+            assert_runtime_managed_consent(runtime)
             completed = await self.repository.complete_photon_message(
                 receipt_id=receipt_id,
                 lease_token=lease_token,
@@ -512,6 +515,9 @@ class HermesCloudPhotonAdapter:
                 binding=refreshed_binding,
                 connection_id=request.connection_id,
             )
+            # The sidecar response is the Photon egress boundary. A revocation
+            # after model completion must prevent delivery of the stored text.
+            assert_runtime_managed_consent(runtime)
             return PhotonAdapterResult(
                 receipt_id=receipt_id,
                 status="awaiting_delivery",

--- a/backend/ella/services/hermes_cloud_policy.py
+++ b/backend/ella/services/hermes_cloud_policy.py
@@ -54,15 +54,17 @@ def assert_cloud_identity_gate(
     model_route: Optional[str] = None,
     memory_provider: Optional[str] = None,
     photon_scope: Optional[str] = None,
-) -> None:
-    """Reject real identities until an exact managed-cloud consent grant exists."""
+) -> str:
+    """Return the server-owned grant epoch for an allowed cloud identity."""
     if cloud_synthetic_only():
         if uid not in _synthetic_uids():
             raise ProvisioningError("hermes_cloud_synthetic_identity_required", retryable=False)
-        return
+        return (
+            "synthetic:" + hashlib.sha256(f"{ai_consent.CURRENT_POLICY_VERSION}\x1f{uid}".encode("utf-8")).hexdigest()
+        )
     _assert_deployed_cloud_consent_policy()
     try:
-        ai_consent.assert_managed_cloud_consent(
+        return ai_consent.assert_managed_cloud_consent(
             uid,
             profile_uid=str(profile_uid or ""),
             runtime_provider=str(runtime_provider or ""),

--- a/backend/ella/services/hermes_cloud_policy.py
+++ b/backend/ella/services/hermes_cloud_policy.py
@@ -19,7 +19,12 @@ APPROVAL_SCHEMA_VERSION = "ella-hermes-cloud-approval-v1"
 SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 GIT_SHA_RE = re.compile(r"^[a-f0-9]{40}$")
 TRUE_VALUES = {"1", "true", "yes", "on"}
-MANAGED_CLOUD_PROCESSORS = {"hermes-cloud", "honcho-cloud"}
+MANAGED_CLOUD_PROCESSORS = {
+    "nous-hermes-cloud",
+    "honcho-cloud",
+    "openai-codex",
+    "photon",
+}
 
 
 def _stable_json(value: Any) -> str:
@@ -41,39 +46,54 @@ def assert_cloud_operator_gate() -> None:
     _assert_deployed_cloud_consent_policy()
 
 
-def assert_cloud_identity_gate(uid: str) -> None:
+def assert_cloud_identity_gate(
+    uid: str,
+    *,
+    profile_uid: Optional[str] = None,
+    runtime_provider: Optional[str] = None,
+    model_route: Optional[str] = None,
+    memory_provider: Optional[str] = None,
+    photon_scope: Optional[str] = None,
+) -> None:
     """Reject real identities until an exact managed-cloud consent grant exists."""
     if cloud_synthetic_only():
         if uid not in _synthetic_uids():
             raise ProvisioningError("hermes_cloud_synthetic_identity_required", retryable=False)
         return
-    required_version, required_hash = _assert_deployed_cloud_consent_policy()
-    status = ai_consent.get_ai_consent_service().status(uid)
-    consent = dict(status.get("consent") or {})
-    if (
-        status.get("authorized") is not True
-        or consent.get("decision") != "granted"
-        or consent.get("policy_version") != required_version
-        or consent.get("processor_set_hash") != required_hash
-        or not consent.get("receipt_id")
-    ):
-        raise ProvisioningError("hermes_cloud_consent_required", retryable=False)
+    _assert_deployed_cloud_consent_policy()
+    try:
+        ai_consent.assert_managed_cloud_consent(
+            uid,
+            profile_uid=str(profile_uid or ""),
+            runtime_provider=str(runtime_provider or ""),
+            model_route=str(model_route or ""),
+            memory_provider=str(memory_provider or ""),
+            photon_scope=str(photon_scope or ""),
+        )
+    except ai_consent.ManagedCloudConsentError as exc:
+        raise ProvisioningError(exc.code, retryable=False) from exc
 
 
-def _assert_deployed_cloud_consent_policy() -> tuple[str, str]:
+def _assert_deployed_cloud_consent_policy() -> tuple[str, str, str, str]:
     required_version = os.getenv("ELLA_HERMES_CLOUD_CONSENT_POLICY_VERSION", "").strip()
     required_hash = os.getenv("ELLA_HERMES_CLOUD_CONSENT_PROCESSOR_SET_HASH", "").strip()
+    required_scope_version = os.getenv("ELLA_HERMES_CLOUD_CONSENT_SCOPE_VERSION", "").strip()
+    required_scope_hash = os.getenv("ELLA_HERMES_CLOUD_CONSENT_SCOPE_HASH", "").strip()
     if (
         not required_version
         or not required_hash
+        or not required_scope_version
+        or not required_scope_hash
         or required_version != ai_consent.CURRENT_POLICY_VERSION
         or required_hash != ai_consent.CURRENT_PROCESSOR_SET_HASH
+        or required_scope_version != ai_consent.CURRENT_SCOPE_VERSION
+        or required_scope_hash != ai_consent.CURRENT_SCOPE_HASH
         or not MANAGED_CLOUD_PROCESSORS.issubset(
             {str(processor.get("id") or "") for processor in ai_consent.PROCESSORS if isinstance(processor, dict)}
         )
     ):
         raise ProvisioningError("hermes_cloud_consent_policy_not_deployed", retryable=False)
-    return required_version, required_hash
+    return required_version, required_hash, required_scope_version, required_scope_hash
 
 
 @dataclass(frozen=True)

--- a/backend/ella/services/hermes_cloud_runtime.py
+++ b/backend/ella/services/hermes_cloud_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import hmac
 import json
 import os
 from dataclasses import dataclass
@@ -33,8 +34,8 @@ DEFAULT_MAX_OUTPUT_TOKENS = 1024
 DEFAULT_MAX_TOOL_CALLS = 2
 
 
-def assert_runtime_managed_consent(runtime: IsolatedRuntime) -> None:
-    assert_cloud_identity_gate(
+def assert_runtime_managed_consent(runtime: IsolatedRuntime) -> str:
+    return assert_cloud_identity_gate(
         runtime.uid,
         profile_uid=runtime.uid,
         runtime_provider=runtime.provider,
@@ -153,6 +154,7 @@ class HermesCloudTurnRequest:
     instructions: str
     started_at: datetime
     client_metadata: dict[str, Any]
+    consent_grant_epoch: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -173,6 +175,7 @@ def _request_hash(request: HermesCloudTurnRequest) -> str:
             request.channel,
             request.client_interaction_id,
             request.user_input,
+            request.consent_grant_epoch or "",
         )
     )
     return hashlib.sha256(material.encode("utf-8")).hexdigest()
@@ -256,7 +259,15 @@ class HermesCloudRuntimeService:
     ) -> HermesCloudTurnResult:
         if runtime.provider != "hermes_cloud" or runtime.uid != request.uid:
             raise ProvisioningError("hermes_cloud_runtime_required", retryable=False)
-        assert_runtime_managed_consent(runtime)
+        current_grant_epoch = assert_runtime_managed_consent(runtime)
+        if request.consent_grant_epoch and not hmac.compare_digest(
+            request.consent_grant_epoch,
+            current_grant_epoch,
+        ):
+            raise ProvisioningError(
+                "managed_cloud_consent_grant_changed",
+                retryable=False,
+            )
         if runtime.status == "shadow" and not self.allow_shadow:
             raise ProvisioningError("hermes_cloud_shadow_not_routable", retryable=False)
         if not request.client_interaction_id.strip():
@@ -418,7 +429,15 @@ class HermesCloudRuntimeService:
             # Consent may be revoked while canonical ingest/admission work is in
             # flight. Recheck at the last boundary before protected content is
             # sent to Hermes Cloud and its OpenAI model route.
-            assert_runtime_managed_consent(runtime)
+            current_grant_epoch = assert_runtime_managed_consent(runtime)
+            if request.consent_grant_epoch and not hmac.compare_digest(
+                request.consent_grant_epoch,
+                current_grant_epoch,
+            ):
+                raise ProvisioningError(
+                    "managed_cloud_consent_grant_changed",
+                    retryable=False,
+                )
             provider_started = True
             turn = await self.cloud_client.create_response(
                 {

--- a/backend/ella/services/hermes_cloud_runtime.py
+++ b/backend/ella/services/hermes_cloud_runtime.py
@@ -13,6 +13,10 @@ from typing import Any, Optional
 from database import voice_canary as voice_canary_db
 from database.ella_provisioning import EllaProvisioningRepository, RuntimePoolClaimError
 from ella.routers.canonical_events import CanonicalEventIn, CanonicalEventStore
+from ella.services.ai_consent import (
+    MANAGED_CLOUD_MEMORY_PROVIDER,
+    MANAGED_CLOUD_PHOTON_SCOPE,
+)
 from ella.services.hermes_cloud import (
     HermesCloudClient,
     estimate_max_turn_cost_microusd,
@@ -27,6 +31,17 @@ HERMES_CLOUD_PHOTON_MODE = "hermes-cloud-photon"
 DEFAULT_MAX_INPUT_TOKENS = 8192
 DEFAULT_MAX_OUTPUT_TOKENS = 1024
 DEFAULT_MAX_TOOL_CALLS = 2
+
+
+def assert_runtime_managed_consent(runtime: IsolatedRuntime) -> None:
+    assert_cloud_identity_gate(
+        runtime.uid,
+        profile_uid=runtime.uid,
+        runtime_provider=runtime.provider,
+        model_route=f"openai-codex/{runtime.expected_model}",
+        memory_provider=MANAGED_CLOUD_MEMORY_PROVIDER,
+        photon_scope=MANAGED_CLOUD_PHOTON_SCOPE,
+    )
 
 
 def _bounded_env_int(name: str, default: int, minimum: int, maximum: int) -> int:
@@ -241,7 +256,7 @@ class HermesCloudRuntimeService:
     ) -> HermesCloudTurnResult:
         if runtime.provider != "hermes_cloud" or runtime.uid != request.uid:
             raise ProvisioningError("hermes_cloud_runtime_required", retryable=False)
-        assert_cloud_identity_gate(request.uid)
+        assert_runtime_managed_consent(runtime)
         if runtime.status == "shadow" and not self.allow_shadow:
             raise ProvisioningError("hermes_cloud_shadow_not_routable", retryable=False)
         if not request.client_interaction_id.strip():
@@ -400,6 +415,10 @@ class HermesCloudRuntimeService:
             if not reservation.allowed:
                 raise ProvisioningError(reservation.code, retryable=False)
 
+            # Consent may be revoked while canonical ingest/admission work is in
+            # flight. Recheck at the last boundary before protected content is
+            # sent to Hermes Cloud and its OpenAI model route.
+            assert_runtime_managed_consent(runtime)
             provider_started = True
             turn = await self.cloud_client.create_response(
                 {

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -22,6 +22,10 @@ from database.ella_provisioning import (
     ProvisioningSchemaNotReadyError,
     RuntimePoolClaimError,
 )
+from ella.services.ai_consent import (
+    MANAGED_CLOUD_MEMORY_PROVIDER,
+    MANAGED_CLOUD_PHOTON_SCOPE,
+)
 from ella.services.hermes_cloud import (
     HermesCloudClient,
     HonchoCloudProvisionClient,
@@ -551,7 +555,6 @@ class ProvisioningCoordinator:
         binding: Optional[dict[str, Any]] = None
         claim_token = ""
         try:
-            assert_cloud_identity_gate(identity.uid)
             pool_policy = await self.repository.get_cloud_pool_admission_policy()
             if not pool_policy:
                 pool_state = await self.repository.reconcile_cloud_pool_alert(
@@ -570,10 +573,23 @@ class ProvisioningCoordinator:
                     },
                 )
                 return
+            expected_model = str(pool_policy["model"])
+
+            def assert_current_cloud_consent() -> None:
+                assert_cloud_identity_gate(
+                    identity.uid,
+                    profile_uid=identity.uid,
+                    runtime_provider=str(pool_policy["provider"]),
+                    model_route=f"openai-codex/{expected_model}",
+                    memory_provider=MANAGED_CLOUD_MEMORY_PROVIDER,
+                    photon_scope=MANAGED_CLOUD_PHOTON_SCOPE,
+                )
+
+            assert_current_cloud_consent()
             admission = await runtime_admission(
                 uid=identity.uid,
                 provider=str(pool_policy["provider"]),
-                model=str(pool_policy["model"]),
+                model=expected_model,
             )
             if not admission.allowed:
                 raise ProvisioningError(
@@ -586,9 +602,7 @@ class ProvisioningCoordinator:
                 job_id=str(job["id"]),
                 lease_seconds=cloud_pool_claim_lease_seconds(),
             )
-            pool_state = await self.repository.reconcile_cloud_pool_alert(
-                threshold=cloud_pool_low_water_threshold()
-            )
+            pool_state = await self.repository.reconcile_cloud_pool_alert(threshold=cloud_pool_low_water_threshold())
             await self._publish_pool_alert(alert_publisher, pool_state)
             if not binding:
                 await self.repository.update_job(
@@ -607,7 +621,7 @@ class ProvisioningCoordinator:
             claim_token = str(binding.get("claim_token") or "")
             if not claim_token:
                 raise ProvisioningError("runtime_pool_claim_incomplete", retryable=False)
-            if str(binding.get("expected_model") or "") != str(pool_policy["model"]):
+            if str(binding.get("expected_model") or "") != expected_model:
                 raise ProvisioningError("runtime_pool_policy_changed", retryable=False)
 
             async def record_side_effect(effect: dict[str, str]) -> None:
@@ -622,10 +636,12 @@ class ProvisioningCoordinator:
                     },
                 )
 
+            assert_current_cloud_consent()
             honcho = await honcho_client.ensure_profile(
                 binding,
                 on_side_effect=record_side_effect,
             )
+            assert_current_cloud_consent()
             preflight = await cloud_client.preflight(binding)
             health_receipt = {
                 **preflight.receipt,
@@ -634,9 +650,7 @@ class ProvisioningCoordinator:
                     "observed_peer_sha256": hashlib.sha256(honcho["observed_peer"].encode("utf-8")).hexdigest(),
                     "observer_peer_sha256": hashlib.sha256(honcho["observer_peer"].encode("utf-8")).hexdigest(),
                 },
-                "admission_revision": (
-                    int(admission.entitlement.get("revision") or 0) if admission.entitlement else 0
-                ),
+                "admission_revision": (int(admission.entitlement.get("revision") or 0) if admission.entitlement else 0),
             }
             activated = await self.repository.finalize_cloud_pool_claim(
                 uid=identity.uid,
@@ -708,11 +722,7 @@ class ProvisioningCoordinator:
     async def _publish_pool_alert(self, publisher: Any, pool_state: dict[str, Any]) -> None:
         try:
             alert = pool_state.get("alert")
-            delivered = bool(
-                alert
-                and not alert.get("delivered_at")
-                and await publisher.publish(pool_state)
-            )
+            delivered = bool(alert and not alert.get("delivered_at") and await publisher.publish(pool_state))
             if delivered:
                 await self.repository.mark_cloud_pool_alert_delivered(str(alert["id"]))
         except Exception:

--- a/backend/ella/services/runtime_resolver.py
+++ b/backend/ella/services/runtime_resolver.py
@@ -9,6 +9,10 @@ from typing import Optional
 from urllib.parse import urlparse
 
 from database.ella_provisioning import EllaProvisioningRepository
+from ella.services.ai_consent import (
+    MANAGED_CLOUD_MEMORY_PROVIDER,
+    MANAGED_CLOUD_PHOTON_SCOPE,
+)
 from ella.services.hermes_cloud import (
     HermesCloudClient,
     validate_prompt_artifact_receipt,
@@ -90,13 +94,11 @@ def runtime_from_binding(binding: dict, uid: str, *, allow_shadow: bool = False)
         raise ProvisioningError("plato_binding_forbidden", retryable=False)
 
     if provider == "hermes_cloud":
-        assert_cloud_identity_gate(uid)
         if any(
             binding.get(field)
             for field in ("workspace_root", "internal_gateway_url", "gateway_port", "service_label", "credential_ref")
         ):
             raise ProvisioningError("cloud_binding_contains_local_runtime", retryable=False)
-        gateway_url, gateway_token = HermesCloudClient.credentials(binding)
         prompt_artifact_receipt = validate_prompt_artifact_receipt(binding)
         workspace_root = ""
         runtime_instance_id = str(binding.get("runtime_instance_id") or "")
@@ -104,6 +106,15 @@ def runtime_from_binding(binding: dict, uid: str, *, allow_shadow: bool = False)
         model_context_window_tokens = int(prompt_artifact_receipt["model_context_window_tokens"])
         if not runtime_instance_id or not expected_model:
             raise ProvisioningError("cloud_runtime_receipt_incomplete", retryable=False)
+        assert_cloud_identity_gate(
+            uid,
+            profile_uid=uid,
+            runtime_provider=provider,
+            model_route=f"openai-codex/{expected_model}",
+            memory_provider=MANAGED_CLOUD_MEMORY_PROVIDER,
+            photon_scope=MANAGED_CLOUD_PHOTON_SCOPE,
+        )
+        gateway_url, gateway_token = HermesCloudClient.credentials(binding)
     else:
         workspace_root = str(binding.get("workspace_root") or "")
         profiles_root = os.getenv("ELLA_HERMES_PROFILES_ROOT", "/Users/ellaai/.hermes/profiles")

--- a/backend/migrations/009_create_hermes_cloud_runtime_pool.sql
+++ b/backend/migrations/009_create_hermes_cloud_runtime_pool.sql
@@ -276,6 +276,11 @@ CREATE TABLE ella_photon_message_receipts (
     expected_model TEXT,
     policy_commit_sha VARCHAR(40),
     command_tier_version TEXT,
+    consent_grant_epoch VARCHAR(96) NOT NULL
+        CHECK (
+            length(consent_grant_epoch) >= 16
+            AND length(consent_grant_epoch) <= 96
+        ),
     usage JSONB NOT NULL DEFAULT '{}'::jsonb,
     preflight_receipt JSONB NOT NULL DEFAULT '{}'::jsonb,
     writeback_receipt JSONB NOT NULL DEFAULT '{}'::jsonb,

--- a/backend/tests/unit/test_ella_ai_consent.py
+++ b/backend/tests/unit/test_ella_ai_consent.py
@@ -347,7 +347,7 @@ def test_exact_v6_account_profile_and_scope_authorize_managed_cloud(monkeypatch)
     monkeypatch.setattr(consent, "_repository", repository)
     _enable_managed_cloud(monkeypatch)
 
-    assert _assert_exact_managed_cloud_consent() == "user-a"
+    assert _assert_exact_managed_cloud_consent() == result["consent"]["receipt_id"]
     assert result["consent"]["profile_binding_id"] == consent.derive_profile_binding_id(
         account_uid="user-a",
         profile_uid="user-a",

--- a/backend/tests/unit/test_ella_ai_consent.py
+++ b/backend/tests/unit/test_ella_ai_consent.py
@@ -218,6 +218,62 @@ def test_firestore_transaction_replay_does_not_rewrite_current_state():
     assert state == current_state
 
 
+def test_firestore_current_pointer_and_receipt_are_read_in_one_transaction():
+    class Snapshot:
+        def __init__(self, data):
+            self.exists = data is not None
+            self._data = data or {}
+
+        def to_dict(self):
+            return dict(self._data)
+
+    class ReceiptRef:
+        def __init__(self, snapshot):
+            self.snapshot = snapshot
+
+        def get(self, transaction):
+            assert transaction is transaction_instance
+            return self.snapshot
+
+    class ReceiptCollection:
+        def document(self, receipt_id):
+            assert receipt_id == "aicr_revoked"
+            return ReceiptRef(
+                Snapshot(
+                    {
+                        "receipt_id": "aicr_revoked",
+                        "decision": "revoked",
+                    }
+                )
+            )
+
+    class UserRef:
+        def get(self, transaction):
+            assert transaction is transaction_instance
+            return Snapshot(
+                {
+                    "ai_consent": {
+                        "receipt_id": "aicr_revoked",
+                        "decision": "revoked",
+                    }
+                }
+            )
+
+        def collection(self, name):
+            assert name == "ai_consent_receipts"
+            return ReceiptCollection()
+
+    transaction_instance = object()
+    state, receipt = consent._read_firestore_current_receipt.to_wrap(
+        transaction_instance,
+        UserRef(),
+    )
+
+    assert state["receipt_id"] == "aicr_revoked"
+    assert receipt["receipt_id"] == "aicr_revoked"
+    assert receipt["decision"] == "revoked"
+
+
 def test_stale_grant_is_rejected_but_stale_decline_is_recorded():
     service = _service()
 
@@ -296,6 +352,46 @@ def test_exact_v6_account_profile_and_scope_authorize_managed_cloud(monkeypatch)
         account_uid="user-a",
         profile_uid="user-a",
     )
+
+
+def test_revocation_cannot_interleave_between_current_pointer_and_receipt_reads(
+    monkeypatch,
+):
+    class RevocationAtReadRepository(consent.InMemoryConsentRepository):
+        def __init__(self):
+            super().__init__()
+            self.service = None
+            self.revoked = False
+            self.legacy_state_reads = 0
+
+        def get_state(self, uid):
+            self.legacy_state_reads += 1
+            return super().get_state(uid)
+
+        def get_current(self, uid):
+            if not self.revoked:
+                self.revoked = True
+                self.service.submit(
+                    uid,
+                    _submission(
+                        decision="revoked",
+                        request_id="request-race-revoke",
+                    ),
+                )
+            return super().get_current(uid)
+
+    repository = RevocationAtReadRepository()
+    service = _service(repository)
+    repository.service = service
+    service.submit("user-a", _submission())
+    monkeypatch.setattr(consent, "_repository", repository)
+    _enable_managed_cloud(monkeypatch)
+
+    with pytest.raises(consent.ManagedCloudConsentError) as error:
+        _assert_exact_managed_cloud_consent()
+
+    assert error.value.code == "managed_cloud_consent_required"
+    assert repository.legacy_state_reads == 0
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/test_ella_ai_consent.py
+++ b/backend/tests/unit/test_ella_ai_consent.py
@@ -1,3 +1,4 @@
+import hashlib
 from datetime import datetime, timezone
 
 import pytest
@@ -15,6 +16,8 @@ def _submission(
     request_id="request-0001",
     policy_version=consent.CURRENT_POLICY_VERSION,
     processor_set_hash=consent.CURRENT_PROCESSOR_SET_HASH,
+    scope_version=consent.CURRENT_SCOPE_VERSION,
+    scope_hash=consent.CURRENT_SCOPE_HASH,
 ):
     return consent.ConsentSubmission(
         decision=decision,
@@ -24,6 +27,8 @@ def _submission(
         app_version="1.0.0",
         build_number="804",
         locale="en-US",
+        scope_version=scope_version,
+        scope_hash=scope_hash,
     )
 
 
@@ -34,11 +39,13 @@ def _service(repository=None):
     )
 
 
-def test_policy_covers_current_chat_voice_stt_and_tts_surface():
+def test_policy_matches_exact_managed_cloud_v6_contract():
     policy = consent.AiConsentService.policy()
 
-    assert policy["version"] == "ai-data-processors-v5"
-    assert policy["processor_set_hash"] == "sha256:9c2529babbd6241f20242cf0836baf7e1899d05bb3d945a0d38a357113d4cbc4"
+    assert policy["version"] == "ai-data-processors-v6"
+    assert policy["processor_set_hash"] == "sha256:dd84e4a9da1166cff66e5de55c2570d0496a2c89d46ca431530e993758616296"
+    assert policy["scope_version"] == "managed-cloud-internal-pilot-v1"
+    assert policy["scope_hash"] == "sha256:727b1db818ce79090a02279f1cc6d15dfc3d65a58592b13fbed53ad048c38a30"
     assert (
         "|".join(
             [
@@ -49,6 +56,10 @@ def test_policy_covers_current_chat_voice_stt_and_tts_surface():
                 "hermes-self-hosted:agent-runtime",
                 "honcho-self-hosted:memory-context",
                 "ella-self-hosted-tts:tts",
+                "nous-hermes-cloud:managed-agent-runtime",
+                "honcho-cloud:derived-memory-context",
+                "openai-codex:managed-agent-model",
+                "photon:messaging-delivery",
                 "openrouter:model-routing",
                 "google-gemini:language-live-voice",
                 "openai:language-live-voice",
@@ -60,6 +71,7 @@ def test_policy_covers_current_chat_voice_stt_and_tts_surface():
         )
         == policy["canonical_processor_set"]
     )
+    assert consent.CURRENT_SCOPE_HASH == f"sha256:{hashlib.sha256(policy['canonical_scope'].encode()).hexdigest()}"
 
 
 def test_missing_consent_is_fail_closed_when_enforcement_is_enabled(monkeypatch):
@@ -87,6 +99,13 @@ def test_exact_policy_grant_is_server_timestamped_and_authorizes(monkeypatch):
     assert result["receipt"]["receipt_id"].startswith("aicr_")
     assert "user-a" not in result["receipt"]["receipt_id"]
     assert result["receipt"]["subject_uid"] == "user-a"
+    assert result["receipt"]["profile_binding_id"] == consent.derive_profile_binding_id(
+        account_uid="user-a",
+        profile_uid="user-a",
+    )
+    assert result["receipt"]["scope_version"] == consent.CURRENT_SCOPE_VERSION
+    assert result["receipt"]["scope_hash"] == consent.CURRENT_SCOPE_HASH
+    assert result["receipt"]["processor_ids"] == [processor["id"] for processor in consent.PROCESSORS]
     assert result["receipt"]["server_decided_at"] == "2026-07-26T23:45:00+00:00"
     assert result["receipt"]["build_number"] == "804"
     assert result["enforcement_required"] is True
@@ -238,6 +257,156 @@ def test_revoke_supersedes_prior_grant():
     assert revoked["account_deletion"]["path"] == "/v1/users/delete-account"
 
 
+def _enable_managed_cloud(monkeypatch, uid="user-a"):
+    monkeypatch.setenv("ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED_UIDS", uid)
+
+
+def _assert_exact_managed_cloud_consent(uid="user-a", profile_uid="user-a"):
+    return consent.assert_managed_cloud_consent(
+        uid,
+        profile_uid=profile_uid,
+        runtime_provider=consent.MANAGED_CLOUD_RUNTIME_PROVIDER,
+        model_route=consent.MANAGED_CLOUD_MODEL_ROUTE,
+        memory_provider=consent.MANAGED_CLOUD_MEMORY_PROVIDER,
+        photon_scope=consent.MANAGED_CLOUD_PHOTON_SCOPE,
+    )
+
+
+def test_managed_cloud_real_data_defaults_off_even_with_exact_v6_grant(monkeypatch):
+    repository = consent.InMemoryConsentRepository()
+    _service(repository).submit("user-a", _submission())
+    monkeypatch.setattr(consent, "_repository", repository)
+    monkeypatch.delenv("ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED", raising=False)
+    monkeypatch.delenv("ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED_UIDS", raising=False)
+
+    with pytest.raises(consent.ManagedCloudConsentError) as error:
+        _assert_exact_managed_cloud_consent()
+
+    assert error.value.code == "managed_cloud_real_data_disabled"
+
+
+def test_exact_v6_account_profile_and_scope_authorize_managed_cloud(monkeypatch):
+    repository = consent.InMemoryConsentRepository()
+    result = _service(repository).submit("user-a", _submission())
+    monkeypatch.setattr(consent, "_repository", repository)
+    _enable_managed_cloud(monkeypatch)
+
+    assert _assert_exact_managed_cloud_consent() == "user-a"
+    assert result["consent"]["profile_binding_id"] == consent.derive_profile_binding_id(
+        account_uid="user-a",
+        profile_uid="user-a",
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("runtime_provider", "hermes"),
+        ("model_route", "openai/gpt-5.6-terra"),
+        ("memory_provider", "honcho-self-hosted"),
+        (
+            "photon_scope",
+            "shared_test_line_explicit_contact_v1;allow_all=true;caregiver=false;attachments=false",
+        ),
+    ],
+)
+def test_managed_cloud_route_provider_or_scope_drift_fails_closed(monkeypatch, field, value):
+    repository = consent.InMemoryConsentRepository()
+    _service(repository).submit("user-a", _submission())
+    monkeypatch.setattr(consent, "_repository", repository)
+    _enable_managed_cloud(monkeypatch)
+    route = {
+        "profile_uid": "user-a",
+        "runtime_provider": consent.MANAGED_CLOUD_RUNTIME_PROVIDER,
+        "model_route": consent.MANAGED_CLOUD_MODEL_ROUTE,
+        "memory_provider": consent.MANAGED_CLOUD_MEMORY_PROVIDER,
+        "photon_scope": consent.MANAGED_CLOUD_PHOTON_SCOPE,
+    }
+    route[field] = value
+
+    with pytest.raises(consent.ManagedCloudConsentError) as error:
+        consent.assert_managed_cloud_consent("user-a", **route)
+
+    assert error.value.code == "managed_cloud_consent_scope_drift"
+
+
+def test_managed_cloud_account_and_profile_switches_fail_closed(monkeypatch):
+    repository = consent.InMemoryConsentRepository()
+    _service(repository).submit("user-a", _submission())
+    monkeypatch.setattr(consent, "_repository", repository)
+    _enable_managed_cloud(monkeypatch, "user-a,user-b")
+
+    with pytest.raises(consent.ManagedCloudConsentError) as account_error:
+        _assert_exact_managed_cloud_consent(uid="user-b", profile_uid="user-a")
+    assert account_error.value.code == "managed_cloud_consent_required"
+
+    with pytest.raises(consent.ManagedCloudConsentError) as profile_error:
+        _assert_exact_managed_cloud_consent(uid="user-a", profile_uid="profile-b")
+    assert profile_error.value.code == "managed_cloud_consent_stale"
+
+
+@pytest.mark.parametrize("terminal_state", ["declined", "revoked", "deleted"])
+def test_managed_cloud_decline_revoke_and_delete_fail_closed(monkeypatch, terminal_state):
+    repository = consent.InMemoryConsentRepository()
+    service = _service(repository)
+    service.submit("user-a", _submission())
+    if terminal_state == "deleted":
+        repository.states.pop("user-a")
+        repository.receipts = {key: value for key, value in repository.receipts.items() if key[0] != "user-a"}
+    else:
+        service.submit(
+            "user-a",
+            _submission(
+                decision=terminal_state,
+                request_id=f"request-{terminal_state}",
+            ),
+        )
+    monkeypatch.setattr(consent, "_repository", repository)
+    _enable_managed_cloud(monkeypatch)
+
+    with pytest.raises(consent.ManagedCloudConsentError) as error:
+        _assert_exact_managed_cloud_consent()
+
+    assert error.value.code == "managed_cloud_consent_required"
+
+
+def test_missing_or_mutated_immutable_receipt_fails_closed(monkeypatch):
+    repository = consent.InMemoryConsentRepository()
+    result = _service(repository).submit("user-a", _submission())
+    monkeypatch.setattr(consent, "_repository", repository)
+    _enable_managed_cloud(monkeypatch)
+    receipt_id = result["receipt"]["receipt_id"]
+
+    repository.receipts.pop(("user-a", receipt_id))
+    with pytest.raises(consent.ManagedCloudConsentError) as missing:
+        _assert_exact_managed_cloud_consent()
+    assert missing.value.code == "managed_cloud_consent_required"
+
+    repository.receipts[("user-a", receipt_id)] = {
+        **result["receipt"],
+        "processor_set_hash": "sha256:mutated",
+    }
+    with pytest.raises(consent.ManagedCloudConsentError) as mutated:
+        _assert_exact_managed_cloud_consent()
+    assert mutated.value.code == "managed_cloud_consent_required"
+
+
+def test_v5_or_malformed_server_receipt_cannot_authorize_managed_cloud(monkeypatch):
+    repository = consent.InMemoryConsentRepository()
+    _service(repository).submit("user-a", _submission())
+    monkeypatch.setattr(consent, "_repository", repository)
+    _enable_managed_cloud(monkeypatch)
+
+    repository.states["user-a"]["policy_version"] = "ai-data-processors-v5"
+    with pytest.raises(consent.ManagedCloudConsentError):
+        _assert_exact_managed_cloud_consent()
+
+    repository.states["user-a"]["policy_version"] = consent.CURRENT_POLICY_VERSION
+    repository.states["user-a"]["server_decided_at"] = "not-a-timestamp"
+    with pytest.raises(consent.ManagedCloudConsentError):
+        _assert_exact_managed_cloud_consent()
+
+
 @pytest.mark.parametrize("decision", ["declined", "revoked"])
 def test_decline_and_revoke_block_central_target_uid_egress(monkeypatch, decision):
     repository = consent.InMemoryConsentRepository()
@@ -259,9 +428,7 @@ def test_decline_and_revoke_block_central_target_uid_egress(monkeypatch, decisio
 
 
 def test_account_deletion_receipt_is_opaque_and_completed():
-    receipt = consent.build_account_deletion_receipt(
-        now=lambda: datetime(2026, 7, 26, 20, 15, tzinfo=timezone.utc)
-    )
+    receipt = consent.build_account_deletion_receipt(now=lambda: datetime(2026, 7, 26, 20, 15, tzinfo=timezone.utc))
 
     assert receipt["request_id"].startswith("aidel_")
     assert len(receipt["request_id"]) == len("aidel_") + 32
@@ -441,3 +608,41 @@ def test_policy_is_public_but_status_and_receipts_require_firebase_auth(monkeypa
     status_response = client.get("/v1/users/ai-consent")
     assert status_response.status_code == 200
     assert status_response.json()["subject_uid"] == "user-a"
+
+
+def test_authenticated_api_records_exact_v6_profile_bound_receipt(monkeypatch):
+    service = _service()
+    monkeypatch.setattr(ai_consent, "get_ai_consent_service", lambda: service)
+    app = FastAPI()
+    app.include_router(ai_consent.router)
+    app.dependency_overrides[consent.auth.get_current_user_uid] = lambda: "user-a"
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/users/ai-consent",
+        json={
+            "decision": "granted",
+            "policy_version": consent.CURRENT_POLICY_VERSION,
+            "processor_set_hash": consent.CURRENT_PROCESSOR_SET_HASH,
+            "scope_version": consent.CURRENT_SCOPE_VERSION,
+            "scope_hash": consent.CURRENT_SCOPE_HASH,
+            "request_id": "request-api-v6",
+            "app_version": "1.0.0",
+            "build_number": "804",
+            "locale": "en-US",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["authorized"] is True
+    assert body["receipt"]["subject_uid"] == "user-a"
+    assert body["receipt"]["profile_binding_id"] == consent.derive_profile_binding_id(
+        account_uid="user-a",
+        profile_uid="user-a",
+    )
+    assert body["receipt"]["policy_version"] == consent.CURRENT_POLICY_VERSION
+    assert body["receipt"]["processor_set_hash"] == consent.CURRENT_PROCESSOR_SET_HASH
+    assert body["receipt"]["scope_version"] == consent.CURRENT_SCOPE_VERSION
+    assert body["receipt"]["scope_hash"] == consent.CURRENT_SCOPE_HASH
+    assert body["receipt"]["server_decided_at"] == "2026-07-26T23:45:00+00:00"

--- a/backend/tests/unit/test_hermes_cloud_migration.py
+++ b/backend/tests/unit/test_hermes_cloud_migration.py
@@ -37,6 +37,7 @@ def test_hermes_cloud_migration_contains_fail_closed_pool_invariants():
         "ella_photon_message_receipts_inbound_key",
         "ella_photon_message_receipts_outbound_key",
         "ella_photon_message_receipts_delivery_key",
+        "consent_grant_epoch varchar(96) not null",
         "attempt_count integer not null default 1",
         "lease_token uuid",
         "lease_expires_at timestamptz",

--- a/backend/tests/unit/test_hermes_cloud_photon.py
+++ b/backend/tests/unit/test_hermes_cloud_photon.py
@@ -132,6 +132,7 @@ class FakeRepository:
         self.claim_calls = []
         self.quota_calls = []
         self.failures = []
+        self.consent_quarantines = []
         self.ack_calls = []
         self.completed_runtime_receipts = set()
         self.crash_before_quota = False
@@ -288,6 +289,18 @@ class FakeRepository:
     def expire_active_lease(self):
         row = next(iter(self.messages.values()))
         row["lease_expires_at"] = datetime.now(timezone.utc) - timedelta(seconds=1)
+
+    async def quarantine_photon_delivery_for_consent(self, **kwargs):
+        self.consent_quarantines.append(dict(kwargs))
+        row = next(item for item in self.messages.values() if item["id"] == kwargs["receipt_id"])
+        if row["status"] != "awaiting_delivery":
+            raise RuntimePoolClaimError("photon_consent_quarantine_conflict")
+        row.update(
+            status="uncertain",
+            error_code=kwargs["error_code"],
+            reconciliation_status="manual_required",
+        )
+        return dict(row)
 
     async def get_photon_message_receipt(self, **kwargs):
         for item in self.messages.values():
@@ -504,6 +517,58 @@ def test_consent_revoked_after_model_turn_blocks_photon_outbound_handoff(monkeyp
     assert next(iter(repository.messages.values()))["status"] == "uncertain"
 
 
+def test_consent_revoked_after_receipt_completion_quarantines_delivery(monkeypatch):
+    adapter, repository, runtime_service = _adapter()
+    asyncio.run(adapter.preflight(_preflight()))
+    checks = 0
+
+    def revoked_after_completion(_runtime):
+        nonlocal checks
+        checks += 1
+        if checks == 2:
+            raise ProvisioningError("managed_cloud_consent_required", retryable=False)
+
+    monkeypatch.setattr(
+        hermes_cloud_photon,
+        "assert_runtime_managed_consent",
+        revoked_after_completion,
+    )
+
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(adapter.handle_inbound(_message()))
+
+    receipt = next(iter(repository.messages.values()))
+    assert error.value.code == "managed_cloud_consent_required"
+    assert receipt["status"] == "uncertain"
+    assert receipt["reconciliation_status"] == "manual_required"
+    assert repository.consent_quarantines[-1]["receipt_id"] == receipt["id"]
+    assert len(runtime_service.provider_calls) == 1
+
+
+def test_replay_rechecks_consent_and_quarantines_before_returning_text(monkeypatch):
+    adapter, repository, runtime_service = _adapter()
+    asyncio.run(adapter.preflight(_preflight()))
+    first = asyncio.run(adapter.handle_inbound(_message()))
+    assert first.outbound_text == "Synthetic answer."
+
+    def revoked(_runtime):
+        raise ProvisioningError("managed_cloud_consent_required", retryable=False)
+
+    monkeypatch.setattr(
+        hermes_cloud_photon,
+        "assert_runtime_managed_consent",
+        revoked,
+    )
+
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(adapter.handle_inbound(_message()))
+
+    receipt = next(iter(repository.messages.values()))
+    assert error.value.code == "managed_cloud_consent_required"
+    assert receipt["status"] == "uncertain"
+    assert len(runtime_service.provider_calls) == 1
+
+
 def _stable_persisted(repository):
     return json.dumps(
         {
@@ -659,8 +724,14 @@ def test_sidecar_disconnect_after_writeback_returns_no_delivery():
 
     assert error.value.code == "photon_sidecar_not_ready"
     receipt = next(iter(repository.messages.values()))
-    assert receipt["status"] == "uncertain"
+    assert receipt["status"] == "awaiting_delivery"
     assert receipt["canonical_outbound_event_id"] == "canonical-outbound"
+
+    repository.binding["sidecar_connected_at"] = datetime.now(timezone.utc)
+    recovered = asyncio.run(adapter.handle_inbound(_message()))
+    assert recovered.status == "awaiting_delivery"
+    assert recovered.duplicate is True
+    assert len(runtime_service.provider_calls) == 1
 
 
 def test_stale_claimed_receipt_is_reclaimed_before_quota_or_provider_work():

--- a/backend/tests/unit/test_hermes_cloud_photon.py
+++ b/backend/tests/unit/test_hermes_cloud_photon.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 from database.ella_provisioning import RuntimePoolClaimError
 from ella.routers.photon import create_photon_router
 from ella.routers.canonical_events import CanonicalEventIn, InMemoryCanonicalEventStore
-from ella.services import hermes_cloud_photon
+from ella.services import ai_consent, hermes_cloud_photon
 from ella.services.hermes_cloud import HermesCloudPreflight
 from ella.services.hermes_cloud_photon import (
     PHOTON_ALLOWED_REGULAR_COMMANDS,
@@ -66,6 +66,56 @@ def _config(*, authorize_synthetic_fixture: bool = True) -> PhotonAdapterConfig:
             else frozenset()
         ),
     )
+
+
+def _consent_submission(
+    *,
+    request_id: str,
+    decision: str = "granted",
+) -> ai_consent.ConsentSubmission:
+    return ai_consent.ConsentSubmission(
+        decision=decision,
+        policy_version=ai_consent.CURRENT_POLICY_VERSION,
+        processor_set_hash=ai_consent.CURRENT_PROCESSOR_SET_HASH,
+        request_id=request_id,
+        app_version="1.0.0",
+        build_number="804",
+        locale="en-US",
+        scope_version=ai_consent.CURRENT_SCOPE_VERSION,
+        scope_hash=ai_consent.CURRENT_SCOPE_HASH,
+    )
+
+
+def _enable_real_managed_consent(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_ONLY", "false")
+    monkeypatch.setenv(
+        "ELLA_HERMES_CLOUD_CONSENT_POLICY_VERSION",
+        ai_consent.CURRENT_POLICY_VERSION,
+    )
+    monkeypatch.setenv(
+        "ELLA_HERMES_CLOUD_CONSENT_PROCESSOR_SET_HASH",
+        ai_consent.CURRENT_PROCESSOR_SET_HASH,
+    )
+    monkeypatch.setenv(
+        "ELLA_HERMES_CLOUD_CONSENT_SCOPE_VERSION",
+        ai_consent.CURRENT_SCOPE_VERSION,
+    )
+    monkeypatch.setenv(
+        "ELLA_HERMES_CLOUD_CONSENT_SCOPE_HASH",
+        ai_consent.CURRENT_SCOPE_HASH,
+    )
+    monkeypatch.setenv(
+        "ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED_UIDS",
+        "synthetic-owner",
+    )
+    repository = ai_consent.InMemoryConsentRepository()
+    service = ai_consent.AiConsentService(repository)
+    first = service.submit(
+        "synthetic-owner",
+        _consent_submission(request_id="photon-grant-a"),
+    )
+    monkeypatch.setattr(ai_consent, "_repository", repository)
+    return service, first["consent"]["receipt_id"]
 
 
 def _runtime(**updates) -> IsolatedRuntime:
@@ -156,6 +206,12 @@ class FakeRepository:
         )
         return dict(self.binding)
 
+    async def get_photon_message_by_inbound(self, **kwargs):
+        row = self.messages.get(kwargs["inbound_provider_message_key"])
+        if row and row["inbound_payload_sha256"] != kwargs["inbound_payload_sha256"]:
+            raise RuntimePoolClaimError("photon_duplicate_payload_conflict")
+        return dict(row) if row else None
+
     async def claim_photon_message(self, **kwargs):
         self.claim_calls.append(dict(kwargs))
         key = kwargs["inbound_provider_message_key"]
@@ -163,6 +219,21 @@ class FakeRepository:
         if existing:
             if existing["inbound_payload_sha256"] != kwargs["inbound_payload_sha256"]:
                 raise RuntimePoolClaimError("photon_duplicate_payload_conflict")
+            if existing["consent_grant_epoch"] != kwargs["consent_grant_epoch"]:
+                if existing["status"] in {"claimed", "running", "awaiting_delivery"}:
+                    existing.update(
+                        status="uncertain",
+                        reconciliation_status="manual_required",
+                        error_code="managed_cloud_consent_grant_changed",
+                        lease_token=None,
+                        lease_expires_at=None,
+                    )
+                return {
+                    **existing,
+                    "inserted": False,
+                    "reclaimed": False,
+                    "acquired": False,
+                }
             stale = existing["status"] in {"claimed", "running"} and (
                 not isinstance(existing.get("lease_expires_at"), datetime)
                 or existing["lease_expires_at"] <= datetime.now(timezone.utc)
@@ -209,6 +280,7 @@ class FakeRepository:
             "inbound_payload_sha256": kwargs["inbound_payload_sha256"],
             "delivery_idempotency_key": "00000000-0000-0000-0000-000000000004",
             "status": "claimed",
+            "consent_grant_epoch": kwargs["consent_grant_epoch"],
             "quota_reserved": False,
             "writeback_receipt": {},
             "provider_started": False,
@@ -503,11 +575,21 @@ def test_sidecar_preflight_turn_replay_and_delivery_ack_are_idempotent_and_opaqu
 def test_consent_revoked_after_model_turn_blocks_photon_outbound_handoff(monkeypatch):
     adapter, repository, runtime_service = _adapter()
     asyncio.run(adapter.preflight(_preflight()))
+    grant_epoch = hermes_cloud_photon.assert_runtime_managed_consent(_runtime())
+    checks = 0
 
-    def revoked(_runtime):
+    def revoked_after_provider(_runtime):
+        nonlocal checks
+        checks += 1
+        if checks == 1:
+            return grant_epoch
         raise ProvisioningError("managed_cloud_consent_required", retryable=False)
 
-    monkeypatch.setattr(hermes_cloud_photon, "assert_runtime_managed_consent", revoked)
+    monkeypatch.setattr(
+        hermes_cloud_photon,
+        "assert_runtime_managed_consent",
+        revoked_after_provider,
+    )
 
     with pytest.raises(ProvisioningError) as error:
         asyncio.run(adapter.handle_inbound(_message()))
@@ -518,21 +600,23 @@ def test_consent_revoked_after_model_turn_blocks_photon_outbound_handoff(monkeyp
 
 
 def test_consent_revoked_after_receipt_completion_quarantines_delivery(monkeypatch):
+    consent_service, _ = _enable_real_managed_consent(monkeypatch)
     adapter, repository, runtime_service = _adapter()
     asyncio.run(adapter.preflight(_preflight()))
-    checks = 0
+    original_complete = repository.complete_photon_message
 
-    def revoked_after_completion(_runtime):
-        nonlocal checks
-        checks += 1
-        if checks == 2:
-            raise ProvisioningError("managed_cloud_consent_required", retryable=False)
+    async def complete_then_revoke(**kwargs):
+        result = await original_complete(**kwargs)
+        consent_service.submit(
+            "synthetic-owner",
+            _consent_submission(
+                request_id="photon-revoke-after-completion",
+                decision="revoked",
+            ),
+        )
+        return result
 
-    monkeypatch.setattr(
-        hermes_cloud_photon,
-        "assert_runtime_managed_consent",
-        revoked_after_completion,
-    )
+    repository.complete_photon_message = complete_then_revoke
 
     with pytest.raises(ProvisioningError) as error:
         asyncio.run(adapter.handle_inbound(_message()))
@@ -546,18 +630,22 @@ def test_consent_revoked_after_receipt_completion_quarantines_delivery(monkeypat
 
 
 def test_replay_rechecks_consent_and_quarantines_before_returning_text(monkeypatch):
+    consent_service, _ = _enable_real_managed_consent(monkeypatch)
     adapter, repository, runtime_service = _adapter()
     asyncio.run(adapter.preflight(_preflight()))
     first = asyncio.run(adapter.handle_inbound(_message()))
     assert first.outbound_text == "Synthetic answer."
 
-    def revoked(_runtime):
+    async def production_resolver_gate_would_block(_uid, _repository):
         raise ProvisioningError("managed_cloud_consent_required", retryable=False)
 
-    monkeypatch.setattr(
-        hermes_cloud_photon,
-        "assert_runtime_managed_consent",
-        revoked,
+    adapter.runtime_resolver = production_resolver_gate_would_block
+    consent_service.submit(
+        "synthetic-owner",
+        _consent_submission(
+            request_id="photon-revoke-before-replay",
+            decision="revoked",
+        ),
     )
 
     with pytest.raises(ProvisioningError) as error:
@@ -566,6 +654,85 @@ def test_replay_rechecks_consent_and_quarantines_before_returning_text(monkeypat
     receipt = next(iter(repository.messages.values()))
     assert error.value.code == "managed_cloud_consent_required"
     assert receipt["status"] == "uncertain"
+    assert len(runtime_service.provider_calls) == 1
+
+
+def test_replay_rechecks_epoch_after_canonical_reconstruction(monkeypatch):
+    consent_service, _ = _enable_real_managed_consent(monkeypatch)
+    adapter, repository, runtime_service = _adapter()
+    asyncio.run(adapter.preflight(_preflight()))
+    first = asyncio.run(adapter.handle_inbound(_message()))
+    original_get_event = adapter.event_store.get_event
+
+    async def read_then_revoke(**kwargs):
+        event = await original_get_event(**kwargs)
+        consent_service.submit(
+            "synthetic-owner",
+            _consent_submission(
+                request_id="photon-revoke-during-replay-read",
+                decision="revoked",
+            ),
+        )
+        return event
+
+    adapter.event_store.get_event = read_then_revoke
+
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(adapter.handle_inbound(_message()))
+
+    receipt = next(iter(repository.messages.values()))
+    assert error.value.code == "managed_cloud_consent_required"
+    assert first.outbound_text == "Synthetic answer."
+    assert receipt["status"] == "uncertain"
+    assert receipt["reconciliation_status"] == "manual_required"
+    assert len(runtime_service.provider_calls) == 1
+
+
+def test_revoke_then_regrant_never_releases_output_from_prior_grant(monkeypatch):
+    consent_service, grant_a = _enable_real_managed_consent(monkeypatch)
+    adapter, repository, runtime_service = _adapter()
+    asyncio.run(adapter.preflight(_preflight()))
+    original_run_turn = runtime_service.run_turn
+
+    async def disconnect_after_writeback(runtime, request):
+        result = await original_run_turn(runtime, request)
+        repository.binding["sidecar_connected_at"] = NOW - timedelta(minutes=2)
+        return result
+
+    runtime_service.run_turn = disconnect_after_writeback
+    with pytest.raises(ProvisioningError) as disconnected:
+        asyncio.run(adapter.handle_inbound(_message()))
+    assert disconnected.value.code == "photon_sidecar_not_ready"
+
+    receipt = next(iter(repository.messages.values()))
+    assert receipt["status"] == "awaiting_delivery"
+    assert receipt["consent_grant_epoch"] == grant_a
+    consent_service.submit(
+        "synthetic-owner",
+        _consent_submission(
+            request_id="photon-revoke-between-grants",
+            decision="revoked",
+        ),
+    )
+    regranted = consent_service.submit(
+        "synthetic-owner",
+        _consent_submission(request_id="photon-grant-c"),
+    )
+    grant_c = regranted["consent"]["receipt_id"]
+    assert grant_a != grant_c
+
+    async def production_resolver_would_accept_new_grant(_uid, _repository):
+        raise AssertionError("duplicate replay must be checked before runtime resolution")
+
+    adapter.runtime_resolver = production_resolver_would_accept_new_grant
+    repository.binding["sidecar_connected_at"] = datetime.now(timezone.utc)
+
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(adapter.handle_inbound(_message()))
+
+    assert error.value.code == "managed_cloud_consent_grant_changed"
+    assert receipt["status"] == "uncertain"
+    assert receipt["reconciliation_status"] == "manual_required"
     assert len(runtime_service.provider_calls) == 1
 
 
@@ -707,7 +874,8 @@ def test_runtime_or_writeback_failure_is_uncertain_and_never_returns_delivery():
     assert next(iter(repository.messages.values()))["status"] == "uncertain"
 
 
-def test_sidecar_disconnect_after_writeback_returns_no_delivery():
+def test_sidecar_disconnect_after_writeback_returns_no_delivery(monkeypatch):
+    _enable_real_managed_consent(monkeypatch)
     adapter, repository, runtime_service = _adapter()
     asyncio.run(adapter.preflight(_preflight()))
     original_run_turn = runtime_service.run_turn
@@ -728,6 +896,11 @@ def test_sidecar_disconnect_after_writeback_returns_no_delivery():
     assert receipt["canonical_outbound_event_id"] == "canonical-outbound"
 
     repository.binding["sidecar_connected_at"] = datetime.now(timezone.utc)
+
+    async def production_resolver_must_not_run_for_replay(_uid, _repository):
+        raise AssertionError("same-grant replay must not re-enter runtime resolution")
+
+    adapter.runtime_resolver = production_resolver_must_not_run_for_replay
     recovered = asyncio.run(adapter.handle_inbound(_message()))
     assert recovered.status == "awaiting_delivery"
     assert recovered.duplicate is True

--- a/backend/tests/unit/test_hermes_cloud_photon.py
+++ b/backend/tests/unit/test_hermes_cloud_photon.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from database.ella_provisioning import RuntimePoolClaimError
 from ella.routers.photon import create_photon_router
 from ella.routers.canonical_events import CanonicalEventIn, InMemoryCanonicalEventStore
+from ella.services import hermes_cloud_photon
 from ella.services.hermes_cloud import HermesCloudPreflight
 from ella.services.hermes_cloud_photon import (
     PHOTON_ALLOWED_REGULAR_COMMANDS,
@@ -36,6 +37,12 @@ PROVIDER_MESSAGE_ID = "provider-message-raw"
 
 class SimulatedProcessCrash(BaseException):
     pass
+
+
+@pytest.fixture(autouse=True)
+def synthetic_owner_gate(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_ONLY", "true")
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_UIDS", "synthetic-owner")
 
 
 def _opaque_key(namespace: str, raw_value: str) -> str:
@@ -480,6 +487,23 @@ def test_sidecar_preflight_turn_replay_and_delivery_ack_are_idempotent_and_opaqu
     assert len(runtime_service.calls) == 1
 
 
+def test_consent_revoked_after_model_turn_blocks_photon_outbound_handoff(monkeypatch):
+    adapter, repository, runtime_service = _adapter()
+    asyncio.run(adapter.preflight(_preflight()))
+
+    def revoked(_runtime):
+        raise ProvisioningError("managed_cloud_consent_required", retryable=False)
+
+    monkeypatch.setattr(hermes_cloud_photon, "assert_runtime_managed_consent", revoked)
+
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(adapter.handle_inbound(_message()))
+
+    assert error.value.code == "managed_cloud_consent_required"
+    assert len(runtime_service.calls) == 1
+    assert next(iter(repository.messages.values()))["status"] == "uncertain"
+
+
 def _stable_persisted(repository):
     return json.dumps(
         {
@@ -635,7 +659,7 @@ def test_sidecar_disconnect_after_writeback_returns_no_delivery():
 
     assert error.value.code == "photon_sidecar_not_ready"
     receipt = next(iter(repository.messages.values()))
-    assert receipt["status"] == "awaiting_delivery"
+    assert receipt["status"] == "uncertain"
     assert receipt["canonical_outbound_event_id"] == "canonical-outbound"
 
 

--- a/backend/tests/unit/test_hermes_cloud_policy.py
+++ b/backend/tests/unit/test_hermes_cloud_policy.py
@@ -49,6 +49,28 @@ def _signed_manifest(value, key):
     }
 
 
+def _managed_route(uid="user-a"):
+    return {
+        "profile_uid": uid,
+        "runtime_provider": ai_consent.MANAGED_CLOUD_RUNTIME_PROVIDER,
+        "model_route": ai_consent.MANAGED_CLOUD_MODEL_ROUTE,
+        "memory_provider": ai_consent.MANAGED_CLOUD_MEMORY_PROVIDER,
+        "photon_scope": ai_consent.MANAGED_CLOUD_PHOTON_SCOPE,
+    }
+
+
+def _deploy_v6(monkeypatch, uid="user-a"):
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_ONLY", "false")
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_CONSENT_POLICY_VERSION", ai_consent.CURRENT_POLICY_VERSION)
+    monkeypatch.setenv(
+        "ELLA_HERMES_CLOUD_CONSENT_PROCESSOR_SET_HASH",
+        ai_consent.CURRENT_PROCESSOR_SET_HASH,
+    )
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_CONSENT_SCOPE_VERSION", ai_consent.CURRENT_SCOPE_VERSION)
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_CONSENT_SCOPE_HASH", ai_consent.CURRENT_SCOPE_HASH)
+    monkeypatch.setenv("ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED_UIDS", uid)
+
+
 def test_synthetic_gate_rejects_identity_outside_exact_allowlist(monkeypatch):
     monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_ONLY", "true")
     monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_UIDS", "synthetic-a")
@@ -70,38 +92,68 @@ def test_managed_cloud_gate_requires_exact_policy_and_current_receipt(monkeypatc
         ai_consent.CURRENT_PROCESSOR_SET_HASH,
     )
     with pytest.raises(ProvisioningError) as error:
-        assert_cloud_identity_gate("user-a")
+        assert_cloud_identity_gate("user-a", **_managed_route())
     assert error.value.code == "hermes_cloud_consent_policy_not_deployed"
 
-    monkeypatch.setattr(
-        ai_consent,
-        "PROCESSORS",
-        (
-            *ai_consent.PROCESSORS,
-            {"id": "hermes-cloud"},
-            {"id": "honcho-cloud"},
+    _deploy_v6(monkeypatch)
+    repository = ai_consent.InMemoryConsentRepository()
+    ai_consent.AiConsentService(repository).submit(
+        "user-a",
+        ai_consent.ConsentSubmission(
+            decision="granted",
+            policy_version=ai_consent.CURRENT_POLICY_VERSION,
+            processor_set_hash=ai_consent.CURRENT_PROCESSOR_SET_HASH,
+            request_id="request-0001",
+            app_version="1.0.0",
+            build_number="804",
+            locale="en-US",
+            scope_version=ai_consent.CURRENT_SCOPE_VERSION,
+            scope_hash=ai_consent.CURRENT_SCOPE_HASH,
         ),
     )
-
-    class Consent:
-        def status(self, uid):
-            return {
-                "authorized": True,
-                "consent": {
-                    "decision": "granted",
-                    "policy_version": ai_consent.CURRENT_POLICY_VERSION,
-                    "processor_set_hash": ai_consent.CURRENT_PROCESSOR_SET_HASH,
-                    "receipt_id": "receipt-a",
-                },
-            }
-
-    monkeypatch.setattr(ai_consent, "get_ai_consent_service", lambda: Consent())
-    assert_cloud_identity_gate("user-a")
+    monkeypatch.setattr(ai_consent, "_repository", repository)
+    assert_cloud_identity_gate("user-a", **_managed_route())
 
     monkeypatch.setenv("ELLA_HERMES_CLOUD_CONSENT_POLICY_VERSION", "stale-policy")
     with pytest.raises(ProvisioningError) as error:
-        assert_cloud_identity_gate("user-a")
+        assert_cloud_identity_gate("user-a", **_managed_route())
     assert error.value.code == "hermes_cloud_consent_policy_not_deployed"
+
+
+def test_real_cloud_gate_rejects_default_off_scope_drift_and_profile_switch(monkeypatch):
+    _deploy_v6(monkeypatch)
+    repository = ai_consent.InMemoryConsentRepository()
+    ai_consent.AiConsentService(repository).submit(
+        "user-a",
+        ai_consent.ConsentSubmission(
+            decision="granted",
+            policy_version=ai_consent.CURRENT_POLICY_VERSION,
+            processor_set_hash=ai_consent.CURRENT_PROCESSOR_SET_HASH,
+            request_id="request-0001",
+            app_version="1.0.0",
+            build_number="804",
+            locale="en-US",
+            scope_version=ai_consent.CURRENT_SCOPE_VERSION,
+            scope_hash=ai_consent.CURRENT_SCOPE_HASH,
+        ),
+    )
+    monkeypatch.setattr(ai_consent, "_repository", repository)
+
+    monkeypatch.delenv("ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED_UIDS")
+    with pytest.raises(ProvisioningError) as disabled:
+        assert_cloud_identity_gate("user-a", **_managed_route())
+    assert disabled.value.code == "managed_cloud_real_data_disabled"
+
+    monkeypatch.setenv("ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED_UIDS", "user-a")
+    drifted = _managed_route()
+    drifted["model_route"] = "openai-codex/other-model"
+    with pytest.raises(ProvisioningError) as drift:
+        assert_cloud_identity_gate("user-a", **drifted)
+    assert drift.value.code == "managed_cloud_consent_scope_drift"
+
+    with pytest.raises(ProvisioningError) as profile:
+        assert_cloud_identity_gate("user-a", **_managed_route("profile-b"))
+    assert profile.value.code == "managed_cloud_consent_stale"
 
 
 def test_approval_manifest_is_server_signed_and_tamper_evident(tmp_path):

--- a/backend/tests/unit/test_hermes_cloud_provider.py
+++ b/backend/tests/unit/test_hermes_cloud_provider.py
@@ -439,6 +439,44 @@ def test_cloud_runtime_resolver_is_fail_closed_and_contains_no_local_route(cloud
     assert error.value.code == "cloud_binding_contains_local_runtime"
 
 
+def test_cloud_runtime_resolver_checks_consent_before_loading_credentials(cloud_env, monkeypatch):
+    binding = {
+        **_binding(),
+        "id": "binding-a",
+        "omi_uid": "user-a",
+        "provider": "hermes_cloud",
+        "status": "active",
+        "active": True,
+        "health_state": "healthy",
+        "profile_name": "cloud-user-a",
+        "agent_id": "hermes-cloud",
+        "runtime_instance_id": "instance-a",
+        "honcho_workspace": "workspace-a",
+        "observed_peer": "user-a",
+        "observer_peer": "companion-a",
+        "revision": 2,
+        "workspace_root": None,
+        "internal_gateway_url": None,
+        "gateway_port": None,
+        "service_label": None,
+        "credential_ref": None,
+    }
+
+    def denied(*_args, **_kwargs):
+        raise ProvisioningError("managed_cloud_consent_required", retryable=False)
+
+    def credentials_forbidden(_binding):
+        raise AssertionError("credentials must not load before consent")
+
+    monkeypatch.setattr(runtime_resolver, "assert_cloud_identity_gate", denied)
+    monkeypatch.setattr(runtime_resolver.HermesCloudClient, "credentials", credentials_forbidden)
+
+    with pytest.raises(ProvisioningError) as error:
+        runtime_from_binding(binding, "user-a")
+
+    assert error.value.code == "managed_cloud_consent_required"
+
+
 @pytest.mark.parametrize(
     ("body_update", "expected_code"),
     [

--- a/backend/tests/unit/test_hermes_cloud_provisioning.py
+++ b/backend/tests/unit/test_hermes_cloud_provisioning.py
@@ -1,6 +1,7 @@
 import asyncio
 from types import SimpleNamespace
 
+from ella.services import provisioning
 from ella.services.hermes_cloud import HermesCloudPreflight
 from ella.services.provisioning import (
     HermesProvisionClient,
@@ -202,9 +203,7 @@ def test_cloud_preflight_failure_quarantines_claim_and_never_publishes(monkeypat
     coordinator = ProvisioningCoordinator(
         repository,
         ForbiddenLocalClient(),
-        cloud_client=FakeCloud(
-            error=ProvisioningError("hermes_cloud_tool_drift", retryable=False)
-        ),
+        cloud_client=FakeCloud(error=ProvisioningError("hermes_cloud_tool_drift", retryable=False)),
         honcho_client=FakeHoncho(),
         alert_publisher=FakeAlert(),
         runtime_admission=allow_runtime,
@@ -216,6 +215,39 @@ def test_cloud_preflight_failure_quarantines_claim_and_never_publishes(monkeypat
     assert repository.quarantined[0]["reason"] == "hermes_cloud_tool_drift"
     assert repository.jobs[-1]["state"] == "blocked"
     assert repository.rollbacks[-1]["rollback_receipt"]["status"] == "cleaned"
+
+
+def test_consent_revoked_after_claim_blocks_honcho_and_cloud_side_effects(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS", "synthetic-user")
+    repository = FakeRepository()
+    cloud = FakeCloud()
+    honcho = FakeHoncho()
+    checks = 0
+
+    def consent_gate(*_args, **_kwargs):
+        nonlocal checks
+        checks += 1
+        if checks == 2:
+            raise ProvisioningError("managed_cloud_consent_required", retryable=False)
+
+    monkeypatch.setattr(provisioning, "assert_cloud_identity_gate", consent_gate)
+    coordinator = ProvisioningCoordinator(
+        repository,
+        ForbiddenLocalClient(),
+        cloud_client=cloud,
+        honcho_client=honcho,
+        alert_publisher=FakeAlert(),
+        runtime_admission=allow_runtime,
+    )
+
+    asyncio.run(coordinator.process_claimed_job(job=_job(), identity=_identity()))
+
+    assert checks == 2
+    assert repository.claims == 1
+    assert honcho.calls == []
+    assert cloud.calls == []
+    assert repository.finalized == []
+    assert repository.quarantined[0]["reason"] == "managed_cloud_consent_required"
 
 
 def test_empty_pool_emits_durable_low_water_and_stays_retryable(monkeypatch):
@@ -279,9 +311,7 @@ def test_partial_honcho_side_effects_are_cleaned_and_claim_is_quarantined(monkey
     coordinator = ProvisioningCoordinator(
         repository,
         ForbiddenLocalClient(),
-        cloud_client=FakeCloud(
-            error=ProvisioningError("hermes_cloud_tool_drift", retryable=True)
-        ),
+        cloud_client=FakeCloud(error=ProvisioningError("hermes_cloud_tool_drift", retryable=True)),
         honcho_client=honcho,
         alert_publisher=FakeAlert(),
         runtime_admission=allow_runtime,
@@ -302,9 +332,7 @@ def test_cleanup_failure_requires_manual_intervention(monkeypatch):
     coordinator = ProvisioningCoordinator(
         repository,
         ForbiddenLocalClient(),
-        cloud_client=FakeCloud(
-            error=ProvisioningError("hermes_cloud_tool_drift", retryable=True)
-        ),
+        cloud_client=FakeCloud(error=ProvisioningError("hermes_cloud_tool_drift", retryable=True)),
         honcho_client=FakeHoncho(cleanup_error=RuntimeError("cleanup failed")),
         alert_publisher=FakeAlert(),
         runtime_admission=allow_runtime,

--- a/backend/tests/unit/test_hermes_cloud_runtime.py
+++ b/backend/tests/unit/test_hermes_cloud_runtime.py
@@ -284,6 +284,43 @@ def test_consent_revoked_after_reservation_blocks_provider_call(monkeypatch):
     assert policy.released
 
 
+def test_consent_regrant_epoch_change_after_reservation_blocks_provider_call(
+    monkeypatch,
+):
+    repository = FakeRepository()
+    policy = FakePolicy()
+    cloud = FakeCloudClient()
+    epochs = iter(("aicr_" + ("a" * 32), "aicr_" + ("c" * 32)))
+
+    monkeypatch.setattr(
+        hermes_cloud_runtime,
+        "assert_runtime_managed_consent",
+        lambda _runtime: next(epochs),
+    )
+    service = HermesCloudRuntimeService(
+        repository=repository,
+        event_store=InMemoryCanonicalEventStore(),
+        cloud_client=cloud,
+        voice_policy=policy,
+        cost_estimator=lambda usage: 0,
+        max_cost_estimator=lambda **kwargs: 1,
+    )
+    request = HermesCloudTurnRequest(
+        **{
+            **_request().__dict__,
+            "consent_grant_epoch": "aicr_" + ("a" * 32),
+        }
+    )
+
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(service.run_turn(_runtime(), request))
+
+    assert error.value.code == "managed_cloud_consent_grant_changed"
+    assert cloud.calls == []
+    assert policy.reserved
+    assert policy.released
+
+
 def test_same_interaction_id_with_changed_payload_fails_closed():
     repository = FakeRepository()
     service = HermesCloudRuntimeService(

--- a/backend/tests/unit/test_hermes_cloud_runtime.py
+++ b/backend/tests/unit/test_hermes_cloud_runtime.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from ella.services import hermes_cloud_runtime
 from ella.routers.canonical_events import InMemoryCanonicalEventStore
 from ella.services.hermes_cloud import HermesCloudTurn
 from ella.services.hermes_cloud_runtime import (
@@ -249,6 +250,38 @@ def test_photon_turn_uses_photon_entitlement_mode():
     asyncio.run(service.run_turn(_runtime(), request))
 
     assert policy.accepted[0]["mode"] == "hermes-cloud-photon"
+
+
+def test_consent_revoked_after_reservation_blocks_provider_call(monkeypatch):
+    repository = FakeRepository()
+    policy = FakePolicy()
+    cloud = FakeCloudClient()
+    checks = 0
+
+    def consent_gate(_runtime):
+        nonlocal checks
+        checks += 1
+        if checks == 2:
+            raise ProvisioningError("managed_cloud_consent_required", retryable=False)
+
+    monkeypatch.setattr(hermes_cloud_runtime, "assert_runtime_managed_consent", consent_gate)
+    service = HermesCloudRuntimeService(
+        repository=repository,
+        event_store=InMemoryCanonicalEventStore(),
+        cloud_client=cloud,
+        voice_policy=policy,
+        cost_estimator=lambda usage: 0,
+        max_cost_estimator=lambda **kwargs: 1,
+    )
+
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(service.run_turn(_runtime(), _request()))
+
+    assert error.value.code == "managed_cloud_consent_required"
+    assert checks == 2
+    assert cloud.calls == []
+    assert policy.reserved
+    assert policy.released
 
 
 def test_same_interaction_id_with_changed_payload_fails_closed():


### PR DESCRIPTION
## Summary

Implements the backend half of the exact managed-cloud consent v6 contract for ellaaicare/ella-ai#1123.

This is intentionally stacked on Hermes Cloud runtime PR #336 at exact base `874d310ab0087dbcf182e2176a4dded0c7dc45de`. It must not merge or deploy independently of the reviewed cloud-runtime foundation.

## Contract

- policy: `ai-data-processors-v6`
- processor hash: `sha256:dd84e4a9da1166cff66e5de55c2570d0496a2c89d46ca431530e993758616296`
- scope: `managed-cloud-internal-pilot-v1`
- scope hash: `sha256:727b1db818ce79090a02279f1cc6d15dfc3d65a58592b13fbed53ad048c38a30`
- protected processors: Nous Research/Hermes Cloud, OpenAI via `openai-codex/gpt-5.6-terra`, Honcho Cloud, and Photon

## Changes

- stores an immutable server-timestamped receipt bound to the authenticated account, server-derived profile binding, exact processor IDs, policy hash, and scope hash;
- requires the current state pointer to match the immutable receipt field-for-field;
- fails closed for v5, missing/mutated/deleted receipts, decline/revoke, account/profile changes, and runtime/model/memory/Photon scope drift;
- keeps managed-cloud real-data rollout default off and independently UID-gated;
- rechecks consent before cloud credential loading, Honcho profile creation, Hermes/OpenAI calls, and Photon outbound handoff;
- marks post-writeback Photon failures uncertain so revoked content cannot remain replayable as deliverable;
- extends the path-scoped cloud-runtime CI to run on stacked PRs and clean Linux runners.

## Validation

- `198 passed` in the exact Hermes Cloud/isolation failure-path suite
- Black check: 14 touched Python files clean
- `py_compile`: clean
- workflow YAML parse: clean
- `git diff --check`: clean
- processor and scope hashes independently recomputed and matched the accepted iOS v6 contract

No deployment, vendor mutation, production enforcement, flag enablement, or real-user data was used.
