### PR TITLE
Route OMI enrichment through Hermes Cloud

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     paths:
       - "backend/database/ella_provisioning.py"
+      - "backend/database/hermes_cloud_enrichment_outbox.py"
       - "backend/database/voice_canary.py"
+      - "backend/ella/__init__.py"
       - "backend/ella/routers/canonical_events.py"
       - "backend/ella/routers/ai_consent.py"
       - "backend/ella/routers/chat.py"
@@ -15,6 +17,7 @@ on:
       - "backend/ella/routers/voice.py"
       - "backend/ella/services/hermes_cloud.py"
       - "backend/ella/services/hermes_cloud_enrichment.py"
+      - "backend/ella/services/hermes_cloud_enrichment_outbox.py"
       - "backend/ella/services/hermes_cloud_enrichment_dependencies.py"
       - "backend/ella/services/ai_consent.py"
       - "backend/ella/services/hermes_cloud_policy.py"
@@ -41,7 +44,9 @@ on:
     branches: [main]
     paths:
       - "backend/database/ella_provisioning.py"
+      - "backend/database/hermes_cloud_enrichment_outbox.py"
       - "backend/database/voice_canary.py"
+      - "backend/ella/__init__.py"
       - "backend/ella/routers/canonical_events.py"
       - "backend/ella/routers/ai_consent.py"
       - "backend/ella/routers/chat.py"
@@ -52,6 +57,7 @@ on:
       - "backend/ella/routers/voice.py"
       - "backend/ella/services/hermes_cloud.py"
       - "backend/ella/services/hermes_cloud_enrichment.py"
+      - "backend/ella/services/hermes_cloud_enrichment_outbox.py"
       - "backend/ella/services/hermes_cloud_enrichment_dependencies.py"
       - "backend/ella/services/ai_consent.py"
       - "backend/ella/services/hermes_cloud_policy.py"
@@ -128,12 +134,14 @@ jobs:
         run: >-
           python -m py_compile
           database/ella_provisioning.py
+          database/hermes_cloud_enrichment_outbox.py
           database/voice_canary.py
           ella/routers/ai_consent.py
           ella/routers/hermes_cloud_enrichment.py
           ella/services/ai_consent.py
           ella/services/hermes_cloud.py
           ella/services/hermes_cloud_enrichment.py
+          ella/services/hermes_cloud_enrichment_outbox.py
           ella/services/hermes_cloud_enrichment_dependencies.py
           ella/services/hermes_cloud_photon.py
           ella/services/hermes_cloud_policy.py
@@ -159,6 +167,7 @@ jobs:
           tests/unit/test_hermes_cloud_provisioning.py
           tests/unit/test_hermes_cloud_runtime.py
           tests/unit/test_hermes_cloud_enrichment.py
+          tests/unit/test_hermes_cloud_enrichment_outbox.py
           tests/unit/test_hermes_cloud_enrichment_router.py
           tests/unit/test_ella_postprocess_cloud_routing.py
           tests/unit/test_ella_chat_temporal_context.py

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -8,11 +8,14 @@ on:
       - "backend/ella/routers/canonical_events.py"
       - "backend/ella/routers/ai_consent.py"
       - "backend/ella/routers/chat.py"
+      - "backend/ella/routers/hermes_cloud_enrichment.py"
       - "backend/ella/routers/onboarding.py"
       - "backend/ella/routers/photon.py"
       - "backend/ella/routers/resolve.py"
       - "backend/ella/routers/voice.py"
       - "backend/ella/services/hermes_cloud.py"
+      - "backend/ella/services/hermes_cloud_enrichment.py"
+      - "backend/ella/services/hermes_cloud_enrichment_dependencies.py"
       - "backend/ella/services/ai_consent.py"
       - "backend/ella/services/hermes_cloud_policy.py"
       - "backend/ella/services/hermes_cloud_photon.py"
@@ -22,13 +25,16 @@ on:
       - "backend/ella/services/runtime_resolver.py"
       - "backend/migrations/009_create_hermes_cloud_runtime_pool.sql"
       - "backend/scripts/hermes_cloud_pool_admin.py"
+      - "backend/scripts/hermes_cloud_enrichment_smoke.py"
       - "backend/scripts/hermes_cloud_shadow.py"
+      - "backend/utils/ella/postprocess.py"
       - "backend/tests/unit/test_ella_provisioning_repository.py"
       - "backend/tests/postgres/test_hermes_cloud_pool_postgres.py"
       - "backend/tests/unit/test_ella_ai_consent.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
       - "backend/tests/unit/test_ella_runtime_route_isolation.py"
       - "backend/tests/unit/test_hermes_cloud_*.py"
+      - "backend/tests/unit/test_ella_postprocess_cloud_routing.py"
       - "backend/tests/unit/test_voice_proxy_auth.py"
       - ".github/workflows/hermes-cloud-runtime-tests.yml"
   push:
@@ -39,11 +45,14 @@ on:
       - "backend/ella/routers/canonical_events.py"
       - "backend/ella/routers/ai_consent.py"
       - "backend/ella/routers/chat.py"
+      - "backend/ella/routers/hermes_cloud_enrichment.py"
       - "backend/ella/routers/onboarding.py"
       - "backend/ella/routers/photon.py"
       - "backend/ella/routers/resolve.py"
       - "backend/ella/routers/voice.py"
       - "backend/ella/services/hermes_cloud.py"
+      - "backend/ella/services/hermes_cloud_enrichment.py"
+      - "backend/ella/services/hermes_cloud_enrichment_dependencies.py"
       - "backend/ella/services/ai_consent.py"
       - "backend/ella/services/hermes_cloud_policy.py"
       - "backend/ella/services/hermes_cloud_photon.py"
@@ -53,13 +62,16 @@ on:
       - "backend/ella/services/runtime_resolver.py"
       - "backend/migrations/009_create_hermes_cloud_runtime_pool.sql"
       - "backend/scripts/hermes_cloud_pool_admin.py"
+      - "backend/scripts/hermes_cloud_enrichment_smoke.py"
       - "backend/scripts/hermes_cloud_shadow.py"
+      - "backend/utils/ella/postprocess.py"
       - "backend/tests/unit/test_ella_provisioning_repository.py"
       - "backend/tests/postgres/test_hermes_cloud_pool_postgres.py"
       - "backend/tests/unit/test_ella_ai_consent.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
       - "backend/tests/unit/test_ella_runtime_route_isolation.py"
       - "backend/tests/unit/test_hermes_cloud_*.py"
+      - "backend/tests/unit/test_ella_postprocess_cloud_routing.py"
       - "backend/tests/unit/test_voice_proxy_auth.py"
       - ".github/workflows/hermes-cloud-runtime-tests.yml"
 
@@ -118,8 +130,11 @@ jobs:
           database/ella_provisioning.py
           database/voice_canary.py
           ella/routers/ai_consent.py
+          ella/routers/hermes_cloud_enrichment.py
           ella/services/ai_consent.py
           ella/services/hermes_cloud.py
+          ella/services/hermes_cloud_enrichment.py
+          ella/services/hermes_cloud_enrichment_dependencies.py
           ella/services/hermes_cloud_photon.py
           ella/services/hermes_cloud_policy.py
           ella/services/hermes_cloud_runtime.py
@@ -128,7 +143,9 @@ jobs:
           ella/services/runtime_errors.py
           ella/services/runtime_resolver.py
           scripts/hermes_cloud_pool_admin.py
+          scripts/hermes_cloud_enrichment_smoke.py
           scripts/hermes_cloud_shadow.py
+          utils/ella/postprocess.py
 
       - name: Run Hermes Cloud and isolation failure-path tests
         run: >-
@@ -141,6 +158,9 @@ jobs:
           tests/unit/test_hermes_cloud_provider.py
           tests/unit/test_hermes_cloud_provisioning.py
           tests/unit/test_hermes_cloud_runtime.py
+          tests/unit/test_hermes_cloud_enrichment.py
+          tests/unit/test_hermes_cloud_enrichment_router.py
+          tests/unit/test_ella_postprocess_cloud_routing.py
           tests/unit/test_ella_chat_temporal_context.py
           tests/unit/test_ella_provisioning_repository.py
           tests/unit/test_ella_runtime_route_isolation.py

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -61,7 +61,7 @@ FIREBASE_PROJECT_ID=
 ELLA_AI_CONSENT_ENFORCEMENT_ENABLED=false
 ELLA_AI_CONSENT_ENFORCEMENT_UIDS=
 ELLA_INTERNAL_VOICE_TTS_TOKEN=
-# Managed-cloud v6 remains independently fail-closed. Keep real data disabled
+# Managed-cloud v7 remains independently fail-closed. Keep real data disabled
 # until the exact policy/scope receipt is deployed and synthetic canaries pass.
 ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED=false
 ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED_UIDS=

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -71,6 +71,14 @@ ELLA_HERMES_CLOUD_CONSENT_POLICY_VERSION=
 ELLA_HERMES_CLOUD_CONSENT_PROCESSOR_SET_HASH=
 ELLA_HERMES_CLOUD_CONSENT_SCOPE_VERSION=
 ELLA_HERMES_CLOUD_CONSENT_SCOPE_HASH=
+# OMI enrichment canary. Every UID in the selector is fail-closed: it uses the
+# loopback adapter and never falls through to n8n/Mini conversation-ready.
+# Its entitlement mode_allowlist must include hermes-cloud-enrichment.
+ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED=false
+ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS=
+ELLA_HERMES_CLOUD_ENRICHMENT_URL=http://127.0.0.1:8000/v1/ella/internal/hermes-cloud/enrichment/run
+ELLA_HERMES_CLOUD_ENRICHMENT_TIMEOUT=180
+ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN=
 
 # Ella isolated Hermes onboarding. Keep both flags false until the provisioning
 # schema is migrated and a synthetic two-user 8210 canary passes.

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -79,6 +79,7 @@ ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS=
 ELLA_HERMES_CLOUD_ENRICHMENT_URL=http://127.0.0.1:8000/v1/ella/internal/hermes-cloud/enrichment/run
 ELLA_HERMES_CLOUD_ENRICHMENT_TIMEOUT=180
 ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN=
+ELLA_HERMES_CLOUD_ENRICHMENT_MAX_OUTPUT_ATTEMPTS=3
 
 # Ella isolated Hermes onboarding. Keep both flags false until the provisioning
 # schema is migrated and a synthetic two-user 8210 canary passes.

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -1099,6 +1099,7 @@ class EllaProvisioningRepository:
         scope_id: str,
         client_interaction_id: str,
         request_hash: str,
+        compatible_request_hashes: tuple[str, ...] = (),
         correlation_id: str,
         canonical_user_event_id: str,
         canonical_assistant_event_id: str,
@@ -1139,9 +1140,54 @@ class EllaProvisioningRepository:
             canonical_assistant_event_id,
         )
         result = dict(row)
-        if str(result.get("request_hash") or "") != request_hash:
+        stored_request_hash = str(result.get("request_hash") or "")
+        if stored_request_hash != request_hash and stored_request_hash not in compatible_request_hashes:
             raise RuntimePoolClaimError("runtime_interaction_payload_conflict")
         return result
