### PR TITLE
Serialize authority mutations with Hermes broker decisions

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -3,6 +3,9 @@ name: Hermes Cloud Runtime Tests
 on:
   pull_request:
     paths:
+      - "backend/contracts/authority_advisory_lock_v1.json"
+      - "backend/contracts/README.md"
+      - "backend/database/authority_advisory_lock.py"
       - "backend/database/ella_provisioning.py"
       - "backend/database/hermes_cloud_enrichment_outbox.py"
       - "backend/database/invitations.py"
@@ -48,13 +51,17 @@ on:
       - "backend/scripts/hermes_cloud_pool_admin.py"
       - "backend/scripts/hermes_cloud_enrichment_smoke.py"
       - "backend/scripts/hermes_cloud_shadow.py"
+      - "backend/scripts/voice_canary_admin.py"
       - "backend/utils/ella/postprocess.py"
       - "backend/utils/ella/scanner_keyterms.py"
       - "backend/ella/docs/HERMES_CLOUD_RUNTIME_TARGETS_RUNBOOK.md"
       - "backend/ella/docs/hermes-cloud-runtime-targets.openapi.yaml"
       - "backend/tests/unit/test_ella_provisioning_repository.py"
+      - "backend/tests/unit/test_authority_advisory_lock.py"
+      - "backend/tests/unit/test_authority_writer_guard.py"
       - "backend/tests/unit/test_ella_provisioning_service.py"
       - "backend/tests/postgres/test_hermes_cloud_pool_postgres.py"
+      - "backend/tests/postgres/test_authority_advisory_lock_postgres.py"
       - "backend/tests/postgres/test_invitation_redemption_postgres.py"
       - "backend/tests/postgres/test_runtime_migration_atomicity_postgres.py"
       - "backend/tests/unit/test_ella_ai_consent.py"
@@ -75,6 +82,9 @@ on:
   push:
     branches: [main]
     paths:
+      - "backend/contracts/authority_advisory_lock_v1.json"
+      - "backend/contracts/README.md"
+      - "backend/database/authority_advisory_lock.py"
       - "backend/database/ella_provisioning.py"
       - "backend/database/hermes_cloud_enrichment_outbox.py"
       - "backend/database/invitations.py"
@@ -120,13 +130,17 @@ on:
       - "backend/scripts/hermes_cloud_pool_admin.py"
       - "backend/scripts/hermes_cloud_enrichment_smoke.py"
       - "backend/scripts/hermes_cloud_shadow.py"
+      - "backend/scripts/voice_canary_admin.py"
       - "backend/utils/ella/postprocess.py"
       - "backend/utils/ella/scanner_keyterms.py"
       - "backend/ella/docs/HERMES_CLOUD_RUNTIME_TARGETS_RUNBOOK.md"
       - "backend/ella/docs/hermes-cloud-runtime-targets.openapi.yaml"
       - "backend/tests/unit/test_ella_provisioning_repository.py"
+      - "backend/tests/unit/test_authority_advisory_lock.py"
+      - "backend/tests/unit/test_authority_writer_guard.py"
       - "backend/tests/unit/test_ella_provisioning_service.py"
       - "backend/tests/postgres/test_hermes_cloud_pool_postgres.py"
+      - "backend/tests/postgres/test_authority_advisory_lock_postgres.py"
       - "backend/tests/postgres/test_invitation_redemption_postgres.py"
       - "backend/tests/postgres/test_runtime_migration_atomicity_postgres.py"
       - "backend/tests/unit/test_ella_ai_consent.py"
@@ -201,6 +215,7 @@ jobs:
       - name: Compile Hermes Cloud runtime modules
         run: >-
           python -m py_compile
+          database/authority_advisory_lock.py
           database/ella_provisioning.py
           database/hermes_cloud_enrichment_outbox.py
           database/invitations.py
@@ -237,12 +252,14 @@ jobs:
           scripts/hermes_cloud_pool_admin.py
           scripts/hermes_cloud_enrichment_smoke.py
           scripts/hermes_cloud_shadow.py
+          scripts/voice_canary_admin.py
           utils/ella/postprocess.py
           utils/ella/scanner_keyterms.py
 
       - name: Validate formatting and OpenAPI contract
         run: >-
           black --check --line-length 120 --skip-string-normalization
+          database/authority_advisory_lock.py
           database/ella_provisioning.py database/invitations.py
           database/managed_cloud_consent.py
           database/runtime_targets.py database/voice_canary.py
@@ -257,7 +274,10 @@ jobs:
           ella/services/observer_extractor.py
           ella/services/provisioning.py ella/services/runtime_resolver.py
           ella/services/summary_recovery.py utils/ella/scanner_keyterms.py
+          scripts/voice_canary_admin.py
           tests/unit/test_ella_callbacks_summary_update.py
+          tests/unit/test_authority_advisory_lock.py
+          tests/unit/test_authority_writer_guard.py
           tests/unit/test_ella_ai_consent.py
           tests/unit/test_ella_conversation_corrections.py
           tests/unit/test_ella_guardian_delivery.py
@@ -272,6 +292,7 @@ jobs:
           tests/unit/test_memory_reinterpretation_outbox.py
           tests/unit/test_scanner_keyterms.py
           tests/postgres/test_hermes_cloud_pool_postgres.py
+          tests/postgres/test_authority_advisory_lock_postgres.py
           tests/postgres/test_invitation_redemption_postgres.py
           tests/postgres/test_runtime_migration_atomicity_postgres.py
           &&
@@ -331,6 +352,18 @@ jobs:
 
       - name: Run exact reviewed boundary collections
         run: |
+          test "$(
+            pytest --collect-only -q \
+              tests/unit/test_authority_advisory_lock.py \
+              tests/unit/test_authority_writer_guard.py \
+              tests/postgres/test_authority_advisory_lock_postgres.py |
+              grep -c '::'
+          )" -eq 19
+          pytest \
+            tests/unit/test_authority_advisory_lock.py \
+            tests/unit/test_authority_writer_guard.py \
+            tests/postgres/test_authority_advisory_lock_postgres.py \
+            -v
           test "$(pytest --collect-only -q tests/unit/test_ella_callbacks_summary_update.py | grep -c '::')" -eq 15
           pytest tests/unit/test_ella_callbacks_summary_update.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_conversation_corrections.py | grep -c '::')" -eq 64

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -358,7 +358,7 @@ jobs:
               tests/unit/test_authority_writer_guard.py \
               tests/postgres/test_authority_advisory_lock_postgres.py |
               grep -c '::'
-          )" -eq 19
+          )" -eq 29
           pytest \
             tests/unit/test_authority_advisory_lock.py \
             tests/unit/test_authority_writer_guard.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -325,7 +325,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 349
+          test "$collected" -eq 351
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \
@@ -358,7 +358,7 @@ jobs:
               tests/unit/test_authority_writer_guard.py \
               tests/postgres/test_authority_advisory_lock_postgres.py |
               grep -c '::'
-          )" -eq 29
+          )" -eq 63
           pytest \
             tests/unit/test_authority_advisory_lock.py \
             tests/unit/test_authority_writer_guard.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -358,7 +358,7 @@ jobs:
               tests/unit/test_authority_writer_guard.py \
               tests/postgres/test_authority_advisory_lock_postgres.py |
               grep -c '::'
-          )" -eq 63
+          )" -eq 65
           pytest \
             tests/unit/test_authority_advisory_lock.py \
             tests/unit/test_authority_writer_guard.py \

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -3,6 +3,8 @@ name: Invite Redemption Tests
 on:
   pull_request:
     paths:
+      - "backend/contracts/authority_advisory_lock_v1.json"
+      - "backend/database/authority_advisory_lock.py"
       - "backend/database/invitations.py"
       - "backend/database/managed_cloud_consent.py"
       - "backend/database/runtime_targets.py"
@@ -25,6 +27,8 @@ on:
   push:
     branches: [main]
     paths:
+      - "backend/contracts/authority_advisory_lock_v1.json"
+      - "backend/database/authority_advisory_lock.py"
       - "backend/database/invitations.py"
       - "backend/database/managed_cloud_consent.py"
       - "backend/database/runtime_targets.py"
@@ -94,6 +98,7 @@ jobs:
       - name: Compile invite and entitlement modules
         run: >-
           python -m py_compile
+          database/authority_advisory_lock.py
           database/invitations.py
           database/managed_cloud_consent.py
           database/runtime_targets.py
@@ -114,7 +119,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 42
+          test "$collected" -eq 44
           pytest \
             tests/unit/test_invitation_redemption.py \
             tests/unit/test_voice_canary.py \

--- a/backend/contracts/README.md
+++ b/backend/contracts/README.md
@@ -14,6 +14,11 @@ the candidate account/profile outside the mutation transaction, take the v1
 transaction lock as the first statement, then lock and verify ownership before
 any protected row lock or mutation.
 
+The cross-repo derivation helpers accept canonical UUID text only. OMI validates
+that asyncpg ownership values are `uuid.UUID` instances at the database boundary,
+then explicitly converts those trusted values to text before deriving the key.
+Implicit stringification is rejected.
+
 The sole authority-neutral writer is warm-pool registration. It may only insert
 an unowned, inactive `pool_available` row and may never update or claim an
 owner-bound row. The writer-inventory guard fails if that SQL shape changes or a

--- a/backend/contracts/README.md
+++ b/backend/contracts/README.md
@@ -14,12 +14,28 @@ the candidate account/profile outside the mutation transaction, take the v1
 transaction lock as the first statement, then lock and verify ownership before
 any protected row lock or mutation.
 
+Lock acquisition returns an opaque, non-copyable proof registered only by the
+contract module. Every proof-gated mutation rechecks that the same asyncpg
+connection is in the same PostgreSQL transaction and still owns the exact
+advisory lock. Proofs fail closed when forged, moved to another connection, or
+reused after commit or rollback.
+
 The cross-repo derivation helpers accept canonical UUID text only. OMI validates
 that asyncpg ownership values are `uuid.UUID` instances at the database boundary,
 then explicitly converts those trusted values to text before deriving the key.
 Implicit stringification is rejected.
 
+Identity creation uses a fixed UUIDv5 namespace plus the verified Firebase UID
+to derive a deterministic provisional self-owner. The writer locks that key
+before any user row lock or insert, then re-reads both UID and email ownership.
+An existing row with any other owner fails closed. Existing identity updates,
+activation, and runtime-driven user activation use the resolved owner key and
+perform the same locked re-read before mutation.
+
 The sole authority-neutral writer is warm-pool registration. It may only insert
 an unowned, inactive `pool_available` row and may never update or claim an
 owner-bound row. The writer-inventory guard fails if that SQL shape changes or a
-new protected-table writer appears.
+new protected-table writer appears. The legacy Mini auto-provision path's
+`users.identities` phone merge is separately inventoried as non-authoritative:
+it cannot alter user ID, UID, email, profile class, or status, and widening that
+statement fails the guard.

--- a/backend/contracts/README.md
+++ b/backend/contracts/README.md
@@ -1,0 +1,20 @@
+# Cross-service authority lock
+
+`authority_advisory_lock_v1.json` is vendored byte-for-byte from
+`ellaaicare/ella-ai#1155` at
+`ed216b71f6350a46fda847843fee4fedc0e5cb9f`. Its reviewed SHA-256 is:
+
+```text
+1a92c0d335742560fff71b4630b95e1424bccdafb15c6245c8a554f4ea19eb69
+```
+
+`database/authority_advisory_lock.py` verifies that digest at runtime and
+implements the contract's six vectors. Owner-bound OMI authority writers resolve
+the candidate account/profile outside the mutation transaction, take the v1
+transaction lock as the first statement, then lock and verify ownership before
+any protected row lock or mutation.
+
+The sole authority-neutral writer is warm-pool registration. It may only insert
+an unowned, inactive `pool_available` row and may never update or claim an
+owner-bound row. The writer-inventory guard fails if that SQL shape changes or a
+new protected-table writer appears.

--- a/backend/contracts/authority_advisory_lock_v1.json
+++ b/backend/contracts/authority_advisory_lock_v1.json
@@ -1,0 +1,120 @@
+{
+  "contract": "ella-managed-cloud-authority-lock",
+  "version": "1",
+  "status": "proposed",
+  "purpose": "Advisory-lock key both the Hermes webhook broker and the OMI authority writers must derive identically so authority decisions serialize across services. The key is a lock coordinate, not a credential.",
+  "normative_sources": {
+    "broker_implementation": "services/hermes-webhook-broker/hermes_authority_lock.py",
+    "broker_pull_request": "ellaaicare/ella-ai#1155",
+    "gate_comment": "5114988392",
+    "omi_target_base": "ellaaicare/omi main@abb5d4cc7440c8ca28d1d4c180302e601417fbd4"
+  },
+  "inputs": {
+    "fields": [
+      "account_id",
+      "profile_id"
+    ],
+    "field_order_is_significant": true,
+    "type": "RFC 4122 UUID",
+    "accepted_form": "8-4-4-4-12 hyphenated hex, case-insensitive",
+    "rejected_forms": [
+      "braces",
+      "urn:uuid: prefix",
+      "unhyphenated 32-hex",
+      "empty",
+      "null",
+      "non-UUID text",
+      "raw bytes"
+    ],
+    "rejection_is_fail_closed": true,
+    "rejection_must_occur_before": "any row lock, advisory lock, or mutation"
+  },
+  "encoding": {
+    "domain_ascii": "ella-managed-cloud-authority-lock-v1",
+    "domain_byte_length": 36,
+    "field_count": 2,
+    "uuid_byte_length": 16,
+    "uuid_byte_order": "RFC 4122 network byte order (big-endian), raw bytes not text",
+    "length_prefix": "4-byte big-endian unsigned integer (u32be)",
+    "preimage_layout": "u32be(len(domain)) || domain || u32be(field_count) || u32be(16) || account_id_bytes || u32be(16) || profile_id_bytes",
+    "preimage_total_bytes": 84
+  },
+  "digest": {
+    "algorithm": "SHA-256",
+    "output_bytes": 32
+  },
+  "key": {
+    "derivation": "first 8 bytes of the SHA-256 digest",
+    "interpretation": "big-endian two's-complement signed 64-bit integer",
+    "equivalent_sql_type": "bigint",
+    "postgres_call": "pg_advisory_xact_lock(bigint)",
+    "forbidden": [
+      "pg_advisory_xact_lock(int4, int4)",
+      "hashtextextended",
+      "any formatted-string key",
+      "any unversioned domain"
+    ]
+  },
+  "acquisition_rules": {
+    "transaction_scoped": true,
+    "must_be_first_action_in_transaction": true,
+    "before_any_broker_row_lock": true,
+    "unknown_owner_procedure": "unlocked lookup solely to choose the key, then acquire the key, then re-read under lock and verify the exact owner; fail closed on mismatch"
+  },
+  "test_vectors": [
+    {
+      "name": "all_zero_v4",
+      "account_id": "00000000-0000-4000-8000-000000000000",
+      "profile_id": "00000000-0000-4000-8000-000000000000",
+      "preimage_length": 84,
+      "preimage_hex": "00000024656c6c612d6d616e616765642d636c6f75642d617574686f726974792d6c6f636b2d76310000000200000010000000000000400080000000000000000000001000000000000040008000000000000000",
+      "sha256_hex": "aae1ab8bf83f9ac043fd5f8e38d65992219690d0e68c557386f3d0e645ebc81f",
+      "advisory_key_int64": -6133432599848183104
+    },
+    {
+      "name": "same_account_and_profile",
+      "account_id": "11111111-1111-4111-8111-111111111111",
+      "profile_id": "11111111-1111-4111-8111-111111111111",
+      "preimage_length": 84,
+      "preimage_hex": "00000024656c6c612d6d616e616765642d636c6f75642d617574686f726974792d6c6f636b2d76310000000200000010111111111111411181111111111111110000001011111111111141118111111111111111",
+      "sha256_hex": "9c993236e5d0fefc09a16d60982f923eb3cba4d851673e0a8e0bbe0be0afc792",
+      "advisory_key_int64": -7162638520990761220
+    },
+    {
+      "name": "distinct_account_profile",
+      "account_id": "11111111-1111-4111-8111-111111111111",
+      "profile_id": "22222222-2222-4222-8222-222222222222",
+      "preimage_length": 84,
+      "preimage_hex": "00000024656c6c612d6d616e616765642d636c6f75642d617574686f726974792d6c6f636b2d76310000000200000010111111111111411181111111111111110000001022222222222242228222222222222222",
+      "sha256_hex": "edaa7dd8315d8896763a9d0ce2bf50632c70bce7732b01a88729164198a8bf59",
+      "advisory_key_int64": -1321105173185197930
+    },
+    {
+      "name": "field_order_swapped",
+      "account_id": "22222222-2222-4222-8222-222222222222",
+      "profile_id": "11111111-1111-4111-8111-111111111111",
+      "preimage_length": 84,
+      "preimage_hex": "00000024656c6c612d6d616e616765642d636c6f75642d617574686f726974792d6c6f636b2d76310000000200000010222222222222422282222222222222220000001011111111111141118111111111111111",
+      "sha256_hex": "c792681caf4aed4c58c78d878103a0f15e94f5843191036432225a3cbc9022d7",
+      "advisory_key_int64": -4066073041152840372
+    },
+    {
+      "name": "max_hex",
+      "account_id": "ffffffff-ffff-4fff-bfff-ffffffffffff",
+      "profile_id": "ffffffff-ffff-4fff-bfff-ffffffffffff",
+      "preimage_length": 84,
+      "preimage_hex": "00000024656c6c612d6d616e616765642d636c6f75642d617574686f726974792d6c6f636b2d76310000000200000010ffffffffffff4fffbfffffffffffffff00000010ffffffffffff4fffbfffffffffffffff",
+      "sha256_hex": "588a3e8ad16c6d52cecf3df73c6bb624331e018686186bda001de9a3e88c01f5",
+      "advisory_key_int64": 6379980588063681874
+    },
+    {
+      "name": "uppercase_input_same_key",
+      "account_id": "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE",
+      "profile_id": "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+      "preimage_length": 84,
+      "preimage_hex": "00000024656c6c612d6d616e616765642d636c6f75642d617574686f726974792d6c6f636b2d76310000000200000010aaaaaaaabbbb4ccc8dddeeeeeeeeeeee00000010aaaaaaaabbbb4ccc8dddeeeeeeeeeeee",
+      "sha256_hex": "6631eaba99a6130f5f9f7927ce3d956d48ffe84bc86e0692baf84b5553866c6f",
+      "advisory_key_int64": 7363924952890086159
+    }
+  ]
+}

--- a/backend/database/authority_advisory_lock.py
+++ b/backend/database/authority_advisory_lock.py
@@ -13,6 +13,7 @@ import json
 import re
 import struct
 import uuid
+import weakref
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -26,8 +27,10 @@ CONTRACT_ARTIFACT_SHA256 = "1a92c0d335742560fff71b4630b95e1424bccdafb15c6245c8a5
 AUTHORITY_LOCK_DOMAIN = b"ella-managed-cloud-authority-lock-v1"
 AUTHORITY_LOCK_FIELD_COUNT = 2
 UUID_BYTE_LENGTH = 16
