### PR TITLE
Add protected synthetic invite operator

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -325,7 +325,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 351
+          test "$collected" -eq 355
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "backend/contracts/authority_advisory_lock_v1.json"
       - "backend/database/authority_advisory_lock.py"
+      - "backend/database/invitation_operator.py"
       - "backend/database/invitations.py"
       - "backend/database/managed_cloud_consent.py"
       - "backend/database/runtime_targets.py"
@@ -19,8 +20,12 @@ on:
       - "backend/migrations/011_create_invitation_redemption.sql"
       - "backend/migrations/012_create_account_profile_runtime_targets.sql"
       - "backend/migrations/013_create_managed_cloud_consent_authority.sql"
+      - "backend/migrations/014_add_synthetic_invitation_operator_audit.sql"
+      - "backend/scripts/synthetic_invite_admin.py"
       - "backend/ella/docs/INVITE_REDEMPTION_CONTROL_PLANE.md"
+      - "backend/ella/docs/SYNTHETIC_INVITE_OPERATOR.md"
       - "backend/tests/unit/test_invitation_redemption.py"
+      - "backend/tests/unit/test_synthetic_invite_admin.py"
       - "backend/tests/postgres/test_invitation_redemption_postgres.py"
       - "backend/tests/postgres/test_runtime_migration_atomicity_postgres.py"
       - ".github/workflows/invite-redemption-tests.yml"
@@ -29,6 +34,7 @@ on:
     paths:
       - "backend/contracts/authority_advisory_lock_v1.json"
       - "backend/database/authority_advisory_lock.py"
+      - "backend/database/invitation_operator.py"
       - "backend/database/invitations.py"
       - "backend/database/managed_cloud_consent.py"
       - "backend/database/runtime_targets.py"
@@ -43,8 +49,12 @@ on:
       - "backend/migrations/011_create_invitation_redemption.sql"
       - "backend/migrations/012_create_account_profile_runtime_targets.sql"
       - "backend/migrations/013_create_managed_cloud_consent_authority.sql"
+      - "backend/migrations/014_add_synthetic_invitation_operator_audit.sql"
+      - "backend/scripts/synthetic_invite_admin.py"
       - "backend/ella/docs/INVITE_REDEMPTION_CONTROL_PLANE.md"
+      - "backend/ella/docs/SYNTHETIC_INVITE_OPERATOR.md"
       - "backend/tests/unit/test_invitation_redemption.py"
+      - "backend/tests/unit/test_synthetic_invite_admin.py"
       - "backend/tests/postgres/test_invitation_redemption_postgres.py"
       - "backend/tests/postgres/test_runtime_migration_atomicity_postgres.py"
       - ".github/workflows/invite-redemption-tests.yml"
@@ -99,6 +109,7 @@ jobs:
         run: >-
           python -m py_compile
           database/authority_advisory_lock.py
+          database/invitation_operator.py
           database/invitations.py
           database/managed_cloud_consent.py
           database/runtime_targets.py
@@ -108,20 +119,23 @@ jobs:
           ella/services/consent_authority.py
           ella/services/invitation_authority.py
           ella/services/hermes_cloud_policy.py
+          scripts/synthetic_invite_admin.py
 
       - name: Run unit and PostgreSQL security tests
         run: |
           collected="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
+              tests/unit/test_synthetic_invite_admin.py \
               tests/unit/test_voice_canary.py \
               tests/postgres/test_invitation_redemption_postgres.py \
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 44
+          test "$collected" -eq 59
           pytest \
             tests/unit/test_invitation_redemption.py \
+            tests/unit/test_synthetic_invite_admin.py \
             tests/unit/test_voice_canary.py \
             tests/postgres/test_invitation_redemption_postgres.py \
             tests/postgres/test_runtime_migration_atomicity_postgres.py \

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -89,6 +89,13 @@ ELLA_HERMES_CLOUD_PROVISIONING_ENABLED=false
 ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS=
 ELLA_RUNTIME_BINDINGS_ENABLED=false
 ELLA_RUNTIME_BINDINGS_ENABLED_UIDS=
+# Root-only invitation redemption. Ordinary/App Review admission stays off for
+# the synthetic operator cohort. Keep the pepper in the server secret store.
+ELLA_INVITE_REDEMPTION_ENABLED=false
+ELLA_INVITE_ORDINARY_SELF_SERVICE_ENABLED=false
+ELLA_INVITE_APP_REVIEW_ENABLED=false
+ELLA_INVITE_HMAC_PEPPER=
+ELLA_INVITE_OPERATOR_ENVIRONMENT=
 # Enable only after the voice proxy uses authenticated Hermes context/tools and
 # has no OpenClaw fallback for isolated sessions.
 ELLA_ISOLATED_VOICE_ROUTING_ENABLED=false

