### PR TITLE
feat(ella): allowlisted Hermes broker ordinary prototype

### DIFF
--- a/backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md
+++ b/backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md
@@ -1,0 +1,112 @@
+# Hermes broker ordinary prototype (OMI)
+
+Fail-closed, default-off adapter so **one exact synthetic account/profile** can
+use the merged Ella first-party Hermes webhook broker instead of calling
+Hermes Cloud `/v1/responses` directly.
+
+Controlling product cut line: Greg PROTOTYPE CUT LINE (allowlisted synthetic
+only; no global switch; no Plato/Mini fallback).
+
+## Pins
+
+| Surface | SHA |
+|---|---|
+| OMI base main | `a9af15c4373cd5456acfac89d3e9f07e8506b580` |
+| Ella broker merge (main) | `114c30dec5312360c860e95ff46b18ad37e5f4ed` |
+
+## Behaviour
+
+| User class | Transport |
+|---|---|
+| Flag off (default) | Existing direct Hermes Cloud `/v1/responses` |
+| Flag on, not exact allowlist | Existing direct path unchanged |
+| Flag on + exact synthetic account/profile (+ optional binding) | Broker `POST .../admit` then bounded poll for terminal result |
+
+On broker failure/timeout/mismatch: **explicit `ProvisioningError`**, content-free
+where required. **No** fallback to direct Hermes, Plato, Mini, or OpenClaw.
+
+## Env (names only)
+
+```text
+# Master switch — must be the exact lowercase string "true"
+ELLA_HERMES_BROKER_PROTOTYPE_ENABLED=false
+
+# Exact allowlist (opaque ids)
+ELLA_HERMES_BROKER_PROTOTYPE_ACCOUNT_ID=
+ELLA_HERMES_BROKER_PROTOTYPE_PROFILE_ID=   # usually same as account/uid
+ELLA_HERMES_BROKER_PROTOTYPE_BINDING_ID=   # optional; when set must match runtime.binding_id
+
+# Private broker HTTPS endpoint (host must match allowlist)
+ELLA_HERMES_BROKER_BASE_URL=https://broker.example.internal
+ELLA_HERMES_BROKER_ALLOWED_HOST=broker.example.internal
+
+# Service auth — reference only
+ELLA_HERMES_BROKER_SERVICE_TOKEN_REF=env:ELLA_HERMES_BROKER_SERVICE_TOKEN
+# ELLA_HERMES_BROKER_SERVICE_TOKEN is set in the secret store, never committed
+
+# Bounded wait
+ELLA_HERMES_BROKER_POLL_INTERVAL_SECONDS=0.5
+ELLA_HERMES_BROKER_POLL_TIMEOUT_SECONDS=45
+ELLA_HERMES_BROKER_CALLBACK_DEADLINE_SECONDS=90
+```
+
+## Rollback
+
+Set `ELLA_HERMES_BROKER_PROTOTYPE_ENABLED` to any value other than exact `true`
+(or unset). All traffic returns to the pre-prototype direct path.
+
+## Companion change required on ella-ai (blocker for live smoke)
+
+Merged broker routes include admit, callback, and workers only — **no owner-pinned
+result read/wait API**. Canonical writeback stores a **content-free**
+`result_sha256`; the answer lives in `broker_writeback_outbox.result_json`.
+
+Minimal companion (ella-ai):
+
+```http
+GET /v1/ella/internal/hermes-webhook-broker/requests/{request_id}
+  ?account_id=<uuid-or-opaque>&profile_id=<uuid-or-opaque>
+Authorization: Bearer <ELLA_HERMES_BROKER_SERVICE_TOKEN>
+```
+
+Requirements:
+
+1. Service auth identical to admit.
+2. Re-prove request owner (`account_id`/`profile_id`) under the shared authority
+   key before returning anything.
+3. Return bounded JSON, for example:
+
+```json
+{
+  "status": "pending|awaiting_callback|completed|failed|quarantined|...",
+  "request_id": "hwb_...",
+  "correlation_id": "hwb:...",
+  "account_id": "...",
+  "profile_id": "...",
+  "lane": "chat_turn",
+  "outcome": "success|error|null",
+  "duplicate": false,
+  "result": { "answer": "...", "session_key": "...", "session_id": "...", "canonical_user_event_id": "..." }
+}
+```
+
+4. Until completed/failed, `result` may be null. Never return another owner's row.
+5. Cap body size (≤256KiB) and apply read timeouts.
+
+Until that endpoint exists, the OMI prototype returns
+`hermes_broker_prototype_result_endpoint_missing` after a successful admit when
+GET yields HTTP 404 — fail closed, no direct-path bypass.
+
+## Out of scope (see ella-ai#1157)
+
+Production concurrency, warm pool, global rollout, multi-tenant scaling, invite
+issuance (dashboard + omi#333).
+
+## Code map
+
+| File | Role |
+|---|---|
+| `ella/services/hermes_broker_prototype.py` | Flag + exact allowlist |
+| `ella/services/hermes_broker_client.py` | Admit + poll client |
+| `ella/services/hermes_cloud_runtime.py` | Transport selection at provider send |
+| `tests/unit/test_hermes_broker_prototype.py` | Focused fake-broker coverage |

--- a/backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md
+++ b/backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md
@@ -31,9 +31,10 @@ where required. **No** fallback to direct Hermes, Plato, Mini, or OpenClaw.
 # Master switch — must be the exact lowercase string "true"
 ELLA_HERMES_BROKER_PROTOTYPE_ENABLED=false
 
-# Exact allowlist (opaque ids)
+# Exact allowlist — canonical owner UUIDs (ella_runtime_bindings.account_user_id /
+# profile_user_id = users.id), NOT the auth omi_uid string.
 ELLA_HERMES_BROKER_PROTOTYPE_ACCOUNT_ID=
-ELLA_HERMES_BROKER_PROTOTYPE_PROFILE_ID=   # usually same as account/uid
+ELLA_HERMES_BROKER_PROTOTYPE_PROFILE_ID=
 ELLA_HERMES_BROKER_PROTOTYPE_BINDING_ID=   # optional; when set must match runtime.binding_id
 
 # Private broker HTTPS endpoint (host must match allowlist)

--- a/backend/ella/services/hermes_broker_client.py
+++ b/backend/ella/services/hermes_broker_client.py
@@ -1,0 +1,486 @@
+"""Private first-party Hermes webhook-broker client (ordinary prototype).
+
+Submits one admit request to the merged Ella broker and waits for a terminal
+result via the companion GET contract. Never calls unpublished Hermes
+`/v1/responses` and never falls back to Plato/Mini.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+from urllib.parse import urlparse
+
+import httpx
+
+from ella.services.hermes_broker_prototype import (
+    ADMIT_PATH,
+    RESULT_PATH_PREFIX,
+    HermesBrokerPrototypeConfig,
+    resolve_service_token,
+)
+from ella.services.runtime_errors import ProvisioningError
+
+MAX_ADMISSION_BODY_BYTES = 65_536
+MAX_RESULT_BODY_BYTES = 262_144
+
+
+@dataclass(frozen=True)
+class BrokerTerminalTurn:
+    """Mapped terminal chat/enrichment result for existing OMI consumers."""
+
+    text: str
+    request_id: str
+    correlation_id: str
+    response_id: str
+    usage: dict[str, int]
+    model: str
+    duplicate: bool
+
+
+class HermesBrokerClient:
+    """HTTPS client pinned to the allowlisted private broker host."""
+
+    def __init__(
+        self,
+        config: HermesBrokerPrototypeConfig,
+        *,
+        http_client_factory=None,
+        sleep=asyncio.sleep,
+        clock=time.time,
+    ):
+        self.config = config
+        self.http_client_factory = http_client_factory or (
+            lambda timeout: httpx.AsyncClient(
+                timeout=timeout,
+                follow_redirects=False,
+                trust_env=False,
+            )
+        )
+        self.sleep = sleep
+        self.clock = clock
+
+    def _headers(self) -> dict[str, str]:
+        token = resolve_service_token(self.config.service_token_ref)
+        return {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Host": self.config.allowed_host,
+        }
+
+    def _assert_url(self, url: str, *, expected_path_prefix: str) -> None:
+        parsed = urlparse(url)
+        if (
+            parsed.scheme != "https"
+            or parsed.hostname != self.config.allowed_host
+            or parsed.username
+            or parsed.password
+            or parsed.query
+            or parsed.fragment
+            or (parsed.port not in (None, 443))
+            or not parsed.path.startswith(expected_path_prefix)
+        ):
+            raise ProvisioningError(
+                "hermes_broker_prototype_url_not_allowlisted",
+                retryable=False,
+            )
+
+    async def admit(
+        self,
+        *,
+        account_id: str,
+        profile_id: str,
+        runtime_binding_ref: str,
+        lane: str,
+        source_event_id: str,
+        consent_epoch: str,
+        payload: Mapping[str, Any],
+        deadline_at: int,
+        pass_kind: Optional[str] = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "account_id": account_id,
+            "profile_id": profile_id,
+            "runtime_binding_ref": runtime_binding_ref,
+            "lane": lane,
+            "source_event_id": source_event_id,
+            "consent_epoch": consent_epoch,
+            "payload": dict(payload),
+            "deadline_at": int(deadline_at),
+        }
+        if pass_kind is not None:
+            body["pass_kind"] = pass_kind
+        url = f"{self.config.base_url}{ADMIT_PATH}"
+        self._assert_url(url, expected_path_prefix=ADMIT_PATH)
+        try:
+            async with self.http_client_factory(timeout=min(30.0, self.config.poll_timeout_seconds)) as client:
+                response = await client.post(url, headers=self._headers(), json=body)
+        except httpx.TimeoutException as exc:
+            raise ProvisioningError(
+                "hermes_broker_prototype_admit_timeout",
+                retryable=True,
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise ProvisioningError(
+                "hermes_broker_prototype_unavailable",
+                retryable=True,
+            ) from exc
+        return self._parse_json(
+            response,
+            max_bytes=MAX_ADMISSION_BODY_BYTES,
+            invalid_code="hermes_broker_prototype_admit_invalid",
+        )
+
+    async def wait_for_terminal(
+        self,
+        *,
+        request_id: str,
+        account_id: str,
+        profile_id: str,
+        correlation_id: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Poll the companion GET contract until terminal, error, or timeout."""
+        if not request_id or "/" in request_id or ".." in request_id:
+            raise ProvisioningError(
+                "hermes_broker_prototype_request_id_invalid",
+                retryable=False,
+            )
+        url = f"{self.config.base_url}{RESULT_PATH_PREFIX}{request_id}"
+        self._assert_url(url, expected_path_prefix=RESULT_PATH_PREFIX)
+        deadline = float(self.clock()) + float(self.config.poll_timeout_seconds)
+        last: Optional[dict[str, Any]] = None
+        while float(self.clock()) < deadline:
+            try:
+                async with self.http_client_factory(timeout=min(15.0, self.config.poll_timeout_seconds)) as client:
+                    response = await client.get(
+                        url,
+                        headers=self._headers(),
+                        params={
+                            "account_id": account_id,
+                            "profile_id": profile_id,
+                        },
+                    )
+            except httpx.TimeoutException as exc:
+                raise ProvisioningError(
+                    "hermes_broker_prototype_poll_timeout",
+                    retryable=True,
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise ProvisioningError(
+                    "hermes_broker_prototype_unavailable",
+                    retryable=True,
+                ) from exc
+            if response.status_code == 404:
+                # Companion endpoint missing on deployed broker.
+                raise ProvisioningError(
+                    "hermes_broker_prototype_result_endpoint_missing",
+                    retryable=False,
+                    detail={
+                        "companion": (
+                            "GET /v1/ella/internal/hermes-webhook-broker/requests/"
+                            "{request_id}?account_id=&profile_id= "
+                            "must return owner-pinned terminal status + bounded result "
+                            "from broker_writeback_outbox.result_json (service auth)."
+                        ),
+                    },
+                )
+            last = self._parse_json(
+                response,
+                max_bytes=MAX_RESULT_BODY_BYTES,
+                invalid_code="hermes_broker_prototype_result_invalid",
+            )
+            self._assert_owner(last, account_id=account_id, profile_id=profile_id)
+            if correlation_id and last.get("correlation_id") not in (None, correlation_id):
+                raise ProvisioningError(
+                    "hermes_broker_prototype_correlation_mismatch",
+                    retryable=False,
+                )
+            status = str(last.get("status") or "")
+            if status in {
+                "completed",
+                "callback_verified",
+                "writeback_completed",
+                "success",
+            }:
+                return last
+            if status in {
+                "failed",
+                "error",
+                "quarantined",
+                "blocked",
+                "expired",
+            }:
+                raise ProvisioningError(
+                    f"hermes_broker_prototype_{status}",
+                    retryable=False,
+                )
+            # pending / dispatching / awaiting_callback
+            await self.sleep(self.config.poll_interval_seconds)
+        raise ProvisioningError(
+            "hermes_broker_prototype_wait_timeout",
+            retryable=True,
+            detail={"last_status": (last or {}).get("status")},
+        )
+
+    async def run_chat_turn(
+        self,
+        *,
+        account_id: str,
+        profile_id: str,
+        runtime_binding_ref: str,
+        consent_epoch: str,
+        message: str,
+        session_key: str,
+        session_id: str,
+        source_event_id: str,
+        expected_model: str,
+        context: Optional[dict[str, Any]] = None,
+    ) -> BrokerTerminalTurn:
+        now = int(self.clock())
+        payload: dict[str, Any] = {
+            "message": message,
+            "session_key": session_key,
+            "session_id": session_id,
+            "canonical_user_event_id": source_event_id,
+        }
+        if context is not None:
+            payload["context"] = context
+        admission = await self.admit(
+            account_id=account_id,
+            profile_id=profile_id,
+            runtime_binding_ref=runtime_binding_ref,
+            lane="chat_turn",
+            source_event_id=source_event_id,
+            consent_epoch=consent_epoch,
+            payload=payload,
+            deadline_at=now + int(self.config.deadline_seconds),
+        )
+        if str(admission.get("status")) == "skipped_mini_retained":
+            raise ProvisioningError(
+                "hermes_broker_prototype_skipped_mini",
+                retryable=False,
+            )
+        request_id = str(admission.get("request_id") or "").strip()
+        correlation_id = str(admission.get("correlation_id") or "").strip()
+        if not request_id:
+            raise ProvisioningError(
+                "hermes_broker_prototype_admit_invalid",
+                retryable=True,
+            )
+        terminal = await self.wait_for_terminal(
+            request_id=request_id,
+            account_id=account_id,
+            profile_id=profile_id,
+            correlation_id=correlation_id or None,
+        )
+        return self._map_chat_result(
+            terminal,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            expected_model=expected_model,
+            session_key=session_key,
+            session_id=session_id,
+            source_event_id=source_event_id,
+            admission_duplicate=bool(admission.get("duplicate")),
+        )
+
+    async def run_transcript_user_summary(
+        self,
+        *,
+        account_id: str,
+        profile_id: str,
+        runtime_binding_ref: str,
+        consent_epoch: str,
+        source_event_id: str,
+        transcript_segments: list[dict[str, Any]],
+        expected_model: str,
+        existing_summary: Optional[dict[str, Any]] = None,
+    ) -> BrokerTerminalTurn:
+        now = int(self.clock())
+        payload: dict[str, Any] = {"transcript_segments": transcript_segments}
+        if existing_summary is not None:
+            payload["existing_summary"] = existing_summary
+        admission = await self.admit(
+            account_id=account_id,
+            profile_id=profile_id,
+            runtime_binding_ref=runtime_binding_ref,
+            lane="transcript_summary_enrichment",
+            source_event_id=source_event_id,
+            consent_epoch=consent_epoch,
+            payload=payload,
+            deadline_at=now + int(self.config.deadline_seconds),
+            pass_kind="user_summary",
+        )
+        request_id = str(admission.get("request_id") or "").strip()
+        correlation_id = str(admission.get("correlation_id") or "").strip()
+        if not request_id:
+            raise ProvisioningError(
+                "hermes_broker_prototype_admit_invalid",
+                retryable=True,
+            )
+        terminal = await self.wait_for_terminal(
+            request_id=request_id,
+            account_id=account_id,
+            profile_id=profile_id,
+            correlation_id=correlation_id or None,
+        )
+        return self._map_summary_result(
+            terminal,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            expected_model=expected_model,
+            admission_duplicate=bool(admission.get("duplicate")),
+        )
+
+    def _map_chat_result(
+        self,
+        terminal: Mapping[str, Any],
+        *,
+        request_id: str,
+        correlation_id: str,
+        expected_model: str,
+        session_key: str,
+        session_id: str,
+        source_event_id: str,
+        admission_duplicate: bool,
+    ) -> BrokerTerminalTurn:
+        outcome = str(terminal.get("outcome") or "success")
+        if outcome == "error":
+            raise ProvisioningError(
+                "hermes_broker_prototype_provider_error",
+                retryable=True,
+            )
+        result = terminal.get("result")
+        if not isinstance(result, dict):
+            raise ProvisioningError(
+                "hermes_broker_prototype_result_invalid",
+                retryable=True,
+            )
+        # Fail closed on identity mismatch / cross-owner projection.
+        for key, expected in (
+            ("session_key", session_key),
+            ("session_id", session_id),
+            ("canonical_user_event_id", source_event_id),
+        ):
+            observed = result.get(key)
+            if observed is not None and str(observed) != str(expected):
+                raise ProvisioningError(
+                    "hermes_broker_prototype_result_identity_mismatch",
+                    retryable=False,
+                )
+        answer = str(result.get("answer") or "").strip()
+        if not answer:
+            raise ProvisioningError(
+                "hermes_broker_prototype_empty_answer",
+                retryable=True,
+            )
+        usage = result.get("usage") if isinstance(result.get("usage"), dict) else {}
+        try:
+            normalized_usage = {
+                "input_tokens": max(0, int(usage.get("input_tokens", 0))),
+                "output_tokens": max(0, int(usage.get("output_tokens", 0))),
+            }
+        except (TypeError, ValueError) as exc:
+            raise ProvisioningError(
+                "hermes_broker_prototype_usage_invalid",
+                retryable=False,
+            ) from exc
+        model = str(result.get("model") or expected_model).strip() or expected_model
+        response_id = str(
+            result.get("response_id") or result.get("canonical_assistant_event_id") or f"broker:{request_id}"
+        ).strip()
+        return BrokerTerminalTurn(
+            text=answer,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            response_id=response_id,
+            usage=normalized_usage,
+            model=model,
+            duplicate=bool(terminal.get("duplicate")) or admission_duplicate,
+        )
+
+    def _map_summary_result(
+        self,
+        terminal: Mapping[str, Any],
+        *,
+        request_id: str,
+        correlation_id: str,
+        expected_model: str,
+        admission_duplicate: bool,
+    ) -> BrokerTerminalTurn:
+        outcome = str(terminal.get("outcome") or "success")
+        if outcome == "error":
+            raise ProvisioningError(
+                "hermes_broker_prototype_provider_error",
+                retryable=True,
+            )
+        result = terminal.get("result")
+        if not isinstance(result, dict):
+            raise ProvisioningError(
+                "hermes_broker_prototype_result_invalid",
+                retryable=True,
+            )
+        # Map user-summary envelope into a single text payload for existing
+        # enrichment validators (they re-parse JSON from the model text).
+        text = json.dumps(result, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        if not text or text == "{}":
+            raise ProvisioningError(
+                "hermes_broker_prototype_empty_answer",
+                retryable=True,
+            )
+        return BrokerTerminalTurn(
+            text=text,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            response_id=str(result.get("response_id") or f"broker:{request_id}"),
+            usage={"input_tokens": 0, "output_tokens": 0},
+            model=expected_model,
+            duplicate=bool(terminal.get("duplicate")) or admission_duplicate,
+        )
+
+    @staticmethod
+    def _assert_owner(body: Mapping[str, Any], *, account_id: str, profile_id: str) -> None:
+        observed_account = body.get("account_id")
+        observed_profile = body.get("profile_id")
+        if observed_account is not None and str(observed_account) != str(account_id):
+            raise ProvisioningError(
+                "hermes_broker_prototype_cross_account_result",
+                retryable=False,
+            )
+        if observed_profile is not None and str(observed_profile) != str(profile_id):
+            raise ProvisioningError(
+                "hermes_broker_prototype_cross_profile_result",
+                retryable=False,
+            )
+
+    @staticmethod
+    def _parse_json(response: httpx.Response, *, max_bytes: int, invalid_code: str) -> dict[str, Any]:
+        if response.status_code in {401, 403}:
+            raise ProvisioningError(
+                "hermes_broker_prototype_auth_failed",
+                retryable=False,
+            )
+        if response.status_code >= 500:
+            raise ProvisioningError(
+                "hermes_broker_prototype_unavailable",
+                retryable=True,
+            )
+        if response.status_code not in {200, 202}:
+            raise ProvisioningError(invalid_code, retryable=True)
+        raw = response.content or b""
+        if len(raw) > max_bytes:
+            raise ProvisioningError(
+                "hermes_broker_prototype_body_too_large",
+                retryable=False,
+            )
+        try:
+            body = response.json()
+        except ValueError as exc:
+            raise ProvisioningError(invalid_code, retryable=True) from exc
+        if not isinstance(body, dict):
+            raise ProvisioningError(invalid_code, retryable=True)
+        return body

--- a/backend/ella/services/hermes_broker_client.py
+++ b/backend/ella/services/hermes_broker_client.py
@@ -141,12 +141,19 @@ class HermesBrokerClient:
         request_id: str,
         account_id: str,
         profile_id: str,
+        lane: str,
         correlation_id: Optional[str] = None,
     ) -> dict[str, Any]:
         """Poll the companion GET contract until terminal, error, or timeout."""
         if not request_id or "/" in request_id or ".." in request_id:
             raise ProvisioningError(
                 "hermes_broker_prototype_request_id_invalid",
+                retryable=False,
+            )
+        expected_lane = str(lane or "").strip()
+        if not expected_lane:
+            raise ProvisioningError(
+                "hermes_broker_prototype_lane_required",
                 retryable=False,
             )
         url = f"{self.config.base_url}{RESULT_PATH_PREFIX}{request_id}"
@@ -199,6 +206,7 @@ class HermesBrokerClient:
                 account_id=account_id,
                 profile_id=profile_id,
                 correlation_id=correlation_id,
+                lane=expected_lane,
                 require_terminal_identity=False,
             )
             status = str(last.get("status") or "").strip()
@@ -213,13 +221,14 @@ class HermesBrokerClient:
                 "writeback_completed",
                 "success",
             }:
-                # Terminal success must carry full owner/request/correlation pins.
+                # Terminal success must carry full owner/request/correlation/lane pins.
                 self._assert_terminal_envelope(
                     last,
                     request_id=request_id,
                     account_id=account_id,
                     profile_id=profile_id,
                     correlation_id=correlation_id,
+                    lane=expected_lane,
                     require_terminal_identity=True,
                 )
                 return last
@@ -236,6 +245,7 @@ class HermesBrokerClient:
                     account_id=account_id,
                     profile_id=profile_id,
                     correlation_id=correlation_id,
+                    lane=expected_lane,
                     require_terminal_identity=True,
                 )
                 raise ProvisioningError(
@@ -300,6 +310,7 @@ class HermesBrokerClient:
             account_id=account_id,
             profile_id=profile_id,
             correlation_id=correlation_id,
+            lane="chat_turn",
         )
         return self._map_chat_result(
             terminal,
@@ -351,6 +362,7 @@ class HermesBrokerClient:
             account_id=account_id,
             profile_id=profile_id,
             correlation_id=correlation_id,
+            lane="transcript_summary_enrichment",
         )
         return self._map_summary_result(
             terminal,
@@ -514,9 +526,10 @@ class HermesBrokerClient:
         account_id: str,
         profile_id: str,
         correlation_id: Optional[str],
+        lane: str,
         require_terminal_identity: bool,
     ) -> None:
-        """Owner/request pins are mandatory; omissions fail closed."""
+        """Owner/request/lane pins are mandatory on terminal; omissions fail closed."""
         if require_terminal_identity:
             cls._require_exact_field(
                 body,
@@ -551,8 +564,15 @@ class HermesBrokerClient:
                 omitted_code="hermes_broker_prototype_correlation_omitted",
                 mismatch_code="hermes_broker_prototype_correlation_mismatch",
             )
+            cls._require_exact_field(
+                body,
+                "lane",
+                lane,
+                omitted_code="hermes_broker_prototype_lane_omitted",
+                mismatch_code="hermes_broker_prototype_cross_lane_result",
+            )
             return
-        # Non-terminal polls still reject cross-owner / wrong-request when present.
+        # Non-terminal polls still reject cross-owner / wrong-request / wrong-lane when present.
         if "request_id" in body and body.get("request_id") is not None:
             if str(body.get("request_id")).strip() and str(body.get("request_id")) != str(request_id):
                 raise ProvisioningError(
@@ -575,6 +595,12 @@ class HermesBrokerClient:
             if str(body.get("correlation_id")).strip() and str(body.get("correlation_id")) != str(correlation_id):
                 raise ProvisioningError(
                     "hermes_broker_prototype_correlation_mismatch",
+                    retryable=False,
+                )
+        if "lane" in body and body.get("lane") is not None:
+            if str(body.get("lane")).strip() and str(body.get("lane")) != str(lane):
+                raise ProvisioningError(
+                    "hermes_broker_prototype_cross_lane_result",
                     retryable=False,
                 )
 

--- a/backend/ella/services/hermes_broker_client.py
+++ b/backend/ella/services/hermes_broker_client.py
@@ -193,19 +193,35 @@ class HermesBrokerClient:
                 max_bytes=MAX_RESULT_BODY_BYTES,
                 invalid_code="hermes_broker_prototype_result_invalid",
             )
-            self._assert_owner(last, account_id=account_id, profile_id=profile_id)
-            if correlation_id and last.get("correlation_id") not in (None, correlation_id):
+            self._assert_terminal_envelope(
+                last,
+                request_id=request_id,
+                account_id=account_id,
+                profile_id=profile_id,
+                correlation_id=correlation_id,
+                require_terminal_identity=False,
+            )
+            status = str(last.get("status") or "").strip()
+            if not status:
                 raise ProvisioningError(
-                    "hermes_broker_prototype_correlation_mismatch",
+                    "hermes_broker_prototype_status_omitted",
                     retryable=False,
                 )