+IDENTITY_OWNER_NAMESPACE = uuid.UUID("d9b4e06b-3553-5f97-b04d-6e88f730b94f")
 
 _CANONICAL_UUID_RE = re.compile(r"\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-" r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\Z")
+_PROOF_ISSUER = object()
 
 
 class AuthorityLockError(RuntimeError):
@@ -56,11 +59,45 @@ class AuthorityOwner:
 
 
 @dataclass(frozen=True)
-class AuthorityLockProof:
-    """In-process proof that the caller acquired the v1 transaction lock."""
+class IdentityOwnerResolution:
+    owner: AuthorityOwner
+    allow_create: bool
 
+
+class AuthorityLockProof:
+    """Opaque handle verified against PostgreSQL before every helper mutation."""
+
+    __slots__ = ("__weakref__",)
+
+    def __new__(cls, issuer: object = None) -> "AuthorityLockProof":
+        if issuer is not _PROOF_ISSUER:
+            raise AuthorityLockError("authority_lock_proof_construction_forbidden")
+        return super().__new__(cls)
+
+    def __copy__(self) -> "AuthorityLockProof":
+        raise AuthorityLockError("authority_lock_proof_copy_forbidden")
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> "AuthorityLockProof":
+        del memo
+        raise AuthorityLockError("authority_lock_proof_copy_forbidden")
+
+    def __reduce__(self) -> tuple[Any, ...]:
+        raise AuthorityLockError("authority_lock_proof_serialization_forbidden")
+
+    def __repr__(self) -> str:
+        return "AuthorityLockProof(<opaque>)"
+
+
+@dataclass(frozen=True)
+class _AuthorityLockProofState:
     owner: AuthorityOwner
     key: int
+    connection: asyncpg.Connection
+    backend_pid: int
+    transaction_id: int
+
+
+_PROOF_STATES: weakref.WeakKeyDictionary[AuthorityLockProof, _AuthorityLockProofState] = weakref.WeakKeyDictionary()
 
 
 def contract_artifact_path() -> Path:
@@ -133,6 +170,42 @@ def authority_lock_key(account_id: Any, profile_id: Any) -> int:
     return int.from_bytes(authority_lock_digest(account_id, profile_id)[:8], byteorder="big", signed=True)
 
 
+def _advisory_lock_parts(key: int) -> tuple[int, int]:
+    unsigned_key = key & ((1 << 64) - 1)
+    return (unsigned_key >> 32) & 0xFFFFFFFF, unsigned_key & 0xFFFFFFFF
+
+
+async def _read_transaction_lock_state(
+    connection: asyncpg.Connection,
+    *,
+    key: int,
+) -> tuple[int, int, bool]:
+    class_id, object_id = _advisory_lock_parts(key)
+    row = await connection.fetchrow(
+        """
+        SELECT
+            pg_backend_pid() AS backend_pid,
+            txid_current() AS transaction_id,
+            EXISTS (
+                SELECT 1
+                FROM pg_locks
+                WHERE locktype = 'advisory'
+                  AND pid = pg_backend_pid()
+                  AND classid::bigint = $1
+                  AND objid::bigint = $2
+                  AND objsubid = 1
+                  AND mode = 'ExclusiveLock'
+                  AND granted
+            ) AS lock_held
+        """,
+        class_id,
+        object_id,
+    )
+    if not row:
+        raise AuthorityLockError("authority_lock_proof_state_unavailable")
+    return int(row["backend_pid"]), int(row["transaction_id"]), bool(row["lock_held"])
+
+
 async def acquire_authority_lock(
     connection: asyncpg.Connection,
     *,
@@ -145,20 +218,64 @@ async def acquire_authority_lock(
     profile_id = str(_validated_database_uuid(owner.profile_id, field="profile_id"))
     key = authority_lock_key(account_id, profile_id)
     await connection.execute("SELECT pg_advisory_xact_lock($1::bigint)", key)
-    return AuthorityLockProof(owner=owner, key=key)
+    backend_pid, transaction_id, lock_held = await _read_transaction_lock_state(
+        connection,
+        key=key,
+    )
+    if not lock_held:
+        raise AuthorityLockError("authority_lock_not_held")
+    proof = AuthorityLockProof(_PROOF_ISSUER)
+    _PROOF_STATES[proof] = _AuthorityLockProofState(
+        owner=owner,
+        key=key,
+        connection=connection,
+        backend_pid=backend_pid,
+        transaction_id=transaction_id,
+    )
+    return proof
 
 
-def require_self_owner_lock(
+async def require_authority_lock(
+    connection: asyncpg.Connection,
+    proof: AuthorityLockProof,
+    *,
+    owner: AuthorityOwner,
+) -> None:
+    """Verify an opaque proof against this connection's current transaction."""
+    if type(proof) is not AuthorityLockProof:
+        raise AuthorityLockError("authority_lock_proof_missing")
+    state = _PROOF_STATES.get(proof)
+    if state is None:
+        raise AuthorityLockError("authority_lock_proof_forged")
+    if connection is not state.connection:
+        raise AuthorityLockError("authority_lock_proof_connection_mismatch")
+    if owner != state.owner:
+        raise AuthorityLockError("authority_lock_proof_owner_mismatch")
+    backend_pid, transaction_id, lock_held = await _read_transaction_lock_state(
+        connection,
+        key=state.key,
+    )
+    if backend_pid != state.backend_pid:
+        raise AuthorityLockError("authority_lock_proof_connection_mismatch")
+    if transaction_id != state.transaction_id:
+        raise AuthorityLockError("authority_lock_proof_transaction_stale")
+    if not lock_held:
+        raise AuthorityLockError("authority_lock_proof_lock_missing")
+
+
+async def require_self_owner_lock(
+    connection: asyncpg.Connection,
     proof: AuthorityLockProof,
     *,
     user_id: Any,
 ) -> None:
-    """Fail closed unless a helper received the exact self-profile lock proof."""
-    if not isinstance(proof, AuthorityLockProof):
-        raise AuthorityLockError("authority_lock_proof_missing")
+    """Fail closed unless this transaction holds the exact self-profile lock."""
     current = _validated_database_uuid(user_id, field="user_id")
-    if proof.owner.account_id != current or proof.owner.profile_id != current:
-        raise AuthorityLockError("authority_lock_proof_owner_mismatch")
+    await require_authority_lock(
+        connection,
+        proof,
+        owner=AuthorityOwner.from_values(current, current),
+    )
 
 
 async def resolve_self_owner_unlocked(
@@ -176,13 +293,93 @@ async def resolve_self_owner_unlocked(
     return AuthorityOwner.from_values(row["id"], row["id"])
 
 
+def provisional_identity_owner(uid: str) -> AuthorityOwner:
+    if not isinstance(uid, str) or not uid:
+        raise AuthorityLockError("authority_lock_identity_uid_missing")
+    owner_id = uuid.uuid5(IDENTITY_OWNER_NAMESPACE, uid)
+    return AuthorityOwner.from_values(owner_id, owner_id)
+
+
+async def resolve_identity_owner_unlocked(
+    connection: asyncpg.Connection,
+    *,
+    uid: str,
+    email: str,
+) -> IdentityOwnerResolution:
+    """Resolve one existing owner or a deterministic not-yet-created owner."""
+    rows = await connection.fetch(
+        """
+        SELECT id
+        FROM users
+        WHERE omi_uid = $1 OR lower(email) = lower($2)
+        ORDER BY id
+        """,
+        uid,
+        email,
+    )
+    owner_ids = {_validated_database_uuid(row["id"], field="user_id") for row in rows}
+    if len(owner_ids) > 1:
+        raise AuthorityLockError("authority_lock_identity_conflict")
+    if owner_ids:
+        owner_id = next(iter(owner_ids))
+        return IdentityOwnerResolution(
+            owner=AuthorityOwner.from_values(owner_id, owner_id),
+            allow_create=False,
+        )
+    return IdentityOwnerResolution(
+        owner=provisional_identity_owner(uid),
+        allow_create=True,
+    )
+
+
+async def verify_identity_owner_after_lock(
+    connection: asyncpg.Connection,
+    *,
+    uid: str,
+    email: str,
+    resolution: IdentityOwnerResolution,
+    proof: AuthorityLockProof,
+) -> tuple[Mapping[str, Any], ...]:
+    """Re-read and lock identity ownership; unexpected ownership fails closed."""
+    await require_authority_lock(
+        connection,
+        proof,
+        owner=resolution.owner,
+    )
+    rows = await connection.fetch(
+        """
+        SELECT id, omi_uid, email, name, timezone, status
+        FROM users
+        WHERE omi_uid = $1 OR lower(email) = lower($2)
+        ORDER BY id
+        FOR UPDATE
+        """,
+        uid,
+        email,
+    )
+    owner_ids = {_validated_database_uuid(row["id"], field="user_id") for row in rows}
+    if len(owner_ids) > 1 or (owner_ids and owner_ids != {resolution.owner.account_id}):
+        raise AuthorityLockError("authority_lock_owner_drift")
+    if not owner_ids:
+        if not resolution.allow_create or resolution.owner != provisional_identity_owner(uid):
+            raise AuthorityLockError("authority_lock_owner_drift")
+        return ()
+    return tuple(rows)
+
+
 async def verify_self_owner_after_lock(
     connection: asyncpg.Connection,
     *,
     uid: str,
     owner: AuthorityOwner,
+    proof: AuthorityLockProof,
 ) -> uuid.UUID:
     """Lock and re-read ownership after the v1 advisory lock; drift fails closed."""
+    await require_authority_lock(
+        connection,
+        proof,
+        owner=owner,
+    )
     row = await connection.fetchrow(
         "SELECT id FROM users WHERE omi_uid = $1 FOR UPDATE",
         uid,

--- a/backend/database/authority_advisory_lock.py
+++ b/backend/database/authority_advisory_lock.py
@@ -1,0 +1,180 @@
+"""Shared managed-cloud authority advisory-lock contract.
+
+The vendored artifact is byte-pinned to ellaaicare/ella-ai#1155. This module is
+the only OMI implementation of its UUID framing and signed PostgreSQL bigint
+derivation. Authority writers must take this transaction-scoped lock before any
+row lock or mutation for the same account/profile pair.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import struct
+import uuid
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Mapping
+
+import asyncpg
+
+CONTRACT_VERSION = "1"
+CONTRACT_ARTIFACT_NAME = "authority_advisory_lock_v1.json"
+CONTRACT_ARTIFACT_SHA256 = "1a92c0d335742560fff71b4630b95e1424bccdafb15c6245c8a554f4ea19eb69"
+AUTHORITY_LOCK_DOMAIN = b"ella-managed-cloud-authority-lock-v1"
+AUTHORITY_LOCK_FIELD_COUNT = 2
+UUID_BYTE_LENGTH = 16
+
+_CANONICAL_UUID_RE = re.compile(r"\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-" r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\Z")
+
+
+class AuthorityLockError(RuntimeError):
+    """The cross-service lock contract could not be satisfied."""
+
+    def __init__(self, code: str, detail: str = "") -> None:
+        self.code = code
+        super().__init__(f"{code}: {detail}" if detail else code)
+
+
+@dataclass(frozen=True)
+class AuthorityOwner:
+    account_id: uuid.UUID
+    profile_id: uuid.UUID
+
+    @classmethod
+    def from_values(cls, account_id: Any, profile_id: Any) -> "AuthorityOwner":
+        canonical_uuid_bytes(account_id, field="account_id")
+        canonical_uuid_bytes(profile_id, field="profile_id")
+        return cls(account_id=uuid.UUID(str(account_id)), profile_id=uuid.UUID(str(profile_id)))
+
+
+@dataclass(frozen=True)
+class AuthorityLockProof:
+    """In-process proof that the caller acquired the v1 transaction lock."""
+
+    owner: AuthorityOwner
+    key: int
+
+
+def contract_artifact_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "contracts" / CONTRACT_ARTIFACT_NAME
+
+
+@lru_cache(maxsize=1)
+def load_verified_contract_artifact() -> Mapping[str, Any]:
+    artifact_bytes = contract_artifact_path().read_bytes()
+    artifact_sha256 = hashlib.sha256(artifact_bytes).hexdigest()
+    if artifact_sha256 != CONTRACT_ARTIFACT_SHA256:
+        raise AuthorityLockError("authority_lock_contract_artifact_drift")
+    try:
+        artifact = json.loads(artifact_bytes)
+    except json.JSONDecodeError as exc:
+        raise AuthorityLockError("authority_lock_contract_artifact_invalid") from exc
+    if (
+        not isinstance(artifact, dict)
+        or artifact.get("contract") != "ella-managed-cloud-authority-lock"
+        or artifact.get("version") != CONTRACT_VERSION
+        or artifact.get("encoding", {}).get("domain_ascii") != AUTHORITY_LOCK_DOMAIN.decode("ascii")
+        or artifact.get("encoding", {}).get("field_count") != AUTHORITY_LOCK_FIELD_COUNT
+        or artifact.get("key", {}).get("postgres_call") != "pg_advisory_xact_lock(bigint)"
+    ):
+        raise AuthorityLockError("authority_lock_contract_artifact_mismatch")
+    return artifact
+
+
+def canonical_uuid_bytes(value: Any, *, field: str) -> bytes:
+    if value is None:
+        raise AuthorityLockError("authority_lock_owner_missing", field)
+    if isinstance(value, bytes):
+        raise AuthorityLockError("authority_lock_owner_not_text", field)
+    text = str(value)
+    if not text:
+        raise AuthorityLockError("authority_lock_owner_missing", field)
+    if not _CANONICAL_UUID_RE.match(text):
+        raise AuthorityLockError("authority_lock_owner_not_canonical_uuid", field)
+    return bytes.fromhex(text.replace("-", "").lower())
+
+
+def authority_lock_preimage(account_id: Any, profile_id: Any) -> bytes:
+    load_verified_contract_artifact()
+    account_bytes = canonical_uuid_bytes(account_id, field="account_id")
+    profile_bytes = canonical_uuid_bytes(profile_id, field="profile_id")
+    return b"".join(
+        (
+            struct.pack("!I", len(AUTHORITY_LOCK_DOMAIN)),
+            AUTHORITY_LOCK_DOMAIN,
+            struct.pack("!I", AUTHORITY_LOCK_FIELD_COUNT),
+            struct.pack("!I", UUID_BYTE_LENGTH),
+            account_bytes,
+            struct.pack("!I", UUID_BYTE_LENGTH),
+            profile_bytes,
+        )
+    )
+
+
+def authority_lock_digest(account_id: Any, profile_id: Any) -> bytes:
+    return hashlib.sha256(authority_lock_preimage(account_id, profile_id)).digest()
+
+
+def authority_lock_key(account_id: Any, profile_id: Any) -> int:
+    return int.from_bytes(authority_lock_digest(account_id, profile_id)[:8], byteorder="big", signed=True)
+
+
+async def acquire_authority_lock(
+    connection: asyncpg.Connection,
+    *,
+    owner: AuthorityOwner,
+) -> AuthorityLockProof:
+    """Take the v1 lock. This must be the first statement in the transaction."""
+    key = authority_lock_key(owner.account_id, owner.profile_id)
+    await connection.execute("SELECT pg_advisory_xact_lock($1::bigint)", key)
+    return AuthorityLockProof(owner=owner, key=key)
+
+
+def require_self_owner_lock(
+    proof: AuthorityLockProof,
+    *,
+    user_id: Any,
+) -> None:
+    """Fail closed unless a helper received the exact self-profile lock proof."""
+    if not isinstance(proof, AuthorityLockProof):
+        raise AuthorityLockError("authority_lock_proof_missing")
+    current = uuid.UUID(str(user_id))
+    if proof.owner.account_id != current or proof.owner.profile_id != current:
+        raise AuthorityLockError("authority_lock_proof_owner_mismatch")
+
+
+async def resolve_self_owner_unlocked(
+    connection: asyncpg.Connection,
+    *,
+    uid: str,
+) -> AuthorityOwner:
+    """Resolve a candidate self-profile owner outside the mutation transaction."""
+    row = await connection.fetchrow(
+        "SELECT id FROM users WHERE omi_uid = $1",
+        uid,
+    )
+    if not row:
+        raise AuthorityLockError("authority_lock_owner_missing")
+    return AuthorityOwner.from_values(row["id"], row["id"])
+
+
+async def verify_self_owner_after_lock(
+    connection: asyncpg.Connection,
+    *,
+    uid: str,
+    owner: AuthorityOwner,
+) -> uuid.UUID:
+    """Lock and re-read ownership after the v1 advisory lock; drift fails closed."""
+    row = await connection.fetchrow(
+        "SELECT id FROM users WHERE omi_uid = $1 FOR UPDATE",
+        uid,
+    )
+    if not row:
+        raise AuthorityLockError("authority_lock_owner_missing")
+    current = uuid.UUID(str(row["id"]))
+    if current != owner.account_id or current != owner.profile_id:
+        raise AuthorityLockError("authority_lock_owner_drift")
+    return current

--- a/backend/database/authority_advisory_lock.py
+++ b/backend/database/authority_advisory_lock.py
@@ -43,11 +43,16 @@ class AuthorityOwner:
     account_id: uuid.UUID
     profile_id: uuid.UUID
 
+    def __post_init__(self) -> None:
+        _validated_database_uuid(self.account_id, field="account_id")
+        _validated_database_uuid(self.profile_id, field="profile_id")
+
     @classmethod
     def from_values(cls, account_id: Any, profile_id: Any) -> "AuthorityOwner":
-        canonical_uuid_bytes(account_id, field="account_id")
-        canonical_uuid_bytes(profile_id, field="profile_id")
-        return cls(account_id=uuid.UUID(str(account_id)), profile_id=uuid.UUID(str(profile_id)))
+        return cls(
+            account_id=_validated_database_uuid(account_id, field="account_id"),
+            profile_id=_validated_database_uuid(profile_id, field="profile_id"),
+        )
 
 
 @dataclass(frozen=True)
@@ -84,17 +89,23 @@ def load_verified_contract_artifact() -> Mapping[str, Any]:
     return artifact
 
 
+def _validated_database_uuid(value: Any, *, field: str) -> uuid.UUID:
+    if not isinstance(value, uuid.UUID):
+        raise AuthorityLockError("authority_lock_owner_not_database_uuid", field)
+    canonical_uuid_bytes(str(value), field=field)
+    return value
+
+
 def canonical_uuid_bytes(value: Any, *, field: str) -> bytes:
     if value is None:
         raise AuthorityLockError("authority_lock_owner_missing", field)
-    if isinstance(value, bytes):
+    if not isinstance(value, str):
         raise AuthorityLockError("authority_lock_owner_not_text", field)
-    text = str(value)
-    if not text:
+    if not value:
         raise AuthorityLockError("authority_lock_owner_missing", field)
-    if not _CANONICAL_UUID_RE.match(text):
+    if not _CANONICAL_UUID_RE.match(value):
         raise AuthorityLockError("authority_lock_owner_not_canonical_uuid", field)
-    return bytes.fromhex(text.replace("-", "").lower())
+    return bytes.fromhex(value.replace("-", "").lower())
 
 
 def authority_lock_preimage(account_id: Any, profile_id: Any) -> bytes:
@@ -128,7 +139,11 @@ async def acquire_authority_lock(
     owner: AuthorityOwner,
 ) -> AuthorityLockProof:
     """Take the v1 lock. This must be the first statement in the transaction."""
-    key = authority_lock_key(owner.account_id, owner.profile_id)
+    if not isinstance(owner, AuthorityOwner):
+        raise AuthorityLockError("authority_lock_owner_invalid")
+    account_id = str(_validated_database_uuid(owner.account_id, field="account_id"))
+    profile_id = str(_validated_database_uuid(owner.profile_id, field="profile_id"))
+    key = authority_lock_key(account_id, profile_id)
     await connection.execute("SELECT pg_advisory_xact_lock($1::bigint)", key)
     return AuthorityLockProof(owner=owner, key=key)
 
@@ -141,7 +156,7 @@ def require_self_owner_lock(
     """Fail closed unless a helper received the exact self-profile lock proof."""
     if not isinstance(proof, AuthorityLockProof):
         raise AuthorityLockError("authority_lock_proof_missing")
-    current = uuid.UUID(str(user_id))
+    current = _validated_database_uuid(user_id, field="user_id")
     if proof.owner.account_id != current or proof.owner.profile_id != current:
         raise AuthorityLockError("authority_lock_proof_owner_mismatch")
 
@@ -174,7 +189,7 @@ async def verify_self_owner_after_lock(
     )
     if not row:
         raise AuthorityLockError("authority_lock_owner_missing")
-    current = uuid.UUID(str(row["id"]))
+    current = _validated_database_uuid(row["id"], field="user_id")
     if current != owner.account_id or current != owner.profile_id:
         raise AuthorityLockError("authority_lock_owner_drift")
     return current

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 
 import asyncpg
 
+from database import authority_advisory_lock
 from database import voice_canary as voice_canary_db
 from database.runtime_targets import (
     CLOUD_RUNTIME_MODEL,
@@ -709,7 +710,15 @@ class EllaProvisioningRepository:
         lease_expires_at = datetime.now(timezone.utc) + timedelta(seconds=max(30, lease_seconds))
         job_uuid = uuid.UUID(str(job_id))
         async with self.pool.acquire() as connection:
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+                connection,
+                uid=uid,
+            )
             async with connection.transaction():
+                await authority_advisory_lock.acquire_authority_lock(
+                    connection,
+                    owner=owner,
+                )
                 admission = await voice_canary_db.revalidate_runtime_activation_on_connection(
                     connection,
                     uid=uid,
@@ -719,6 +728,11 @@ class EllaProvisioningRepository:
                 )
                 if not admission.allowed:
                     raise RuntimePoolClaimError(f"runtime_admission_{admission.code}")
+                await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=uid,
+                    owner=owner,
+                )
                 existing = await connection.fetchrow(
                     """
                     SELECT b.*, u.omi_uid, u.profile_class
@@ -835,7 +849,15 @@ class EllaProvisioningRepository:
         job_uuid = uuid.UUID(str(job_id))
         token_uuid = uuid.UUID(str(claim_token))
         async with self.pool.acquire() as connection:
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+                connection,
+                uid=uid,
+            )
             async with connection.transaction():
+                await authority_advisory_lock.acquire_authority_lock(
+                    connection,
+                    owner=owner,
+                )
                 admission = await voice_canary_db.revalidate_runtime_activation_on_connection(
                     connection,
                     uid=uid,
@@ -847,6 +869,11 @@ class EllaProvisioningRepository:
                 )
                 if not admission.allowed:
                     raise RuntimePoolClaimError(f"runtime_admission_{admission.code}")
+                await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=uid,
+                    owner=owner,
+                )
                 entitlement = admission.entitlement or {}
                 if (
                     str(entitlement.get("consent_policy_version") or "") != lineage.policy_version
@@ -1086,7 +1113,20 @@ class EllaProvisioningRepository:
         health_receipt: Optional[dict[str, Any]] = None,
     ) -> Optional[dict[str, Any]]:
         async with self.pool.acquire() as connection:
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+                connection,
+                uid=uid,
+            )
             async with connection.transaction():
+                await authority_advisory_lock.acquire_authority_lock(
+                    connection,
+                    owner=owner,
+                )
+                await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=uid,
+                    owner=owner,
+                )
                 selected = await connection.fetchrow(
                     """
                     SELECT b.*
@@ -1272,7 +1312,15 @@ class EllaProvisioningRepository:
             raise ValueError("invalid_cloud_runtime_policy")
         lineage = authority_lineage.validate()
         async with self.pool.acquire() as connection:
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+                connection,
+                uid=uid,
+            )
             async with connection.transaction():
+                await authority_advisory_lock.acquire_authority_lock(
+                    connection,
+                    owner=owner,
+                )
                 admission = await voice_canary_db.revalidate_runtime_activation_on_connection(
                     connection,
                     uid=uid,
@@ -1284,6 +1332,11 @@ class EllaProvisioningRepository:
                 )
                 if not admission.allowed:
                     raise RuntimePoolClaimError(f"runtime_admission_{admission.code}")
+                await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=uid,
+                    owner=owner,
+                )
                 entitlement = admission.entitlement or {}
                 if (
                     str(entitlement.get("consent_policy_version") or "") != lineage.policy_version
@@ -2305,63 +2358,78 @@ class EllaProvisioningRepository:
         return dict(row)
 
     async def stage_runtime_binding(self, *, uid: str, binding: dict[str, Any]) -> dict[str, Any]:
-        row = await self.pool.fetchrow(
-            """
-            INSERT INTO ella_runtime_bindings (
-                id, user_id, role, provider, profile_name, agent_id, workspace_root,
-                internal_gateway_url, gateway_port, service_label, credential_ref,
-                honcho_workspace, observed_peer, observer_peer, template_version,
-                model_policy_version, voice_policy_version, health_state,
-                health_receipt, revision, active
+        async with self.pool.acquire() as connection:
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+                connection,
+                uid=uid,
             )
-            SELECT
-                $1, u.id, $3, $4, $5, $6, $7, $8, $9, $10, $11,
-                $12, $13, $14, $15, $16, $17, $18, $19::jsonb, 1, false
-            FROM users u
-            WHERE u.omi_uid = $2
-            ON CONFLICT (user_id, role, provider)
-            WHERE provider <> 'hermes_cloud'
-            DO UPDATE
-            SET profile_name = EXCLUDED.profile_name,
-                agent_id = EXCLUDED.agent_id,
-                workspace_root = EXCLUDED.workspace_root,
-                internal_gateway_url = EXCLUDED.internal_gateway_url,
-                gateway_port = EXCLUDED.gateway_port,
-                service_label = EXCLUDED.service_label,
-                credential_ref = EXCLUDED.credential_ref,
-                honcho_workspace = EXCLUDED.honcho_workspace,
-                observed_peer = EXCLUDED.observed_peer,
-                observer_peer = EXCLUDED.observer_peer,
-                template_version = EXCLUDED.template_version,
-                model_policy_version = EXCLUDED.model_policy_version,
-                voice_policy_version = EXCLUDED.voice_policy_version,
-                health_state = EXCLUDED.health_state,
-                health_receipt = EXCLUDED.health_receipt,
-                revision = ella_runtime_bindings.revision + 1,
-                active = ella_runtime_bindings.active,
-                updated_at = CURRENT_TIMESTAMP
-            RETURNING *
-            """,
-            uuid.uuid4(),
-            uid,
-            binding.get("role", "user"),
-            binding["provider"],
-            binding.get("profile_name"),
-            binding["agent_id"],
-            binding.get("workspace_root"),
-            binding.get("internal_gateway_url"),
-            binding.get("gateway_port"),
-            binding.get("service_label"),
-            binding.get("credential_ref"),
-            binding.get("honcho_workspace"),
-            binding.get("observed_peer"),
-            binding.get("observer_peer"),
-            binding["template_version"],
-            binding["model_policy_version"],
-            binding["voice_policy_version"],
-            binding.get("health_state", "pending"),
-            json.dumps(binding.get("health_receipt") or {}),
-        )
+            async with connection.transaction():
+                await authority_advisory_lock.acquire_authority_lock(
+                    connection,
+                    owner=owner,
+                )
+                await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=uid,
+                    owner=owner,
+                )
+                row = await connection.fetchrow(
+                    """
+                    INSERT INTO ella_runtime_bindings (
+                        id, user_id, role, provider, profile_name, agent_id, workspace_root,
+                        internal_gateway_url, gateway_port, service_label, credential_ref,
+                        honcho_workspace, observed_peer, observer_peer, template_version,
+                        model_policy_version, voice_policy_version, health_state,
+                        health_receipt, revision, active
+                    )
+                    SELECT
+                        $1, u.id, $3, $4, $5, $6, $7, $8, $9, $10, $11,
+                        $12, $13, $14, $15, $16, $17, $18, $19::jsonb, 1, false
+                    FROM users u
+                    WHERE u.omi_uid = $2
+                    ON CONFLICT (user_id, role, provider)
+                    WHERE provider <> 'hermes_cloud'
+                    DO UPDATE
+                    SET profile_name = EXCLUDED.profile_name,
+                        agent_id = EXCLUDED.agent_id,
+                        workspace_root = EXCLUDED.workspace_root,
+                        internal_gateway_url = EXCLUDED.internal_gateway_url,
+                        gateway_port = EXCLUDED.gateway_port,
+                        service_label = EXCLUDED.service_label,
+                        credential_ref = EXCLUDED.credential_ref,
+                        honcho_workspace = EXCLUDED.honcho_workspace,
+                        observed_peer = EXCLUDED.observed_peer,
+                        observer_peer = EXCLUDED.observer_peer,
+                        template_version = EXCLUDED.template_version,
+                        model_policy_version = EXCLUDED.model_policy_version,
+                        voice_policy_version = EXCLUDED.voice_policy_version,
+                        health_state = EXCLUDED.health_state,
+                        health_receipt = EXCLUDED.health_receipt,
+                        revision = ella_runtime_bindings.revision + 1,
+                        active = ella_runtime_bindings.active,
+                        updated_at = CURRENT_TIMESTAMP
+                    RETURNING *
+                    """,
+                    uuid.uuid4(),
+                    uid,
+                    binding.get("role", "user"),
+                    binding["provider"],
+                    binding.get("profile_name"),
+                    binding["agent_id"],
+                    binding.get("workspace_root"),
+                    binding.get("internal_gateway_url"),
+                    binding.get("gateway_port"),
+                    binding.get("service_label"),
+                    binding.get("credential_ref"),
+                    binding.get("honcho_workspace"),
+                    binding.get("observed_peer"),
+                    binding.get("observer_peer"),
+                    binding["template_version"],
+                    binding["model_policy_version"],
+                    binding["voice_policy_version"],
+                    binding.get("health_state", "pending"),
+                    json.dumps(binding.get("health_receipt") or {}),
+                )
         if not row:
             raise LookupError("user_not_found")
         return dict(row)
@@ -2374,7 +2442,20 @@ class EllaProvisioningRepository:
         role: str = "user",
     ) -> dict[str, Any]:
         async with self.pool.acquire() as connection:
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+                connection,
+                uid=uid,
+            )
             async with connection.transaction():
+                await authority_advisory_lock.acquire_authority_lock(
+                    connection,
+                    owner=owner,
+                )
+                await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=uid,
+                    owner=owner,
+                )
                 selected = await connection.fetchrow(
                     """
                     SELECT b.*

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -347,16 +347,24 @@ class EllaProvisioningRepository:
             raise IdentityConflictError("identity_missing_email")
 
         async with self.pool.acquire() as connection:
+            resolution = await authority_advisory_lock.resolve_identity_owner_unlocked(
+                connection,
+                uid=uid,
+                email=email,
+            )
             async with connection.transaction():
-                by_uid = await connection.fetchrow(
-                    """
-                    SELECT id, omi_uid, email, name, timezone
-                    FROM users
-                    WHERE omi_uid = $1
-                    FOR UPDATE
-                    """,
-                    uid,
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(
+                    connection,
+                    owner=resolution.owner,
                 )
+                identity_rows = await authority_advisory_lock.verify_identity_owner_after_lock(
+                    connection,
+                    uid=uid,
+                    email=email,
+                    resolution=resolution,
+                    proof=owner_lock,
+                )
+                by_uid = next((row for row in identity_rows if row["omi_uid"] == uid), None)
                 if by_uid:
                     if str(by_uid["email"]).lower() != email.lower():
                         raise IdentityConflictError("uid_email_mismatch")
@@ -377,14 +385,9 @@ class EllaProvisioningRepository:
                     )
                     return dict(updated)
 
-                by_email = await connection.fetchrow(
-                    """
-                    SELECT id, omi_uid, email
-                    FROM users
-                    WHERE lower(email) = lower($1)
-                    FOR UPDATE
-                    """,
-                    email,
+                by_email = next(
+                    (row for row in identity_rows if str(row["email"] or "").lower() == email.lower()),
+                    None,
                 )
                 if by_email:
                     existing_uid = by_email["omi_uid"]
@@ -410,7 +413,6 @@ class EllaProvisioningRepository:
                     )
                     return dict(updated)
 
-                user_id = uuid.uuid4()
                 inserted = await connection.fetchrow(
                     """
                     INSERT INTO users (
@@ -424,7 +426,7 @@ class EllaProvisioningRepository:
                     )
                     RETURNING id, omi_uid, email, name, timezone, status
                     """,
-                    user_id,
+                    resolution.owner.account_id,
                     email,
                     name,
                     timezone_name,
@@ -715,7 +717,7 @@ class EllaProvisioningRepository:
                 uid=uid,
             )
             async with connection.transaction():
-                await authority_advisory_lock.acquire_authority_lock(
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(
                     connection,
                     owner=owner,
                 )
@@ -732,6 +734,7 @@ class EllaProvisioningRepository:
                     connection,
                     uid=uid,
                     owner=owner,
+                    proof=owner_lock,
                 )
                 existing = await connection.fetchrow(
                     """
@@ -854,7 +857,7 @@ class EllaProvisioningRepository:
                 uid=uid,
             )
             async with connection.transaction():
-                await authority_advisory_lock.acquire_authority_lock(
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(
                     connection,
                     owner=owner,
                 )
@@ -873,6 +876,7 @@ class EllaProvisioningRepository:
                     connection,
                     uid=uid,
                     owner=owner,
+                    proof=owner_lock,
                 )
                 entitlement = admission.entitlement or {}
                 if (
@@ -1118,7 +1122,7 @@ class EllaProvisioningRepository:
                 uid=uid,
             )
             async with connection.transaction():
-                await authority_advisory_lock.acquire_authority_lock(
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(
                     connection,
                     owner=owner,
                 )
@@ -1126,6 +1130,7 @@ class EllaProvisioningRepository:
                     connection,
                     uid=uid,
                     owner=owner,
+                    proof=owner_lock,
                 )
                 selected = await connection.fetchrow(
                     """
@@ -1317,7 +1322,7 @@ class EllaProvisioningRepository:
                 uid=uid,
             )
             async with connection.transaction():
-                await authority_advisory_lock.acquire_authority_lock(
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(
                     connection,
                     owner=owner,
                 )
@@ -1336,6 +1341,7 @@ class EllaProvisioningRepository:
                     connection,
                     uid=uid,
                     owner=owner,
+                    proof=owner_lock,
                 )
                 entitlement = admission.entitlement or {}
                 if (
@@ -2364,7 +2370,7 @@ class EllaProvisioningRepository:
                 uid=uid,
             )
             async with connection.transaction():
-                await authority_advisory_lock.acquire_authority_lock(
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(
                     connection,
                     owner=owner,
                 )
@@ -2372,6 +2378,7 @@ class EllaProvisioningRepository:
                     connection,
                     uid=uid,
                     owner=owner,
+                    proof=owner_lock,
                 )
                 row = await connection.fetchrow(
                     """
@@ -2447,7 +2454,7 @@ class EllaProvisioningRepository:
                 uid=uid,
             )
             async with connection.transaction():
-                await authority_advisory_lock.acquire_authority_lock(
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(
                     connection,
                     owner=owner,
                 )
@@ -2455,6 +2462,7 @@ class EllaProvisioningRepository:
                     connection,
                     uid=uid,
                     owner=owner,
+                    proof=owner_lock,
                 )
                 selected = await connection.fetchrow(
                     """
@@ -2504,14 +2512,30 @@ class EllaProvisioningRepository:
                 return dict(activated)
 
     async def activate_user(self, uid: str) -> None:
-        result = await self.pool.execute(
-            """
-            UPDATE users
-            SET status = 'ACTIVE', updated_at = CURRENT_TIMESTAMP
-            WHERE omi_uid = $1
-            """,
-            uid,
-        )
+        async with self.pool.acquire() as connection:
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+                connection,
+                uid=uid,
+            )
+            async with connection.transaction():
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(
+                    connection,
+                    owner=owner,
+                )
+                await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=uid,
+                    owner=owner,
+                    proof=owner_lock,
+                )
+                result = await connection.execute(
+                    """
+                    UPDATE users
+                    SET status = 'ACTIVE', updated_at = CURRENT_TIMESTAMP
+                    WHERE omi_uid = $1
+                    """,
+                    uid,
+                )
         if result == "UPDATE 0":
             raise LookupError("user_not_found")
 

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -396,16 +396,15 @@ class EllaProvisioningRepository:
                     updated = await connection.fetchrow(
                         """
                         UPDATE users
-                        SET omi_uid = $2,
-                            name = $3,
-                            timezone = $4,
+                        SET omi_uid = $1,
+                            name = $2,
+                            timezone = $3,
                             identities = COALESCE(identities, '{}'::jsonb)
-                                || jsonb_build_object('omi_uid', $2::text, 'email', email),
+                                || jsonb_build_object('omi_uid', $1::text, 'email', email),
                             updated_at = CURRENT_TIMESTAMP
-                        WHERE id = $5
+                        WHERE id = $4
                         RETURNING id, omi_uid, email, name, timezone, status
                         """,
-                        email,
                         uid,
                         name,
                         timezone_name,

--- a/backend/database/invitations.py
+++ b/backend/database/invitations.py
@@ -16,7 +16,7 @@ from typing import Any, Awaitable, Callable, Optional
 
 import asyncpg
 
-from database import managed_cloud_consent, voice_canary
+from database import authority_advisory_lock, managed_cloud_consent, voice_canary
 from database.runtime_targets import (
     CLOUD_RUNTIME_MODEL,
     CLOUD_RUNTIME_PROVIDER,
@@ -462,7 +462,15 @@ async def redeem_invitation(
 
     pool = await voice_canary.get_pool()
     async with pool.acquire() as conn:
+        owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+            conn,
+            uid=uid,
+        )
         async with conn.transaction():
+            owner_lock = await authority_advisory_lock.acquire_authority_lock(
+                conn,
+                owner=owner,
+            )
             await voice_canary.lock_runtime_authority_on_connection(
                 conn,
                 uid=uid,
@@ -552,6 +560,7 @@ async def redeem_invitation(
                         config=settings,
                         pilot_admission=pilot_admission,
                         pilot_admission_revalidator=pilot_admission_revalidator,
+                        owner_lock=owner_lock,
                     )
 
     if isinstance(result, InviteRedemptionFailure):
@@ -573,6 +582,7 @@ async def _redeem_locked_invitation(
     config: InvitationConfig,
     pilot_admission: InvitationPilotAdmission,
     pilot_admission_revalidator: PilotAdmissionRevalidator,
+    owner_lock: authority_advisory_lock.AuthorityLockProof,
 ) -> dict[str, Any] | InviteRedemptionFailure:
     invitation_id = invitation["id"]
     target_account_ref, target_profile_ref = invitation_target_refs(
@@ -609,6 +619,7 @@ async def _redeem_locked_invitation(
     try:
         consent_authority_epoch = await managed_cloud_consent.lock_or_bootstrap_grant_on_connection(
             conn,
+            owner_lock=owner_lock,
             grant=managed_cloud_consent.ManagedCloudGrant(
                 account_uid=pilot_admission.account_uid,
                 profile_uid=pilot_admission.profile_uid,

--- a/backend/database/invitations.py
+++ b/backend/database/invitations.py
@@ -560,6 +560,7 @@ async def redeem_invitation(
                         config=settings,
                         pilot_admission=pilot_admission,
                         pilot_admission_revalidator=pilot_admission_revalidator,
+                        owner=owner,
                         owner_lock=owner_lock,
                     )
 
@@ -582,6 +583,7 @@ async def _redeem_locked_invitation(
     config: InvitationConfig,
     pilot_admission: InvitationPilotAdmission,
     pilot_admission_revalidator: PilotAdmissionRevalidator,
+    owner: authority_advisory_lock.AuthorityOwner,
     owner_lock: authority_advisory_lock.AuthorityLockProof,
 ) -> dict[str, Any] | InviteRedemptionFailure:
     invitation_id = invitation["id"]
@@ -619,6 +621,7 @@ async def _redeem_locked_invitation(
     try:
         consent_authority_epoch = await managed_cloud_consent.lock_or_bootstrap_grant_on_connection(
             conn,
+            owner=owner,
             owner_lock=owner_lock,
             grant=managed_cloud_consent.ManagedCloudGrant(
                 account_uid=pilot_admission.account_uid,

--- a/backend/database/managed_cloud_consent.py
+++ b/backend/database/managed_cloud_consent.py
@@ -11,7 +11,7 @@ from typing import Any, Literal
 
 import asyncpg
 
-from database import voice_canary
+from database import authority_advisory_lock, voice_canary
 
 AuthorityDecision = Literal["granted", "declined", "revoked"]
 
@@ -114,7 +114,12 @@ async def _quarantine_on_connection(
     uid: str,
     user_id: uuid.UUID,
     reason: str,
+    owner_lock: authority_advisory_lock.AuthorityLockProof,
 ) -> None:
+    authority_advisory_lock.require_self_owner_lock(
+        owner_lock,
+        user_id=user_id,
+    )
     await conn.execute(
         """
         UPDATE voice_entitlements
@@ -174,15 +179,19 @@ async def lock_or_bootstrap_grant_on_connection(
     conn: asyncpg.Connection,
     *,
     grant: ManagedCloudGrant,
+    owner_lock: authority_advisory_lock.AuthorityLockProof,
 ) -> uuid.UUID:
-    """Lock the exact grant epoch for the remainder of the caller transaction."""
+    """Lock the exact grant epoch after the caller acquires the v1 owner lock."""
     grant.validate()
-    user_id = await conn.fetchval(
-        "SELECT id FROM users WHERE omi_uid = $1 FOR UPDATE",
-        grant.account_uid,
+    user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+        conn,
+        uid=grant.account_uid,
+        owner=owner_lock.owner,
     )
-    if not user_id:
-        raise ManagedCloudAuthorityDenied("managed_cloud_authority_user_missing")
+    authority_advisory_lock.require_self_owner_lock(
+        owner_lock,
+        user_id=user_id,
+    )
     row = await conn.fetchrow(
         """
         SELECT *
@@ -223,17 +232,24 @@ async def synchronize_grant(
     try:
         pool = await voice_canary.get_pool()
         async with pool.acquire() as conn:
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+                conn,
+                uid=grant.account_uid,
+            )
             async with conn.transaction():
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(
+                    conn,
+                    owner=owner,
+                )
                 await voice_canary.lock_runtime_authority_on_connection(
                     conn,
                     uid=grant.account_uid,
                 )
-                user_id = await conn.fetchval(
-                    "SELECT id FROM users WHERE omi_uid = $1 FOR UPDATE",
-                    grant.account_uid,
+                user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+                    conn,
+                    uid=grant.account_uid,
+                    owner=owner,
                 )
-                if not user_id:
-                    raise ManagedCloudAuthorityUnavailable("managed_cloud_authority_user_missing")
                 row = await conn.fetchrow(
                     """
                     SELECT *
@@ -299,6 +315,7 @@ async def synchronize_grant(
                         uid=grant.account_uid,
                         user_id=user_id,
                         reason="managed_cloud_consent_grant_changed",
+                        owner_lock=owner_lock,
                     )
                 if row is None or not _grant_matches(row, grant):
                     raise ManagedCloudAuthorityUnavailable("managed_cloud_authority_grant_failed")
@@ -318,17 +335,24 @@ async def synchronize_denial(
     try:
         pool = await voice_canary.get_pool()
         async with pool.acquire() as conn:
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+                conn,
+                uid=uid,
+            )
             async with conn.transaction():
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(
+                    conn,
+                    owner=owner,
+                )
                 await voice_canary.lock_runtime_authority_on_connection(
                     conn,
                     uid=uid,
                 )
-                user_id = await conn.fetchval(
-                    "SELECT id FROM users WHERE omi_uid = $1 FOR UPDATE",
-                    uid,
+                user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+                    conn,
+                    uid=uid,
+                    owner=owner,
                 )
-                if not user_id:
-                    raise ManagedCloudAuthorityUnavailable("managed_cloud_authority_user_missing")
                 row = await conn.fetchrow(
                     """
                     SELECT *
@@ -374,6 +398,7 @@ async def synchronize_denial(
                     uid=uid,
                     user_id=user_id,
                     reason=f"managed_cloud_consent_{decision}",
+                    owner_lock=owner_lock,
                 )
                 if row is None or row["decision"] != decision:
                     raise ManagedCloudAuthorityUnavailable("managed_cloud_authority_denial_failed")

--- a/backend/database/managed_cloud_consent.py
+++ b/backend/database/managed_cloud_consent.py
@@ -116,7 +116,8 @@ async def _quarantine_on_connection(
     reason: str,
     owner_lock: authority_advisory_lock.AuthorityLockProof,
 ) -> None:
-    authority_advisory_lock.require_self_owner_lock(
+    await authority_advisory_lock.require_self_owner_lock(
+        conn,
         owner_lock,
         user_id=user_id,
     )
@@ -179,6 +180,7 @@ async def lock_or_bootstrap_grant_on_connection(
     conn: asyncpg.Connection,
     *,
     grant: ManagedCloudGrant,
+    owner: authority_advisory_lock.AuthorityOwner,
     owner_lock: authority_advisory_lock.AuthorityLockProof,
 ) -> uuid.UUID:
     """Lock the exact grant epoch after the caller acquires the v1 owner lock."""
@@ -186,9 +188,11 @@ async def lock_or_bootstrap_grant_on_connection(
     user_id = await authority_advisory_lock.verify_self_owner_after_lock(
         conn,
         uid=grant.account_uid,
-        owner=owner_lock.owner,
+        owner=owner,
+        proof=owner_lock,
     )
-    authority_advisory_lock.require_self_owner_lock(
+    await authority_advisory_lock.require_self_owner_lock(
+        conn,
         owner_lock,
         user_id=user_id,
     )
@@ -249,6 +253,7 @@ async def synchronize_grant(
                     conn,
                     uid=grant.account_uid,
                     owner=owner,
+                    proof=owner_lock,
                 )
                 row = await conn.fetchrow(
                     """
@@ -352,6 +357,7 @@ async def synchronize_denial(
                     conn,
                     uid=uid,
                     owner=owner,
+                    proof=owner_lock,
                 )
                 row = await conn.fetchrow(
                     """

--- a/backend/database/voice_canary.py
+++ b/backend/database/voice_canary.py
@@ -15,6 +15,8 @@ from typing import Any, Optional
 
 import asyncpg
 
+from database import authority_advisory_lock
+
 DEFAULT_DAILY_LIMIT_S = 45 * 60
 DEFAULT_MONTHLY_LIMIT_S = 12 * 60 * 60
 DEFAULT_MAX_SESSION_S = 20 * 60
@@ -475,6 +477,102 @@ async def get_entitlement(uid: str) -> Optional[dict[str, Any]]:
     async with pool.acquire() as conn:
         row = await conn.fetchrow("SELECT * FROM voice_entitlements WHERE uid = $1", uid)
         return _record_dict(row) or None
+
+
+async def upsert_entitlement(
+    *,
+    uid: str,
+    plan: str,
+    daily_limit_s: int,
+    monthly_limit_s: int,
+    max_session_s: int,
+    max_concurrent: int,
+    soft_limit_ratio: float,
+    provider_allowlist: list[str],
+    mode_allowlist: list[str],
+    fallback_policy: dict[str, Any],
+    operator_note: str,
+) -> dict[str, Any]:
+    """Create or reactivate an entitlement under the cross-service owner lock."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        owner = await authority_advisory_lock.resolve_self_owner_unlocked(conn, uid=uid)
+        async with conn.transaction():
+            await authority_advisory_lock.acquire_authority_lock(conn, owner=owner)
+            await lock_runtime_authority_on_connection(conn, uid=uid)
+            await authority_advisory_lock.verify_self_owner_after_lock(conn, uid=uid, owner=owner)
+            row = await conn.fetchrow(
+                """
+                INSERT INTO voice_entitlements (
+                    uid, status, plan, daily_limit_s, monthly_limit_s,
+                    max_session_s, max_concurrent, soft_limit_ratio,
+                    provider_allowlist, mode_allowlist, fallback_policy, operator_note
+                ) VALUES (
+                    $1, 'active', $2, $3, $4, $5, $6, $7, $8::text[], $9::text[],
+                    $10::jsonb, $11
+                )
+                ON CONFLICT (uid) DO UPDATE SET
+                    status = 'active',
+                    plan = EXCLUDED.plan,
+                    revision = voice_entitlements.revision + 1,
+                    daily_limit_s = EXCLUDED.daily_limit_s,
+                    monthly_limit_s = EXCLUDED.monthly_limit_s,
+                    max_session_s = EXCLUDED.max_session_s,
+                    max_concurrent = EXCLUDED.max_concurrent,
+                    soft_limit_ratio = EXCLUDED.soft_limit_ratio,
+                    provider_allowlist = EXCLUDED.provider_allowlist,
+                    mode_allowlist = EXCLUDED.mode_allowlist,
+                    fallback_policy = EXCLUDED.fallback_policy,
+                    operator_note = EXCLUDED.operator_note,
+                    updated_at = NOW()
+                RETURNING *
+                """,
+                uid,
+                plan,
+                daily_limit_s,
+                monthly_limit_s,
+                max_session_s,
+                max_concurrent,
+                soft_limit_ratio,
+                provider_allowlist,
+                mode_allowlist,
+                json.dumps(fallback_policy),
+                operator_note,
+            )
+            return _record_dict(row)
+
+
+async def update_entitlement_status(
+    *,
+    uid: str,
+    status: str,
+    operator_note: Optional[str] = None,
+) -> Optional[dict[str, Any]]:
+    """Suspend, revoke, or expire an entitlement under the shared owner lock."""
+    if status not in {"suspended", "revoked", "expired"}:
+        raise ValueError("invalid_entitlement_status")
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        owner = await authority_advisory_lock.resolve_self_owner_unlocked(conn, uid=uid)
+        async with conn.transaction():
+            await authority_advisory_lock.acquire_authority_lock(conn, owner=owner)
+            await lock_runtime_authority_on_connection(conn, uid=uid)
+            await authority_advisory_lock.verify_self_owner_after_lock(conn, uid=uid, owner=owner)
+            row = await conn.fetchrow(
+                """
+                UPDATE voice_entitlements
+                SET status = $2,
+                    revision = revision + 1,
+                    operator_note = COALESCE($3, operator_note),
+                    updated_at = NOW()
+                WHERE uid = $1
+                RETURNING *
+                """,
+                uid,
+                status,
+                operator_note,
+            )
+            return _record_dict(row) or None
 
 
 async def _runtime_activation_decision(
@@ -1389,8 +1487,11 @@ async def delete_user_voice_data(uid: str) -> dict[str, int]:
     """Deletion exception to the append-only rule, used by the operator receipt."""
     pool = await get_pool()
     async with pool.acquire() as conn:
+        owner = await authority_advisory_lock.resolve_self_owner_unlocked(conn, uid=uid)
         async with conn.transaction():
+            await authority_advisory_lock.acquire_authority_lock(conn, owner=owner)
             await lock_runtime_authority_on_connection(conn, uid=uid)
+            await authority_advisory_lock.verify_self_owner_after_lock(conn, uid=uid, owner=owner)
             counts = {
                 "active_sessions": _as_int(
                     await conn.fetchval("SELECT COUNT(*) FROM voice_active_sessions WHERE uid = $1", uid)

--- a/backend/database/voice_canary.py
+++ b/backend/database/voice_canary.py
@@ -498,9 +498,14 @@ async def upsert_entitlement(
     async with pool.acquire() as conn:
         owner = await authority_advisory_lock.resolve_self_owner_unlocked(conn, uid=uid)
         async with conn.transaction():
-            await authority_advisory_lock.acquire_authority_lock(conn, owner=owner)
+            owner_lock = await authority_advisory_lock.acquire_authority_lock(conn, owner=owner)
             await lock_runtime_authority_on_connection(conn, uid=uid)
-            await authority_advisory_lock.verify_self_owner_after_lock(conn, uid=uid, owner=owner)
+            await authority_advisory_lock.verify_self_owner_after_lock(
+                conn,
+                uid=uid,
+                owner=owner,
+                proof=owner_lock,
+            )
             row = await conn.fetchrow(
                 """
                 INSERT INTO voice_entitlements (
@@ -555,9 +560,14 @@ async def update_entitlement_status(
     async with pool.acquire() as conn:
         owner = await authority_advisory_lock.resolve_self_owner_unlocked(conn, uid=uid)
         async with conn.transaction():
-            await authority_advisory_lock.acquire_authority_lock(conn, owner=owner)
+            owner_lock = await authority_advisory_lock.acquire_authority_lock(conn, owner=owner)
             await lock_runtime_authority_on_connection(conn, uid=uid)
-            await authority_advisory_lock.verify_self_owner_after_lock(conn, uid=uid, owner=owner)
+            await authority_advisory_lock.verify_self_owner_after_lock(
+                conn,
+                uid=uid,
+                owner=owner,
+                proof=owner_lock,
+            )
             row = await conn.fetchrow(
                 """
                 UPDATE voice_entitlements
@@ -1489,9 +1499,14 @@ async def delete_user_voice_data(uid: str) -> dict[str, int]:
     async with pool.acquire() as conn:
         owner = await authority_advisory_lock.resolve_self_owner_unlocked(conn, uid=uid)
         async with conn.transaction():
-            await authority_advisory_lock.acquire_authority_lock(conn, owner=owner)
+            owner_lock = await authority_advisory_lock.acquire_authority_lock(conn, owner=owner)
             await lock_runtime_authority_on_connection(conn, uid=uid)
-            await authority_advisory_lock.verify_self_owner_after_lock(conn, uid=uid, owner=owner)
+            await authority_advisory_lock.verify_self_owner_after_lock(
+                conn,
+                uid=uid,
+                owner=owner,
+                proof=owner_lock,
+            )
             counts = {
                 "active_sessions": _as_int(
                     await conn.fetchval("SELECT COUNT(*) FROM voice_active_sessions WHERE uid = $1", uid)

--- a/backend/scripts/voice_canary_admin.py
+++ b/backend/scripts/voice_canary_admin.py
@@ -29,69 +29,31 @@ def _print(payload: Any) -> None:
 
 
 async def _grant(args: argparse.Namespace) -> None:
-    pool = await voice_canary.get_pool()
-    async with pool.acquire() as conn:
-        row = await conn.fetchrow(
-            """
-            INSERT INTO voice_entitlements (
-                uid, status, plan, daily_limit_s, monthly_limit_s,
-                max_session_s, max_concurrent, soft_limit_ratio,
-                provider_allowlist, mode_allowlist, fallback_policy, operator_note
-            ) VALUES (
-                $1, 'active', $2, $3, $4, $5, $6, $7, $8::text[], $9::text[],
-                $10::jsonb, $11
-            )
-            ON CONFLICT (uid) DO UPDATE SET
-                status = 'active',
-                plan = EXCLUDED.plan,
-                revision = voice_entitlements.revision + 1,
-                daily_limit_s = EXCLUDED.daily_limit_s,
-                monthly_limit_s = EXCLUDED.monthly_limit_s,
-                max_session_s = EXCLUDED.max_session_s,
-                max_concurrent = EXCLUDED.max_concurrent,
-                soft_limit_ratio = EXCLUDED.soft_limit_ratio,
-                provider_allowlist = EXCLUDED.provider_allowlist,
-                mode_allowlist = EXCLUDED.mode_allowlist,
-                fallback_policy = EXCLUDED.fallback_policy,
-                operator_note = EXCLUDED.operator_note,
-                updated_at = NOW()
-            RETURNING *
-            """,
-            args.uid,
-            args.plan,
-            args.daily_minutes * 60,
-            args.monthly_hours * 60 * 60,
-            args.max_session_minutes * 60,
-            args.max_concurrent,
-            args.soft_warning_percent / 100,
-            args.provider,
-            args.mode,
-            json.dumps(DEFAULT_FALLBACK_POLICY),
-            args.note,
-        )
-    _print({"action": "grant", "entitlement": dict(row)})
+    row = await voice_canary.upsert_entitlement(
+        uid=args.uid,
+        plan=args.plan,
+        daily_limit_s=args.daily_minutes * 60,
+        monthly_limit_s=args.monthly_hours * 60 * 60,
+        max_session_s=args.max_session_minutes * 60,
+        max_concurrent=args.max_concurrent,
+        soft_limit_ratio=args.soft_warning_percent / 100,
+        provider_allowlist=args.provider,
+        mode_allowlist=args.mode,
+        fallback_policy=DEFAULT_FALLBACK_POLICY,
+        operator_note=args.note,
+    )
+    _print({"action": "grant", "entitlement": row})
 
 
 async def _status(args: argparse.Namespace) -> None:
-    pool = await voice_canary.get_pool()
-    async with pool.acquire() as conn:
-        row = await conn.fetchrow(
-            """
-            UPDATE voice_entitlements
-            SET status = $2,
-                revision = revision + 1,
-                operator_note = COALESCE($3, operator_note),
-                updated_at = NOW()
-            WHERE uid = $1
-            RETURNING *
-            """,
-            args.uid,
-            args.status,
-            args.note,
-        )
+    row = await voice_canary.update_entitlement_status(
+        uid=args.uid,
+        status=args.status,
+        operator_note=args.note,
+    )
     if not row:
         raise SystemExit(f"No entitlement exists for {args.uid}")
-    _print({"action": args.status, "entitlement": dict(row)})
+    _print({"action": args.status, "entitlement": row})
 
 
 async def _kill(args: argparse.Namespace) -> None:

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -1,0 +1,351 @@
+import asyncio
+import os
+import uuid
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+from database import authority_advisory_lock, managed_cloud_consent, voice_canary
+
+TEST_DSN = os.getenv("ELLA_TEST_POSTGRES_DSN", "").strip()
+MIGRATIONS = Path(__file__).resolve().parents[2] / "migrations"
+
+pytestmark = pytest.mark.skipif(
+    not TEST_DSN,
+    reason="ELLA_TEST_POSTGRES_DSN is required for authority-lock PostgreSQL tests",
+)
+
+BASE_PROVISIONING_SCHEMA = """
+CREATE TABLE users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    omi_uid TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL DEFAULT 'Synthetic User',
+    status TEXT NOT NULL DEFAULT 'ACTIVE',
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE ella_provisioning_jobs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    target_schema_version TEXT NOT NULL,
+    client_request_id TEXT,
+    request_payload_hash TEXT NOT NULL DEFAULT '',
+    state TEXT NOT NULL DEFAULT 'pending',
+    stage TEXT NOT NULL DEFAULT 'identity_ready',
+    retryable BOOLEAN NOT NULL DEFAULT true,
+    error_code TEXT,
+    error_detail JSONB NOT NULL DEFAULT '{}'::jsonb,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    receipts JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE ella_runtime_bindings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    role TEXT NOT NULL DEFAULT 'user',
+    provider TEXT NOT NULL,
+    profile_name TEXT UNIQUE,
+    agent_id TEXT NOT NULL,
+    workspace_root TEXT,
+    internal_gateway_url TEXT,
+    gateway_port INTEGER UNIQUE,
+    service_label TEXT UNIQUE,
+    credential_ref TEXT,
+    honcho_workspace TEXT UNIQUE,
+    observed_peer TEXT UNIQUE,
+    observer_peer TEXT UNIQUE,
+    template_version TEXT NOT NULL,
+    model_policy_version TEXT NOT NULL,
+    voice_policy_version TEXT NOT NULL,
+    health_state TEXT NOT NULL DEFAULT 'pending',
+    health_receipt JSONB NOT NULL DEFAULT '{}'::jsonb,
+    revision INTEGER NOT NULL DEFAULT 1,
+    active BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT ella_runtime_bindings_user_id_fkey
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX ella_runtime_bindings_user_role_provider_key
+    ON ella_runtime_bindings(user_id, role, provider);
+"""
+
+
+async def _run_with_database(scenario):
+    schema = f"authority_lock_{uuid.uuid4().hex}"
+    admin = await asyncpg.connect(TEST_DSN)
+    await admin.execute(f'CREATE SCHEMA "{schema}"')
+    pool = await asyncpg.create_pool(
+        TEST_DSN,
+        min_size=1,
+        max_size=6,
+        server_settings={"search_path": schema},
+    )
+    previous_voice_pool = voice_canary._pool
+    voice_canary._pool = pool
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(BASE_PROVISIONING_SCHEMA)
+            for name in (
+                "008_create_voice_canary_controls.sql",
+                "009_create_hermes_cloud_runtime_pool.sql",
+                "010_add_cloud_profile_class.sql",
+                "011_create_invitation_redemption.sql",
+                "012_create_account_profile_runtime_targets.sql",
+                "013_create_managed_cloud_consent_authority.sql",
+            ):
+                await conn.execute((MIGRATIONS / name).read_text(encoding="utf-8"))
+        await scenario(pool)
+    finally:
+        voice_canary._pool = previous_voice_pool
+        await pool.close()
+        await admin.execute(f'DROP SCHEMA "{schema}" CASCADE')
+        await admin.close()
+
+
+async def _seed_grant(pool, uid):
+    async with pool.acquire() as conn:
+        user_id = await conn.fetchval(
+            """
+            INSERT INTO users (omi_uid, profile_class)
+            VALUES ($1, 'synthetic')
+            RETURNING id
+            """,
+            uid,
+        )
+        await conn.execute(
+            """
+            INSERT INTO voice_entitlements (
+                uid, status, provider_allowlist, model_allowlist
+            ) VALUES (
+                $1, 'active', ARRAY['hermes_cloud'], ARRAY['gpt-5.6-terra']
+            )
+            """,
+            uid,
+        )
+        await conn.execute(
+            """
+            INSERT INTO ella_managed_cloud_consent_authority (
+                user_id, decision, consent_receipt_ref, profile_binding_id,
+                policy_version, processor_set_hash, scope_version, scope_hash
+            ) VALUES (
+                $1, 'granted', $2, 'synthetic-profile', 'ai-data-processors-v8',
+                $3, 'managed-cloud-internal-pilot-v2', $4
+            )
+            """,
+            user_id,
+            "sha256:" + ("1" * 64),
+            "sha256:" + ("2" * 64),
+            "sha256:" + ("3" * 64),
+        )
+    return authority_advisory_lock.AuthorityOwner.from_values(user_id, user_id)
+
+
+def test_broker_lock_blocks_omi_revoke_until_release_without_partial_mutation():
+    async def scenario(pool):
+        uid = "synthetic-broker-blocks-revoke"
+        owner = await _seed_grant(pool, uid)
+        async with pool.acquire() as broker_conn:
+            transaction = broker_conn.transaction()
+            await transaction.start()
+            await authority_advisory_lock.acquire_authority_lock(
+                broker_conn,
+                owner=owner,
+            )
+            revoke = asyncio.create_task(
+                managed_cloud_consent.synchronize_denial(
+                    uid=uid,
+                    decision="revoked",
+                )
+            )
+            await asyncio.sleep(0.15)
+            assert not revoke.done()
+            async with pool.acquire() as observer:
+                assert (
+                    await observer.fetchval(
+                        """
+                        SELECT decision
+                        FROM ella_managed_cloud_consent_authority
+                        WHERE user_id = $1
+                        """,
+                        owner.account_id,
+                    )
+                    == "granted"
+                )
+                assert (
+                    await observer.fetchval(
+                        "SELECT status FROM voice_entitlements WHERE uid = $1",
+                        uid,
+                    )
+                    == "active"
+                )
+            await transaction.commit()
+            result = await asyncio.wait_for(revoke, timeout=3)
+            assert result["decision"] == "revoked"
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_omi_revoke_lock_blocks_broker_and_releases_without_deadlock():
+    async def scenario(pool):
+        uid = "synthetic-revoke-blocks-broker"
+        owner = await _seed_grant(pool, uid)
+        key = authority_advisory_lock.authority_lock_key(
+            owner.account_id,
+            owner.profile_id,
+        )
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                CREATE FUNCTION hold_authority_revoke() RETURNS trigger AS $$
+                BEGIN
+                    PERFORM pg_sleep(0.6);
+                    RETURN NEW;
+                END
+                $$ LANGUAGE plpgsql
+                """
+            )
+            await conn.execute(
+                """
+                CREATE TRIGGER hold_authority_revoke
+                BEFORE UPDATE ON ella_managed_cloud_consent_authority
+                FOR EACH ROW EXECUTE FUNCTION hold_authority_revoke()
+                """
+            )
+
+        revoke = asyncio.create_task(
+            managed_cloud_consent.synchronize_denial(
+                uid=uid,
+                decision="revoked",
+            )
+        )
+        for _attempt in range(40):
+            async with pool.acquire() as probe:
+                acquired = await probe.fetchval(
+                    "SELECT pg_try_advisory_lock($1::bigint)",
+                    key,
+                )
+                if acquired:
+                    await probe.execute(
+                        "SELECT pg_advisory_unlock($1::bigint)",
+                        key,
+                    )
+                else:
+                    break
+            await asyncio.sleep(0.025)
+        else:
+            pytest.fail("OMI writer never acquired the shared v1 lock")
+
+        broker_acquired = asyncio.Event()
+
+        async def broker_waiter():
+            async with pool.acquire() as broker_conn:
+                async with broker_conn.transaction():
+                    await authority_advisory_lock.acquire_authority_lock(
+                        broker_conn,
+                        owner=owner,
+                    )
+                    broker_acquired.set()
+
+        broker = asyncio.create_task(broker_waiter())
+        await asyncio.sleep(0.1)
+        assert not broker_acquired.is_set()
+        result = await asyncio.wait_for(revoke, timeout=3)
+        assert result["decision"] == "revoked"
+        await asyncio.wait_for(broker, timeout=3)
+        assert broker_acquired.is_set()
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_account_profile_lock_isolation_allows_unrelated_writer():
+    async def scenario(pool):
+        uid_a = "synthetic-lock-a"
+        uid_b = "synthetic-lock-b"
+        owner_a = await _seed_grant(pool, uid_a)
+        await _seed_grant(pool, uid_b)
+        async with pool.acquire() as conn:
+            transaction = conn.transaction()
+            await transaction.start()
+            await authority_advisory_lock.acquire_authority_lock(
+                conn,
+                owner=owner_a,
+            )
+            result = await asyncio.wait_for(
+                managed_cloud_consent.synchronize_denial(
+                    uid=uid_b,
+                    decision="revoked",
+                ),
+                timeout=2,
+            )
+            assert result["decision"] == "revoked"
+            await transaction.rollback()
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_owner_drift_after_unlocked_lookup_fails_closed_before_mutation():
+    async def scenario(pool):
+        uid = "synthetic-owner-drift"
+        original_owner = await _seed_grant(pool, uid)
+        async with pool.acquire() as conn:
+            candidate = await authority_advisory_lock.resolve_self_owner_unlocked(
+                conn,
+                uid=uid,
+            )
+            await conn.execute(
+                "UPDATE users SET omi_uid = $2 WHERE id = $1",
+                original_owner.account_id,
+                f"{uid}-moved",
+            )
+            replacement_id = await conn.fetchval(
+                """
+                INSERT INTO users (omi_uid, profile_class)
+                VALUES ($1, 'synthetic')
+                RETURNING id
+                """,
+                uid,
+            )
+            async with conn.transaction():
+                await authority_advisory_lock.acquire_authority_lock(
+                    conn,
+                    owner=candidate,
+                )
+                with pytest.raises(
+                    authority_advisory_lock.AuthorityLockError,
+                    match="authority_lock_owner_drift",
+                ):
+                    await authority_advisory_lock.verify_self_owner_after_lock(
+                        conn,
+                        uid=uid,
+                        owner=candidate,
+                    )
+        async with pool.acquire() as observer:
+            assert (
+                await observer.fetchval(
+                    """
+                    SELECT COUNT(*)
+                    FROM ella_managed_cloud_consent_authority
+                    WHERE user_id = $1
+                    """,
+                    replacement_id,
+                )
+                == 0
+            )
+            assert (
+                await observer.fetchval(
+                    """
+                    SELECT decision
+                    FROM ella_managed_cloud_consent_authority
+                    WHERE user_id = $1
+                    """,
+                    original_owner.account_id,
+                )
+                == "granted"
+            )
+
+    asyncio.run(_run_with_database(scenario))

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -625,7 +625,7 @@ async def _prepare_writer_case(
             expected_after=0,
         )
 
-    if name in {"identity_create", "identity_update", "user_activate"}:
+    if name in {"identity_create", "identity_update", "identity_bind", "user_activate"}:
         email = f"{uid}@example.invalid"
         if name == "identity_create":
             owner = authority_advisory_lock.provisional_identity_owner(uid)
@@ -650,17 +650,59 @@ async def _prepare_writer_case(
             )
 
         async with pool.acquire() as conn:
-            user_id = await conn.fetchval(
-                """
-                INSERT INTO users (
-                    omi_uid, email, name, status, profile_class
-                ) VALUES ($1, $2, 'Synthetic Before', 'PENDING', 'synthetic')
-                RETURNING id
-                """,
-                uid,
-                email,
-            )
+            if name == "identity_bind":
+                user_id = await conn.fetchval(
+                    """
+                    INSERT INTO users (
+                        email, name, status, profile_class
+                    ) VALUES ($1, 'Synthetic Before', 'PENDING', 'synthetic')
+                    RETURNING id
+                    """,
+                    email,
+                )
+            else:
+                user_id = await conn.fetchval(
+                    """
+                    INSERT INTO users (
+                        omi_uid, email, name, status, profile_class
+                    ) VALUES ($1, $2, 'Synthetic Before', 'PENDING', 'synthetic')
+                    RETURNING id
+                    """,
+                    uid,
+                    email,
+                )
         owner = authority_advisory_lock.AuthorityOwner.from_values(user_id, user_id)
+        if name == "identity_bind":
+
+            async def snapshot():
+                row = await pool.fetchrow(
+                    """
+                    SELECT omi_uid, name, timezone, identities ->> 'omi_uid'
+                    FROM users
+                    WHERE id = $1
+                    """,
+                    user_id,
+                )
+                return tuple(row.values())
+
+            return _WriterCase(
+                owner=owner,
+                writer=lambda: repository.ensure_user_identity(
+                    uid=uid,
+                    email=email,
+                    name="Synthetic Bound",
+                    timezone_name="America/Los_Angeles",
+                ),
+                snapshot=snapshot,
+                expected_before=(None, "Synthetic Before", "UTC", None),
+                expected_after=(
+                    uid,
+                    "Synthetic Bound",
+                    "America/Los_Angeles",
+                    uid,
+                ),
+            )
+
         if name == "identity_update":
 
             async def snapshot():
@@ -926,6 +968,7 @@ async def _prepare_writer_case(
         "entitlement_delete",
         "identity_create",
         "identity_update",
+        "identity_bind",
         "user_activate",
         "runtime_stage",
         "runtime_activate",
@@ -1331,6 +1374,160 @@ def test_users_writer_owner_drift_fails_closed_with_zero_protected_write(writer_
             )
         assert tuple(original.values()) == ("Original Owner", "PENDING")
         assert tuple(replacement.values()) == ("Replacement Owner", "PENDING")
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_identity_bind_owner_drift_rolls_back_without_partial_write_and_releases_lock():
+    async def scenario(pool):
+        uid = "synthetic-users-drift-identity-bind"
+        email = f"{uid}@example.invalid"
+        async with pool.acquire() as conn:
+            original_id = await conn.fetchval(
+                """
+                INSERT INTO users (
+                    email, name, status, profile_class
+                ) VALUES (
+                    $1, 'Original Email Owner', 'PENDING', 'synthetic'
+                )
+                RETURNING id
+                """,
+                email,
+            )
+        owner = authority_advisory_lock.AuthorityOwner.from_values(
+            original_id,
+            original_id,
+        )
+        repository = EllaProvisioningRepository(pool)
+
+        async with pool.acquire() as broker:
+            transaction = broker.transaction()
+            await transaction.start()
+            await authority_advisory_lock.acquire_authority_lock(
+                broker,
+                owner=owner,
+            )
+            writer = asyncio.create_task(
+                repository.ensure_user_identity(
+                    uid=uid,
+                    email=email,
+                    name="Unauthorized Bind",
+                    timezone_name="America/Los_Angeles",
+                )
+            )
+            await _wait_for_advisory_waiter(pool, owner)
+            assert not writer.done()
+            async with pool.acquire() as drift:
+                async with drift.transaction():
+                    await drift.execute(
+                        """
+                        UPDATE users
+                        SET email = $2,
+                            profile_class = 'real'
+                        WHERE id = $1
+                        """,
+                        original_id,
+                        f"{uid}-moved@example.invalid",
+                    )
+                    replacement_id = await drift.fetchval(
+                        """
+                        INSERT INTO users (
+                            email, name, status, profile_class
+                        ) VALUES (
+                            $1, 'Replacement Email Owner', 'PENDING', 'synthetic'
+                        )
+                        RETURNING id
+                        """,
+                        email,
+                    )
+            await transaction.commit()
+
+        with pytest.raises(
+            authority_advisory_lock.AuthorityLockError,
+            match="authority_lock_owner_drift",
+        ):
+            await asyncio.wait_for(writer, timeout=5)
+
+        async with pool.acquire() as observer:
+            original = await observer.fetchrow(
+                """
+                SELECT omi_uid, email, name, timezone, profile_class,
+                       identities ->> 'omi_uid'
+                FROM users
+                WHERE id = $1
+                """,
+                original_id,
+            )
+            replacement = await observer.fetchrow(
+                """
+                SELECT omi_uid, email, name, timezone, profile_class,
+                       identities ->> 'omi_uid'
+                FROM users
+                WHERE id = $1
+                """,
+                replacement_id,
+            )
+            authority_counts = await observer.fetchrow(
+                """
+                SELECT
+                    (
+                        SELECT COUNT(*)
+                        FROM ella_managed_cloud_consent_authority
+                        WHERE user_id = ANY($1::uuid[])
+                    ) AS consent_rows,
+                    (
+                        SELECT COUNT(*)
+                        FROM ella_runtime_targets
+                        WHERE account_user_id = ANY($1::uuid[])
+                           OR profile_user_id = ANY($1::uuid[])
+                    ) AS target_rows,
+                    (
+                        SELECT COUNT(*)
+                        FROM ella_runtime_bindings
+                        WHERE user_id = ANY($1::uuid[])
+                    ) AS binding_rows,
+                    (
+                        SELECT COUNT(*)
+                        FROM voice_entitlements
+                        WHERE uid = $2
+                    ) AS entitlement_rows
+                """,
+                [original_id, replacement_id],
+                uid,
+            )
+
+        assert tuple(original.values()) == (
+            None,
+            f"{uid}-moved@example.invalid",
+            "Original Email Owner",
+            "UTC",
+            "real",
+            None,
+        )
+        assert tuple(replacement.values()) == (
+            None,
+            email,
+            "Replacement Email Owner",
+            "UTC",
+            "synthetic",
+            None,
+        )
+        assert tuple(authority_counts.values()) == (0, 0, 0, 0)
+
+        async with pool.acquire() as probe:
+            async with probe.transaction():
+                proof = await asyncio.wait_for(
+                    authority_advisory_lock.acquire_authority_lock(
+                        probe,
+                        owner=owner,
+                    ),
+                    timeout=2,
+                )
+                await authority_advisory_lock.require_authority_lock(
+                    probe,
+                    proof,
+                    owner=owner,
+                )
 
     asyncio.run(_run_with_database(scenario))
 

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -195,8 +195,8 @@ def test_omi_revoke_lock_blocks_broker_and_releases_without_deadlock():
         uid = "synthetic-revoke-blocks-broker"
         owner = await _seed_grant(pool, uid)
         key = authority_advisory_lock.authority_lock_key(
-            owner.account_id,
-            owner.profile_id,
+            str(owner.account_id),
+            str(owner.profile_id),
         )
         async with pool.acquire() as conn:
             await conn.execute(
@@ -288,42 +288,69 @@ def test_account_profile_lock_isolation_allows_unrelated_writer():
     asyncio.run(_run_with_database(scenario))
 
 
-def test_owner_drift_after_unlocked_lookup_fails_closed_before_mutation():
+def test_synchronize_denial_owner_drift_after_unlocked_lookup_fails_closed_before_mutation(monkeypatch):
     async def scenario(pool):
         uid = "synthetic-owner-drift"
         original_owner = await _seed_grant(pool, uid)
-        async with pool.acquire() as conn:
-            candidate = await authority_advisory_lock.resolve_self_owner_unlocked(
-                conn,
-                uid=uid,
+        candidate_resolved = asyncio.Event()
+        original_resolver = authority_advisory_lock.resolve_self_owner_unlocked
+
+        async def resolve_and_signal(connection, *, uid):
+            owner = await original_resolver(connection, uid=uid)
+            candidate_resolved.set()
+            return owner
+
+        monkeypatch.setattr(
+            authority_advisory_lock,
+            "resolve_self_owner_unlocked",
+            resolve_and_signal,
+        )
+
+        async with pool.acquire() as broker_conn:
+            broker_transaction = broker_conn.transaction()
+            await broker_transaction.start()
+            await authority_advisory_lock.acquire_authority_lock(
+                broker_conn,
+                owner=original_owner,
             )
-            await conn.execute(
-                "UPDATE users SET omi_uid = $2 WHERE id = $1",
-                original_owner.account_id,
-                f"{uid}-moved",
-            )
-            replacement_id = await conn.fetchval(
-                """
-                INSERT INTO users (omi_uid, profile_class)
-                VALUES ($1, 'synthetic')
-                RETURNING id
-                """,
-                uid,
-            )
-            async with conn.transaction():
-                await authority_advisory_lock.acquire_authority_lock(
-                    conn,
-                    owner=candidate,
+            denial = asyncio.create_task(
+                managed_cloud_consent.synchronize_denial(
+                    uid=uid,
+                    decision="revoked",
                 )
-                with pytest.raises(
-                    authority_advisory_lock.AuthorityLockError,
-                    match="authority_lock_owner_drift",
-                ):
-                    await authority_advisory_lock.verify_self_owner_after_lock(
-                        conn,
-                        uid=uid,
-                        owner=candidate,
+            )
+            await asyncio.wait_for(candidate_resolved.wait(), timeout=2)
+            await asyncio.sleep(0.05)
+            assert not denial.done()
+
+            async with pool.acquire() as owner_writer:
+                async with owner_writer.transaction():
+                    await owner_writer.execute(
+                        "UPDATE users SET omi_uid = $2 WHERE id = $1",
+                        original_owner.account_id,
+                        f"{uid}-moved",
                     )
+                    replacement_id = await owner_writer.fetchval(
+                        """
+                        INSERT INTO users (omi_uid, profile_class)
+                        VALUES ($1, 'synthetic')
+                        RETURNING id
+                        """,
+                        uid,
+                    )
+
+            await broker_transaction.commit()
+            with pytest.raises(
+                managed_cloud_consent.ManagedCloudAuthorityUnavailable,
+                match="managed_cloud_authority_unavailable",
+            ) as raised:
+                await asyncio.wait_for(denial, timeout=3)
+            assert isinstance(
+                raised.value.__cause__,
+                authority_advisory_lock.AuthorityLockError,
+            )
+            assert raised.value.__cause__.code == "authority_lock_owner_drift"
+
         async with pool.acquire() as observer:
             assert (
                 await observer.fetchval(
@@ -346,6 +373,13 @@ def test_owner_drift_after_unlocked_lookup_fails_closed_before_mutation():
                     original_owner.account_id,
                 )
                 == "granted"
+            )
+            assert (
+                await observer.fetchval(
+                    "SELECT status FROM voice_entitlements WHERE uid = $1",
+                    uid,
+                )
+                == "active"
             )
 
     asyncio.run(_run_with_database(scenario))

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -1,15 +1,25 @@
 import asyncio
 import os
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Awaitable, Callable
 
 import asyncpg
 import pytest
 
 from database import authority_advisory_lock, managed_cloud_consent, voice_canary
+from database.ella_provisioning import EllaProvisioningRepository
+from database.runtime_targets import RuntimeTargetLineage
 
 TEST_DSN = os.getenv("ELLA_TEST_POSTGRES_DSN", "").strip()
 MIGRATIONS = Path(__file__).resolve().parents[2] / "migrations"
+LINEAGE = RuntimeTargetLineage(
+    policy_version="ai-data-processors-v8",
+    processor_set_hash="sha256:" + ("1" * 64),
+    scope_version="managed-cloud-internal-pilot-v2",
+    scope_hash="sha256:" + ("2" * 64),
+)
 
 pytestmark = pytest.mark.skipif(
     not TEST_DSN,
@@ -19,9 +29,14 @@ pytestmark = pytest.mark.skipif(
 BASE_PROVISIONING_SCHEMA = """
 CREATE TABLE users (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    omi_uid TEXT NOT NULL UNIQUE,
+    omi_uid TEXT UNIQUE,
+    email TEXT UNIQUE,
     name TEXT NOT NULL DEFAULT 'Synthetic User',
+    timezone TEXT NOT NULL DEFAULT 'UTC',
     status TEXT NOT NULL DEFAULT 'ACTIVE',
+    identities JSONB NOT NULL DEFAULT '{}'::jsonb,
+    settings JSONB NOT NULL DEFAULT '{}'::jsonb,
+    tags TEXT[] NOT NULL DEFAULT ARRAY[]::text[],
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -143,6 +158,188 @@ async def _seed_grant(pool, uid):
             "sha256:" + ("3" * 64),
         )
     return authority_advisory_lock.AuthorityOwner.from_values(user_id, user_id)
+
+
+def _prompt_receipt() -> dict[str, Any]:
+    return {
+        "schema_version": "ella-hermes-cloud-approval-v1",
+        "prompt_pack_version": "prompt-v1",
+        "model_policy_version": "model-policy-v1",
+        "expected_model": "gpt-5.6-terra",
+        "model_context_window_tokens": 16384,
+        "policy_commit_sha": "a" * 40,
+        "lane_s_review_url": "https://github.com/ellaaicare/ella-ai/pull/1124",
+        "approval_manifest_sha256": "b" * 64,
+        "content_free": True,
+        "soul_sha256": "c" * 64,
+        "observed_soul_sha256": "c" * 64,
+        "agents_sha256": "d" * 64,
+        "observed_agents_sha256": "d" * 64,
+        "model_policy_sha256": "e" * 64,
+        "observed_model_policy_sha256": "e" * 64,
+    }
+
+
+def _managed_cloud_grant(uid: str, *, revision: str = "one") -> managed_cloud_consent.ManagedCloudGrant:
+    return managed_cloud_consent.ManagedCloudGrant(
+        account_uid=uid,
+        profile_uid=uid,
+        consent_receipt_id=f"synthetic-receipt-{revision}",
+        profile_binding_id=f"synthetic-profile-{revision}",
+        policy_version=LINEAGE.policy_version,
+        processor_set_hash=LINEAGE.processor_set_hash,
+        scope_version=LINEAGE.scope_version,
+        scope_hash=LINEAGE.scope_hash,
+    )
+
+
+async def _wait_for_advisory_waiter(
+    pool: asyncpg.Pool,
+    owner: authority_advisory_lock.AuthorityOwner,
+) -> None:
+    key = authority_advisory_lock.authority_lock_key(
+        str(owner.account_id),
+        str(owner.profile_id),
+    )
+    class_id, object_id = authority_advisory_lock._advisory_lock_parts(key)
+    for _attempt in range(100):
+        async with pool.acquire() as observer:
+            waiting = await observer.fetchval(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM pg_locks
+                    WHERE locktype = 'advisory'
+                      AND classid::bigint = $1
+                      AND objid::bigint = $2
+                      AND objsubid = 1
+                      AND mode = 'ExclusiveLock'
+                      AND NOT granted
+                )
+                """,
+                class_id,
+                object_id,
+            )
+        if waiting:
+            return
+        await asyncio.sleep(0.02)
+    pytest.fail("production writer never waited on the shared v1 authority lock")
+
+
+@dataclass
+class _WriterCase:
+    owner: authority_advisory_lock.AuthorityOwner
+    writer: Callable[[], Awaitable[Any]]
+    snapshot: Callable[[], Awaitable[Any]]
+    expected_before: Any
+    expected_after: Any
+
+
+async def _assert_serialized_writer(
+    pool: asyncpg.Pool,
+    case: _WriterCase,
+) -> None:
+    assert await case.snapshot() == case.expected_before
+    async with pool.acquire() as broker_conn:
+        transaction = broker_conn.transaction()
+        await transaction.start()
+        await authority_advisory_lock.acquire_authority_lock(
+            broker_conn,
+            owner=case.owner,
+        )
+        writer = asyncio.create_task(case.writer())
+        await _wait_for_advisory_waiter(pool, case.owner)
+        assert not writer.done()
+        assert await case.snapshot() == case.expected_before
+        await transaction.commit()
+    await asyncio.wait_for(writer, timeout=5)
+    assert await case.snapshot() == case.expected_after
+
+
+async def _seed_cloud_writer(
+    pool: asyncpg.Pool,
+    *,
+    uid: str,
+    instance: str,
+) -> tuple[
+    EllaProvisioningRepository,
+    authority_advisory_lock.AuthorityOwner,
+    str,
+    int,
+]:
+    async with pool.acquire() as conn:
+        user_id = await conn.fetchval(
+            """
+            INSERT INTO users (omi_uid, email, profile_class)
+            VALUES ($1, $2, 'synthetic')
+            RETURNING id
+            """,
+            uid,
+            f"{uid}@example.invalid",
+        )
+        job_id = await conn.fetchval(
+            """
+            INSERT INTO ella_provisioning_jobs (
+                user_id, target_schema_version
+            ) VALUES ($1, 'hermes-cloud-user-v1')
+            RETURNING id
+            """,
+            user_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO voice_entitlements (
+                uid, status, provider_allowlist, model_allowlist,
+                mode_allowlist, consent_policy_version,
+                consent_processor_set_hash, consent_scope_version,
+                consent_scope_hash
+            ) VALUES (
+                $1, 'active', ARRAY['hermes_cloud'],
+                ARRAY['gpt-5.6-terra'],
+                ARRAY[
+                    'hermes-cloud-chat', 'hermes-cloud-voice',
+                    'hermes-cloud-transcript', 'hermes-cloud-guardian',
+                    'hermes-cloud-photon'
+                ],
+                $2, $3, $4, $5
+            )
+            """,
+            uid,
+            LINEAGE.policy_version,
+            LINEAGE.processor_set_hash,
+            LINEAGE.scope_version,
+            LINEAGE.scope_hash,
+        )
+    repository = EllaProvisioningRepository(pool)
+    await repository.register_cloud_pool_binding(
+        runtime_instance_id=instance,
+        profile_name=f"profile-{instance}",
+        agent_id="hermes-cloud",
+        api_base_url_ref="env:ELLA_HERMES_CLOUD_API_URL_SYNTHETIC",
+        api_key_ref="env:ELLA_HERMES_CLOUD_API_KEY_SYNTHETIC",
+        honcho_api_key_ref=None,
+        template_version="template-v1",
+        prompt_pack_version="prompt-v1",
+        prompt_artifact_receipt=_prompt_receipt(),
+        model_policy_version="model-policy-v1",
+        voice_policy_version="voice-policy-v1",
+        expected_model="gpt-5.6-terra",
+        allowed_tools=[],
+        required_capabilities=["responses_api"],
+        health_receipt={"status": "ok", "content_free": True},
+    )
+    admission = await voice_canary.evaluate_runtime_activation(
+        uid=uid,
+        provider="hermes_cloud",
+        model="gpt-5.6-terra",
+    )
+    assert admission.allowed
+    return (
+        repository,
+        authority_advisory_lock.AuthorityOwner.from_values(user_id, user_id),
+        str(job_id),
+        int(admission.entitlement["revision"]),
+    )
 
 
 def test_broker_lock_blocks_omi_revoke_until_release_without_partial_mutation():
@@ -288,6 +485,668 @@ def test_account_profile_lock_isolation_allows_unrelated_writer():
     asyncio.run(_run_with_database(scenario))
 
 
+async def _prepare_writer_case(
+    pool: asyncpg.Pool,
+    name: str,
+) -> _WriterCase:
+    uid = f"synthetic-writer-{name.replace('_', '-')}"
+    repository = EllaProvisioningRepository(pool)
+
+    if name == "consent_grant":
+        async with pool.acquire() as conn:
+            user_id = await conn.fetchval(
+                "INSERT INTO users (omi_uid, email, profile_class) VALUES ($1, $2, 'synthetic') RETURNING id",
+                uid,
+                f"{uid}@example.invalid",
+            )
+        owner = authority_advisory_lock.AuthorityOwner.from_values(user_id, user_id)
+
+        async def snapshot():
+            return await pool.fetchval(
+                "SELECT decision FROM ella_managed_cloud_consent_authority WHERE user_id = $1",
+                user_id,
+            )
+
+        return _WriterCase(
+            owner=owner,
+            writer=lambda: managed_cloud_consent.synchronize_grant(
+                grant=_managed_cloud_grant(uid),
+            ),
+            snapshot=snapshot,
+            expected_before=None,
+            expected_after="granted",
+        )
+
+    if name == "consent_regrant":
+        owner = await _seed_grant(pool, uid)
+
+        async def snapshot():
+            row = await pool.fetchrow(
+                """
+                SELECT a.profile_binding_id, a.revision,
+                       (
+                           SELECT status
+                           FROM voice_entitlements
+                           WHERE uid = $2
+                       ) AS entitlement_status
+                FROM ella_managed_cloud_consent_authority a
+                WHERE a.user_id = $1
+                """,
+                owner.account_id,
+                uid,
+            )
+            return tuple(row.values())
+
+        return _WriterCase(
+            owner=owner,
+            writer=lambda: managed_cloud_consent.synchronize_grant(
+                grant=_managed_cloud_grant(uid, revision="two"),
+            ),
+            snapshot=snapshot,
+            expected_before=("synthetic-profile", 1, "active"),
+            expected_after=("synthetic-profile-two", 2, "revoked"),
+        )
+
+    if name in {"entitlement_upsert", "entitlement_status", "entitlement_delete"}:
+        async with pool.acquire() as conn:
+            user_id = await conn.fetchval(
+                "INSERT INTO users (omi_uid, email, profile_class) VALUES ($1, $2, 'synthetic') RETURNING id",
+                uid,
+                f"{uid}@example.invalid",
+            )
+            if name != "entitlement_upsert":
+                await conn.execute(
+                    "INSERT INTO voice_entitlements (uid, status) VALUES ($1, 'active')",
+                    uid,
+                )
+        owner = authority_advisory_lock.AuthorityOwner.from_values(user_id, user_id)
+
+        if name == "entitlement_upsert":
+
+            async def snapshot():
+                row = await pool.fetchrow(
+                    "SELECT status, plan FROM voice_entitlements WHERE uid = $1",
+                    uid,
+                )
+                return tuple(row.values()) if row else None
+
+            return _WriterCase(
+                owner=owner,
+                writer=lambda: voice_canary.upsert_entitlement(
+                    uid=uid,
+                    plan="synthetic",
+                    daily_limit_s=300,
+                    monthly_limit_s=3000,
+                    max_session_s=120,
+                    max_concurrent=1,
+                    soft_limit_ratio=0.8,
+                    provider_allowlist=["hermes_cloud"],
+                    mode_allowlist=["hermes-cloud-chat"],
+                    fallback_policy={"enabled": False, "order": []},
+                    operator_note="synthetic authority writer probe",
+                ),
+                snapshot=snapshot,
+                expected_before=None,
+                expected_after=("active", "synthetic"),
+            )
+
+        async def entitlement_snapshot():
+            return await pool.fetchval(
+                "SELECT status FROM voice_entitlements WHERE uid = $1",
+                uid,
+            )
+
+        if name == "entitlement_status":
+            return _WriterCase(
+                owner=owner,
+                writer=lambda: voice_canary.update_entitlement_status(
+                    uid=uid,
+                    status="suspended",
+                    operator_note="synthetic authority writer probe",
+                ),
+                snapshot=entitlement_snapshot,
+                expected_before="active",
+                expected_after="suspended",
+            )
+
+        async def entitlement_count():
+            return int(
+                await pool.fetchval(
+                    "SELECT COUNT(*) FROM voice_entitlements WHERE uid = $1",
+                    uid,
+                )
+            )
+
+        return _WriterCase(
+            owner=owner,
+            writer=lambda: voice_canary.delete_user_voice_data(uid),
+            snapshot=entitlement_count,
+            expected_before=1,
+            expected_after=0,
+        )
+
+    if name in {"identity_create", "identity_update", "user_activate"}:
+        email = f"{uid}@example.invalid"
+        if name == "identity_create":
+            owner = authority_advisory_lock.provisional_identity_owner(uid)
+
+            async def snapshot():
+                return await pool.fetchval(
+                    "SELECT id FROM users WHERE omi_uid = $1",
+                    uid,
+                )
+
+            return _WriterCase(
+                owner=owner,
+                writer=lambda: repository.ensure_user_identity(
+                    uid=uid,
+                    email=email,
+                    name="Synthetic Created",
+                    timezone_name="UTC",
+                ),
+                snapshot=snapshot,
+                expected_before=None,
+                expected_after=owner.account_id,
+            )
+
+        async with pool.acquire() as conn:
+            user_id = await conn.fetchval(
+                """
+                INSERT INTO users (
+                    omi_uid, email, name, status, profile_class
+                ) VALUES ($1, $2, 'Synthetic Before', 'PENDING', 'synthetic')
+                RETURNING id
+                """,
+                uid,
+                email,
+            )
+        owner = authority_advisory_lock.AuthorityOwner.from_values(user_id, user_id)
+        if name == "identity_update":
+
+            async def snapshot():
+                return await pool.fetchval(
+                    "SELECT name FROM users WHERE id = $1",
+                    user_id,
+                )
+
+            return _WriterCase(
+                owner=owner,
+                writer=lambda: repository.ensure_user_identity(
+                    uid=uid,
+                    email=email,
+                    name="Synthetic After",
+                    timezone_name="UTC",
+                ),
+                snapshot=snapshot,
+                expected_before="Synthetic Before",
+                expected_after="Synthetic After",
+            )
+
+        async def status_snapshot():
+            return await pool.fetchval(
+                "SELECT status FROM users WHERE id = $1",
+                user_id,
+            )
+
+        return _WriterCase(
+            owner=owner,
+            writer=lambda: repository.activate_user(uid),
+            snapshot=status_snapshot,
+            expected_before="PENDING",
+            expected_after="ACTIVE",
+        )
+
+    if name in {"runtime_stage", "runtime_activate"}:
+        async with pool.acquire() as conn:
+            user_id = await conn.fetchval(
+                """
+                INSERT INTO users (
+                    omi_uid, email, status, profile_class
+                ) VALUES ($1, $2, 'PENDING', 'synthetic')
+                RETURNING id
+                """,
+                uid,
+                f"{uid}@example.invalid",
+            )
+            if name == "runtime_activate":
+                await conn.execute(
+                    """
+                    INSERT INTO ella_runtime_bindings (
+                        user_id, role, provider, profile_name, agent_id,
+                        template_version, model_policy_version,
+                        voice_policy_version, health_state, active
+                    ) VALUES (
+                        $1, 'user', 'hermes', $2, 'synthetic-agent',
+                        'template-v1', 'model-policy-v1',
+                        'voice-policy-v1', 'healthy', false
+                    )
+                    """,
+                    user_id,
+                    f"profile-{uid}",
+                )
+        owner = authority_advisory_lock.AuthorityOwner.from_values(user_id, user_id)
+        if name == "runtime_stage":
+
+            async def snapshot():
+                return int(
+                    await pool.fetchval(
+                        "SELECT COUNT(*) FROM ella_runtime_bindings WHERE user_id = $1",
+                        user_id,
+                    )
+                )
+
+            return _WriterCase(
+                owner=owner,
+                writer=lambda: repository.stage_runtime_binding(
+                    uid=uid,
+                    binding={
+                        "provider": "hermes",
+                        "profile_name": f"profile-{uid}",
+                        "agent_id": "synthetic-agent",
+                        "template_version": "template-v1",
+                        "model_policy_version": "model-policy-v1",
+                        "voice_policy_version": "voice-policy-v1",
+                    },
+                ),
+                snapshot=snapshot,
+                expected_before=0,
+                expected_after=1,
+            )
+
+        async def activation_snapshot():
+            row = await pool.fetchrow(
+                """
+                SELECT b.active, u.status
+                FROM ella_runtime_bindings b
+                JOIN users u ON u.id = b.user_id
+                WHERE b.user_id = $1 AND b.provider = 'hermes'
+                """,
+                user_id,
+            )
+            return tuple(row.values())
+
+        return _WriterCase(
+            owner=owner,
+            writer=lambda: repository.activate_runtime_binding(
+                uid=uid,
+                provider="hermes",
+            ),
+            snapshot=activation_snapshot,
+            expected_before=(False, "PENDING"),
+            expected_after=(True, "ACTIVE"),
+        )
+
+    if name in {"cloud_claim", "cloud_finalize", "cloud_quarantine", "cloud_promote"}:
+        repository, owner, job_id, revision = await _seed_cloud_writer(
+            pool,
+            uid=uid,
+            instance=f"instance-{name}",
+        )
+
+        if name == "cloud_claim":
+
+            async def snapshot():
+                return await pool.fetchval(
+                    "SELECT status FROM ella_runtime_bindings WHERE runtime_instance_id = $1",
+                    f"instance-{name}",
+                )
+
+            return _WriterCase(
+                owner=owner,
+                writer=lambda: repository.claim_cloud_pool_binding(
+                    uid=uid,
+                    job_id=job_id,
+                    lease_seconds=120,
+                    admitted_entitlement_revision=revision,
+                    provider="hermes_cloud",
+                    model="gpt-5.6-terra",
+                    required_profile_class="synthetic",
+                ),
+                snapshot=snapshot,
+                expected_before="pool_available",
+                expected_after="claiming",
+            )
+
+        claimed = await repository.claim_cloud_pool_binding(
+            uid=uid,
+            job_id=job_id,
+            lease_seconds=120,
+            admitted_entitlement_revision=revision,
+            provider="hermes_cloud",
+            model="gpt-5.6-terra",
+            required_profile_class="synthetic",
+        )
+        claim_token = str(claimed["claim_token"])
+        if name == "cloud_finalize":
+
+            async def snapshot():
+                row = await pool.fetchrow(
+                    """
+                    SELECT b.status, COUNT(t.id)::integer AS target_count
+                    FROM ella_runtime_bindings b
+                    LEFT JOIN ella_runtime_targets t ON t.runtime_binding_id = b.id
+                    WHERE b.id = $1
+                    GROUP BY b.status
+                    """,
+                    claimed["id"],
+                )
+                return tuple(row.values())
+
+            return _WriterCase(
+                owner=owner,
+                writer=lambda: repository.finalize_cloud_pool_claim(
+                    uid=uid,
+                    job_id=job_id,
+                    claim_token=claim_token,
+                    admitted_entitlement_revision=revision,
+                    authority_lineage=LINEAGE,
+                    status="internal_canary",
+                    health_receipt={
+                        "status": "ok",
+                        "content_free": True,
+                        **LINEAGE.as_dict(),
+                        "admission_revision": revision,
+                    },
+                ),
+                snapshot=snapshot,
+                expected_before=("claiming", 0),
+                expected_after=("internal_canary", 5),
+            )
+
+        if name == "cloud_quarantine":
+
+            async def snapshot():
+                return await pool.fetchval(
+                    "SELECT status FROM ella_runtime_bindings WHERE id = $1",
+                    claimed["id"],
+                )
+
+            return _WriterCase(
+                owner=owner,
+                writer=lambda: repository.quarantine_cloud_pool_claim(
+                    uid=uid,
+                    job_id=job_id,
+                    claim_token=claim_token,
+                    reason="synthetic authority writer probe",
+                    health_receipt={"content_free": True},
+                ),
+                snapshot=snapshot,
+                expected_before="claiming",
+                expected_after="quarantined",
+            )
+
+        finalized = await repository.finalize_cloud_pool_claim(
+            uid=uid,
+            job_id=job_id,
+            claim_token=claim_token,
+            admitted_entitlement_revision=revision,
+            authority_lineage=LINEAGE,
+            status="shadow",
+            health_receipt={
+                "status": "ok",
+                "content_free": True,
+                **LINEAGE.as_dict(),
+                "admission_revision": revision,
+            },
+        )
+
+        async def snapshot():
+            row = await pool.fetchrow(
+                "SELECT status, active FROM ella_runtime_bindings WHERE id = $1",
+                finalized["id"],
+            )
+            return tuple(row.values())
+
+        return _WriterCase(
+            owner=owner,
+            writer=lambda: repository.promote_cloud_binding(
+                uid=uid,
+                binding_id=str(finalized["id"]),
+                expected_revision=int(finalized["revision"]),
+                target_status="internal_canary",
+                required_profile_class="synthetic",
+                admitted_entitlement_revision=revision,
+                authority_lineage=LINEAGE,
+            ),
+            snapshot=snapshot,
+            expected_before=("shadow", False),
+            expected_after=("internal_canary", True),
+        )
+
+    raise AssertionError(f"unhandled writer case: {name}")
+
+
+@pytest.mark.parametrize(
+    "name",
+    (
+        "consent_grant",
+        "consent_regrant",
+        "entitlement_upsert",
+        "entitlement_status",
+        "entitlement_delete",
+        "identity_create",
+        "identity_update",
+        "user_activate",
+        "runtime_stage",
+        "runtime_activate",
+        "cloud_claim",
+        "cloud_finalize",
+        "cloud_quarantine",
+        "cloud_promote",
+    ),
+)
+def test_each_production_writer_waits_before_mutation_and_commits_after_release(name):
+    async def scenario(pool):
+        case = await _prepare_writer_case(pool, name)
+        await _assert_serialized_writer(pool, case)
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def _authority_error_code(error: BaseException) -> str | None:
+    current: BaseException | None = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, authority_advisory_lock.AuthorityLockError):
+            return current.code
+        current = current.__cause__ or current.__context__
+    return None
+
+
+@pytest.mark.parametrize(
+    "name",
+    (
+        "consent_grant",
+        "consent_regrant",
+        "entitlement_upsert",
+        "entitlement_status",
+        "entitlement_delete",
+        "user_activate",
+        "runtime_stage",
+        "runtime_activate",
+        "cloud_claim",
+        "cloud_finalize",
+        "cloud_quarantine",
+        "cloud_promote",
+    ),
+)
+def test_each_existing_owner_writer_reproves_owner_and_rolls_back_on_drift(name):
+    async def scenario(pool):
+        uid = f"synthetic-writer-{name.replace('_', '-')}"
+        case = await _prepare_writer_case(pool, name)
+        async with pool.acquire() as broker:
+            transaction = broker.transaction()
+            await transaction.start()
+            await authority_advisory_lock.acquire_authority_lock(
+                broker,
+                owner=case.owner,
+            )
+            writer = asyncio.create_task(case.writer())
+            await _wait_for_advisory_waiter(pool, case.owner)
+            assert not writer.done()
+            async with pool.acquire() as drift:
+                async with drift.transaction():
+                    await drift.execute(
+                        """
+                        UPDATE users
+                        SET omi_uid = $2, email = $3
+                        WHERE id = $1
+                        """,
+                        case.owner.account_id,
+                        f"{uid}-moved",
+                        f"{uid}-moved@example.invalid",
+                    )
+                    await drift.execute(
+                        """
+                        INSERT INTO users (
+                            omi_uid, email, name, status, profile_class
+                        ) VALUES (
+                            $1, $2, 'Replacement Owner', 'PENDING', 'synthetic'
+                        )
+                        """,
+                        uid,
+                        f"{uid}@replacement.invalid",
+                    )
+            await transaction.commit()
+
+        with pytest.raises(Exception) as raised:
+            await asyncio.wait_for(writer, timeout=5)
+        assert _authority_error_code(raised.value) == "authority_lock_owner_drift"
+        assert await case.snapshot() == case.expected_before
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_authority_lock_proof_is_connection_and_transaction_bound():
+    async def scenario(pool):
+        uid = "synthetic-proof-lifecycle"
+        owner = await _seed_grant(pool, uid)
+
+        async with pool.acquire() as first:
+            committed = first.transaction()
+            await committed.start()
+            proof = await authority_advisory_lock.acquire_authority_lock(
+                first,
+                owner=owner,
+            )
+            await authority_advisory_lock.require_authority_lock(
+                first,
+                proof,
+                owner=owner,
+            )
+
+            async with pool.acquire() as other:
+                with pytest.raises(
+                    authority_advisory_lock.AuthorityLockError,
+                    match="authority_lock_proof_connection_mismatch",
+                ):
+                    await managed_cloud_consent._quarantine_on_connection(
+                        other,
+                        uid=uid,
+                        user_id=owner.account_id,
+                        reason="synthetic_cross_connection_probe",
+                        owner_lock=proof,
+                    )
+
+            await committed.commit()
+            with pytest.raises(
+                authority_advisory_lock.AuthorityLockError,
+                match="authority_lock_proof_transaction_stale",
+            ):
+                await managed_cloud_consent._quarantine_on_connection(
+                    first,
+                    uid=uid,
+                    user_id=owner.account_id,
+                    reason="synthetic_post_commit_probe",
+                    owner_lock=proof,
+                )
+
+            rolled_back = first.transaction()
+            await rolled_back.start()
+            rollback_proof = await authority_advisory_lock.acquire_authority_lock(
+                first,
+                owner=owner,
+            )
+            await rolled_back.rollback()
+            with pytest.raises(
+                authority_advisory_lock.AuthorityLockError,
+                match="authority_lock_proof_transaction_stale",
+            ):
+                await managed_cloud_consent._quarantine_on_connection(
+                    first,
+                    uid=uid,
+                    user_id=owner.account_id,
+                    reason="synthetic_post_rollback_probe",
+                    owner_lock=rollback_proof,
+                )
+
+        async with pool.acquire() as observer:
+            assert (
+                await observer.fetchval(
+                    """
+                    SELECT decision
+                    FROM ella_managed_cloud_consent_authority
+                    WHERE user_id = $1
+                    """,
+                    owner.account_id,
+                )
+                == "granted"
+            )
+            assert (
+                await observer.fetchval(
+                    "SELECT status FROM voice_entitlements WHERE uid = $1",
+                    uid,
+                )
+                == "active"
+            )
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_forged_proof_cannot_reach_proof_gated_production_mutation():
+    async def scenario(pool):
+        uid = "synthetic-forged-proof"
+        owner = await _seed_grant(pool, uid)
+        forged = object.__new__(authority_advisory_lock.AuthorityLockProof)
+
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                with pytest.raises(
+                    authority_advisory_lock.AuthorityLockError,
+                    match="authority_lock_proof_forged",
+                ):
+                    await managed_cloud_consent._quarantine_on_connection(
+                        conn,
+                        uid=uid,
+                        user_id=owner.account_id,
+                        reason="synthetic_forgery_probe",
+                        owner_lock=forged,
+                    )
+
+        async with pool.acquire() as observer:
+            assert (
+                await observer.fetchval(
+                    """
+                    SELECT decision
+                    FROM ella_managed_cloud_consent_authority
+                    WHERE user_id = $1
+                    """,
+                    owner.account_id,
+                )
+                == "granted"
+            )
+            assert (
+                await observer.fetchval(
+                    "SELECT status FROM voice_entitlements WHERE uid = $1",
+                    uid,
+                )
+                == "active"
+            )
+
+    asyncio.run(_run_with_database(scenario))
+
+
 def test_synchronize_denial_owner_drift_after_unlocked_lookup_fails_closed_before_mutation(monkeypatch):
     async def scenario(pool):
         uid = "synthetic-owner-drift"
@@ -381,5 +1240,160 @@ def test_synchronize_denial_owner_drift_after_unlocked_lookup_fails_closed_befor
                 )
                 == "active"
             )
+
+    asyncio.run(_run_with_database(scenario))
+
+
+@pytest.mark.parametrize("writer_name", ("ensure_user_identity", "activate_user"))
+def test_users_writer_owner_drift_fails_closed_with_zero_protected_write(writer_name):
+    async def scenario(pool):
+        uid = f"synthetic-users-drift-{writer_name}"
+        email = f"{uid}@example.invalid"
+        async with pool.acquire() as conn:
+            original_id = await conn.fetchval(
+                """
+                INSERT INTO users (
+                    omi_uid, email, name, status, profile_class
+                ) VALUES (
+                    $1, $2, 'Original Owner', 'PENDING', 'synthetic'
+                )
+                RETURNING id
+                """,
+                uid,
+                email,
+            )
+        owner = authority_advisory_lock.AuthorityOwner.from_values(
+            original_id,
+            original_id,
+        )
+        repository = EllaProvisioningRepository(pool)
+        async with pool.acquire() as broker:
+            transaction = broker.transaction()
+            await transaction.start()
+            await authority_advisory_lock.acquire_authority_lock(
+                broker,
+                owner=owner,
+            )
+            if writer_name == "ensure_user_identity":
+                writer = asyncio.create_task(
+                    repository.ensure_user_identity(
+                        uid=uid,
+                        email=email,
+                        name="Unauthorized Update",
+                        timezone_name="UTC",
+                    )
+                )
+            else:
+                writer = asyncio.create_task(repository.activate_user(uid))
+
+            await _wait_for_advisory_waiter(pool, owner)
+            assert not writer.done()
+            async with pool.acquire() as drift:
+                async with drift.transaction():
+                    await drift.execute(
+                        """
+                        UPDATE users
+                        SET omi_uid = $2, email = $3
+                        WHERE id = $1
+                        """,
+                        original_id,
+                        f"{uid}-moved",
+                        f"{uid}-moved@example.invalid",
+                    )
+                    replacement_id = await drift.fetchval(
+                        """
+                        INSERT INTO users (
+                            omi_uid, email, name, status, profile_class
+                        ) VALUES (
+                            $1, $2, 'Replacement Owner', 'PENDING', 'synthetic'
+                        )
+                        RETURNING id
+                        """,
+                        uid,
+                        email,
+                    )
+            await transaction.commit()
+
+        with pytest.raises(
+            authority_advisory_lock.AuthorityLockError,
+            match="authority_lock_owner_drift",
+        ):
+            await asyncio.wait_for(writer, timeout=5)
+
+        async with pool.acquire() as observer:
+            original = await observer.fetchrow(
+                "SELECT name, status FROM users WHERE id = $1",
+                original_id,
+            )
+            replacement = await observer.fetchrow(
+                "SELECT name, status FROM users WHERE id = $1",
+                replacement_id,
+            )
+        assert tuple(original.values()) == ("Original Owner", "PENDING")
+        assert tuple(replacement.values()) == ("Replacement Owner", "PENDING")
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_new_identity_owner_collision_after_lookup_fails_closed():
+    async def scenario(pool):
+        uid = "synthetic-new-owner-collision"
+        email = f"{uid}@example.invalid"
+        owner = authority_advisory_lock.provisional_identity_owner(uid)
+        repository = EllaProvisioningRepository(pool)
+        async with pool.acquire() as broker:
+            transaction = broker.transaction()
+            await transaction.start()
+            await authority_advisory_lock.acquire_authority_lock(
+                broker,
+                owner=owner,
+            )
+            writer = asyncio.create_task(
+                repository.ensure_user_identity(
+                    uid=uid,
+                    email=email,
+                    name="Provisional Owner",
+                    timezone_name="UTC",
+                )
+            )
+            await _wait_for_advisory_waiter(pool, owner)
+            async with pool.acquire() as drift:
+                replacement_id = await drift.fetchval(
+                    """
+                    INSERT INTO users (
+                        omi_uid, email, name, status, profile_class
+                    ) VALUES (
+                        $1, $2, 'Replacement Owner', 'PENDING', 'synthetic'
+                    )
+                    RETURNING id
+                    """,
+                    uid,
+                    email,
+                )
+            await transaction.commit()
+
+        with pytest.raises(
+            authority_advisory_lock.AuthorityLockError,
+            match="authority_lock_owner_drift",
+        ):
+            await asyncio.wait_for(writer, timeout=5)
+        async with pool.acquire() as observer:
+            rows = await observer.fetch(
+                """
+                SELECT id, name, status
+                FROM users
+                WHERE omi_uid = $1 OR id = $2
+                ORDER BY id
+                """,
+                uid,
+                owner.account_id,
+            )
+        assert [dict(row) for row in rows] == [
+            {
+                "id": replacement_id,
+                "name": "Replacement Owner",
+                "status": "PENDING",
+            }
+        ]
 
     asyncio.run(_run_with_database(scenario))

--- a/backend/tests/postgres/test_invitation_redemption_postgres.py
+++ b/backend/tests/postgres/test_invitation_redemption_postgres.py
@@ -9,7 +9,12 @@ from typing import Awaitable, Callable, Iterable
 import asyncpg
 import pytest
 
-from database import invitations, managed_cloud_consent, voice_canary
+from database import (
+    authority_advisory_lock,
+    invitations,
+    managed_cloud_consent,
+    voice_canary,
+)
 from database.ella_provisioning import (
     EllaProvisioningRepository,
     RuntimePoolClaimError,
@@ -435,6 +440,211 @@ def test_same_uid_retry_is_idempotent_and_privacy_safe():
     asyncio.run(_run_with_database(scenario))
 
 
+def test_broker_lock_blocks_invitation_before_capacity_or_entitlement_mutation():
+    async def scenario(pool: asyncpg.Pool) -> None:
+        uid = "synthetic-broker-blocks-invite"
+        invitation_id, reservation_id = await _seed_invitation(
+            pool,
+            code="EFGH-2345",
+            target_uids=[uid],
+        )
+        async with pool.acquire() as conn:
+            user_id = await conn.fetchval(
+                "SELECT id FROM users WHERE omi_uid = $1",
+                uid,
+            )
+        owner = authority_advisory_lock.AuthorityOwner.from_values(
+            user_id,
+            user_id,
+        )
+        key = authority_advisory_lock.authority_lock_key(
+            str(owner.account_id),
+            str(owner.profile_id),
+        )
+        class_id, object_id = authority_advisory_lock._advisory_lock_parts(key)
+
+        async def snapshot():
+            async with pool.acquire() as observer:
+                row = await observer.fetchrow(
+                    """
+                    SELECT i.state, i.redemption_count, r.consumed_slots,
+                           (
+                               SELECT COUNT(*)::integer
+                               FROM voice_entitlements e
+                               WHERE e.uid = $3
+                           ) AS entitlement_count
+                    FROM ella_invitations i
+                    JOIN ella_invitation_capacity_reservations r
+                      ON r.id = i.capacity_reservation_id
+                    WHERE i.id = $1::uuid
+                      AND r.id = $2::uuid
+                    """,
+                    invitation_id,
+                    reservation_id,
+                    uid,
+                )
+                return tuple(row.values())
+
+        assert await snapshot() == ("sent", 0, 0, 0)
+        async with pool.acquire() as broker:
+            transaction = broker.transaction()
+            await transaction.start()
+            await authority_advisory_lock.acquire_authority_lock(
+                broker,
+                owner=owner,
+            )
+            redemption = asyncio.create_task(_redeem(uid, "EFGH-2345"))
+            for _attempt in range(100):
+                async with pool.acquire() as probe:
+                    waiting = await probe.fetchval(
+                        """
+                        SELECT EXISTS (
+                            SELECT 1
+                            FROM pg_locks
+                            WHERE locktype = 'advisory'
+                              AND classid::bigint = $1
+                              AND objid::bigint = $2
+                              AND objsubid = 1
+                              AND mode = 'ExclusiveLock'
+                              AND NOT granted
+                        )
+                        """,
+                        class_id,
+                        object_id,
+                    )
+                if waiting:
+                    break
+                await asyncio.sleep(0.02)
+            else:
+                pytest.fail("invitation writer never waited on the shared v1 lock")
+            assert not redemption.done()
+            assert await snapshot() == ("sent", 0, 0, 0)
+            await transaction.commit()
+
+        result = await asyncio.wait_for(redemption, timeout=5)
+        assert result["status"] == "invited"
+        assert await snapshot() == ("redeemed", 1, 1, 1)
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_invitation_reproves_owner_and_rolls_back_on_concurrent_drift():
+    async def scenario(pool: asyncpg.Pool) -> None:
+        uid = "synthetic-invite-owner-drift"
+        invitation_id, reservation_id = await _seed_invitation(
+            pool,
+            code="KMNP-2345",
+            target_uids=[uid],
+        )
+        async with pool.acquire() as conn:
+            user_id = await conn.fetchval(
+                "SELECT id FROM users WHERE omi_uid = $1",
+                uid,
+            )
+        owner = authority_advisory_lock.AuthorityOwner.from_values(
+            user_id,
+            user_id,
+        )
+        key = authority_advisory_lock.authority_lock_key(
+            str(owner.account_id),
+            str(owner.profile_id),
+        )
+        class_id, object_id = authority_advisory_lock._advisory_lock_parts(key)
+
+        async def snapshot():
+            async with pool.acquire() as observer:
+                row = await observer.fetchrow(
+                    """
+                    SELECT i.state, i.redemption_count, r.consumed_slots,
+                           (
+                               SELECT COUNT(*)::integer
+                               FROM voice_entitlements e
+                               WHERE e.uid = $3
+                           ) AS entitlement_count
+                    FROM ella_invitations i
+                    JOIN ella_invitation_capacity_reservations r
+                      ON r.id = i.capacity_reservation_id
+                    WHERE i.id = $1::uuid
+                      AND r.id = $2::uuid
+                    """,
+                    invitation_id,
+                    reservation_id,
+                    uid,
+                )
+                return tuple(row.values())
+
+        async with pool.acquire() as broker:
+            transaction = broker.transaction()
+            await transaction.start()
+            await authority_advisory_lock.acquire_authority_lock(
+                broker,
+                owner=owner,
+            )
+            redemption = asyncio.create_task(_redeem(uid, "KMNP-2345"))
+            for _attempt in range(100):
+                async with pool.acquire() as probe:
+                    waiting = await probe.fetchval(
+                        """
+                        SELECT EXISTS (
+                            SELECT 1
+                            FROM pg_locks
+                            WHERE locktype = 'advisory'
+                              AND classid::bigint = $1
+                              AND objid::bigint = $2
+                              AND objsubid = 1
+                              AND mode = 'ExclusiveLock'
+                              AND NOT granted
+                        )
+                        """,
+                        class_id,
+                        object_id,
+                    )
+                if waiting:
+                    break
+                await asyncio.sleep(0.02)
+            else:
+                pytest.fail("invitation writer never waited on the shared v1 lock")
+
+            async with pool.acquire() as drift:
+                async with drift.transaction():
+                    await drift.execute(
+                        "UPDATE users SET omi_uid = $2 WHERE id = $1",
+                        user_id,
+                        f"{uid}-moved",
+                    )
+                    replacement_id = await drift.fetchval(
+                        """
+                        INSERT INTO users (omi_uid, profile_class)
+                        VALUES ($1, 'synthetic')
+                        RETURNING id
+                        """,
+                        uid,
+                    )
+            await transaction.commit()
+
+        with pytest.raises(
+            authority_advisory_lock.AuthorityLockError,
+            match="authority_lock_owner_drift",
+        ):
+            await asyncio.wait_for(redemption, timeout=5)
+        assert await snapshot() == ("sent", 0, 0, 0)
+        async with pool.acquire() as observer:
+            assert (
+                await observer.fetchval(
+                    """
+                    SELECT COUNT(*)
+                    FROM ella_managed_cloud_consent_authority
+                    WHERE user_id IN ($1, $2)
+                    """,
+                    user_id,
+                    replacement_id,
+                )
+                == 0
+            )
+
+    asyncio.run(_run_with_database(scenario))
+
+
 def test_forwarded_or_cross_profile_code_cannot_mutate_capacity_or_entitlement():
     async def scenario(pool: asyncpg.Pool) -> None:
         owner = "synthetic-target-owner"
@@ -610,10 +820,11 @@ def test_revocation_started_after_revalidation_is_serialized_and_quarantines_gra
         resume_before_insert = asyncio.Event()
         original_lock = managed_cloud_consent.lock_or_bootstrap_grant_on_connection
 
-        async def pause_after_revalidation(conn, *, grant, owner_lock):
+        async def pause_after_revalidation(conn, *, grant, owner, owner_lock):
             epoch = await original_lock(
                 conn,
                 grant=grant,
+                owner=owner,
                 owner_lock=owner_lock,
             )
             authority_locked.set()

--- a/backend/tests/postgres/test_invitation_redemption_postgres.py
+++ b/backend/tests/postgres/test_invitation_redemption_postgres.py
@@ -610,8 +610,12 @@ def test_revocation_started_after_revalidation_is_serialized_and_quarantines_gra
         resume_before_insert = asyncio.Event()
         original_lock = managed_cloud_consent.lock_or_bootstrap_grant_on_connection
 
-        async def pause_after_revalidation(conn, *, grant):
-            epoch = await original_lock(conn, grant=grant)
+        async def pause_after_revalidation(conn, *, grant, owner_lock):
+            epoch = await original_lock(
+                conn,
+                grant=grant,
+                owner_lock=owner_lock,
+            )
             authority_locked.set()
             await resume_before_insert.wait()
             return epoch

--- a/backend/tests/unit/test_authority_advisory_lock.py
+++ b/backend/tests/unit/test_authority_advisory_lock.py
@@ -23,6 +23,11 @@ from database.authority_advisory_lock import (
 )
 
 
+class UUIDStringifiable:
+    def __str__(self):
+        return "00000000-0000-4000-8000-000000000000"
+
+
 def test_vendored_contract_artifact_has_exact_reviewed_bytes():
     artifact_path = contract_artifact_path()
     assert artifact_path == Path(__file__).resolve().parents[2] / "contracts" / "authority_advisory_lock_v1.json"
@@ -49,6 +54,10 @@ def test_all_six_cross_repo_vectors_match_exact_bytes_digest_and_signed_key():
         (None, "authority_lock_owner_missing"),
         ("", "authority_lock_owner_missing"),
         (b"00000000-0000-4000-8000-000000000000", "authority_lock_owner_not_text"),
+        (uuid.UUID("00000000-0000-4000-8000-000000000000"), "authority_lock_owner_not_text"),
+        (UUIDStringifiable(), "authority_lock_owner_not_text"),
+        (123, "authority_lock_owner_not_text"),
+        (["00000000-0000-4000-8000-000000000000"], "authority_lock_owner_not_text"),
         ("{00000000-0000-4000-8000-000000000000}", "authority_lock_owner_not_canonical_uuid"),
         ("urn:uuid:00000000-0000-4000-8000-000000000000", "authority_lock_owner_not_canonical_uuid"),
         ("00000000000040008000000000000000", "authority_lock_owner_not_canonical_uuid"),
@@ -63,6 +72,38 @@ def test_noncanonical_owner_forms_fail_closed_without_echoing_value(value, code)
         assert str(value) not in str(raised.value)
 
 
+@pytest.mark.parametrize(
+    "value",
+    (
+        uuid.UUID("00000000-0000-4000-8000-000000000000"),
+        UUIDStringifiable(),
+        123,
+        ["00000000-0000-4000-8000-000000000000"],
+        b"00000000-0000-4000-8000-000000000000",
+    ),
+)
+def test_key_contract_rejects_non_text_owners(value):
+    canonical = "11111111-1111-4111-8111-111111111111"
+    with pytest.raises(AuthorityLockError, match="authority_lock_owner_not_text"):
+        authority_lock_key(value, canonical)
+    with pytest.raises(AuthorityLockError, match="authority_lock_owner_not_text"):
+        authority_lock_key(canonical, value)
+
+
+def test_authority_owner_accepts_only_trusted_database_uuid_values():
+    account_id = uuid.UUID("11111111-1111-4111-8111-111111111111")
+    profile_id = uuid.UUID("22222222-2222-4222-8222-222222222222")
+
+    assert AuthorityOwner.from_values(account_id, profile_id) == AuthorityOwner(
+        account_id=account_id,
+        profile_id=profile_id,
+    )
+    with pytest.raises(AuthorityLockError, match="authority_lock_owner_not_database_uuid"):
+        AuthorityOwner.from_values(str(account_id), profile_id)
+    with pytest.raises(AuthorityLockError, match="authority_lock_owner_not_database_uuid"):
+        AuthorityOwner.from_values(account_id, UUIDStringifiable())
+
+
 def test_account_profile_order_is_part_of_key():
     account_id = "11111111-1111-4111-8111-111111111111"
     profile_id = "22222222-2222-4222-8222-222222222222"
@@ -75,7 +116,7 @@ def test_self_owner_proof_rejects_missing_and_cross_owner_values():
     owner = AuthorityOwner.from_values(owner_id, owner_id)
     proof = AuthorityLockProof(
         owner=owner,
-        key=authority_lock_key(owner_id, owner_id),
+        key=authority_lock_key(str(owner_id), str(owner_id)),
     )
 
     require_self_owner_lock(proof, user_id=owner_id)
@@ -97,8 +138,8 @@ def test_acquisition_uses_one_signed_bigint_and_returns_owner_proof():
             self.calls.append((query, args))
             return "SELECT 1"
 
-    account_id = "11111111-1111-4111-8111-111111111111"
-    profile_id = "22222222-2222-4222-8222-222222222222"
+    account_id = uuid.UUID("11111111-1111-4111-8111-111111111111")
+    profile_id = uuid.UUID("22222222-2222-4222-8222-222222222222")
     owner = AuthorityOwner.from_values(account_id, profile_id)
     connection = Connection()
 
@@ -106,7 +147,7 @@ def test_acquisition_uses_one_signed_bigint_and_returns_owner_proof():
 
     assert proof == AuthorityLockProof(
         owner=owner,
-        key=authority_lock_key(account_id, profile_id),
+        key=authority_lock_key(str(account_id), str(profile_id)),
     )
     assert connection.calls == [
         (

--- a/backend/tests/unit/test_authority_advisory_lock.py
+++ b/backend/tests/unit/test_authority_advisory_lock.py
@@ -1,0 +1,116 @@
+import asyncio
+import hashlib
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+
+from database.authority_advisory_lock import (
+    AUTHORITY_LOCK_DOMAIN,
+    CONTRACT_ARTIFACT_SHA256,
+    AuthorityLockError,
+    AuthorityLockProof,
+    AuthorityOwner,
+    acquire_authority_lock,
+    authority_lock_digest,
+    authority_lock_key,
+    authority_lock_preimage,
+    canonical_uuid_bytes,
+    contract_artifact_path,
+    load_verified_contract_artifact,
+    require_self_owner_lock,
+)
+
+
+def test_vendored_contract_artifact_has_exact_reviewed_bytes():
+    artifact_path = contract_artifact_path()
+    assert artifact_path == Path(__file__).resolve().parents[2] / "contracts" / "authority_advisory_lock_v1.json"
+    assert hashlib.sha256(artifact_path.read_bytes()).hexdigest() == CONTRACT_ARTIFACT_SHA256
+    artifact = load_verified_contract_artifact()
+    assert artifact["version"] == "1"
+    assert artifact["encoding"]["domain_ascii"] == AUTHORITY_LOCK_DOMAIN.decode("ascii")
+    assert len(artifact["test_vectors"]) == 6
+
+
+def test_all_six_cross_repo_vectors_match_exact_bytes_digest_and_signed_key():
+    vectors = json.loads(contract_artifact_path().read_text(encoding="utf-8"))["test_vectors"]
+    for vector in vectors:
+        preimage = authority_lock_preimage(vector["account_id"], vector["profile_id"])
+        assert len(preimage) == vector["preimage_length"]
+        assert preimage.hex() == vector["preimage_hex"]
+        assert authority_lock_digest(vector["account_id"], vector["profile_id"]).hex() == vector["sha256_hex"]
+        assert authority_lock_key(vector["account_id"], vector["profile_id"]) == vector["advisory_key_int64"]
+
+
+@pytest.mark.parametrize(
+    ("value", "code"),
+    (
+        (None, "authority_lock_owner_missing"),
+        ("", "authority_lock_owner_missing"),
+        (b"00000000-0000-4000-8000-000000000000", "authority_lock_owner_not_text"),
+        ("{00000000-0000-4000-8000-000000000000}", "authority_lock_owner_not_canonical_uuid"),
+        ("urn:uuid:00000000-0000-4000-8000-000000000000", "authority_lock_owner_not_canonical_uuid"),
+        ("00000000000040008000000000000000", "authority_lock_owner_not_canonical_uuid"),
+        ("not-an-owner", "authority_lock_owner_not_canonical_uuid"),
+    ),
+)
+def test_noncanonical_owner_forms_fail_closed_without_echoing_value(value, code):
+    with pytest.raises(AuthorityLockError) as raised:
+        canonical_uuid_bytes(value, field="account_id")
+    assert raised.value.code == code
+    if value not in (None, ""):
+        assert str(value) not in str(raised.value)
+
+
+def test_account_profile_order_is_part_of_key():
+    account_id = "11111111-1111-4111-8111-111111111111"
+    profile_id = "22222222-2222-4222-8222-222222222222"
+    assert authority_lock_key(account_id, profile_id) != authority_lock_key(profile_id, account_id)
+
+
+def test_self_owner_proof_rejects_missing_and_cross_owner_values():
+    owner_id = uuid.uuid4()
+    other_id = uuid.uuid4()
+    owner = AuthorityOwner.from_values(owner_id, owner_id)
+    proof = AuthorityLockProof(
+        owner=owner,
+        key=authority_lock_key(owner_id, owner_id),
+    )
+
+    require_self_owner_lock(proof, user_id=owner_id)
+    with pytest.raises(AuthorityLockError, match="authority_lock_proof_missing"):
+        require_self_owner_lock(None, user_id=owner_id)
+    with pytest.raises(
+        AuthorityLockError,
+        match="authority_lock_proof_owner_mismatch",
+    ):
+        require_self_owner_lock(proof, user_id=other_id)
+
+
+def test_acquisition_uses_one_signed_bigint_and_returns_owner_proof():
+    class Connection:
+        def __init__(self):
+            self.calls = []
+
+        async def execute(self, query, *args):
+            self.calls.append((query, args))
+            return "SELECT 1"
+
+    account_id = "11111111-1111-4111-8111-111111111111"
+    profile_id = "22222222-2222-4222-8222-222222222222"
+    owner = AuthorityOwner.from_values(account_id, profile_id)
+    connection = Connection()
+
+    proof = asyncio.run(acquire_authority_lock(connection, owner=owner))
+
+    assert proof == AuthorityLockProof(
+        owner=owner,
+        key=authority_lock_key(account_id, profile_id),
+    )
+    assert connection.calls == [
+        (
+            "SELECT pg_advisory_xact_lock($1::bigint)",
+            (proof.key,),
+        )
+    ]

--- a/backend/tests/unit/test_authority_advisory_lock.py
+++ b/backend/tests/unit/test_authority_advisory_lock.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import hashlib
 import json
 import uuid
@@ -110,34 +111,51 @@ def test_account_profile_order_is_part_of_key():
     assert authority_lock_key(account_id, profile_id) != authority_lock_key(profile_id, account_id)
 
 
-def test_self_owner_proof_rejects_missing_and_cross_owner_values():
+class Connection:
+    def __init__(self, *, backend_pid=1234, transaction_id=5678, lock_held=True):
+        self.backend_pid = backend_pid
+        self.transaction_id = transaction_id
+        self.lock_held = lock_held
+        self.calls = []
+
+    async def execute(self, query, *args):
+        self.calls.append(("execute", query, args))
+        return "SELECT 1"
+
+    async def fetchrow(self, query, *args):
+        self.calls.append(("fetchrow", query, args))
+        return {
+            "backend_pid": self.backend_pid,
+            "transaction_id": self.transaction_id,
+            "lock_held": self.lock_held,
+        }
+
+
+def test_self_owner_proof_rejects_missing_cross_owner_forged_and_copied_values():
     owner_id = uuid.uuid4()
     other_id = uuid.uuid4()
     owner = AuthorityOwner.from_values(owner_id, owner_id)
-    proof = AuthorityLockProof(
-        owner=owner,
-        key=authority_lock_key(str(owner_id), str(owner_id)),
-    )
+    connection = Connection()
+    proof = asyncio.run(acquire_authority_lock(connection, owner=owner))
 
-    require_self_owner_lock(proof, user_id=owner_id)
+    asyncio.run(require_self_owner_lock(connection, proof, user_id=owner_id))
     with pytest.raises(AuthorityLockError, match="authority_lock_proof_missing"):
-        require_self_owner_lock(None, user_id=owner_id)
+        asyncio.run(require_self_owner_lock(connection, None, user_id=owner_id))
     with pytest.raises(
         AuthorityLockError,
         match="authority_lock_proof_owner_mismatch",
     ):
-        require_self_owner_lock(proof, user_id=other_id)
+        asyncio.run(require_self_owner_lock(connection, proof, user_id=other_id))
+    with pytest.raises(AuthorityLockError, match="authority_lock_proof_construction_forbidden"):
+        AuthorityLockProof()
+    forged = object.__new__(AuthorityLockProof)
+    with pytest.raises(AuthorityLockError, match="authority_lock_proof_forged"):
+        asyncio.run(require_self_owner_lock(connection, forged, user_id=owner_id))
+    with pytest.raises(AuthorityLockError, match="authority_lock_proof_copy_forbidden"):
+        copy.copy(proof)
 
 
 def test_acquisition_uses_one_signed_bigint_and_returns_owner_proof():
-    class Connection:
-        def __init__(self):
-            self.calls = []
-
-        async def execute(self, query, *args):
-            self.calls.append((query, args))
-            return "SELECT 1"
-
     account_id = uuid.UUID("11111111-1111-4111-8111-111111111111")
     profile_id = uuid.UUID("22222222-2222-4222-8222-222222222222")
     owner = AuthorityOwner.from_values(account_id, profile_id)
@@ -145,13 +163,29 @@ def test_acquisition_uses_one_signed_bigint_and_returns_owner_proof():
 
     proof = asyncio.run(acquire_authority_lock(connection, owner=owner))
 
-    assert proof == AuthorityLockProof(
-        owner=owner,
-        key=authority_lock_key(str(account_id), str(profile_id)),
+    expected_key = authority_lock_key(str(account_id), str(profile_id))
+    assert type(proof) is AuthorityLockProof
+    assert repr(proof) == "AuthorityLockProof(<opaque>)"
+    assert connection.calls[0] == (
+        "execute",
+        "SELECT pg_advisory_xact_lock($1::bigint)",
+        (expected_key,),
     )
-    assert connection.calls == [
-        (
-            "SELECT pg_advisory_xact_lock($1::bigint)",
-            (proof.key,),
+    assert connection.calls[1][0] == "fetchrow"
+    assert connection.calls[1][2] == (
+        (expected_key & ((1 << 64) - 1)) >> 32,
+        expected_key & 0xFFFFFFFF,
+    )
+
+
+def test_acquisition_fails_when_transaction_lock_is_not_observable():
+    owner_id = uuid.uuid4()
+    owner = AuthorityOwner.from_values(owner_id, owner_id)
+    connection = Connection(lock_held=False)
+    with pytest.raises(AuthorityLockError, match="authority_lock_not_held"):
+        asyncio.run(
+            acquire_authority_lock(
+                connection,
+                owner=owner,
+            )
         )
-    ]

--- a/backend/tests/unit/test_authority_writer_guard.py
+++ b/backend/tests/unit/test_authority_writer_guard.py
@@ -1,0 +1,112 @@
+import ast
+import re
+from pathlib import Path
+
+BACKEND = Path(__file__).resolve().parents[2]
+PROTECTED_TABLES = {
+    "ella_managed_cloud_consent_authority",
+    "voice_entitlements",
+    "ella_runtime_targets",
+    "ella_runtime_bindings",
+}
+MUTATION_RE = re.compile(
+    r"\b(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+"
+    r"(ella_managed_cloud_consent_authority|voice_entitlements|"
+    r"ella_runtime_targets|ella_runtime_bindings)\b",
+    re.IGNORECASE,
+)
+
+EXPECTED_WRITERS = {
+    ("database/ella_provisioning.py", "activate_runtime_binding"),
+    ("database/ella_provisioning.py", "claim_cloud_pool_binding"),
+    ("database/ella_provisioning.py", "finalize_cloud_pool_claim"),
+    ("database/ella_provisioning.py", "promote_cloud_binding"),
+    ("database/ella_provisioning.py", "quarantine_cloud_pool_claim"),
+    ("database/ella_provisioning.py", "register_cloud_pool_binding"),
+    ("database/ella_provisioning.py", "stage_runtime_binding"),
+    ("database/invitations.py", "_redeem_locked_invitation"),
+    ("database/managed_cloud_consent.py", "_quarantine_on_connection"),
+    ("database/managed_cloud_consent.py", "lock_or_bootstrap_grant_on_connection"),
+    ("database/managed_cloud_consent.py", "synchronize_denial"),
+    ("database/managed_cloud_consent.py", "synchronize_grant"),
+    ("database/voice_canary.py", "delete_user_voice_data"),
+    ("database/voice_canary.py", "update_entitlement_status"),
+    ("database/voice_canary.py", "upsert_entitlement"),
+}
+
+DIRECT_LOCKED_WRITERS = EXPECTED_WRITERS - {
+    ("database/ella_provisioning.py", "register_cloud_pool_binding"),
+    ("database/invitations.py", "_redeem_locked_invitation"),
+    ("database/managed_cloud_consent.py", "_quarantine_on_connection"),
+    ("database/managed_cloud_consent.py", "lock_or_bootstrap_grant_on_connection"),
+}
+
+PROOF_GATED_HELPERS = {
+    ("database/invitations.py", "_redeem_locked_invitation"),
+    ("database/managed_cloud_consent.py", "_quarantine_on_connection"),
+    ("database/managed_cloud_consent.py", "lock_or_bootstrap_grant_on_connection"),
+}
+
+
+def _functions_with_protected_mutations():
+    writers = {}
+    for directory in ("database", "scripts"):
+        for path in sorted((BACKEND / directory).glob("*.py")):
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                    continue
+                strings = "\n".join(
+                    item.value
+                    for item in ast.walk(node)
+                    if isinstance(item, ast.Constant) and isinstance(item.value, str)
+                )
+                tables = set(MUTATION_RE.findall(strings))
+                if tables:
+                    key = (str(path.relative_to(BACKEND)), node.name)
+                    writers[key] = {
+                        "source": ast.get_source_segment(source, node) or "",
+                        "tables": {table.lower() for table in tables},
+                    }
+    return writers
+
+
+def test_protected_authority_writer_inventory_is_closed_and_explicit():
+    writers = _functions_with_protected_mutations()
+    assert set(writers) == EXPECTED_WRITERS
+    assert set().union(*(entry["tables"] for entry in writers.values())) == PROTECTED_TABLES
+    assert not any(path.startswith("scripts/") for path, _function in writers)
+
+
+def test_every_owner_bound_writer_has_direct_lock_or_lock_proof():
+    writers = _functions_with_protected_mutations()
+    for key in DIRECT_LOCKED_WRITERS:
+        source = writers[key]["source"]
+        assert "acquire_authority_lock(" in source, key
+        assert re.search(
+            r"async with [^\n]+\.transaction\(\):\n"
+            r"\s+(?:owner_lock = )?await authority_advisory_lock"
+            r"\.acquire_authority_lock\(",
+            source,
+        ), key
+        assert source.index("acquire_authority_lock(") < min(
+            index for token in ("INSERT INTO", "UPDATE ", "DELETE FROM") if (index := source.find(token)) >= 0
+        ), key
+    for key in PROOF_GATED_HELPERS:
+        source = writers[key]["source"]
+        assert "owner_lock" in source, key
+        if key[1] != "_redeem_locked_invitation":
+            assert "require_self_owner_lock(" in source, key
+
+
+def test_unowned_pool_registration_is_the_only_authority_neutral_exception():
+    source = _functions_with_protected_mutations()[("database/ella_provisioning.py", "register_cloud_pool_binding")][
+        "source"
+    ]
+    assert "'pool_available'" in source
+    assert "$1, NULL, 'user', 'hermes_cloud', 'pool_available'" in source
+    assert "'healthy', $16::jsonb, 1, false" in source
+    assert "DO NOTHING" in source
+    assert "DO UPDATE" not in source
+    assert "runtime_instance_already_claimed" in source

--- a/backend/tests/unit/test_authority_writer_guard.py
+++ b/backend/tests/unit/test_authority_writer_guard.py
@@ -78,7 +78,7 @@ REAL_POSTGRES_WRITER_COVERAGE = {
     ),
     ("database/ella_provisioning.py", "ensure_user_identity"): (
         "tests/postgres/test_authority_advisory_lock_postgres.py",
-        '"identity_create"',
+        ('"identity_create"', '"identity_update"', '"identity_bind"'),
     ),
     ("database/ella_provisioning.py", "finalize_cloud_pool_claim"): (
         "tests/postgres/test_authority_advisory_lock_postgres.py",
@@ -206,9 +206,10 @@ def test_every_owner_bound_writer_is_pinned_to_real_postgres_contention_coverage
     assert set(REAL_POSTGRES_WRITER_COVERAGE) == EXPECTED_WRITERS - {
         ("database/ella_provisioning.py", "register_cloud_pool_binding"),
     }
-    for key, (relative_path, marker) in REAL_POSTGRES_WRITER_COVERAGE.items():
+    for key, (relative_path, marker_spec) in REAL_POSTGRES_WRITER_COVERAGE.items():
         source = (BACKEND / relative_path).read_text(encoding="utf-8")
-        assert marker in source, key
+        markers = (marker_spec,) if isinstance(marker_spec, str) else marker_spec
+        assert all(marker in source for marker in markers), key
 
 
 def test_every_owner_bound_writer_has_direct_lock_or_lock_proof():

--- a/backend/tests/unit/test_authority_writer_guard.py
+++ b/backend/tests/unit/test_authority_writer_guard.py
@@ -84,15 +84,18 @@ def test_every_owner_bound_writer_has_direct_lock_or_lock_proof():
     for key in DIRECT_LOCKED_WRITERS:
         source = writers[key]["source"]
         assert "acquire_authority_lock(" in source, key
+        assert "verify_self_owner_after_lock(" in source, key
         assert re.search(
             r"async with [^\n]+\.transaction\(\):\n"
             r"\s+(?:owner_lock = )?await authority_advisory_lock"
             r"\.acquire_authority_lock\(",
             source,
         ), key
-        assert source.index("acquire_authority_lock(") < min(
+        first_mutation = min(
             index for token in ("INSERT INTO", "UPDATE ", "DELETE FROM") if (index := source.find(token)) >= 0
-        ), key
+        )
+        assert source.index("acquire_authority_lock(") < source.index("verify_self_owner_after_lock("), key
+        assert source.index("verify_self_owner_after_lock(") < first_mutation, key
     for key in PROOF_GATED_HELPERS:
         source = writers[key]["source"]
         assert "owner_lock" in source, key

--- a/backend/tests/unit/test_authority_writer_guard.py
+++ b/backend/tests/unit/test_authority_writer_guard.py
@@ -8,17 +8,24 @@ PROTECTED_TABLES = {
     "voice_entitlements",
     "ella_runtime_targets",
     "ella_runtime_bindings",
+    "users",
 }
 MUTATION_RE = re.compile(
     r"\b(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+"
     r"(ella_managed_cloud_consent_authority|voice_entitlements|"
-    r"ella_runtime_targets|ella_runtime_bindings)\b",
+    r"ella_runtime_targets|ella_runtime_bindings|users)\b",
+    re.IGNORECASE,
+)
+USER_MUTATION_RE = re.compile(
+    r"\b(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+users\b",
     re.IGNORECASE,
 )
 
 EXPECTED_WRITERS = {
     ("database/ella_provisioning.py", "activate_runtime_binding"),
+    ("database/ella_provisioning.py", "activate_user"),
     ("database/ella_provisioning.py", "claim_cloud_pool_binding"),
+    ("database/ella_provisioning.py", "ensure_user_identity"),
     ("database/ella_provisioning.py", "finalize_cloud_pool_claim"),
     ("database/ella_provisioning.py", "promote_cloud_binding"),
     ("database/ella_provisioning.py", "quarantine_cloud_pool_claim"),
@@ -46,6 +53,82 @@ PROOF_GATED_HELPERS = {
     ("database/managed_cloud_consent.py", "_quarantine_on_connection"),
     ("database/managed_cloud_consent.py", "lock_or_bootstrap_grant_on_connection"),
 }
+EXPECTED_GLOBAL_USER_WRITERS = {
+    ("database/ella_provisioning.py", "activate_runtime_binding"),
+    ("database/ella_provisioning.py", "activate_user"),
+    ("database/ella_provisioning.py", "ensure_user_identity"),
+    ("database/ella_provisioning.py", "finalize_cloud_pool_claim"),
+    ("ella/utils/auto_provision.py", "auto_provision_user"),
+}
+NON_AUTHORITY_USER_WRITERS = {
+    ("ella/utils/auto_provision.py", "auto_provision_user"),
+}
+REAL_POSTGRES_WRITER_COVERAGE = {
+    ("database/ella_provisioning.py", "activate_runtime_binding"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        '"runtime_activate"',
+    ),
+    ("database/ella_provisioning.py", "activate_user"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        '"user_activate"',
+    ),
+    ("database/ella_provisioning.py", "claim_cloud_pool_binding"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        '"cloud_claim"',
+    ),
+    ("database/ella_provisioning.py", "ensure_user_identity"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        '"identity_create"',
+    ),
+    ("database/ella_provisioning.py", "finalize_cloud_pool_claim"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        '"cloud_finalize"',
+    ),
+    ("database/ella_provisioning.py", "promote_cloud_binding"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        '"cloud_promote"',
+    ),
+    ("database/ella_provisioning.py", "quarantine_cloud_pool_claim"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        '"cloud_quarantine"',
+    ),
+    ("database/ella_provisioning.py", "stage_runtime_binding"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        '"runtime_stage"',
+    ),
+    ("database/invitations.py", "_redeem_locked_invitation"): (
+        "tests/postgres/test_invitation_redemption_postgres.py",
+        "test_broker_lock_blocks_invitation_before_capacity_or_entitlement_mutation",
+    ),
+    ("database/managed_cloud_consent.py", "_quarantine_on_connection"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        '"consent_regrant"',
+    ),
+    ("database/managed_cloud_consent.py", "lock_or_bootstrap_grant_on_connection"): (
+        "tests/postgres/test_invitation_redemption_postgres.py",
+        "test_broker_lock_blocks_invitation_before_capacity_or_entitlement_mutation",
+    ),
+    ("database/managed_cloud_consent.py", "synchronize_denial"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        "test_broker_lock_blocks_omi_revoke_until_release_without_partial_mutation",
+    ),
+    ("database/managed_cloud_consent.py", "synchronize_grant"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        '"consent_grant"',
+    ),
+    ("database/voice_canary.py", "delete_user_voice_data"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        '"entitlement_delete"',
+    ),
+    ("database/voice_canary.py", "update_entitlement_status"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        '"entitlement_status"',
+    ),
+    ("database/voice_canary.py", "upsert_entitlement"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        '"entitlement_upsert"',
+    ),
+}
 
 
 def _functions_with_protected_mutations():
@@ -72,6 +155,31 @@ def _functions_with_protected_mutations():
     return writers
 
 
+def _functions_with_global_user_mutations():
+    writers = {}
+    for directory in ("database", "ella", "scripts"):
+        for path in sorted((BACKEND / directory).rglob("*.py")):
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                    continue
+                mutation_strings = [
+                    item.value
+                    for item in ast.walk(node)
+                    if isinstance(item, ast.Constant)
+                    and isinstance(item.value, str)
+                    and USER_MUTATION_RE.search(item.value)
+                ]
+                if mutation_strings:
+                    key = (str(path.relative_to(BACKEND)), node.name)
+                    writers[key] = {
+                        "source": ast.get_source_segment(source, node) or "",
+                        "mutations": mutation_strings,
+                    }
+    return writers
+
+
 def test_protected_authority_writer_inventory_is_closed_and_explicit():
     writers = _functions_with_protected_mutations()
     assert set(writers) == EXPECTED_WRITERS
@@ -79,23 +187,54 @@ def test_protected_authority_writer_inventory_is_closed_and_explicit():
     assert not any(path.startswith("scripts/") for path, _function in writers)
 
 
+def test_global_users_writer_inventory_is_closed_and_authority_scoped():
+    writers = _functions_with_global_user_mutations()
+    assert set(writers) == EXPECTED_GLOBAL_USER_WRITERS
+    assert set(writers) - NON_AUTHORITY_USER_WRITERS <= EXPECTED_WRITERS
+
+    legacy_phone_write = writers[("ella/utils/auto_provision.py", "auto_provision_user")]
+    assert len(legacy_phone_write["mutations"]) == 1
+    statement = legacy_phone_write["mutations"][0]
+    set_clause = statement.upper().split(" SET ", 1)[1].split(" WHERE ", 1)[0]
+    assert "IDENTITIES =" in set_clause
+    assert not any(
+        f"{column.upper()} =" in set_clause for column in ("id", "omi_uid", "email", "profile_class", "status")
+    )
+
+
+def test_every_owner_bound_writer_is_pinned_to_real_postgres_contention_coverage():
+    assert set(REAL_POSTGRES_WRITER_COVERAGE) == EXPECTED_WRITERS - {
+        ("database/ella_provisioning.py", "register_cloud_pool_binding"),
+    }
+    for key, (relative_path, marker) in REAL_POSTGRES_WRITER_COVERAGE.items():
+        source = (BACKEND / relative_path).read_text(encoding="utf-8")
+        assert marker in source, key
+
+
 def test_every_owner_bound_writer_has_direct_lock_or_lock_proof():
     writers = _functions_with_protected_mutations()
     for key in DIRECT_LOCKED_WRITERS:
         source = writers[key]["source"]
         assert "acquire_authority_lock(" in source, key
-        assert "verify_self_owner_after_lock(" in source, key
+        verification_indices = [
+            source.index(token)
+            for token in ("verify_self_owner_after_lock(", "verify_identity_owner_after_lock(")
+            if token in source
+        ]
+        assert verification_indices, key
         assert re.search(
             r"async with [^\n]+\.transaction\(\):\n"
-            r"\s+(?:owner_lock = )?await authority_advisory_lock"
+            r"\s+owner_lock = await authority_advisory_lock"
             r"\.acquire_authority_lock\(",
             source,
         ), key
+        assert "proof=owner_lock" in source, key
         first_mutation = min(
             index for token in ("INSERT INTO", "UPDATE ", "DELETE FROM") if (index := source.find(token)) >= 0
         )
-        assert source.index("acquire_authority_lock(") < source.index("verify_self_owner_after_lock("), key
-        assert source.index("verify_self_owner_after_lock(") < first_mutation, key
+        verification_index = min(verification_indices)
+        assert source.index("acquire_authority_lock(") < verification_index, key
+        assert verification_index < first_mutation, key
     for key in PROOF_GATED_HELPERS:
         source = writers[key]["source"]
         assert "owner_lock" in source, key

--- a/backend/tests/unit/test_ella_provisioning_repository.py
+++ b/backend/tests/unit/test_ella_provisioning_repository.py
@@ -20,6 +20,16 @@ LINEAGE = RuntimeTargetLineage(
 )
 
 
+def _lock_state_row(query):
+    if "pg_backend_pid() AS backend_pid" in query:
+        return {
+            "backend_pid": 101,
+            "transaction_id": 202,
+            "lock_held": True,
+        }
+    return None
+
+
 class _AsyncContext:
     def __init__(self, value):
         self.value = value
@@ -38,8 +48,22 @@ class _Connection:
     def transaction(self):
         return _AsyncContext(self)
 
+    async def execute(self, query, *_args):
+        self.queries.append(query)
+        if "pg_advisory_xact_lock" in query:
+            return "SELECT 1"
+        raise AssertionError(query)
+
+    async def fetch(self, query, *_args):
+        self.queries.append(query)
+        if "FROM users" in query:
+            return []
+        raise AssertionError(query)
+
     async def fetchrow(self, query, *args):
         self.queries.append(query)
+        if lock_state := _lock_state_row(query):
+            return lock_state
         if "INSERT INTO users" not in query:
             return None
 
@@ -71,6 +95,8 @@ class _LookupPool:
 
     async def fetchrow(self, query, *args):
         self.calls.append((query, args))
+        if lock_state := _lock_state_row(query):
+            return lock_state
         if "SELECT id FROM users WHERE omi_uid" in query:
             owner_id = self.owner_id
             if owner_id is None and isinstance(self.result, dict):
@@ -118,7 +144,7 @@ def test_fresh_identity_insert_casts_jsonb_parameters():
         "status": "PENDING",
     }
     assert isinstance(result["id"], uuid.UUID)
-    assert len(connection.queries) == 3
+    assert len(connection.queries) == 6
 
 
 def test_retained_runtime_requires_active_owned_cluster_with_agent_id():
@@ -173,6 +199,8 @@ class _CloudClaimConnection:
 
     async def fetchrow(self, query, *args):
         self.queries.append(query)
+        if lock_state := _lock_state_row(query):
+            return lock_state
         if "SELECT id FROM users WHERE omi_uid" in query:
             return {"id": self.user_id}
         if "FROM voice_entitlements" in query:
@@ -382,6 +410,8 @@ class _ExpiredFinalizeConnection:
         raise AssertionError(query)
 
     async def fetchrow(self, query, *args):
+        if lock_state := _lock_state_row(query):
+            return lock_state
         if "SELECT id FROM users WHERE omi_uid" in query:
             return {"id": self.user_id}
         if "b.claim_job_id = $2" in query:

--- a/backend/tests/unit/test_ella_provisioning_repository.py
+++ b/backend/tests/unit/test_ella_provisioning_repository.py
@@ -64,12 +64,25 @@ class _Pool:
 
 
 class _LookupPool:
-    def __init__(self, result):
+    def __init__(self, result, *, owner_id=None):
         self.result = result
+        self.owner_id = owner_id
         self.calls = []
 
     async def fetchrow(self, query, *args):
         self.calls.append((query, args))
+        if "SELECT id FROM users WHERE omi_uid" in query:
+            owner_id = self.owner_id
+            if owner_id is None and isinstance(self.result, dict):
+                owner_id = (
+                    self.result.get("account_user_id")
+                    or self.result.get("profile_user_id")
+                    or self.result.get("user_id")
+                    or self.result.get("id")
+                )
+            return {"id": owner_id}
+        if "SELECT id FROM users WHERE omi_uid" in query and "FOR UPDATE" in query:
+            return {"id": self.owner_id}
         return self.result
 
     async def execute(self, query, *args):
@@ -160,6 +173,8 @@ class _CloudClaimConnection:
 
     async def fetchrow(self, query, *args):
         self.queries.append(query)
+        if "SELECT id FROM users WHERE omi_uid" in query:
+            return {"id": self.user_id}
         if "FROM voice_entitlements" in query:
             return {
                 "uid": args[0],
@@ -355,14 +370,24 @@ def test_cloud_pool_registration_persists_prompt_artifact_receipt():
 
 
 class _ExpiredFinalizeConnection:
+    def __init__(self):
+        self.user_id = uuid.uuid4()
+
     def transaction(self):
         return _AsyncContext(self)
 
+    async def execute(self, query, *_args):
+        if "pg_advisory_xact_lock" in query:
+            return "SELECT 1"
+        raise AssertionError(query)
+
     async def fetchrow(self, query, *args):
+        if "SELECT id FROM users WHERE omi_uid" in query:
+            return {"id": self.user_id}
         if "b.claim_job_id = $2" in query:
             return {
                 "id": uuid.uuid4(),
-                "user_id": uuid.uuid4(),
+                "user_id": self.user_id,
                 "role": "user",
                 "status": "claiming",
                 "api_base_url_ref": "env:ELLA_HERMES_CLOUD_API_URL_SYNTHETIC",
@@ -528,14 +553,15 @@ def test_runtime_interaction_claim_serializes_scope_and_assigns_predecessor_at_c
 
 
 def test_shadow_promotion_is_explicit_owner_scoped_revision_cas(monkeypatch):
+    owner_id = uuid.uuid4()
     pool = _LookupPool(
         {
             "id": uuid.uuid4(),
             "status": "internal_canary",
             "active": True,
             "revision": 3,
-            "account_user_id": uuid.uuid4(),
-            "profile_user_id": uuid.uuid4(),
+            "account_user_id": owner_id,
+            "profile_user_id": owner_id,
             "role": "user",
             "runtime_target_mode": "hermes-cloud-chat",
             "runtime_instance_id": "instance-a",
@@ -549,7 +575,8 @@ def test_shadow_promotion_is_explicit_owner_scoped_revision_cas(monkeypatch):
                 "scope_hash": "sha256:" + ("2" * 64),
                 "admission_revision": 3,
             },
-        }
+        },
+        owner_id=owner_id,
     )
     binding_id = str(uuid.uuid4())
 
@@ -583,7 +610,7 @@ def test_shadow_promotion_is_explicit_owner_scoped_revision_cas(monkeypatch):
         )
     )
 
-    query, args = pool.calls[0]
+    query, args = next((query, args) for query, args in pool.calls if "UPDATE ella_runtime_bindings b" in query)
     assert result["status"] == "internal_canary"
     assert "u.omi_uid = $2" in query
     assert "b.status = 'shadow'" in query


### PR DESCRIPTION
## Summary
- vendor the exact `authority_advisory_lock_v1.json` bytes from `ellaaicare/ella-ai#1155@ed216b71f6350a46fda847843fee4fedc0e5cb9f`
- implement the byte/semantic-exact UUID framing, SHA-256 signed-int64 key, and one-argument `pg_advisory_xact_lock(bigint)` contract
- acquire the shared transaction lock before existing advisory/row locks for managed-cloud consent, invitation/entitlement, runtime claim/bind/rebind/quarantine/promotion, retained binding stage/activation, and voice-data deletion writers
- move operator entitlement SQL behind guarded database APIs
- fail closed after unlocked owner lookup unless the locked re-read still maps to the exact account/profile
- pin a closed static writer inventory and real two-connection PostgreSQL concurrency regressions

## Exact source contract
- broker head: `ellaaicare/ella-ai#1155@ed216b71f6350a46fda847843fee4fedc0e5cb9f`
- broker base: `60ffe1d2c5fc636bdd0c15cb3765666da007bcc1`
- vendored path: `backend/contracts/authority_advisory_lock_v1.json`
- SHA-256: `1a92c0d335742560fff71b4630b95e1424bccdafb15c6245c8a554f4ea19eb69`
- OMI base: `abb5d4cc7440c8ca28d1d4c180302e601417fbd4`

The handoff's shortened artifact digest omitted its final two hexadecimal characters. This PR uses the complete digest independently verified from the exact Git object and the authoritative issue receipt.

## Writer coverage
Protected tables are closed by a source guard:
- `ella_managed_cloud_consent_authority`: grant, rotation/regrant, decline, revoke, invite bootstrap
- `voice_entitlements`: invite grant, operator grant/reactivation, suspend/revoke/expire, consent quarantine, user voice-data deletion
- `ella_runtime_targets`: publish and revoke/quarantine
- `ella_runtime_bindings`: claim, finalize/bind, quarantine/retire, explicit promotion/rebind, retained stage/activation

Three internal mutation helpers require an in-process proof returned only by the exact lock acquisition. The one authority-neutral exception is warm-pool registration: it is structurally limited to inserting an unowned, inactive `pool_available` row, uses `DO NOTHING`, and rejects an already claimed instance. It cannot participate in an account/profile broker decision until the separately locked claim writer binds it. The guard pins this exact SQL shape and fails on any new protected-table writer.

## Validation
- local and hosted Hermes runtime/isolation suite: 349/349
- local and hosted exact authority contract/guard/PostgreSQL collection: 29/29, no skips
- local and hosted invite collection: 42/42
- local and hosted voice collection: 47/47
- focused exact collection: 29/29
  - all six artifact vectors
  - exact one-signed-bigint SQL call
  - closed writer inventory and first-statement source guard
  - broker lock blocks OMI revoke before mutation
  - OMI revoke blocks broker lock
  - release completes without deadlock
  - unrelated account/profile does not block
  - production `synchronize_denial` re-reads ownership after lock and fails before protected mutation when ownership drifts
- Black 24.8.0 clean, line length 120, skip string normalization
- `py_compile` clean
- workflow YAML and contract JSON parsed
- diff checks clean
- exact one-commit Gitleaks scan clean (redacted output)
- hosted runs: runtime `30439907429`, invite `30439907343`, voice `30439907541`

## Compatibility and rollback
No migration is added or changed. Existing consent disclosure/receipt behavior and migration lineage remain intact. Rollback is the source revert of this commit; no live schema rollback is required. Runtime behavior intentionally becomes fail-closed when a protected writer cannot resolve and re-verify the owner.

## Safety
Source/tests only. No merge, deploy, live migration, vendor/Honcho/n8n/routing/flag/traffic mutation, secrets, or real user data.

Refs: ellaaicare/ella-ai#1156, ellaaicare/ella-ai#1155, ellaaicare/ella-ai#1124.