+
+    async def count_runtime_interaction_failures(
+        self,
+        *,
+        scope_id: str,
+        client_interaction_id: str,
+        error_code: str,
+    ) -> int:
+        value = await self.pool.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM ella_runtime_interactions
+            WHERE scope_id = $1
+              AND error_code = $3
+              AND (
+                  client_interaction_id = $2
+                  OR POSITION(($2 || ':format-retry:') IN client_interaction_id) = 1
+              )
+            """,
+            uuid.UUID(str(scope_id)),
+            client_interaction_id,
+            error_code,
+        )
+        return int(value or 0)
+
+    async def invalidate_completed_runtime_interaction(
+        self,
+        *,
+        interaction_id: str,
+        error_code: str,
+    ) -> None:
+        await self.pool.execute(
+            """
+            UPDATE ella_runtime_interactions
+            SET status = 'failed',
+                error_code = $2,
+                completed_at = NULL,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = $1
+              AND status = 'completed'
+            """,
+            uuid.UUID(str(interaction_id)),
+            error_code[:120],
+        )
 
     async def claim_runtime_interaction(self, interaction_id: str) -> Optional[dict[str, Any]]:
         interaction_uuid = uuid.UUID(str(interaction_id))

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -1099,7 +1099,6 @@ class EllaProvisioningRepository:
         scope_id: str,
         client_interaction_id: str,
         request_hash: str,
-        compatible_request_hashes: tuple[str, ...] = (),
         correlation_id: str,
         canonical_user_event_id: str,
         canonical_assistant_event_id: str,
@@ -1140,8 +1139,7 @@ class EllaProvisioningRepository:
             canonical_assistant_event_id,
         )
         result = dict(row)
-        stored_request_hash = str(result.get("request_hash") or "")
-        if stored_request_hash != request_hash and stored_request_hash not in compatible_request_hashes:
+        if str(result.get("request_hash") or "") != request_hash:
             raise RuntimePoolClaimError("runtime_interaction_payload_conflict")
         return result
 

--- a/backend/database/hermes_cloud_enrichment_outbox.py
+++ b/backend/database/hermes_cloud_enrichment_outbox.py
@@ -1,0 +1,239 @@
+"""Durable Firestore outbox for OMI conversation enrichment delivery."""
+
+from __future__ import annotations
+
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from google.cloud.firestore_v1 import FieldFilter, transactional
+
+from database._client import db
+
+COLLECTION = "ella_hermes_cloud_enrichment_outbox"
+PENDING_STATUSES = ("pending", "retryable", "running")
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _aware(value: Any) -> Optional[datetime]:
+    if not isinstance(value, datetime):
+        return None
+    return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+
+
+@transactional
+def _enqueue_transaction(
+    transaction,
+    reference,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    snapshot = reference.get(transaction=transaction)
+    if snapshot.exists:
+        existing = snapshot.to_dict() or {}
+        immutable_fields = (
+            "uid",
+            "conversation_id",
+            "client_interaction_id",
+            "transcript_sha256",
+        )
+        if any(existing.get(field) != payload.get(field) for field in immutable_fields):
+            raise ValueError("hermes_cloud_enrichment_outbox_identity_conflict")
+        return existing
+    transaction.set(reference, payload)
+    return payload
+
+
+@transactional
+def _claim_transaction(
+    transaction,
+    reference,
+    *,
+    now: datetime,
+    lease_seconds: int,
+) -> Optional[dict[str, Any]]:
+    snapshot = reference.get(transaction=transaction)
+    if not snapshot.exists:
+        return None
+    current = snapshot.to_dict() or {}
+    status = current.get("status")
+    next_attempt_at = _aware(current.get("next_attempt_at"))
+    lease_expires_at = _aware(current.get("lease_expires_at"))
+    ready = status in {"pending", "retryable"} and (next_attempt_at is None or next_attempt_at <= now)
+    lease_expired = status == "running" and (lease_expires_at is None or lease_expires_at <= now)
+    if not ready and not lease_expired:
+        return None
+
+    lease_token = secrets.token_urlsafe(24)
+    claimed = {
+        **current,
+        "status": "running",
+        "lease_token": lease_token,
+        "lease_expires_at": now + timedelta(seconds=lease_seconds),
+        "attempt_count": int(current.get("attempt_count") or 0) + 1,
+        "updated_at": now,
+    }
+    transaction.update(
+        reference,
+        {
+            "status": claimed["status"],
+            "lease_token": claimed["lease_token"],
+            "lease_expires_at": claimed["lease_expires_at"],
+            "attempt_count": claimed["attempt_count"],
+            "updated_at": claimed["updated_at"],
+        },
+    )
+    return claimed
+
+
+@transactional
+def _complete_transaction(
+    transaction,
+    reference,
+    *,
+    lease_token: str,
+    receipt: dict[str, Any],
+    now: datetime,
+) -> bool:
+    snapshot = reference.get(transaction=transaction)
+    current = snapshot.to_dict() if snapshot.exists else {}
+    if not current or current.get("status") != "running" or current.get("lease_token") != lease_token:
+        return False
+    transaction.update(
+        reference,
+        {
+            "status": "completed",
+            "receipt": receipt,
+            "last_error_code": None,
+            "lease_token": None,
+            "lease_expires_at": None,
+            "completed_at": now,
+            "updated_at": now,
+        },
+    )
+    return True
+
+
+@transactional
+def _fail_transaction(
+    transaction,
+    reference,
+    *,
+    lease_token: str,
+    error_code: str,
+    retryable: bool,
+    next_attempt_at: Optional[datetime],
+    now: datetime,
+) -> bool:
+    snapshot = reference.get(transaction=transaction)
+    current = snapshot.to_dict() if snapshot.exists else {}
+    if not current or current.get("status") != "running" or current.get("lease_token") != lease_token:
+        return False
+    transaction.update(
+        reference,
+        {
+            "status": "retryable" if retryable else "blocked",
+            "last_error_code": error_code[:120],
+            "next_attempt_at": next_attempt_at if retryable else None,
+            "lease_token": None,
+            "lease_expires_at": None,
+            "updated_at": now,
+        },
+    )
+    return True
+
+
+class FirestoreHermesCloudEnrichmentOutbox:
+    def __init__(self, firestore_db: Any = db):
+        self.db = firestore_db
+
+    def enqueue(
+        self,
+        *,
+        job_id: str,
+        uid: str,
+        conversation_id: str,
+        client_interaction_id: str,
+        transcript_sha256: str,
+        policy_version: str,
+    ) -> dict[str, Any]:
+        now = _utcnow()
+        payload = {
+            "job_id": job_id,
+            "uid": uid,
+            "conversation_id": conversation_id,
+            "client_interaction_id": client_interaction_id,
+            "transcript_sha256": transcript_sha256,
+            "policy_version": policy_version,
+            "status": "pending",
+            "attempt_count": 0,
+            "next_attempt_at": now,
+            "lease_token": None,
+            "lease_expires_at": None,
+            "last_error_code": None,
+            "receipt": None,
+            "created_at": now,
+            "updated_at": now,
+        }
+        reference = self.db.collection(COLLECTION).document(job_id)
+        return _enqueue_transaction(self.db.transaction(), reference, payload)
+
+    def claim_next(
+        self,
+        *,
+        lease_seconds: int,
+        scan_limit: int = 50,
+    ) -> Optional[dict[str, Any]]:
+        now = _utcnow()
+        query = (
+            self.db.collection(COLLECTION)
+            .where(filter=FieldFilter("status", "in", list(PENDING_STATUSES)))
+            .limit(scan_limit)
+        )
+        for snapshot in query.stream():
+            claimed = _claim_transaction(
+                self.db.transaction(),
+                snapshot.reference,
+                now=now,
+                lease_seconds=lease_seconds,
+            )
+            if claimed:
+                return claimed
+        return None
+
+    def complete(
+        self,
+        *,
+        job_id: str,
+        lease_token: str,
+        receipt: dict[str, Any],
+    ) -> bool:
+        return _complete_transaction(
+            self.db.transaction(),
+            self.db.collection(COLLECTION).document(job_id),
+            lease_token=lease_token,
+            receipt=receipt,
+            now=_utcnow(),
+        )
+
+    def fail(
+        self,
+        *,
+        job_id: str,
+        lease_token: str,
+        error_code: str,
+        retryable: bool,
+        retry_after_seconds: int,
+    ) -> bool:
+        now = _utcnow()
+        return _fail_transaction(
+            self.db.transaction(),
+            self.db.collection(COLLECTION).document(job_id),
+            lease_token=lease_token,
+            error_code=error_code,
+            retryable=retryable,
+            next_attempt_at=(now + timedelta(seconds=max(1, retry_after_seconds)) if retryable else None),
+            now=now,
+        )

--- a/backend/ella/README.md
+++ b/backend/ella/README.md
@@ -276,11 +276,18 @@ The ensure job also creates or repairs the UID-scoped OMI Firestore identity. Mi
 ### AI processing consent
 
 `/v1/users/ai-consent` is the server authority for the versioned AI/data-sharing
-policy. The current `ai-data-processors-v5` manifest includes Soniox and
-Speechmatics STT, Inworld TTS, and Ella's self-hosted Kokoro/Fish TTS in
-addition to the model, memory, infrastructure, and fallback recipients. The
-authenticated Firebase UID selects both the current state and the
-immutable receipt subcollection; callers cannot submit or select another UID.
+policy. The current `ai-data-processors-v7` manifest includes Soniox and
+Speechmatics STT, Inworld TTS, Ella's self-hosted Kokoro/Fish TTS, Hermes
+Cloud, Honcho Cloud, OpenAI Codex, and Photon in addition to the remaining
+model, memory, infrastructure, and fallback recipients. V7 requires renewed
+consent for revised legal/plain-language disclosure, including the
+`Honcho / Plastic Labs` label and revised Hermes/Honcho data descriptions.
+The canonical processor IDs/functions and managed-cloud scope did not change
+from v6, so their hashes intentionally remain stable. Authorization still
+requires the exact policy version, processor-set hash, scope version, and scope
+hash together; matching hashes from a v6 receipt do not authorize v7. The
+authenticated Firebase UID selects both the current state and the immutable
+receipt subcollection; callers cannot submit or select another UID.
 
 - `GET /v1/users/ai-consent/policy` returns the required legal-recipient
   manifest, policy version, processor-set hash, and managed-cloud scope

--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -425,11 +425,17 @@ def _register_routers(app) -> None:
         from ella.services.hermes_cloud_enrichment_dependencies import (
             create_default_hermes_cloud_enrichment_service,
         )
+        from ella.services.hermes_cloud_enrichment_outbox import (
+            start_worker as start_enrichment_worker,
+            stop_worker as stop_enrichment_worker,
+        )
 
         app.include_router(
             create_hermes_cloud_enrichment_router(create_default_hermes_cloud_enrichment_service),
             tags=["Hermes Cloud Enrichment"],
         )
+        app.add_event_handler("startup", start_enrichment_worker)
+        app.add_event_handler("shutdown", stop_enrichment_worker)
         print(
             "  🌐 /v1/ella/internal/hermes-cloud/enrichment/* - OMI enrichment adapter",
             flush=True,

--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -417,6 +417,26 @@ def _register_routers(app) -> None:
     except ImportError as e:
         print(f"  ⚠️ Hermes Cloud Photon adapter not available: {e}", flush=True)
 
+    # Loopback-only OMI enrichment handoff into the bound Hermes Cloud runtime.
+    try:
+        from ella.routers.hermes_cloud_enrichment import (
+            create_hermes_cloud_enrichment_router,
+        )
+        from ella.services.hermes_cloud_enrichment_dependencies import (
+            create_default_hermes_cloud_enrichment_service,
+        )
+
+        app.include_router(
+            create_hermes_cloud_enrichment_router(create_default_hermes_cloud_enrichment_service),
+            tags=["Hermes Cloud Enrichment"],
+        )
+        print(
+            "  🌐 /v1/ella/internal/hermes-cloud/enrichment/* - OMI enrichment adapter",
+            flush=True,
+        )
+    except ImportError as e:
+        print(f"  ⚠️ Hermes Cloud enrichment adapter not available: {e}", flush=True)
+
     # Authenticated, idempotent per-user Hermes onboarding
     try:
         app.include_router(onboarding_router, tags=["Ella Onboarding"])

--- a/backend/ella/routers/hermes_cloud_enrichment.py
+++ b/backend/ella/routers/hermes_cloud_enrichment.py
@@ -18,6 +18,24 @@ class HermesCloudEnrichmentIn(BaseModel):
 
     uid: str = Field(min_length=1, max_length=256)
     conversation_id: str = Field(min_length=1, max_length=256)
+    outbox_job_id: Optional[str] = Field(
+        default=None,
+        min_length=68,
+        max_length=68,
+        pattern=r"^hce_[0-9a-f]{64}$",
+    )
+    client_interaction_id: Optional[str] = Field(
+        default=None,
+        min_length=79,
+        max_length=79,
+        pattern=r"^omi-enrichment:[0-9a-f]{64}$",
+    )
+    transcript_sha256: Optional[str] = Field(
+        default=None,
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-f]{64}$",
+    )
 
 
 def _require_service_token(presented: Optional[str]) -> None:
@@ -41,7 +59,11 @@ def _http_error(exc: ProvisioningError) -> HTTPException:
     )
 
 
-def _public_result(result: Any) -> dict[str, Any]:
+def _public_result(
+    result: Any,
+    *,
+    outbox_job_id: Optional[str],
+) -> dict[str, Any]:
     return {
         "ok": True,
         "status": "applied",
@@ -55,6 +77,8 @@ def _public_result(result: Any) -> dict[str, Any]:
         "summary_sha256": result.summary_sha256,
         "provider_response_present": result.provider_response_present,
         "duplicate": result.duplicate,
+        "outbox_job_id": outbox_job_id,
+        "client_interaction_id": result.client_interaction_id,
         "content_free": True,
     }
 
@@ -84,9 +108,14 @@ def create_hermes_cloud_enrichment_router(
                 uid=payload.uid,
                 conversation_id=payload.conversation_id,
                 allow_shadow=False,
+                expected_client_interaction_id=payload.client_interaction_id,
+                expected_transcript_sha256=payload.transcript_sha256,
             )
         except ProvisioningError as exc:
             raise _http_error(exc) from exc
-        return _public_result(result)
+        return _public_result(
+            result,
+            outbox_job_id=payload.outbox_job_id,
+        )
 
     return router

--- a/backend/ella/routers/hermes_cloud_enrichment.py
+++ b/backend/ella/routers/hermes_cloud_enrichment.py
@@ -1,0 +1,92 @@
+"""Authenticated first-party OMI enrichment boundary for Hermes Cloud."""
+
+from __future__ import annotations
+
+import hmac
+import os
+from typing import Any, Awaitable, Callable, Optional
+
+from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from ella.services.hermes_cloud_enrichment import HermesCloudEnrichmentService
+from ella.services.runtime_errors import ProvisioningError
+
+
+class HermesCloudEnrichmentIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    uid: str = Field(min_length=1, max_length=256)
+    conversation_id: str = Field(min_length=1, max_length=256)
+
+
+def _require_service_token(presented: Optional[str]) -> None:
+    expected = os.getenv("ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN", "")
+    if len(expected) < 32:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "hermes_cloud_enrichment_auth_not_configured"},
+        )
+    if not presented or not hmac.compare_digest(presented.encode(), expected.encode()):
+        raise HTTPException(
+            status_code=401,
+            detail={"code": "invalid_hermes_cloud_enrichment_token"},
+        )
+
+
+def _http_error(exc: ProvisioningError) -> HTTPException:
+    return HTTPException(
+        status_code=503 if exc.retryable else 409,
+        detail={"code": exc.code},
+    )
+
+
+def _public_result(result: Any) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "status": "applied",
+        "conversation_id": result.conversation_id,
+        "runtime_binding_id": result.runtime_binding_id,
+        "runtime_interaction_id": result.runtime_interaction_id,
+        "active_summary_version_id": result.active_summary_version_id,
+        "canonical_user_event_id": result.canonical_user_event_id,
+        "canonical_assistant_event_id": result.canonical_assistant_event_id,
+        "transcript_sha256": result.transcript_sha256,
+        "summary_sha256": result.summary_sha256,
+        "provider_response_present": result.provider_response_present,
+        "duplicate": result.duplicate,
+        "content_free": True,
+    }
+
+
+def create_hermes_cloud_enrichment_router(
+    service_factory: Callable[[], Awaitable[HermesCloudEnrichmentService]],
+) -> APIRouter:
+    router = APIRouter(
+        prefix="/v1/ella/internal/hermes-cloud/enrichment",
+        tags=["Hermes Cloud Enrichment"],
+    )
+
+    async def _service() -> HermesCloudEnrichmentService:
+        return await service_factory()
+
+    @router.post("/run")
+    async def run(
+        payload: HermesCloudEnrichmentIn,
+        x_service_token: Optional[str] = Header(
+            default=None,
+            alias="X-Ella-Hermes-Cloud-Enrichment-Token",
+        ),
+    ) -> dict[str, Any]:
+        _require_service_token(x_service_token)
+        try:
+            result = await (await _service()).enrich(
+                uid=payload.uid,
+                conversation_id=payload.conversation_id,
+                allow_shadow=False,
+            )
+        except ProvisioningError as exc:
+            raise _http_error(exc) from exc
+        return _public_result(result)
+
+    return router

--- a/backend/ella/services/ai_consent.py
+++ b/backend/ella/services/ai_consent.py
@@ -19,6 +19,9 @@ from utils.other import endpoints as auth
 
 ConsentDecision = Literal["granted", "declined", "revoked"]
 
+# V7 changes the legal/plain-language disclosure, not the processor topology or
+# managed-cloud scope. Authority therefore requires this exact version together
+# with the unchanged canonical processor and scope hashes below.
 CURRENT_POLICY_VERSION = "ai-data-processors-v7"
 CANONICAL_PROCESSOR_SET = (
     "deepgram:stt|soniox:stt|speechmatics:stt|firebase:auth-infrastructure|"

--- a/backend/ella/services/ai_consent.py
+++ b/backend/ella/services/ai_consent.py
@@ -19,7 +19,7 @@ from utils.other import endpoints as auth
 
 ConsentDecision = Literal["granted", "declined", "revoked"]
 
-CURRENT_POLICY_VERSION = "ai-data-processors-v6"
+CURRENT_POLICY_VERSION = "ai-data-processors-v7"
 CANONICAL_PROCESSOR_SET = (
     "deepgram:stt|soniox:stt|speechmatics:stt|firebase:auth-infrastructure|"
     "hermes-self-hosted:agent-runtime|honcho-self-hosted:memory-context|ella-self-hosted-tts:tts|"
@@ -102,18 +102,15 @@ PROCESSORS: tuple[dict[str, Any], ...] = (
         "id": "nous-hermes-cloud",
         "legal_recipient": "Nous Research / Hermes Cloud",
         "function": "Managed agent runtime",
-        "data": (
-            "Prompt policy, messages, transcripts, selected first-party context, "
-            "session metadata, and model or tool usage"
-        ),
+        "data": ("What the person says or types, details they choose to share, " "and basic session information"),
         "provider_aliases": ["hermes-cloud", "hermes_cloud", "nous-hermes-cloud"],
         "third_party": True,
     },
     {
         "id": "honcho-cloud",
-        "legal_recipient": "Honcho Cloud",
+        "legal_recipient": "Honcho / Plastic Labs",
         "function": "Profile-bound derived memory and context",
-        "data": ("Consented derived memory, selected context, and memory relationships " "for the bound profile"),
+        "data": ("Details from conversations and information the person chooses " "to save for the bound profile"),
         "provider_aliases": ["honcho-cloud", "honcho_cloud", "honcho_cloud_profile_isolated"],
         "third_party": True,
     },

--- a/backend/ella/services/hermes_cloud_enrichment.py
+++ b/backend/ella/services/hermes_cloud_enrichment.py
@@ -1,0 +1,367 @@
+"""Fail-closed OMI conversation enrichment through a bound Hermes Cloud runtime."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+
+from database.ella_provisioning import EllaProvisioningRepository
+from ella.routers.canonical_events import CanonicalEventStore
+from ella.services.hermes_cloud_runtime import (
+    HermesCloudRuntimeService,
+    HermesCloudTurnRequest,
+)
+from ella.services.runtime_errors import ProvisioningError
+from ella.services.runtime_resolver import IsolatedRuntime, runtime_from_binding
+from models.conversation import CategoryEnum
+
+HERMES_CLOUD_ENRICHMENT_CHANNEL = "omi_enrichment"
+HERMES_CLOUD_ENRICHMENT_POLICY_VERSION = "hermes-cloud-enrichment-v1"
+JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+ENRICHMENT_INSTRUCTIONS = """You are Ella's OMI conversation enrichment worker.
+
+Use the complete authoritative transcript in the input and only relevant facts available through the approved read-only companion context. Return exactly one JSON object and no surrounding prose.
+
+Rules:
+- Ground every claim in the transcript or approved companion context.
+- Do not invent people, locations, relationships, health facts, or actions.
+- The overview must start with "[Ella] ".
+- Keep the title short and free of markdown.
+- category must be one of: personal, education, health, finance, legal, philosophy, spiritual, science, entrepreneurship, parenting, romantic, travel, inspiration, technology, business, social, work, sports, politics, literature, history, architecture, music, weather, news, entertainment, psychology, real, design, family, economics, environment, other.
+- Include concise ella_tags and an ella_signal object.
+- Do not contact anyone, deliver Guardian or caregiver messages, or mutate memory.
+
+Return exactly:
+{
+  "title": "short title",
+  "overview": "[Ella] grounded enriched summary",
+  "emoji": "one emoji",
+  "category": "category",
+  "ella_tags": ["omi", "enriched"],
+  "ella_signal": {
+    "salience": "low|medium|high",
+    "memory_promotion": "none|candidate|promoted",
+    "noise_level": "none|low|medium|high",
+    "contains_media": false,
+    "contains_user_speech": true,
+    "guardian_relevant": false
+  }
+}"""
+
+
+@dataclass(frozen=True)
+class HermesCloudEnrichmentResult:
+    conversation_id: str
+    runtime_binding_id: str
+    runtime_interaction_id: str
+    active_summary_version_id: str
+    canonical_user_event_id: str
+    canonical_assistant_event_id: str
+    transcript_sha256: str
+    summary_sha256: str
+    provider_response_present: bool
+    duplicate: bool
+
+
+def _structured_summary(conversation: dict[str, Any]) -> dict[str, Any]:
+    structured = conversation.get("structured") or {}
+    return {
+        "title": structured.get("title") or conversation.get("title") or "",
+        "overview": structured.get("overview") or conversation.get("overview") or "",
+        "emoji": structured.get("emoji") or conversation.get("emoji") or "",
+        "category": str(structured.get("category") or conversation.get("category") or "other"),
+    }
+
+
+def _transcript_source(conversation: dict[str, Any]) -> tuple[str, str]:
+    source = json.dumps(
+        conversation.get("transcript_segments") or [],
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return source, hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+
+def _extract_json_object(content: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        match = JSON_OBJECT_RE.search(content)
+        if not match:
+            raise
+        parsed = json.loads(match.group(0))
+    if not isinstance(parsed, dict):
+        raise ValueError("Summary model response was not a JSON object")
+    return parsed
+
+
+def _normalize_summary(
+    result: dict[str, Any],
+    fallback: dict[str, Any],
+) -> dict[str, Any]:
+    title = str(result.get("title") or fallback.get("title") or "Enriched Conversation").strip()
+    overview = str(result.get("overview") or fallback.get("overview") or "").strip()
+    if not overview:
+        raise ValueError("Summary model response missing overview")
+    if not overview.startswith("[Ella] "):
+        overview = "[Ella] " + overview.removeprefix("[Ella]").strip()
+    emoji = str(result.get("emoji") or fallback.get("emoji") or "\U0001fab6").strip()[:4] or "\U0001fab6"
+    category = str(result.get("category") or fallback.get("category") or "other").strip().lower()
+    category = {
+        "media": CategoryEnum.entertainment.value,
+        "romance": CategoryEnum.romance.value,
+    }.get(category, category)
+    if category not in {item.value for item in CategoryEnum}:
+        category = CategoryEnum.other.value
+
+    raw_tags = result.get("ella_tags")
+    tags = (
+        [str(tag).strip().lower() for tag in raw_tags if str(tag or "").strip()] if isinstance(raw_tags, list) else []
+    )
+    for tag in reversed(("omi", "enriched")):
+        if tag not in tags:
+            tags.insert(0, tag)
+
+    raw_signal = result.get("ella_signal")
+    signal = raw_signal if isinstance(raw_signal, dict) else {}
+    return {
+        "title": title,
+        "overview": overview,
+        "emoji": emoji,
+        "category": category,
+        "ella_tags": tags[:12],
+        "ella_signal": {
+            "salience": str(signal.get("salience") or "medium"),
+            "memory_promotion": str(signal.get("memory_promotion") or "none"),
+            "noise_level": str(signal.get("noise_level") or "low"),
+            "contains_media": bool(signal.get("contains_media", False)),
+            "contains_user_speech": bool(signal.get("contains_user_speech", True)),
+            "guardian_relevant": bool(signal.get("guardian_relevant", False)),
+        },
+    }
+
+
+def _started_at(conversation: dict[str, Any]) -> datetime:
+    value = conversation.get("started_at")
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            parsed = None
+        if parsed is not None:
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc)
+
+
+def _summary_sha256(summary: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            summary,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _interaction_identity(
+    uid: str,
+    conversation_id: str,
+    transcript_sha256: str,
+) -> tuple[str, str]:
+    policy_sha256 = hashlib.sha256(ENRICHMENT_INSTRUCTIONS.encode("utf-8")).hexdigest()
+    digest = hashlib.sha256(
+        (
+            f"{uid}|{conversation_id}|{transcript_sha256}|" f"{HERMES_CLOUD_ENRICHMENT_POLICY_VERSION}|{policy_sha256}"
+        ).encode("utf-8")
+    ).hexdigest()
+    return f"omi-enrichment:{digest}", f"omi-enrichment:{digest[:32]}"
+
+
+def _input_payload(
+    conversation: dict[str, Any],
+    transcript_sha256: str,
+) -> str:
+    conversation_id = str(conversation.get("id") or "")
+    payload = {
+        "source": "omi_conversation",
+        "conversation_id_sha256": hashlib.sha256(conversation_id.encode("utf-8")).hexdigest(),
+        "transcript_sha256": transcript_sha256,
+        "transcript_segments": conversation.get("transcript_segments") or [],
+        "existing_summary": _structured_summary(conversation),
+    }
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+
+
+class HermesCloudEnrichmentService:
+    def __init__(
+        self,
+        *,
+        repository: EllaProvisioningRepository,
+        event_store: CanonicalEventStore,
+        runtime_service_factory: Optional[Callable[[bool], HermesCloudRuntimeService]] = None,
+        conversation_reader: Callable[[str, str], Optional[dict[str, Any]]],
+        summary_applier: Callable[..., Any],
+    ):
+        self.repository = repository
+        self.event_store = event_store
+        self.runtime_service_factory = runtime_service_factory
+        self.conversation_reader = conversation_reader
+        self.summary_applier = summary_applier
+
+    def _runtime_service(self, allow_shadow: bool) -> HermesCloudRuntimeService:
+        if self.runtime_service_factory is not None:
+            return self.runtime_service_factory(allow_shadow)
+        return HermesCloudRuntimeService(
+            repository=self.repository,
+            event_store=self.event_store,
+            allow_shadow=allow_shadow,
+        )
+
+    async def _runtime(self, uid: str, *, allow_shadow: bool) -> IsolatedRuntime:
+        binding = await self.repository.resolve_cloud_binding_state(uid)
+        if not binding:
+            raise ProvisioningError(
+                "hermes_cloud_enrichment_not_provisioned",
+                retryable=True,
+            )
+        runtime = runtime_from_binding(binding, uid, allow_shadow=allow_shadow)
+        if runtime.provider != "hermes_cloud":
+            raise ProvisioningError(
+                "hermes_cloud_enrichment_runtime_required",
+                retryable=False,
+            )
+        return runtime
+
+    async def enrich(
+        self,
+        *,
+        uid: str,
+        conversation_id: str,
+        allow_shadow: bool = False,
+    ) -> HermesCloudEnrichmentResult:
+        if not uid or not conversation_id:
+            raise ProvisioningError(
+                "hermes_cloud_enrichment_identity_required",
+                retryable=False,
+            )
+        runtime = await self._runtime(uid, allow_shadow=allow_shadow)
+        conversation = await asyncio.to_thread(
+            self.conversation_reader,
+            uid,
+            conversation_id,
+        )
+        if conversation is None:
+            raise ProvisioningError(
+                "hermes_cloud_enrichment_conversation_not_found",
+                retryable=False,
+            )
+        if str(conversation.get("id") or "") != conversation_id:
+            raise ProvisioningError(
+                "hermes_cloud_enrichment_ownership_mismatch",
+                retryable=False,
+            )
+
+        _, transcript_sha256 = _transcript_source(conversation)
+        active_summary_version_id = conversation.get("active_summary_version_id")
+        client_interaction_id, trace_id = _interaction_identity(
+            uid,
+            conversation_id,
+            transcript_sha256,
+        )
+        request = HermesCloudTurnRequest(
+            uid=uid,
+            client_interaction_id=client_interaction_id,
+            correlation_id=trace_id,
+            channel=HERMES_CLOUD_ENRICHMENT_CHANNEL,
+            user_input=_input_payload(conversation, transcript_sha256),
+            instructions=ENRICHMENT_INSTRUCTIONS,
+            started_at=_started_at(conversation),
+            client_metadata={
+                "synthetic": uid.startswith(("synthetic-", "staging-synthetic-")),
+                "source": "omi_conversation_postprocess",
+                "policy_version": HERMES_CLOUD_ENRICHMENT_POLICY_VERSION,
+                "conversation_id_sha256": hashlib.sha256(conversation_id.encode("utf-8")).hexdigest(),
+                "transcript_sha256": transcript_sha256,
+            },
+            user_scan_policy="none",
+        )
+        turn = await self._runtime_service(allow_shadow).run_turn(runtime, request)
+        summary = _normalize_summary(
+            _extract_json_object(turn.text),
+            _structured_summary(conversation),
+        )
+
+        current = await asyncio.to_thread(
+            self.conversation_reader,
+            uid,
+            conversation_id,
+        )
+        if current is None:
+            raise ProvisioningError(
+                "hermes_cloud_enrichment_conversation_removed",
+                retryable=False,
+            )
+        _, current_transcript_sha256 = _transcript_source(current)
+        if current_transcript_sha256 != transcript_sha256:
+            raise ProvisioningError(
+                "hermes_cloud_enrichment_transcript_changed",
+                retryable=True,
+            )
+        current_enrichment = current.get("enrichment_state") or {}
+        same_applied_trace = bool(
+            current_enrichment.get("trace_id") == trace_id and current_enrichment.get("status") == "writeback_applied"
+        )
+        if not same_applied_trace and current.get("active_summary_version_id") != active_summary_version_id:
+            raise ProvisioningError(
+                "hermes_cloud_enrichment_summary_changed",
+                retryable=True,
+            )
+
+        apply_result = await self.summary_applier(
+            uid=uid,
+            conversation_id=conversation_id,
+            trace_id=trace_id,
+            active_summary_version_id=current.get("active_summary_version_id"),
+            summary=summary,
+            summary_kind="hermes_enriched",
+            summary_source="hermes_cloud",
+            require_canonical=True,
+            require_based_on_match=not same_applied_trace,
+            preserve_generated_results=True,
+        )
+        version_id = str(apply_result.get("active_summary_version_id") or "")
+        if not version_id or apply_result.get("canonical_confirmed") is not True:
+            raise ProvisioningError(
+                "hermes_cloud_enrichment_writeback_unconfirmed",
+                retryable=True,
+            )
+
+        return HermesCloudEnrichmentResult(
+            conversation_id=conversation_id,
+            runtime_binding_id=runtime.binding_id,
+            runtime_interaction_id=turn.runtime_interaction_id,
+            active_summary_version_id=version_id,
+            canonical_user_event_id=turn.canonical_user_event_id,
+            canonical_assistant_event_id=turn.canonical_assistant_event_id,
+            transcript_sha256=transcript_sha256,
+            summary_sha256=_summary_sha256(summary),
+            provider_response_present=bool(turn.response_id),
+            duplicate=turn.duplicate or same_applied_trace,
+        )

--- a/backend/ella/services/hermes_cloud_enrichment.py
+++ b/backend/ella/services/hermes_cloud_enrichment.py
@@ -67,6 +67,15 @@ class HermesCloudEnrichmentResult:
     summary_sha256: str
     provider_response_present: bool
     duplicate: bool
+    client_interaction_id: str
+
+
+@dataclass(frozen=True)
+class HermesCloudEnrichmentIdentity:
+    job_id: str
+    client_interaction_id: str
+    trace_id: str
+    transcript_sha256: str
 
 
 def _structured_summary(conversation: dict[str, Any]) -> dict[str, Any]:
@@ -188,6 +197,33 @@ def _interaction_identity(
     return f"omi-enrichment:{digest}", f"omi-enrichment:{digest[:32]}"
 
 
+def build_enrichment_identity(
+    *,
+    uid: str,
+    conversation_id: str,
+    conversation: dict[str, Any],
+) -> HermesCloudEnrichmentIdentity:
+    _, transcript_sha256 = _transcript_source(conversation)
+    client_interaction_id, trace_id = _interaction_identity(
+        uid,
+        conversation_id,
+        transcript_sha256,
+    )
+    return HermesCloudEnrichmentIdentity(
+        job_id=("hce_" + hashlib.sha256(client_interaction_id.encode("utf-8")).hexdigest()),
+        client_interaction_id=client_interaction_id,
+        trace_id=trace_id,
+        transcript_sha256=transcript_sha256,
+    )
+
+
+def _validate_enrichment_output(content: str) -> None:
+    _normalize_summary(
+        _extract_json_object(content),
+        {},
+    )
+
+
 def _input_payload(
     conversation: dict[str, Any],
     transcript_sha256: str,
@@ -255,6 +291,8 @@ class HermesCloudEnrichmentService:
         uid: str,
         conversation_id: str,
         allow_shadow: bool = False,
+        expected_client_interaction_id: Optional[str] = None,
+        expected_transcript_sha256: Optional[str] = None,
     ) -> HermesCloudEnrichmentResult:
         if not uid or not conversation_id:
             raise ProvisioningError(
@@ -278,17 +316,27 @@ class HermesCloudEnrichmentService:
                 retryable=False,
             )
 
-        _, transcript_sha256 = _transcript_source(conversation)
-        active_summary_version_id = conversation.get("active_summary_version_id")
-        client_interaction_id, trace_id = _interaction_identity(
-            uid,
-            conversation_id,
-            transcript_sha256,
+        identity = build_enrichment_identity(
+            uid=uid,
+            conversation_id=conversation_id,
+            conversation=conversation,
         )
+        transcript_sha256 = identity.transcript_sha256
+        if expected_client_interaction_id and expected_client_interaction_id != identity.client_interaction_id:
+            raise ProvisioningError(
+                "hermes_cloud_enrichment_interaction_changed",
+                retryable=False,
+            )
+        if expected_transcript_sha256 and expected_transcript_sha256 != transcript_sha256:
+            raise ProvisioningError(
+                "hermes_cloud_enrichment_transcript_changed",
+                retryable=False,
+            )
+        active_summary_version_id = conversation.get("active_summary_version_id")
         request = HermesCloudTurnRequest(
             uid=uid,
-            client_interaction_id=client_interaction_id,
-            correlation_id=trace_id,
+            client_interaction_id=identity.client_interaction_id,
+            correlation_id=identity.trace_id,
             channel=HERMES_CLOUD_ENRICHMENT_CHANNEL,
             user_input=_input_payload(conversation, transcript_sha256),
             instructions=ENRICHMENT_INSTRUCTIONS,
@@ -302,7 +350,11 @@ class HermesCloudEnrichmentService:
             },
             user_scan_policy="none",
         )
-        turn = await self._runtime_service(allow_shadow).run_turn(runtime, request)
+        turn = await self._runtime_service(allow_shadow).run_turn(
+            runtime,
+            request,
+            response_validator=_validate_enrichment_output,
+        )
         summary = _normalize_summary(
             _extract_json_object(turn.text),
             _structured_summary(conversation),
@@ -326,7 +378,8 @@ class HermesCloudEnrichmentService:
             )
         current_enrichment = current.get("enrichment_state") or {}
         same_applied_trace = bool(
-            current_enrichment.get("trace_id") == trace_id and current_enrichment.get("status") == "writeback_applied"
+            current_enrichment.get("trace_id") == identity.trace_id
+            and current_enrichment.get("status") == "writeback_applied"
         )
         if not same_applied_trace and current.get("active_summary_version_id") != active_summary_version_id:
             raise ProvisioningError(
@@ -337,7 +390,7 @@ class HermesCloudEnrichmentService:
         apply_result = await self.summary_applier(
             uid=uid,
             conversation_id=conversation_id,
-            trace_id=trace_id,
+            trace_id=identity.trace_id,
             active_summary_version_id=current.get("active_summary_version_id"),
             summary=summary,
             summary_kind="hermes_enriched",
@@ -364,4 +417,5 @@ class HermesCloudEnrichmentService:
             summary_sha256=_summary_sha256(summary),
             provider_response_present=bool(turn.response_id),
             duplicate=turn.duplicate or same_applied_trace,
+            client_interaction_id=identity.client_interaction_id,
         )

--- a/backend/ella/services/hermes_cloud_enrichment_dependencies.py
+++ b/backend/ella/services/hermes_cloud_enrichment_dependencies.py
@@ -1,0 +1,17 @@
+"""Production dependency wiring for Hermes Cloud OMI enrichment."""
+
+import database.conversations as conversations_db
+from database.ella_provisioning import EllaProvisioningRepository
+from ella.routers.canonical_events import PostgresCanonicalEventStore, _get_pool
+from ella.services.hermes_cloud_enrichment import HermesCloudEnrichmentService
+from ella.services.summary_recovery import apply_summary_update
+
+
+async def create_default_hermes_cloud_enrichment_service() -> HermesCloudEnrichmentService:
+    pool = await _get_pool()
+    return HermesCloudEnrichmentService(
+        repository=EllaProvisioningRepository(pool),
+        event_store=PostgresCanonicalEventStore(),
+        conversation_reader=conversations_db.get_conversation,
+        summary_applier=apply_summary_update,
+    )

--- a/backend/ella/services/hermes_cloud_enrichment_outbox.py
+++ b/backend/ella/services/hermes_cloud_enrichment_outbox.py
@@ -1,0 +1,247 @@
+"""Retryable delivery worker for the durable Hermes Cloud enrichment outbox."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from typing import Any, Optional, Protocol
+from urllib.parse import urlsplit
+
+import requests
+
+from database.hermes_cloud_enrichment_outbox import (
+    FirestoreHermesCloudEnrichmentOutbox,
+)
+
+HERMES_CLOUD_ENRICHMENT_PATH = "/v1/ella/internal/hermes-cloud/enrichment/run"
+DEFAULT_URL = "http://127.0.0.1:8000" "/v1/ella/internal/hermes-cloud/enrichment/run"
+
+
+class EnrichmentOutboxRepository(Protocol):
+    def claim_next(
+        self,
+        *,
+        lease_seconds: int,
+        scan_limit: int = 50,
+    ) -> Optional[dict[str, Any]]: ...
+
+    def complete(
+        self,
+        *,
+        job_id: str,
+        lease_token: str,
+        receipt: dict[str, Any],
+    ) -> bool: ...
+
+    def fail(
+        self,
+        *,
+        job_id: str,
+        lease_token: str,
+        error_code: str,
+        retryable: bool,
+        retry_after_seconds: int,
+    ) -> bool: ...
+
+
+@dataclass(frozen=True)
+class DeliveryResult:
+    ok: bool
+    error_code: str = ""
+    retryable: bool = True
+    receipt: Optional[dict[str, Any]] = None
+
+
+def is_safe_enrichment_url(url: str) -> bool:
+    parsed = urlsplit(url)
+    return bool(
+        parsed.scheme == "http"
+        and parsed.hostname in {"127.0.0.1", "::1", "localhost"}
+        and parsed.path == HERMES_CLOUD_ENRICHMENT_PATH
+        and not parsed.username
+        and not parsed.password
+        and not parsed.query
+        and not parsed.fragment
+    )
+
+
+def _error_code(response: requests.Response) -> str:
+    try:
+        body = response.json()
+    except ValueError:
+        return "hermes_cloud_enrichment_invalid_error_receipt"
+    detail = body.get("detail") if isinstance(body, dict) else None
+    code = detail.get("code") if isinstance(detail, dict) else None
+    return str(code)[:120] if isinstance(code, str) and code else f"hermes_cloud_enrichment_http_{response.status_code}"
+
+
+def deliver_enrichment_job(job: dict[str, Any]) -> DeliveryResult:
+    if os.getenv("ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED", "false").lower() != "true":
+        return DeliveryResult(False, "hermes_cloud_enrichment_disabled")
+    token = os.getenv("ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN", "")
+    if len(token) < 32:
+        return DeliveryResult(
+            False,
+            "hermes_cloud_enrichment_auth_not_configured",
+        )
+    url = os.getenv("ELLA_HERMES_CLOUD_ENRICHMENT_URL", DEFAULT_URL)
+    if not is_safe_enrichment_url(url):
+        return DeliveryResult(False, "hermes_cloud_enrichment_url_invalid")
+    try:
+        timeout = float(os.getenv("ELLA_HERMES_CLOUD_ENRICHMENT_TIMEOUT", "180"))
+    except ValueError:
+        return DeliveryResult(False, "hermes_cloud_enrichment_timeout_invalid")
+    if timeout <= 0 or timeout > 600:
+        return DeliveryResult(False, "hermes_cloud_enrichment_timeout_invalid")
+
+    payload = {
+        "uid": job["uid"],
+        "conversation_id": job["conversation_id"],
+        "outbox_job_id": job["job_id"],
+        "client_interaction_id": job["client_interaction_id"],
+        "transcript_sha256": job["transcript_sha256"],
+    }
+    try:
+        response = requests.post(
+            url,
+            json=payload,
+            headers={
+                "Content-Type": "application/json",
+                "X-Ella-Hermes-Cloud-Enrichment-Token": token,
+            },
+            timeout=timeout,
+        )
+    except requests.Timeout:
+        return DeliveryResult(False, "hermes_cloud_enrichment_timeout")
+    except requests.RequestException:
+        return DeliveryResult(False, "hermes_cloud_enrichment_unavailable")
+    if response.status_code != 200:
+        return DeliveryResult(
+            False,
+            _error_code(response),
+            retryable=(response.status_code in {401, 408, 425, 429} or response.status_code >= 500),
+        )
+    try:
+        body = response.json()
+    except ValueError:
+        return DeliveryResult(False, "hermes_cloud_enrichment_invalid_receipt")
+    valid = (
+        isinstance(body, dict)
+        and body.get("ok") is True
+        and body.get("status") == "applied"
+        and body.get("content_free") is True
+        and body.get("outbox_job_id") == job["job_id"]
+        and body.get("client_interaction_id") == job["client_interaction_id"]
+        and body.get("transcript_sha256") == job["transcript_sha256"]
+    )
+    if not valid:
+        return DeliveryResult(False, "hermes_cloud_enrichment_invalid_receipt")
+    return DeliveryResult(
+        True,
+        receipt={
+            "runtime_interaction_id": body.get("runtime_interaction_id"),
+            "active_summary_version_id": body.get("active_summary_version_id"),
+            "duplicate": bool(body.get("duplicate")),
+            "content_free": True,
+        },
+    )
+
+
+class HermesCloudEnrichmentOutboxWorker:
+    def __init__(
+        self,
+        repository: EnrichmentOutboxRepository,
+        *,
+        deliver=deliver_enrichment_job,
+        lease_seconds: int = 240,
+        retry_base_seconds: int = 10,
+        poll_seconds: float = 2.0,
+    ):
+        self.repository = repository
+        self.deliver = deliver
+        self.lease_seconds = lease_seconds
+        self.retry_base_seconds = retry_base_seconds
+        self.poll_seconds = poll_seconds
+
+    async def run_once(self) -> bool:
+        job = await asyncio.to_thread(
+            self.repository.claim_next,
+            lease_seconds=self.lease_seconds,
+        )
+        if not job:
+            return False
+        result = await asyncio.to_thread(self.deliver, job)
+        if result.ok:
+            completed = await asyncio.to_thread(
+                self.repository.complete,
+                job_id=job["job_id"],
+                lease_token=job["lease_token"],
+                receipt=result.receipt or {"content_free": True},
+            )
+            if not completed:
+                raise RuntimeError("hermes_cloud_enrichment_lease_lost")
+            return True
+        retry_after = min(
+            900,
+            self.retry_base_seconds * (2 ** min(int(job.get("attempt_count") or 1) - 1, 6)),
+        )
+        failed = await asyncio.to_thread(
+            self.repository.fail,
+            job_id=job["job_id"],
+            lease_token=job["lease_token"],
+            error_code=result.error_code,
+            retryable=result.retryable,
+            retry_after_seconds=retry_after,
+        )
+        if not failed:
+            raise RuntimeError("hermes_cloud_enrichment_lease_lost")
+        return True
+
+    async def run_forever(self) -> None:
+        while True:
+            try:
+                worked = await self.run_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                print(
+                    "[HERMES_CLOUD_ENRICHMENT_OUTBOX] worker error " f"type={type(exc).__name__}",
+                    flush=True,
+                )
+                worked = False
+            if not worked:
+                await asyncio.sleep(self.poll_seconds)
+
+
+_worker_task: Optional[asyncio.Task] = None
+
+
+async def start_worker(
+    worker: Optional[HermesCloudEnrichmentOutboxWorker] = None,
+) -> None:
+    global _worker_task
+    selected = {
+        value.strip()
+        for value in os.getenv(
+            "ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS",
+            "",
+        ).split(",")
+        if value.strip()
+    }
+    if not selected or (_worker_task and not _worker_task.done()):
+        return
+    active_worker = worker or HermesCloudEnrichmentOutboxWorker(FirestoreHermesCloudEnrichmentOutbox())
+    _worker_task = asyncio.create_task(active_worker.run_forever())
+
+
+async def stop_worker() -> None:
+    global _worker_task
+    if not _worker_task:
+        return
+    _worker_task.cancel()
+    try:
+        await _worker_task
+    except asyncio.CancelledError:
+        pass
+    _worker_task = None

--- a/backend/ella/services/hermes_cloud_enrichment_outbox.py
+++ b/backend/ella/services/hermes_cloud_enrichment_outbox.py
@@ -120,7 +120,7 @@ def deliver_enrichment_job(job: dict[str, Any]) -> DeliveryResult:
         return DeliveryResult(
             False,
             _error_code(response),
-            retryable=(response.status_code in {401, 408, 425, 429} or response.status_code >= 500),
+            retryable=(response.status_code in {408, 425, 429} or response.status_code >= 500),
         )
     try:
         body = response.json()

--- a/backend/ella/services/hermes_cloud_runtime.py
+++ b/backend/ella/services/hermes_cloud_runtime.py
@@ -8,7 +8,7 @@ import hmac
 import json
 import os
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -35,6 +35,7 @@ HERMES_CLOUD_ENRICHMENT_CHANNEL = "omi_enrichment"
 DEFAULT_MAX_INPUT_TOKENS = 8192
 DEFAULT_MAX_OUTPUT_TOKENS = 1024
 DEFAULT_MAX_TOOL_CALLS = 2
+INVALID_OUTPUT_ERROR = "hermes_cloud_enrichment_output_invalid"
 
 
 def assert_runtime_managed_consent(runtime: IsolatedRuntime) -> str:
@@ -187,6 +188,37 @@ def _request_hash(request: HermesCloudTurnRequest) -> str:
     return hashlib.sha256(material.encode("utf-8")).hexdigest()
 
 
+def _legacy_request_hash(request: HermesCloudTurnRequest) -> str:
+    """Hash used before instructions and scan policy became identity fields."""
+    material = "\x1f".join(
+        (
+            request.uid,
+            request.channel,
+            request.client_interaction_id,
+            request.user_input,
+            request.consent_grant_epoch or "",
+        )
+    )
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def _validate_provider_response(
+    response_validator: Optional[Callable[[str], None]],
+    text: str,
+) -> None:
+    if response_validator is None:
+        return
+    try:
+        response_validator(text)
+    except ProvisioningError:
+        raise
+    except Exception as exc:
+        raise ProvisioningError(
+            INVALID_OUTPUT_ERROR,
+            retryable=True,
+        ) from exc
+
+
 def _event_identity(request: HermesCloudTurnRequest) -> tuple[str, str, str]:
     digest = hashlib.sha256(
         f"{request.uid}|{request.channel}|{request.client_interaction_id}".encode("utf-8")
@@ -264,6 +296,7 @@ class HermesCloudRuntimeService:
         request: HermesCloudTurnRequest,
         *,
         before_provider_call: Optional[Callable[[], Awaitable[None]]] = None,
+        response_validator: Optional[Callable[[str], None]] = None,
     ) -> HermesCloudTurnResult:
         if runtime.provider != "hermes_cloud" or runtime.uid != request.uid:
             raise ProvisioningError("hermes_cloud_runtime_required", retryable=False)
@@ -285,8 +318,6 @@ class HermesCloudRuntimeService:
                 "hermes_cloud_scan_policy_invalid",
                 retryable=False,
             )
-        source_identity, user_event_id, assistant_event_id = _event_identity(request)
-        request_hash = _request_hash(request)
         scope = await self.repository.get_or_create_runtime_scope(
             uid=request.uid,
             binding_id=runtime.binding_id,
@@ -294,11 +325,38 @@ class HermesCloudRuntimeService:
             channel=request.channel,
             allow_shadow=self.allow_shadow,
         )
+        if response_validator is not None:
+            invalid_attempts = await self.repository.count_runtime_interaction_failures(
+                scope_id=str(scope["id"]),
+                client_interaction_id=request.client_interaction_id,
+                error_code=INVALID_OUTPUT_ERROR,
+            )
+            max_attempts = _bounded_env_int(
+                "ELLA_HERMES_CLOUD_ENRICHMENT_MAX_OUTPUT_ATTEMPTS",
+                3,
+                1,
+                10,
+            )
+            if invalid_attempts >= max_attempts:
+                raise ProvisioningError(
+                    "hermes_cloud_enrichment_output_exhausted",
+                    retryable=False,
+                )
+            if invalid_attempts:
+                request = replace(
+                    request,
+                    client_interaction_id=(f"{request.client_interaction_id}:format-retry:" f"{invalid_attempts}"),
+                )
+        source_identity, user_event_id, assistant_event_id = _event_identity(request)
+        request_hash = _request_hash(request)
         try:
             interaction = await self.repository.get_or_create_runtime_interaction(
                 scope_id=str(scope["id"]),
                 client_interaction_id=request.client_interaction_id,
                 request_hash=request_hash,
+                compatible_request_hashes=(
+                    (_legacy_request_hash(request),) if request.channel == HERMES_CLOUD_ENRICHMENT_CHANNEL else ()
+                ),
                 correlation_id=request.correlation_id,
                 canonical_user_event_id=user_event_id,
                 canonical_assistant_event_id=assistant_event_id,
@@ -314,6 +372,17 @@ class HermesCloudRuntimeService:
             )
             if not stored:
                 raise ProvisioningError("hermes_cloud_completed_turn_missing_event", retryable=True)
+            try:
+                _validate_provider_response(
+                    response_validator,
+                    str(stored.get("text") or ""),
+                )
+            except ProvisioningError:
+                await self.repository.invalidate_completed_runtime_interaction(
+                    interaction_id=str(interaction["id"]),
+                    error_code=INVALID_OUTPUT_ERROR,
+                )
+                raise
             return HermesCloudTurnResult(
                 text=str(stored.get("text") or ""),
                 response_id=str(interaction.get("provider_response_id") or ""),
@@ -339,6 +408,17 @@ class HermesCloudRuntimeService:
                     "hermes_cloud_recovered_turn_missing_provider_ref",
                     retryable=False,
                 )
+            try:
+                _validate_provider_response(
+                    response_validator,
+                    str(recovered.get("text") or ""),
+                )
+            except ProvisioningError:
+                await self.repository.fail_runtime_interaction(
+                    interaction_id=str(claimed["id"]),
+                    error_code=INVALID_OUTPUT_ERROR,
+                )
+                raise
             await self.repository.complete_runtime_interaction(
                 interaction_id=str(claimed["id"]),
                 provider_response_id=provider_response_id,
@@ -527,6 +607,7 @@ class HermesCloudRuntimeService:
             if not quota.allowed:
                 raise ProvisioningError(quota.code, retryable=False)
 
+            _validate_provider_response(response_validator, turn.text)
             assistant_event = _event(
                 request=request,
                 session_key=str(scope["session_key"]),

--- a/backend/ella/services/hermes_cloud_runtime.py
+++ b/backend/ella/services/hermes_cloud_runtime.py
@@ -188,20 +188,6 @@ def _request_hash(request: HermesCloudTurnRequest) -> str:
     return hashlib.sha256(material.encode("utf-8")).hexdigest()
 
 
-def _legacy_request_hash(request: HermesCloudTurnRequest) -> str:
-    """Hash used before instructions and scan policy became identity fields."""
-    material = "\x1f".join(
-        (
-            request.uid,
-            request.channel,
-            request.client_interaction_id,
-            request.user_input,
-            request.consent_grant_epoch or "",
-        )
-    )
-    return hashlib.sha256(material.encode("utf-8")).hexdigest()
-
-
 def _validate_provider_response(
     response_validator: Optional[Callable[[str], None]],
     text: str,
@@ -356,9 +342,6 @@ class HermesCloudRuntimeService:
                 scope_id=str(scope["id"]),
                 client_interaction_id=request.client_interaction_id,
                 request_hash=request_hash,
-                compatible_request_hashes=(
-                    (_legacy_request_hash(request),) if request.channel == HERMES_CLOUD_ENRICHMENT_CHANNEL else ()
-                ),
                 correlation_id=request.correlation_id,
                 canonical_user_event_id=user_event_id,
                 canonical_assistant_event_id=assistant_event_id,

--- a/backend/ella/services/hermes_cloud_runtime.py
+++ b/backend/ella/services/hermes_cloud_runtime.py
@@ -29,7 +29,9 @@ from ella.services.runtime_errors import ProvisioningError
 from ella.services.runtime_resolver import IsolatedRuntime
 
 HERMES_CLOUD_CHAT_MODE = "hermes-cloud-chat"
+HERMES_CLOUD_ENRICHMENT_MODE = "hermes-cloud-enrichment"
 HERMES_CLOUD_PHOTON_MODE = "hermes-cloud-photon"
+HERMES_CLOUD_ENRICHMENT_CHANNEL = "omi_enrichment"
 DEFAULT_MAX_INPUT_TOKENS = 8192
 DEFAULT_MAX_OUTPUT_TOKENS = 1024
 DEFAULT_MAX_TOOL_CALLS = 2
@@ -156,6 +158,7 @@ class HermesCloudTurnRequest:
     started_at: datetime
     client_metadata: dict[str, Any]
     consent_grant_epoch: Optional[str] = None
+    user_scan_policy: str = "immediate"
 
 
 @dataclass(frozen=True)
@@ -176,7 +179,9 @@ def _request_hash(request: HermesCloudTurnRequest) -> str:
             request.channel,
             request.client_interaction_id,
             request.user_input,
+            request.instructions,
             request.consent_grant_epoch or "",
+            request.user_scan_policy,
         )
     )
     return hashlib.sha256(material.encode("utf-8")).hexdigest()
@@ -218,7 +223,7 @@ def _event(
         started_at=started_at,
         ended_at=now if role == "assistant" else None,
         privacy_scope="user_private",
-        scan_policy="immediate" if role == "user" else "none",
+        scan_policy=request.user_scan_policy if role == "user" else "none",
         source_ref={
             "source_identity": source_identity,
             "client_interaction_id": request.client_interaction_id,
@@ -275,6 +280,11 @@ class HermesCloudRuntimeService:
             raise ProvisioningError("hermes_cloud_shadow_not_routable", retryable=False)
         if not request.client_interaction_id.strip():
             raise ProvisioningError("client_interaction_id_required", retryable=False)
+        if request.user_scan_policy not in {"immediate", "none"}:
+            raise ProvisioningError(
+                "hermes_cloud_scan_policy_invalid",
+                retryable=False,
+            )
         source_identity, user_event_id, assistant_event_id = _event_identity(request)
         request_hash = _request_hash(request)
         scope = await self.repository.get_or_create_runtime_scope(
@@ -388,6 +398,12 @@ class HermesCloudRuntimeService:
             entitlement = await self.voice_policy.get_entitlement(request.uid)
             if not entitlement:
                 raise ProvisioningError("no_entitlement", retryable=False)
+            if request.channel == "photon":
+                entitlement_mode = HERMES_CLOUD_PHOTON_MODE
+            elif request.channel == HERMES_CLOUD_ENRICHMENT_CHANNEL:
+                entitlement_mode = HERMES_CLOUD_ENRICHMENT_MODE
+            else:
+                entitlement_mode = HERMES_CLOUD_CHAT_MODE
             admission = await self.voice_policy.accept_session(
                 uid=request.uid,
                 session_id=str(claimed["hermes_session_id"]),
@@ -395,7 +411,7 @@ class HermesCloudRuntimeService:
                 entitlement_revision=int(entitlement["revision"]),
                 provider="hermes_cloud",
                 model=runtime.expected_model,
-                mode=(HERMES_CLOUD_PHOTON_MODE if request.channel == "photon" else HERMES_CLOUD_CHAT_MODE),
+                mode=entitlement_mode,
             )
             if not admission.allowed:
                 raise ProvisioningError(admission.code, retryable=False)

--- a/backend/ella/services/hermes_cloud_runtime.py
+++ b/backend/ella/services/hermes_cloud_runtime.py
@@ -318,6 +318,7 @@ class HermesCloudRuntimeService:
                 "hermes_cloud_scan_policy_invalid",
                 retryable=False,
             )
+        stable_user_request = request
         scope = await self.repository.get_or_create_runtime_scope(
             uid=request.uid,
             binding_id=runtime.binding_id,
@@ -347,7 +348,8 @@ class HermesCloudRuntimeService:
                     request,
                     client_interaction_id=(f"{request.client_interaction_id}:format-retry:" f"{invalid_attempts}"),
                 )
-        source_identity, user_event_id, assistant_event_id = _event_identity(request)
+        user_source_identity, user_event_id, _ = _event_identity(stable_user_request)
+        assistant_source_identity, _, assistant_event_id = _event_identity(request)
         request_hash = _request_hash(request)
         try:
             interaction = await self.repository.get_or_create_runtime_interaction(
@@ -368,7 +370,7 @@ class HermesCloudRuntimeService:
             stored = await self.event_store.get_event(
                 uid=request.uid,
                 event_id=assistant_event_id,
-                source_identity=source_identity,
+                source_identity=assistant_source_identity,
             )
             if not stored:
                 raise ProvisioningError("hermes_cloud_completed_turn_missing_event", retryable=True)
@@ -399,7 +401,7 @@ class HermesCloudRuntimeService:
         recovered = await self.event_store.get_event(
             uid=request.uid,
             event_id=assistant_event_id,
-            source_identity=source_identity,
+            source_identity=assistant_source_identity,
         )
         if recovered:
             provider_response_id = str((recovered.get("source_ref") or {}).get("provider_response_id") or "")
@@ -451,7 +453,7 @@ class HermesCloudRuntimeService:
             user_event = _event(
                 request=request,
                 session_key=str(scope["session_key"]),
-                source_identity=source_identity,
+                source_identity=user_source_identity,
                 event_id=user_event_id,
                 role="user",
                 text=request.user_input,
@@ -460,7 +462,7 @@ class HermesCloudRuntimeService:
             user_receipt = await self.repository.claim_runtime_ingestion(
                 binding_id=runtime.binding_id,
                 canonical_event_id=user_event_id,
-                source_identity=source_identity,
+                source_identity=user_source_identity,
                 event_revision=1,
                 provenance="canonical_writeback",
             )
@@ -611,7 +613,7 @@ class HermesCloudRuntimeService:
             assistant_event = _event(
                 request=request,
                 session_key=str(scope["session_key"]),
-                source_identity=source_identity,
+                source_identity=assistant_source_identity,
                 event_id=assistant_event_id,
                 role="assistant",
                 text=turn.text,
@@ -621,7 +623,7 @@ class HermesCloudRuntimeService:
             assistant_receipt = await self.repository.claim_runtime_ingestion(
                 binding_id=runtime.binding_id,
                 canonical_event_id=assistant_event_id,
-                source_identity=source_identity,
+                source_identity=assistant_source_identity,
                 event_revision=1,
                 provenance="hermes_response",
             )

--- a/backend/scripts/hermes_cloud_enrichment_smoke.py
+++ b/backend/scripts/hermes_cloud_enrichment_smoke.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Run one synthetic OMI enrichment cycle through Hermes Cloud."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+
+from ella.services.hermes_cloud_enrichment_dependencies import (
+    create_default_hermes_cloud_enrichment_service,
+)
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _synthetic_guard(uid: str) -> None:
+    if os.getenv("ELLA_HERMES_CLOUD_SYNTHETIC_ONLY", "").strip().lower() != "true":
+        raise SystemExit("ELLA_HERMES_CLOUD_SYNTHETIC_ONLY=true is required")
+    configured = {item.strip() for item in os.getenv("ELLA_HERMES_CLOUD_SYNTHETIC_UIDS", "").split(",") if item.strip()}
+    if not uid.startswith(("synthetic-", "staging-synthetic-")) or uid not in configured:
+        raise SystemExit("UID must be an explicitly configured synthetic identity")
+
+
+async def run(uid: str, conversation_id: str, *, allow_shadow: bool) -> dict:
+    _synthetic_guard(uid)
+    service = await create_default_hermes_cloud_enrichment_service()
+    first = await service.enrich(
+        uid=uid,
+        conversation_id=conversation_id,
+        allow_shadow=allow_shadow,
+    )
+    replay = await service.enrich(
+        uid=uid,
+        conversation_id=conversation_id,
+        allow_shadow=allow_shadow,
+    )
+    if first.duplicate:
+        raise SystemExit("first execution was already completed; use a fresh synthetic conversation")
+    if not replay.duplicate:
+        raise SystemExit("same-transcript replay did not deduplicate")
+    if (
+        first.active_summary_version_id != replay.active_summary_version_id
+        or first.canonical_user_event_id != replay.canonical_user_event_id
+        or first.canonical_assistant_event_id != replay.canonical_assistant_event_id
+    ):
+        raise SystemExit("replay changed durable enrichment identities")
+    if not first.provider_response_present:
+        raise SystemExit("Hermes Cloud provider response receipt is missing")
+
+    return {
+        "ok": True,
+        "synthetic_only": True,
+        "allow_shadow": allow_shadow,
+        "runtime": "hermes_cloud",
+        "enrichment_status": "writeback_applied",
+        "first_duplicate": first.duplicate,
+        "replay_duplicate": replay.duplicate,
+        "uid_sha256": _sha256(uid),
+        "conversation_id_sha256": _sha256(conversation_id),
+        "binding_id_sha256": _sha256(first.runtime_binding_id),
+        "runtime_interaction_id_sha256": _sha256(first.runtime_interaction_id),
+        "active_summary_version_id_sha256": _sha256(first.active_summary_version_id),
+        "canonical_user_event_id_sha256": _sha256(first.canonical_user_event_id),
+        "canonical_assistant_event_id_sha256": _sha256(first.canonical_assistant_event_id),
+        "transcript_sha256": first.transcript_sha256,
+        "summary_sha256": first.summary_sha256,
+        "provider_response_present": first.provider_response_present,
+        "mini_fallback_calls": 0,
+        "openclaw_fallback_calls": 0,
+        "content_free_receipt": True,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--uid", required=True)
+    parser.add_argument("--conversation-id", required=True)
+    parser.add_argument(
+        "--allow-shadow",
+        action="store_true",
+        help="Permit the explicitly synthetic shadow binding without promoting it.",
+    )
+    args = parser.parse_args()
+    print(
+        json.dumps(
+            asyncio.run(
+                run(
+                    args.uid,
+                    args.conversation_id,
+                    allow_shadow=args.allow_shadow,
+                )
+            ),
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/unit/test_ella_ai_consent.py
+++ b/backend/tests/unit/test_ella_ai_consent.py
@@ -39,10 +39,10 @@ def _service(repository=None):
     )
 
 
-def test_policy_matches_exact_managed_cloud_v6_contract():
+def test_policy_matches_exact_managed_cloud_v7_contract():
     policy = consent.AiConsentService.policy()
 
-    assert policy["version"] == "ai-data-processors-v6"
+    assert policy["version"] == "ai-data-processors-v7"
     assert policy["processor_set_hash"] == "sha256:dd84e4a9da1166cff66e5de55c2570d0496a2c89d46ca431530e993758616296"
     assert policy["scope_version"] == "managed-cloud-internal-pilot-v1"
     assert policy["scope_hash"] == "sha256:727b1db818ce79090a02279f1cc6d15dfc3d65a58592b13fbed53ad048c38a30"
@@ -72,6 +72,144 @@ def test_policy_matches_exact_managed_cloud_v6_contract():
         == policy["canonical_processor_set"]
     )
     assert consent.CURRENT_SCOPE_HASH == f"sha256:{hashlib.sha256(policy['canonical_scope'].encode()).hexdigest()}"
+    processors = {processor["id"]: processor for processor in policy["processors"]}
+    assert processors["nous-hermes-cloud"] == {
+        "id": "nous-hermes-cloud",
+        "legal_recipient": "Nous Research / Hermes Cloud",
+        "function": "Managed agent runtime",
+        "data": ("What the person says or types, details they choose to share, " "and basic session information"),
+        "provider_aliases": [
+            "hermes-cloud",
+            "hermes_cloud",
+            "nous-hermes-cloud",
+        ],
+        "third_party": True,
+    }
+    assert processors["honcho-cloud"] == {
+        "id": "honcho-cloud",
+        "legal_recipient": "Honcho / Plastic Labs",
+        "function": "Profile-bound derived memory and context",
+        "data": ("Details from conversations and information the person chooses " "to save for the bound profile"),
+        "provider_aliases": [
+            "honcho-cloud",
+            "honcho_cloud",
+            "honcho_cloud_profile_isolated",
+        ],
+        "third_party": True,
+    }
+    assert [
+        (
+            processor["id"],
+            processor["legal_recipient"],
+            processor["function"],
+            processor["data"],
+            processor["third_party"],
+        )
+        for processor in policy["processors"]
+    ] == [
+        ("deepgram", "Deepgram", "Speech transcription", "Live or stored microphone audio", True),
+        ("soniox", "Soniox", "Speech transcription", "Live or stored microphone audio", True),
+        (
+            "speechmatics",
+            "Speechmatics",
+            "Speech transcription",
+            "Live or stored microphone audio",
+            True,
+        ),
+        (
+            "firebase",
+            "Google Firebase",
+            "Authentication and service infrastructure",
+            "Account and service metadata",
+            True,
+        ),
+        (
+            "hermes-self-hosted",
+            "Ella self-hosted Hermes",
+            "Agent reasoning",
+            "Messages, transcripts, and selected memory context",
+            False,
+        ),
+        (
+            "honcho-self-hosted",
+            "Ella self-hosted Honcho",
+            "Memory context",
+            "Derived text and selected memory relationships",
+            False,
+        ),
+        (
+            "ella-self-hosted-tts",
+            "Ella self-hosted voice synthesis",
+            "Voice synthesis",
+            "Response text",
+            False,
+        ),
+        (
+            "nous-hermes-cloud",
+            "Nous Research / Hermes Cloud",
+            "Managed agent runtime",
+            "What the person says or types, details they choose to share, and basic session information",
+            True,
+        ),
+        (
+            "honcho-cloud",
+            "Honcho / Plastic Labs",
+            "Profile-bound derived memory and context",
+            "Details from conversations and information the person chooses to save for the bound profile",
+            True,
+        ),
+        (
+            "openai-codex",
+            "OpenAI",
+            "Managed agent model processing",
+            "Model input and output through the approved OpenAI Codex OAuth route",
+            True,
+        ),
+        (
+            "photon",
+            "Photon",
+            "Test/shared-line message delivery",
+            "Message content and messaging identifiers for one explicitly allowed test contact",
+            True,
+        ),
+        (
+            "openrouter",
+            "OpenRouter",
+            "Model routing",
+            "Messages, transcripts, and selected memory context",
+            True,
+        ),
+        (
+            "google-gemini",
+            "Google Gemini",
+            "Language processing and live voice",
+            "Text, selected context, or live microphone audio",
+            True,
+        ),
+        (
+            "openai",
+            "OpenAI",
+            "Language processing and live voice",
+            "Text, selected context, or live microphone audio",
+            True,
+        ),
+        ("groq", "Groq", "Language processing", "Text and selected context", True),
+        (
+            "xai-grok",
+            "xAI Grok",
+            "Language processing and live voice",
+            "Text, selected context, or live microphone audio",
+            True,
+        ),
+        ("inworld", "Inworld AI", "Voice synthesis", "Response text", True),
+        (
+            "elevenlabs",
+            "ElevenLabs",
+            "Fallback voice synthesis",
+            "Response text",
+            True,
+        ),
+    ]
 
 
 def test_missing_consent_is_fail_closed_when_enforcement_is_enabled(monkeypatch):
@@ -299,6 +437,31 @@ def test_stale_grant_is_rejected_but_stale_decline_is_recorded():
     assert declined["consent"]["decision"] == "declined"
 
 
+def test_v6_grant_is_rejected_and_cannot_pass_protected_route_gate(
+    monkeypatch,
+):
+    repository = consent.InMemoryConsentRepository()
+    service = _service(repository)
+    with pytest.raises(consent.ConsentPolicyMismatch):
+        service.submit(
+            "user-a",
+            _submission(policy_version="ai-data-processors-v6"),
+        )
+
+    current = service.submit("user-a", _submission())
+    receipt_id = current["receipt"]["receipt_id"]
+    repository.states["user-a"]["policy_version"] = "ai-data-processors-v6"
+    repository.receipts[("user-a", receipt_id)]["policy_version"] = "ai-data-processors-v6"
+    monkeypatch.setattr(consent, "_repository", repository)
+    monkeypatch.setenv("ELLA_AI_CONSENT_ENFORCEMENT_UIDS", "user-a")
+
+    with pytest.raises(HTTPException) as error:
+        consent.assert_current_ai_consent("user-a")
+
+    assert error.value.status_code == 403
+    assert error.value.detail["required_policy_version"] == ("ai-data-processors-v7")
+
+
 def test_revoke_supersedes_prior_grant():
     service = _service()
     service.submit("user-a", _submission())
@@ -328,7 +491,7 @@ def _assert_exact_managed_cloud_consent(uid="user-a", profile_uid="user-a"):
     )
 
 
-def test_managed_cloud_real_data_defaults_off_even_with_exact_v6_grant(monkeypatch):
+def test_managed_cloud_real_data_defaults_off_even_with_exact_v7_grant(monkeypatch):
     repository = consent.InMemoryConsentRepository()
     _service(repository).submit("user-a", _submission())
     monkeypatch.setattr(consent, "_repository", repository)
@@ -341,7 +504,7 @@ def test_managed_cloud_real_data_defaults_off_even_with_exact_v6_grant(monkeypat
     assert error.value.code == "managed_cloud_real_data_disabled"
 
 
-def test_exact_v6_account_profile_and_scope_authorize_managed_cloud(monkeypatch):
+def test_exact_v7_account_profile_and_scope_authorize_managed_cloud(monkeypatch):
     repository = consent.InMemoryConsentRepository()
     result = _service(repository).submit("user-a", _submission())
     monkeypatch.setattr(consent, "_repository", repository)
@@ -487,13 +650,13 @@ def test_missing_or_mutated_immutable_receipt_fails_closed(monkeypatch):
     assert mutated.value.code == "managed_cloud_consent_required"
 
 
-def test_v5_or_malformed_server_receipt_cannot_authorize_managed_cloud(monkeypatch):
+def test_v6_or_malformed_server_receipt_cannot_authorize_managed_cloud(monkeypatch):
     repository = consent.InMemoryConsentRepository()
     _service(repository).submit("user-a", _submission())
     monkeypatch.setattr(consent, "_repository", repository)
     _enable_managed_cloud(monkeypatch)
 
-    repository.states["user-a"]["policy_version"] = "ai-data-processors-v5"
+    repository.states["user-a"]["policy_version"] = "ai-data-processors-v6"
     with pytest.raises(consent.ManagedCloudConsentError):
         _assert_exact_managed_cloud_consent()
 
@@ -706,7 +869,7 @@ def test_policy_is_public_but_status_and_receipts_require_firebase_auth(monkeypa
     assert status_response.json()["subject_uid"] == "user-a"
 
 
-def test_authenticated_api_records_exact_v6_profile_bound_receipt(monkeypatch):
+def test_authenticated_api_records_exact_v7_profile_bound_receipt(monkeypatch):
     service = _service()
     monkeypatch.setattr(ai_consent, "get_ai_consent_service", lambda: service)
     app = FastAPI()
@@ -722,7 +885,7 @@ def test_authenticated_api_records_exact_v6_profile_bound_receipt(monkeypatch):
             "processor_set_hash": consent.CURRENT_PROCESSOR_SET_HASH,
             "scope_version": consent.CURRENT_SCOPE_VERSION,
             "scope_hash": consent.CURRENT_SCOPE_HASH,
-            "request_id": "request-api-v6",
+            "request_id": "request-api-v7",
             "app_version": "1.0.0",
             "build_number": "804",
             "locale": "en-US",

--- a/backend/tests/unit/test_ella_postprocess_cloud_routing.py
+++ b/backend/tests/unit/test_ella_postprocess_cloud_routing.py
@@ -1,0 +1,142 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from utils.ella import postprocess
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, body=None):
+        self.status_code = status_code
+        self._body = body or {}
+
+    def json(self):
+        return self._body
+
+
+def _conversation():
+    return SimpleNamespace(
+        id="conversation-a",
+        started_at=datetime.now(timezone.utc),
+        finished_at=datetime.now(timezone.utc),
+        language="en",
+        status="completed",
+        structured=SimpleNamespace(
+            title="Synthetic",
+            overview="Synthetic summary",
+            emoji="",
+            category="other",
+        ),
+        transcript_segments=[SimpleNamespace(is_user=True, speaker="SPEAKER_0", text="Synthetic input")],
+    )
+
+
+def _configure_cloud(monkeypatch, *, enabled=True, url=None):
+    monkeypatch.setattr(postprocess, "POSTPROCESS_ENABLED", True)
+    monkeypatch.setattr(
+        postprocess,
+        "HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS",
+        frozenset({"synthetic-user"}),
+    )
+    monkeypatch.setattr(
+        postprocess,
+        "HERMES_CLOUD_ENRICHMENT_ENABLED",
+        enabled,
+    )
+    monkeypatch.setattr(
+        postprocess,
+        "HERMES_CLOUD_ENRICHMENT_TOKEN",
+        "x" * 32,
+    )
+    monkeypatch.setattr(
+        postprocess,
+        "HERMES_CLOUD_ENRICHMENT_URL",
+        url or "http://127.0.0.1:8000/v1/ella/internal/hermes-cloud/enrichment/run",
+    )
+
+
+def test_cloud_selected_uid_uses_loopback_and_never_legacy_ready(monkeypatch):
+    _configure_cloud(monkeypatch)
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append((url, kwargs))
+        if url == postprocess.HERMES_CLOUD_ENRICHMENT_URL:
+            return FakeResponse(
+                body={
+                    "ok": True,
+                    "status": "applied",
+                    "content_free": True,
+                    "duplicate": False,
+                }
+            )
+        return FakeResponse()
+
+    monkeypatch.setattr(postprocess.requests, "post", fake_post)
+
+    postprocess.fire_postprocess_webhook("synthetic-user", _conversation())
+
+    assert [url for url, _ in calls] == [
+        postprocess.POSTPROCESS_WEBHOOK_URL,
+        postprocess.HERMES_CLOUD_ENRICHMENT_URL,
+    ]
+    assert postprocess.CONVERSATION_READY_WEBHOOK_URL not in [url for url, _ in calls]
+    cloud_headers = calls[1][1]["headers"]
+    assert cloud_headers["X-Ella-Hermes-Cloud-Enrichment-Token"] == "x" * 32
+
+
+def test_cloud_selected_uid_fails_closed_when_gate_is_disabled(monkeypatch):
+    _configure_cloud(monkeypatch, enabled=False)
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append(url)
+        return FakeResponse()
+
+    monkeypatch.setattr(postprocess.requests, "post", fake_post)
+
+    postprocess.fire_postprocess_webhook("synthetic-user", _conversation())
+
+    assert calls == [postprocess.POSTPROCESS_WEBHOOK_URL]
+    assert postprocess.CONVERSATION_READY_WEBHOOK_URL not in calls
+
+
+def test_cloud_selected_uid_rejects_non_loopback_adapter_without_fallback(
+    monkeypatch,
+):
+    _configure_cloud(
+        monkeypatch,
+        url="https://example.test/v1/ella/internal/hermes-cloud/enrichment/run",
+    )
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append(url)
+        return FakeResponse()
+
+    monkeypatch.setattr(postprocess.requests, "post", fake_post)
+
+    postprocess.fire_postprocess_webhook("synthetic-user", _conversation())
+
+    assert calls == [postprocess.POSTPROCESS_WEBHOOK_URL]
+    assert postprocess.CONVERSATION_READY_WEBHOOK_URL not in calls
+
+
+def test_cloud_selected_uid_provider_failure_never_falls_back(monkeypatch):
+    _configure_cloud(monkeypatch)
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append(url)
+        if url == postprocess.HERMES_CLOUD_ENRICHMENT_URL:
+            return FakeResponse(status_code=503)
+        return FakeResponse()
+
+    monkeypatch.setattr(postprocess.requests, "post", fake_post)
+
+    postprocess.fire_postprocess_webhook("synthetic-user", _conversation())
+
+    assert calls == [
+        postprocess.POSTPROCESS_WEBHOOK_URL,
+        postprocess.HERMES_CLOUD_ENRICHMENT_URL,
+    ]
+    assert postprocess.CONVERSATION_READY_WEBHOOK_URL not in calls

--- a/backend/tests/unit/test_ella_postprocess_cloud_routing.py
+++ b/backend/tests/unit/test_ella_postprocess_cloud_routing.py
@@ -39,7 +39,7 @@ def _configure_cloud(monkeypatch):
     )
 
 
-def test_cloud_selected_uid_queues_before_webhook_and_never_legacy_ready(
+def test_cloud_selected_uid_queues_and_skips_all_legacy_webhooks(
     monkeypatch,
 ):
     _configure_cloud(monkeypatch)
@@ -60,8 +60,7 @@ def test_cloud_selected_uid_queues_before_webhook_and_never_legacy_ready(
     postprocess.fire_postprocess_webhook("synthetic-user", _conversation())
 
     assert queued == [("synthetic-user", "conversation-a")]
-    assert [url for url, _ in calls] == [postprocess.POSTPROCESS_WEBHOOK_URL]
-    assert postprocess.CONVERSATION_READY_WEBHOOK_URL not in [url for url, _ in calls]
+    assert calls == []
 
 
 def test_cloud_selected_uid_queues_even_when_generic_postprocess_is_disabled(
@@ -113,9 +112,20 @@ def test_cloud_selected_uid_outbox_failure_never_falls_back(monkeypatch):
     assert postprocess.CONVERSATION_READY_WEBHOOK_URL not in calls
 
 
-def test_cloud_selected_uid_never_posts_directly_to_cloud_or_mini(monkeypatch):
+def test_cloud_selected_uid_never_serializes_or_posts_legacy_payload(monkeypatch):
     _configure_cloud(monkeypatch)
     calls = []
+
+    class BoundaryConversation:
+        id = "conversation-a"
+
+        @property
+        def structured(self):
+            raise AssertionError("selected cloud path read legacy structured content")
+
+        @property
+        def transcript_segments(self):
+            raise AssertionError("selected cloud path read legacy transcript content")
 
     def fake_post(url, **kwargs):
         calls.append(url)
@@ -128,7 +138,41 @@ def test_cloud_selected_uid_never_posts_directly_to_cloud_or_mini(monkeypatch):
     )
     monkeypatch.setattr(postprocess.requests, "post", fake_post)
 
-    postprocess.fire_postprocess_webhook("synthetic-user", _conversation())
+    postprocess.fire_postprocess_webhook("synthetic-user", BoundaryConversation())
 
-    assert calls == [postprocess.POSTPROCESS_WEBHOOK_URL]
-    assert postprocess.CONVERSATION_READY_WEBHOOK_URL not in calls
+    assert calls == []
+
+
+def test_non_selected_uid_preserves_both_legacy_webhooks(monkeypatch):
+    monkeypatch.setattr(postprocess, "POSTPROCESS_ENABLED", True)
+    monkeypatch.setattr(
+        postprocess,
+        "HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS",
+        frozenset({"synthetic-user"}),
+    )
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append((url, kwargs["json"]))
+        return FakeResponse()
+
+    class ImmediateThread:
+        def __init__(self, *, target, args, daemon):
+            self.target = target
+            self.args = args
+            self.daemon = daemon
+
+        def start(self):
+            self.target(*self.args)
+
+    monkeypatch.setattr(postprocess.requests, "post", fake_post)
+    monkeypatch.setattr(postprocess.threading, "Thread", ImmediateThread)
+
+    postprocess.fire_postprocess_webhook("legacy-user", _conversation())
+
+    assert [url for url, _ in calls] == [
+        postprocess.POSTPROCESS_WEBHOOK_URL,
+        postprocess.CONVERSATION_READY_WEBHOOK_URL,
+    ]
+    assert calls[0][1]["structured"]["overview"] == "Synthetic summary"
+    assert calls[1][1]["transcript"] == "User: Synthetic input"

--- a/backend/tests/unit/test_ella_postprocess_cloud_routing.py
+++ b/backend/tests/unit/test_ella_postprocess_cloud_routing.py
@@ -30,113 +30,105 @@ def _conversation():
     )
 
 
-def _configure_cloud(monkeypatch, *, enabled=True, url=None):
+def _configure_cloud(monkeypatch):
     monkeypatch.setattr(postprocess, "POSTPROCESS_ENABLED", True)
     monkeypatch.setattr(
         postprocess,
         "HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS",
         frozenset({"synthetic-user"}),
     )
-    monkeypatch.setattr(
-        postprocess,
-        "HERMES_CLOUD_ENRICHMENT_ENABLED",
-        enabled,
-    )
-    monkeypatch.setattr(
-        postprocess,
-        "HERMES_CLOUD_ENRICHMENT_TOKEN",
-        "x" * 32,
-    )
-    monkeypatch.setattr(
-        postprocess,
-        "HERMES_CLOUD_ENRICHMENT_URL",
-        url or "http://127.0.0.1:8000/v1/ella/internal/hermes-cloud/enrichment/run",
-    )
 
 
-def test_cloud_selected_uid_uses_loopback_and_never_legacy_ready(monkeypatch):
+def test_cloud_selected_uid_queues_before_webhook_and_never_legacy_ready(
+    monkeypatch,
+):
     _configure_cloud(monkeypatch)
     calls = []
+    queued = []
 
     def fake_post(url, **kwargs):
         calls.append((url, kwargs))
-        if url == postprocess.HERMES_CLOUD_ENRICHMENT_URL:
-            return FakeResponse(
-                body={
-                    "ok": True,
-                    "status": "applied",
-                    "content_free": True,
-                    "duplicate": False,
-                }
-            )
         return FakeResponse()
 
+    monkeypatch.setattr(
+        postprocess,
+        "enqueue_cloud_enrichment",
+        lambda uid, conversation: queued.append((uid, conversation.id)) or {"status": "pending"},
+    )
     monkeypatch.setattr(postprocess.requests, "post", fake_post)
 
     postprocess.fire_postprocess_webhook("synthetic-user", _conversation())
 
-    assert [url for url, _ in calls] == [
-        postprocess.POSTPROCESS_WEBHOOK_URL,
-        postprocess.HERMES_CLOUD_ENRICHMENT_URL,
-    ]
+    assert queued == [("synthetic-user", "conversation-a")]
+    assert [url for url, _ in calls] == [postprocess.POSTPROCESS_WEBHOOK_URL]
     assert postprocess.CONVERSATION_READY_WEBHOOK_URL not in [url for url, _ in calls]
-    cloud_headers = calls[1][1]["headers"]
-    assert cloud_headers["X-Ella-Hermes-Cloud-Enrichment-Token"] == "x" * 32
 
 
-def test_cloud_selected_uid_fails_closed_when_gate_is_disabled(monkeypatch):
-    _configure_cloud(monkeypatch, enabled=False)
-    calls = []
-
-    def fake_post(url, **kwargs):
-        calls.append(url)
-        return FakeResponse()
-
-    monkeypatch.setattr(postprocess.requests, "post", fake_post)
-
-    postprocess.fire_postprocess_webhook("synthetic-user", _conversation())
-
-    assert calls == [postprocess.POSTPROCESS_WEBHOOK_URL]
-    assert postprocess.CONVERSATION_READY_WEBHOOK_URL not in calls
-
-
-def test_cloud_selected_uid_rejects_non_loopback_adapter_without_fallback(
+def test_cloud_selected_uid_queues_even_when_generic_postprocess_is_disabled(
     monkeypatch,
 ):
-    _configure_cloud(
-        monkeypatch,
-        url="https://example.test/v1/ella/internal/hermes-cloud/enrichment/run",
-    )
+    _configure_cloud(monkeypatch)
+    monkeypatch.setattr(postprocess, "POSTPROCESS_ENABLED", False)
     calls = []
+    queued = []
 
     def fake_post(url, **kwargs):
         calls.append(url)
         return FakeResponse()
 
+    monkeypatch.setattr(
+        postprocess,
+        "enqueue_cloud_enrichment",
+        lambda uid, conversation: queued.append((uid, conversation.id)) or {"status": "pending"},
+    )
     monkeypatch.setattr(postprocess.requests, "post", fake_post)
 
     postprocess.fire_postprocess_webhook("synthetic-user", _conversation())
 
-    assert calls == [postprocess.POSTPROCESS_WEBHOOK_URL]
-    assert postprocess.CONVERSATION_READY_WEBHOOK_URL not in calls
+    assert queued == [("synthetic-user", "conversation-a")]
+    assert calls == []
 
 
-def test_cloud_selected_uid_provider_failure_never_falls_back(monkeypatch):
+def test_cloud_selected_uid_outbox_failure_never_falls_back(monkeypatch):
     _configure_cloud(monkeypatch)
     calls = []
 
     def fake_post(url, **kwargs):
         calls.append(url)
-        if url == postprocess.HERMES_CLOUD_ENRICHMENT_URL:
-            return FakeResponse(status_code=503)
         return FakeResponse()
 
+    def fail_enqueue(uid, conversation):
+        raise RuntimeError("synthetic persistence failure")
+
+    monkeypatch.setattr(
+        postprocess,
+        "enqueue_cloud_enrichment",
+        fail_enqueue,
+    )
     monkeypatch.setattr(postprocess.requests, "post", fake_post)
 
     postprocess.fire_postprocess_webhook("synthetic-user", _conversation())
 
-    assert calls == [
-        postprocess.POSTPROCESS_WEBHOOK_URL,
-        postprocess.HERMES_CLOUD_ENRICHMENT_URL,
-    ]
+    assert calls == []
+    assert postprocess.CONVERSATION_READY_WEBHOOK_URL not in calls
+
+
+def test_cloud_selected_uid_never_posts_directly_to_cloud_or_mini(monkeypatch):
+    _configure_cloud(monkeypatch)
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append(url)
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        postprocess,
+        "enqueue_cloud_enrichment",
+        lambda uid, conversation: {"status": "pending"},
+    )
+    monkeypatch.setattr(postprocess.requests, "post", fake_post)
+
+    postprocess.fire_postprocess_webhook("synthetic-user", _conversation())
+
+    assert calls == [postprocess.POSTPROCESS_WEBHOOK_URL]
     assert postprocess.CONVERSATION_READY_WEBHOOK_URL not in calls

--- a/backend/tests/unit/test_hermes_cloud_enrichment.py
+++ b/backend/tests/unit/test_hermes_cloud_enrichment.py
@@ -59,26 +59,29 @@ class FakeRuntimeService:
     def __init__(self):
         self.calls = []
 
-    async def run_turn(self, runtime, request):
+    async def run_turn(self, runtime, request, *, response_validator=None):
         self.calls.append((runtime, request))
+        text = json.dumps(
+            {
+                "title": "Synthetic cafe order",
+                "overview": "[Ella] A synthetic cafe order was discussed.",
+                "emoji": "☕",
+                "category": "social",
+                "ella_tags": ["omi", "enriched"],
+                "ella_signal": {
+                    "salience": "low",
+                    "memory_promotion": "none",
+                    "noise_level": "none",
+                    "contains_media": False,
+                    "contains_user_speech": True,
+                    "guardian_relevant": False,
+                },
+            }
+        )
+        if response_validator:
+            response_validator(text)
         return SimpleNamespace(
-            text=json.dumps(
-                {
-                    "title": "Synthetic cafe order",
-                    "overview": "[Ella] A synthetic cafe order was discussed.",
-                    "emoji": "☕",
-                    "category": "social",
-                    "ella_tags": ["omi", "enriched"],
-                    "ella_signal": {
-                        "salience": "low",
-                        "memory_promotion": "none",
-                        "noise_level": "none",
-                        "contains_media": False,
-                        "contains_user_speech": True,
-                        "guardian_relevant": False,
-                    },
-                }
-            ),
+            text=text,
             response_id="response-a",
             canonical_user_event_id="event-user",
             canonical_assistant_event_id="event-assistant",
@@ -126,6 +129,7 @@ def test_enrichment_uses_exact_owned_transcript_and_confirmed_writeback():
     assert summary_applier.await_args.kwargs["summary_source"] == "hermes_cloud"
     assert result.active_summary_version_id == "version-enriched"
     assert result.provider_response_present is True
+    assert result.client_interaction_id == request.client_interaction_id
 
 
 def test_enrichment_rejects_transcript_change_before_writeback():

--- a/backend/tests/unit/test_hermes_cloud_enrichment.py
+++ b/backend/tests/unit/test_hermes_cloud_enrichment.py
@@ -1,0 +1,183 @@
+import asyncio
+import json
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ella.services.hermes_cloud_enrichment import HermesCloudEnrichmentService
+from ella.services.provisioning import ProvisioningError
+from ella.services.runtime_resolver import IsolatedRuntime
+
+
+def _runtime() -> IsolatedRuntime:
+    return IsolatedRuntime(
+        uid="synthetic-user",
+        binding_id="binding-a",
+        provider="hermes_cloud",
+        status="internal_canary",
+        profile_name="synthetic-profile",
+        agent_id="hermes-cloud",
+        runtime_instance_id="instance-a",
+        gateway_url="https://cloud.example.test",
+        gateway_token="secret",
+        workspace_root="",
+        honcho_workspace="workspace-a",
+        observed_peer="user-a",
+        observer_peer="companion-a",
+        prompt_pack_version="prompt-v1",
+        expected_model="model-a",
+        model_context_window_tokens=16384,
+        allowed_tools=(),
+        required_capabilities=("responses_api",),
+        model_policy_version="models-v1",
+        voice_policy_version="voice-v1",
+        revision=1,
+    )
+
+
+def _conversation(text: str = "Synthetic cafe order.") -> dict:
+    return {
+        "id": "conversation-a",
+        "started_at": "2026-07-27T10:00:00Z",
+        "transcript_segments": [
+            {"is_user": True, "speaker": "SPEAKER_0", "text": text},
+        ],
+        "structured": {
+            "title": "Initial title",
+            "overview": "Initial summary",
+            "emoji": "📝",
+            "category": "other",
+        },
+        "active_summary_version_id": "version-a",
+        "enrichment_state": {},
+    }
+
+
+class FakeRuntimeService:
+    def __init__(self):
+        self.calls = []
+
+    async def run_turn(self, runtime, request):
+        self.calls.append((runtime, request))
+        return SimpleNamespace(
+            text=json.dumps(
+                {
+                    "title": "Synthetic cafe order",
+                    "overview": "[Ella] A synthetic cafe order was discussed.",
+                    "emoji": "☕",
+                    "category": "social",
+                    "ella_tags": ["omi", "enriched"],
+                    "ella_signal": {
+                        "salience": "low",
+                        "memory_promotion": "none",
+                        "noise_level": "none",
+                        "contains_media": False,
+                        "contains_user_speech": True,
+                        "guardian_relevant": False,
+                    },
+                }
+            ),
+            response_id="response-a",
+            canonical_user_event_id="event-user",
+            canonical_assistant_event_id="event-assistant",
+            duplicate=False,
+            usage={"input_tokens": 10, "output_tokens": 5},
+            runtime_interaction_id="interaction-a",
+        )
+
+
+def test_enrichment_uses_exact_owned_transcript_and_confirmed_writeback():
+    conversation = _conversation()
+    runtime_service = FakeRuntimeService()
+    summary_applier = AsyncMock(
+        return_value={
+            "active_summary_version_id": "version-enriched",
+            "canonical_confirmed": True,
+        }
+    )
+    service = HermesCloudEnrichmentService(
+        repository=SimpleNamespace(),
+        event_store=SimpleNamespace(),
+        runtime_service_factory=lambda allow_shadow: runtime_service,
+        conversation_reader=lambda uid, conversation_id: deepcopy(conversation),
+        summary_applier=summary_applier,
+    )
+    service._runtime = AsyncMock(return_value=_runtime())
+
+    result = asyncio.run(
+        service.enrich(
+            uid="synthetic-user",
+            conversation_id="conversation-a",
+        )
+    )
+
+    runtime, request = runtime_service.calls[0]
+    provider_input = json.loads(request.user_input)
+    assert runtime.provider == "hermes_cloud"
+    assert request.channel == "omi_enrichment"
+    assert request.user_scan_policy == "none"
+    assert request.client_metadata["policy_version"] == "hermes-cloud-enrichment-v1"
+    assert provider_input["transcript_segments"] == conversation["transcript_segments"]
+    assert provider_input["conversation_id_sha256"] != conversation["id"]
+    assert "conversation-a" not in request.user_input
+    assert summary_applier.await_args.kwargs["require_canonical"] is True
+    assert summary_applier.await_args.kwargs["summary_source"] == "hermes_cloud"
+    assert result.active_summary_version_id == "version-enriched"
+    assert result.provider_response_present is True
+
+
+def test_enrichment_rejects_transcript_change_before_writeback():
+    original = _conversation()
+    changed = _conversation("Changed after provider execution.")
+    reads = iter([deepcopy(original), deepcopy(changed)])
+    service = HermesCloudEnrichmentService(
+        repository=SimpleNamespace(),
+        event_store=SimpleNamespace(),
+        runtime_service_factory=lambda allow_shadow: FakeRuntimeService(),
+        conversation_reader=lambda uid, conversation_id: next(reads),
+        summary_applier=AsyncMock(),
+    )
+    service._runtime = AsyncMock(return_value=_runtime())
+
+    with pytest.raises(
+        ProvisioningError,
+        match="hermes_cloud_enrichment_transcript_changed",
+    ):
+        asyncio.run(
+            service.enrich(
+                uid="synthetic-user",
+                conversation_id="conversation-a",
+            )
+        )
+
+    service.summary_applier.assert_not_awaited()
+
+
+def test_enrichment_requires_confirmed_canonical_writeback():
+    conversation = _conversation()
+    service = HermesCloudEnrichmentService(
+        repository=SimpleNamespace(),
+        event_store=SimpleNamespace(),
+        runtime_service_factory=lambda allow_shadow: FakeRuntimeService(),
+        conversation_reader=lambda uid, conversation_id: deepcopy(conversation),
+        summary_applier=AsyncMock(
+            return_value={
+                "active_summary_version_id": "version-enriched",
+                "canonical_confirmed": False,
+            }
+        ),
+    )
+    service._runtime = AsyncMock(return_value=_runtime())
+
+    with pytest.raises(
+        ProvisioningError,
+        match="hermes_cloud_enrichment_writeback_unconfirmed",
+    ):
+        asyncio.run(
+            service.enrich(
+                uid="synthetic-user",
+                conversation_id="conversation-a",
+            )
+        )

--- a/backend/tests/unit/test_hermes_cloud_enrichment_outbox.py
+++ b/backend/tests/unit/test_hermes_cloud_enrichment_outbox.py
@@ -130,6 +130,39 @@ def test_timeout_and_503_are_retryable(
     )
 
 
+def test_401_blocks_until_operator_repairs_loopback_token(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED", "true")
+    monkeypatch.setenv(
+        "ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN",
+        "x" * 32,
+    )
+
+    class UnauthorizedResponse:
+        status_code = 401
+
+        @staticmethod
+        def json():
+            return {"detail": {"code": "hermes_cloud_enrichment_auth_failed"}}
+
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: UnauthorizedResponse(),
+    )
+    result = deliver_enrichment_job(_job())
+    repository = FakeOutbox()
+    worker = HermesCloudEnrichmentOutboxWorker(
+        repository,
+        deliver=lambda job: result,
+    )
+
+    asyncio.run(worker.run_once())
+
+    assert result.retryable is False
+    assert repository.job["status"] == "blocked"
+    assert repository.failures[0]["error_code"] == ("hermes_cloud_enrichment_auth_failed")
+
+
 def test_expired_lease_reclaims_after_process_interruption():
     repository = FakeOutbox()
     first_claim = repository.claim_next(lease_seconds=240)

--- a/backend/tests/unit/test_hermes_cloud_enrichment_outbox.py
+++ b/backend/tests/unit/test_hermes_cloud_enrichment_outbox.py
@@ -1,0 +1,166 @@
+import asyncio
+from copy import deepcopy
+
+import pytest
+import requests
+
+from ella.services.hermes_cloud_enrichment_outbox import (
+    DeliveryResult,
+    HermesCloudEnrichmentOutboxWorker,
+    deliver_enrichment_job,
+)
+
+
+def _job():
+    return {
+        "job_id": "hce_" + ("a" * 64),
+        "uid": "synthetic-user",
+        "conversation_id": "conversation-a",
+        "client_interaction_id": "omi-enrichment:" + ("b" * 64),
+        "transcript_sha256": "c" * 64,
+        "status": "pending",
+        "attempt_count": 0,
+    }
+
+
+class FakeOutbox:
+    def __init__(self):
+        self.job = _job()
+        self.completed = []
+        self.failures = []
+        self.lease_number = 0
+
+    def claim_next(self, *, lease_seconds, scan_limit=50):
+        if self.job["status"] not in {"pending", "retryable", "running"}:
+            return None
+        if self.job["status"] == "running" and not self.job.get("lease_expired"):
+            return None
+        self.lease_number += 1
+        self.job.update(
+            status="running",
+            lease_token=f"lease-{self.lease_number}",
+            attempt_count=self.job["attempt_count"] + 1,
+            lease_expired=False,
+        )
+        return deepcopy(self.job)
+
+    def complete(self, **kwargs):
+        assert kwargs["lease_token"] == self.job["lease_token"]
+        self.job["status"] = "completed"
+        self.completed.append(kwargs)
+        return True
+
+    def fail(self, **kwargs):
+        assert kwargs["lease_token"] == self.job["lease_token"]
+        self.job["status"] = "retryable" if kwargs["retryable"] else "blocked"
+        self.failures.append(kwargs)
+        return True
+
+
+@pytest.mark.parametrize(
+    ("enabled", "token", "expected_code"),
+    [
+        (
+            "false",
+            "",
+            "hermes_cloud_enrichment_disabled",
+        ),
+        (
+            "true",
+            "",
+            "hermes_cloud_enrichment_auth_not_configured",
+        ),
+    ],
+)
+def test_missing_or_disabled_auth_is_durably_retryable(
+    monkeypatch,
+    enabled,
+    token,
+    expected_code,
+):
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN", token)
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED", enabled)
+    repository = FakeOutbox()
+    worker = HermesCloudEnrichmentOutboxWorker(repository)
+
+    asyncio.run(worker.run_once())
+
+    assert repository.job["status"] == "retryable"
+    assert repository.failures[0]["error_code"] == expected_code
+    assert repository.completed == []
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_code"),
+    [
+        ("timeout", "hermes_cloud_enrichment_timeout"),
+        ("503", "hermes_cloud_enrichment_http_503"),
+    ],
+)
+def test_timeout_and_503_are_retryable(
+    monkeypatch,
+    failure,
+    expected_code,
+):
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED", "true")
+    monkeypatch.setenv(
+        "ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN",
+        "x" * 32,
+    )
+
+    def fake_post(*args, **kwargs):
+        if failure == "timeout":
+            raise requests.Timeout()
+        return type(
+            "Response",
+            (),
+            {
+                "status_code": 503,
+                "json": lambda self: {},
+            },
+        )()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    result = deliver_enrichment_job(_job())
+
+    assert result == DeliveryResult(
+        False,
+        expected_code,
+        retryable=True,
+    )
+
+
+def test_expired_lease_reclaims_after_process_interruption():
+    repository = FakeOutbox()
+    first_claim = repository.claim_next(lease_seconds=240)
+    assert first_claim["lease_token"] == "lease-1"
+
+    repository.job["lease_expired"] = True
+    worker = HermesCloudEnrichmentOutboxWorker(
+        repository,
+        deliver=lambda job: DeliveryResult(
+            True,
+            receipt={"content_free": True},
+        ),
+    )
+    asyncio.run(worker.run_once())
+
+    assert repository.job["status"] == "completed"
+    assert repository.completed[0]["lease_token"] == "lease-2"
+
+
+def test_successful_replay_is_idempotent():
+    repository = FakeOutbox()
+    deliveries = []
+    worker = HermesCloudEnrichmentOutboxWorker(
+        repository,
+        deliver=lambda job: deliveries.append(job["job_id"])
+        or DeliveryResult(
+            True,
+            receipt={"content_free": True, "duplicate": True},
+        ),
+    )
+
+    assert asyncio.run(worker.run_once()) is True
+    assert asyncio.run(worker.run_once()) is False
+    assert deliveries == [_job()["job_id"]]

--- a/backend/tests/unit/test_hermes_cloud_enrichment_router.py
+++ b/backend/tests/unit/test_hermes_cloud_enrichment_router.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ella.routers.hermes_cloud_enrichment import (
+    create_hermes_cloud_enrichment_router,
+)
+
+
+class FakeService:
+    def __init__(self):
+        self.calls = []
+
+    async def enrich(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            conversation_id=kwargs["conversation_id"],
+            runtime_binding_id="binding-a",
+            runtime_interaction_id="interaction-a",
+            active_summary_version_id="version-a",
+            canonical_user_event_id="event-user",
+            canonical_assistant_event_id="event-assistant",
+            transcript_sha256="a" * 64,
+            summary_sha256="b" * 64,
+            provider_response_present=True,
+            duplicate=False,
+        )
+
+
+def _client(service):
+    async def factory():
+        return service
+
+    app = FastAPI()
+    app.include_router(create_hermes_cloud_enrichment_router(factory))
+    return TestClient(app)
+
+
+def test_enrichment_router_requires_configured_service_token(monkeypatch):
+    monkeypatch.delenv("ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN", raising=False)
+    response = _client(FakeService()).post(
+        "/v1/ella/internal/hermes-cloud/enrichment/run",
+        json={"uid": "synthetic-user", "conversation_id": "conversation-a"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "hermes_cloud_enrichment_auth_not_configured"
+
+
+def test_enrichment_router_rejects_wrong_service_token(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN", "x" * 32)
+    response = _client(FakeService()).post(
+        "/v1/ella/internal/hermes-cloud/enrichment/run",
+        headers={"X-Ella-Hermes-Cloud-Enrichment-Token": "wrong"},
+        json={"uid": "synthetic-user", "conversation_id": "conversation-a"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_enrichment_router_returns_content_free_receipt(monkeypatch):
+    token = "x" * 32
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN", token)
+    service = FakeService()
+    response = _client(service).post(
+        "/v1/ella/internal/hermes-cloud/enrichment/run",
+        headers={"X-Ella-Hermes-Cloud-Enrichment-Token": token},
+        json={"uid": "synthetic-user", "conversation_id": "conversation-a"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["content_free"] is True
+    assert "text" not in response.json()
+    assert service.calls == [
+        {
+            "uid": "synthetic-user",
+            "conversation_id": "conversation-a",
+            "allow_shadow": False,
+        }
+    ]

--- a/backend/tests/unit/test_hermes_cloud_enrichment_router.py
+++ b/backend/tests/unit/test_hermes_cloud_enrichment_router.py
@@ -25,6 +25,7 @@ class FakeService:
             summary_sha256="b" * 64,
             provider_response_present=True,
             duplicate=False,
+            client_interaction_id=(kwargs.get("expected_client_interaction_id") or "omi-enrichment:" + ("c" * 64)),
         )
 
 
@@ -77,5 +78,33 @@ def test_enrichment_router_returns_content_free_receipt(monkeypatch):
             "uid": "synthetic-user",
             "conversation_id": "conversation-a",
             "allow_shadow": False,
+            "expected_client_interaction_id": None,
+            "expected_transcript_sha256": None,
         }
     ]
+
+
+def test_enrichment_router_binds_outbox_identity(monkeypatch):
+    token = "x" * 32
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN", token)
+    service = FakeService()
+    job_id = "hce_" + ("d" * 64)
+    client_id = "omi-enrichment:" + ("c" * 64)
+    transcript_sha256 = "a" * 64
+    response = _client(service).post(
+        "/v1/ella/internal/hermes-cloud/enrichment/run",
+        headers={"X-Ella-Hermes-Cloud-Enrichment-Token": token},
+        json={
+            "uid": "synthetic-user",
+            "conversation_id": "conversation-a",
+            "outbox_job_id": job_id,
+            "client_interaction_id": client_id,
+            "transcript_sha256": transcript_sha256,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["outbox_job_id"] == job_id
+    assert response.json()["client_interaction_id"] == client_id
+    assert service.calls[0]["expected_client_interaction_id"] == client_id
+    assert service.calls[0]["expected_transcript_sha256"] == transcript_sha256

--- a/backend/tests/unit/test_hermes_cloud_runtime.py
+++ b/backend/tests/unit/test_hermes_cloud_runtime.py
@@ -76,11 +76,7 @@ class FakeRepository:
 
     async def get_or_create_runtime_interaction(self, **kwargs):
         if self.interaction:
-            compatible = kwargs.get("compatible_request_hashes", ())
-            if (
-                self.interaction["request_hash"] != kwargs["request_hash"]
-                and self.interaction["request_hash"] not in compatible
-            ):
+            if self.interaction["request_hash"] != kwargs["request_hash"]:
                 from database.ella_provisioning import RuntimePoolClaimError
 
                 raise RuntimePoolClaimError("runtime_interaction_payload_conflict")
@@ -240,8 +236,7 @@ class RetryRepository(FakeRepository):
             }
             self.interactions[client_id] = interaction
         else:
-            compatible = kwargs.get("compatible_request_hashes", ())
-            if interaction["request_hash"] != kwargs["request_hash"] and interaction["request_hash"] not in compatible:
+            if interaction["request_hash"] != kwargs["request_hash"]:
                 from database.ella_provisioning import RuntimePoolClaimError
 
                 raise RuntimePoolClaimError("runtime_interaction_payload_conflict")
@@ -396,33 +391,6 @@ def test_idempotency_hash_binds_instructions():
 
     with pytest.raises(ProvisioningError, match="runtime_interaction_payload_conflict"):
         asyncio.run(service.run_turn(_runtime(), changed))
-
-
-def test_prior_request_hash_replays_without_payload_conflict():
-    repository = FakeRepository()
-    event_store = InMemoryCanonicalEventStore()
-    service = HermesCloudRuntimeService(
-        repository=repository,
-        event_store=event_store,
-        cloud_client=FakeCloudClient(),
-        voice_policy=FakePolicy(),
-        cost_estimator=lambda usage: 0,
-        max_cost_estimator=lambda **kwargs: 1,
-    )
-    request = HermesCloudTurnRequest(
-        **{
-            **_request().__dict__,
-            "channel": "omi_enrichment",
-            "user_scan_policy": "none",
-        }
-    )
-    first = asyncio.run(service.run_turn(_runtime(), request))
-    repository.interaction["request_hash"] = hermes_cloud_runtime._legacy_request_hash(request)
-
-    replay = asyncio.run(service.run_turn(_runtime(), request))
-
-    assert first.duplicate is False
-    assert replay.duplicate is True
 
 
 def test_malformed_output_is_failed_before_completion_and_replays_fresh():

--- a/backend/tests/unit/test_hermes_cloud_runtime.py
+++ b/backend/tests/unit/test_hermes_cloud_runtime.py
@@ -255,6 +255,70 @@ def test_photon_turn_uses_photon_entitlement_mode():
     assert policy.accepted[0]["mode"] == "hermes-cloud-photon"
 
 
+def test_enrichment_turn_uses_distinct_mode_and_disables_user_scan():
+    repository = FakeRepository()
+    event_store = InMemoryCanonicalEventStore()
+    policy = FakePolicy()
+    service = HermesCloudRuntimeService(
+        repository=repository,
+        event_store=event_store,
+        cloud_client=FakeCloudClient(),
+        voice_policy=policy,
+        cost_estimator=lambda usage: 0,
+        max_cost_estimator=lambda **kwargs: 1,
+    )
+    request = HermesCloudTurnRequest(
+        **{
+            **_request().__dict__,
+            "channel": "omi_enrichment",
+            "user_scan_policy": "none",
+        }
+    )
+
+    result = asyncio.run(service.run_turn(_runtime(), request))
+    source_identity = "hermes_cloud:omi_enrichment:interaction:" + result.canonical_user_event_id.split(":")[1]
+    user_event = asyncio.run(
+        event_store.get_event(
+            uid=request.uid,
+            event_id=result.canonical_user_event_id,
+            source_identity=source_identity,
+        )
+    )
+
+    assert policy.accepted[0]["mode"] == "hermes-cloud-enrichment"
+    assert user_event["scan_policy"] == "none"
+
+
+def test_turn_rejects_invalid_user_scan_policy_before_ingest():
+    service = HermesCloudRuntimeService(
+        repository=FakeRepository(),
+        event_store=InMemoryCanonicalEventStore(),
+        cloud_client=FakeCloudClient(),
+        voice_policy=FakePolicy(),
+    )
+    request = HermesCloudTurnRequest(**{**_request().__dict__, "user_scan_policy": "guardian"})
+
+    with pytest.raises(ProvisioningError, match="hermes_cloud_scan_policy_invalid"):
+        asyncio.run(service.run_turn(_runtime(), request))
+
+
+def test_idempotency_hash_binds_instructions():
+    repository = FakeRepository()
+    service = HermesCloudRuntimeService(
+        repository=repository,
+        event_store=InMemoryCanonicalEventStore(),
+        cloud_client=FakeCloudClient(),
+        voice_policy=FakePolicy(),
+        cost_estimator=lambda usage: 0,
+        max_cost_estimator=lambda **kwargs: 1,
+    )
+    asyncio.run(service.run_turn(_runtime(), _request()))
+    changed = HermesCloudTurnRequest(**{**_request().__dict__, "instructions": "Different policy."})
+
+    with pytest.raises(ProvisioningError, match="runtime_interaction_payload_conflict"):
+        asyncio.run(service.run_turn(_runtime(), changed))
+
+
 def test_provider_boundary_callback_runs_after_final_checks_and_before_cloud(
     monkeypatch,
 ):

--- a/backend/tests/unit/test_hermes_cloud_runtime.py
+++ b/backend/tests/unit/test_hermes_cloud_runtime.py
@@ -76,7 +76,11 @@ class FakeRepository:
 
     async def get_or_create_runtime_interaction(self, **kwargs):
         if self.interaction:
-            if self.interaction["request_hash"] != kwargs["request_hash"]:
+            compatible = kwargs.get("compatible_request_hashes", ())
+            if (
+                self.interaction["request_hash"] != kwargs["request_hash"]
+                and self.interaction["request_hash"] not in compatible
+            ):
                 from database.ella_provisioning import RuntimePoolClaimError
 
                 raise RuntimePoolClaimError("runtime_interaction_payload_conflict")
@@ -94,6 +98,13 @@ class FakeRepository:
         }
         return dict(self.interaction)
 
+    async def count_runtime_interaction_failures(self, **kwargs):
+        return 0
+
+    async def invalidate_completed_runtime_interaction(self, **kwargs):
+        self.interaction["status"] = "failed"
+        self.interaction["error_code"] = kwargs["error_code"]
+
     async def claim_runtime_interaction(self, interaction_id):
         if self.interaction["status"] not in {"pending", "failed"}:
             return None
@@ -110,6 +121,7 @@ class FakeRepository:
 
     async def fail_runtime_interaction(self, **kwargs):
         self.interaction["status"] = "failed"
+        self.interaction["error_code"] = kwargs["error_code"]
         self.failures.append(kwargs["error_code"])
 
     async def record_runtime_provider_receipt(self, **kwargs):
@@ -202,6 +214,73 @@ class FakeCloudClient:
             usage=self.usage,
             model="model-a",
             tool_calls=self.tool_calls,
+        )
+
+
+class RetryRepository(FakeRepository):
+    def __init__(self):
+        super().__init__()
+        self.interactions = {}
+
+    async def get_or_create_runtime_interaction(self, **kwargs):
+        client_id = kwargs["client_interaction_id"]
+        interaction = self.interactions.get(client_id)
+        if interaction is None:
+            interaction = {
+                "id": f"interaction-{len(self.interactions) + 1}",
+                "status": "pending",
+                "request_hash": kwargs["request_hash"],
+                "client_interaction_id": client_id,
+                "hermes_session_id": f"session-{len(self.interactions) + 1}",
+                "idempotency_key": f"request-{len(self.interactions) + 1}",
+                "previous_response_id": None,
+                "previous_response_usage": {},
+                "provider_response_id": None,
+                "usage": {},
+            }
+            self.interactions[client_id] = interaction
+        else:
+            compatible = kwargs.get("compatible_request_hashes", ())
+            if interaction["request_hash"] != kwargs["request_hash"] and interaction["request_hash"] not in compatible:
+                from database.ella_provisioning import RuntimePoolClaimError
+
+                raise RuntimePoolClaimError("runtime_interaction_payload_conflict")
+        self.interaction = interaction
+        return dict(interaction)
+
+    async def count_runtime_interaction_failures(self, **kwargs):
+        base = kwargs["client_interaction_id"]
+        return sum(
+            1
+            for client_id, interaction in self.interactions.items()
+            if (client_id == base or client_id.startswith(base + ":format-retry:"))
+            and interaction.get("error_code") == kwargs["error_code"]
+        )
+
+    async def invalidate_completed_runtime_interaction(self, **kwargs):
+        interaction = next(value for value in self.interactions.values() if value["id"] == kwargs["interaction_id"])
+        interaction.update(
+            status="failed",
+            error_code=kwargs["error_code"],
+        )
+
+
+class SequencedCloudClient(FakeCloudClient):
+    def __init__(self, responses):
+        super().__init__()
+        self.responses = iter(responses)
+
+    async def create_response(self, binding, **kwargs):
+        self.calls.append((binding, kwargs))
+        before_provider_send = kwargs.get("before_provider_send")
+        if before_provider_send is not None:
+            await before_provider_send()
+        return HermesCloudTurn(
+            response_id=f"response-{len(self.calls)}",
+            text=next(self.responses),
+            usage=self.usage,
+            model="model-a",
+            tool_calls=0,
         )
 
 
@@ -317,6 +396,129 @@ def test_idempotency_hash_binds_instructions():
 
     with pytest.raises(ProvisioningError, match="runtime_interaction_payload_conflict"):
         asyncio.run(service.run_turn(_runtime(), changed))
+
+
+def test_prior_request_hash_replays_without_payload_conflict():
+    repository = FakeRepository()
+    event_store = InMemoryCanonicalEventStore()
+    service = HermesCloudRuntimeService(
+        repository=repository,
+        event_store=event_store,
+        cloud_client=FakeCloudClient(),
+        voice_policy=FakePolicy(),
+        cost_estimator=lambda usage: 0,
+        max_cost_estimator=lambda **kwargs: 1,
+    )
+    request = HermesCloudTurnRequest(
+        **{
+            **_request().__dict__,
+            "channel": "omi_enrichment",
+            "user_scan_policy": "none",
+        }
+    )
+    first = asyncio.run(service.run_turn(_runtime(), request))
+    repository.interaction["request_hash"] = hermes_cloud_runtime._legacy_request_hash(request)
+
+    replay = asyncio.run(service.run_turn(_runtime(), request))
+
+    assert first.duplicate is False
+    assert replay.duplicate is True
+
+
+def test_malformed_output_is_failed_before_completion_and_replays_fresh():
+    repository = RetryRepository()
+    cloud = SequencedCloudClient(
+        [
+            "not-json",
+            '{"overview":"Synthetic valid result"}',
+        ]
+    )
+    service = HermesCloudRuntimeService(
+        repository=repository,
+        event_store=InMemoryCanonicalEventStore(),
+        cloud_client=cloud,
+        voice_policy=FakePolicy(),
+        cost_estimator=lambda usage: 0,
+        max_cost_estimator=lambda **kwargs: 1,
+    )
+
+    with pytest.raises(
+        ProvisioningError,
+        match="hermes_cloud_enrichment_output_invalid",
+    ):
+        asyncio.run(
+            service.run_turn(
+                _runtime(),
+                _request(),
+                response_validator=lambda text: __import__("json").loads(text),
+            )
+        )
+
+    first = repository.interactions["client-turn-1"]
+    assert first["status"] == "failed"
+    assert first["error_code"] == "hermes_cloud_enrichment_output_invalid"
+
+    valid = asyncio.run(
+        service.run_turn(
+            _runtime(),
+            _request(),
+            response_validator=lambda text: __import__("json").loads(text),
+        )
+    )
+    replay = asyncio.run(
+        service.run_turn(
+            _runtime(),
+            _request(),
+            response_validator=lambda text: __import__("json").loads(text),
+        )
+    )
+
+    assert valid.duplicate is False
+    assert replay.duplicate is True
+    assert len(cloud.calls) == 2
+    assert repository.interactions["client-turn-1:format-retry:1"]["status"] == "completed"
+
+
+def test_completed_malformed_output_is_invalidated_then_recovered():
+    repository = RetryRepository()
+    cloud = SequencedCloudClient(
+        [
+            "not-json",
+            '{"overview":"Synthetic valid result"}',
+        ]
+    )
+    service = HermesCloudRuntimeService(
+        repository=repository,
+        event_store=InMemoryCanonicalEventStore(),
+        cloud_client=cloud,
+        voice_policy=FakePolicy(),
+        cost_estimator=lambda usage: 0,
+        max_cost_estimator=lambda **kwargs: 1,
+    )
+    asyncio.run(service.run_turn(_runtime(), _request()))
+
+    with pytest.raises(
+        ProvisioningError,
+        match="hermes_cloud_enrichment_output_invalid",
+    ):
+        asyncio.run(
+            service.run_turn(
+                _runtime(),
+                _request(),
+                response_validator=lambda text: __import__("json").loads(text),
+            )
+        )
+
+    recovered = asyncio.run(
+        service.run_turn(
+            _runtime(),
+            _request(),
+            response_validator=lambda text: __import__("json").loads(text),
+        )
+    )
+
+    assert recovered.duplicate is False
+    assert len(cloud.calls) == 2
 
 
 def test_provider_boundary_callback_runs_after_final_checks_and_before_cloud(

--- a/backend/tests/unit/test_hermes_cloud_runtime.py
+++ b/backend/tests/unit/test_hermes_cloud_runtime.py
@@ -477,6 +477,7 @@ def test_malformed_output_is_failed_before_completion_and_replays_fresh():
     assert replay.duplicate is True
     assert len(cloud.calls) == 2
     assert repository.interactions["client-turn-1:format-retry:1"]["status"] == "completed"
+    assert len(repository.receipts) == 2
 
 
 def test_completed_malformed_output_is_invalidated_then_recovered():

--- a/backend/utils/ella/postprocess.py
+++ b/backend/utils/ella/postprocess.py
@@ -5,25 +5,123 @@
 # processing (summarizer agent, caregiver notifications, etc.)
 
 import os
-import time
 import threading
+import time
+from urllib.parse import urlsplit
+
 import requests
-from typing import Optional
 
 from .config import ELLA_CONFIG
 
 # Configurable via environment variable
 POSTPROCESS_WEBHOOK_URL = os.getenv(
-    'ELLA_POSTPROCESS_WEBHOOK_URL',
-    f'{ELLA_CONFIG.n8n_base_url}/webhook/conversation-completed'
+    'ELLA_POSTPROCESS_WEBHOOK_URL', f'{ELLA_CONFIG.n8n_base_url}/webhook/conversation-completed'
 )
 POSTPROCESS_ENABLED = os.getenv('ELLA_POSTPROCESS_ENABLED', 'true').lower() == 'true'
 POSTPROCESS_TIMEOUT = float(os.getenv('ELLA_POSTPROCESS_TIMEOUT', '10'))
 
 CONVERSATION_READY_WEBHOOK_URL = os.getenv(
-    'ELLA_CONVERSATION_READY_WEBHOOK',
-    f'{ELLA_CONFIG.n8n_base_url}/webhook/conversation-ready'
+    'ELLA_CONVERSATION_READY_WEBHOOK', f'{ELLA_CONFIG.n8n_base_url}/webhook/conversation-ready'
 )
+
+HERMES_CLOUD_ENRICHMENT_ENABLED = os.getenv('ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED', 'false').lower() == 'true'
+HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS = frozenset(
+    item.strip() for item in os.getenv('ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS', '').split(',') if item.strip()
+)
+HERMES_CLOUD_ENRICHMENT_URL = os.getenv(
+    'ELLA_HERMES_CLOUD_ENRICHMENT_URL',
+    'http://127.0.0.1:8000/v1/ella/internal/hermes-cloud/enrichment/run',
+)
+HERMES_CLOUD_ENRICHMENT_TIMEOUT = float(os.getenv('ELLA_HERMES_CLOUD_ENRICHMENT_TIMEOUT', '180'))
+HERMES_CLOUD_ENRICHMENT_TOKEN = os.getenv(
+    'ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN',
+    '',
+)
+HERMES_CLOUD_ENRICHMENT_PATH = '/v1/ella/internal/hermes-cloud/enrichment/run'
+
+
+def _is_safe_enrichment_url(url: str) -> bool:
+    parsed = urlsplit(url)
+    return bool(
+        parsed.scheme == 'http'
+        and parsed.hostname in {'127.0.0.1', '::1', 'localhost'}
+        and parsed.path == HERMES_CLOUD_ENRICHMENT_PATH
+        and not parsed.username
+        and not parsed.password
+        and not parsed.query
+        and not parsed.fragment
+    )
+
+
+def _fire_cloud_enrichment(uid: str, conversation_id: str, conv_short: str) -> bool:
+    if not HERMES_CLOUD_ENRICHMENT_ENABLED:
+        print(
+            f"[FLOW:POSTPROCESS] BLOCKED hermes-cloud enrichment disabled " f"uid={uid} conv={conv_short}",
+            flush=True,
+        )
+        return False
+    if len(HERMES_CLOUD_ENRICHMENT_TOKEN) < 32:
+        print(
+            f"[FLOW:POSTPROCESS] BLOCKED hermes-cloud enrichment auth missing " f"uid={uid} conv={conv_short}",
+            flush=True,
+        )
+        return False
+    if not _is_safe_enrichment_url(HERMES_CLOUD_ENRICHMENT_URL):
+        print(
+            f"[FLOW:POSTPROCESS] BLOCKED hermes-cloud enrichment URL is not loopback " f"uid={uid} conv={conv_short}",
+            flush=True,
+        )
+        return False
+
+    started = time.time()
+    try:
+        response = requests.post(
+            HERMES_CLOUD_ENRICHMENT_URL,
+            json={'uid': uid, 'conversation_id': conversation_id},
+            headers={
+                'Content-Type': 'application/json',
+                'X-Ella-Hermes-Cloud-Enrichment-Token': HERMES_CLOUD_ENRICHMENT_TOKEN,
+            },
+            timeout=HERMES_CLOUD_ENRICHMENT_TIMEOUT,
+        )
+        elapsed_ms = int((time.time() - started) * 1000)
+        if response.status_code != 200:
+            print(
+                f"[FLOW:POSTPROCESS] ERROR hermes-cloud enrichment "
+                f"uid={uid} conv={conv_short} status={response.status_code} "
+                f"latency={elapsed_ms}ms",
+                flush=True,
+            )
+            return False
+        body = response.json()
+        if (
+            not isinstance(body, dict)
+            or body.get('ok') is not True
+            or body.get('status') != 'applied'
+            or body.get('content_free') is not True
+        ):
+            print(
+                f"[FLOW:POSTPROCESS] ERROR hermes-cloud enrichment invalid receipt "
+                f"uid={uid} conv={conv_short} latency={elapsed_ms}ms",
+                flush=True,
+            )
+            return False
+        print(
+            f"[FLOW:POSTPROCESS] OK hermes-cloud enrichment "
+            f"uid={uid} conv={conv_short} duplicate={bool(body.get('duplicate'))} "
+            f"latency={elapsed_ms}ms",
+            flush=True,
+        )
+        return True
+    except (requests.RequestException, ValueError) as exc:
+        elapsed_ms = int((time.time() - started) * 1000)
+        print(
+            f"[FLOW:POSTPROCESS] ERROR hermes-cloud enrichment "
+            f"uid={uid} conv={conv_short} error={type(exc).__name__} "
+            f"latency={elapsed_ms}ms",
+            flush=True,
+        )
+        return False
 
 
 def fire_postprocess_webhook(uid: str, conversation) -> None:
@@ -86,21 +184,43 @@ def fire_postprocess_webhook(uid: str, conversation) -> None:
 
         title = structured.get('title', 'untitled')
         emoji = structured.get('emoji', '')
-        print(f"[FLOW:POSTPROCESS] firing webhook uid={uid} conv={conv_short} title={title} emoji={emoji} url={POSTPROCESS_WEBHOOK_URL}", flush=True)
-
-        response = requests.post(
-            POSTPROCESS_WEBHOOK_URL,
-            json=payload,
-            headers={'Content-Type': 'application/json'},
-            timeout=POSTPROCESS_TIMEOUT,
+        print(
+            f"[FLOW:POSTPROCESS] firing webhook uid={uid} conv={conv_short} title={title} emoji={emoji} url={POSTPROCESS_WEBHOOK_URL}",
+            flush=True,
         )
 
-        _elapsed_completed = int((time.time() - _start) * 1000)
+        try:
+            response = requests.post(
+                POSTPROCESS_WEBHOOK_URL,
+                json=payload,
+                headers={'Content-Type': 'application/json'},
+                timeout=POSTPROCESS_TIMEOUT,
+            )
+            _elapsed_completed = int((time.time() - _start) * 1000)
+            if response.status_code == 200:
+                print(
+                    f"[FLOW:POSTPROCESS] OK conversation-completed uid={uid} conv={conv_short} status=200 latency={_elapsed_completed}ms",
+                    flush=True,
+                )
+            else:
+                print(
+                    f"[FLOW:POSTPROCESS] ERROR conversation-completed uid={uid} conv={conv_short} status={response.status_code} latency={_elapsed_completed}ms",
+                    flush=True,
+                )
+        except requests.RequestException as exc:
+            _elapsed_completed = int((time.time() - _start) * 1000)
+            print(
+                f"[FLOW:POSTPROCESS] ERROR conversation-completed uid={uid} "
+                f"conv={conv_short} error={type(exc).__name__} "
+                f"latency={_elapsed_completed}ms",
+                flush=True,
+            )
 
-        if response.status_code == 200:
-            print(f"[FLOW:POSTPROCESS] OK conversation-completed uid={uid} conv={conv_short} status=200 latency={_elapsed_completed}ms", flush=True)
-        else:
-            print(f"[FLOW:POSTPROCESS] ERROR conversation-completed uid={uid} conv={conv_short} status={response.status_code} latency={_elapsed_completed}ms", flush=True)
+        if uid in HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS:
+            _fire_cloud_enrichment(uid, conversation.id, conv_short)
+            # A cloud-selected profile must never fall through to the legacy
+            # n8n -> Mini/OpenClaw conversation-ready path.
+            return
 
         # Notify the user's OpenClaw agent via conversation-ready webhook (fire-and-forget)
         ready_payload = {
@@ -119,20 +239,31 @@ def fire_postprocess_webhook(uid: str, conversation) -> None:
                 _t = time.time()
                 r = requests.post(_url, json=_payload, headers={'Content-Type': 'application/json'}, timeout=60)
                 _ms = int((time.time() - _t) * 1000)
-                print(f"[FLOW:POSTPROCESS] conversation-ready uid={_uid} conv={_conv_short} segments={_segments} status={r.status_code} latency={_ms}ms", flush=True)
+                print(
+                    f"[FLOW:POSTPROCESS] conversation-ready uid={_uid} conv={_conv_short} segments={_segments} status={r.status_code} latency={_ms}ms",
+                    flush=True,
+                )
             except Exception as _e:
-                print(f"[FLOW:POSTPROCESS] ERROR conversation-ready uid={_uid} conv={_conv_short} error={_e}", flush=True)
+                print(
+                    f"[FLOW:POSTPROCESS] ERROR conversation-ready uid={_uid} conv={_conv_short} error={_e}", flush=True
+                )
 
         threading.Thread(
             target=_fire_ready,
             args=(CONVERSATION_READY_WEBHOOK_URL, ready_payload, uid, conv_short, segment_count),
             daemon=True,
         ).start()
-        print(f"[FLOW:POSTPROCESS] conversation-ready fired async uid={uid} conv={conv_short} segments={segment_count}", flush=True)
+        print(
+            f"[FLOW:POSTPROCESS] conversation-ready fired async uid={uid} conv={conv_short} segments={segment_count}",
+            flush=True,
+        )
 
     except requests.Timeout:
         _elapsed = int((time.time() - _start) * 1000)
-        print(f"[FLOW:POSTPROCESS] TIMEOUT uid={uid} conv={conv_short} timeout={POSTPROCESS_TIMEOUT}s latency={_elapsed}ms", flush=True)
+        print(
+            f"[FLOW:POSTPROCESS] TIMEOUT uid={uid} conv={conv_short} timeout={POSTPROCESS_TIMEOUT}s latency={_elapsed}ms",
+            flush=True,
+        )
     except requests.RequestException as e:
         _elapsed = int((time.time() - _start) * 1000)
         print(f"[FLOW:POSTPROCESS] ERROR uid={uid} conv={conv_short} error={e} latency={_elapsed}ms", flush=True)

--- a/backend/utils/ella/postprocess.py
+++ b/backend/utils/ella/postprocess.py
@@ -7,7 +7,6 @@
 import os
 import threading
 import time
-from urllib.parse import urlsplit
 
 import requests
 
@@ -24,104 +23,54 @@ CONVERSATION_READY_WEBHOOK_URL = os.getenv(
     'ELLA_CONVERSATION_READY_WEBHOOK', f'{ELLA_CONFIG.n8n_base_url}/webhook/conversation-ready'
 )
 
-HERMES_CLOUD_ENRICHMENT_ENABLED = os.getenv('ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED', 'false').lower() == 'true'
 HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS = frozenset(
     item.strip() for item in os.getenv('ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS', '').split(',') if item.strip()
 )
-HERMES_CLOUD_ENRICHMENT_URL = os.getenv(
-    'ELLA_HERMES_CLOUD_ENRICHMENT_URL',
-    'http://127.0.0.1:8000/v1/ella/internal/hermes-cloud/enrichment/run',
-)
-HERMES_CLOUD_ENRICHMENT_TIMEOUT = float(os.getenv('ELLA_HERMES_CLOUD_ENRICHMENT_TIMEOUT', '180'))
-HERMES_CLOUD_ENRICHMENT_TOKEN = os.getenv(
-    'ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN',
-    '',
-)
-HERMES_CLOUD_ENRICHMENT_PATH = '/v1/ella/internal/hermes-cloud/enrichment/run'
 
 
-def _is_safe_enrichment_url(url: str) -> bool:
-    parsed = urlsplit(url)
-    return bool(
-        parsed.scheme == 'http'
-        and parsed.hostname in {'127.0.0.1', '::1', 'localhost'}
-        and parsed.path == HERMES_CLOUD_ENRICHMENT_PATH
-        and not parsed.username
-        and not parsed.password
-        and not parsed.query
-        and not parsed.fragment
+def _conversation_payload(conversation) -> dict:
+    if hasattr(conversation, "model_dump"):
+        return conversation.model_dump(mode="json")
+    if hasattr(conversation, "dict"):
+        return conversation.dict()
+    segments = []
+    for segment in getattr(conversation, "transcript_segments", []) or []:
+        segments.append(
+            {
+                "is_user": bool(getattr(segment, "is_user", False)),
+                "speaker": getattr(segment, "speaker", None),
+                "text": getattr(segment, "text", ""),
+            }
+        )
+    return {
+        "id": getattr(conversation, "id", ""),
+        "transcript_segments": segments,
+    }
+
+
+def enqueue_cloud_enrichment(uid: str, conversation) -> dict:
+    from database.hermes_cloud_enrichment_outbox import (
+        FirestoreHermesCloudEnrichmentOutbox,
+    )
+    from ella.services.hermes_cloud_enrichment import (
+        HERMES_CLOUD_ENRICHMENT_POLICY_VERSION,
+        build_enrichment_identity,
     )
 
-
-def _fire_cloud_enrichment(uid: str, conversation_id: str, conv_short: str) -> bool:
-    if not HERMES_CLOUD_ENRICHMENT_ENABLED:
-        print(
-            f"[FLOW:POSTPROCESS] BLOCKED hermes-cloud enrichment disabled " f"uid={uid} conv={conv_short}",
-            flush=True,
-        )
-        return False
-    if len(HERMES_CLOUD_ENRICHMENT_TOKEN) < 32:
-        print(
-            f"[FLOW:POSTPROCESS] BLOCKED hermes-cloud enrichment auth missing " f"uid={uid} conv={conv_short}",
-            flush=True,
-        )
-        return False
-    if not _is_safe_enrichment_url(HERMES_CLOUD_ENRICHMENT_URL):
-        print(
-            f"[FLOW:POSTPROCESS] BLOCKED hermes-cloud enrichment URL is not loopback " f"uid={uid} conv={conv_short}",
-            flush=True,
-        )
-        return False
-
-    started = time.time()
-    try:
-        response = requests.post(
-            HERMES_CLOUD_ENRICHMENT_URL,
-            json={'uid': uid, 'conversation_id': conversation_id},
-            headers={
-                'Content-Type': 'application/json',
-                'X-Ella-Hermes-Cloud-Enrichment-Token': HERMES_CLOUD_ENRICHMENT_TOKEN,
-            },
-            timeout=HERMES_CLOUD_ENRICHMENT_TIMEOUT,
-        )
-        elapsed_ms = int((time.time() - started) * 1000)
-        if response.status_code != 200:
-            print(
-                f"[FLOW:POSTPROCESS] ERROR hermes-cloud enrichment "
-                f"uid={uid} conv={conv_short} status={response.status_code} "
-                f"latency={elapsed_ms}ms",
-                flush=True,
-            )
-            return False
-        body = response.json()
-        if (
-            not isinstance(body, dict)
-            or body.get('ok') is not True
-            or body.get('status') != 'applied'
-            or body.get('content_free') is not True
-        ):
-            print(
-                f"[FLOW:POSTPROCESS] ERROR hermes-cloud enrichment invalid receipt "
-                f"uid={uid} conv={conv_short} latency={elapsed_ms}ms",
-                flush=True,
-            )
-            return False
-        print(
-            f"[FLOW:POSTPROCESS] OK hermes-cloud enrichment "
-            f"uid={uid} conv={conv_short} duplicate={bool(body.get('duplicate'))} "
-            f"latency={elapsed_ms}ms",
-            flush=True,
-        )
-        return True
-    except (requests.RequestException, ValueError) as exc:
-        elapsed_ms = int((time.time() - started) * 1000)
-        print(
-            f"[FLOW:POSTPROCESS] ERROR hermes-cloud enrichment "
-            f"uid={uid} conv={conv_short} error={type(exc).__name__} "
-            f"latency={elapsed_ms}ms",
-            flush=True,
-        )
-        return False
+    conversation_id = str(getattr(conversation, "id", "") or "")
+    identity = build_enrichment_identity(
+        uid=uid,
+        conversation_id=conversation_id,
+        conversation=_conversation_payload(conversation),
+    )
+    return FirestoreHermesCloudEnrichmentOutbox().enqueue(
+        job_id=identity.job_id,
+        uid=uid,
+        conversation_id=conversation_id,
+        client_interaction_id=identity.client_interaction_id,
+        transcript_sha256=identity.transcript_sha256,
+        policy_version=HERMES_CLOUD_ENRICHMENT_POLICY_VERSION,
+    )
 
 
 def fire_postprocess_webhook(uid: str, conversation) -> None:
@@ -136,6 +85,25 @@ def fire_postprocess_webhook(uid: str, conversation) -> None:
         uid: User ID
         conversation: Conversation object (already saved to Firestore)
     """
+    cloud_selected = uid in HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS
+    if cloud_selected:
+        try:
+            queued = enqueue_cloud_enrichment(uid, conversation)
+        except Exception as exc:
+            print(
+                f"[FLOW:POSTPROCESS] BLOCKED hermes-cloud enrichment outbox "
+                f"uid={uid} conv={conversation.id[:8]} "
+                f"error={type(exc).__name__}",
+                flush=True,
+            )
+            return
+        print(
+            f"[FLOW:POSTPROCESS] QUEUED hermes-cloud enrichment "
+            f"uid={uid} conv={conversation.id[:8]} "
+            f"status={queued.get('status')}",
+            flush=True,
+        )
+
     if not POSTPROCESS_ENABLED:
         print(f"[FLOW:POSTPROCESS] DISABLED uid={uid} conv={conversation.id[:8]}...", flush=True)
         return
@@ -216,10 +184,9 @@ def fire_postprocess_webhook(uid: str, conversation) -> None:
                 flush=True,
             )
 
-        if uid in HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS:
-            _fire_cloud_enrichment(uid, conversation.id, conv_short)
-            # A cloud-selected profile must never fall through to the legacy
-            # n8n -> Mini/OpenClaw conversation-ready path.
+        if cloud_selected:
+            # Durable outbox delivery owns cloud enrichment. A selected profile
+            # never falls through to the legacy n8n/Mini conversation-ready path.
             return
 
         # Notify the user's OpenClaw agent via conversation-ready webhook (fire-and-forget)

--- a/backend/utils/ella/postprocess.py
+++ b/backend/utils/ella/postprocess.py
@@ -103,6 +103,9 @@ def fire_postprocess_webhook(uid: str, conversation) -> None:
             f"status={queued.get('status')}",
             flush=True,
         )
+        # The durable cloud outbox exclusively owns selected conversations.
+        # Return before deriving or sending any legacy n8n/Mini payload.
+        return
 
     if not POSTPROCESS_ENABLED:
         print(f"[FLOW:POSTPROCESS] DISABLED uid={uid} conv={conversation.id[:8]}...", flush=True)
@@ -183,11 +186,6 @@ def fire_postprocess_webhook(uid: str, conversation) -> None:
                 f"latency={_elapsed_completed}ms",
                 flush=True,
             )
-
-        if cloud_selected:
-            # Durable outbox delivery owns cloud enrichment. A selected profile
-            # never falls through to the legacy n8n/Mini conversation-ready path.
-            return
 
         # Notify the user's OpenClaw agent via conversation-ready webhook (fire-and-forget)
         ready_payload = {


### PR DESCRIPTION
## Summary

Implements the missing backend enrichment adapter for ellaaicare/ella-ai#1124. A selected OMI profile now sends its exact UID-owned conversation through the bound `hermes_cloud` runtime and canonical summary CAS/writeback instead of the legacy n8n `conversation-ready` -> Mini provision path.

## Safety contract

- cohort-gated and default-off
- selected cloud UIDs fail closed on disabled auth, invalid loopback URL, runtime failure, or writeback failure
- no selected request falls through to Mini or OpenClaw
- dedicated `hermes-cloud-enrichment` entitlement mode
- user canonical event uses `scan_policy=none`; no Guardian/caregiver path
- exact transcript hash, policy-bound idempotency identity, replay dedupe, active-summary CAS, and confirmed canonical writeback
- internal adapter requires a dedicated 32+ character service token and rejects extra request fields
- synthetic smoke emits content-free hashed receipts

## Validation

- focused enrichment/runtime suite: `30 passed`
- broader Hermes Cloud/isolation unit matrix: `234 passed`
- Python compile: passed
- workflow YAML parse: passed
- `git diff --check`: passed
- staged Gitleaks scan: no leaks

The updated hosted workflow also runs the new focused tests and the existing disposable-PostgreSQL gate.

## Operational state

Source/tests only. No migration, deployment, service restart, Mini/n8n/vendor mutation, credential change, pool registration/claim, entitlement change, or real-user traffic was performed. Migration 009 and all Hermes Cloud activation flags remain off in production.

Related: ellaaicare/ella-ai#1124.