-            status = str(last.get("status") or "")
             if status in {
                 "completed",
                 "callback_verified",
                 "writeback_completed",
                 "success",
             }:
+                # Terminal success must carry full owner/request/correlation pins.
+                self._assert_terminal_envelope(
+                    last,
+                    request_id=request_id,
+                    account_id=account_id,
+                    profile_id=profile_id,
+                    correlation_id=correlation_id,
+                    require_terminal_identity=True,
+                )
                 return last
             if status in {
                 "failed",
@@ -214,6 +230,14 @@ class HermesBrokerClient:
                 "blocked",
                 "expired",
             }:
+                self._assert_terminal_envelope(
+                    last,
+                    request_id=request_id,
+                    account_id=account_id,
+                    profile_id=profile_id,
+                    correlation_id=correlation_id,
+                    require_terminal_identity=True,
+                )
                 raise ProvisioningError(
                     f"hermes_broker_prototype_{status}",
                     retryable=False,
@@ -266,7 +290,7 @@ class HermesBrokerClient:
             )
         request_id = str(admission.get("request_id") or "").strip()
         correlation_id = str(admission.get("correlation_id") or "").strip()
-        if not request_id:
+        if not request_id or not correlation_id:
             raise ProvisioningError(
                 "hermes_broker_prototype_admit_invalid",
                 retryable=True,
@@ -275,7 +299,7 @@ class HermesBrokerClient:
             request_id=request_id,
             account_id=account_id,
             profile_id=profile_id,
-            correlation_id=correlation_id or None,
+            correlation_id=correlation_id,
         )
         return self._map_chat_result(
             terminal,
@@ -317,7 +341,7 @@ class HermesBrokerClient:
         )
         request_id = str(admission.get("request_id") or "").strip()
         correlation_id = str(admission.get("correlation_id") or "").strip()
-        if not request_id:
+        if not request_id or not correlation_id:
             raise ProvisioningError(
                 "hermes_broker_prototype_admit_invalid",
                 retryable=True,
@@ -326,7 +350,7 @@ class HermesBrokerClient:
             request_id=request_id,
             account_id=account_id,
             profile_id=profile_id,
-            correlation_id=correlation_id or None,
+            correlation_id=correlation_id,
         )
         return self._map_summary_result(
             terminal,
@@ -348,11 +372,21 @@ class HermesBrokerClient:
         source_event_id: str,
         admission_duplicate: bool,
     ) -> BrokerTerminalTurn:
-        outcome = str(terminal.get("outcome") or "success")
-        if outcome == "error":
+        outcome = terminal.get("outcome")
+        if outcome is None or str(outcome).strip() == "":
+            raise ProvisioningError(
+                "hermes_broker_prototype_outcome_omitted",
+                retryable=False,
+            )
+        if str(outcome) == "error":
             raise ProvisioningError(
                 "hermes_broker_prototype_provider_error",
                 retryable=True,
+            )
+        if str(outcome) != "success":
+            raise ProvisioningError(
+                "hermes_broker_prototype_outcome_invalid",
+                retryable=False,
             )
         result = terminal.get("result")
         if not isinstance(result, dict):
@@ -360,24 +394,29 @@ class HermesBrokerClient:
                 "hermes_broker_prototype_result_invalid",
                 retryable=True,
             )
-        # Fail closed on identity mismatch / cross-owner projection.
+        # Exact lane-result identity is required (no optional omission).
         for key, expected in (
             ("session_key", session_key),
             ("session_id", session_id),
             ("canonical_user_event_id", source_event_id),
         ):
-            observed = result.get(key)
-            if observed is not None and str(observed) != str(expected):
+            if key not in result or result.get(key) is None or str(result.get(key)).strip() == "":
+                raise ProvisioningError(
+                    "hermes_broker_prototype_result_identity_omitted",
+                    retryable=False,
+                )
+            if str(result.get(key)) != str(expected):
                 raise ProvisioningError(
                     "hermes_broker_prototype_result_identity_mismatch",
                     retryable=False,
                 )
-        answer = str(result.get("answer") or "").strip()
-        if not answer:
+        answer = result.get("answer")
+        if answer is None or str(answer).strip() == "":
             raise ProvisioningError(
                 "hermes_broker_prototype_empty_answer",
                 retryable=True,
             )
+        answer = str(answer).strip()
         usage = result.get("usage") if isinstance(result.get("usage"), dict) else {}
         try:
             normalized_usage = {
@@ -412,14 +451,24 @@ class HermesBrokerClient:
         expected_model: str,
         admission_duplicate: bool,
     ) -> BrokerTerminalTurn:
-        outcome = str(terminal.get("outcome") or "success")
-        if outcome == "error":
+        outcome = terminal.get("outcome")
+        if outcome is None or str(outcome).strip() == "":
+            raise ProvisioningError(
+                "hermes_broker_prototype_outcome_omitted",
+                retryable=False,
+            )
+        if str(outcome) == "error":
             raise ProvisioningError(
                 "hermes_broker_prototype_provider_error",
                 retryable=True,
             )
+        if str(outcome) != "success":
+            raise ProvisioningError(
+                "hermes_broker_prototype_outcome_invalid",
+                retryable=False,
+            )
         result = terminal.get("result")
-        if not isinstance(result, dict):
+        if not isinstance(result, dict) or not result:
             raise ProvisioningError(
                 "hermes_broker_prototype_result_invalid",
                 retryable=True,
@@ -443,19 +492,91 @@ class HermesBrokerClient:
         )
 
     @staticmethod
