### PR TITLE
Name managed cloud processors and require consent v7

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -29,7 +29,7 @@ class SharedPreferencesUtil {
 
   static const bool isPublicBuild = bool.fromEnvironment('ELLA_PUBLIC_BUILD');
   static const bool isTodayDesignPreview = bool.fromEnvironment('ELLA_TODAY_DESIGN_PREVIEW');
-  static const String currentAiConsentContractVersion = 'ai-data-processors-v6';
+  static const String currentAiConsentContractVersion = 'ai-data-processors-v7';
   static const String currentAiConsentProcessorSetHash =
       'sha256:dd84e4a9da1166cff66e5de55c2570d0496a2c89d46ca431530e993758616296';
   static const String currentAiConsentScopeVersion = 'managed-cloud-internal-pilot-v1';

--- a/app/lib/ella/services/ai_consent_policy.dart
+++ b/app/lib/ella/services/ai_consent_policy.dart
@@ -163,14 +163,13 @@ class AiConsentPolicy {
         id: 'nous-hermes-cloud',
         name: 'Nous Research / Hermes Cloud',
         function: 'Managed agent runtime',
-        data:
-            'Prompt policy, messages, transcripts, selected first-party context, session metadata, and model or tool usage',
+        data: 'What the person says or types, details they choose to share, and basic session information',
       ),
       AiConsentProcessor(
         id: 'honcho-cloud',
-        name: 'Honcho Cloud',
+        name: 'Honcho / Plastic Labs',
         function: 'Profile-bound derived memory and context',
-        data: 'Consented derived memory, selected context, and memory relationships for the bound profile',
+        data: 'Details from conversations and information the person chooses to save for the bound profile',
       ),
       AiConsentProcessor(
         id: 'openai-codex',

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10483,7 +10483,7 @@
   "aiConsentActiveAudioStopped": "Ella could not verify AI permission. Cloud sharing and voice chat have stopped.",
   "deleteAccountServerConfirmationFailed": "Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.",
   "deleteAccountLocalCleanupFailed": "Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.",
-  "aiConsentManagedCloudIntro": "Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:",
+  "aiConsentManagedCloudIntro": "Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:",
   "@aiConsentManagedCloudIntro": {
     "description": "Introduces the named managed-cloud processors before first use"
   },

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10469,21 +10469,21 @@
   "todayReadMore": "Read more",
   "voiceModalEndAction": "End",
   "ellaAuthDataDisclosure": "Google Firebase processes your account and basic service information for secure sign-in and app infrastructure. Apple or Google also processes the sign-in method you choose. Signing in does not turn on listening or AI sharing; Ella asks separately before sending audio, transcripts, messages, or memory context to AI processors.",
-  "aiConsentCompactSummary": "Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.",
+  "aiConsentCompactSummary": "Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.",
   "aiConsentProcessorDetailsLink": "Full processor details in Privacy Policy",
-  "aiConsentNoSharingBeforeAllow": "Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.",
+  "aiConsentNoSharingBeforeAllow": "Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.",
   "aiConsentRevokeAction": "Revoke AI permission",
   "aiConsentDeleteDataAction": "Delete my account and data",
   "aiConsentAllowedStatus": "Managed cloud AI allowed for this account and profile",
-  "aiConsentNotAllowedStatus": "Managed cloud AI sharing is off — v6 permission required",
+  "aiConsentNotAllowedStatus": "Cloud AI permission is off — v7 permission required",
   "aiConsentRevokeSyncFailed": "Sharing is stopped on this device. Ella could not confirm the server update; try again before using another device.",
   "aiConsentOffGateTitle": "AI sharing is off",
-  "aiConsentOffGateBody": "Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.",
+  "aiConsentOffGateBody": "Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.",
   "aiConsentReviewAction": "Review AI permission",
-  "aiConsentActiveAudioStopped": "AI permission could not be verified. Recording and voice chat stopped.",
+  "aiConsentActiveAudioStopped": "Ella could not verify AI permission. Cloud sharing and voice chat have stopped.",
   "deleteAccountServerConfirmationFailed": "Ella could not confirm account deletion. Your account and local data are unchanged. Please try again.",
   "deleteAccountLocalCleanupFailed": "Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.",
-  "aiConsentManagedCloudIntro": "For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:",
+  "aiConsentManagedCloudIntro": "Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:",
   "@aiConsentManagedCloudIntro": {
     "description": "Introduces the named managed-cloud processors before first use"
   },
@@ -10491,7 +10491,7 @@
   "@aiConsentHermesCloudTitle": {
     "description": "Legal recipient and product name for the managed agent runtime"
   },
-  "aiConsentHermesCloudBody": "Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.",
+  "aiConsentHermesCloudBody": "Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.",
   "@aiConsentHermesCloudBody": {
     "description": "Data categories and purpose for Hermes Cloud"
   },
@@ -10499,27 +10499,27 @@
   "@aiConsentOpenAiManagedTitle": {
     "description": "Legal recipient for the approved managed model route"
   },
-  "aiConsentOpenAiManagedBody": "Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.",
+  "aiConsentOpenAiManagedBody": "Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.",
   "@aiConsentOpenAiManagedBody": {
     "description": "Data categories and purpose for the managed OpenAI route"
   },
-  "aiConsentHonchoCloudTitle": "Honcho Cloud",
+  "aiConsentHonchoCloudTitle": "Honcho / Plastic Labs",
   "@aiConsentHonchoCloudTitle": {
     "description": "Legal recipient and product name for managed derived memory"
   },
-  "aiConsentHonchoCloudBody": "Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.",
+  "aiConsentHonchoCloudBody": "Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.",
   "@aiConsentHonchoCloudBody": {
-    "description": "Data categories and purpose for Honcho Cloud"
+    "description": "Data categories and purpose for Honcho / Plastic Labs"
   },
   "aiConsentPhotonTitle": "Photon",
   "@aiConsentPhotonTitle": {
     "description": "Legal recipient for the narrow messaging channel"
   },
-  "aiConsentPhotonBody": "Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.",
+  "aiConsentPhotonBody": "Sends iMessage content and basic delivery details only to one person you choose for testing.",
   "@aiConsentPhotonBody": {
     "description": "Data categories and purpose for Photon"
   },
-  "aiConsentManagedCloudScope": "This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.",
+  "aiConsentManagedCloudScope": "This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.",
   "@aiConsentManagedCloudScope": {
     "description": "Explains the exact managed-cloud profile and messaging scope"
   }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -16608,7 +16608,7 @@ abstract class AppLocalizations {
   /// Introduces the named managed-cloud processors before first use
   ///
   /// In en, this message translates to:
-  /// **'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:'**
+  /// **'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:'**
   String get aiConsentManagedCloudIntro;
 
   /// Legal recipient and product name for the managed agent runtime

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -16206,7 +16206,7 @@ abstract class AppLocalizations {
   /// Locked first-run listening consent title
   ///
   /// In en, this message translates to:
-  /// **'Ella listens to help remember.'**
+  /// **'Choose how Ella uses cloud AI'**
   String get aiConsentTitle;
 
   /// Locked consent body naming Ella routing and the data sent before the Deepgram processor name
@@ -16524,7 +16524,7 @@ abstract class AppLocalizations {
   /// No description provided for @aiConsentCompactSummary.
   ///
   /// In en, this message translates to:
-  /// **'Ella sends only the data needed for a feature through its secure backend. Speech transcription may send live or stored microphone audio to Deepgram, Soniox, or Speechmatics. Answers, summaries, and memory assistance send messages, transcripts, and selected memory context through Ella\'s self-hosted Hermes agent runtime and Honcho memory service, and may send that text to OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok; OpenRouter may route it to the selected model provider. Live voice may send microphone audio and selected context to Google Gemini, OpenAI, or xAI Grok. Spoken replies use Ella\'s self-hosted Kokoro or Fish voice synthesis, or may send response text to Inworld AI or ElevenLabs. Google Firebase processes account and service metadata for authentication and infrastructure. Summaries are shared only with family members you choose.'**
+  /// **'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.'**
   String get aiConsentCompactSummary;
 
   /// No description provided for @aiConsentProcessorDetailsLink.
@@ -16536,7 +16536,7 @@ abstract class AppLocalizations {
   /// No description provided for @aiConsentNoSharingBeforeAllow.
   ///
   /// In en, this message translates to:
-  /// **'Ella will not send audio, transcripts, messages, or memory context to these AI processors until you choose Allow. Not now keeps listening and AI features off. You can review or revoke this permission in Settings.'**
+  /// **'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.'**
   String get aiConsentNoSharingBeforeAllow;
 
   /// No description provided for @aiConsentRevokeAction.
@@ -16554,13 +16554,13 @@ abstract class AppLocalizations {
   /// No description provided for @aiConsentAllowedStatus.
   ///
   /// In en, this message translates to:
-  /// **'Allowed for this account'**
+  /// **'Managed cloud AI allowed for this account and profile'**
   String get aiConsentAllowedStatus;
 
   /// No description provided for @aiConsentNotAllowedStatus.
   ///
   /// In en, this message translates to:
-  /// **'Not allowed — AI sharing is off'**
+  /// **'Cloud AI permission is off — v7 permission required'**
   String get aiConsentNotAllowedStatus;
 
   /// No description provided for @aiConsentRevokeSyncFailed.
@@ -16578,7 +16578,7 @@ abstract class AppLocalizations {
   /// No description provided for @aiConsentOffGateBody.
   ///
   /// In en, this message translates to:
-  /// **'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.'**
+  /// **'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.'**
   String get aiConsentOffGateBody;
 
   /// No description provided for @aiConsentReviewAction.
@@ -16590,7 +16590,7 @@ abstract class AppLocalizations {
   /// No description provided for @aiConsentActiveAudioStopped.
   ///
   /// In en, this message translates to:
-  /// **'AI permission could not be verified. Recording and voice chat stopped.'**
+  /// **'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.'**
   String get aiConsentActiveAudioStopped;
 
   /// No description provided for @deleteAccountServerConfirmationFailed.
@@ -16608,7 +16608,7 @@ abstract class AppLocalizations {
   /// Introduces the named managed-cloud processors before first use
   ///
   /// In en, this message translates to:
-  /// **'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:'**
+  /// **'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:'**
   String get aiConsentManagedCloudIntro;
 
   /// Legal recipient and product name for the managed agent runtime
@@ -16620,7 +16620,7 @@ abstract class AppLocalizations {
   /// Data categories and purpose for Hermes Cloud
   ///
   /// In en, this message translates to:
-  /// **'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.'**
+  /// **'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.'**
   String get aiConsentHermesCloudBody;
 
   /// Legal recipient for the approved managed model route
@@ -16632,19 +16632,19 @@ abstract class AppLocalizations {
   /// Data categories and purpose for the managed OpenAI route
   ///
   /// In en, this message translates to:
-  /// **'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.'**
+  /// **'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.'**
   String get aiConsentOpenAiManagedBody;
 
   /// Legal recipient and product name for managed derived memory
   ///
   /// In en, this message translates to:
-  /// **'Honcho Cloud'**
+  /// **'Honcho / Plastic Labs'**
   String get aiConsentHonchoCloudTitle;
 
-  /// Data categories and purpose for Honcho Cloud
+  /// Data categories and purpose for Honcho / Plastic Labs
   ///
   /// In en, this message translates to:
-  /// **'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.'**
+  /// **'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.'**
   String get aiConsentHonchoCloudBody;
 
   /// Legal recipient for the narrow messaging channel
@@ -16656,13 +16656,13 @@ abstract class AppLocalizations {
   /// Data categories and purpose for Photon
   ///
   /// In en, this message translates to:
-  /// **'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.'**
+  /// **'Sends iMessage content and basic delivery details only to one person you choose for testing.'**
   String get aiConsentPhotonBody;
 
   /// Explains the exact managed-cloud profile and messaging scope
   ///
   /// In en, this message translates to:
-  /// **'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.'**
+  /// **'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.'**
   String get aiConsentManagedCloudScope;
 }
 

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8807,14 +8807,14 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8826,7 +8826,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8837,13 +8837,14 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8852,30 +8853,40 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8856,7 +8856,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8944,7 +8944,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -8895,14 +8895,14 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8914,7 +8914,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8925,13 +8925,14 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8940,30 +8941,40 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8960,7 +8960,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -8911,14 +8911,14 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8930,7 +8930,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8941,13 +8941,14 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8956,30 +8957,40 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8858,14 +8858,14 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8877,7 +8877,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8888,13 +8888,14 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8903,30 +8904,40 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8907,7 +8907,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8847,14 +8847,14 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8866,7 +8866,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8877,13 +8877,14 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8892,30 +8893,40 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8896,7 +8896,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8929,14 +8929,14 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8948,7 +8948,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8959,13 +8959,14 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8974,30 +8975,40 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -8978,7 +8978,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8969,7 +8969,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -8920,14 +8920,14 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8939,7 +8939,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8950,13 +8950,14 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8965,30 +8966,40 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8909,7 +8909,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8860,14 +8860,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8879,7 +8879,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8890,13 +8890,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8905,30 +8906,40 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8877,14 +8877,14 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8896,7 +8896,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8907,13 +8907,14 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8922,30 +8923,40 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -8926,7 +8926,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8862,14 +8862,14 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8881,7 +8881,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8892,13 +8892,14 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8907,30 +8908,40 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8911,7 +8911,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8861,14 +8861,14 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8880,7 +8880,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8891,13 +8891,14 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8906,30 +8907,40 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8910,7 +8910,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8985,7 +8985,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -8936,14 +8936,14 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8955,7 +8955,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8966,13 +8966,14 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8981,30 +8982,40 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8843,14 +8843,14 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8862,7 +8862,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8873,13 +8873,14 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8888,30 +8889,40 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8892,7 +8892,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8900,14 +8900,14 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8919,7 +8919,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8930,13 +8930,14 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8945,30 +8946,40 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -8949,7 +8949,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8924,7 +8924,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8875,14 +8875,14 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8894,7 +8894,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8905,13 +8905,14 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8920,30 +8921,40 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8961,7 +8961,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -8912,14 +8912,14 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8931,7 +8931,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8942,13 +8942,14 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8957,30 +8958,40 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8778,7 +8778,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8729,14 +8729,14 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8748,7 +8748,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8759,13 +8759,14 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8774,30 +8775,40 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8780,7 +8780,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8731,14 +8731,14 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8750,7 +8750,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8761,13 +8761,14 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8776,30 +8777,40 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8917,7 +8917,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8868,14 +8868,14 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8887,7 +8887,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8898,13 +8898,14 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8913,30 +8914,40 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8880,14 +8880,14 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8899,7 +8899,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8910,13 +8910,14 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8925,30 +8926,40 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -8929,7 +8929,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8886,14 +8886,14 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8905,7 +8905,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8916,13 +8916,14 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8931,30 +8932,40 @@ class AppLocalizationsMs extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -8935,7 +8935,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8937,7 +8937,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -8888,14 +8888,14 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8907,7 +8907,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8918,13 +8918,14 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8933,30 +8934,40 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8907,7 +8907,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8858,14 +8858,14 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8877,7 +8877,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8888,13 +8888,14 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8903,30 +8904,40 @@ class AppLocalizationsNo extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8881,14 +8881,14 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8900,7 +8900,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8911,13 +8911,14 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8926,30 +8927,40 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -8930,7 +8930,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8863,14 +8863,14 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8882,7 +8882,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8893,13 +8893,14 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8908,30 +8909,40 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8912,7 +8912,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8950,7 +8950,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -8901,14 +8901,14 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8920,7 +8920,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8931,13 +8931,14 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8946,30 +8947,40 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8937,7 +8937,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -8888,14 +8888,14 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8907,7 +8907,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8918,13 +8918,14 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8933,30 +8934,40 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8853,14 +8853,14 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8872,7 +8872,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8883,13 +8883,14 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8898,30 +8899,40 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8902,7 +8902,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8868,14 +8868,14 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8887,7 +8887,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8898,13 +8898,14 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8913,30 +8914,40 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8917,7 +8917,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8825,14 +8825,14 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8844,7 +8844,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8855,13 +8855,14 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8870,30 +8871,40 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8874,7 +8874,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8876,14 +8876,14 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8895,7 +8895,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8906,13 +8906,14 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8921,30 +8922,40 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -8925,7 +8925,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8875,14 +8875,14 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8894,7 +8894,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8905,13 +8905,14 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8920,30 +8921,40 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -8924,7 +8924,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8914,7 +8914,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8865,14 +8865,14 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8884,7 +8884,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8895,13 +8895,14 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8910,30 +8911,40 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8719,14 +8719,14 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get aiConsentCompactSummary =>
-      'Other enabled Ella features may use these already disclosed processors: Deepgram, Soniox, or Speechmatics for microphone transcription; Ella self-hosted Hermes, Honcho, Kokoro, or Fish; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok for text or live voice; Inworld AI or ElevenLabs for spoken replies; and Google Firebase for account and service infrastructure. Only the data needed for the chosen feature is sent through Ella’s secure backend.';
+      'Other Ella features may also use Deepgram, Soniox, or Speechmatics to turn speech into words; Ella’s own Hermes, Honcho, Kokoro, or Fish services; OpenRouter, Google Gemini, OpenAI, Groq, or xAI Grok to help answer or support live voice; Inworld AI or ElevenLabs to speak replies; and Google Firebase for sign-in and app services. Ella sends only what the feature needs through its secure backend.';
 
   @override
   String get aiConsentProcessorDetailsLink => 'Full processor details in Privacy Policy';
 
   @override
   String get aiConsentNoSharingBeforeAllow =>
-      'Ella will not send audio, transcripts, messages, selected memory context, or Photon message content to these processors until you choose Allow. Not now keeps cloud listening, AI, memory, voice, and messaging features off. You can review or revoke this permission in Settings.';
+      'Ella will not send what you say or type, messages, details from your saved memories, or Photon messages to these companies until you choose Allow. Not now keeps these cloud AI, memory, voice, and messaging features off. You can review or remove this permission in Settings.';
 
   @override
   String get aiConsentRevokeAction => 'Revoke AI permission';
@@ -8738,7 +8738,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get aiConsentAllowedStatus => 'Managed cloud AI allowed for this account and profile';
 
   @override
-  String get aiConsentNotAllowedStatus => 'Managed cloud AI sharing is off — v6 permission required';
+  String get aiConsentNotAllowedStatus => 'Cloud AI permission is off — v7 permission required';
 
   @override
   String get aiConsentRevokeSyncFailed =>
@@ -8749,13 +8749,14 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get aiConsentOffGateBody =>
-      'Ella will not provision AI features or send audio, transcripts, messages, or memory context while permission is off. You can review the disclosure whenever you are ready.';
+      'Ella will not set up these cloud AI features or send what you say or type, messages, or details from your saved memories while permission is off. You can review this information whenever you are ready.';
 
   @override
   String get aiConsentReviewAction => 'Review AI permission';
 
   @override
-  String get aiConsentActiveAudioStopped => 'AI permission could not be verified. Recording and voice chat stopped.';
+  String get aiConsentActiveAudioStopped =>
+      'Ella could not verify AI permission. Cloud sharing and voice chat have stopped.';
 
   @override
   String get deleteAccountServerConfirmationFailed =>
@@ -8764,30 +8765,40 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get deleteAccountLocalCleanupFailed =>
       'Your account was deleted, but this device could not finish local cleanup. Restart Ella and try signing out again.';
+
   @override
   String get aiConsentManagedCloudIntro =>
-      'For the managed cloud experience, Ella may send only the data needed for the feature you choose to these named partners:';
+      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';
+
   @override
   String get aiConsentHermesCloudBody =>
-      'Runs Ella’s managed agent. It may receive messages, voice or transcript text, selected first-party context, session metadata, prompt policy, and model or tool usage so Ella can answer and continue a session.';
+      'Runs Ella’s cloud companion. It may receive what you say or type, details you choose to share, and basic information needed to keep your conversation going.';
+
   @override
   String get aiConsentOpenAiManagedTitle => 'OpenAI';
+
   @override
   String get aiConsentOpenAiManagedBody =>
-      'Processes model input and output through Ella’s approved OpenAI Codex OAuth route so the managed agent can generate a response. Ella does not expose an OpenAI key to the app.';
+      'Helps Ella prepare an answer. It may receive what you say or type and the details needed for your request through Ella’s secure connection.';
+
   @override
-  String get aiConsentHonchoCloudTitle => 'Honcho Cloud';
+  String get aiConsentHonchoCloudTitle => 'Honcho / Plastic Labs';
+
   @override
   String get aiConsentHonchoCloudBody =>
-      'Stores and retrieves consented derived memory and selected context for this server-bound profile so Ella can remember relevant details. It is not Ella’s canonical record.';
+      'Helps Ella remember useful details for your account. It may receive details from your conversations and information you choose to save. Ella keeps its own main copy of your information.';
+
   @override
   String get aiConsentPhotonTitle => 'Photon';
+
   @override
   String get aiConsentPhotonBody =>
-      'Delivers iMessage content and the messaging identifiers needed for one explicitly allowed test contact on a shared test line.';
+      'Sends iMessage content and basic delivery details only to one person you choose for testing.';
+
   @override
   String get aiConsentManagedCloudScope =>
-      'This permission is bound to the signed-in account and its server-selected profile. Photon remains test-contact-only: no allow-all recipients, caregiver delivery, or inbound attachments. A provider, model route, profile, or messaging-scope change requires permission again.';
+      'This permission belongs only to the signed-in account and selected profile. Photon can message only one person you choose for testing. It cannot message everyone, contact family support, or accept files. If these company, profile, or messaging choices change, Ella will ask again.';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8768,7 +8768,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get aiConsentManagedCloudIntro =>
-      'Before Ella sends anything to these companies, please choose whether you agree. Ella uses only the company needed for the feature you choose:';
+      'Please choose whether you agree to Ella sharing with these companies. The companies involved depend on the feature you choose:';
 
   @override
   String get aiConsentHermesCloudTitle => 'Nous Research / Hermes Cloud';

--- a/app/test/backend/preferences_public_mode_test.dart
+++ b/app/test/backend/preferences_public_mode_test.dart
@@ -85,12 +85,12 @@ void main() {
     expect(preferences.hasAccountBoundAiConsent('uid-a'), isTrue);
   });
 
-  test('existing v5 account requires v6 before any managed-cloud AI action', () async {
+  test('existing v6 account requires v7 before any managed-cloud AI action', () async {
     SharedPreferences.setMockInitialValues({
       'aiConsentAccepted': true,
       'aiConsentAcceptedAt': '2026-01-01T00:00:00Z',
-      'aiConsentContractVersion': 'ai-data-processors-v5',
-      'aiConsentReceiptId': 'aicr_v5-receipt-a',
+      'aiConsentContractVersion': 'ai-data-processors-v6',
+      'aiConsentReceiptId': 'aicr_v6-receipt-a',
       'aiConsentReceiptUid': 'uid-a',
     });
     await SharedPreferencesUtil.init();
@@ -101,7 +101,7 @@ void main() {
     expect(preferences.hasPriorAccountBoundAiConsent('uid-b'), isFalse);
   });
 
-  test('deferred v6 remains inactive until a server-verified account and profile grant', () {
+  test('deferred v7 remains inactive until a server-verified account and profile grant', () {
     final preferences = SharedPreferencesUtil();
     preferences.uid = 'uid-a';
 
@@ -119,7 +119,7 @@ void main() {
     _markServerVerified(preferences, uid: 'uid-a', receiptId: 'aicr_receipt-a');
     expect(preferences.aiConsentAccepted, isTrue);
     expect(preferences.isCurrentAiConsentDeferred, isFalse);
-    expect(preferences.aiConsentContractVersion, 'ai-data-processors-v6');
+    expect(preferences.aiConsentContractVersion, 'ai-data-processors-v7');
   });
 
   test('receipt-less acceptance clears stale authority and remains fail closed', () async {

--- a/app/test/ella/services/ai_consent_policy_test.dart
+++ b/app/test/ella/services/ai_consent_policy_test.dart
@@ -7,9 +7,10 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/services/ai_consent_policy.dart';
 
 void main() {
-  test('v6 fallback manifest matches the accepted managed-cloud processor and scope contract', () {
+  test('v7 fallback manifest matches the managed-cloud processor and scope contract', () {
     const policy = AiConsentPolicy.bundled;
     expect(policy.version, SharedPreferencesUtil.currentAiConsentContractVersion);
+    expect(policy.version, 'ai-data-processors-v7');
     expect(policy.processorSetHash, SharedPreferencesUtil.currentAiConsentProcessorSetHash);
     expect(policy.processorSetHash, startsWith('sha256:'));
     expect(policy.processorSetHash, 'sha256:${sha256.convert(utf8.encode(policy.canonicalProcessorSet))}');
@@ -29,7 +30,7 @@ void main() {
         'Ella self-hosted Honcho',
         'Ella self-hosted voice synthesis',
         'Nous Research / Hermes Cloud',
-        'Honcho Cloud',
+        'Honcho / Plastic Labs',
         'Photon',
         'OpenRouter',
         'Google Gemini',
@@ -63,11 +64,14 @@ void main() {
     expect(policy.isBundledCurrent, isFalse);
   });
 
-  test('a v5 policy cannot authorize the managed-cloud v6 scope', () {
+  test('a v6 policy cannot authorize the managed-cloud v7 disclosure', () {
     final policy = AiConsentPolicy.fromJson({
-      'version': 'ai-data-processors-v5',
-      'processor_set_hash': 'sha256:9c2529babbd6241f20242cf0836baf7e1899d05bb3d945a0d38a357113d4cbc4',
+      'version': 'ai-data-processors-v6',
+      'processor_set_hash': SharedPreferencesUtil.currentAiConsentProcessorSetHash,
       'canonical_processor_set': AiConsentPolicy.bundled.canonicalProcessorSet,
+      'scope_version': AiConsentPolicy.bundled.scopeVersion,
+      'scope_hash': AiConsentPolicy.bundled.scopeHash,
+      'canonical_scope': AiConsentPolicy.bundled.canonicalScope,
       'processors': const [],
     });
 

--- a/app/test/ella/widgets/ai_consent_sheet_test.dart
+++ b/app/test/ella/widgets/ai_consent_sheet_test.dart
@@ -70,6 +70,13 @@ void main() {
 
     final disclosure =
         tester.widgetList<RichText>(find.byType(RichText)).map((widget) => widget.text.toPlainText()).join(' ');
+    expect(
+      disclosure,
+      contains(
+        'Please choose whether you agree to Ella sharing with these companies. '
+        'The companies involved depend on the feature you choose:',
+      ),
+    );
     expect(disclosure, contains('secure backend'));
     expect(disclosure, contains('Nous Research / Hermes Cloud'));
     expect(disclosure, contains('what you say or type'));

--- a/app/test/ella/widgets/ai_consent_sheet_test.dart
+++ b/app/test/ella/widgets/ai_consent_sheet_test.dart
@@ -72,24 +72,19 @@ void main() {
         tester.widgetList<RichText>(find.byType(RichText)).map((widget) => widget.text.toPlainText()).join(' ');
     expect(disclosure, contains('secure backend'));
     expect(disclosure, contains('Nous Research / Hermes Cloud'));
-    expect(disclosure, contains('messages, voice or transcript text'));
+    expect(disclosure, contains('what you say or type'));
     expect(disclosure, contains('OpenAI'));
-    expect(disclosure, contains('OpenAI Codex OAuth route'));
-    expect(disclosure, contains('Honcho Cloud'));
-    expect(disclosure, contains('derived memory'));
+    expect(disclosure, contains('Honcho / Plastic Labs'));
+    expect(disclosure, contains('remember useful details'));
     expect(disclosure, contains('Photon'));
-    expect(disclosure, contains('messaging identifiers'));
-    expect(disclosure, contains('one explicitly allowed test contact'));
-    expect(disclosure, contains('no allow-all recipients'));
-    expect(disclosure, contains('caregiver delivery'));
-    expect(disclosure, contains('inbound attachments'));
-    expect(disclosure, contains('requires permission again'));
+    expect(disclosure, contains('one person you choose for testing'));
+    expect(disclosure, contains('cannot message everyone'));
+    expect(disclosure, contains('Ella will ask again'));
     expect(disclosure, contains('Deepgram'));
     expect(disclosure, contains('Soniox'));
     expect(disclosure, contains('Speechmatics'));
     expect(disclosure, contains('Google Firebase'));
-    expect(disclosure, contains('self-hosted Hermes'));
-    expect(disclosure, contains('Ella self-hosted Hermes, Honcho'));
+    expect(disclosure, contains('Ella’s own Hermes, Honcho'));
     expect(disclosure, contains('OpenRouter'));
     expect(disclosure, contains('Google Gemini'));
     expect(disclosure, contains('OpenAI'));
@@ -99,10 +94,24 @@ void main() {
     expect(disclosure, contains('Inworld AI'));
     expect(disclosure, contains('Kokoro'));
     expect(disclosure, contains('Fish'));
-    expect(disclosure, contains('selected memory context'));
-    expect(disclosure, contains('will not send audio, transcripts, messages, selected memory context'));
+    expect(disclosure, contains('details from your saved memories'));
     expect(disclosure, contains('Full processor details in Privacy Policy'));
     expect(find.text('Not now'), findsOneWidget);
+
+    final normalizedDisclosure = disclosure.toLowerCase();
+    for (final bannedWord in const [
+      'monitor',
+      'alert',
+      'emergency',
+      'detect',
+      'track',
+      'transcript',
+      'recording',
+      'omi',
+      'fragment',
+    ]) {
+      expect(normalizedDisclosure, isNot(contains(bannedWord)), reason: 'Consent copy contains "$bannedWord"');
+    }
   });
 
   testWidgets('accept records the current processor contract', (tester) async {


### PR DESCRIPTION
## Scope

Updates the iOS managed-cloud disclosure for the Hermes Cloud migration tracked in https://github.com/ellaaicare/ella-ai/issues/1124 and the consent gate in https://github.com/ellaaicare/ella-ai/issues/1123.

- Names Nous Research / Hermes Cloud and Honcho / Plastic Labs before protected data egress.
- Keeps every existing processor named in the compact disclosure and bundled policy.
- Moves the exact account/profile-bound consent contract from `ai-data-processors-v6` to `ai-data-processors-v7`, so v6 receipts fail closed and users are prompted again.
- Rewrites the locked surface in plain person language and removes the project-banned technical/surveillance terms from the rendered consent sheet.
- Regenerates Flutter localizations and adds v6-to-v7 re-consent coverage.

## Provenance

- Base: `origin/feature/phase-a-testflight` at `487ded6eb832ab1c33ed29dea172ec5a7b53be5e`
- Head: `b1ce20b534d22db43f0638aaaeb71e47b52c3595`
- Repository: `ellaaicare/omi` only; no BasedHardware writes.

## Validation

- Consent/protected-egress/onboarding/revoke-delete suite: 41/41
- Full Flutter suite: 242/242
- `app/test.sh`: capture provider 18/18; transcript 3/3
- Targeted `flutter analyze`: no issues
- `flutter gen-l10n`: completed
- `git diff --check`: clean

## Merge gates

- Lane S locked-copy approval on the exact old/new text posted below.
- Backend must expose the exact matching `ai-data-processors-v7` policy, including legal recipient `Honcho / Plastic Labs`; until then iOS intentionally fails closed.

No build, TestFlight, App Store Connect mutation, backend change, or deployment is included.