--- a/backend/database/invitation_operator.py
+++ b/backend/database/invitation_operator.py
@@ -801,6 +801,7 @@ async def _with_exact_receipt(
             if operation == "cleanup":
                 return await _cleanup_locked(
                     conn,
+                    owner_lock=proof,
                     row=row,
                     user=user,
                     identity=identity,
@@ -916,6 +917,7 @@ async def _revoke_locked(
 async def _cleanup_locked(
     conn: asyncpg.Connection,
     *,
+    owner_lock: authority_advisory_lock.AuthorityLockProof,
     row: dict[str, Any],
     user: dict[str, Any],
     identity: SyntheticInvitationIdentity,
@@ -943,6 +945,11 @@ async def _cleanup_locked(
     )
     artifacts["voice_entitlement"] = False
     _assert_pristine_artifacts(artifacts)
+    await authority_advisory_lock.require_self_owner_lock(
+        conn,
+        owner_lock,
+        user_id=user["id"],
+    )
     updated = dict(
         await conn.fetchrow(
             """

--- a/backend/database/invitation_operator.py
+++ b/backend/database/invitation_operator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import hmac
 import json
 import re
@@ -28,6 +29,7 @@ FORBIDDEN_IDENTITIES = {
 MIN_EXPIRY = timedelta(minutes=5)
 MAX_EXPIRY = timedelta(hours=24)
 OPERATOR_POLICY = invitations.SYNTHETIC_OPERATOR_ENTITLEMENT_POLICY
+RECOVERY_BINDING_VERSION = "synthetic-invitation-recovery-v1"
 
 
 class SyntheticInvitationOperatorError(RuntimeError):
@@ -76,6 +78,60 @@ def _utc(value: datetime) -> datetime:
 
 def _operator_source(context: SyntheticInvitationContext) -> str:
     return f"synthetic-invite-operator:{context.environment}:{context.operator}"
+
+
+def synthetic_invitation_recovery_binding_hmac(
+    *,
+    identity: SyntheticInvitationIdentity,
+    context: SyntheticInvitationContext,
+    admission: invitations.InvitationPilotAdmission,
+    code: str,
+    code_file_ref_hmac: str,
+    expires_at: datetime,
+    config: invitations.InvitationConfig,
+) -> str:
+    """Bind a protected-file recovery receipt to the complete issuance intent."""
+    identity.validate()
+    context.validate()
+    normalized_code = invitations.normalize_invite_code(code)
+    expiry = _utc(expires_at)
+    if (
+        not normalized_code
+        or not isinstance(admission, invitations.InvitationPilotAdmission)
+        or admission.account_uid != identity.account_uid
+        or admission.profile_uid != identity.profile_uid
+        or not re.fullmatch(r"[0-9a-f]{64}", code_file_ref_hmac)
+    ):
+        raise SyntheticInvitationOperatorError("operator_issue_contract_invalid")
+    payload = json.dumps(
+        {
+            "account_uid": identity.account_uid,
+            "code_file_ref_hmac": code_file_ref_hmac,
+            "code_hmac": invitations.code_hmac(config, normalized_code),
+            "consent_policy_version": admission.policy_version,
+            "consent_processor_set_hash": admission.processor_set_hash,
+            "consent_receipt_id": admission.consent_receipt_id,
+            "consent_scope_hash": admission.scope_hash,
+            "consent_scope_version": admission.scope_version,
+            "environment": context.environment,
+            "expected_database": context.expected_database,
+            "expires_at": expiry.isoformat(),
+            "operator": context.operator,
+            "policy_revision": OPERATOR_POLICY_REVISION,
+            "profile_binding_id": admission.profile_binding_id,
+            "profile_uid": identity.profile_uid,
+            "purpose": OPERATOR_PURPOSE,
+            "uid": identity.uid,
+            "version": RECOVERY_BINDING_VERSION,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hmac.new(
+        config.hmac_pepper,
+        b"synthetic-invitation-recovery-v1\x1f" + payload,
+        hashlib.sha256,
+    ).hexdigest()
 
 
 def _json_object(value: Any) -> dict[str, Any]:
@@ -399,6 +455,7 @@ async def issue_synthetic_invitation(
     code: str,
     code_file_existed: bool,
     code_file_ref_hmac: str,
+    recovery_binding_hmac: str,
     expires_at: datetime,
     config: invitations.InvitationConfig,
 ) -> dict[str, Any]:
@@ -416,12 +473,24 @@ async def issue_synthetic_invitation(
         or expiry <= now
         or expiry > now + MAX_EXPIRY
         or not re.fullmatch(r"[0-9a-f]{64}", code_file_ref_hmac)
+        or not re.fullmatch(r"[0-9a-f]{64}", recovery_binding_hmac)
     ):
         raise SyntheticInvitationOperatorError("operator_issue_contract_invalid")
     if not config.redemption_enabled or config.ordinary_enabled or config.app_review_enabled:
         raise SyntheticInvitationOperatorError("operator_invite_flags_invalid")
 
     invitation_code_hmac = invitations.code_hmac(config, normalized_code)
+    expected_recovery_binding_hmac = synthetic_invitation_recovery_binding_hmac(
+        identity=identity,
+        context=context,
+        admission=admission,
+        code=code,
+        code_file_ref_hmac=code_file_ref_hmac,
+        expires_at=expiry,
+        config=config,
+    )
+    if not hmac.compare_digest(recovery_binding_hmac, expected_recovery_binding_hmac):
+        raise SyntheticInvitationOperatorError("operator_stale_code_receipt")
     account_ref_hmac, profile_ref_hmac = invitations.invitation_target_refs(
         config,
         account_uid=identity.account_uid,
@@ -489,8 +558,6 @@ async def issue_synthetic_invitation(
                     profile_class=str(user["profile_class"]),
                     idempotent=True,
                 )
-            if code_file_existed:
-                raise SyntheticInvitationOperatorError("operator_stale_code_receipt")
             if expiry < now + MIN_EXPIRY:
                 raise SyntheticInvitationOperatorError("operator_expiry_too_soon")
 
@@ -572,6 +639,7 @@ async def issue_synthetic_invitation(
                     "profile_class": "synthetic",
                     "expires_at": expiry.isoformat(),
                     "code_file_ref_hmac": code_file_ref_hmac,
+                    "reconciled_from_protected_file": code_file_existed,
                     "content_free": True,
                 },
             )

--- a/backend/database/invitation_operator.py
+++ b/backend/database/invitation_operator.py
@@ -1,0 +1,988 @@
+"""Root-CLI database contract for one disposable synthetic invitation."""
+
+from __future__ import annotations
+
+import hmac
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+import asyncpg
+
+from database import authority_advisory_lock, invitations, voice_canary
+
+OPERATOR_PURPOSE = "hermes_cloud_synthetic_prototype"
+OPERATOR_POLICY_REVISION = invitations.SYNTHETIC_OPERATOR_POLICY_REVISION
+OPERATOR_POOL_KEY = "synthetic_operator"
+SAFE_CONTEXT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+FORBIDDEN_IDENTITIES = {
+    "plato-eval",
+    "plato_eval",
+    "real-crypto-plato",
+    "real_crypto_plato",
+    "realcryptoplato",
+}
+MIN_EXPIRY = timedelta(minutes=5)
+MAX_EXPIRY = timedelta(hours=24)
+OPERATOR_POLICY = invitations.SYNTHETIC_OPERATOR_ENTITLEMENT_POLICY
+
+
+class SyntheticInvitationOperatorError(RuntimeError):
+    """A content-free operator refusal safe to surface on stderr."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True)
+class SyntheticInvitationIdentity:
+    uid: str
+    account_uid: str
+    profile_uid: str
+
+    def validate(self) -> None:
+        values = (self.uid, self.account_uid, self.profile_uid)
+        if (
+            any(not isinstance(value, str) or not value or len(value) > 256 for value in values)
+            or len(set(values)) != 1
+            or not self.uid.startswith(("synthetic-", "staging-synthetic-"))
+            or any(value.strip().lower() in FORBIDDEN_IDENTITIES for value in values)
+        ):
+            raise SyntheticInvitationOperatorError("operator_identity_refused")
+
+
+@dataclass(frozen=True)
+class SyntheticInvitationContext:
+    environment: str
+    expected_database: str
+    operator: str
+
+    def validate(self) -> None:
+        if not all(
+            SAFE_CONTEXT_RE.fullmatch(value) for value in (self.environment, self.expected_database, self.operator)
+        ):
+            raise SyntheticInvitationOperatorError("operator_context_invalid")
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        raise SyntheticInvitationOperatorError("operator_expiry_timezone_required")
+    return value.astimezone(timezone.utc)
+
+
+def _operator_source(context: SyntheticInvitationContext) -> str:
+    return f"synthetic-invite-operator:{context.environment}:{context.operator}"
+
+
+def _json_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return dict(parsed) if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _safe_receipt(row: dict[str, Any], *, profile_class: str, idempotent: bool = False) -> dict[str, Any]:
+    expires_at = row.get("expires_at")
+    return {
+        "receipt_id": str(row["id"]),
+        "purpose": OPERATOR_PURPOSE,
+        "required_profile_class": "synthetic",
+        "current_profile_class": profile_class,
+        "state": str(row["state"]),
+        "delivery_state": str(row["delivery_state"]),
+        "redemption_count": int(row["redemption_count"]),
+        "max_redemptions": int(row["max_redemptions"]),
+        "expires_at": _utc(expires_at).isoformat() if expires_at else None,
+        "version": int(row["version"]),
+        "idempotent": idempotent,
+        "content_free": True,
+    }
+
+
+async def _database_guard(
+    conn: asyncpg.Connection,
+    context: SyntheticInvitationContext,
+) -> None:
+    actual_database = str(await conn.fetchval("SELECT current_database()") or "")
+    if not hmac.compare_digest(actual_database, context.expected_database):
+        raise SyntheticInvitationOperatorError("operator_database_mismatch")
+
+
+async def _lock_owner(
+    conn: asyncpg.Connection,
+    identity: SyntheticInvitationIdentity,
+    owner: authority_advisory_lock.AuthorityOwner,
+) -> authority_advisory_lock.AuthorityLockProof:
+    proof = await authority_advisory_lock.acquire_authority_lock(conn, owner=owner)
+    await voice_canary.lock_runtime_authority_on_connection(conn, uid=identity.uid)
+    await conn.execute(
+        "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+        f"synthetic-invitation-operator-v1:{identity.uid}",
+    )
+    return proof
+
+
+async def _locked_user(
+    conn: asyncpg.Connection,
+    identity: SyntheticInvitationIdentity,
+    owner: authority_advisory_lock.AuthorityOwner,
+    proof: authority_advisory_lock.AuthorityLockProof,
+) -> dict[str, Any]:
+    await authority_advisory_lock.require_authority_lock(conn, proof, owner=owner)
+    row = await conn.fetchrow(
+        """
+        SELECT id, omi_uid, status, profile_class
+        FROM users
+        WHERE omi_uid = $1
+        FOR UPDATE
+        """,
+        identity.uid,
+    )
+    if not row or row["id"] != owner.account_id or owner.account_id != owner.profile_id:
+        raise SyntheticInvitationOperatorError("operator_identity_drift")
+    user = dict(row)
+    if str(user["status"]) != "ACTIVE":
+        raise SyntheticInvitationOperatorError("operator_user_not_active")
+    return user
+
+
+async def _artifact_snapshot(
+    conn: asyncpg.Connection,
+    *,
+    user_id: uuid.UUID,
+    uid: str,
+) -> dict[str, bool]:
+    row = await conn.fetchrow(
+        """
+        SELECT
+            EXISTS (
+                SELECT 1 FROM voice_entitlements WHERE uid = $2
+            ) AS voice_entitlement,
+            EXISTS (
+                SELECT 1 FROM ella_provisioning_jobs WHERE user_id = $1
+            ) AS provisioning_job,
+            EXISTS (
+                SELECT 1
+                FROM ella_runtime_bindings
+                WHERE user_id = $1
+                   OR account_user_id = $1
+                   OR profile_user_id = $1
+            ) AS runtime_binding,
+            EXISTS (
+                SELECT 1
+                FROM ella_runtime_targets
+                WHERE account_user_id = $1 OR profile_user_id = $1
+            ) AS runtime_target,
+            EXISTS (
+                SELECT 1
+                FROM ella_managed_cloud_consent_authority
+                WHERE user_id = $1
+            ) AS consent_authority
+        """,
+        user_id,
+        uid,
+    )
+    if not row:
+        raise SyntheticInvitationOperatorError("operator_artifact_check_unavailable")
+    return {key: bool(value) for key, value in dict(row).items()}
+
+
+def _assert_pristine_artifacts(artifacts: dict[str, bool]) -> None:
+    if any(artifacts.values()):
+        raise SyntheticInvitationOperatorError("operator_existing_profile_artifacts")
+
+
+async def _operator_rows_for_target(
+    conn: asyncpg.Connection,
+    *,
+    account_ref_hmac: str,
+    profile_ref_hmac: str,
+    for_update: bool,
+) -> list[dict[str, Any]]:
+    lock_clause = "FOR UPDATE OF i, t, r" if for_update else ""
+    rows = await conn.fetch(
+        f"""
+        SELECT
+            i.*,
+            t.id AS target_id,
+            t.account_ref_hmac,
+            t.profile_ref_hmac,
+            t.required_profile_class,
+            t.consumed_at AS target_consumed_at,
+            r.id AS reservation_id,
+            r.pool_key,
+            r.state AS reservation_state,
+            r.reserved_slots,
+            r.consumed_slots,
+            (
+                SELECT COUNT(*)
+                FROM ella_invitation_audit_receipts a
+                WHERE a.invitation_id = i.id
+                  AND a.event_type = 'operator_issued'
+            ) AS operator_issued_audit_count,
+            (
+                SELECT jsonb_build_object(
+                    'metadata', a.metadata,
+                    'source_ref_hmac', a.source_ref_hmac
+                )
+                FROM ella_invitation_audit_receipts a
+                WHERE a.invitation_id = i.id
+                  AND a.event_type = 'operator_issued'
+                ORDER BY a.created_at, a.id
+                LIMIT 1
+            ) AS operator_issued_receipt
+        FROM ella_invitation_targets t
+        JOIN ella_invitations i ON i.id = t.invitation_id
+        JOIN ella_invitation_capacity_reservations r
+          ON r.id = i.capacity_reservation_id
+        WHERE t.account_ref_hmac = $1
+          AND t.profile_ref_hmac = $2
+          AND i.kind = 'ordinary'
+          AND i.cohort = $3
+        ORDER BY i.created_at, i.id
+        {lock_clause}
+        """,
+        account_ref_hmac,
+        profile_ref_hmac,
+        invitations.SYNTHETIC_OPERATOR_COHORT,
+    )
+    return [dict(row) for row in rows]
+
+
+def _assert_stored_operator_row_shape(
+    row: dict[str, Any],
+    *,
+    identity: SyntheticInvitationIdentity,
+    config: invitations.InvitationConfig,
+) -> None:
+    account_ref_hmac, profile_ref_hmac = invitations.invitation_target_refs(
+        config,
+        account_uid=identity.account_uid,
+        profile_uid=identity.profile_uid,
+    )
+    try:
+        policy = invitations.normalize_entitlement_policy(row["entitlement_policy"])
+    except invitations.InviteConfigurationError as exc:
+        raise SyntheticInvitationOperatorError("operator_invitation_policy_drift") from exc
+    checks = (
+        invitations.is_synthetic_operator_invitation(row),
+        hmac.compare_digest(str(row["account_ref_hmac"]), account_ref_hmac),
+        hmac.compare_digest(str(row["profile_ref_hmac"]), profile_ref_hmac),
+        str(row["required_profile_class"]) == "synthetic",
+        str(row["pool_key"]) == OPERATOR_POOL_KEY,
+        int(row["reserved_slots"]) == 1,
+        int(row["consumed_slots"]) in {0, 1},
+        str(row["entitlement_policy_revision"]) == OPERATOR_POLICY_REVISION,
+        policy == OPERATOR_POLICY,
+        int(row.get("operator_issued_audit_count") or 0) == 1,
+    )
+    if not all(checks):
+        raise SyntheticInvitationOperatorError("operator_invitation_drift")
+
+
+def _assert_issued_context(
+    row: dict[str, Any],
+    *,
+    identity: SyntheticInvitationIdentity,
+    context: SyntheticInvitationContext,
+    config: invitations.InvitationConfig,
+    expected_code_file_ref_hmac: Optional[str] = None,
+) -> None:
+    receipt = _json_object(row.get("operator_issued_receipt"))
+    metadata = _json_object(receipt.get("metadata"))
+    _, expected_source_ref_hmac = invitations.invitation_audit_refs(
+        config,
+        uid=identity.uid,
+        source=_operator_source(context),
+    )
+    stored_source_ref_hmac = str(receipt.get("source_ref_hmac") or "")
+    context_matches = (
+        bool(stored_source_ref_hmac)
+        and hmac.compare_digest(stored_source_ref_hmac, expected_source_ref_hmac)
+        and metadata.get("purpose") == OPERATOR_PURPOSE
+        and metadata.get("environment") == context.environment
+        and metadata.get("profile_class") == "synthetic"
+        and metadata.get("content_free") is True
+    )
+    if not context_matches:
+        raise SyntheticInvitationOperatorError("operator_receipt_context_mismatch")
+    if expected_code_file_ref_hmac is not None:
+        stored_file_ref = str(metadata.get("code_file_ref_hmac") or "")
+        if not stored_file_ref or not hmac.compare_digest(
+            stored_file_ref,
+            expected_code_file_ref_hmac,
+        ):
+            raise SyntheticInvitationOperatorError("operator_stale_code_receipt")
+
+
+def _assert_operator_row_shape(
+    row: dict[str, Any],
+    *,
+    identity: SyntheticInvitationIdentity,
+    context: SyntheticInvitationContext,
+    admission: invitations.InvitationPilotAdmission,
+    config: invitations.InvitationConfig,
+    expected_code_hmac: Optional[str] = None,
+    expected_expires_at: Optional[datetime] = None,
+    expected_code_file_ref_hmac: Optional[str] = None,
+) -> None:
+    _assert_stored_operator_row_shape(
+        row,
+        identity=identity,
+        config=config,
+    )
+    _assert_issued_context(
+        row,
+        identity=identity,
+        context=context,
+        config=config,
+        expected_code_file_ref_hmac=expected_code_file_ref_hmac,
+    )
+    consent_matches = (
+        row["required_consent_policy_version"] == admission.policy_version
+        and row["required_consent_processor_set_hash"] == admission.processor_set_hash
+        and row["required_consent_scope_version"] == admission.scope_version
+        and row["required_consent_scope_hash"] == admission.scope_hash
+    )
+    if not consent_matches:
+        raise SyntheticInvitationOperatorError("operator_invitation_consent_drift")
+    if expected_code_hmac is not None and not hmac.compare_digest(
+        str(row["code_hmac"]),
+        expected_code_hmac,
+    ):
+        raise SyntheticInvitationOperatorError("operator_stale_code_receipt")
+    if expected_expires_at is not None and _utc(row["expires_at"]) != _utc(expected_expires_at):
+        raise SyntheticInvitationOperatorError("operator_invitation_expiry_drift")
+
+
+async def _record_operator_audit(
+    conn: asyncpg.Connection,
+    *,
+    invitation_id: uuid.UUID,
+    identity: SyntheticInvitationIdentity,
+    context: SyntheticInvitationContext,
+    config: invitations.InvitationConfig,
+    event_type: str,
+    metadata: dict[str, Any],
+) -> None:
+    uid_ref_hmac, source_ref_hmac = invitations.invitation_audit_refs(
+        config,
+        uid=identity.uid,
+        source=_operator_source(context),
+    )
+    await invitations._record_audit(
+        conn,
+        invitation_id=invitation_id,
+        uid_ref_hmac=uid_ref_hmac,
+        source_ref_hmac=source_ref_hmac,
+        event_type=event_type,
+        support_code=invitations._support_code(),
+        correlation_id=invitations._correlation_id(),
+        metadata=metadata,
+    )
+
+
+async def issue_synthetic_invitation(
+    *,
+    identity: SyntheticInvitationIdentity,
+    context: SyntheticInvitationContext,
+    admission: invitations.InvitationPilotAdmission,
+    code: str,
+    code_file_existed: bool,
+    code_file_ref_hmac: str,
+    expires_at: datetime,
+    config: invitations.InvitationConfig,
+) -> dict[str, Any]:
+    """Create or safely recover one protected-file-backed invitation."""
+    identity.validate()
+    context.validate()
+    now = datetime.now(timezone.utc)
+    normalized_code = invitations.normalize_invite_code(code)
+    expiry = _utc(expires_at)
+    if (
+        not normalized_code
+        or not isinstance(admission, invitations.InvitationPilotAdmission)
+        or admission.account_uid != identity.account_uid
+        or admission.profile_uid != identity.profile_uid
+        or expiry <= now
+        or expiry > now + MAX_EXPIRY
+        or not re.fullmatch(r"[0-9a-f]{64}", code_file_ref_hmac)
+    ):
+        raise SyntheticInvitationOperatorError("operator_issue_contract_invalid")
+    if not config.redemption_enabled or config.ordinary_enabled or config.app_review_enabled:
+        raise SyntheticInvitationOperatorError("operator_invite_flags_invalid")
+
+    invitation_code_hmac = invitations.code_hmac(config, normalized_code)
+    account_ref_hmac, profile_ref_hmac = invitations.invitation_target_refs(
+        config,
+        account_uid=identity.account_uid,
+        profile_uid=identity.profile_uid,
+    )
+    pool = await voice_canary.get_pool()
+    async with pool.acquire() as conn:
+        await _database_guard(conn, context)
+        owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+            conn,
+            uid=identity.uid,
+        )
+        async with conn.transaction():
+            proof = await _lock_owner(conn, identity, owner)
+            user = await _locked_user(conn, identity, owner, proof)
+            if str(user["profile_class"]) != "synthetic":
+                raise SyntheticInvitationOperatorError("operator_real_profile_refused")
+            existing = await _operator_rows_for_target(
+                conn,
+                account_ref_hmac=account_ref_hmac,
+                profile_ref_hmac=profile_ref_hmac,
+                for_update=True,
+            )
+            if len(existing) > 1:
+                raise SyntheticInvitationOperatorError("operator_invitation_history_conflict")
+            if existing:
+                row = existing[0]
+                _assert_operator_row_shape(
+                    row,
+                    identity=identity,
+                    context=context,
+                    admission=admission,
+                    config=config,
+                    expected_code_hmac=invitation_code_hmac,
+                    expected_expires_at=expiry,
+                    expected_code_file_ref_hmac=code_file_ref_hmac,
+                )
+                if (
+                    not code_file_existed
+                    or str(row["state"]) != "sent"
+                    or str(row["delivery_state"]) != "sent"
+                    or row["target_consumed_at"] is not None
+                    or int(row["redemption_count"]) != 0
+                    or str(row["reservation_state"]) != "reserved"
+                    or int(row["consumed_slots"]) != 0
+                    or _utc(row["expires_at"]) <= now
+                ):
+                    raise SyntheticInvitationOperatorError("operator_invitation_not_retryable")
+                await _record_operator_audit(
+                    conn,
+                    invitation_id=row["id"],
+                    identity=identity,
+                    context=context,
+                    config=config,
+                    event_type="operator_idempotent_retry",
+                    metadata={
+                        "purpose": OPERATOR_PURPOSE,
+                        "environment": context.environment,
+                        "code_file_ref_hmac": code_file_ref_hmac,
+                        "content_free": True,
+                    },
+                )
+                return _safe_receipt(
+                    row,
+                    profile_class=str(user["profile_class"]),
+                    idempotent=True,
+                )
+            if code_file_existed:
+                raise SyntheticInvitationOperatorError("operator_stale_code_receipt")
+            if expiry < now + MIN_EXPIRY:
+                raise SyntheticInvitationOperatorError("operator_expiry_too_soon")
+
+            _assert_pristine_artifacts(
+                await _artifact_snapshot(
+                    conn,
+                    user_id=user["id"],
+                    uid=identity.uid,
+                )
+            )
+            if await conn.fetchval(
+                "SELECT EXISTS (SELECT 1 FROM ella_invitations WHERE code_hmac = $1)",
+                invitation_code_hmac,
+            ):
+                raise SyntheticInvitationOperatorError("operator_code_collision")
+
+            reservation_id = await conn.fetchval(
+                """
+                INSERT INTO ella_invitation_capacity_reservations (
+                    pool_key, state, reserved_slots, expires_at
+                ) VALUES ($1, 'reserved', 1, $2)
+                RETURNING id
+                """,
+                OPERATOR_POOL_KEY,
+                expiry,
+            )
+            invitation_id = await conn.fetchval(
+                """
+                INSERT INTO ella_invitations (
+                    capacity_reservation_id, kind, code_hmac, display_hint,
+                    state, delivery_state, usage_mode, max_redemptions,
+                    reserved_setup_slots, entitlement_policy_revision,
+                    entitlement_policy, required_consent_policy_version,
+                    required_consent_processor_set_hash,
+                    required_consent_scope_version, required_consent_scope_hash,
+                    cohort, exclude_from_product_analytics,
+                    first_sent_at, expires_at
+                ) VALUES (
+                    $1, 'ordinary', $2, NULL,
+                    'sent', 'sent', 'single_use', 1,
+                    1, $3, $4::jsonb, $5, $6, $7, $8,
+                    $9, TRUE, $10, $11
+                )
+                RETURNING id
+                """,
+                reservation_id,
+                invitation_code_hmac,
+                OPERATOR_POLICY_REVISION,
+                json.dumps(OPERATOR_POLICY, sort_keys=True),
+                admission.policy_version,
+                admission.processor_set_hash,
+                admission.scope_version,
+                admission.scope_hash,
+                invitations.SYNTHETIC_OPERATOR_COHORT,
+                now,
+                expiry,
+            )
+            await conn.execute(
+                """
+                INSERT INTO ella_invitation_targets (
+                    invitation_id, account_ref_hmac, profile_ref_hmac,
+                    required_profile_class
+                ) VALUES ($1, $2, $3, 'synthetic')
+                """,
+                invitation_id,
+                account_ref_hmac,
+                profile_ref_hmac,
+            )
+            await _record_operator_audit(
+                conn,
+                invitation_id=invitation_id,
+                identity=identity,
+                context=context,
+                config=config,
+                event_type="operator_issued",
+                metadata={
+                    "purpose": OPERATOR_PURPOSE,
+                    "environment": context.environment,
+                    "profile_class": "synthetic",
+                    "expires_at": expiry.isoformat(),
+                    "code_file_ref_hmac": code_file_ref_hmac,
+                    "content_free": True,
+                },
+            )
+            row = {
+                "id": invitation_id,
+                "state": "sent",
+                "delivery_state": "sent",
+                "redemption_count": 0,
+                "max_redemptions": 1,
+                "expires_at": expiry,
+                "version": 1,
+            }
+            return _safe_receipt(
+                row,
+                profile_class=str(user["profile_class"]),
+            )
+
+
+def _receipt_uuid(receipt_id: str) -> uuid.UUID:
+    try:
+        value = uuid.UUID(receipt_id)
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise SyntheticInvitationOperatorError("operator_receipt_invalid") from exc
+    if str(value) != receipt_id:
+        raise SyntheticInvitationOperatorError("operator_receipt_invalid")
+    return value
+
+
+async def _load_exact_receipt(
+    conn: asyncpg.Connection,
+    *,
+    receipt_id: uuid.UUID,
+    identity: SyntheticInvitationIdentity,
+    context: SyntheticInvitationContext,
+    config: invitations.InvitationConfig,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    account_ref_hmac, profile_ref_hmac = invitations.invitation_target_refs(
+        config,
+        account_uid=identity.account_uid,
+        profile_uid=identity.profile_uid,
+    )
+    row = await conn.fetchrow(
+        """
+        SELECT
+            i.*,
+            t.id AS target_id,
+            t.account_ref_hmac,
+            t.profile_ref_hmac,
+            t.required_profile_class,
+            t.consumed_at AS target_consumed_at,
+            r.id AS reservation_id,
+            r.pool_key,
+            r.state AS reservation_state,
+            r.reserved_slots,
+            r.consumed_slots,
+            (
+                SELECT COUNT(*)
+                FROM ella_invitation_audit_receipts a
+                WHERE a.invitation_id = i.id
+                  AND a.event_type = 'operator_issued'
+            ) AS operator_issued_audit_count,
+            (
+                SELECT jsonb_build_object(
+                    'metadata', a.metadata,
+                    'source_ref_hmac', a.source_ref_hmac
+                )
+                FROM ella_invitation_audit_receipts a
+                WHERE a.invitation_id = i.id
+                  AND a.event_type = 'operator_issued'
+                ORDER BY a.created_at, a.id
+                LIMIT 1
+            ) AS operator_issued_receipt
+        FROM ella_invitations i
+        JOIN ella_invitation_targets t ON t.invitation_id = i.id
+        JOIN ella_invitation_capacity_reservations r
+          ON r.id = i.capacity_reservation_id
+        WHERE i.id = $1
+          AND t.account_ref_hmac = $2
+          AND t.profile_ref_hmac = $3
+        FOR UPDATE OF i, t, r
+        """,
+        receipt_id,
+        account_ref_hmac,
+        profile_ref_hmac,
+    )
+    user = await conn.fetchrow(
+        """
+        SELECT id, omi_uid, status, profile_class
+        FROM users
+        WHERE omi_uid = $1
+        FOR UPDATE
+        """,
+        identity.uid,
+    )
+    if not row or not user:
+        raise SyntheticInvitationOperatorError("operator_receipt_binding_mismatch")
+    stored = dict(row)
+    _assert_stored_operator_row_shape(
+        stored,
+        identity=identity,
+        config=config,
+    )
+    _assert_issued_context(
+        stored,
+        identity=identity,
+        context=context,
+        config=config,
+    )
+    return stored, dict(user)
+
+
+async def _with_exact_receipt(
+    *,
+    receipt_id: str,
+    identity: SyntheticInvitationIdentity,
+    context: SyntheticInvitationContext,
+    config: invitations.InvitationConfig,
+    operation: str,
+    expected_version: Optional[int] = None,
+) -> dict[str, Any]:
+    identity.validate()
+    context.validate()
+    parsed_receipt_id = _receipt_uuid(receipt_id)
+    pool = await voice_canary.get_pool()
+    async with pool.acquire() as conn:
+        await _database_guard(conn, context)
+        owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+            conn,
+            uid=identity.uid,
+        )
+        async with conn.transaction():
+            proof = await _lock_owner(conn, identity, owner)
+            locked_user = await _locked_user(conn, identity, owner, proof)
+            row, user = await _load_exact_receipt(
+                conn,
+                receipt_id=parsed_receipt_id,
+                identity=identity,
+                context=context,
+                config=config,
+            )
+            if locked_user["id"] != user["id"]:
+                raise SyntheticInvitationOperatorError("operator_identity_drift")
+            if expected_version is not None and (expected_version < 1 or int(row["version"]) != expected_version):
+                raise SyntheticInvitationOperatorError("operator_stale_receipt")
+            if operation == "show":
+                return _safe_receipt(
+                    row,
+                    profile_class=str(user["profile_class"]),
+                )
+            if operation == "revoke":
+                return await _revoke_locked(
+                    conn,
+                    row=row,
+                    user=user,
+                    identity=identity,
+                    context=context,
+                    config=config,
+                )
+            if operation == "cleanup":
+                return await _cleanup_locked(
+                    conn,
+                    row=row,
+                    user=user,
+                    identity=identity,
+                    context=context,
+                    config=config,
+                )
+            raise SyntheticInvitationOperatorError("operator_action_invalid")
+
+
+async def _has_redemption_or_entitlement(
+    conn: asyncpg.Connection,
+    *,
+    invitation_id: uuid.UUID,
+    uid: str,
+) -> bool:
+    return bool(
+        await conn.fetchval(
+            """
+            SELECT
+                EXISTS (
+                    SELECT 1
+                    FROM ella_invitation_redemptions
+                    WHERE invitation_id = $1
+                )
+                OR EXISTS (
+                    SELECT 1
+                    FROM voice_entitlements
+                    WHERE invitation_id = $1 OR uid = $2
+                )
+            """,
+            invitation_id,
+            uid,
+        )
+    )
+
+
+async def _revoke_locked(
+    conn: asyncpg.Connection,
+    *,
+    row: dict[str, Any],
+    user: dict[str, Any],
+    identity: SyntheticInvitationIdentity,
+    context: SyntheticInvitationContext,
+    config: invitations.InvitationConfig,
+) -> dict[str, Any]:
+    if str(user["profile_class"]) != "synthetic":
+        raise SyntheticInvitationOperatorError("operator_profile_class_drift")
+    if str(row["state"]) == "revoked":
+        return _safe_receipt(
+            row,
+            profile_class=str(user["profile_class"]),
+            idempotent=True,
+        )
+    if (
+        str(row["state"]) not in {"issued", "sent"}
+        or row["target_consumed_at"] is not None
+        or int(row["redemption_count"]) != 0
+        or await _has_redemption_or_entitlement(
+            conn,
+            invitation_id=row["id"],
+            uid=identity.uid,
+        )
+    ):
+        raise SyntheticInvitationOperatorError("operator_revoke_refused")
+    now = datetime.now(timezone.utc)
+    updated = dict(
+        await conn.fetchrow(
+            """
+            UPDATE ella_invitations
+            SET state = 'revoked',
+                delivery_state = 'suppressed',
+                revoked_at = $2,
+                version = version + 1,
+                updated_at = $2
+            WHERE id = $1
+            RETURNING *
+            """,
+            row["id"],
+            now,
+        )
+    )
+    await conn.execute(
+        """
+        UPDATE ella_invitation_capacity_reservations
+        SET state = 'released',
+            released_at = $2,
+            version = version + 1,
+            updated_at = $2
+        WHERE id = $1 AND state = 'reserved'
+        """,
+        row["reservation_id"],
+        now,
+    )
+    await _record_operator_audit(
+        conn,
+        invitation_id=row["id"],
+        identity=identity,
+        context=context,
+        config=config,
+        event_type="operator_revoked",
+        metadata={
+            "purpose": OPERATOR_PURPOSE,
+            "environment": context.environment,
+            "content_free": True,
+        },
+    )
+    return _safe_receipt(
+        updated,
+        profile_class=str(user["profile_class"]),
+    )
+
+
+async def _cleanup_locked(
+    conn: asyncpg.Connection,
+    *,
+    row: dict[str, Any],
+    user: dict[str, Any],
+    identity: SyntheticInvitationIdentity,
+    context: SyntheticInvitationContext,
+    config: invitations.InvitationConfig,
+) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    expired = bool(row.get("expires_at") and _utc(row["expires_at"]) <= now)
+    if (
+        str(user["profile_class"]) != "synthetic"
+        or (str(row["state"]) != "revoked" and not expired)
+        or row["target_consumed_at"] is not None
+        or int(row["redemption_count"]) != 0
+        or await _has_redemption_or_entitlement(
+            conn,
+            invitation_id=row["id"],
+            uid=identity.uid,
+        )
+    ):
+        raise SyntheticInvitationOperatorError("operator_cleanup_refused")
+    artifacts = await _artifact_snapshot(
+        conn,
+        user_id=user["id"],
+        uid=identity.uid,
+    )
+    artifacts["voice_entitlement"] = False
+    _assert_pristine_artifacts(artifacts)
+    updated = dict(
+        await conn.fetchrow(
+            """
+            UPDATE ella_invitations
+            SET state = CASE WHEN state = 'revoked' THEN state ELSE 'expired' END,
+                delivery_state = 'suppressed',
+                version = version + 1,
+                updated_at = $2
+            WHERE id = $1
+            RETURNING *
+            """,
+            row["id"],
+            now,
+        )
+    )
+    capacity_state = "expired" if updated["state"] == "expired" else "released"
+    await conn.execute(
+        """
+        UPDATE ella_invitation_capacity_reservations
+        SET state = $2,
+            released_at = CASE WHEN $2 = 'released' THEN $3 ELSE released_at END,
+            version = version + 1,
+            updated_at = $3
+        WHERE id = $1 AND state IN ('reserved', 'released')
+        """,
+        row["reservation_id"],
+        capacity_state,
+        now,
+    )
+    changed = await conn.fetchval(
+        """
+        UPDATE users
+        SET profile_class = 'real'
+        WHERE id = $1 AND omi_uid = $2 AND profile_class = 'synthetic'
+        RETURNING id
+        """,
+        user["id"],
+        identity.uid,
+    )
+    if changed != user["id"]:
+        raise SyntheticInvitationOperatorError("operator_profile_class_drift")
+    await _record_operator_audit(
+        conn,
+        invitation_id=row["id"],
+        identity=identity,
+        context=context,
+        config=config,
+        event_type="operator_cleanup",
+        metadata={
+            "purpose": OPERATOR_PURPOSE,
+            "environment": context.environment,
+            "profile_class": "real",
+            "content_free": True,
+        },
+    )
+    return _safe_receipt(
+        updated,
+        profile_class="real",
+    )
+
+
+async def show_synthetic_invitation(
+    *,
+    receipt_id: str,
+    identity: SyntheticInvitationIdentity,
+    context: SyntheticInvitationContext,
+    config: invitations.InvitationConfig,
+) -> dict[str, Any]:
+    return await _with_exact_receipt(
+        receipt_id=receipt_id,
+        identity=identity,
+        context=context,
+        config=config,
+        operation="show",
+    )
+
+
+async def revoke_synthetic_invitation(
+    *,
+    receipt_id: str,
+    expected_version: int,
+    identity: SyntheticInvitationIdentity,
+    context: SyntheticInvitationContext,
+    config: invitations.InvitationConfig,
+) -> dict[str, Any]:
+    return await _with_exact_receipt(
+        receipt_id=receipt_id,
+        expected_version=expected_version,
+        identity=identity,
+        context=context,
+        config=config,
+        operation="revoke",
+    )
+
+
+async def cleanup_synthetic_invitation(
+    *,
+    receipt_id: str,
+    expected_version: int,
+    identity: SyntheticInvitationIdentity,
+    context: SyntheticInvitationContext,
+    config: invitations.InvitationConfig,
+) -> dict[str, Any]:
+    return await _with_exact_receipt(
+        receipt_id=receipt_id,
+        expected_version=expected_version,
+        identity=identity,
+        context=context,
+        config=config,
+        operation="cleanup",
+    )

--- a/backend/database/invitations.py
+++ b/backend/database/invitations.py
@@ -30,6 +30,23 @@ SAFE_APP_BUILD_RE = re.compile(r"^[A-Za-z0-9._+-]{1,32}$")
 PILOT_RUNTIME_PROVIDER = CLOUD_RUNTIME_PROVIDER
 PILOT_MODEL = CLOUD_RUNTIME_MODEL
 PILOT_TARGET_MODES = CLOUD_RUNTIME_TARGET_MODES
+SYNTHETIC_OPERATOR_COHORT = "synthetic_operator"
+SYNTHETIC_OPERATOR_POLICY_REVISION = "synthetic-operator-v1"
+SYNTHETIC_OPERATOR_ENTITLEMENT_POLICY = {
+    "plan": "synthetic_canary",
+    "daily_limit_s": 2700,
+    "monthly_limit_s": 43200,
+    "max_session_s": 1200,
+    "max_concurrent": 1,
+    "max_audio_bytes_per_session": 120_000_000,
+    "max_audio_bytes_per_minute": 6_000_000,
+    "soft_limit_ratio": 0.8,
+    "hard_limit_ratio": 1.0,
+    "provider_allowlist": [PILOT_RUNTIME_PROVIDER],
+    "model_allowlist": [PILOT_MODEL],
+    "mode_allowlist": list(PILOT_TARGET_MODES),
+    "fallback_policy": {"enabled": False, "order": []},
+}
 
 
 @dataclass(frozen=True)
@@ -167,6 +184,46 @@ def invitation_target_refs(
     return (
         _hmac_ref(config, "target-account-v1", account_uid),
         _hmac_ref(config, "target-profile-v1", profile_uid),
+    )
+
+
+def invitation_audit_refs(
+    config: InvitationConfig,
+    *,
+    uid: str,
+    source: str,
+) -> tuple[str, str]:
+    """Return domain-separated references for content-free lifecycle receipts."""
+    if not uid or not source:
+        raise ValueError("audit uid and source are required")
+    return (
+        _hmac_ref(config, "uid-v1", uid),
+        _hmac_ref(config, "source-v1", source),
+    )
+
+
+def invitation_code_file_ref(config: InvitationConfig, absolute_path: str) -> str:
+    """Return a privacy-safe reference to the protected owner handoff path."""
+    if not absolute_path.startswith("/"):
+        raise ValueError("absolute code file path required")
+    return _hmac_ref(config, "code-file-v1", absolute_path)
+
+
+def is_synthetic_operator_invitation(invitation: dict[str, Any]) -> bool:
+    """Identify the root-issued single-profile prototype contract."""
+    try:
+        policy = normalize_entitlement_policy(invitation.get("entitlement_policy"))
+    except InviteConfigurationError:
+        return False
+    return bool(
+        str(invitation.get("kind") or "") == "ordinary"
+        and str(invitation.get("cohort") or "") == SYNTHETIC_OPERATOR_COHORT
+        and str(invitation.get("entitlement_policy_revision") or "") == SYNTHETIC_OPERATOR_POLICY_REVISION
+        and policy == SYNTHETIC_OPERATOR_ENTITLEMENT_POLICY
+        and bool(invitation.get("exclude_from_product_analytics"))
+        and str(invitation.get("usage_mode") or "") == "single_use"
+        and int(invitation.get("max_redemptions") or 0) == 1
+        and int(invitation.get("reserved_setup_slots") or 0) == 1
     )
 
 
@@ -760,7 +817,8 @@ async def _redeem_locked_invitation(
         )
 
     kind = str(invitation["kind"])
-    kind_enabled = config.ordinary_enabled if kind == "ordinary" else config.app_review_enabled
+    synthetic_operator = is_synthetic_operator_invitation(invitation)
+    kind_enabled = synthetic_operator or (config.ordinary_enabled if kind == "ordinary" else config.app_review_enabled)
     if not kind_enabled:
         await _record_audit(
             conn,

--- a/backend/ella/docs/INVITE_REDEMPTION_CONTROL_PLANE.md
+++ b/backend/ella/docs/INVITE_REDEMPTION_CONTROL_PLANE.md
@@ -14,9 +14,9 @@ Issue: `ellaaicare/ella-ai#1126`. Product and security contract:
   profile binding and must match one target before entitlement or capacity
   changes.
 - Redemption requires an exact current `ai-data-processors-v8` grant, presence
-  in both exact Hermes Cloud provisioning and synthetic UID allowlists, and a
-  persisted `users.profile_class = 'synthetic'`. Global rollout flags do not
-  satisfy this pilot-only gate.
+  in the runtime-binding, Hermes Cloud provisioning, Hermes Cloud synthetic,
+  and AI-consent exact UID allowlists, and a persisted
+  `users.profile_class = 'synthetic'`. Global rollout flags must remain false.
 - The transaction locks the invitation and capacity reservation, creates the
   `invited` voice entitlement, records redemption/audit receipts, consumes
   ordinary capacity, and marks an ordinary invitation redeemed.
@@ -35,8 +35,13 @@ ELLA_INVITE_REDEMPTION_ENABLED=false
 ELLA_INVITE_ORDINARY_SELF_SERVICE_ENABLED=false
 ELLA_INVITE_APP_REVIEW_ENABLED=false
 ELLA_HERMES_CLOUD_SYNTHETIC_ONLY=true
+ELLA_RUNTIME_BINDINGS_ENABLED=false
+ELLA_RUNTIME_BINDINGS_ENABLED_UIDS=
+ELLA_HERMES_CLOUD_PROVISIONING_ENABLED=false
 ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS=
 ELLA_HERMES_CLOUD_SYNTHETIC_UIDS=
+ELLA_AI_CONSENT_ENFORCEMENT_ENABLED=false
+ELLA_AI_CONSENT_ENFORCEMENT_UIDS=
 ```
 
 `ELLA_INVITE_HMAC_PEPPER` is required when the endpoint is enabled. Store it in
@@ -47,10 +52,11 @@ receipt, migration, issue, workflow JSON, or log.
 local reverse-proxy addresses. Forwarded source headers are ignored unless the
 direct peer is on this list.
 
-Phase 1 keeps ordinary self-service off. Enabling the global route alone does
-not permit ordinary or App Review redemption. The exact UID must be present in
-both cloud allowlists, have a current v8 consent receipt bound to the same
-account/profile, and have a synthetic database profile classification.
+Phase 1 keeps ordinary self-service off. Enabling the redemption route alone
+does not permit ordinary or App Review redemption. The exact UID must be
+present in all four pilot allowlists, have a current v8 consent receipt bound to
+the same account/profile, and have a synthetic database profile
+classification.
 
 ## Migration
 
@@ -70,6 +76,8 @@ psql "$ELLA_POSTGRES_DSN" \
   -f backend/migrations/012_create_account_profile_runtime_targets.sql
 psql "$ELLA_POSTGRES_DSN" \
   -f backend/migrations/013_create_managed_cloud_consent_authority.sql
+psql "$ELLA_POSTGRES_DSN" \
+  -f backend/migrations/014_add_synthetic_invitation_operator_audit.sql
 ```
 
 The migration is forward-only and idempotent. It adds:
@@ -85,6 +93,7 @@ The migration is forward-only and idempotent. It adds:
   require exact ready Hermes Cloud binding/endpoint/credential/mode ownership.
 - a per-UID managed-cloud consent authority epoch that serializes consent
   mutation through invitation entitlement publication and revocation quarantine.
+- content-free audit event types for the root-only synthetic operator lifecycle.
 
 It does not seed codes, grants, or production users.
 
@@ -124,8 +133,9 @@ synthetic code must remain unconsumed and must not create an entitlement.
 3. Deploy the exact reviewed OMI backend and voice proxy revisions with all
    invitation flags off.
 4. Run authenticated synthetic/non-family reads and disabled-redemption checks.
-5. Keep global cloud and ordinary self-service flags off. Enable only the exact
-   synthetic test UID in both cloud allowlists and issue its HMAC-bound target.
+5. Keep global cloud and ordinary self-service flags off. Add only the exact
+   synthetic test UID to the four pilot allowlists and issue its HMAC-bound
+   target through the protected operator ceremony.
 6. Verify same-UID retry, two-UID exclusion, typed failures, rate limiting,
    canonical entitlement, `ellaaicare/ella-ai#1124` ensure idempotency, and authoritative quota
    frames.
@@ -150,3 +160,7 @@ authoritative emergency stop.
 No production invitation, entitlement, vendor workspace, or provisioning claim
 may be created until the AI consent gate in `ellaaicare/ella-ai#1123` and the independent release
 review are green.
+
+The protected one-profile synthetic issuance lifecycle is documented in
+`SYNTHETIC_INVITE_OPERATOR.md`. It keeps ordinary/App Review admission off and
+does not send codes or seed broker/runtime tables.

--- a/backend/ella/docs/SYNTHETIC_INVITE_OPERATOR.md
+++ b/backend/ella/docs/SYNTHETIC_INVITE_OPERATOR.md
@@ -70,8 +70,17 @@ install -d -o root -g root -m 0700 /var/lib/ella/invite-codes
 The CLI accepts an immediate child of that directory only. It opens the
 directory and file with no-follow semantics, creates the file exclusively, and
 finishes with root ownership and mode `0400`. An existing secure file is read
-internally only to recover an interrupted, already-committed issuance; it is
-never printed.
+internally only to reconcile an interrupted issuance; it is never printed.
+
+Before creating the code file, the CLI creates and fsyncs an immutable,
+content-free recovery receipt in the same root-only directory, then fsyncs the
+parent after each durable file creation. The receipt HMAC binds the exact code,
+path, UID/account/profile, consent lineage, expiry, database, environment, and
+operator. If a transaction rolls back or its commit result is lost, rerun the
+exact command and path: a matching receipt may safely finish a row-absent
+issuance or converge to the committed row. A missing or mismatched receipt
+fails closed. Never delete or replace the protected code to resolve an
+ambiguous result.
 
 Enter the approved root session with the server environment and ADC already
 loaded. Do not preserve an untrusted caller environment or `PYTHONPATH`. From

--- a/backend/ella/docs/SYNTHETIC_INVITE_OPERATOR.md
+++ b/backend/ella/docs/SYNTHETIC_INVITE_OPERATOR.md
@@ -1,0 +1,159 @@
+# Synthetic Invitation Operator
+
+This is the root-only, one-profile ceremony for the disposable Hermes Cloud
+prototype. It issues the existing eight-character invitation format consumed by
+`POST /v1/invite/redeem`; it does not email or text a code, create a user, seed
+broker/runtime tables, or enable a rollout.
+
+## Preconditions
+
+Apply migration `014_add_synthetic_invitation_operator_audit.sql` after
+migrations 008-013. It only extends the existing invitation-audit event
+constraint.
+
+The exact Firebase UID, account UID, and profile UID must be identical and use
+the reserved `synthetic-` or `staging-synthetic-` prefix. The PostgreSQL user
+must already be `ACTIVE` and explicitly classified
+`profile_class = 'synthetic'`. Issuance refuses a `real` profile, an existing
+entitlement, provisioning job, runtime binding/target, managed-cloud authority,
+any prior operator invitation history, or the protected Plato identities.
+The disposable authenticated account must already hold the exact current v8 AI
+consent grant and receipt in Firestore. Issuance reads that authority and stores
+only its HMAC-backed SQL lineage; it does not create or bypass consent.
+
+The exact UID must appear in all four lists:
+
+```text
+ELLA_RUNTIME_BINDINGS_ENABLED_UIDS
+ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS
+ELLA_HERMES_CLOUD_SYNTHETIC_UIDS
+ELLA_AI_CONSENT_ENFORCEMENT_UIDS
+```
+
+Keep these global rollout flags false:
+
+```text
+ELLA_RUNTIME_BINDINGS_ENABLED=false
+ELLA_HERMES_PROVISIONING_ENABLED=false
+ELLA_HERMES_CLOUD_PROVISIONING_ENABLED=false
+ELLA_AI_CONSENT_ENFORCEMENT_ENABLED=false
+ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED=false
+ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED=false
+ELLA_ISOLATED_VOICE_ROUTING_ENABLED=false
+ELLA_INVITE_ORDINARY_SELF_SERVICE_ENABLED=false
+ELLA_INVITE_APP_REVIEW_ENABLED=false
+```
+
+The synthetic and redemption gates are the only required non-false gates:
+
+```text
+ELLA_HERMES_CLOUD_SYNTHETIC_ONLY=true
+ELLA_INVITE_REDEMPTION_ENABLED=true
+ELLA_INVITE_OPERATOR_ENVIRONMENT=<exact-environment-name>
+GOOGLE_CLOUD_PROJECT=<exact-firestore-project>
+```
+
+`ELLA_INVITE_HMAC_PEPPER` must be a server-side secret of at least 32 bytes.
+Never place its value in a command, issue, receipt, log, or code-output file.
+Run the command with approved Application Default Credentials for the exact
+`GOOGLE_CLOUD_PROJECT`. The CLI constructs the Firestore client directly in
+memory; it does not serialize `SERVICE_ACCOUNT_JSON` or any credential.
+
+## Protected code handoff
+
+Create one dedicated directory before issuance:
+
+```bash
+install -d -o root -g root -m 0700 /var/lib/ella/invite-codes
+```
+
+The CLI accepts an immediate child of that directory only. It opens the
+directory and file with no-follow semantics, creates the file exclusively, and
+finishes with root ownership and mode `0400`. An existing secure file is read
+internally only to recover an interrupted, already-committed issuance; it is
+never printed.
+
+Enter the approved root session with the server environment and ADC already
+loaded. Do not preserve an untrusted caller environment or `PYTHONPATH`. From
+`backend/`, use one fixed UTC expiry no more than 24 hours ahead:
+
+```bash
+python scripts/synthetic_invite_admin.py issue \
+  --uid SYNTHETIC_UID \
+  --account-uid SYNTHETIC_UID \
+  --profile-uid SYNTHETIC_UID \
+  --expected-environment EXPECTED_ENVIRONMENT \
+  --expected-database EXPECTED_DATABASE \
+  --expected-firestore-project EXPECTED_FIRESTORE_PROJECT \
+  --operator OPERATOR_ID \
+  --expires-at 2026-07-30T00:00:00Z \
+  --approved-code-output-root /var/lib/ella/invite-codes \
+  --code-output-file /var/lib/ella/invite-codes/ONE_TIME_RECEIPT.code
+```
+
+Stdout contains only a content-free invitation receipt UUID and protected path
+reference. If the process outcome is uncertain, rerun the exact same command and
+path. A matching database invitation converges to the same receipt; a stale
+file, different code, drifted binding, collision, or terminal invitation state
+fails closed. Use `show` to obtain its state, expiry, and version.
+
+The approved Infra/owner ceremony may read the protected file interactively
+from the root session. Do not use a command that copies it into shell history,
+logs, issue comments, chat, or a process argument. The executable order is:
+create the disposable authenticated account/profile, record its current v8
+consent grant, issue this invitation, redeem it through authenticated
+`POST /v1/invite/redeem` (which revalidates the same v8 authority before any SQL
+mutation), then continue with `/v1/ella/onboarding/ensure` and provisioning.
+
+## Inspect, revoke, and clean up
+
+Keep the exact synthetic-only gate, all four UID allowlists, and all global
+flags in the states above until cleanup is complete. `show`, `revoke`, and
+`cleanup` recheck them before touching PostgreSQL. `show` never reads or reveals
+the code:
+
+```bash
+python scripts/synthetic_invite_admin.py show \
+  --uid SYNTHETIC_UID \
+  --account-uid SYNTHETIC_UID \
+  --profile-uid SYNTHETIC_UID \
+  --expected-environment EXPECTED_ENVIRONMENT \
+  --expected-database EXPECTED_DATABASE \
+  --operator OPERATOR_ID \
+  --receipt-id RECEIPT_UUID
+```
+
+Before redemption, revoke with the exact version returned by `show`:
+
+```bash
+python scripts/synthetic_invite_admin.py revoke \
+  --uid SYNTHETIC_UID \
+  --account-uid SYNTHETIC_UID \
+  --profile-uid SYNTHETIC_UID \
+  --expected-environment EXPECTED_ENVIRONMENT \
+  --expected-database EXPECTED_DATABASE \
+  --operator OPERATOR_ID \
+  --receipt-id RECEIPT_UUID \
+  --expected-version VERSION
+```
+
+After revocation, or after the invitation has expired, cleanup releases its
+reservation and changes only that still-unredeemed disposable PostgreSQL
+profile from `synthetic` back to `real`. It refuses redeemed entitlements,
+runtime/provisioning artifacts, binding drift, or a stale version:
+
+```bash
+python scripts/synthetic_invite_admin.py cleanup \
+  --uid SYNTHETIC_UID \
+  --account-uid SYNTHETIC_UID \
+  --profile-uid SYNTHETIC_UID \
+  --expected-environment EXPECTED_ENVIRONMENT \
+  --expected-database EXPECTED_DATABASE \
+  --operator OPERATOR_ID \
+  --receipt-id RECEIPT_UUID \
+  --expected-version VERSION
+```
+
+The invitation, target HMACs, and content-free audit receipts remain as
+idempotency evidence. Broker tables and the `realcryptoplato` / `plato_eval`
+route are outside this ceremony.

--- a/backend/ella/services/invitation_authority.py
+++ b/backend/ella/services/invitation_authority.py
@@ -18,19 +18,48 @@ from ella.services.hermes_cloud_policy import (
     current_cloud_authority,
 )
 
+PILOT_UID_ALLOWLISTS = (
+    "ELLA_RUNTIME_BINDINGS_ENABLED_UIDS",
+    "ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS",
+    "ELLA_HERMES_CLOUD_SYNTHETIC_UIDS",
+    "ELLA_AI_CONSENT_ENFORCEMENT_UIDS",
+)
+PILOT_GLOBAL_FLAGS_REQUIRED_FALSE = (
+    "ELLA_RUNTIME_BINDINGS_ENABLED",
+    "ELLA_HERMES_PROVISIONING_ENABLED",
+    "ELLA_HERMES_CLOUD_PROVISIONING_ENABLED",
+    "ELLA_AI_CONSENT_ENFORCEMENT_ENABLED",
+    "ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED",
+    "ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED",
+    "ELLA_ISOLATED_VOICE_ROUTING_ENABLED",
+    "ELLA_INVITE_ORDINARY_SELF_SERVICE_ENABLED",
+    "ELLA_INVITE_APP_REVIEW_ENABLED",
+)
+TRUE_VALUES = {"1", "true", "yes", "on"}
+
 
 def _exact_allowlist(name: str) -> set[str]:
     return {value.strip() for value in os.getenv(name, "").split(",") if value.strip()}
 
 
-def authorize_invitation_pilot(uid: str) -> InvitationPilotAdmission:
-    """Authorize the exact synthetic profile before redemption can mutate SQL."""
+def _global_flag_enabled(name: str) -> bool:
+    return os.getenv(name, "false").strip().lower() in TRUE_VALUES
+
+
+def assert_invitation_pilot_rollout(uid: str) -> None:
+    """Require the exact synthetic canary while every global rollout remains off."""
     if (
-        not cloud_synthetic_only()
-        or uid not in _exact_allowlist("ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS")
-        or uid not in _exact_allowlist("ELLA_HERMES_CLOUD_SYNTHETIC_UIDS")
+        not uid
+        or not cloud_synthetic_only()
+        or any(_global_flag_enabled(name) for name in PILOT_GLOBAL_FLAGS_REQUIRED_FALSE)
+        or any(uid not in _exact_allowlist(name) for name in PILOT_UID_ALLOWLISTS)
     ):
         raise InvitePilotGateDenied("invite_pilot_identity_not_allowed")
+
+
+def authorize_invitation_pilot(uid: str) -> InvitationPilotAdmission:
+    """Authorize the exact synthetic profile before redemption can mutate SQL."""
+    assert_invitation_pilot_rollout(uid)
     try:
         authority = current_cloud_authority(
             uid,

--- a/backend/migrations/014_add_synthetic_invitation_operator_audit.sql
+++ b/backend/migrations/014_add_synthetic_invitation_operator_audit.sql
@@ -1,0 +1,18 @@
+-- Content-free lifecycle receipts for the root-only synthetic invitation
+-- operator. No invitation format, target binding, or user schema changes.
+
+BEGIN;
+
+ALTER TABLE ella_invitation_audit_receipts
+    DROP CONSTRAINT IF EXISTS ella_invitation_audit_receipts_event_type_check;
+
+ALTER TABLE ella_invitation_audit_receipts
+    ADD CONSTRAINT ella_invitation_audit_receipts_event_type_check
+    CHECK (event_type IN (
+        'redeemed', 'idempotent_retry', 'invalid', 'expired', 'capacity',
+        'rate_limited', 'policy_invalid', 'redemption_disabled',
+        'operator_issued', 'operator_idempotent_retry', 'operator_revoked',
+        'operator_cleanup'
+    ));
+
+COMMIT;

--- a/backend/scripts/synthetic_invite_admin.py
+++ b/backend/scripts/synthetic_invite_admin.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""Root-only protected-file ceremony for one synthetic Ella invitation."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import stat
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from google.cloud import firestore
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from database import invitation_operator, invitations
+from ella.services import ai_consent
+from ella.services.invitation_authority import (
+    assert_invitation_pilot_rollout,
+    authorize_invitation_pilot,
+)
+
+ROOT_UID = 0
+CODE_FILE_CREATE_MODE = 0o600
+CODE_FILE_FINAL_MODE = 0o400
+CODE_FILE_ALLOWED_MODES = {CODE_FILE_CREATE_MODE, CODE_FILE_FINAL_MODE}
+MAX_CODE_FILE_BYTES = 32
+SAFE_CODE_FILENAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+class ProtectedCodeFileError(RuntimeError):
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def _print_receipt(action: str, receipt: dict[str, Any], *, code_output_file: str = "") -> None:
+    payload = {
+        "action": action,
+        **receipt,
+    }
+    if code_output_file:
+        payload["code_output_file"] = code_output_file
+    print(json.dumps(payload, sort_keys=True))
+
+
+def _require_root() -> None:
+    if os.geteuid() != ROOT_UID:
+        raise SystemExit("operator_refused:root_required")
+
+
+def _lexical_absolute_path(value: str, *, error_code: str) -> Path:
+    if not value or not os.path.isabs(value) or os.path.normpath(value) != value:
+        raise ProtectedCodeFileError(error_code)
+    return Path(value)
+
+
+def _open_secure_root(path: Path, *, expected_owner_uid: int) -> int:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise ProtectedCodeFileError("code_output_root_unavailable") from exc
+    metadata = os.fstat(descriptor)
+    mode = stat.S_IMODE(metadata.st_mode)
+    if not stat.S_ISDIR(metadata.st_mode) or metadata.st_uid != expected_owner_uid or mode != 0o700:
+        os.close(descriptor)
+        raise ProtectedCodeFileError("code_output_root_insecure")
+    return descriptor
+
+
+def _read_existing_code(
+    root_descriptor: int,
+    filename: str,
+    *,
+    expected_owner_uid: int,
+) -> str:
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(filename, flags, dir_fd=root_descriptor)
+    except OSError as exc:
+        raise ProtectedCodeFileError("code_output_file_unavailable") from exc
+    try:
+        metadata = os.fstat(descriptor)
+        mode = stat.S_IMODE(metadata.st_mode)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != expected_owner_uid
+            or mode not in CODE_FILE_ALLOWED_MODES
+            or metadata.st_nlink != 1
+            or metadata.st_size < 9
+            or metadata.st_size > MAX_CODE_FILE_BYTES
+        ):
+            raise ProtectedCodeFileError("code_output_file_insecure")
+        content = os.read(descriptor, MAX_CODE_FILE_BYTES + 1)
+        if len(content) > MAX_CODE_FILE_BYTES:
+            raise ProtectedCodeFileError("code_output_file_insecure")
+        try:
+            code = content.decode("ascii").rstrip("\n")
+        except UnicodeDecodeError as exc:
+            raise ProtectedCodeFileError("code_output_file_invalid") from exc
+        normalized = invitations.normalize_invite_code(code)
+        if not normalized or code != f"{normalized[:4]}-{normalized[4:]}":
+            raise ProtectedCodeFileError("code_output_file_invalid")
+        return code
+    finally:
+        os.close(descriptor)
+
+
+def prepare_protected_code_file(
+    *,
+    approved_root: str,
+    code_output_file: str,
+    expected_owner_uid: int = ROOT_UID,
+) -> tuple[str, bool]:
+    """Create the code once or securely recover it for an idempotent retry."""
+    root = _lexical_absolute_path(
+        approved_root,
+        error_code="code_output_root_must_be_absolute",
+    )
+    output = _lexical_absolute_path(
+        code_output_file,
+        error_code="code_output_file_must_be_absolute",
+    )
+    if output.parent != root or not SAFE_CODE_FILENAME_RE.fullmatch(output.name):
+        raise ProtectedCodeFileError("code_output_file_outside_approved_root")
+    root_descriptor = _open_secure_root(
+        root,
+        expected_owner_uid=expected_owner_uid,
+    )
+    generated_code = invitations.generate_invite_code()
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        try:
+            descriptor = os.open(
+                output.name,
+                flags,
+                CODE_FILE_CREATE_MODE,
+                dir_fd=root_descriptor,
+            )
+        except FileExistsError:
+            generated_code = ""
+            return (
+                _read_existing_code(
+                    root_descriptor,
+                    output.name,
+                    expected_owner_uid=expected_owner_uid,
+                ),
+                True,
+            )
+        except OSError as exc:
+            generated_code = ""
+            raise ProtectedCodeFileError("code_output_file_create_failed") from exc
+
+        try:
+            payload = (generated_code + "\n").encode("ascii")
+            offset = 0
+            while offset < len(payload):
+                written = os.write(descriptor, payload[offset:])
+                if written <= 0:
+                    raise ProtectedCodeFileError("code_output_file_write_failed")
+                offset += written
+            os.fsync(descriptor)
+            os.fchmod(descriptor, CODE_FILE_FINAL_MODE)
+            metadata = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_uid != expected_owner_uid
+                or stat.S_IMODE(metadata.st_mode) != CODE_FILE_FINAL_MODE
+                or metadata.st_nlink != 1
+            ):
+                raise ProtectedCodeFileError("code_output_file_insecure")
+        finally:
+            os.close(descriptor)
+        return generated_code, False
+    finally:
+        os.close(root_descriptor)
+
+
+def _parse_expiry(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise SystemExit("operator_refused:expiry_invalid") from exc
+    if parsed.tzinfo is None:
+        raise SystemExit("operator_refused:expiry_timezone_required")
+    return parsed.astimezone(timezone.utc)
+
+
+def _configuration() -> invitations.InvitationConfig:
+    try:
+        config = invitations.InvitationConfig.from_env()
+    except invitations.InviteConfigurationError as exc:
+        raise SystemExit("operator_refused:invite_configuration_invalid") from exc
+    if not config.redemption_enabled or config.ordinary_enabled or config.app_review_enabled:
+        raise SystemExit("operator_refused:invite_flags_invalid")
+    return config
+
+
+def _identity(args: argparse.Namespace) -> invitation_operator.SyntheticInvitationIdentity:
+    identity = invitation_operator.SyntheticInvitationIdentity(
+        uid=args.uid,
+        account_uid=args.account_uid,
+        profile_uid=args.profile_uid,
+    )
+    try:
+        identity.validate()
+    except invitation_operator.SyntheticInvitationOperatorError as exc:
+        raise SystemExit(f"operator_refused:{exc.code}") from exc
+    return identity
+
+
+def _context(args: argparse.Namespace) -> invitation_operator.SyntheticInvitationContext:
+    configured_environment = os.getenv("ELLA_INVITE_OPERATOR_ENVIRONMENT", "").strip()
+    if (
+        not configured_environment
+        or not args.expected_environment
+        or configured_environment != args.expected_environment
+    ):
+        raise SystemExit("operator_refused:environment_mismatch")
+    context = invitation_operator.SyntheticInvitationContext(
+        environment=args.expected_environment,
+        expected_database=args.expected_database,
+        operator=args.operator,
+    )
+    try:
+        context.validate()
+    except invitation_operator.SyntheticInvitationOperatorError as exc:
+        raise SystemExit(f"operator_refused:{exc.code}") from exc
+    return context
+
+
+def _configure_consent_authority(expected_firestore_project: str) -> None:
+    configured_project = os.getenv("GOOGLE_CLOUD_PROJECT", "").strip()
+    if not expected_firestore_project or not configured_project or configured_project != expected_firestore_project:
+        raise SystemExit("operator_refused:firestore_project_mismatch")
+    try:
+        firestore_db = firestore.Client(project=expected_firestore_project)
+    except Exception as exc:
+        raise SystemExit("operator_refused:consent_authority_unavailable") from exc
+    ai_consent.configure_firestore_db(firestore_db)
+
+
+def _assert_issue_rollout(
+    uid: str,
+    *,
+    expected_firestore_project: str,
+) -> invitations.InvitationPilotAdmission:
+    try:
+        assert_invitation_pilot_rollout(uid)
+        _configure_consent_authority(expected_firestore_project)
+        return authorize_invitation_pilot(uid)
+    except invitations.InvitePilotGateDenied as exc:
+        raise SystemExit("operator_refused:pilot_rollout_invalid") from exc
+
+
+def _assert_lifecycle_rollout(uid: str) -> None:
+    try:
+        assert_invitation_pilot_rollout(uid)
+    except invitations.InvitePilotGateDenied as exc:
+        raise SystemExit("operator_refused:pilot_rollout_invalid") from exc
+
+
+async def _issue(args: argparse.Namespace) -> None:
+    identity = _identity(args)
+    context = _context(args)
+    config = _configuration()
+    admission = _assert_issue_rollout(
+        identity.uid,
+        expected_firestore_project=args.expected_firestore_project,
+    )
+    expires_at = _parse_expiry(args.expires_at)
+    try:
+        code, existed = prepare_protected_code_file(
+            approved_root=args.approved_code_output_root,
+            code_output_file=args.code_output_file,
+            expected_owner_uid=ROOT_UID,
+        )
+        code_file_ref_hmac = invitations.invitation_code_file_ref(
+            config,
+            args.code_output_file,
+        )
+        receipt = await invitation_operator.issue_synthetic_invitation(
+            identity=identity,
+            context=context,
+            admission=admission,
+            code=code,
+            code_file_existed=existed,
+            code_file_ref_hmac=code_file_ref_hmac,
+            expires_at=expires_at,
+            config=config,
+        )
+    except ProtectedCodeFileError as exc:
+        raise SystemExit(f"operator_refused:{exc.code}") from exc
+    except invitation_operator.SyntheticInvitationOperatorError as exc:
+        raise SystemExit(f"operator_refused:{exc.code}") from exc
+    finally:
+        if "code" in locals():
+            code = ""
+    _print_receipt(
+        "issue",
+        {
+            "receipt_id": receipt["receipt_id"],
+            "content_free": True,
+        },
+        code_output_file=args.code_output_file,
+    )
+
+
+async def _show(args: argparse.Namespace) -> None:
+    identity = _identity(args)
+    context = _context(args)
+    config = _configuration()
+    _assert_lifecycle_rollout(identity.uid)
+    try:
+        receipt = await invitation_operator.show_synthetic_invitation(
+            receipt_id=args.receipt_id,
+            identity=identity,
+            context=context,
+            config=config,
+        )
+    except invitation_operator.SyntheticInvitationOperatorError as exc:
+        raise SystemExit(f"operator_refused:{exc.code}") from exc
+    _print_receipt("show", receipt)
+
+
+async def _revoke(args: argparse.Namespace) -> None:
+    identity = _identity(args)
+    context = _context(args)
+    config = _configuration()
+    _assert_lifecycle_rollout(identity.uid)
+    try:
+        receipt = await invitation_operator.revoke_synthetic_invitation(
+            receipt_id=args.receipt_id,
+            expected_version=args.expected_version,
+            identity=identity,
+            context=context,
+            config=config,
+        )
+    except invitation_operator.SyntheticInvitationOperatorError as exc:
+        raise SystemExit(f"operator_refused:{exc.code}") from exc
+    _print_receipt("revoke", receipt)
+
+
+async def _cleanup(args: argparse.Namespace) -> None:
+    identity = _identity(args)
+    context = _context(args)
+    config = _configuration()
+    _assert_lifecycle_rollout(identity.uid)
+    try:
+        receipt = await invitation_operator.cleanup_synthetic_invitation(
+            receipt_id=args.receipt_id,
+            expected_version=args.expected_version,
+            identity=identity,
+            context=context,
+            config=config,
+        )
+    except invitation_operator.SyntheticInvitationOperatorError as exc:
+        raise SystemExit(f"operator_refused:{exc.code}") from exc
+    _print_receipt("cleanup", receipt)
+
+
+def _add_identity_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--uid", required=True)
+    parser.add_argument("--account-uid", required=True)
+    parser.add_argument("--profile-uid", required=True)
+    parser.add_argument("--expected-environment", required=True)
+    parser.add_argument("--expected-database", required=True)
+    parser.add_argument("--operator", required=True)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    issue = subparsers.add_parser("issue")
+    _add_identity_arguments(issue)
+    issue.add_argument("--expected-firestore-project", required=True)
+    issue.add_argument("--expires-at", required=True)
+    issue.add_argument("--approved-code-output-root", required=True)
+    issue.add_argument("--code-output-file", required=True)
+    issue.set_defaults(handler=_issue)
+
+    show = subparsers.add_parser("show")
+    _add_identity_arguments(show)
+    show.add_argument("--receipt-id", required=True)
+    show.set_defaults(handler=_show)
+
+    revoke = subparsers.add_parser("revoke")
+    _add_identity_arguments(revoke)
+    revoke.add_argument("--receipt-id", required=True)
+    revoke.add_argument("--expected-version", required=True, type=int)
+    revoke.set_defaults(handler=_revoke)
+
+    cleanup = subparsers.add_parser("cleanup")
+    _add_identity_arguments(cleanup)
+    cleanup.add_argument("--receipt-id", required=True)
+    cleanup.add_argument("--expected-version", required=True, type=int)
+    cleanup.set_defaults(handler=_cleanup)
+    return parser
+
+
+async def _main() -> None:
+    _require_root()
+    args = _parser().parse_args()
+    await args.handler(args)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(_main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/backend/scripts/synthetic_invite_admin.py
+++ b/backend/scripts/synthetic_invite_admin.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 import os
 import re
 import stat
 import sys
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from google.cloud import firestore
 
@@ -30,13 +32,22 @@ CODE_FILE_CREATE_MODE = 0o600
 CODE_FILE_FINAL_MODE = 0o400
 CODE_FILE_ALLOWED_MODES = {CODE_FILE_CREATE_MODE, CODE_FILE_FINAL_MODE}
 MAX_CODE_FILE_BYTES = 32
+MAX_RECOVERY_RECEIPT_BYTES = 512
 SAFE_CODE_FILENAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+RECOVERY_RECEIPT_VERSION = invitation_operator.RECOVERY_BINDING_VERSION
 
 
 class ProtectedCodeFileError(RuntimeError):
     def __init__(self, code: str) -> None:
         self.code = code
         super().__init__(code)
+
+
+@dataclass(frozen=True)
+class PreparedProtectedCode:
+    code: str
+    existed: bool
+    recovery_binding_hmac: str
 
 
 def _print_receipt(action: str, receipt: dict[str, Any], *, code_output_file: str = "") -> None:
@@ -87,6 +98,8 @@ def _read_existing_code(
         flags |= os.O_NOFOLLOW
     try:
         descriptor = os.open(filename, flags, dir_fd=root_descriptor)
+    except FileNotFoundError:
+        raise
     except OSError as exc:
         raise ProtectedCodeFileError("code_output_file_unavailable") from exc
     try:
@@ -116,12 +129,107 @@ def _read_existing_code(
         os.close(descriptor)
 
 
+def _recovery_receipt_filename(code_filename: str) -> str:
+    filename_ref = hashlib.sha256(code_filename.encode("utf-8")).hexdigest()
+    return f".synthetic-invite-recovery-{filename_ref}.json"
+
+
+def _write_exclusive_protected_file(
+    root_descriptor: int,
+    filename: str,
+    payload: bytes,
+    *,
+    expected_owner_uid: int,
+    create_error: str,
+) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(
+            filename,
+            flags,
+            CODE_FILE_CREATE_MODE,
+            dir_fd=root_descriptor,
+        )
+    except OSError as exc:
+        raise ProtectedCodeFileError(create_error) from exc
+    try:
+        offset = 0
+        while offset < len(payload):
+            written = os.write(descriptor, payload[offset:])
+            if written <= 0:
+                raise ProtectedCodeFileError("code_output_file_write_failed")
+            offset += written
+        os.fchmod(descriptor, CODE_FILE_FINAL_MODE)
+        os.fsync(descriptor)
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != expected_owner_uid
+            or stat.S_IMODE(metadata.st_mode) != CODE_FILE_FINAL_MODE
+            or metadata.st_nlink != 1
+            or metadata.st_size != len(payload)
+        ):
+            raise ProtectedCodeFileError("code_output_file_insecure")
+    finally:
+        os.close(descriptor)
+    try:
+        os.fsync(root_descriptor)
+    except OSError as exc:
+        raise ProtectedCodeFileError("code_output_parent_sync_failed") from exc
+
+
+def _read_recovery_receipt(
+    root_descriptor: int,
+    filename: str,
+    *,
+    expected_owner_uid: int,
+    expected_binding_hmac: str,
+) -> None:
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(filename, flags, dir_fd=root_descriptor)
+    except OSError as exc:
+        raise ProtectedCodeFileError("code_recovery_receipt_unavailable") from exc
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != expected_owner_uid
+            or stat.S_IMODE(metadata.st_mode) != CODE_FILE_FINAL_MODE
+            or metadata.st_nlink != 1
+            or metadata.st_size < 1
+            or metadata.st_size > MAX_RECOVERY_RECEIPT_BYTES
+        ):
+            raise ProtectedCodeFileError("code_recovery_receipt_insecure")
+        content = os.read(descriptor, MAX_RECOVERY_RECEIPT_BYTES + 1)
+        if len(content) > MAX_RECOVERY_RECEIPT_BYTES:
+            raise ProtectedCodeFileError("code_recovery_receipt_insecure")
+    finally:
+        os.close(descriptor)
+    try:
+        receipt = json.loads(content.decode("ascii"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ProtectedCodeFileError("code_recovery_receipt_invalid") from exc
+    expected = {
+        "binding_hmac": expected_binding_hmac,
+        "content_free": True,
+        "version": RECOVERY_RECEIPT_VERSION,
+    }
+    if receipt != expected:
+        raise ProtectedCodeFileError("code_recovery_receipt_mismatch")
+
+
 def prepare_protected_code_file(
     *,
     approved_root: str,
     code_output_file: str,
+    recovery_binding_for_code: Callable[[str], str],
     expected_owner_uid: int = ROOT_UID,
-) -> tuple[str, bool]:
+) -> PreparedProtectedCode:
     """Create the code once or securely recover it for an idempotent retry."""
     root = _lexical_absolute_path(
         approved_root,
@@ -137,53 +245,68 @@ def prepare_protected_code_file(
         root,
         expected_owner_uid=expected_owner_uid,
     )
-    generated_code = invitations.generate_invite_code()
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
+    generated_code = ""
     try:
         try:
-            descriptor = os.open(
+            existing_code = _read_existing_code(
+                root_descriptor,
                 output.name,
-                flags,
-                CODE_FILE_CREATE_MODE,
-                dir_fd=root_descriptor,
+                expected_owner_uid=expected_owner_uid,
             )
-        except FileExistsError:
-            generated_code = ""
-            return (
-                _read_existing_code(
-                    root_descriptor,
-                    output.name,
-                    expected_owner_uid=expected_owner_uid,
-                ),
-                True,
+        except FileNotFoundError:
+            generated_code = invitations.generate_invite_code()
+            recovery_binding_hmac = recovery_binding_for_code(generated_code)
+            if not re.fullmatch(r"[0-9a-f]{64}", recovery_binding_hmac):
+                raise ProtectedCodeFileError("code_recovery_binding_invalid")
+            recovery_receipt = json.dumps(
+                {
+                    "binding_hmac": recovery_binding_hmac,
+                    "content_free": True,
+                    "version": RECOVERY_RECEIPT_VERSION,
+                },
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("ascii")
+            _write_exclusive_protected_file(
+                root_descriptor,
+                _recovery_receipt_filename(output.name),
+                recovery_receipt,
+                expected_owner_uid=expected_owner_uid,
+                create_error="code_recovery_receipt_create_failed",
             )
-        except OSError as exc:
-            generated_code = ""
-            raise ProtectedCodeFileError("code_output_file_create_failed") from exc
+            _write_exclusive_protected_file(
+                root_descriptor,
+                output.name,
+                (generated_code + "\n").encode("ascii"),
+                expected_owner_uid=expected_owner_uid,
+                create_error="code_output_file_create_failed",
+            )
+            return PreparedProtectedCode(
+                code=generated_code,
+                existed=False,
+                recovery_binding_hmac=recovery_binding_hmac,
+            )
 
-        try:
-            payload = (generated_code + "\n").encode("ascii")
-            offset = 0
-            while offset < len(payload):
-                written = os.write(descriptor, payload[offset:])
-                if written <= 0:
-                    raise ProtectedCodeFileError("code_output_file_write_failed")
-                offset += written
-            os.fsync(descriptor)
-            os.fchmod(descriptor, CODE_FILE_FINAL_MODE)
-            metadata = os.fstat(descriptor)
-            if (
-                not stat.S_ISREG(metadata.st_mode)
-                or metadata.st_uid != expected_owner_uid
-                or stat.S_IMODE(metadata.st_mode) != CODE_FILE_FINAL_MODE
-                or metadata.st_nlink != 1
-            ):
-                raise ProtectedCodeFileError("code_output_file_insecure")
-        finally:
-            os.close(descriptor)
-        return generated_code, False
+        recovery_binding_hmac = recovery_binding_for_code(existing_code)
+        if not re.fullmatch(r"[0-9a-f]{64}", recovery_binding_hmac):
+            raise ProtectedCodeFileError("code_recovery_binding_invalid")
+        _read_recovery_receipt(
+            root_descriptor,
+            _recovery_receipt_filename(output.name),
+            expected_owner_uid=expected_owner_uid,
+            expected_binding_hmac=recovery_binding_hmac,
+        )
+        return PreparedProtectedCode(
+            code=existing_code,
+            existed=True,
+            recovery_binding_hmac=recovery_binding_hmac,
+        )
+    except ProtectedCodeFileError:
+        raise
+    except OSError as exc:
+        if generated_code:
+            generated_code = ""
+        raise ProtectedCodeFileError("code_output_file_create_failed") from exc
     finally:
         os.close(root_descriptor)
 
@@ -282,22 +405,36 @@ async def _issue(args: argparse.Namespace) -> None:
     )
     expires_at = _parse_expiry(args.expires_at)
     try:
-        code, existed = prepare_protected_code_file(
-            approved_root=args.approved_code_output_root,
-            code_output_file=args.code_output_file,
-            expected_owner_uid=ROOT_UID,
-        )
         code_file_ref_hmac = invitations.invitation_code_file_ref(
             config,
             args.code_output_file,
+        )
+
+        def recovery_binding_for_code(code: str) -> str:
+            return invitation_operator.synthetic_invitation_recovery_binding_hmac(
+                identity=identity,
+                context=context,
+                admission=admission,
+                code=code,
+                code_file_ref_hmac=code_file_ref_hmac,
+                expires_at=expires_at,
+                config=config,
+            )
+
+        prepared = prepare_protected_code_file(
+            approved_root=args.approved_code_output_root,
+            code_output_file=args.code_output_file,
+            recovery_binding_for_code=recovery_binding_for_code,
+            expected_owner_uid=ROOT_UID,
         )
         receipt = await invitation_operator.issue_synthetic_invitation(
             identity=identity,
             context=context,
             admission=admission,
-            code=code,
-            code_file_existed=existed,
+            code=prepared.code,
+            code_file_existed=prepared.existed,
             code_file_ref_hmac=code_file_ref_hmac,
+            recovery_binding_hmac=prepared.recovery_binding_hmac,
             expires_at=expires_at,
             config=config,
         )
@@ -305,9 +442,11 @@ async def _issue(args: argparse.Namespace) -> None:
         raise SystemExit(f"operator_refused:{exc.code}") from exc
     except invitation_operator.SyntheticInvitationOperatorError as exc:
         raise SystemExit(f"operator_refused:{exc.code}") from exc
+    except Exception:
+        raise SystemExit("operator_refused:invitation_outcome_ambiguous") from None
     finally:
-        if "code" in locals():
-            code = ""
+        if "prepared" in locals():
+            prepared = None
     _print_receipt(
         "issue",
         {

--- a/backend/tests/postgres/test_invitation_redemption_postgres.py
+++ b/backend/tests/postgres/test_invitation_redemption_postgres.py
@@ -11,6 +11,7 @@ import pytest
 
 from database import (
     authority_advisory_lock,
+    invitation_operator,
     invitations,
     managed_cloud_consent,
     voice_canary,
@@ -32,6 +33,13 @@ CONFIG = invitations.InvitationConfig(
     redemption_enabled=True,
     ordinary_enabled=True,
     app_review_enabled=True,
+    progressive_backoff_enabled=False,
+)
+OPERATOR_CONFIG = invitations.InvitationConfig(
+    hmac_pepper=CONFIG.hmac_pepper,
+    redemption_enabled=True,
+    ordinary_enabled=False,
+    app_review_enabled=False,
     progressive_backoff_enabled=False,
 )
 POLICY = {
@@ -175,10 +183,10 @@ async def _run_with_database(
                 "011_create_invitation_redemption.sql",
                 "012_create_account_profile_runtime_targets.sql",
                 "013_create_managed_cloud_consent_authority.sql",
+                "014_add_synthetic_invitation_operator_audit.sql",
             ):
                 await conn.execute((MIGRATIONS / name).read_text(encoding="utf-8"))
-            assert await conn.fetchval(
-                """
+            assert await conn.fetchval("""
                 SELECT EXISTS (
                     SELECT 1
                     FROM information_schema.columns
@@ -187,8 +195,7 @@ async def _run_with_database(
                       AND column_name = 'profile_class'
                       AND is_nullable = 'NO'
                 )
-                """
-            )
+                """)
             assert await conn.fetchval("SELECT to_regclass('ella_invitation_targets') IS NOT NULL")
         await scenario(pool)
     finally:
@@ -355,6 +362,15 @@ def _grant_v7(repository: ai_consent.InMemoryConsentRepository, uid: str) -> Non
             scope_hash=ai_consent.CURRENT_SCOPE_HASH,
         ),
     )
+
+
+def _set_pilot_rollout(monkeypatch, uids: Iterable[str]) -> None:
+    value = ",".join(uids)
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_ONLY", "true")
+    for name in invitation_authority.PILOT_UID_ALLOWLISTS:
+        monkeypatch.setenv(name, value)
+    for name in invitation_authority.PILOT_GLOBAL_FLAGS_REQUIRED_FALSE:
+        monkeypatch.setenv(name, "false")
 
 
 def test_same_uid_retry_is_idempotent_and_privacy_safe():
@@ -735,9 +751,7 @@ def test_consent_revocation_at_insert_boundary_rolls_back_all_redemption_mutatio
         uid = "synthetic-consent-race"
         repository = ai_consent.InMemoryConsentRepository()
         monkeypatch.setattr(ai_consent, "_repository", repository)
-        monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_ONLY", "true")
-        monkeypatch.setenv("ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS", uid)
-        monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_UIDS", uid)
+        _set_pilot_rollout(monkeypatch, [uid])
         _grant_v7(repository, uid)
         invitation_id, reservation_id = await _seed_invitation(
             pool,
@@ -806,9 +820,7 @@ def test_revocation_started_after_revalidation_is_serialized_and_quarantines_gra
         uid = "synthetic-consent-serialized"
         repository = ai_consent.InMemoryConsentRepository()
         monkeypatch.setattr(ai_consent, "_repository", repository)
-        monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_ONLY", "true")
-        monkeypatch.setenv("ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS", uid)
-        monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_UIDS", uid)
+        _set_pilot_rollout(monkeypatch, [uid])
         _grant_v7(repository, uid)
         invitation_id, reservation_id = await _seed_invitation(
             pool,
@@ -1046,8 +1058,7 @@ def test_revocation_transaction_error_rolls_back_epoch_and_quarantine():
                 """,
                 uid,
             )
-            await conn.execute(
-                """
+            await conn.execute("""
                 CREATE FUNCTION fail_consent_quarantine() RETURNS trigger
                 LANGUAGE plpgsql AS $$
                 BEGIN
@@ -1059,8 +1070,7 @@ def test_revocation_transaction_error_rolls_back_epoch_and_quarantine():
                 FOR EACH ROW
                 WHEN (NEW.status = 'revoked')
                 EXECUTE FUNCTION fail_consent_quarantine();
-                """
-            )
+                """)
 
         with pytest.raises(managed_cloud_consent.ManagedCloudAuthorityUnavailable):
             await managed_cloud_consent.synchronize_denial(
@@ -1240,15 +1250,10 @@ def test_rate_limit_uses_hmac_refs_and_emits_authoritative_retry():
         assert error.value.retry_after_s and error.value.retry_after_s <= 900
 
         async with pool.acquire() as conn:
-            stored = [
-                dict(row)
-                for row in await conn.fetch(
-                    """
+            stored = [dict(row) for row in await conn.fetch("""
                     SELECT uid_ref_hmac, source_ref_hmac
                     FROM ella_invitation_rate_limit_events
-                    """
-                )
-            ]
+                    """)]
         assert len(stored) == 5
         serialized = json.dumps(stored)
         assert uid not in serialized
@@ -1280,6 +1285,508 @@ def test_ordinary_feature_gate_cannot_create_entitlement_or_consume_code():
             reservation_id=reservation_id,
             uid=uid,
         )
+
+    asyncio.run(_run_with_database(scenario))
+
+
+async def _issue_operator_invitation(
+    pool: asyncpg.Pool,
+    *,
+    uid: str,
+    code: str,
+    expires_at: datetime,
+    code_file_existed: bool = False,
+    expected_database: str | None = None,
+    code_file_path: str | None = None,
+    environment: str = "postgres_test",
+    operator: str = "pytest",
+) -> dict:
+    if expected_database is None:
+        async with pool.acquire() as conn:
+            expected_database = str(await conn.fetchval("SELECT current_database()"))
+    return await invitation_operator.issue_synthetic_invitation(
+        identity=invitation_operator.SyntheticInvitationIdentity(
+            uid=uid,
+            account_uid=uid,
+            profile_uid=uid,
+        ),
+        context=invitation_operator.SyntheticInvitationContext(
+            environment=environment,
+            expected_database=expected_database,
+            operator=operator,
+        ),
+        admission=_admission(uid),
+        code=code,
+        code_file_existed=code_file_existed,
+        code_file_ref_hmac=invitations.invitation_code_file_ref(
+            OPERATOR_CONFIG,
+            code_file_path or f"/root/ella-invites/{uid}.code",
+        ),
+        expires_at=expires_at,
+        config=OPERATOR_CONFIG,
+    )
+
+
+def test_operator_issue_redeem_is_hmac_only_single_use_and_idempotent():
+    async def scenario(pool: asyncpg.Pool) -> None:
+        uid = "synthetic-operator-redeem"
+        expiry = datetime.now(timezone.utc) + timedelta(hours=1)
+        async with pool.acquire() as conn:
+            await _ensure_users(conn, [uid])
+
+        issued = await _issue_operator_invitation(
+            pool,
+            uid=uid,
+            code="ABCD-2345",
+            expires_at=expiry,
+        )
+        with pytest.raises(
+            invitation_operator.SyntheticInvitationOperatorError,
+            match="operator_stale_code_receipt",
+        ):
+            await _issue_operator_invitation(
+                pool,
+                uid=uid,
+                code="ABCD-2345",
+                expires_at=expiry,
+                code_file_existed=True,
+                code_file_path="/root/ella-invites/copied.code",
+            )
+        retried = await _issue_operator_invitation(
+            pool,
+            uid=uid,
+            code="ABCD-2345",
+            expires_at=expiry,
+            code_file_existed=True,
+        )
+        assert issued["receipt_id"] == retried["receipt_id"]
+        assert retried["idempotent"] is True
+        with pytest.raises(
+            invitation_operator.SyntheticInvitationOperatorError,
+            match="operator_receipt_context_mismatch",
+        ):
+            await _issue_operator_invitation(
+                pool,
+                uid=uid,
+                code="ABCD-2345",
+                expires_at=expiry,
+                code_file_existed=True,
+                environment="other_environment",
+            )
+        with pytest.raises(
+            invitation_operator.SyntheticInvitationOperatorError,
+            match="operator_receipt_context_mismatch",
+        ):
+            await invitation_operator.show_synthetic_invitation(
+                receipt_id=issued["receipt_id"],
+                identity=invitation_operator.SyntheticInvitationIdentity(uid, uid, uid),
+                context=invitation_operator.SyntheticInvitationContext(
+                    "postgres_test",
+                    await _current_database(pool),
+                    "other_operator",
+                ),
+                config=OPERATOR_CONFIG,
+            )
+
+        first = await _redeem(
+            uid,
+            "ABCD-2345",
+            config=OPERATOR_CONFIG,
+        )
+        second = await _redeem(
+            uid,
+            "abcd 2345",
+            config=OPERATOR_CONFIG,
+        )
+        assert first["status"] == second["status"] == "invited"
+        assert first["revision"] == second["revision"] == 1
+
+        async with pool.acquire() as conn:
+            invitation = dict(
+                await conn.fetchrow(
+                    """
+                    SELECT code_hmac, display_hint, state, redemption_count,
+                           cohort, exclude_from_product_analytics
+                    FROM ella_invitations
+                    WHERE id = $1::uuid
+                    """,
+                    issued["receipt_id"],
+                )
+            )
+            target = dict(
+                await conn.fetchrow(
+                    """
+                    SELECT account_ref_hmac, profile_ref_hmac,
+                           required_profile_class, consumed_at
+                    FROM ella_invitation_targets
+                    WHERE invitation_id = $1::uuid
+                    """,
+                    issued["receipt_id"],
+                )
+            )
+            counts = dict(
+                await conn.fetchrow(
+                    """
+                    SELECT
+                        (
+                            SELECT COUNT(*) FROM ella_invitations
+                            WHERE cohort = $2
+                        ) AS invitations,
+                        (
+                            SELECT COUNT(*) FROM ella_invitation_redemptions
+                            WHERE invitation_id = $1::uuid
+                        ) AS redemptions,
+                        (
+                            SELECT COUNT(*) FROM ella_invitation_audit_receipts
+                            WHERE invitation_id = $1::uuid
+                              AND event_type = 'operator_issued'
+                        ) AS issued_audits,
+                        (
+                            SELECT COUNT(*) FROM ella_invitation_audit_receipts
+                            WHERE invitation_id = $1::uuid
+                              AND event_type = 'operator_idempotent_retry'
+                        ) AS retry_audits
+                    """,
+                    issued["receipt_id"],
+                    invitations.SYNTHETIC_OPERATOR_COHORT,
+                )
+            )
+        serialized = json.dumps(
+            {"invitation": invitation, "target": target},
+            default=str,
+        )
+        assert "ABCD-2345" not in serialized
+        assert "ABCD2345" not in serialized
+        assert uid not in serialized
+        assert invitation["display_hint"] is None
+        assert invitation["state"] == "redeemed"
+        assert invitation["redemption_count"] == 1
+        assert invitation["cohort"] == invitations.SYNTHETIC_OPERATOR_COHORT
+        assert invitation["exclude_from_product_analytics"] is True
+        assert target["required_profile_class"] == "synthetic"
+        assert target["consumed_at"] is not None
+        assert counts == {
+            "invitations": 1,
+            "redemptions": 1,
+            "issued_audits": 1,
+            "retry_audits": 1,
+        }
+
+        with pytest.raises(
+            invitation_operator.SyntheticInvitationOperatorError,
+            match="operator_revoke_refused",
+        ):
+            await invitation_operator.revoke_synthetic_invitation(
+                receipt_id=issued["receipt_id"],
+                expected_version=2,
+                identity=invitation_operator.SyntheticInvitationIdentity(uid, uid, uid),
+                context=invitation_operator.SyntheticInvitationContext(
+                    "postgres_test",
+                    await _current_database(pool),
+                    "pytest",
+                ),
+                config=OPERATOR_CONFIG,
+            )
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_operator_policy_drift_cannot_bypass_disabled_ordinary_gate():
+    async def scenario(pool: asyncpg.Pool) -> None:
+        uid = "synthetic-operator-policy-drift"
+        expiry = datetime.now(timezone.utc) + timedelta(hours=1)
+        async with pool.acquire() as conn:
+            await _ensure_users(conn, [uid])
+        issued = await _issue_operator_invitation(
+            pool,
+            uid=uid,
+            code="CDEF-2345",
+            expires_at=expiry,
+        )
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE ella_invitations
+                SET entitlement_policy = jsonb_set(
+                    entitlement_policy,
+                    '{daily_limit_s}',
+                    '999999'::jsonb
+                )
+                WHERE id = $1::uuid
+                """,
+                issued["receipt_id"],
+            )
+
+        with pytest.raises(invitations.InviteRedemptionFailure) as error:
+            await _redeem(
+                uid,
+                "CDEF-2345",
+                config=OPERATOR_CONFIG,
+            )
+        assert error.value.code == "invalid"
+        async with pool.acquire() as conn:
+            state = dict(
+                await conn.fetchrow(
+                    """
+                    SELECT i.redemption_count, t.consumed_at,
+                           r.state AS reservation_state
+                    FROM ella_invitations i
+                    JOIN ella_invitation_targets t
+                      ON t.invitation_id = i.id
+                    JOIN ella_invitation_capacity_reservations r
+                      ON r.id = i.capacity_reservation_id
+                    WHERE i.id = $1::uuid
+                    """,
+                    issued["receipt_id"],
+                )
+            )
+        assert state == {
+            "redemption_count": 0,
+            "consumed_at": None,
+            "reservation_state": "reserved",
+        }
+
+    asyncio.run(_run_with_database(scenario))
+
+
+async def _current_database(pool: asyncpg.Pool) -> str:
+    async with pool.acquire() as conn:
+        return str(await conn.fetchval("SELECT current_database()"))
+
+
+def test_operator_revoke_cleanup_is_exact_and_real_user_safe():
+    async def scenario(pool: asyncpg.Pool) -> None:
+        uid = "synthetic-operator-cleanup"
+        other_uid = "synthetic-operator-other"
+        expiry = datetime.now(timezone.utc) + timedelta(hours=1)
+        async with pool.acquire() as conn:
+            await _ensure_users(conn, [uid, other_uid])
+        issued = await _issue_operator_invitation(
+            pool,
+            uid=uid,
+            code="EFGH-2345",
+            expires_at=expiry,
+        )
+        context = invitation_operator.SyntheticInvitationContext(
+            "postgres_test",
+            await _current_database(pool),
+            "pytest",
+        )
+        with pytest.raises(
+            invitation_operator.SyntheticInvitationOperatorError,
+            match="operator_receipt_binding_mismatch",
+        ):
+            await invitation_operator.show_synthetic_invitation(
+                receipt_id=issued["receipt_id"],
+                identity=invitation_operator.SyntheticInvitationIdentity(
+                    other_uid,
+                    other_uid,
+                    other_uid,
+                ),
+                context=context,
+                config=OPERATOR_CONFIG,
+            )
+        with pytest.raises(
+            invitation_operator.SyntheticInvitationOperatorError,
+            match="operator_stale_receipt",
+        ):
+            await invitation_operator.revoke_synthetic_invitation(
+                receipt_id=issued["receipt_id"],
+                expected_version=99,
+                identity=invitation_operator.SyntheticInvitationIdentity(uid, uid, uid),
+                context=context,
+                config=OPERATOR_CONFIG,
+            )
+
+        revoked = await invitation_operator.revoke_synthetic_invitation(
+            receipt_id=issued["receipt_id"],
+            expected_version=1,
+            identity=invitation_operator.SyntheticInvitationIdentity(uid, uid, uid),
+            context=context,
+            config=OPERATOR_CONFIG,
+        )
+        assert revoked["state"] == "revoked"
+        assert revoked["version"] == 2
+        assert revoked["current_profile_class"] == "synthetic"
+
+        cleaned = await invitation_operator.cleanup_synthetic_invitation(
+            receipt_id=issued["receipt_id"],
+            expected_version=2,
+            identity=invitation_operator.SyntheticInvitationIdentity(uid, uid, uid),
+            context=context,
+            config=OPERATOR_CONFIG,
+        )
+        assert cleaned["state"] == "revoked"
+        assert cleaned["version"] == 3
+        assert cleaned["current_profile_class"] == "real"
+        shown = await invitation_operator.show_synthetic_invitation(
+            receipt_id=issued["receipt_id"],
+            identity=invitation_operator.SyntheticInvitationIdentity(uid, uid, uid),
+            context=context,
+            config=OPERATOR_CONFIG,
+        )
+        assert shown["current_profile_class"] == "real"
+
+        async with pool.acquire() as conn:
+            state = dict(
+                await conn.fetchrow(
+                    """
+                    SELECT i.state, i.delivery_state, r.state AS reservation_state,
+                           u.profile_class,
+                           (
+                               SELECT COUNT(*)
+                               FROM ella_invitation_audit_receipts a
+                               WHERE a.invitation_id = i.id
+                                 AND a.event_type IN (
+                                     'operator_revoked', 'operator_cleanup'
+                                 )
+                           ) AS lifecycle_audits
+                    FROM ella_invitations i
+                    JOIN ella_invitation_capacity_reservations r
+                      ON r.id = i.capacity_reservation_id
+                    JOIN ella_invitation_targets t
+                      ON t.invitation_id = i.id
+                    JOIN users u ON u.omi_uid = $2
+                    WHERE i.id = $1::uuid
+                    """,
+                    issued["receipt_id"],
+                    uid,
+                )
+            )
+        assert state == {
+            "state": "revoked",
+            "delivery_state": "suppressed",
+            "reservation_state": "released",
+            "profile_class": "real",
+            "lifecycle_audits": 2,
+        }
+
+        with pytest.raises(
+            invitation_operator.SyntheticInvitationOperatorError,
+            match="operator_real_profile_refused|operator_stale_code_receipt",
+        ):
+            await _issue_operator_invitation(
+                pool,
+                uid=uid,
+                code="JKMN-2345",
+                expires_at=expiry,
+            )
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_operator_refuses_real_existing_collision_wrong_database_and_expiry():
+    async def scenario(pool: asyncpg.Pool) -> None:
+        real_uid = "synthetic-operator-real-refusal"
+        collision_uid = "synthetic-operator-collision"
+        existing_uid = "synthetic-existing-code-owner"
+        expiry_uid = "synthetic-operator-expired"
+        artifact_uid = "synthetic-operator-existing-artifact"
+        stale_uid = "synthetic-operator-stale-file"
+        expiry = datetime.now(timezone.utc) + timedelta(hours=1)
+        async with pool.acquire() as conn:
+            await _ensure_users(conn, [real_uid], profile_class="real")
+            await _ensure_users(
+                conn,
+                [collision_uid, expiry_uid, artifact_uid, stale_uid],
+            )
+            await conn.execute(
+                "INSERT INTO voice_entitlements (uid) VALUES ($1)",
+                artifact_uid,
+            )
+        with pytest.raises(
+            invitation_operator.SyntheticInvitationOperatorError,
+            match="operator_real_profile_refused",
+        ):
+            await _issue_operator_invitation(
+                pool,
+                uid=real_uid,
+                code="JKMN-2345",
+                expires_at=expiry,
+            )
+        with pytest.raises(
+            invitation_operator.SyntheticInvitationOperatorError,
+            match="operator_database_mismatch",
+        ):
+            await _issue_operator_invitation(
+                pool,
+                uid=collision_uid,
+                code="MNPQ-2345",
+                expires_at=expiry,
+                expected_database="wrong_database",
+            )
+        with pytest.raises(
+            invitation_operator.SyntheticInvitationOperatorError,
+            match="operator_existing_profile_artifacts",
+        ):
+            await _issue_operator_invitation(
+                pool,
+                uid=artifact_uid,
+                code="NPQR-2345",
+                expires_at=expiry,
+            )
+        with pytest.raises(
+            invitation_operator.SyntheticInvitationOperatorError,
+            match="operator_stale_code_receipt",
+        ):
+            await _issue_operator_invitation(
+                pool,
+                uid=stale_uid,
+                code="PQRS-2345",
+                expires_at=expiry,
+                code_file_existed=True,
+            )
+
+        await _seed_invitation(
+            pool,
+            code="RSTU-2345",
+            target_uids=[existing_uid],
+        )
+        with pytest.raises(
+            invitation_operator.SyntheticInvitationOperatorError,
+            match="operator_code_collision",
+        ):
+            await _issue_operator_invitation(
+                pool,
+                uid=collision_uid,
+                code="RSTU-2345",
+                expires_at=expiry,
+            )
+
+        issued = await _issue_operator_invitation(
+            pool,
+            uid=expiry_uid,
+            code="VWXY-2345",
+            expires_at=expiry,
+        )
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE ella_invitations
+                SET expires_at = NOW() - INTERVAL '1 minute'
+                WHERE id = $1::uuid
+                """,
+                issued["receipt_id"],
+            )
+        with pytest.raises(invitations.InviteRedemptionFailure) as error:
+            await _redeem(
+                expiry_uid,
+                "VWXY-2345",
+                config=OPERATOR_CONFIG,
+            )
+        assert error.value.code == "expired"
+        async with pool.acquire() as conn:
+            assert (
+                await conn.fetchval(
+                    """
+                    SELECT redemption_count
+                    FROM ella_invitations
+                    WHERE id = $1::uuid
+                    """,
+                    issued["receipt_id"],
+                )
+                == 0
+            )
 
     asyncio.run(_run_with_database(scenario))
 
@@ -1332,7 +1839,7 @@ def test_app_review_code_remains_capped_and_requires_prebound_targets():
     asyncio.run(_run_with_database(scenario))
 
 
-def test_default_gate_requires_v7_exact_allowlists_and_synthetic_profile(
+def test_default_gate_requires_v8_exact_allowlists_and_synthetic_profile(
     monkeypatch,
 ):
     async def scenario(pool: asyncpg.Pool) -> None:
@@ -1344,14 +1851,9 @@ def test_default_gate_requires_v7_exact_allowlists_and_synthetic_profile(
         monkeypatch.setattr(ai_consent, "_repository", repository)
         for uid in (allowed, no_allowlist, real_profile):
             _grant_v7(repository, uid)
-        monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_ONLY", "true")
-        monkeypatch.setenv(
-            "ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS",
-            ",".join((allowed, no_consent, real_profile)),
-        )
-        monkeypatch.setenv(
-            "ELLA_HERMES_CLOUD_SYNTHETIC_UIDS",
-            ",".join((allowed, no_consent, real_profile)),
+        _set_pilot_rollout(
+            monkeypatch,
+            [allowed, no_consent, real_profile],
         )
 
         allowed_id, _ = await _seed_invitation(
@@ -1657,15 +2159,11 @@ def test_kill_switch_after_invite_blocks_claim_and_preserves_pool(monkeypatch):
             )
         assert error.value.code == "runtime_admission_provider_disabled"
         async with pool.acquire() as conn:
-            binding = dict(
-                await conn.fetchrow(
-                    """
+            binding = dict(await conn.fetchrow("""
                     SELECT status, user_id, claim_job_id, claim_token
                     FROM ella_runtime_bindings
                     WHERE runtime_instance_id = 'kill-switch-a'
-                    """
-                )
-            )
+                    """))
         assert binding == {
             "status": "pool_available",
             "user_id": None,

--- a/backend/tests/postgres/test_invitation_redemption_postgres.py
+++ b/backend/tests/postgres/test_invitation_redemption_postgres.py
@@ -1659,13 +1659,56 @@ async def _current_database(pool: asyncpg.Pool) -> str:
         return str(await conn.fetchval("SELECT current_database()"))
 
 
+async def _wait_for_operator_authority_waiter(
+    pool: asyncpg.Pool,
+    owner: authority_advisory_lock.AuthorityOwner,
+) -> None:
+    key = authority_advisory_lock.authority_lock_key(
+        str(owner.account_id),
+        str(owner.profile_id),
+    )
+    class_id, object_id = authority_advisory_lock._advisory_lock_parts(key)
+    for _attempt in range(100):
+        async with pool.acquire() as observer:
+            waiting = await observer.fetchval(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM pg_locks
+                    WHERE locktype = 'advisory'
+                      AND classid::bigint = $1
+                      AND objid::bigint = $2
+                      AND objsubid = 1
+                      AND mode = 'ExclusiveLock'
+                      AND NOT granted
+                )
+                """,
+                class_id,
+                object_id,
+            )
+        if waiting:
+            return
+        await asyncio.sleep(0.02)
+    pytest.fail("operator cleanup never waited on the shared v1 authority lock")
+
+
 def test_operator_revoke_cleanup_is_exact_and_real_user_safe():
     async def scenario(pool: asyncpg.Pool) -> None:
         uid = "synthetic-operator-cleanup"
         other_uid = "synthetic-operator-other"
+        contention_uid = "synthetic-operator-cleanup-contention"
+        owner_drift_uid = "synthetic-operator-cleanup-owner-drift"
         expiry = datetime.now(timezone.utc) + timedelta(hours=1)
         async with pool.acquire() as conn:
-            await _ensure_users(conn, [uid, other_uid])
+            await _ensure_users(
+                conn,
+                [
+                    uid,
+                    other_uid,
+                    contention_uid,
+                    owner_drift_uid,
+                ],
+            )
         issued = await _issue_operator_invitation(
             pool,
             uid=uid,
@@ -1776,6 +1819,191 @@ def test_operator_revoke_cleanup_is_exact_and_real_user_safe():
                 code="JKMN-2345",
                 expires_at=expiry,
             )
+
+        contention_issue = await _issue_operator_invitation(
+            pool,
+            uid=contention_uid,
+            code="MNPR-2345",
+            expires_at=expiry,
+        )
+        await invitation_operator.revoke_synthetic_invitation(
+            receipt_id=contention_issue["receipt_id"],
+            expected_version=1,
+            identity=invitation_operator.SyntheticInvitationIdentity(
+                contention_uid,
+                contention_uid,
+                contention_uid,
+            ),
+            context=context,
+            config=OPERATOR_CONFIG,
+        )
+        async with pool.acquire() as conn:
+            contention_user_id = await conn.fetchval(
+                "SELECT id FROM users WHERE omi_uid = $1",
+                contention_uid,
+            )
+        contention_owner = authority_advisory_lock.AuthorityOwner.from_values(
+            contention_user_id,
+            contention_user_id,
+        )
+        async with pool.acquire() as broker:
+            transaction = broker.transaction()
+            await transaction.start()
+            await authority_advisory_lock.acquire_authority_lock(
+                broker,
+                owner=contention_owner,
+            )
+            cleanup_task = asyncio.create_task(
+                invitation_operator.cleanup_synthetic_invitation(
+                    receipt_id=contention_issue["receipt_id"],
+                    expected_version=2,
+                    identity=invitation_operator.SyntheticInvitationIdentity(
+                        contention_uid,
+                        contention_uid,
+                        contention_uid,
+                    ),
+                    context=context,
+                    config=OPERATOR_CONFIG,
+                )
+            )
+            await _wait_for_operator_authority_waiter(
+                pool,
+                contention_owner,
+            )
+            assert not cleanup_task.done()
+            async with pool.acquire() as observer:
+                blocked_state = dict(
+                    await observer.fetchrow(
+                        """
+                        SELECT u.profile_class, i.state, i.version
+                        FROM users u
+                        JOIN ella_invitation_targets t
+                          ON t.account_ref_hmac = $2
+                        JOIN ella_invitations i ON i.id = t.invitation_id
+                        WHERE u.id = $1 AND i.id = $3::uuid
+                        """,
+                        contention_user_id,
+                        invitations.invitation_target_refs(
+                            OPERATOR_CONFIG,
+                            account_uid=contention_uid,
+                            profile_uid=contention_uid,
+                        )[0],
+                        contention_issue["receipt_id"],
+                    )
+                )
+            assert blocked_state == {
+                "profile_class": "synthetic",
+                "state": "revoked",
+                "version": 2,
+            }
+            await transaction.commit()
+        contention_cleaned = await asyncio.wait_for(cleanup_task, timeout=5)
+        assert contention_cleaned["current_profile_class"] == "real"
+
+        owner_drift_issue = await _issue_operator_invitation(
+            pool,
+            uid=owner_drift_uid,
+            code="QRST-2345",
+            expires_at=expiry,
+        )
+        await invitation_operator.revoke_synthetic_invitation(
+            receipt_id=owner_drift_issue["receipt_id"],
+            expected_version=1,
+            identity=invitation_operator.SyntheticInvitationIdentity(
+                owner_drift_uid,
+                owner_drift_uid,
+                owner_drift_uid,
+            ),
+            context=context,
+            config=OPERATOR_CONFIG,
+        )
+        async with pool.acquire() as conn:
+            owner_drift_user_id = await conn.fetchval(
+                "SELECT id FROM users WHERE omi_uid = $1",
+                owner_drift_uid,
+            )
+        owner_drift_owner = authority_advisory_lock.AuthorityOwner.from_values(
+            owner_drift_user_id,
+            owner_drift_user_id,
+        )
+        async with pool.acquire() as broker:
+            transaction = broker.transaction()
+            await transaction.start()
+            await authority_advisory_lock.acquire_authority_lock(
+                broker,
+                owner=owner_drift_owner,
+            )
+            owner_drift_cleanup = asyncio.create_task(
+                invitation_operator.cleanup_synthetic_invitation(
+                    receipt_id=owner_drift_issue["receipt_id"],
+                    expected_version=2,
+                    identity=invitation_operator.SyntheticInvitationIdentity(
+                        owner_drift_uid,
+                        owner_drift_uid,
+                        owner_drift_uid,
+                    ),
+                    context=context,
+                    config=OPERATOR_CONFIG,
+                )
+            )
+            await _wait_for_operator_authority_waiter(
+                pool,
+                owner_drift_owner,
+            )
+            async with pool.acquire() as drift:
+                async with drift.transaction():
+                    await drift.execute(
+                        "UPDATE users SET omi_uid = $2 WHERE id = $1",
+                        owner_drift_user_id,
+                        f"{owner_drift_uid}-moved",
+                    )
+                    replacement_id = await drift.fetchval(
+                        """
+                        INSERT INTO users (omi_uid, profile_class)
+                        VALUES ($1, 'synthetic')
+                        RETURNING id
+                        """,
+                        owner_drift_uid,
+                    )
+            await transaction.commit()
+
+        with pytest.raises(
+            invitation_operator.SyntheticInvitationOperatorError,
+            match="operator_identity_drift",
+        ):
+            await asyncio.wait_for(owner_drift_cleanup, timeout=5)
+        async with pool.acquire() as observer:
+            owner_drift_state = dict(
+                await observer.fetchrow(
+                    """
+                    SELECT
+                        (SELECT profile_class FROM users WHERE id = $1)
+                            AS original_profile_class,
+                        (SELECT profile_class FROM users WHERE id = $2)
+                            AS replacement_profile_class,
+                        i.state,
+                        i.version,
+                        (
+                            SELECT COUNT(*)::integer
+                            FROM ella_invitation_audit_receipts a
+                            WHERE a.invitation_id = i.id
+                              AND a.event_type = 'operator_cleanup'
+                        ) AS cleanup_audits
+                    FROM ella_invitations i
+                    WHERE i.id = $3::uuid
+                    """,
+                    owner_drift_user_id,
+                    replacement_id,
+                    owner_drift_issue["receipt_id"],
+                )
+            )
+        assert owner_drift_state == {
+            "original_profile_class": "synthetic",
+            "replacement_profile_class": "synthetic",
+            "state": "revoked",
+            "version": 2,
+            "cleanup_audits": 0,
+        }
 
     asyncio.run(_run_with_database(scenario))
 

--- a/backend/tests/postgres/test_invitation_redemption_postgres.py
+++ b/backend/tests/postgres/test_invitation_redemption_postgres.py
@@ -186,7 +186,8 @@ async def _run_with_database(
                 "014_add_synthetic_invitation_operator_audit.sql",
             ):
                 await conn.execute((MIGRATIONS / name).read_text(encoding="utf-8"))
-            assert await conn.fetchval("""
+            assert await conn.fetchval(
+                """
                 SELECT EXISTS (
                     SELECT 1
                     FROM information_schema.columns
@@ -195,7 +196,8 @@ async def _run_with_database(
                       AND column_name = 'profile_class'
                       AND is_nullable = 'NO'
                 )
-                """)
+                """
+            )
             assert await conn.fetchval("SELECT to_regclass('ella_invitation_targets') IS NOT NULL")
         await scenario(pool)
     finally:
@@ -1058,7 +1060,8 @@ def test_revocation_transaction_error_rolls_back_epoch_and_quarantine():
                 """,
                 uid,
             )
-            await conn.execute("""
+            await conn.execute(
+                """
                 CREATE FUNCTION fail_consent_quarantine() RETURNS trigger
                 LANGUAGE plpgsql AS $$
                 BEGIN
@@ -1070,7 +1073,8 @@ def test_revocation_transaction_error_rolls_back_epoch_and_quarantine():
                 FOR EACH ROW
                 WHEN (NEW.status = 'revoked')
                 EXECUTE FUNCTION fail_consent_quarantine();
-                """)
+                """
+            )
 
         with pytest.raises(managed_cloud_consent.ManagedCloudAuthorityUnavailable):
             await managed_cloud_consent.synchronize_denial(
@@ -1250,10 +1254,15 @@ def test_rate_limit_uses_hmac_refs_and_emits_authoritative_retry():
         assert error.value.retry_after_s and error.value.retry_after_s <= 900
 
         async with pool.acquire() as conn:
-            stored = [dict(row) for row in await conn.fetch("""
+            stored = [
+                dict(row)
+                for row in await conn.fetch(
+                    """
                     SELECT uid_ref_hmac, source_ref_hmac
                     FROM ella_invitation_rate_limit_events
-                    """)]
+                    """
+                )
+            ]
         assert len(stored) == 5
         serialized = json.dumps(stored)
         assert uid not in serialized
@@ -2159,11 +2168,15 @@ def test_kill_switch_after_invite_blocks_claim_and_preserves_pool(monkeypatch):
             )
         assert error.value.code == "runtime_admission_provider_disabled"
         async with pool.acquire() as conn:
-            binding = dict(await conn.fetchrow("""
+            binding = dict(
+                await conn.fetchrow(
+                    """
                     SELECT status, user_id, claim_job_id, claim_token
                     FROM ella_runtime_bindings
                     WHERE runtime_instance_id = 'kill-switch-a'
-                    """))
+                    """
+                )
+            )
         assert binding == {
             "status": "pool_available",
             "user_id": None,

--- a/backend/tests/postgres/test_invitation_redemption_postgres.py
+++ b/backend/tests/postgres/test_invitation_redemption_postgres.py
@@ -1309,28 +1309,45 @@ async def _issue_operator_invitation(
     code_file_path: str | None = None,
     environment: str = "postgres_test",
     operator: str = "pytest",
+    recovery_receipt_valid: bool = True,
 ) -> dict:
     if expected_database is None:
         async with pool.acquire() as conn:
             expected_database = str(await conn.fetchval("SELECT current_database()"))
+    identity = invitation_operator.SyntheticInvitationIdentity(
+        uid=uid,
+        account_uid=uid,
+        profile_uid=uid,
+    )
+    context = invitation_operator.SyntheticInvitationContext(
+        environment=environment,
+        expected_database=expected_database,
+        operator=operator,
+    )
+    admission = _admission(uid)
+    code_file_ref_hmac = invitations.invitation_code_file_ref(
+        OPERATOR_CONFIG,
+        code_file_path or f"/root/ella-invites/{uid}.code",
+    )
+    recovery_binding_hmac = invitation_operator.synthetic_invitation_recovery_binding_hmac(
+        identity=identity,
+        context=context,
+        admission=admission,
+        code=code,
+        code_file_ref_hmac=code_file_ref_hmac,
+        expires_at=expires_at,
+        config=OPERATOR_CONFIG,
+    )
+    if not recovery_receipt_valid:
+        recovery_binding_hmac = "0" * 64
     return await invitation_operator.issue_synthetic_invitation(
-        identity=invitation_operator.SyntheticInvitationIdentity(
-            uid=uid,
-            account_uid=uid,
-            profile_uid=uid,
-        ),
-        context=invitation_operator.SyntheticInvitationContext(
-            environment=environment,
-            expected_database=expected_database,
-            operator=operator,
-        ),
-        admission=_admission(uid),
+        identity=identity,
+        context=context,
+        admission=admission,
         code=code,
         code_file_existed=code_file_existed,
-        code_file_ref_hmac=invitations.invitation_code_file_ref(
-            OPERATOR_CONFIG,
-            code_file_path or f"/root/ella-invites/{uid}.code",
-        ),
+        code_file_ref_hmac=code_file_ref_hmac,
+        recovery_binding_hmac=recovery_binding_hmac,
         expires_at=expires_at,
         config=OPERATOR_CONFIG,
     )
@@ -1339,9 +1356,14 @@ async def _issue_operator_invitation(
 def test_operator_issue_redeem_is_hmac_only_single_use_and_idempotent():
     async def scenario(pool: asyncpg.Pool) -> None:
         uid = "synthetic-operator-redeem"
+        precommit_uid = "synthetic-operator-precommit-recovery"
+        postcommit_uid = "synthetic-operator-postcommit-recovery"
         expiry = datetime.now(timezone.utc) + timedelta(hours=1)
         async with pool.acquire() as conn:
-            await _ensure_users(conn, [uid])
+            await _ensure_users(
+                conn,
+                [uid, precommit_uid, postcommit_uid],
+            )
 
         issued = await _issue_operator_invitation(
             pool,
@@ -1397,6 +1419,80 @@ def test_operator_issue_redeem_is_hmac_only_single_use_and_idempotent():
                 config=OPERATOR_CONFIG,
             )
 
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                CREATE FUNCTION fail_operator_issue_audit() RETURNS trigger
+                LANGUAGE plpgsql AS $$
+                BEGIN
+                    RAISE EXCEPTION 'injected operator precommit failure';
+                END;
+                $$;
+                CREATE TRIGGER fail_operator_issue_audit
+                BEFORE INSERT ON ella_invitation_audit_receipts
+                FOR EACH ROW
+                WHEN (NEW.event_type = 'operator_issued')
+                EXECUTE FUNCTION fail_operator_issue_audit();
+                """
+            )
+        with pytest.raises(
+            asyncpg.PostgresError,
+            match="injected operator precommit failure",
+        ):
+            await _issue_operator_invitation(
+                pool,
+                uid=precommit_uid,
+                code="BCDE-2345",
+                expires_at=expiry,
+            )
+        async with pool.acquire() as conn:
+            assert not await conn.fetchval(
+                "SELECT EXISTS (SELECT 1 FROM ella_invitations WHERE code_hmac = $1)",
+                invitations.code_hmac(OPERATOR_CONFIG, "BCDE2345"),
+            )
+            await conn.execute(
+                """
+                DROP TRIGGER fail_operator_issue_audit
+                    ON ella_invitation_audit_receipts;
+                DROP FUNCTION fail_operator_issue_audit();
+                """
+            )
+        precommit_recovered = await _issue_operator_invitation(
+            pool,
+            uid=precommit_uid,
+            code="BCDE-2345",
+            expires_at=expiry,
+            code_file_existed=True,
+        )
+        assert precommit_recovered["idempotent"] is False
+
+        postcommit_receipt = {}
+
+        async def issue_then_lose_commit_result() -> None:
+            committed = await _issue_operator_invitation(
+                pool,
+                uid=postcommit_uid,
+                code="DEFG-2345",
+                expires_at=expiry,
+            )
+            postcommit_receipt.update(committed)
+            raise ConnectionError("injected postcommit outcome ambiguity")
+
+        with pytest.raises(
+            ConnectionError,
+            match="injected postcommit outcome ambiguity",
+        ):
+            await issue_then_lose_commit_result()
+        postcommit_recovered = await _issue_operator_invitation(
+            pool,
+            uid=postcommit_uid,
+            code="DEFG-2345",
+            expires_at=expiry,
+            code_file_existed=True,
+        )
+        assert postcommit_recovered["receipt_id"] == postcommit_receipt["receipt_id"]
+        assert postcommit_recovered["idempotent"] is True
+
         first = await _redeem(
             uid,
             "ABCD-2345",
@@ -1439,7 +1535,7 @@ def test_operator_issue_redeem_is_hmac_only_single_use_and_idempotent():
                     SELECT
                         (
                             SELECT COUNT(*) FROM ella_invitations
-                            WHERE cohort = $2
+                            WHERE cohort = $2 AND id = $1::uuid
                         ) AS invitations,
                         (
                             SELECT COUNT(*) FROM ella_invitation_redemptions
@@ -1744,6 +1840,7 @@ def test_operator_refuses_real_existing_collision_wrong_database_and_expiry():
                 code="PQRS-2345",
                 expires_at=expiry,
                 code_file_existed=True,
+                recovery_receipt_valid=False,
             )
 
         await _seed_invitation(

--- a/backend/tests/unit/test_authority_writer_guard.py
+++ b/backend/tests/unit/test_authority_writer_guard.py
@@ -31,6 +31,7 @@ EXPECTED_WRITERS = {
     ("database/ella_provisioning.py", "quarantine_cloud_pool_claim"),
     ("database/ella_provisioning.py", "register_cloud_pool_binding"),
     ("database/ella_provisioning.py", "stage_runtime_binding"),
+    ("database/invitation_operator.py", "_cleanup_locked"),
     ("database/invitations.py", "_redeem_locked_invitation"),
     ("database/managed_cloud_consent.py", "_quarantine_on_connection"),
     ("database/managed_cloud_consent.py", "lock_or_bootstrap_grant_on_connection"),
@@ -43,12 +44,14 @@ EXPECTED_WRITERS = {
 
 DIRECT_LOCKED_WRITERS = EXPECTED_WRITERS - {
     ("database/ella_provisioning.py", "register_cloud_pool_binding"),
+    ("database/invitation_operator.py", "_cleanup_locked"),
     ("database/invitations.py", "_redeem_locked_invitation"),
     ("database/managed_cloud_consent.py", "_quarantine_on_connection"),
     ("database/managed_cloud_consent.py", "lock_or_bootstrap_grant_on_connection"),
 }
 
 PROOF_GATED_HELPERS = {
+    ("database/invitation_operator.py", "_cleanup_locked"),
     ("database/invitations.py", "_redeem_locked_invitation"),
     ("database/managed_cloud_consent.py", "_quarantine_on_connection"),
     ("database/managed_cloud_consent.py", "lock_or_bootstrap_grant_on_connection"),
@@ -58,6 +61,7 @@ EXPECTED_GLOBAL_USER_WRITERS = {
     ("database/ella_provisioning.py", "activate_user"),
     ("database/ella_provisioning.py", "ensure_user_identity"),
     ("database/ella_provisioning.py", "finalize_cloud_pool_claim"),
+    ("database/invitation_operator.py", "_cleanup_locked"),
     ("ella/utils/auto_provision.py", "auto_provision_user"),
 }
 NON_AUTHORITY_USER_WRITERS = {
@@ -99,6 +103,10 @@ REAL_POSTGRES_WRITER_COVERAGE = {
     ("database/invitations.py", "_redeem_locked_invitation"): (
         "tests/postgres/test_invitation_redemption_postgres.py",
         "test_broker_lock_blocks_invitation_before_capacity_or_entitlement_mutation",
+    ),
+    ("database/invitation_operator.py", "_cleanup_locked"): (
+        "tests/postgres/test_invitation_redemption_postgres.py",
+        "test_operator_revoke_cleanup_is_exact_and_real_user_safe",
     ),
     ("database/managed_cloud_consent.py", "_quarantine_on_connection"): (
         "tests/postgres/test_authority_advisory_lock_postgres.py",

--- a/backend/tests/unit/test_invitation_redemption.py
+++ b/backend/tests/unit/test_invitation_redemption.py
@@ -130,15 +130,17 @@ def test_target_refs_are_domain_separated_and_contain_no_identity():
     assert "account-a" not in account_ref + profile_ref
 
 
-def test_pilot_gate_requires_exact_v7_consent_and_both_uid_allowlists(
+def test_pilot_gate_requires_exact_v8_consent_and_all_uid_allowlists(
     monkeypatch,
 ):
     uid = "synthetic-pilot"
     repository = ai_consent.InMemoryConsentRepository()
     monkeypatch.setattr(ai_consent, "_repository", repository)
     monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_ONLY", "true")
-    monkeypatch.setenv("ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS", uid)
-    monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_UIDS", uid)
+    for name in invitation_authority.PILOT_UID_ALLOWLISTS:
+        monkeypatch.setenv(name, uid)
+    for name in invitation_authority.PILOT_GLOBAL_FLAGS_REQUIRED_FALSE:
+        monkeypatch.setenv(name, "false")
 
     with pytest.raises(invitations.InvitePilotGateDenied):
         invitation_authority.authorize_invitation_pilot(uid)
@@ -161,7 +163,12 @@ def test_pilot_gate_requires_exact_v7_consent_and_both_uid_allowlists(
     assert admission.policy_version == "ai-data-processors-v8"
     assert admission.account_uid == admission.profile_uid == uid
 
-    monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_UIDS", "")
+    monkeypatch.setenv("ELLA_RUNTIME_BINDINGS_ENABLED_UIDS", "")
+    with pytest.raises(invitations.InvitePilotGateDenied):
+        invitation_authority.authorize_invitation_pilot(uid)
+
+    monkeypatch.setenv("ELLA_RUNTIME_BINDINGS_ENABLED_UIDS", uid)
+    monkeypatch.setenv("ELLA_RUNTIME_BINDINGS_ENABLED", "true")
     with pytest.raises(invitations.InvitePilotGateDenied):
         invitation_authority.authorize_invitation_pilot(uid)
 

--- a/backend/tests/unit/test_synthetic_invite_admin.py
+++ b/backend/tests/unit/test_synthetic_invite_admin.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+import hashlib
 import os
 import stat
 from datetime import datetime, timedelta, timezone
@@ -31,7 +32,12 @@ def _admission(uid: str = "synthetic-iris") -> invitations.InvitationPilotAdmiss
     )
 
 
-def _issue_args(root, output) -> argparse.Namespace:
+def _issue_args(
+    root,
+    output,
+    *,
+    expires_at: datetime | None = None,
+) -> argparse.Namespace:
     return argparse.Namespace(
         uid="synthetic-iris",
         account_uid="synthetic-iris",
@@ -40,10 +46,14 @@ def _issue_args(root, output) -> argparse.Namespace:
         expected_database="ella_ai",
         expected_firestore_project="ella-ai-care",
         operator="iris",
-        expires_at=(datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
+        expires_at=(expires_at or datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
         approved_code_output_root=str(root),
         code_output_file=str(output),
     )
+
+
+def _file_recovery_binding(code: str) -> str:
+    return hashlib.sha256(f"unit-recovery:{code}".encode("ascii")).hexdigest()
 
 
 def test_identity_requires_one_exact_non_plato_subject():
@@ -65,31 +75,51 @@ def test_identity_requires_one_exact_non_plato_subject():
             _identity(forbidden).validate()
 
 
-def test_protected_code_file_is_exclusive_root_scoped_and_owner_read_only(tmp_path):
+def test_protected_code_file_is_exclusive_root_scoped_and_owner_read_only(tmp_path, monkeypatch):
     approved = tmp_path / "approved"
     approved.mkdir(mode=0o700)
     output = approved / "invite-code"
     owner_uid = os.geteuid()
+    directory_fsyncs = []
+    original_fsync = os.fsync
 
-    code, existed = synthetic_invite_admin.prepare_protected_code_file(
+    def tracking_fsync(descriptor):
+        directory_fsyncs.append(stat.S_ISDIR(os.fstat(descriptor).st_mode))
+        original_fsync(descriptor)
+
+    monkeypatch.setattr(synthetic_invite_admin.os, "fsync", tracking_fsync)
+
+    prepared = synthetic_invite_admin.prepare_protected_code_file(
         approved_root=str(approved),
         code_output_file=str(output),
+        recovery_binding_for_code=_file_recovery_binding,
         expected_owner_uid=owner_uid,
     )
-    retry_code, retry_existed = synthetic_invite_admin.prepare_protected_code_file(
+    retried = synthetic_invite_admin.prepare_protected_code_file(
         approved_root=str(approved),
         code_output_file=str(output),
+        recovery_binding_for_code=_file_recovery_binding,
         expected_owner_uid=owner_uid,
     )
 
-    assert not existed
-    assert retry_existed
-    assert retry_code == code
-    assert invitations.normalize_invite_code(code)
+    assert not prepared.existed
+    assert retried.existed
+    assert retried.code == prepared.code
+    assert retried.recovery_binding_hmac == prepared.recovery_binding_hmac
+    assert invitations.normalize_invite_code(prepared.code)
     metadata = output.stat()
     assert stat.S_IMODE(metadata.st_mode) == 0o400
     assert metadata.st_uid == owner_uid
     assert metadata.st_nlink == 1
+    recovery_receipt_path = approved / synthetic_invite_admin._recovery_receipt_filename(output.name)
+    recovery_metadata = recovery_receipt_path.stat()
+    assert stat.S_IMODE(recovery_metadata.st_mode) == 0o400
+    assert recovery_metadata.st_uid == owner_uid
+    assert recovery_metadata.st_nlink == 1
+    recovery_receipt = recovery_receipt_path.read_text(encoding="ascii")
+    assert prepared.code not in recovery_receipt
+    assert prepared.recovery_binding_hmac in recovery_receipt
+    assert directory_fsyncs.count(True) == 2
 
 
 @pytest.mark.parametrize(
@@ -109,6 +139,7 @@ def test_protected_code_file_rejects_unapproved_paths(
         synthetic_invite_admin.prepare_protected_code_file(
             approved_root=root_value,
             code_output_file=output_value,
+            recovery_binding_for_code=_file_recovery_binding,
             expected_owner_uid=os.geteuid(),
         )
     assert error.value.code == expected_code
@@ -122,6 +153,7 @@ def test_protected_code_file_rejects_insecure_root_and_symlink(tmp_path):
         synthetic_invite_admin.prepare_protected_code_file(
             approved_root=str(insecure),
             code_output_file=str(insecure / "invite"),
+            recovery_binding_for_code=_file_recovery_binding,
             expected_owner_uid=os.geteuid(),
         )
     assert error.value.code == "code_output_root_insecure"
@@ -137,6 +169,7 @@ def test_protected_code_file_rejects_insecure_root_and_symlink(tmp_path):
         synthetic_invite_admin.prepare_protected_code_file(
             approved_root=str(approved),
             code_output_file=str(output),
+            recovery_binding_for_code=_file_recovery_binding,
             expected_owner_uid=os.geteuid(),
         )
     assert error.value.code == "code_output_file_unavailable"
@@ -151,6 +184,11 @@ def test_issue_receipt_and_failures_never_emit_the_code(
     approved.mkdir(mode=0o700)
     output = approved / "invite"
     captured_code = {}
+    issue_args = _issue_args(
+        approved,
+        output,
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
 
     async def fake_issue(**kwargs):
         captured_code["value"] = kwargs["code"]
@@ -178,7 +216,7 @@ def test_issue_receipt_and_failures_never_emit_the_code(
     monkeypatch.setenv("ELLA_INVITE_APP_REVIEW_ENABLED", "false")
     monkeypatch.setenv("ELLA_INVITE_HMAC_PEPPER", "p" * 32)
 
-    asyncio.run(synthetic_invite_admin._issue(_issue_args(approved, output)))
+    asyncio.run(synthetic_invite_admin._issue(issue_args))
 
     emitted = capsys.readouterr()
     secret = captured_code["value"]
@@ -207,11 +245,69 @@ def test_issue_receipt_and_failures_never_emit_the_code(
         fake_failure,
     )
     with pytest.raises(SystemExit) as error:
-        asyncio.run(synthetic_invite_admin._issue(_issue_args(approved, output)))
+        asyncio.run(synthetic_invite_admin._issue(issue_args))
     failed_emitted = capsys.readouterr()
     assert secret not in str(error.value)
     assert secret not in failed_emitted.out
     assert secret not in failed_emitted.err
+
+    ambiguous_output = approved / "ambiguous-invite"
+    ambiguous_attempts = []
+    ambiguous_args = _issue_args(
+        approved,
+        ambiguous_output,
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+    async def fake_ambiguous_issue(**kwargs):
+        ambiguous_attempts.append(dict(kwargs))
+        if len(ambiguous_attempts) == 1:
+            raise ConnectionError("injected transaction outcome ambiguity")
+        return {
+            "receipt_id": "22222222-2222-2222-2222-222222222222",
+            "state": "sent",
+            "version": 1,
+            "content_free": True,
+        }
+
+    monkeypatch.setattr(
+        synthetic_invite_admin.invitation_operator,
+        "issue_synthetic_invitation",
+        fake_ambiguous_issue,
+    )
+    with pytest.raises(
+        SystemExit,
+        match="operator_refused:invitation_outcome_ambiguous",
+    ):
+        asyncio.run(
+            synthetic_invite_admin._issue(
+                ambiguous_args,
+            )
+        )
+    ambiguous_failure = capsys.readouterr()
+    ambiguous_code = ambiguous_attempts[0]["code"]
+    assert ambiguous_output.exists()
+    assert ambiguous_code not in ambiguous_failure.out
+    assert ambiguous_code not in ambiguous_failure.err
+
+    asyncio.run(
+        synthetic_invite_admin._issue(
+            ambiguous_args,
+        )
+    )
+    ambiguous_retry = capsys.readouterr()
+    assert ambiguous_attempts[0]["code_file_existed"] is False
+    assert ambiguous_attempts[1]["code_file_existed"] is True
+    assert ambiguous_attempts[0]["code"] == ambiguous_attempts[1]["code"]
+    assert ambiguous_attempts[0]["recovery_binding_hmac"] == ambiguous_attempts[1]["recovery_binding_hmac"]
+    assert ambiguous_code not in ambiguous_retry.out
+    assert ambiguous_code not in ambiguous_retry.err
+    recovery_receipt_path = approved / synthetic_invite_admin._recovery_receipt_filename(
+        ambiguous_output.name,
+    )
+    recovery_receipt = recovery_receipt_path.read_text(encoding="ascii")
+    assert ambiguous_code not in recovery_receipt
+    assert '"content_free":true' in recovery_receipt
 
 
 def test_environment_and_flag_drift_fail_before_file_creation(monkeypatch, tmp_path):

--- a/backend/tests/unit/test_synthetic_invite_admin.py
+++ b/backend/tests/unit/test_synthetic_invite_admin.py
@@ -1,0 +1,353 @@
+import argparse
+import asyncio
+import os
+import stat
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from database import invitation_operator, invitations
+from scripts import synthetic_invite_admin
+
+
+def _identity(uid: str = "synthetic-iris") -> invitation_operator.SyntheticInvitationIdentity:
+    return invitation_operator.SyntheticInvitationIdentity(
+        uid=uid,
+        account_uid=uid,
+        profile_uid=uid,
+    )
+
+
+def _admission(uid: str = "synthetic-iris") -> invitations.InvitationPilotAdmission:
+    return invitations.InvitationPilotAdmission(
+        account_uid=uid,
+        profile_uid=uid,
+        consent_receipt_id="synthetic-consent-receipt",
+        profile_binding_id="synthetic-profile-binding",
+        policy_version="ai-data-processors-v8",
+        processor_set_hash="sha256:" + ("a" * 64),
+        scope_version="managed-cloud-v3",
+        scope_hash="sha256:" + ("b" * 64),
+    )
+
+
+def _issue_args(root, output) -> argparse.Namespace:
+    return argparse.Namespace(
+        uid="synthetic-iris",
+        account_uid="synthetic-iris",
+        profile_uid="synthetic-iris",
+        expected_environment="prototype",
+        expected_database="ella_ai",
+        expected_firestore_project="ella-ai-care",
+        operator="iris",
+        expires_at=(datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
+        approved_code_output_root=str(root),
+        code_output_file=str(output),
+    )
+
+
+def test_identity_requires_one_exact_non_plato_subject():
+    _identity().validate()
+    with pytest.raises(
+        invitation_operator.SyntheticInvitationOperatorError,
+        match="operator_identity_refused",
+    ):
+        invitation_operator.SyntheticInvitationIdentity(
+            uid="synthetic-iris",
+            account_uid="different-account",
+            profile_uid="synthetic-iris",
+        ).validate()
+    for forbidden in ("realcryptoplato", "plato_eval", "plato-eval"):
+        with pytest.raises(
+            invitation_operator.SyntheticInvitationOperatorError,
+            match="operator_identity_refused",
+        ):
+            _identity(forbidden).validate()
+
+
+def test_protected_code_file_is_exclusive_root_scoped_and_owner_read_only(tmp_path):
+    approved = tmp_path / "approved"
+    approved.mkdir(mode=0o700)
+    output = approved / "invite-code"
+    owner_uid = os.geteuid()
+
+    code, existed = synthetic_invite_admin.prepare_protected_code_file(
+        approved_root=str(approved),
+        code_output_file=str(output),
+        expected_owner_uid=owner_uid,
+    )
+    retry_code, retry_existed = synthetic_invite_admin.prepare_protected_code_file(
+        approved_root=str(approved),
+        code_output_file=str(output),
+        expected_owner_uid=owner_uid,
+    )
+
+    assert not existed
+    assert retry_existed
+    assert retry_code == code
+    assert invitations.normalize_invite_code(code)
+    metadata = output.stat()
+    assert stat.S_IMODE(metadata.st_mode) == 0o400
+    assert metadata.st_uid == owner_uid
+    assert metadata.st_nlink == 1
+
+
+@pytest.mark.parametrize(
+    ("root_value", "output_value", "expected_code"),
+    [
+        ("relative", "/tmp/invite", "code_output_root_must_be_absolute"),
+        ("/tmp", "relative", "code_output_file_must_be_absolute"),
+        ("/tmp/approved", "/tmp/outside", "code_output_file_outside_approved_root"),
+    ],
+)
+def test_protected_code_file_rejects_unapproved_paths(
+    root_value,
+    output_value,
+    expected_code,
+):
+    with pytest.raises(synthetic_invite_admin.ProtectedCodeFileError) as error:
+        synthetic_invite_admin.prepare_protected_code_file(
+            approved_root=root_value,
+            code_output_file=output_value,
+            expected_owner_uid=os.geteuid(),
+        )
+    assert error.value.code == expected_code
+
+
+def test_protected_code_file_rejects_insecure_root_and_symlink(tmp_path):
+    insecure = tmp_path / "insecure"
+    insecure.mkdir(mode=0o777)
+    insecure.chmod(0o777)
+    with pytest.raises(synthetic_invite_admin.ProtectedCodeFileError) as error:
+        synthetic_invite_admin.prepare_protected_code_file(
+            approved_root=str(insecure),
+            code_output_file=str(insecure / "invite"),
+            expected_owner_uid=os.geteuid(),
+        )
+    assert error.value.code == "code_output_root_insecure"
+
+    approved = tmp_path / "approved"
+    approved.mkdir(mode=0o700)
+    target = approved / "target"
+    target.write_text("ABCD-2345\n", encoding="ascii")
+    target.chmod(0o400)
+    output = approved / "invite"
+    output.symlink_to(target)
+    with pytest.raises(synthetic_invite_admin.ProtectedCodeFileError) as error:
+        synthetic_invite_admin.prepare_protected_code_file(
+            approved_root=str(approved),
+            code_output_file=str(output),
+            expected_owner_uid=os.geteuid(),
+        )
+    assert error.value.code == "code_output_file_unavailable"
+
+
+def test_issue_receipt_and_failures_never_emit_the_code(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    approved = tmp_path / "approved"
+    approved.mkdir(mode=0o700)
+    output = approved / "invite"
+    captured_code = {}
+
+    async def fake_issue(**kwargs):
+        captured_code["value"] = kwargs["code"]
+        return {
+            "receipt_id": "11111111-1111-1111-1111-111111111111",
+            "state": "sent",
+            "version": 1,
+            "content_free": True,
+        }
+
+    monkeypatch.setattr(synthetic_invite_admin, "ROOT_UID", os.geteuid())
+    monkeypatch.setattr(
+        synthetic_invite_admin,
+        "_assert_issue_rollout",
+        lambda _uid, **_kwargs: _admission(),
+    )
+    monkeypatch.setattr(
+        synthetic_invite_admin.invitation_operator,
+        "issue_synthetic_invitation",
+        fake_issue,
+    )
+    monkeypatch.setenv("ELLA_INVITE_OPERATOR_ENVIRONMENT", "prototype")
+    monkeypatch.setenv("ELLA_INVITE_REDEMPTION_ENABLED", "true")
+    monkeypatch.setenv("ELLA_INVITE_ORDINARY_SELF_SERVICE_ENABLED", "false")
+    monkeypatch.setenv("ELLA_INVITE_APP_REVIEW_ENABLED", "false")
+    monkeypatch.setenv("ELLA_INVITE_HMAC_PEPPER", "p" * 32)
+
+    asyncio.run(synthetic_invite_admin._issue(_issue_args(approved, output)))
+
+    emitted = capsys.readouterr()
+    secret = captured_code["value"]
+    assert secret
+    assert secret not in emitted.out
+    assert secret not in emitted.err
+    assert secret not in str(
+        {
+            "receipt_id": "11111111-1111-1111-1111-111111111111",
+            "path": output,
+        }
+    )
+    assert str(output) in emitted.out
+    assert "content_free" in emitted.out
+    assert '"state"' not in emitted.out
+    assert '"version"' not in emitted.out
+
+    async def fake_failure(**_kwargs):
+        raise invitation_operator.SyntheticInvitationOperatorError(
+            "operator_stale_code_receipt",
+        )
+
+    monkeypatch.setattr(
+        synthetic_invite_admin.invitation_operator,
+        "issue_synthetic_invitation",
+        fake_failure,
+    )
+    with pytest.raises(SystemExit) as error:
+        asyncio.run(synthetic_invite_admin._issue(_issue_args(approved, output)))
+    failed_emitted = capsys.readouterr()
+    assert secret not in str(error.value)
+    assert secret not in failed_emitted.out
+    assert secret not in failed_emitted.err
+
+
+def test_environment_and_flag_drift_fail_before_file_creation(monkeypatch, tmp_path):
+    approved = tmp_path / "approved"
+    approved.mkdir(mode=0o700)
+    output = approved / "invite"
+    args = _issue_args(approved, output)
+    monkeypatch.setenv("ELLA_INVITE_OPERATOR_ENVIRONMENT", "wrong")
+    with pytest.raises(SystemExit, match="operator_refused:environment_mismatch"):
+        asyncio.run(synthetic_invite_admin._issue(args))
+    assert not output.exists()
+
+    monkeypatch.setenv("ELLA_INVITE_OPERATOR_ENVIRONMENT", "prototype")
+    monkeypatch.setenv("ELLA_INVITE_REDEMPTION_ENABLED", "true")
+    monkeypatch.setenv("ELLA_INVITE_ORDINARY_SELF_SERVICE_ENABLED", "true")
+    monkeypatch.setenv("ELLA_INVITE_APP_REVIEW_ENABLED", "false")
+    monkeypatch.setenv("ELLA_INVITE_HMAC_PEPPER", "p" * 32)
+    with pytest.raises(SystemExit, match="operator_refused:invite_flags_invalid"):
+        asyncio.run(synthetic_invite_admin._issue(args))
+    assert not output.exists()
+
+
+def test_issue_initializes_explicit_adc_firestore_authority(monkeypatch):
+    project = "ella-ai-care"
+    client = object()
+    configured = {}
+
+    def fake_firestore_client(*, project):
+        configured["client_project"] = project
+        return client
+
+    def fake_configure(value):
+        configured["client"] = value
+
+    def fake_authorize(uid):
+        assert configured == {
+            "client_project": project,
+            "client": client,
+        }
+        return _admission(uid)
+
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", project)
+    monkeypatch.setattr(
+        synthetic_invite_admin,
+        "assert_invitation_pilot_rollout",
+        lambda _uid: None,
+    )
+    monkeypatch.setattr(
+        synthetic_invite_admin.firestore,
+        "Client",
+        fake_firestore_client,
+    )
+    monkeypatch.setattr(
+        synthetic_invite_admin.ai_consent,
+        "configure_firestore_db",
+        fake_configure,
+    )
+    monkeypatch.setattr(
+        synthetic_invite_admin,
+        "authorize_invitation_pilot",
+        fake_authorize,
+    )
+
+    admission = synthetic_invite_admin._assert_issue_rollout(
+        "synthetic-iris",
+        expected_firestore_project=project,
+    )
+    assert admission == _admission()
+
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "wrong-project")
+    with pytest.raises(
+        SystemExit,
+        match="operator_refused:firestore_project_mismatch",
+    ):
+        synthetic_invite_admin._assert_issue_rollout(
+            "synthetic-iris",
+            expected_firestore_project=project,
+        )
+
+
+def test_lifecycle_commands_recheck_rollout_before_database(monkeypatch):
+    args = argparse.Namespace(
+        uid="synthetic-iris",
+        account_uid="synthetic-iris",
+        profile_uid="synthetic-iris",
+        expected_environment="prototype",
+        expected_database="ella_ai",
+        operator="iris",
+        receipt_id="11111111-1111-1111-1111-111111111111",
+        expected_version=1,
+    )
+    monkeypatch.setenv("ELLA_INVITE_OPERATOR_ENVIRONMENT", "prototype")
+    monkeypatch.setenv("ELLA_INVITE_REDEMPTION_ENABLED", "true")
+    monkeypatch.setenv("ELLA_INVITE_ORDINARY_SELF_SERVICE_ENABLED", "false")
+    monkeypatch.setenv("ELLA_INVITE_APP_REVIEW_ENABLED", "false")
+    monkeypatch.setenv("ELLA_INVITE_HMAC_PEPPER", "p" * 32)
+    monkeypatch.setattr(
+        synthetic_invite_admin,
+        "assert_invitation_pilot_rollout",
+        lambda _uid: (_ for _ in ()).throw(
+            invitations.InvitePilotGateDenied("disabled"),
+        ),
+    )
+
+    async def database_must_not_run(**_kwargs):
+        raise AssertionError("database action ran after rollout refusal")
+
+    monkeypatch.setattr(
+        synthetic_invite_admin.invitation_operator,
+        "show_synthetic_invitation",
+        database_must_not_run,
+    )
+    monkeypatch.setattr(
+        synthetic_invite_admin.invitation_operator,
+        "revoke_synthetic_invitation",
+        database_must_not_run,
+    )
+    monkeypatch.setattr(
+        synthetic_invite_admin.invitation_operator,
+        "cleanup_synthetic_invitation",
+        database_must_not_run,
+    )
+
+    for handler in (
+        synthetic_invite_admin._show,
+        synthetic_invite_admin._revoke,
+        synthetic_invite_admin._cleanup,
+    ):
+        with pytest.raises(
+            SystemExit,
+            match="operator_refused:pilot_rollout_invalid",
+        ):
+            asyncio.run(handler(args))
+
+
+def test_non_root_cli_refuses_before_argument_or_secret_processing(monkeypatch):
+    monkeypatch.setattr(synthetic_invite_admin, "ROOT_UID", os.geteuid() + 1)
+    with pytest.raises(SystemExit, match="operator_refused:root_required"):
+        asyncio.run(synthetic_invite_admin._main())


### PR DESCRIPTION
## What changed

- Added a root-only operator CLI for exactly one disposable synthetic account/profile.
- Reused the production invitation code and HMAC schema; plaintext codes exist only in an exclusive, no-follow, root-owned `0400` handoff file.
- Bound issuance, retry, show, revoke, cleanup, and redemption to the exact UID/account/profile, rollout allowlists, consent lineage, environment/operator receipt, synthetic classification, and fixed no-fallback entitlement policy.
- Added fail-closed handling for real users, protected Plato identities, drift, collisions, stale files/receipts, terminal states, expiry, and disabled/global rollout flags.
- Added migration 014 only to extend the existing content-free invitation audit event constraint.
- Added the focused operator runbook and CI coverage.

## Prototype boundary

This PR sends no email/SMS, creates no live user, seeds no broker/runtime tables, reads no operator secret, and performs no deployment or vendor/database mutation. The broker route remains owned by `ellaaicare/ella-ai#1152`; production invitation service/email UX remains owned by `ellaaicare/ella-ai#1157`.

## Validation

- Focused unit + PostgreSQL 16 migration-backed suite: 59 passed.
- Repository backend test runner: passed; its 10 default-DSN PostgreSQL canary tests skipped, while the scoped PostgreSQL suite above ran separately and passed.
- Black, `py_compile`/`compileall`, YAML parse, staged diff check: passed.
- Gitleaks staged scan: no leaks.
- Independent direct-path review: accepted with no remaining blockers.

Base lineage: `a9af15c4373cd5456acfac89d3e9f07e8506b580`.

Tracks `ellaaicare/ella-ai#1124`.