-    def _assert_owner(body: Mapping[str, Any], *, account_id: str, profile_id: str) -> None:
-        observed_account = body.get("account_id")
-        observed_profile = body.get("profile_id")
-        if observed_account is not None and str(observed_account) != str(account_id):
-            raise ProvisioningError(
-                "hermes_broker_prototype_cross_account_result",
-                retryable=False,
+    def _require_exact_field(
+        body: Mapping[str, Any],
+        key: str,
+        expected: str,
+        *,
+        omitted_code: str,
+        mismatch_code: str,
+    ) -> None:
+        if key not in body or body.get(key) is None or str(body.get(key)).strip() == "":
+            raise ProvisioningError(omitted_code, retryable=False)
+        if str(body.get(key)) != str(expected):
+            raise ProvisioningError(mismatch_code, retryable=False)
+
+    @classmethod
+    def _assert_terminal_envelope(
+        cls,
+        body: Mapping[str, Any],
+        *,
+        request_id: str,
+        account_id: str,
+        profile_id: str,
+        correlation_id: Optional[str],
+        require_terminal_identity: bool,
+    ) -> None:
+        """Owner/request pins are mandatory; omissions fail closed."""
+        if require_terminal_identity:
+            cls._require_exact_field(
+                body,
+                "request_id",
+                request_id,
+                omitted_code="hermes_broker_prototype_request_id_omitted",
+                mismatch_code="hermes_broker_prototype_request_id_mismatch",
             )
-        if observed_profile is not None and str(observed_profile) != str(profile_id):
-            raise ProvisioningError(
-                "hermes_broker_prototype_cross_profile_result",
-                retryable=False,
+            cls._require_exact_field(
+                body,
+                "account_id",
+                account_id,
+                omitted_code="hermes_broker_prototype_account_omitted",
+                mismatch_code="hermes_broker_prototype_cross_account_result",
             )
+            cls._require_exact_field(
+                body,
+                "profile_id",
+                profile_id,
+                omitted_code="hermes_broker_prototype_profile_omitted",
+                mismatch_code="hermes_broker_prototype_cross_profile_result",
+            )
+            if not correlation_id:
+                raise ProvisioningError(
+                    "hermes_broker_prototype_correlation_required",
+                    retryable=False,
+                )
+            cls._require_exact_field(
+                body,
+                "correlation_id",
+                correlation_id,
+                omitted_code="hermes_broker_prototype_correlation_omitted",
+                mismatch_code="hermes_broker_prototype_correlation_mismatch",
+            )
+            return
+        # Non-terminal polls still reject cross-owner / wrong-request when present.
+        if "request_id" in body and body.get("request_id") is not None:
+            if str(body.get("request_id")).strip() and str(body.get("request_id")) != str(request_id):
+                raise ProvisioningError(
+                    "hermes_broker_prototype_request_id_mismatch",
+                    retryable=False,
+                )
+        if "account_id" in body and body.get("account_id") is not None:
+            if str(body.get("account_id")).strip() and str(body.get("account_id")) != str(account_id):
+                raise ProvisioningError(
+                    "hermes_broker_prototype_cross_account_result",
+                    retryable=False,
+                )
+        if "profile_id" in body and body.get("profile_id") is not None:
+            if str(body.get("profile_id")).strip() and str(body.get("profile_id")) != str(profile_id):
+                raise ProvisioningError(
+                    "hermes_broker_prototype_cross_profile_result",
+                    retryable=False,
+                )
+        if correlation_id and "correlation_id" in body and body.get("correlation_id") is not None:
+            if str(body.get("correlation_id")).strip() and str(body.get("correlation_id")) != str(correlation_id):
+                raise ProvisioningError(
+                    "hermes_broker_prototype_correlation_mismatch",
+                    retryable=False,
+                )
 
     @staticmethod
     def _parse_json(response: httpx.Response, *, max_bytes: int, invalid_code: str) -> dict[str, Any]:

--- a/backend/ella/services/hermes_broker_prototype.py
+++ b/backend/ella/services/hermes_broker_prototype.py
@@ -1,0 +1,171 @@
+"""Fail-closed allowlist for the ordinary Hermes webhook-broker prototype.
+
+Default OFF. Only an exact synthetic account/profile (and optional binding id)
+may leave the direct Hermes Cloud `/v1/responses` path. All other users keep
+the existing transport byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import urlparse
+
+from ella.services.runtime_errors import ProvisioningError
+from ella.services.runtime_resolver import IsolatedRuntime
+
+# Exact lowercase only — no permissive truthy aliases.
+_TRUE = "true"
+
+# Fixed private broker path prefixes on the allowlisted host.
+ADMIT_PATH = "/v1/ella/internal/hermes-webhook-broker/admit"
+# Companion contract (not yet on merged ella-ai main): bounded result wait.
+# Documented in backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md.
+RESULT_PATH_PREFIX = "/v1/ella/internal/hermes-webhook-broker/requests/"
+
+CHAT_LANE = "chat_turn"
+TRANSCRIPT_LANE = "transcript_summary_enrichment"
+USER_SUMMARY_PASS = "user_summary"
+
+
+@dataclass(frozen=True)
+class HermesBrokerPrototypeConfig:
+    """Secret-free runtime configuration (values resolved only via refs)."""
+
+    enabled: bool
+    account_id: str
+    profile_id: str
+    binding_id: str
+    base_url: str
+    allowed_host: str
+    service_token_ref: str
+    poll_interval_seconds: float
+    poll_timeout_seconds: float
+    deadline_seconds: int
+
+
+def _env(name: str, default: str = "") -> str:
+    return str(os.getenv(name, default) or "").strip()
+
+
+def prototype_enabled_raw() -> bool:
+    # Exact lowercase "true" only — no case-insensitive truthy aliases.
+    return _env("ELLA_HERMES_BROKER_PROTOTYPE_ENABLED") == _TRUE
+
+
+def load_prototype_config() -> Optional[HermesBrokerPrototypeConfig]:
+    """Return config only when the global prototype switch is exactly enabled."""
+    if not prototype_enabled_raw():
+        return None
+    account_id = _env("ELLA_HERMES_BROKER_PROTOTYPE_ACCOUNT_ID")
+    profile_id = _env("ELLA_HERMES_BROKER_PROTOTYPE_PROFILE_ID") or account_id
+    binding_id = _env("ELLA_HERMES_BROKER_PROTOTYPE_BINDING_ID")
+    base_url = _env("ELLA_HERMES_BROKER_BASE_URL").rstrip("/")
+    allowed_host = _env("ELLA_HERMES_BROKER_ALLOWED_HOST")
+    service_token_ref = _env(
+        "ELLA_HERMES_BROKER_SERVICE_TOKEN_REF",
+        "env:ELLA_HERMES_BROKER_SERVICE_TOKEN",
+    )
+    if not account_id or not profile_id or not base_url or not allowed_host:
+        raise ProvisioningError(
+            "hermes_broker_prototype_config_invalid",
+            retryable=False,
+        )
+    if not service_token_ref.startswith("env:") or len(service_token_ref) < 8:
+        raise ProvisioningError(
+            "hermes_broker_prototype_token_ref_invalid",
+            retryable=False,
+        )
+    parsed = urlparse(base_url)
+    if (
+        parsed.scheme != "https"
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or (parsed.port not in (None, 443))
+        or parsed.hostname != allowed_host
+    ):
+        raise ProvisioningError(
+            "hermes_broker_prototype_url_not_allowlisted",
+            retryable=False,
+        )
+    try:
+        poll_interval = float(_env("ELLA_HERMES_BROKER_POLL_INTERVAL_SECONDS", "0.5"))
+        poll_timeout = float(_env("ELLA_HERMES_BROKER_POLL_TIMEOUT_SECONDS", "45"))
+        deadline_seconds = int(_env("ELLA_HERMES_BROKER_CALLBACK_DEADLINE_SECONDS", "90"))
+    except ValueError as exc:
+        raise ProvisioningError(
+            "hermes_broker_prototype_config_invalid",
+            retryable=False,
+        ) from exc
+    if not (0.1 <= poll_interval <= 5.0 and 1.0 <= poll_timeout <= 120.0):
+        raise ProvisioningError(
+            "hermes_broker_prototype_config_invalid",
+            retryable=False,
+        )
+    if not (10 <= deadline_seconds <= 600):
+        raise ProvisioningError(
+            "hermes_broker_prototype_config_invalid",
+            retryable=False,
+        )
+    return HermesBrokerPrototypeConfig(
+        enabled=True,
+        account_id=account_id,
+        profile_id=profile_id,
+        binding_id=binding_id,
+        base_url=base_url,
+        allowed_host=allowed_host,
+        service_token_ref=service_token_ref,
+        poll_interval_seconds=poll_interval,
+        poll_timeout_seconds=poll_timeout,
+        deadline_seconds=deadline_seconds,
+    )
+
+
+def runtime_uses_broker_prototype(
+    runtime: IsolatedRuntime,
+    *,
+    config: Optional[HermesBrokerPrototypeConfig] = None,
+) -> bool:
+    """True only for the exact allowlisted synthetic cloud binding."""
+    cfg = config if config is not None else load_prototype_config()
+    if cfg is None:
+        return False
+    if runtime.provider != "hermes_cloud":
+        return False
+    if str(runtime.profile_class or "").lower() != "synthetic":
+        return False
+    if not hmac.compare_digest(str(runtime.uid), cfg.account_id):
+        return False
+    # Prototype pins one exact profile id (typically equal to the synthetic uid).
+    if not hmac.compare_digest(str(runtime.uid), cfg.profile_id):
+        return False
+    if cfg.binding_id and not hmac.compare_digest(str(runtime.binding_id), cfg.binding_id):
+        return False
+    if runtime.runtime_target_mode and runtime.runtime_target_mode not in {
+        "hermes-cloud-chat",
+        "hermes-cloud-transcript",
+        "hermes-cloud-photon",
+    }:
+        return False
+    return True
+
+
+def resolve_service_token(token_ref: str) -> str:
+    """Resolve env:NAME only. Never logs the value."""
+    if not token_ref.startswith("env:"):
+        raise ProvisioningError(
+            "hermes_broker_prototype_token_ref_invalid",
+            retryable=False,
+        )
+    name = token_ref[4:]
+    value = os.getenv(name)
+    if not value:
+        raise ProvisioningError(
+            "hermes_broker_prototype_token_unavailable",
+            retryable=True,
+        )
+    return value

--- a/backend/ella/services/hermes_broker_prototype.py
+++ b/backend/ella/services/hermes_broker_prototype.py
@@ -138,10 +138,15 @@ def runtime_uses_broker_prototype(
         return False
     if str(runtime.profile_class or "").lower() != "synthetic":
         return False
-    if not hmac.compare_digest(str(runtime.uid), cfg.account_id):
+    # Compare allowlist to canonical broker owner coordinates (users.id UUIDs),
+    # never to the auth uid / omi_uid string.
+    account_user_id = str(runtime.account_user_id or "").strip()
+    profile_user_id = str(runtime.profile_user_id or "").strip()
+    if not account_user_id or not profile_user_id:
         return False
-    # Prototype pins one exact profile id (typically equal to the synthetic uid).
-    if not hmac.compare_digest(str(runtime.uid), cfg.profile_id):
+    if not hmac.compare_digest(account_user_id, cfg.account_id):
+        return False
+    if not hmac.compare_digest(profile_user_id, cfg.profile_id):
         return False
     if cfg.binding_id and not hmac.compare_digest(str(runtime.binding_id), cfg.binding_id):
         return False

--- a/backend/ella/services/hermes_cloud_runtime.py
+++ b/backend/ella/services/hermes_cloud_runtime.py
@@ -10,7 +10,7 @@ import os
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 from database import voice_canary as voice_canary_db
 from database.ella_provisioning import EllaProvisioningRepository, RuntimePoolClaimError
@@ -19,8 +19,14 @@ from ella.services.ai_consent import (
     MANAGED_CLOUD_MEMORY_PROVIDER,
     MANAGED_CLOUD_PHOTON_SCOPE,
 )
+from ella.services.hermes_broker_client import HermesBrokerClient
+from ella.services.hermes_broker_prototype import (
+    load_prototype_config,
+    runtime_uses_broker_prototype,
+)
 from ella.services.hermes_cloud import (
     HermesCloudClient,
+    HermesCloudTurn,
     estimate_max_turn_cost_microusd,
     estimate_turn_cost_microusd,
 )
@@ -291,6 +297,81 @@ class HermesCloudRuntimeService:
         self.max_cost_estimator = max_cost_estimator
         self.allow_shadow = allow_shadow
         self.runtime_revalidator = runtime_revalidator or revalidate_cloud_runtime_authority
+        self.broker_client_factory = HermesBrokerClient
+
+    async def _provider_turn(
+        self,
+        *,
+        runtime: IsolatedRuntime,
+        request: HermesCloudTurnRequest,
+        scope: Mapping[str, Any],
+        claimed: Mapping[str, Any],
+        budget: Mapping[str, int],
+        grant_epoch: str,
+        mark_provider_send_boundary: Callable[[], Awaitable[tuple[str, str]]],
+    ) -> HermesCloudTurn:
+        """Direct `/v1/responses` or allowlisted broker prototype transport."""
+        prototype_config = load_prototype_config()
+        use_broker = runtime_uses_broker_prototype(runtime, config=prototype_config)
+        if not use_broker:
+            return await self.cloud_client.create_response(
+                {
+                    "expected_model": runtime.expected_model,
+                    "model_context_window_tokens": runtime.model_context_window_tokens,
+                    "allowed_tools": list(runtime.allowed_tools),
+                },
+                session_key=str(scope["session_key"]),
+                hermes_session_id=str(claimed["hermes_session_id"]),
+                idempotency_key=str(claimed["idempotency_key"]),
+                user_input=request.user_input,
+                instructions=request.instructions,
+                previous_response_id=claimed.get("previous_response_id"),
+                base_url=runtime.gateway_url,
+                token=runtime.gateway_token,
+                max_output_tokens=budget["max_output_tokens"],
+                max_tool_calls=budget["max_tool_calls"],
+                before_provider_send=mark_provider_send_boundary,
+            )
+
+        # Fail closed: broker path never falls back to direct Hermes or Plato.
+        assert prototype_config is not None
+        await mark_provider_send_boundary()
+        client = self.broker_client_factory(prototype_config)
+        source_event_id = str(request.client_interaction_id or request.correlation_id)
+        if request.channel == HERMES_CLOUD_ENRICHMENT_CHANNEL:
+            # Enrichment instructions already embed transcript JSON; surface a
+            # bounded segment list for the broker transcript lane.
+            terminal = await client.run_transcript_user_summary(
+                account_id=str(runtime.uid),
+                profile_id=str(runtime.uid),
+                runtime_binding_ref=str(runtime.binding_id),
+                consent_epoch=str(grant_epoch),
+                source_event_id=source_event_id,
+                transcript_segments=[
+                    {"speaker": "user", "text": request.user_input[:8000]},
+                ],
+                expected_model=runtime.expected_model,
+            )
+        else:
+            terminal = await client.run_chat_turn(
+                account_id=str(runtime.uid),
+                profile_id=str(runtime.uid),
+                runtime_binding_ref=str(runtime.binding_id),
+                consent_epoch=str(grant_epoch),
+                message=request.user_input,
+                session_key=str(scope["session_key"]),
+                session_id=str(claimed["hermes_session_id"]),
+                source_event_id=source_event_id,
+                expected_model=runtime.expected_model,
+                context={"instructions": request.instructions[:4000]},
+            )
+        return HermesCloudTurn(
+            response_id=terminal.response_id,
+            text=terminal.text,
+            usage=dict(terminal.usage),
+            model=terminal.model,
+            tool_calls=0,
+        )
 
     async def run_turn(
         self,
@@ -574,23 +655,14 @@ class HermesCloudRuntimeService:
                 provider_started = True
                 return current_runtime.gateway_url, current_runtime.gateway_token
 
-            turn = await self.cloud_client.create_response(
-                {
-                    "expected_model": runtime.expected_model,
-                    "model_context_window_tokens": runtime.model_context_window_tokens,
-                    "allowed_tools": list(runtime.allowed_tools),
-                },
-                session_key=str(scope["session_key"]),
-                hermes_session_id=str(claimed["hermes_session_id"]),
-                idempotency_key=str(claimed["idempotency_key"]),
-                user_input=request.user_input,
-                instructions=request.instructions,
-                previous_response_id=claimed.get("previous_response_id"),
-                base_url=runtime.gateway_url,
-                token=runtime.gateway_token,
-                max_output_tokens=budget["max_output_tokens"],
-                max_tool_calls=budget["max_tool_calls"],
-                before_provider_send=mark_provider_send_boundary,
+            turn = await self._provider_turn(
+                runtime=runtime,
+                request=request,
+                scope=scope,
+                claimed=claimed,
+                budget=budget,
+                grant_epoch=current_grant_epoch,
+                mark_provider_send_boundary=mark_provider_send_boundary,
             )
             provider_response_ids = [turn.response_id]
             actual_tool_calls = turn.tool_calls

--- a/backend/ella/services/hermes_cloud_runtime.py
+++ b/backend/ella/services/hermes_cloud_runtime.py
@@ -335,6 +335,13 @@ class HermesCloudRuntimeService:
 
         # Fail closed: broker path never falls back to direct Hermes or Plato.
         assert prototype_config is not None
+        account_user_id = str(runtime.account_user_id or "").strip()
+        profile_user_id = str(runtime.profile_user_id or "").strip()
+        if not account_user_id or not profile_user_id:
+            raise ProvisioningError(
+                "hermes_broker_prototype_owner_coordinates_missing",
+                retryable=False,
+            )
         await mark_provider_send_boundary()
         client = self.broker_client_factory(prototype_config)
         source_event_id = str(request.client_interaction_id or request.correlation_id)
@@ -342,8 +349,8 @@ class HermesCloudRuntimeService:
             # Enrichment instructions already embed transcript JSON; surface a
             # bounded segment list for the broker transcript lane.
             terminal = await client.run_transcript_user_summary(
-                account_id=str(runtime.uid),
-                profile_id=str(runtime.uid),
+                account_id=account_user_id,
+                profile_id=profile_user_id,
                 runtime_binding_ref=str(runtime.binding_id),
                 consent_epoch=str(grant_epoch),
                 source_event_id=source_event_id,
@@ -354,8 +361,8 @@ class HermesCloudRuntimeService:
             )
         else:
             terminal = await client.run_chat_turn(
-                account_id=str(runtime.uid),
-                profile_id=str(runtime.uid),
+                account_id=account_user_id,
+                profile_id=profile_user_id,
                 runtime_binding_ref=str(runtime.binding_id),
                 consent_epoch=str(grant_epoch),
                 message=request.user_input,

--- a/backend/ella/services/runtime_resolver.py
+++ b/backend/ella/services/runtime_resolver.py
@@ -85,6 +85,9 @@ class IsolatedRuntime:
     target_endpoint_ref: str = ""
     target_credential_ref: str = ""
     target_entitlement_revision: int = 0
+    # Canonical broker/authority owner coordinates (users.id UUIDs), not omi_uid.
+    account_user_id: str = ""
+    profile_user_id: str = ""
 
 
 @dataclass(frozen=True)
@@ -266,6 +269,16 @@ def runtime_from_binding(binding: dict, uid: str, *, allow_shadow: bool = False)
     if revision < 1:
         raise ProvisioningError("invalid_binding_revision", retryable=False)
 
+    # Broker and shared advisory-lock scopes use users.id UUIDs from the binding
+    # row (account_user_id/profile_user_id), not the OMI auth uid (omi_uid).
+    account_user_id = str(binding.get("account_user_id") or "").strip()
+    profile_user_id = str(binding.get("profile_user_id") or "").strip()
+    if provider == "hermes_cloud" and (not account_user_id or not profile_user_id):
+        raise ProvisioningError(
+            "hermes_cloud_owner_coordinates_missing",
+            retryable=False,
+        )
+
     return IsolatedRuntime(
         uid=uid,
         binding_id=str(binding.get("id") or ""),
@@ -301,6 +314,8 @@ def runtime_from_binding(binding: dict, uid: str, *, allow_shadow: bool = False)
         target_endpoint_ref=str(binding.get("target_endpoint_ref") or ""),
         target_credential_ref=str(binding.get("target_credential_ref") or ""),
         target_entitlement_revision=int(binding.get("target_entitlement_revision") or 0),
+        account_user_id=account_user_id,
+        profile_user_id=profile_user_id,
     )
 
 

--- a/backend/tests/unit/test_hermes_broker_prototype.py
+++ b/backend/tests/unit/test_hermes_broker_prototype.py
@@ -1,0 +1,626 @@
+"""Focused tests for the allowlisted Hermes broker prototype transport."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Optional
+
+import pytest
+
+from ella.services import hermes_broker_client as client_mod
+from ella.services import hermes_broker_prototype as proto
+from ella.services import hermes_cloud_runtime as runtime_mod
+from ella.services.hermes_broker_client import HermesBrokerClient
+from ella.services.hermes_cloud import HermesCloudTurn
+from ella.services.hermes_cloud_runtime import (
+    HERMES_CLOUD_CHAT_MODE,
+    HERMES_CLOUD_ENRICHMENT_CHANNEL,
+    HERMES_CLOUD_ENRICHMENT_MODE,
+    HermesCloudRuntimeService,
+    HermesCloudTurnRequest,
+)
+from ella.services.runtime_errors import ProvisioningError
+from ella.services.runtime_resolver import IsolatedRuntime
+
+
+def _runtime(
+    *,
+    uid: str = "synthetic-proto-01",
+    binding_id: str = "binding-proto-01",
+    profile_class: str = "synthetic",
+    provider: str = "hermes_cloud",
+    mode: str = HERMES_CLOUD_CHAT_MODE,
+) -> IsolatedRuntime:
+    return IsolatedRuntime(
+        uid=uid,
+        binding_id=binding_id,
+        provider=provider,
+        status="active",
+        profile_name="proto",
+        agent_id="agent-proto",
+        runtime_instance_id="ri-proto",
+        gateway_url="https://hermes.example.internal",
+        gateway_token="direct-token",
+        workspace_root="/tmp/ws",
+        honcho_workspace="hw",
+        observed_peer="op",
+        observer_peer="ob",
+        prompt_pack_version="p1",
+        expected_model="gpt-test",
+        model_context_window_tokens=8192,
+        allowed_tools=(),
+        required_capabilities=("responses_api", "session_key_header"),
+        model_policy_version="mp1",
+        voice_policy_version="vp1",
+        revision=1,
+        profile_class=profile_class,
+        runtime_target_id="target-proto",
+        runtime_target_mode=mode,
+        runtime_target_updated_at="2026-07-29T00:00:00Z",
+        target_endpoint_ref="env:URL",
+        target_credential_ref="env:KEY",
+        target_entitlement_revision=1,
+    )
+
+
+def _enable(monkeypatch, **overrides):
+    env = {
+        "ELLA_HERMES_BROKER_PROTOTYPE_ENABLED": "true",
+        "ELLA_HERMES_BROKER_PROTOTYPE_ACCOUNT_ID": "synthetic-proto-01",
+        "ELLA_HERMES_BROKER_PROTOTYPE_PROFILE_ID": "synthetic-proto-01",
+        "ELLA_HERMES_BROKER_PROTOTYPE_BINDING_ID": "binding-proto-01",
+        "ELLA_HERMES_BROKER_BASE_URL": "https://broker.ella.internal",
+        "ELLA_HERMES_BROKER_ALLOWED_HOST": "broker.ella.internal",
+        "ELLA_HERMES_BROKER_SERVICE_TOKEN_REF": "env:ELLA_HERMES_BROKER_SERVICE_TOKEN",
+        "ELLA_HERMES_BROKER_SERVICE_TOKEN": "service-token-test",
+        "ELLA_HERMES_BROKER_POLL_INTERVAL_SECONDS": "0.1",
+        "ELLA_HERMES_BROKER_POLL_TIMEOUT_SECONDS": "1.0",
+        "ELLA_HERMES_BROKER_CALLBACK_DEADLINE_SECONDS": "30",
+    }
+    env.update(overrides)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, body: Any, *, content: Optional[bytes] = None):
+        self.status_code = status_code
+        self._body = body
+        self.content = content if content is not None else json.dumps(body).encode()
+
+    def json(self):
+        return self._body
+
+
+class FakeHttp:
+    def __init__(self, handler):
+        self.handler = handler
+        self.calls: list[tuple[str, str, dict]] = []
+
+    def factory(self, timeout):
+        parent = self
+
+        class _Client:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return None
+
+            async def post(self, url, **kwargs):
+                parent.calls.append(("POST", url, kwargs))
+                return parent.handler("POST", url, kwargs)
+
+            async def get(self, url, **kwargs):
+                parent.calls.append(("GET", url, kwargs))
+                return parent.handler("GET", url, kwargs)
+
+        return _Client()
+
+
+def test_default_off_does_not_select_broker(monkeypatch):
+    monkeypatch.delenv("ELLA_HERMES_BROKER_PROTOTYPE_ENABLED", raising=False)
+    assert proto.load_prototype_config() is None
+    assert proto.runtime_uses_broker_prototype(_runtime()) is False
+
+
+def test_truthy_alias_not_enabled(monkeypatch):
+    _enable(monkeypatch, ELLA_HERMES_BROKER_PROTOTYPE_ENABLED="TRUE")
+    assert proto.load_prototype_config() is None
+
+
+def test_non_allowlisted_user_keeps_direct_path(monkeypatch):
+    _enable(monkeypatch)
+    other = _runtime(uid="realcryptoplato", profile_class="real")
+    assert proto.runtime_uses_broker_prototype(other) is False
+    assert (
+        proto.runtime_uses_broker_prototype(
+            _runtime(uid="other-synth", profile_class="synthetic", binding_id="binding-proto-01")
+        )
+        is False
+    )
+
+
+def test_binding_pin_required_when_set(monkeypatch):
+    _enable(monkeypatch)
+    assert proto.runtime_uses_broker_prototype(_runtime(binding_id="wrong-binding")) is False
+    assert proto.runtime_uses_broker_prototype(_runtime()) is True
+
+
+def test_success_chat_maps_answer(monkeypatch):
+    _enable(monkeypatch)
+    cfg = proto.load_prototype_config()
+    assert cfg is not None
+
+    def handler(method, url, kwargs):
+        if method == "POST":
+            body = kwargs["json"]
+            assert body["lane"] == "chat_turn"
+            assert body["account_id"] == "synthetic-proto-01"
+            assert body["payload"]["message"] == "hello"
+            assert "Authorization" in kwargs["headers"]
+            return FakeResponse(
+                200,
+                {
+                    "status": "pending",
+                    "request_id": "hwb_req1",
+                    "correlation_id": "hwb:corr1",
+                },
+            )
+        assert method == "GET"
+        assert "hwb_req1" in url
+        params = kwargs.get("params") or {}
+        assert params["account_id"] == "synthetic-proto-01"
+        return FakeResponse(
+            200,
+            {
+                "status": "completed",
+                "request_id": "hwb_req1",
+                "correlation_id": "hwb:corr1",
+                "account_id": "synthetic-proto-01",
+                "profile_id": "synthetic-proto-01",
+                "outcome": "success",
+                "result": {
+                    "answer": "proto answer",
+                    "session_key": "sk",
+                    "session_id": "sid",
+                    "canonical_user_event_id": "evt-1",
+                    "model": "gpt-test",
+                    "usage": {"input_tokens": 3, "output_tokens": 2},
+                },
+            },
+        )
+
+    fake = FakeHttp(handler)
+    client = HermesBrokerClient(cfg, http_client_factory=fake.factory, sleep=_noop_sleep)
+    turn = asyncio.run(
+        client.run_chat_turn(
+            account_id="synthetic-proto-01",
+            profile_id="synthetic-proto-01",
+            runtime_binding_ref="binding-proto-01",
+            consent_epoch="consent.v1",
+            message="hello",
+            session_key="sk",
+            session_id="sid",
+            source_event_id="evt-1",
+            expected_model="gpt-test",
+        )
+    )
+    assert turn.text == "proto answer"
+    assert turn.request_id == "hwb_req1"
+    assert turn.usage["output_tokens"] == 2
+    assert any(c[0] == "POST" for c in fake.calls)
+    assert any(c[0] == "GET" for c in fake.calls)
+
+
+async def _noop_sleep(_seconds):
+    return None
+
+
+def test_correlation_mismatch_fails_closed(monkeypatch):
+    _enable(monkeypatch)
+    cfg = proto.load_prototype_config()
+
+    def handler(method, url, kwargs):
+        if method == "POST":
+            return FakeResponse(
+                200,
+                {"status": "pending", "request_id": "hwb_req1", "correlation_id": "hwb:corr1"},
+            )
+        return FakeResponse(
+            200,
+            {
+                "status": "completed",
+                "request_id": "hwb_req1",
+                "correlation_id": "hwb:OTHER",
+                "account_id": "synthetic-proto-01",
+                "profile_id": "synthetic-proto-01",
+                "outcome": "success",
+                "result": {
+                    "answer": "x",
+                    "session_key": "sk",
+                    "session_id": "sid",
+                    "canonical_user_event_id": "evt-1",
+                },
+            },
+        )
+
+    client = HermesBrokerClient(cfg, http_client_factory=FakeHttp(handler).factory, sleep=_noop_sleep)
+    with pytest.raises(ProvisioningError) as exc:
+        asyncio.run(
+            client.run_chat_turn(
+                account_id="synthetic-proto-01",
+                profile_id="synthetic-proto-01",
+                runtime_binding_ref="binding-proto-01",
+                consent_epoch="consent.v1",
+                message="hello",
+                session_key="sk",
+                session_id="sid",
+                source_event_id="evt-1",
+                expected_model="gpt-test",
+            )
+        )
+    assert exc.value.code == "hermes_broker_prototype_correlation_mismatch"
+
+
+def test_cross_account_result_fails_closed(monkeypatch):
+    _enable(monkeypatch)
+    cfg = proto.load_prototype_config()
+
+    def handler(method, url, kwargs):
+        if method == "POST":
+            return FakeResponse(
+                200,
+                {"status": "pending", "request_id": "hwb_req1", "correlation_id": "hwb:corr1"},
+            )
+        return FakeResponse(
+            200,
+            {
+                "status": "completed",
+                "request_id": "hwb_req1",
+                "correlation_id": "hwb:corr1",
+                "account_id": "someone-else",
+                "profile_id": "synthetic-proto-01",
+                "outcome": "success",
+                "result": {"answer": "x"},
+            },
+        )
+
+    client = HermesBrokerClient(cfg, http_client_factory=FakeHttp(handler).factory, sleep=_noop_sleep)
+    with pytest.raises(ProvisioningError) as exc:
+        asyncio.run(
+            client.run_chat_turn(
+                account_id="synthetic-proto-01",
+                profile_id="synthetic-proto-01",
+                runtime_binding_ref="binding-proto-01",
+                consent_epoch="consent.v1",
+                message="hello",
+                session_key="sk",
+                session_id="sid",
+                source_event_id="evt-1",
+                expected_model="gpt-test",
+            )
+        )
+    assert exc.value.code == "hermes_broker_prototype_cross_account_result"
+
+
+def test_timeout_fails_closed(monkeypatch):
+    _enable(monkeypatch, ELLA_HERMES_BROKER_POLL_TIMEOUT_SECONDS="1.0")
+    cfg = proto.load_prototype_config()
+    clock = {"t": 0.0}
+
+    def now():
+        return clock["t"]
+
+    async def sleep(seconds):
+        # Jump past the wait budget immediately after one poll.
+        clock["t"] += 2.0
+
+    def handler(method, url, kwargs):
+        if method == "POST":
+            return FakeResponse(
+                200,
+                {"status": "pending", "request_id": "hwb_req1", "correlation_id": "hwb:corr1"},
+            )
+        return FakeResponse(
+            200,
+            {
+                "status": "awaiting_callback",
+                "request_id": "hwb_req1",
+                "correlation_id": "hwb:corr1",
+                "account_id": "synthetic-proto-01",
+                "profile_id": "synthetic-proto-01",
+            },
+        )
+
+    client = HermesBrokerClient(
+        cfg,
+        http_client_factory=FakeHttp(handler).factory,
+        sleep=sleep,
+        clock=now,
+    )
+    with pytest.raises(ProvisioningError) as exc:
+        asyncio.run(
+            client.run_chat_turn(
+                account_id="synthetic-proto-01",
+                profile_id="synthetic-proto-01",
+                runtime_binding_ref="binding-proto-01",
+                consent_epoch="consent.v1",
+                message="hello",
+                session_key="sk",
+                session_id="sid",
+                source_event_id="evt-1",
+                expected_model="gpt-test",
+            )
+        )
+    assert exc.value.code == "hermes_broker_prototype_wait_timeout"
+
+
+def test_duplicate_replay_accepted(monkeypatch):
+    _enable(monkeypatch)
+    cfg = proto.load_prototype_config()
+
+    def handler(method, url, kwargs):
+        if method == "POST":
+            return FakeResponse(
+                200,
+                {
+                    "status": "completed",
+                    "request_id": "hwb_req1",
+                    "correlation_id": "hwb:corr1",
+                    "duplicate": True,
+                },
+            )
+        return FakeResponse(
+            200,
+            {
+                "status": "completed",
+                "request_id": "hwb_req1",
+                "correlation_id": "hwb:corr1",
+                "account_id": "synthetic-proto-01",
+                "profile_id": "synthetic-proto-01",
+                "outcome": "success",
+                "duplicate": True,
+                "result": {
+                    "answer": "replayed",
+                    "session_key": "sk",
+                    "session_id": "sid",
+                    "canonical_user_event_id": "evt-1",
+                },
+            },
+        )
+
+    client = HermesBrokerClient(cfg, http_client_factory=FakeHttp(handler).factory, sleep=_noop_sleep)
+    turn = asyncio.run(
+        client.run_chat_turn(
+            account_id="synthetic-proto-01",
+            profile_id="synthetic-proto-01",
+            runtime_binding_ref="binding-proto-01",
+            consent_epoch="consent.v1",
+            message="hello",
+            session_key="sk",
+            session_id="sid",
+            source_event_id="evt-1",
+            expected_model="gpt-test",
+        )
+    )
+    assert turn.duplicate is True
+    assert turn.text == "replayed"
+
+
+def test_missing_result_endpoint_is_explicit_companion_blocker(monkeypatch):
+    _enable(monkeypatch)
+    cfg = proto.load_prototype_config()
+
+    def handler(method, url, kwargs):
+        if method == "POST":
+            return FakeResponse(
+                200,
+                {"status": "pending", "request_id": "hwb_req1", "correlation_id": "hwb:corr1"},
+            )
+        return FakeResponse(404, {"status": "error", "code": "not_found"})
+
+    client = HermesBrokerClient(cfg, http_client_factory=FakeHttp(handler).factory, sleep=_noop_sleep)
+    with pytest.raises(ProvisioningError) as exc:
+        asyncio.run(
+            client.run_chat_turn(
+                account_id="synthetic-proto-01",
+                profile_id="synthetic-proto-01",
+                runtime_binding_ref="binding-proto-01",
+                consent_epoch="consent.v1",
+                message="hello",
+                session_key="sk",
+                session_id="sid",
+                source_event_id="evt-1",
+                expected_model="gpt-test",
+            )
+        )
+    assert exc.value.code == "hermes_broker_prototype_result_endpoint_missing"
+    assert "companion" in (exc.value.detail or {})
+
+
+def test_disallowed_host_rejected(monkeypatch):
+    _enable(
+        monkeypatch,
+        ELLA_HERMES_BROKER_BASE_URL="https://evil.example",
+        ELLA_HERMES_BROKER_ALLOWED_HOST="broker.ella.internal",
+    )
+    with pytest.raises(ProvisioningError) as exc:
+        proto.load_prototype_config()
+    assert exc.value.code == "hermes_broker_prototype_url_not_allowlisted"
+
+
+def test_provider_turn_uses_direct_when_not_allowlisted(monkeypatch):
+    monkeypatch.delenv("ELLA_HERMES_BROKER_PROTOTYPE_ENABLED", raising=False)
+    calls = []
+
+    class DirectClient:
+        async def create_response(self, *args, **kwargs):
+            calls.append("direct")
+            return HermesCloudTurn(
+                response_id="r1",
+                text="direct",
+                usage={"input_tokens": 1, "output_tokens": 1},
+                model="gpt-test",
+                tool_calls=0,
+            )
+
+    service = HermesCloudRuntimeService(
+        repository=object(),  # type: ignore[arg-type]
+        event_store=object(),  # type: ignore[arg-type]
+        cloud_client=DirectClient(),  # type: ignore[arg-type]
+    )
+
+    async def boundary():
+        return ("https://h", "t")
+
+    turn = asyncio.run(
+        service._provider_turn(
+            runtime=_runtime(),
+            request=HermesCloudTurnRequest(
+                uid="synthetic-proto-01",
+                client_interaction_id="evt-1",
+                correlation_id="c1",
+                channel="ios_chat",
+                user_input="hi",
+                instructions="sys",
+                started_at=__import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+                client_metadata={},
+            ),
+            scope={"session_key": "sk"},
+            claimed={"hermes_session_id": "sid", "idempotency_key": "ik"},
+            budget={"max_output_tokens": 64, "max_tool_calls": 0},
+            grant_epoch="ge",
+            mark_provider_send_boundary=boundary,
+        )
+    )
+    assert turn.text == "direct"
+    assert calls == ["direct"]
+
+
+def test_provider_turn_uses_broker_when_allowlisted(monkeypatch):
+    _enable(monkeypatch)
+    calls = []
+
+    class DirectClient:
+        async def create_response(self, *args, **kwargs):
+            calls.append("direct")
+            raise AssertionError("direct path must not run for allowlisted prototype")
+
+    class FakeBroker(HermesBrokerClient):
+        def __init__(self, config):
+            super().__init__(config, sleep=_noop_sleep)
+
+        async def run_chat_turn(self, **kwargs):
+            calls.append("broker")
+            return client_mod.BrokerTerminalTurn(
+                text="via-broker",
+                request_id="hwb_x",
+                correlation_id="hwb:c",
+                response_id="resp",
+                usage={"input_tokens": 1, "output_tokens": 1},
+                model="gpt-test",
+                duplicate=False,
+            )
+
+    service = HermesCloudRuntimeService(
+        repository=object(),  # type: ignore[arg-type]
+        event_store=object(),  # type: ignore[arg-type]
+        cloud_client=DirectClient(),  # type: ignore[arg-type]
+    )
+    service.broker_client_factory = FakeBroker
+
+    async def boundary():
+        calls.append("boundary")
+        return ("https://h", "t")
+
+    turn = asyncio.run(
+        service._provider_turn(
+            runtime=_runtime(),
+            request=HermesCloudTurnRequest(
+                uid="synthetic-proto-01",
+                client_interaction_id="evt-1",
+                correlation_id="c1",
+                channel="ios_chat",
+                user_input="hi",
+                instructions="sys",
+                started_at=__import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+                client_metadata={},
+            ),
+            scope={"session_key": "sk"},
+            claimed={"hermes_session_id": "sid", "idempotency_key": "ik"},
+            budget={"max_output_tokens": 64, "max_tool_calls": 0},
+            grant_epoch="ge",
+            mark_provider_send_boundary=boundary,
+        )
+    )
+    assert turn.text == "via-broker"
+    assert "direct" not in calls
+    assert "broker" in calls
+    assert "boundary" in calls
+
+
+def test_enrichment_channel_uses_transcript_lane(monkeypatch):
+    _enable(monkeypatch)
+    seen = {}
+
+    class FakeBroker(HermesBrokerClient):
+        def __init__(self, config):
+            super().__init__(config, sleep=_noop_sleep)
+
+        async def run_transcript_user_summary(self, **kwargs):
+            seen.update(kwargs)
+            return client_mod.BrokerTerminalTurn(
+                text='{"title":"T","overview":"[Ella] o","emoji":"x","category":"other"}',
+                request_id="hwb_e",
+                correlation_id="hwb:e",
+                response_id="r",
+                usage={"input_tokens": 0, "output_tokens": 0},
+                model="gpt-test",
+                duplicate=False,
+            )
+
+        async def run_chat_turn(self, **kwargs):
+            raise AssertionError("chat lane must not be used for enrichment channel")
+
+    service = HermesCloudRuntimeService(
+        repository=object(),  # type: ignore[arg-type]
+        event_store=object(),  # type: ignore[arg-type]
+    )
+    service.broker_client_factory = FakeBroker
+    service.cloud_client = object()  # type: ignore[assignment]
+
+    async def boundary():
+        return ("https://h", "t")
+
+    turn = asyncio.run(
+        service._provider_turn(
+            runtime=_runtime(mode=HERMES_CLOUD_ENRICHMENT_MODE),
+            request=HermesCloudTurnRequest(
+                uid="synthetic-proto-01",
+                client_interaction_id="evt-enrich",
+                correlation_id="c-enrich",
+                channel=HERMES_CLOUD_ENRICHMENT_CHANNEL,
+                user_input="transcript text",
+                instructions="enrich",
+                started_at=__import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+                client_metadata={},
+            ),
+            scope={"session_key": "sk"},
+            claimed={"hermes_session_id": "sid", "idempotency_key": "ik"},
+            budget={"max_output_tokens": 64, "max_tool_calls": 0},
+            grant_epoch="ge",
+            mark_provider_send_boundary=boundary,
+        )
+    )
+    assert "title" in turn.text
+    assert seen["source_event_id"] == "evt-enrich"
+
+
+def test_sse_mapping_preserves_answer_text():
+    # Mirrors _stream_hermes_cloud_chat emission contract (data line + CRLF).
+    answer = "line1\nline2"
+    data_line = f"data: {answer.replace(chr(10), '__CRLF__')}\n\n"
+    assert "__CRLF__" in data_line
+    assert "data: line1" in data_line

--- a/backend/tests/unit/test_hermes_broker_prototype.py
+++ b/backend/tests/unit/test_hermes_broker_prototype.py
@@ -140,6 +140,7 @@ def _completed_result(**overrides):
         "correlation_id": "hwb:corr1",
         "account_id": ACCOUNT_UUID,
         "profile_id": PROFILE_UUID,
+        "lane": "chat_turn",
         "outcome": "success",
         "result": {
             "answer": "proto answer",
@@ -497,7 +498,75 @@ def test_answer_only_projection_rejected(monkeypatch):
         "hermes_broker_prototype_account_omitted",
         "hermes_broker_prototype_profile_omitted",
         "hermes_broker_prototype_correlation_omitted",
+        "hermes_broker_prototype_lane_omitted",
     }
+
+
+def test_omitted_lane_on_terminal_fails_closed(monkeypatch):
+    """Terminal projection without lane must fail (review 4812248201)."""
+    _enable(monkeypatch)
+    cfg = proto.load_prototype_config()
+
+    def handler(method, url, kwargs):
+        if method == "POST":
+            return FakeResponse(
+                200,
+                {"status": "pending", "request_id": "hwb_req1", "correlation_id": "hwb:corr1"},
+            )
+        body = _completed_result()
+        del body["lane"]
+        return FakeResponse(200, body)
+
+    client = HermesBrokerClient(cfg, http_client_factory=FakeHttp(handler).factory, sleep=_noop_sleep)
+    with pytest.raises(ProvisioningError) as exc:
+        asyncio.run(
+            client.run_chat_turn(
+                account_id=ACCOUNT_UUID,
+                profile_id=PROFILE_UUID,
+                runtime_binding_ref=BINDING_ID,
+                consent_epoch="consent.v1",
+                message="hello",
+                session_key="sk",
+                session_id="sid",
+                source_event_id="evt-1",
+                expected_model="gpt-test",
+            )
+        )
+    assert exc.value.code == "hermes_broker_prototype_lane_omitted"
+
+
+def test_cross_lane_result_fails_closed(monkeypatch):
+    """Chat turn must reject terminal projection for the enrichment lane."""
+    _enable(monkeypatch)
+    cfg = proto.load_prototype_config()
+
+    def handler(method, url, kwargs):
+        if method == "POST":
+            return FakeResponse(
+                200,
+                {"status": "pending", "request_id": "hwb_req1", "correlation_id": "hwb:corr1"},
+            )
+        return FakeResponse(
+            200,
+            _completed_result(lane="transcript_summary_enrichment"),
+        )
+
+    client = HermesBrokerClient(cfg, http_client_factory=FakeHttp(handler).factory, sleep=_noop_sleep)
+    with pytest.raises(ProvisioningError) as exc:
+        asyncio.run(
+            client.run_chat_turn(
+                account_id=ACCOUNT_UUID,
+                profile_id=PROFILE_UUID,
+                runtime_binding_ref=BINDING_ID,
+                consent_epoch="consent.v1",
+                message="hello",
+                session_key="sk",
+                session_id="sid",
+                source_event_id="evt-1",
+                expected_model="gpt-test",
+            )
+        )
+    assert exc.value.code == "hermes_broker_prototype_cross_lane_result"
 
 
 def test_timeout_fails_closed(monkeypatch):

--- a/backend/tests/unit/test_hermes_broker_prototype.py
+++ b/backend/tests/unit/test_hermes_broker_prototype.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 import pytest
 
 from ella.services import hermes_broker_client as client_mod
 from ella.services import hermes_broker_prototype as proto
-from ella.services import hermes_cloud_runtime as runtime_mod
 from ella.services.hermes_broker_client import HermesBrokerClient
 from ella.services.hermes_cloud import HermesCloudTurn
 from ella.services.hermes_cloud_runtime import (
@@ -23,11 +23,19 @@ from ella.services.hermes_cloud_runtime import (
 from ella.services.runtime_errors import ProvisioningError
 from ella.services.runtime_resolver import IsolatedRuntime
 
+# Distinct identities: auth uid != broker owner UUIDs.
+AUTH_UID = "omi-auth-uid-synth-01"
+ACCOUNT_UUID = "11111111-1111-4111-8111-111111111111"
+PROFILE_UUID = "22222222-2222-4222-8222-222222222222"
+BINDING_ID = "33333333-3333-4333-8333-333333333333"
+
 
 def _runtime(
     *,
-    uid: str = "synthetic-proto-01",
-    binding_id: str = "binding-proto-01",
+    uid: str = AUTH_UID,
+    account_user_id: str = ACCOUNT_UUID,
+    profile_user_id: str = PROFILE_UUID,
+    binding_id: str = BINDING_ID,
     profile_class: str = "synthetic",
     provider: str = "hermes_cloud",
     mode: str = HERMES_CLOUD_CHAT_MODE,
@@ -61,15 +69,17 @@ def _runtime(
         target_endpoint_ref="env:URL",
         target_credential_ref="env:KEY",
         target_entitlement_revision=1,
+        account_user_id=account_user_id,
+        profile_user_id=profile_user_id,
     )
 
 
 def _enable(monkeypatch, **overrides):
     env = {
         "ELLA_HERMES_BROKER_PROTOTYPE_ENABLED": "true",
-        "ELLA_HERMES_BROKER_PROTOTYPE_ACCOUNT_ID": "synthetic-proto-01",
-        "ELLA_HERMES_BROKER_PROTOTYPE_PROFILE_ID": "synthetic-proto-01",
-        "ELLA_HERMES_BROKER_PROTOTYPE_BINDING_ID": "binding-proto-01",
+        "ELLA_HERMES_BROKER_PROTOTYPE_ACCOUNT_ID": ACCOUNT_UUID,
+        "ELLA_HERMES_BROKER_PROTOTYPE_PROFILE_ID": PROFILE_UUID,
+        "ELLA_HERMES_BROKER_PROTOTYPE_BINDING_ID": BINDING_ID,
         "ELLA_HERMES_BROKER_BASE_URL": "https://broker.ella.internal",
         "ELLA_HERMES_BROKER_ALLOWED_HOST": "broker.ella.internal",
         "ELLA_HERMES_BROKER_SERVICE_TOKEN_REF": "env:ELLA_HERMES_BROKER_SERVICE_TOKEN",
@@ -119,6 +129,42 @@ class FakeHttp:
         return _Client()
 
 
+async def _noop_sleep(_seconds):
+    return None
+
+
+def _completed_result(**overrides):
+    body = {
+        "status": "completed",
+        "request_id": "hwb_req1",
+        "correlation_id": "hwb:corr1",
+        "account_id": ACCOUNT_UUID,
+        "profile_id": PROFILE_UUID,
+        "outcome": "success",
+        "result": {
+            "answer": "proto answer",
+            "session_key": "sk",
+            "session_id": "sid",
+            "canonical_user_event_id": "evt-1",
+            "model": "gpt-test",
+            "usage": {"input_tokens": 3, "output_tokens": 2},
+        },
+    }
+    body.update(overrides)
+    if "result" in overrides and isinstance(overrides["result"], dict):
+        merged = {
+            "answer": "proto answer",
+            "session_key": "sk",
+            "session_id": "sid",
+            "canonical_user_event_id": "evt-1",
+            "model": "gpt-test",
+            "usage": {"input_tokens": 3, "output_tokens": 2},
+        }
+        merged.update(overrides["result"])
+        body["result"] = merged
+    return body
+
+
 def test_default_off_does_not_select_broker(monkeypatch):
     monkeypatch.delenv("ELLA_HERMES_BROKER_PROTOTYPE_ENABLED", raising=False)
     assert proto.load_prototype_config() is None
@@ -130,13 +176,41 @@ def test_truthy_alias_not_enabled(monkeypatch):
     assert proto.load_prototype_config() is None
 
 
+def test_allowlist_uses_owner_uuids_not_auth_uid(monkeypatch):
+    _enable(monkeypatch)
+    # Same auth uid but wrong owner UUIDs → not selected.
+    assert (
+        proto.runtime_uses_broker_prototype(
+            _runtime(
+                uid=AUTH_UID,
+                account_user_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+                profile_user_id=PROFILE_UUID,
+            )
+        )
+        is False
+    )
+    # Distinct uid vs owner UUIDs matching allowlist → selected.
+    assert proto.runtime_uses_broker_prototype(_runtime()) is True
+
+
+def test_missing_owner_coordinates_not_selected(monkeypatch):
+    _enable(monkeypatch)
+    assert proto.runtime_uses_broker_prototype(_runtime(account_user_id="", profile_user_id="")) is False
+
+
 def test_non_allowlisted_user_keeps_direct_path(monkeypatch):
     _enable(monkeypatch)
     other = _runtime(uid="realcryptoplato", profile_class="real")
     assert proto.runtime_uses_broker_prototype(other) is False
     assert (
         proto.runtime_uses_broker_prototype(
-            _runtime(uid="other-synth", profile_class="synthetic", binding_id="binding-proto-01")
+            _runtime(
+                uid="other-synth",
+                account_user_id="99999999-9999-4999-8999-999999999999",
+                profile_user_id="99999999-9999-4999-8999-999999999999",
+                profile_class="synthetic",
+                binding_id=BINDING_ID,
+            )
         )
         is False
     )
@@ -148,7 +222,7 @@ def test_binding_pin_required_when_set(monkeypatch):
     assert proto.runtime_uses_broker_prototype(_runtime()) is True
 
 
-def test_success_chat_maps_answer(monkeypatch):
+def test_success_chat_maps_answer_with_owner_uuids(monkeypatch):
     _enable(monkeypatch)
     cfg = proto.load_prototype_config()
     assert cfg is not None
@@ -157,7 +231,9 @@ def test_success_chat_maps_answer(monkeypatch):
         if method == "POST":
             body = kwargs["json"]
             assert body["lane"] == "chat_turn"
-            assert body["account_id"] == "synthetic-proto-01"
+            assert body["account_id"] == ACCOUNT_UUID
+            assert body["profile_id"] == PROFILE_UUID
+            assert body["account_id"] != AUTH_UID
             assert body["payload"]["message"] == "hello"
             assert "Authorization" in kwargs["headers"]
             return FakeResponse(
@@ -171,34 +247,17 @@ def test_success_chat_maps_answer(monkeypatch):
         assert method == "GET"
         assert "hwb_req1" in url
         params = kwargs.get("params") or {}
-        assert params["account_id"] == "synthetic-proto-01"
-        return FakeResponse(
-            200,
-            {
-                "status": "completed",
-                "request_id": "hwb_req1",
-                "correlation_id": "hwb:corr1",
-                "account_id": "synthetic-proto-01",
-                "profile_id": "synthetic-proto-01",
-                "outcome": "success",
-                "result": {
-                    "answer": "proto answer",
-                    "session_key": "sk",
-                    "session_id": "sid",
-                    "canonical_user_event_id": "evt-1",
-                    "model": "gpt-test",
-                    "usage": {"input_tokens": 3, "output_tokens": 2},
-                },
-            },
-        )
+        assert params["account_id"] == ACCOUNT_UUID
+        assert params["profile_id"] == PROFILE_UUID
+        return FakeResponse(200, _completed_result())
 
     fake = FakeHttp(handler)
     client = HermesBrokerClient(cfg, http_client_factory=fake.factory, sleep=_noop_sleep)
     turn = asyncio.run(
         client.run_chat_turn(
-            account_id="synthetic-proto-01",
-            profile_id="synthetic-proto-01",
-            runtime_binding_ref="binding-proto-01",
+            account_id=ACCOUNT_UUID,
+            profile_id=PROFILE_UUID,
+            runtime_binding_ref=BINDING_ID,
             consent_epoch="consent.v1",
             message="hello",
             session_key="sk",
@@ -210,12 +269,6 @@ def test_success_chat_maps_answer(monkeypatch):
     assert turn.text == "proto answer"
     assert turn.request_id == "hwb_req1"
     assert turn.usage["output_tokens"] == 2
-    assert any(c[0] == "POST" for c in fake.calls)
-    assert any(c[0] == "GET" for c in fake.calls)
-
-
-async def _noop_sleep(_seconds):
-    return None
 
 
 def test_correlation_mismatch_fails_closed(monkeypatch):
@@ -228,31 +281,15 @@ def test_correlation_mismatch_fails_closed(monkeypatch):
                 200,
                 {"status": "pending", "request_id": "hwb_req1", "correlation_id": "hwb:corr1"},
             )
-        return FakeResponse(
-            200,
-            {
-                "status": "completed",
-                "request_id": "hwb_req1",
-                "correlation_id": "hwb:OTHER",
-                "account_id": "synthetic-proto-01",
-                "profile_id": "synthetic-proto-01",
-                "outcome": "success",
-                "result": {
-                    "answer": "x",
-                    "session_key": "sk",
-                    "session_id": "sid",
-                    "canonical_user_event_id": "evt-1",
-                },
-            },
-        )
+        return FakeResponse(200, _completed_result(correlation_id="hwb:OTHER"))
 
     client = HermesBrokerClient(cfg, http_client_factory=FakeHttp(handler).factory, sleep=_noop_sleep)
     with pytest.raises(ProvisioningError) as exc:
         asyncio.run(
             client.run_chat_turn(
-                account_id="synthetic-proto-01",
-                profile_id="synthetic-proto-01",
-                runtime_binding_ref="binding-proto-01",
+                account_id=ACCOUNT_UUID,
+                profile_id=PROFILE_UUID,
+                runtime_binding_ref=BINDING_ID,
                 consent_epoch="consent.v1",
                 message="hello",
                 session_key="sk",
@@ -276,24 +313,16 @@ def test_cross_account_result_fails_closed(monkeypatch):
             )
         return FakeResponse(
             200,
-            {
-                "status": "completed",
-                "request_id": "hwb_req1",
-                "correlation_id": "hwb:corr1",
-                "account_id": "someone-else",
-                "profile_id": "synthetic-proto-01",
-                "outcome": "success",
-                "result": {"answer": "x"},
-            },
+            _completed_result(account_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
         )
 
     client = HermesBrokerClient(cfg, http_client_factory=FakeHttp(handler).factory, sleep=_noop_sleep)
     with pytest.raises(ProvisioningError) as exc:
         asyncio.run(
             client.run_chat_turn(
-                account_id="synthetic-proto-01",
-                profile_id="synthetic-proto-01",
-                runtime_binding_ref="binding-proto-01",
+                account_id=ACCOUNT_UUID,
+                profile_id=PROFILE_UUID,
+                runtime_binding_ref=BINDING_ID,
                 consent_epoch="consent.v1",
                 message="hello",
                 session_key="sk",
@@ -305,6 +334,172 @@ def test_cross_account_result_fails_closed(monkeypatch):
     assert exc.value.code == "hermes_broker_prototype_cross_account_result"
 
 
+def test_omitted_account_on_terminal_fails_closed(monkeypatch):
+    _enable(monkeypatch)
+    cfg = proto.load_prototype_config()
+
+    def handler(method, url, kwargs):
+        if method == "POST":
+            return FakeResponse(
+                200,
+                {"status": "pending", "request_id": "hwb_req1", "correlation_id": "hwb:corr1"},
+            )
+        body = _completed_result()
+        del body["account_id"]
+        return FakeResponse(200, body)
+
+    client = HermesBrokerClient(cfg, http_client_factory=FakeHttp(handler).factory, sleep=_noop_sleep)
+    with pytest.raises(ProvisioningError) as exc:
+        asyncio.run(
+            client.run_chat_turn(
+                account_id=ACCOUNT_UUID,
+                profile_id=PROFILE_UUID,
+                runtime_binding_ref=BINDING_ID,
+                consent_epoch="consent.v1",
+                message="hello",
+                session_key="sk",
+                session_id="sid",
+                source_event_id="evt-1",
+                expected_model="gpt-test",
+            )
+        )
+    assert exc.value.code == "hermes_broker_prototype_account_omitted"
+
+
+def test_omitted_request_id_on_terminal_fails_closed(monkeypatch):
+    _enable(monkeypatch)
+    cfg = proto.load_prototype_config()
+
+    def handler(method, url, kwargs):
+        if method == "POST":
+            return FakeResponse(
+                200,
+                {"status": "pending", "request_id": "hwb_req1", "correlation_id": "hwb:corr1"},
+            )
+        body = _completed_result()
+        del body["request_id"]
+        return FakeResponse(200, body)
+
+    client = HermesBrokerClient(cfg, http_client_factory=FakeHttp(handler).factory, sleep=_noop_sleep)
+    with pytest.raises(ProvisioningError) as exc:
+        asyncio.run(
+            client.run_chat_turn(
+                account_id=ACCOUNT_UUID,
+                profile_id=PROFILE_UUID,
+                runtime_binding_ref=BINDING_ID,
+                consent_epoch="consent.v1",
+                message="hello",
+                session_key="sk",
+                session_id="sid",
+                source_event_id="evt-1",
+                expected_model="gpt-test",
+            )
+        )
+    assert exc.value.code == "hermes_broker_prototype_request_id_omitted"
+
+
+def test_cross_request_id_mismatch_fails_closed(monkeypatch):
+    _enable(monkeypatch)
+    cfg = proto.load_prototype_config()
+
+    def handler(method, url, kwargs):
+        if method == "POST":
+            return FakeResponse(
+                200,
+                {"status": "pending", "request_id": "hwb_req1", "correlation_id": "hwb:corr1"},
+            )
+        return FakeResponse(200, _completed_result(request_id="hwb_OTHER"))
+
+    client = HermesBrokerClient(cfg, http_client_factory=FakeHttp(handler).factory, sleep=_noop_sleep)
+    with pytest.raises(ProvisioningError) as exc:
+        asyncio.run(
+            client.run_chat_turn(
+                account_id=ACCOUNT_UUID,
+                profile_id=PROFILE_UUID,
+                runtime_binding_ref=BINDING_ID,
+                consent_epoch="consent.v1",
+                message="hello",
+                session_key="sk",
+                session_id="sid",
+                source_event_id="evt-1",
+                expected_model="gpt-test",
+            )
+        )
+    assert exc.value.code == "hermes_broker_prototype_request_id_mismatch"
+
+
+def test_omitted_session_key_in_result_fails_closed(monkeypatch):
+    _enable(monkeypatch)
+    cfg = proto.load_prototype_config()
+
+    def handler(method, url, kwargs):
+        if method == "POST":
+            return FakeResponse(
+                200,
+                {"status": "pending", "request_id": "hwb_req1", "correlation_id": "hwb:corr1"},
+            )
+        body = _completed_result(result={"answer": "x", "session_id": "sid", "canonical_user_event_id": "evt-1"})
+        # remove session_key from result
+        del body["result"]["session_key"]
+        return FakeResponse(200, body)
+
+    client = HermesBrokerClient(cfg, http_client_factory=FakeHttp(handler).factory, sleep=_noop_sleep)
+    with pytest.raises(ProvisioningError) as exc:
+        asyncio.run(
+            client.run_chat_turn(
+                account_id=ACCOUNT_UUID,
+                profile_id=PROFILE_UUID,
+                runtime_binding_ref=BINDING_ID,
+                consent_epoch="consent.v1",
+                message="hello",
+                session_key="sk",
+                session_id="sid",
+                source_event_id="evt-1",
+                expected_model="gpt-test",
+            )
+        )
+    assert exc.value.code == "hermes_broker_prototype_result_identity_omitted"
+
+
+def test_answer_only_projection_rejected(monkeypatch):
+    """Projection with only status+answer must fail (review P1-2)."""
+    _enable(monkeypatch)
+    cfg = proto.load_prototype_config()
+
+    def handler(method, url, kwargs):
+        if method == "POST":
+            return FakeResponse(
+                200,
+                {"status": "pending", "request_id": "hwb_req1", "correlation_id": "hwb:corr1"},
+            )
+        return FakeResponse(
+            200,
+            {"status": "completed", "result": {"answer": "sneaky"}},
+        )
+
+    client = HermesBrokerClient(cfg, http_client_factory=FakeHttp(handler).factory, sleep=_noop_sleep)
+    with pytest.raises(ProvisioningError) as exc:
+        asyncio.run(
+            client.run_chat_turn(
+                account_id=ACCOUNT_UUID,
+                profile_id=PROFILE_UUID,
+                runtime_binding_ref=BINDING_ID,
+                consent_epoch="consent.v1",
+                message="hello",
+                session_key="sk",
+                session_id="sid",
+                source_event_id="evt-1",
+                expected_model="gpt-test",
+            )
+        )
+    assert exc.value.code in {
+        "hermes_broker_prototype_request_id_omitted",
+        "hermes_broker_prototype_account_omitted",
+        "hermes_broker_prototype_profile_omitted",
+        "hermes_broker_prototype_correlation_omitted",
+    }
+
+
 def test_timeout_fails_closed(monkeypatch):
     _enable(monkeypatch, ELLA_HERMES_BROKER_POLL_TIMEOUT_SECONDS="1.0")
     cfg = proto.load_prototype_config()
@@ -314,7 +509,6 @@ def test_timeout_fails_closed(monkeypatch):
         return clock["t"]
 
     async def sleep(seconds):
-        # Jump past the wait budget immediately after one poll.
         clock["t"] += 2.0
 
     def handler(method, url, kwargs):
@@ -329,8 +523,8 @@ def test_timeout_fails_closed(monkeypatch):
                 "status": "awaiting_callback",
                 "request_id": "hwb_req1",
                 "correlation_id": "hwb:corr1",
-                "account_id": "synthetic-proto-01",
-                "profile_id": "synthetic-proto-01",
+                "account_id": ACCOUNT_UUID,
+                "profile_id": PROFILE_UUID,
             },
         )
 
@@ -343,9 +537,9 @@ def test_timeout_fails_closed(monkeypatch):
     with pytest.raises(ProvisioningError) as exc:
         asyncio.run(
             client.run_chat_turn(
-                account_id="synthetic-proto-01",
-                profile_id="synthetic-proto-01",
-                runtime_binding_ref="binding-proto-01",
+                account_id=ACCOUNT_UUID,
+                profile_id=PROFILE_UUID,
+                runtime_binding_ref=BINDING_ID,
                 consent_epoch="consent.v1",
                 message="hello",
                 session_key="sk",
@@ -374,29 +568,23 @@ def test_duplicate_replay_accepted(monkeypatch):
             )
         return FakeResponse(
             200,
-            {
-                "status": "completed",
-                "request_id": "hwb_req1",
-                "correlation_id": "hwb:corr1",
-                "account_id": "synthetic-proto-01",
-                "profile_id": "synthetic-proto-01",
-                "outcome": "success",
-                "duplicate": True,
-                "result": {
+            _completed_result(
+                duplicate=True,
+                result={
                     "answer": "replayed",
                     "session_key": "sk",
                     "session_id": "sid",
                     "canonical_user_event_id": "evt-1",
                 },
-            },
+            ),
         )
 
     client = HermesBrokerClient(cfg, http_client_factory=FakeHttp(handler).factory, sleep=_noop_sleep)
     turn = asyncio.run(
         client.run_chat_turn(
-            account_id="synthetic-proto-01",
-            profile_id="synthetic-proto-01",
-            runtime_binding_ref="binding-proto-01",
+            account_id=ACCOUNT_UUID,
+            profile_id=PROFILE_UUID,
+            runtime_binding_ref=BINDING_ID,
             consent_epoch="consent.v1",
             message="hello",
             session_key="sk",
@@ -425,9 +613,9 @@ def test_missing_result_endpoint_is_explicit_companion_blocker(monkeypatch):
     with pytest.raises(ProvisioningError) as exc:
         asyncio.run(
             client.run_chat_turn(
-                account_id="synthetic-proto-01",
-                profile_id="synthetic-proto-01",
-                runtime_binding_ref="binding-proto-01",
+                account_id=ACCOUNT_UUID,
+                profile_id=PROFILE_UUID,
+                runtime_binding_ref=BINDING_ID,
                 consent_epoch="consent.v1",
                 message="hello",
                 session_key="sk",
@@ -479,13 +667,13 @@ def test_provider_turn_uses_direct_when_not_allowlisted(monkeypatch):
         service._provider_turn(
             runtime=_runtime(),
             request=HermesCloudTurnRequest(
-                uid="synthetic-proto-01",
+                uid=AUTH_UID,
                 client_interaction_id="evt-1",
                 correlation_id="c1",
                 channel="ios_chat",
                 user_input="hi",
                 instructions="sys",
-                started_at=__import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+                started_at=datetime.now(timezone.utc),
                 client_metadata={},
             ),
             scope={"session_key": "sk"},
@@ -499,13 +687,12 @@ def test_provider_turn_uses_direct_when_not_allowlisted(monkeypatch):
     assert calls == ["direct"]
 
 
-def test_provider_turn_uses_broker_when_allowlisted(monkeypatch):
+def test_provider_turn_submits_owner_uuids_not_auth_uid(monkeypatch):
     _enable(monkeypatch)
-    calls = []
+    seen = {}
 
     class DirectClient:
         async def create_response(self, *args, **kwargs):
-            calls.append("direct")
             raise AssertionError("direct path must not run for allowlisted prototype")
 
     class FakeBroker(HermesBrokerClient):
@@ -513,7 +700,7 @@ def test_provider_turn_uses_broker_when_allowlisted(monkeypatch):
             super().__init__(config, sleep=_noop_sleep)
 
         async def run_chat_turn(self, **kwargs):
-            calls.append("broker")
+            seen.update(kwargs)
             return client_mod.BrokerTerminalTurn(
                 text="via-broker",
                 request_id="hwb_x",
@@ -532,20 +719,19 @@ def test_provider_turn_uses_broker_when_allowlisted(monkeypatch):
     service.broker_client_factory = FakeBroker
 
     async def boundary():
-        calls.append("boundary")
         return ("https://h", "t")
 
     turn = asyncio.run(
         service._provider_turn(
             runtime=_runtime(),
             request=HermesCloudTurnRequest(
-                uid="synthetic-proto-01",
+                uid=AUTH_UID,
                 client_interaction_id="evt-1",
                 correlation_id="c1",
                 channel="ios_chat",
                 user_input="hi",
                 instructions="sys",
-                started_at=__import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+                started_at=datetime.now(timezone.utc),
                 client_metadata={},
             ),
             scope={"session_key": "sk"},
@@ -556,9 +742,10 @@ def test_provider_turn_uses_broker_when_allowlisted(monkeypatch):
         )
     )
     assert turn.text == "via-broker"
-    assert "direct" not in calls
-    assert "broker" in calls
-    assert "boundary" in calls
+    assert seen["account_id"] == ACCOUNT_UUID
+    assert seen["profile_id"] == PROFILE_UUID
+    assert seen["account_id"] != AUTH_UID
+    assert seen["runtime_binding_ref"] == BINDING_ID
 
 
 def test_enrichment_channel_uses_transcript_lane(monkeypatch):
@@ -598,13 +785,13 @@ def test_enrichment_channel_uses_transcript_lane(monkeypatch):
         service._provider_turn(
             runtime=_runtime(mode=HERMES_CLOUD_ENRICHMENT_MODE),
             request=HermesCloudTurnRequest(
-                uid="synthetic-proto-01",
+                uid=AUTH_UID,
                 client_interaction_id="evt-enrich",
                 correlation_id="c-enrich",
                 channel=HERMES_CLOUD_ENRICHMENT_CHANNEL,
                 user_input="transcript text",
                 instructions="enrich",
-                started_at=__import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+                started_at=datetime.now(timezone.utc),
                 client_metadata={},
             ),
             scope={"session_key": "sk"},
@@ -615,11 +802,11 @@ def test_enrichment_channel_uses_transcript_lane(monkeypatch):
         )
     )
     assert "title" in turn.text
+    assert seen["account_id"] == ACCOUNT_UUID
     assert seen["source_event_id"] == "evt-enrich"
 
 
 def test_sse_mapping_preserves_answer_text():
-    # Mirrors _stream_hermes_cloud_chat emission contract (data line + CRLF).
     answer = "line1\nline2"
     data_line = f"data: {answer.replace(chr(10), '__CRLF__')}\n\n"
     assert "__CRLF__" in data_line

--- a/backend/tests/unit/test_hermes_cloud_provider.py
+++ b/backend/tests/unit/test_hermes_cloud_provider.py
@@ -70,6 +70,8 @@ def _binding():
     artifact_hash = "a" * 64
     return {
         "id": "binding-a",
+        "account_user_id": "11111111-1111-4111-8111-111111111111",
+        "profile_user_id": "11111111-1111-4111-8111-111111111111",
         "api_base_url_ref": "env:ELLA_HERMES_CLOUD_API_URL_SYNTHETIC",
         "api_key_ref": "env:ELLA_HERMES_CLOUD_API_KEY_SYNTHETIC",
         "honcho_api_key_ref": "env:ELLA_HONCHO_CLOUD_API_KEY_SYNTHETIC",


### PR DESCRIPTION
## Summary

Fail-closed, **default-off** OMI adapter so **one exact synthetic account/profile** can use the merged Ella first-party Hermes webhook broker (`admit` + bounded result wait) for:

- `/v1/ella/chat/stream` (via `HermesCloudRuntimeService`)
- transcript-summary enrichment (same runtime service, enrichment channel)

All other users—including retained Plato/Mini and non-allowlisted synthetics—keep the existing direct Hermes Cloud `/v1/responses` path.

## Pins

| | SHA |
|---|---|
| OMI base `main` | `a9af15c4373cd5456acfac89d3e9f07e8506b580` |
| Head | `d7581303431d428d25f66dd8bc1ae933f092ee34` |
| Ella-ai broker main | `114c30dec5312360c860e95ff46b18ad37e5f4ed` |

## Safety

- Global flag must be exact lowercase `true`
- Exact account/profile (+ optional binding) allowlist
- Fixed HTTPS host allowlist; service token via `env:` ref only
- No Plato/Mini/direct Hermes fallback on broker error
- Rollback: unset flag / set anything other than `true`

## Companion blocker (ella-ai)

Merged broker has **no GET request/result** API; canonical writeback is content-free (`result_sha256` only). Live smoke needs:

`GET /v1/ella/internal/hermes-webhook-broker/requests/{request_id}?account_id=&profile_id=`  
(service auth, owner re-proof, bounded body, returns terminal `result` from `broker_writeback_outbox.result_json`).

Until present, OMI returns `hermes_broker_prototype_result_endpoint_missing` after admit (fail closed). Details: `backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md`.

## Tests

`python3 -m pytest -q tests/unit/test_hermes_broker_prototype.py` → **15 passed**  
(fake broker: success, correlation mismatch, cross-account, timeout, duplicate, missing GET companion, disabled/not-allowlisted, direct path unchanged, SSE mapping, enrichment lane)

## Out of scope

- omi#333 invite UX (untouched)
- Production concurrency / warm-pool / global rollout (ella-ai#1157)
- Deploy / merge

## Tracking

ellaaicare/ella-ai#1124