### PR TITLE
Hermes: bind stock canary and staged synthetic preflight

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -26,7 +26,10 @@ on:
       - "backend/ella/routers/photon.py"
       - "backend/ella/routers/resolve.py"
       - "backend/ella/routers/voice.py"
+      - "backend/ella/services/hermes_broker_client.py"
+      - "backend/ella/services/hermes_broker_prototype.py"
       - "backend/ella/services/hermes_cloud.py"
+      - "backend/ella/services/hermes_cloud_staged_attestation.py"
       - "backend/ella/services/hermes_cloud_enrichment.py"
       - "backend/ella/services/hermes_cloud_enrichment_outbox.py"
       - "backend/ella/services/hermes_cloud_enrichment_dependencies.py"
@@ -54,6 +57,7 @@ on:
       - "backend/scripts/voice_canary_admin.py"
       - "backend/utils/ella/postprocess.py"
       - "backend/utils/ella/scanner_keyterms.py"
+      - "backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md"
       - "backend/ella/docs/HERMES_CLOUD_RUNTIME_TARGETS_RUNBOOK.md"
       - "backend/ella/docs/hermes-cloud-runtime-targets.openapi.yaml"
       - "backend/tests/unit/test_ella_provisioning_repository.py"
@@ -105,7 +109,10 @@ on:
       - "backend/ella/routers/photon.py"
       - "backend/ella/routers/resolve.py"
       - "backend/ella/routers/voice.py"
+      - "backend/ella/services/hermes_broker_client.py"
+      - "backend/ella/services/hermes_broker_prototype.py"
       - "backend/ella/services/hermes_cloud.py"
+      - "backend/ella/services/hermes_cloud_staged_attestation.py"
       - "backend/ella/services/hermes_cloud_enrichment.py"
       - "backend/ella/services/hermes_cloud_enrichment_outbox.py"
       - "backend/ella/services/hermes_cloud_enrichment_dependencies.py"
@@ -133,6 +140,7 @@ on:
       - "backend/scripts/voice_canary_admin.py"
       - "backend/utils/ella/postprocess.py"
       - "backend/utils/ella/scanner_keyterms.py"
+      - "backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md"
       - "backend/ella/docs/HERMES_CLOUD_RUNTIME_TARGETS_RUNBOOK.md"
       - "backend/ella/docs/hermes-cloud-runtime-targets.openapi.yaml"
       - "backend/tests/unit/test_ella_provisioning_repository.py"
@@ -233,7 +241,10 @@ jobs:
           ella/routers/observer.py
           ella/services/ai_consent.py
           ella/services/consent_authority.py
+          ella/services/hermes_broker_client.py
+          ella/services/hermes_broker_prototype.py
           ella/services/hermes_cloud.py
+          ella/services/hermes_cloud_staged_attestation.py
           ella/services/hermes_cloud_enrichment.py
           ella/services/hermes_cloud_enrichment_outbox.py
           ella/services/hermes_cloud_enrichment_dependencies.py
@@ -267,7 +278,10 @@ jobs:
           ella/routers/ai_consent.py ella/routers/chat.py
           ella/routers/guardian.py ella/routers/invites.py
           ella/routers/onboarding.py ella/services/hermes_cloud_policy.py
+          ella/services/hermes_broker_client.py
+          ella/services/hermes_broker_prototype.py
           ella/services/hermes_cloud.py ella/services/hermes_cloud_enrichment.py
+          ella/services/hermes_cloud_staged_attestation.py
           ella/services/hermes_cloud_runtime.py
           ella/services/consent_authority.py ella/services/invitation_authority.py
           ella/services/memory_reinterpretation.py
@@ -287,8 +301,10 @@ jobs:
           tests/unit/test_hermes_cloud_openapi.py
           tests/unit/test_hermes_cloud_enrichment.py
           tests/unit/test_hermes_cloud_photon.py
+          tests/unit/test_hermes_broker_prototype.py
           tests/unit/test_hermes_cloud_provider.py
           tests/unit/test_hermes_cloud_runtime.py
+          tests/unit/test_hermes_cloud_staged_attestation.py
           tests/unit/test_memory_reinterpretation_outbox.py
           tests/unit/test_scanner_keyterms.py
           tests/postgres/test_hermes_cloud_pool_postgres.py
@@ -307,10 +323,12 @@ jobs:
               tests/unit/test_hermes_cloud_migration.py \
               tests/unit/test_hermes_cloud_openapi.py \
               tests/unit/test_hermes_cloud_policy.py \
+              tests/unit/test_hermes_broker_prototype.py \
               tests/unit/test_hermes_cloud_photon.py \
               tests/unit/test_hermes_cloud_provider.py \
               tests/unit/test_hermes_cloud_provisioning.py \
               tests/unit/test_hermes_cloud_runtime.py \
+              tests/unit/test_hermes_cloud_staged_attestation.py \
               tests/unit/test_hermes_cloud_enrichment.py \
               tests/unit/test_hermes_cloud_enrichment_outbox.py \
               tests/unit/test_hermes_cloud_enrichment_router.py \
@@ -325,17 +343,19 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 355
+          test "$collected" -eq 396
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \
             tests/unit/test_hermes_cloud_migration.py \
             tests/unit/test_hermes_cloud_openapi.py \
             tests/unit/test_hermes_cloud_policy.py \
+            tests/unit/test_hermes_broker_prototype.py \
             tests/unit/test_hermes_cloud_photon.py \
             tests/unit/test_hermes_cloud_provider.py \
             tests/unit/test_hermes_cloud_provisioning.py \
             tests/unit/test_hermes_cloud_runtime.py \
+            tests/unit/test_hermes_cloud_staged_attestation.py \
             tests/unit/test_hermes_cloud_enrichment.py \
             tests/unit/test_hermes_cloud_enrichment_outbox.py \
             tests/unit/test_hermes_cloud_enrichment_router.py \

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -566,7 +566,8 @@ class EllaProvisioningRepository:
         return _row_dict(row)
 
     async def get_cloud_pool_admission_policy(self) -> Optional[dict[str, Any]]:
-        rows = await self.pool.fetch("""
+        rows = await self.pool.fetch(
+            """
             SELECT DISTINCT expected_model, model_policy_version
             FROM ella_runtime_bindings
             WHERE provider = 'hermes_cloud'
@@ -574,7 +575,8 @@ class EllaProvisioningRepository:
               AND health_state = 'healthy'
               AND active = false
               AND user_id IS NULL
-            """)
+            """
+        )
         if not rows:
             return None
         policies = {(str(row["expected_model"] or ""), str(row["model_policy_version"] or "")) for row in rows}
@@ -704,14 +706,16 @@ class EllaProvisioningRepository:
         return dict(row)
 
     async def list_cloud_pool_bindings(self) -> list[dict[str, Any]]:
-        rows = await self.pool.fetch("""
+        rows = await self.pool.fetch(
+            """
             SELECT id, runtime_instance_id, status, health_state, expected_model,
                    prompt_pack_version, revision, claimed_at, quarantined_at,
                    quarantine_reason, created_at, updated_at
             FROM ella_runtime_bindings
             WHERE provider = 'hermes_cloud'
             ORDER BY created_at ASC, id ASC
-            """)
+            """
+        )
         return [dict(row) for row in rows]
 
     async def claim_cloud_pool_binding(

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -436,7 +436,7 @@ class EllaProvisioningRepository:
     async def get_user_identity(self, uid: str) -> Optional[dict[str, Any]]:
         row = await self.pool.fetchrow(
             """
-            SELECT id, omi_uid, email, name, timezone, status
+            SELECT id, omi_uid, email, name, timezone, status, profile_class
             FROM users
             WHERE omi_uid = $1
             """,
@@ -566,8 +566,7 @@ class EllaProvisioningRepository:
         return _row_dict(row)
 
     async def get_cloud_pool_admission_policy(self) -> Optional[dict[str, Any]]:
-        rows = await self.pool.fetch(
-            """
+        rows = await self.pool.fetch("""
             SELECT DISTINCT expected_model, model_policy_version
             FROM ella_runtime_bindings
             WHERE provider = 'hermes_cloud'
@@ -575,8 +574,7 @@ class EllaProvisioningRepository:
               AND health_state = 'healthy'
               AND active = false
               AND user_id IS NULL
-            """
-        )
+            """)
         if not rows:
             return None
         policies = {(str(row["expected_model"] or ""), str(row["model_policy_version"] or "")) for row in rows}
@@ -661,7 +659,9 @@ class EllaProvisioningRepository:
             json.dumps(health_receipt),
         )
         if row:
-            return dict(row)
+            result = dict(row)
+            result["_registration_idempotent"] = False
+            return result
         existing = await self.pool.fetchrow(
             """
             SELECT *
@@ -674,19 +674,44 @@ class EllaProvisioningRepository:
             raise RuntimePoolClaimError("runtime_pool_registration_lost")
         if existing["status"] != "pool_available" or existing["user_id"] is not None:
             raise RuntimePoolClaimError("runtime_instance_already_claimed")
-        return dict(existing)
+        result = dict(existing)
+        result["_registration_idempotent"] = True
+        return result
+
+    async def cleanup_cloud_pool_binding(
+        self,
+        *,
+        binding_id: str,
+        runtime_instance_id: str,
+    ) -> dict[str, Any]:
+        """Delete exactly one still-unclaimed pool row for operator rollback."""
+        row = await self.pool.fetchrow(
+            """
+            DELETE FROM ella_runtime_bindings
+            WHERE id = $1
+              AND runtime_instance_id = $2
+              AND provider = 'hermes_cloud'
+              AND status = 'pool_available'
+              AND user_id IS NULL
+              AND active = false
+            RETURNING id, runtime_instance_id
+            """,
+            uuid.UUID(str(binding_id)),
+            runtime_instance_id,
+        )
+        if not row:
+            raise RuntimePoolClaimError("runtime_pool_cleanup_refused")
+        return dict(row)
 
     async def list_cloud_pool_bindings(self) -> list[dict[str, Any]]:
-        rows = await self.pool.fetch(
-            """
+        rows = await self.pool.fetch("""
             SELECT id, runtime_instance_id, status, health_state, expected_model,
                    prompt_pack_version, revision, claimed_at, quarantined_at,
                    quarantine_reason, created_at, updated_at
             FROM ella_runtime_bindings
             WHERE provider = 'hermes_cloud'
             ORDER BY created_at ASC, id ASC
-            """
-        )
+            """)
         return [dict(row) for row in rows]
 
     async def claim_cloud_pool_binding(
@@ -780,10 +805,20 @@ class EllaProvisioningRepository:
                       AND expected_model IS NOT NULL
                       AND jsonb_typeof(allowed_tools) = 'array'
                       AND jsonb_typeof(required_capabilities) = 'array'
+                      AND (
+                            health_receipt->'staged_attestation' IS NULL
+                            OR (
+                                health_receipt #>> '{staged_attestation,uid}' = $1
+                                AND health_receipt #>> '{staged_attestation,account_id}' = $2
+                                AND health_receipt #>> '{staged_attestation,profile_id}' = $2
+                            )
+                      )
                     ORDER BY updated_at ASC, id ASC
                     FOR UPDATE SKIP LOCKED
                     LIMIT 1
-                    """
+                    """,
+                    uid,
+                    str(user_row["id"]),
                 )
                 if not candidate:
                     return None
@@ -797,7 +832,14 @@ class EllaProvisioningRepository:
                         claim_lease_expires_at = $5,
                         status = 'claiming',
                         health_state = 'pending',
-                        health_receipt = '{}'::jsonb,
+                        health_receipt = CASE
+                            WHEN health_receipt->'staged_attestation' IS NOT NULL
+                            THEN jsonb_build_object(
+                                'staged_attestation',
+                                health_receipt->'staged_attestation'
+                            )
+                            ELSE '{}'::jsonb
+                        END,
                         quarantine_reason = NULL,
                         quarantined_at = NULL,
                         revision = revision + 1,

--- a/backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md
+++ b/backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md
@@ -20,7 +20,7 @@ only; no global switch; no Plato/Mini fallback).
 |---|---|
 | Flag off (default) | Existing direct Hermes Cloud `/v1/responses` |
 | Flag on, not exact allowlist | Existing direct path unchanged |
-| Flag on + exact synthetic account/profile (+ optional binding) | Broker `POST .../admit` then bounded poll for terminal result |
+| Flag on + exact synthetic account/profile (+ optional binding) | Broker stock-canary admission then bounded stock-result poll |
 
 On broker failure/timeout/mismatch: **explicit `ProvisioningError`**, content-free
 where required. **No** fallback to direct Hermes, Plato, Mini, or OpenClaw.
@@ -37,9 +37,9 @@ ELLA_HERMES_BROKER_PROTOTYPE_ACCOUNT_ID=
 ELLA_HERMES_BROKER_PROTOTYPE_PROFILE_ID=
 ELLA_HERMES_BROKER_PROTOTYPE_BINDING_ID=   # optional; when set must match runtime.binding_id
 
-# Private broker HTTPS endpoint (host must match allowlist)
-ELLA_HERMES_BROKER_BASE_URL=https://broker.example.internal
-ELLA_HERMES_BROKER_ALLOWED_HOST=broker.example.internal
+# HTTPS:443 normally. The only HTTP exception is the exact host-local mapping:
+ELLA_HERMES_BROKER_BASE_URL=http://127.0.0.1:18097
+ELLA_HERMES_BROKER_ALLOWED_HOST=127.0.0.1
 
 # Service auth — reference only
 ELLA_HERMES_BROKER_SERVICE_TOKEN_REF=env:ELLA_HERMES_BROKER_SERVICE_TOKEN
@@ -56,47 +56,22 @@ ELLA_HERMES_BROKER_CALLBACK_DEADLINE_SECONDS=90
 Set `ELLA_HERMES_BROKER_PROTOTYPE_ENABLED` to any value other than exact `true`
 (or unset). All traffic returns to the pre-prototype direct path.
 
-## Companion change required on ella-ai (blocker for live smoke)
-
-Merged broker routes include admit, callback, and workers only — **no owner-pinned
-result read/wait API**. Canonical writeback stores a **content-free**
-`result_sha256`; the answer lives in `broker_writeback_outbox.result_json`.
-
-Minimal companion (ella-ai):
+## Stock contract
 
 ```http
-GET /v1/ella/internal/hermes-webhook-broker/requests/{request_id}
+POST /v1/ella/internal/hermes-webhook-broker/stock-canary/admit
+GET /v1/ella/internal/hermes-webhook-broker/stock-canary/requests/{request_id}
   ?account_id=<uuid-or-opaque>&profile_id=<uuid-or-opaque>
 Authorization: Bearer <ELLA_HERMES_BROKER_SERVICE_TOKEN>
 ```
 
-Requirements:
-
-1. Service auth identical to admit.
-2. Re-prove request owner (`account_id`/`profile_id`) under the shared authority
-   key before returning anything.
-3. Return bounded JSON, for example:
-
-```json
-{
-  "status": "pending|awaiting_callback|completed|failed|quarantined|...",
-  "request_id": "hwb_...",
-  "correlation_id": "hwb:...",
-  "account_id": "...",
-  "profile_id": "...",
-  "lane": "chat_turn",
-  "outcome": "success|error|null",
-  "duplicate": false,
-  "result": { "answer": "...", "session_key": "...", "session_id": "...", "canonical_user_event_id": "..." }
-}
-```
-
-4. Until completed/failed, `result` may be null. Never return another owner's row.
-5. Cap body size (≤256KiB) and apply read timeouts.
-
-Until that endpoint exists, the OMI prototype returns
-`hermes_broker_prototype_result_endpoint_missing` after a successful admit when
-GET yields HTTP 404 — fail closed, no direct-path bypass.
+Admission always supplies server-owned `delivery_platform=ella_callback_stock`,
+`callback_source=hermes_stock_0_19_quiet_window`, and
+`webhook_route=ella-stock-synthetic`. Results must be the owner-, request-,
+correlation-, and lane-pinned `stock_best_effort_v1` projection with
+`terminal_proof=false`. OMI accepts success only at `writeback_completed`.
+HTTP 404, generic broker projections, terminal-proof claims, or unknown states
+fail closed with no direct/Plato fallback.
 
 ## Out of scope (see ella-ai#1157)
 

--- a/backend/ella/docs/HERMES_CLOUD_RUNTIME_TARGETS_RUNBOOK.md
+++ b/backend/ella/docs/HERMES_CLOUD_RUNTIME_TARGETS_RUNBOOK.md
@@ -104,3 +104,54 @@ SELECT conname FROM pg_constraint WHERE conname IN (
 Rollback is source/config only while flags remain off. If a claim reaches
 `claiming`, rollback quarantines the candidate and records a content-free receipt;
 it does not attempt Honcho cleanup because Cloud memory is not Honcho-backed.
+
+## One-account staged-attestation exception
+
+Use this only for the isolated synthetic canary when Nous direct
+`/health/detailed` and `/v1/*` preflight are unavailable. Normal candidates
+continue through live direct preflight.
+
+The protected receipt reference must be an immediate child of
+`/var/lib/ella/hermes-cloud-attestations`, whose directory is root:root `0700`.
+The receipt must be a regular, single-link, root-owned `0400` or `0600` JSON
+file. It is content-free: no URL, credential, token, payload, or secret.
+Its exact `ella-hermes-cloud-staged-attestation-v1` fields pin:
+
+- attestation/issue/expiry metadata and
+  `stage=pool_registration_and_claim_finalization`;
+- exact synthetic UID plus canonical account/profile UUIDs;
+- runtime instance, template, voice policy, model, tools, capabilities, prompt
+  pack/model policy, and context window;
+- policy commit, approved-manifest SHA-256, and the three prompt artifact
+  SHA-256 values.
+
+Activation uses the existing root-run CLI with a protected candidate JSON. The
+candidate adds only `synthetic_uid`, `account_id`, `profile_id`, and
+`staged_attestation_ref`; secret values remain behind the existing `env:` refs:
+
+```bash
+python backend/scripts/hermes_cloud_pool_admin.py register \
+  --candidate /var/lib/ella/hermes-cloud-attestations/canary-candidate.json
+```
+
+`ELLA_HERMES_CLOUD_STAGED_ATTESTATION_ENABLED=true` and
+`ELLA_HERMES_CLOUD_SYNTHETIC_ONLY=true` are required. Every ordinary global
+rollout flag listed above remains false, and each of these selectors must equal
+the one UID: `ELLA_RUNTIME_BINDINGS_ENABLED_UIDS`,
+`ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS`,
+`ELLA_HERMES_CLOUD_SYNTHETIC_UIDS`, and
+`ELLA_AI_CONSENT_ENFORCEMENT_UIDS`.
+
+Registration emits only binding, attestation digest/id, and exact rollback IDs.
+Before claim finalization, OMI reopens the same protected receipt and rechecks
+all pins. Roll back an unclaimed registration without SQL:
+
+```bash
+python backend/scripts/hermes_cloud_pool_admin.py cleanup \
+  --binding-id <exact-binding-uuid> \
+  --runtime-instance-id <exact-runtime-instance-id>
+```
+
+After a claim starts, the existing fail-closed quarantine/rollback receipt owns
+recovery. General multi-user attestations, replay registries, and leases remain
+deferred to `ellaaicare/ella-ai#1157`.

--- a/backend/ella/services/hermes_broker_client.py
+++ b/backend/ella/services/hermes_broker_client.py
@@ -18,7 +18,11 @@ import httpx
 
 from ella.services.hermes_broker_prototype import (
     ADMIT_PATH,
+    LOOPBACK_BROKER_BASE_URL,
     RESULT_PATH_PREFIX,
+    STOCK_CALLBACK_SOURCE,
+    STOCK_DELIVERY_PLATFORM,
+    STOCK_WEBHOOK_ROUTE,
     HermesBrokerPrototypeConfig,
     resolve_service_token,
 )
@@ -42,7 +46,7 @@ class BrokerTerminalTurn:
 
 
 class HermesBrokerClient:
-    """HTTPS client pinned to the allowlisted private broker host."""
+    """Client pinned to HTTPS:443 or the one synthetic host-loopback route."""
 
     def __init__(
         self,
@@ -74,14 +78,22 @@ class HermesBrokerClient:
 
     def _assert_url(self, url: str, *, expected_path_prefix: str) -> None:
         parsed = urlparse(url)
+        secure_remote = (
+            parsed.scheme == "https" and parsed.hostname == self.config.allowed_host and parsed.port in (None, 443)
+        )
+        pinned_loopback = (
+            self.config.base_url == LOOPBACK_BROKER_BASE_URL
+            and self.config.allowed_host == "127.0.0.1"
+            and parsed.scheme == "http"
+            and parsed.hostname == "127.0.0.1"
+            and parsed.port == 18097
+        )
         if (
-            parsed.scheme != "https"
-            or parsed.hostname != self.config.allowed_host
-            or parsed.username
+            parsed.username
             or parsed.password
             or parsed.query
             or parsed.fragment
-            or (parsed.port not in (None, 443))
+            or not (secure_remote or pinned_loopback)
             or not parsed.path.startswith(expected_path_prefix)
         ):
             raise ProvisioningError(
@@ -111,6 +123,9 @@ class HermesBrokerClient:
             "consent_epoch": consent_epoch,
             "payload": dict(payload),
             "deadline_at": int(deadline_at),
+            "delivery_platform": STOCK_DELIVERY_PLATFORM,
+            "callback_source": STOCK_CALLBACK_SOURCE,
+            "webhook_route": STOCK_WEBHOOK_ROUTE,
         }
         if pass_kind is not None:
             body["pass_kind"] = pass_kind
@@ -129,11 +144,21 @@ class HermesBrokerClient:
                 "hermes_broker_prototype_unavailable",
                 retryable=True,
             ) from exc
-        return self._parse_json(
+        admission = self._parse_json(
             response,
             max_bytes=MAX_ADMISSION_BODY_BYTES,
             invalid_code="hermes_broker_prototype_admit_invalid",
         )
+        if (
+            admission.get("delivery_platform") != STOCK_DELIVERY_PLATFORM
+            or admission.get("callback_source") != STOCK_CALLBACK_SOURCE
+            or admission.get("terminal_proof") is not False
+        ):
+            raise ProvisioningError(
+                "hermes_broker_prototype_stock_semantics_mismatch",
+                retryable=False,
+            )
+        return admission
 
     async def wait_for_terminal(
         self,
@@ -188,10 +213,10 @@ class HermesBrokerClient:
                     retryable=False,
                     detail={
                         "companion": (
-                            "GET /v1/ella/internal/hermes-webhook-broker/requests/"
+                            "GET /v1/ella/internal/hermes-webhook-broker/stock-canary/requests/"
                             "{request_id}?account_id=&profile_id= "
-                            "must return owner-pinned terminal status + bounded result "
-                            "from broker_writeback_outbox.result_json (service auth)."
+                            "must return owner-pinned stock_best_effort_v1 state "
+                            "with terminal_proof=false (service auth)."
                         ),
                     },
                 )
@@ -209,18 +234,18 @@ class HermesBrokerClient:
                 lane=expected_lane,
                 require_terminal_identity=False,
             )
+            if last.get("callback_contract") != "stock_best_effort_v1" or last.get("terminal_proof") is not False:
+                raise ProvisioningError(
+                    "hermes_broker_prototype_stock_semantics_mismatch",
+                    retryable=False,
+                )
             status = str(last.get("status") or "").strip()
             if not status:
                 raise ProvisioningError(
                     "hermes_broker_prototype_status_omitted",
                     retryable=False,
                 )
-            if status in {
-                "completed",
-                "callback_verified",
-                "writeback_completed",
-                "success",
-            }:
+            if status == "writeback_completed":
                 # Terminal success must carry full owner/request/correlation/lane pins.
                 self._assert_terminal_envelope(
                     last,
@@ -233,11 +258,10 @@ class HermesBrokerClient:
                 )
                 return last
             if status in {
-                "failed",
-                "error",
                 "quarantined",
                 "blocked",
                 "expired",
+                "writeback_blocked",
             }:
                 self._assert_terminal_envelope(
                     last,
@@ -252,7 +276,18 @@ class HermesBrokerClient:
                     f"hermes_broker_prototype_{status}",
                     retryable=False,
                 )
-            # pending / dispatching / awaiting_callback
+            if status not in {
+                "pending",
+                "dispatching",
+                "awaiting_callback",
+                "callback_accepted",
+                "writeback_pending",
+                "writeback_retryable",
+            }:
+                raise ProvisioningError(
+                    "hermes_broker_prototype_stock_status_invalid",
+                    retryable=False,
+                )
             await self.sleep(self.config.poll_interval_seconds)
         raise ProvisioningError(
             "hermes_broker_prototype_wait_timeout",

--- a/backend/ella/services/hermes_broker_prototype.py
+++ b/backend/ella/services/hermes_broker_prototype.py
@@ -19,11 +19,13 @@ from ella.services.runtime_resolver import IsolatedRuntime
 # Exact lowercase only — no permissive truthy aliases.
 _TRUE = "true"
 
-# Fixed private broker path prefixes on the allowlisted host.
-ADMIT_PATH = "/v1/ella/internal/hermes-webhook-broker/admit"
-# Companion contract (not yet on merged ella-ai main): bounded result wait.
-# Documented in backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md.
-RESULT_PATH_PREFIX = "/v1/ella/internal/hermes-webhook-broker/requests/"
+# Fixed stock-canary broker paths on the allowlisted host.
+ADMIT_PATH = "/v1/ella/internal/hermes-webhook-broker/stock-canary/admit"
+RESULT_PATH_PREFIX = "/v1/ella/internal/hermes-webhook-broker/stock-canary/requests/"
+LOOPBACK_BROKER_BASE_URL = "http://127.0.0.1:18097"
+STOCK_DELIVERY_PLATFORM = "ella_callback_stock"
+STOCK_CALLBACK_SOURCE = "hermes_stock_0_19_quiet_window"
+STOCK_WEBHOOK_ROUTE = "ella-stock-synthetic"
 
 CHAT_LANE = "chat_turn"
 TRANSCRIPT_LANE = "transcript_summary_enrichment"
@@ -79,14 +81,21 @@ def load_prototype_config() -> Optional[HermesBrokerPrototypeConfig]:
             retryable=False,
         )
     parsed = urlparse(base_url)
+    secure_remote = parsed.scheme == "https" and parsed.hostname == allowed_host and parsed.port in (None, 443)
+    pinned_loopback = (
+        base_url == LOOPBACK_BROKER_BASE_URL
+        and allowed_host == "127.0.0.1"
+        and parsed.scheme == "http"
+        and parsed.hostname == "127.0.0.1"
+        and parsed.port == 18097
+    )
     if (
-        parsed.scheme != "https"
-        or parsed.username
+        parsed.username
         or parsed.password
         or parsed.query
         or parsed.fragment
-        or (parsed.port not in (None, 443))
-        or parsed.hostname != allowed_host
+        or parsed.path not in {"", "/"}
+        or not (secure_remote or pinned_loopback)
     ):
         raise ProvisioningError(
             "hermes_broker_prototype_url_not_allowlisted",

--- a/backend/ella/services/hermes_cloud.py
+++ b/backend/ella/services/hermes_cloud.py
@@ -19,6 +19,7 @@ from ella.services.hermes_cloud_policy import (
     assert_cloud_operator_gate,
     observed_artifacts,
 )
+from ella.services.hermes_cloud_staged_attestation import StagedAttestationVerifier
 from ella.services.runtime_errors import ProvisioningError
 
 CLOUD_SECRET_REF_RE = re.compile(
@@ -716,10 +717,12 @@ class HermesCloudPoolManager:
         repository: Any,
         cloud_client: Optional[HermesCloudClient] = None,
         manifest_store: Optional[ApprovedRuntimeManifestStore] = None,
+        staged_attestation_verifier: Optional[StagedAttestationVerifier] = None,
     ):
         self.repository = repository
         self.cloud_client = cloud_client or HermesCloudClient()
         self.manifest_store = manifest_store or ApprovedRuntimeManifestStore()
+        self.staged_attestation_verifier = staged_attestation_verifier or StagedAttestationVerifier()
 
     async def register(self, candidate: dict[str, Any]) -> dict[str, Any]:
         assert_cloud_operator_gate()
@@ -750,7 +753,43 @@ class HermesCloudPoolManager:
             "required_capabilities": list(manifest.required_capabilities),
             "prompt_artifact_receipt": manifest.binding_receipt(observed),
         }
-        preflight = await self.cloud_client.preflight(effective_candidate)
+        staged_fields = {
+            "synthetic_uid",
+            "account_id",
+            "profile_id",
+            "staged_attestation_ref",
+        }
+        supplied_staged_fields = staged_fields.intersection(candidate)
+        if supplied_staged_fields and supplied_staged_fields != staged_fields:
+            raise ProvisioningError("hermes_cloud_staged_attestation_missing", retryable=False)
+        if supplied_staged_fields:
+            uid = str(candidate["synthetic_uid"])
+            identity = await self.repository.get_user_identity(uid)
+            if (
+                not identity
+                or str(identity.get("status") or "") != "ACTIVE"
+                or str(identity.get("profile_class") or "") != "synthetic"
+                or str(identity.get("id") or "") != str(candidate["account_id"])
+                or str(identity.get("id") or "") != str(candidate["profile_id"])
+            ):
+                raise ProvisioningError("hermes_cloud_staged_attestation_identity_mismatch", retryable=False)
+            staged_receipt = self.staged_attestation_verifier.preflight(
+                effective_candidate,
+                receipt_ref=str(candidate["staged_attestation_ref"]),
+                uid=uid,
+                account_id=str(candidate["account_id"]),
+                profile_id=str(candidate["profile_id"]),
+                profile_class=str(identity["profile_class"]),
+                phase="pool_registration",
+            )
+            preflight = HermesCloudPreflight(
+                model=str(staged_receipt["model"]),
+                tools=tuple(staged_receipt["tools"]),
+                capabilities=tuple(staged_receipt["capabilities"]),
+                receipt=staged_receipt,
+            )
+        else:
+            preflight = await self.cloud_client.preflight(effective_candidate)
         binding = await self.repository.register_cloud_pool_binding(
             runtime_instance_id=str(candidate["runtime_instance_id"]),
             profile_name=str(candidate["profile_name"]),
@@ -767,7 +806,9 @@ class HermesCloudPoolManager:
             required_capabilities=list(preflight.capabilities),
             health_receipt=preflight.receipt,
         )
-        return {
+        if supplied_staged_fields and binding.pop("_registration_idempotent", False):
+            raise ProvisioningError("hermes_cloud_staged_attestation_replay", retryable=False)
+        result = {
             "binding_id": str(binding["id"]),
             "runtime_instance_id": str(binding["runtime_instance_id"]),
             "status": str(binding["status"]),
@@ -778,3 +819,18 @@ class HermesCloudPoolManager:
             "capabilities": list(preflight.capabilities),
             "content_free": True,
         }
+        staged_marker = preflight.receipt.get("staged_attestation")
+        if isinstance(staged_marker, dict):
+            result["staged_attestation"] = {
+                "attestation_id": staged_marker["attestation_id"],
+                "receipt_sha256": staged_marker["receipt_sha256"],
+                "phase": staged_marker["phase"],
+                "content_free": True,
+            }
+            result["rollback"] = {
+                "action": "cleanup_pool_binding",
+                "binding_id": str(binding["id"]),
+                "runtime_instance_id": str(binding["runtime_instance_id"]),
+                "content_free": True,
+            }
+        return result

--- a/backend/ella/services/hermes_cloud_staged_attestation.py
+++ b/backend/ella/services/hermes_cloud_staged_attestation.py
@@ -1,0 +1,269 @@
+"""Protected synthetic-only preflight receipt for one Hermes Cloud canary."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from ella.services.hermes_cloud_policy import cloud_synthetic_only
+from ella.services.runtime_errors import ProvisioningError
+
+SCHEMA_VERSION = "ella-hermes-cloud-staged-attestation-v1"
+APPROVED_ROOT = "/var/lib/ella/hermes-cloud-attestations"
+MAX_RECEIPT_BYTES = 16_384
+SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$")
+SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+GIT_SHA_RE = re.compile(r"^[a-f0-9]{40}$")
+TRUE_VALUES = {"1", "true", "yes", "on"}
+UID_SELECTORS = (
+    "ELLA_RUNTIME_BINDINGS_ENABLED_UIDS",
+    "ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS",
+    "ELLA_HERMES_CLOUD_SYNTHETIC_UIDS",
+    "ELLA_AI_CONSENT_ENFORCEMENT_UIDS",
+)
+GLOBAL_FLAGS_REQUIRED_FALSE = (
+    "ELLA_RUNTIME_BINDINGS_ENABLED",
+    "ELLA_HERMES_PROVISIONING_ENABLED",
+    "ELLA_HERMES_CLOUD_PROVISIONING_ENABLED",
+    "ELLA_AI_CONSENT_ENFORCEMENT_ENABLED",
+    "ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED",
+    "ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED",
+    "ELLA_ISOLATED_VOICE_ROUTING_ENABLED",
+    "ELLA_INVITE_ORDINARY_SELF_SERVICE_ENABLED",
+    "ELLA_INVITE_APP_REVIEW_ENABLED",
+)
+RECEIPT_KEYS = {
+    "schema_version",
+    "attestation_id",
+    "issued_at",
+    "expires_at",
+    "uid",
+    "account_id",
+    "profile_id",
+    "runtime_instance_id",
+    "template_version",
+    "voice_policy_version",
+    "expected_model",
+    "allowed_tools",
+    "required_capabilities",
+    "prompt_pack_version",
+    "model_policy_version",
+    "model_context_window_tokens",
+    "policy_commit_sha",
+    "approval_manifest_sha256",
+    "artifact_sha256",
+    "stage",
+    "content_free",
+}
+
+
+def _fail(code: str) -> None:
+    raise ProvisioningError(code, retryable=False)
+
+
+def _parse_utc(value: Any) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        _fail("hermes_cloud_staged_attestation_time_invalid")
+    if parsed.tzinfo is None:
+        _fail("hermes_cloud_staged_attestation_time_invalid")
+    return parsed.astimezone(timezone.utc)
+
+
+def _json_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return dict(parsed) if isinstance(parsed, dict) else {}
+    return {}
+
+
+class StagedAttestationVerifier:
+    """Read and pin one root-owned content-free receipt without network access."""
+
+    def __init__(
+        self,
+        *,
+        approved_root: str = APPROVED_ROOT,
+        expected_owner_uid: int = 0,
+        clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+    ):
+        self.approved_root = approved_root
+        self.expected_owner_uid = expected_owner_uid
+        self.clock = clock
+
+    def enabled(self) -> bool:
+        return os.getenv("ELLA_HERMES_CLOUD_STAGED_ATTESTATION_ENABLED", "") == "true"
+
+    def assert_gate(self, uid: str) -> None:
+        exact_selectors = all(
+            {item.strip() for item in os.getenv(name, "").split(",") if item.strip()} == {uid} for name in UID_SELECTORS
+        )
+        globals_off = not any(
+            os.getenv(name, "false").strip().lower() in TRUE_VALUES for name in GLOBAL_FLAGS_REQUIRED_FALSE
+        )
+        if (
+            not self.enabled()
+            or not cloud_synthetic_only()
+            or not uid.startswith(("synthetic-", "staging-synthetic-"))
+            or not exact_selectors
+            or not globals_off
+        ):
+            _fail("hermes_cloud_staged_attestation_gate_denied")
+
+    def _read(self, receipt_ref: str) -> tuple[dict[str, Any], str]:
+        if (
+            not receipt_ref
+            or not os.path.isabs(receipt_ref)
+            or os.path.normpath(receipt_ref) != receipt_ref
+            or Path(receipt_ref).parent != Path(self.approved_root)
+            or not SAFE_FILENAME_RE.fullmatch(Path(receipt_ref).name)
+        ):
+            _fail("hermes_cloud_staged_attestation_path_invalid")
+        directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC
+        file_flags = os.O_RDONLY | os.O_CLOEXEC
+        if hasattr(os, "O_NOFOLLOW"):
+            directory_flags |= os.O_NOFOLLOW
+            file_flags |= os.O_NOFOLLOW
+        try:
+            root_fd = os.open(self.approved_root, directory_flags)
+        except OSError as exc:
+            raise ProvisioningError("hermes_cloud_staged_attestation_missing", retryable=False) from exc
+        try:
+            root_stat = os.fstat(root_fd)
+            if (
+                not stat.S_ISDIR(root_stat.st_mode)
+                or root_stat.st_uid != self.expected_owner_uid
+                or stat.S_IMODE(root_stat.st_mode) != 0o700
+            ):
+                _fail("hermes_cloud_staged_attestation_permissions")
+            try:
+                receipt_fd = os.open(Path(receipt_ref).name, file_flags, dir_fd=root_fd)
+            except OSError as exc:
+                raise ProvisioningError("hermes_cloud_staged_attestation_missing", retryable=False) from exc
+            try:
+                receipt_stat = os.fstat(receipt_fd)
+                if (
+                    not stat.S_ISREG(receipt_stat.st_mode)
+                    or receipt_stat.st_uid != self.expected_owner_uid
+                    or stat.S_IMODE(receipt_stat.st_mode) not in {0o400, 0o600}
+                    or receipt_stat.st_nlink != 1
+                    or not 1 <= receipt_stat.st_size <= MAX_RECEIPT_BYTES
+                ):
+                    _fail("hermes_cloud_staged_attestation_permissions")
+                raw = os.read(receipt_fd, MAX_RECEIPT_BYTES + 1)
+            finally:
+                os.close(receipt_fd)
+        finally:
+            os.close(root_fd)
+        if len(raw) > MAX_RECEIPT_BYTES:
+            _fail("hermes_cloud_staged_attestation_invalid")
+        try:
+            receipt = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ProvisioningError("hermes_cloud_staged_attestation_invalid", retryable=False) from exc
+        if not isinstance(receipt, dict) or set(receipt) != RECEIPT_KEYS:
+            _fail("hermes_cloud_staged_attestation_invalid")
+        return receipt, hashlib.sha256(raw).hexdigest()
+
+    def preflight(
+        self,
+        binding: dict[str, Any],
+        *,
+        receipt_ref: str,
+        uid: str,
+        account_id: str,
+        profile_id: str,
+        profile_class: str,
+        phase: str,
+        prior_marker: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        self.assert_gate(uid)
+        if profile_class != "synthetic" or account_id != profile_id:
+            _fail("hermes_cloud_staged_attestation_identity_mismatch")
+        receipt, receipt_sha256 = self._read(receipt_ref)
+        now = self.clock().astimezone(timezone.utc)
+        issued_at = _parse_utc(receipt["issued_at"])
+        expires_at = _parse_utc(receipt["expires_at"])
+        if issued_at > now + timedelta(minutes=5) or expires_at <= now:
+            _fail("hermes_cloud_staged_attestation_stale")
+        try:
+            canonical_account = str(uuid.UUID(str(account_id)))
+            canonical_profile = str(uuid.UUID(str(profile_id)))
+        except ValueError:
+            _fail("hermes_cloud_staged_attestation_identity_mismatch")
+        prompt_receipt = _json_object(binding.get("prompt_artifact_receipt"))
+        artifacts = receipt.get("artifact_sha256")
+        expected_artifacts = {
+            name: str(prompt_receipt.get(f"{name}_sha256") or "") for name in ("soul", "agents", "model_policy")
+        }
+        if (
+            receipt.get("schema_version") != SCHEMA_VERSION
+            or receipt.get("content_free") is not True
+            or receipt.get("stage") != "pool_registration_and_claim_finalization"
+            or not SAFE_ID_RE.fullmatch(str(receipt.get("attestation_id") or ""))
+            or receipt.get("uid") != uid
+            or receipt.get("account_id") != canonical_account
+            or receipt.get("profile_id") != canonical_profile
+            or receipt.get("runtime_instance_id") != str(binding.get("runtime_instance_id") or "")
+            or receipt.get("template_version") != str(binding.get("template_version") or "")
+            or receipt.get("voice_policy_version") != str(binding.get("voice_policy_version") or "")
+            or receipt.get("expected_model") != str(binding.get("expected_model") or "")
+            or receipt.get("allowed_tools") != sorted(set(binding.get("allowed_tools") or []))
+            or receipt.get("required_capabilities") != sorted(set(binding.get("required_capabilities") or []))
+            or receipt.get("prompt_pack_version") != str(binding.get("prompt_pack_version") or "")
+            or receipt.get("model_policy_version") != str(binding.get("model_policy_version") or "")
+            or receipt.get("model_context_window_tokens")
+            != (
+                binding.get("model_context_window_tokens")
+                if binding.get("model_context_window_tokens") is not None
+                else prompt_receipt.get("model_context_window_tokens")
+            )
+            or receipt.get("policy_commit_sha") != str(prompt_receipt.get("policy_commit_sha") or "")
+            or receipt.get("approval_manifest_sha256") != str(prompt_receipt.get("approval_manifest_sha256") or "")
+            or not GIT_SHA_RE.fullmatch(str(receipt.get("policy_commit_sha") or ""))
+            or not SHA256_RE.fullmatch(str(receipt.get("approval_manifest_sha256") or ""))
+            or artifacts != expected_artifacts
+            or any(not SHA256_RE.fullmatch(value) for value in expected_artifacts.values())
+        ):
+            _fail("hermes_cloud_staged_attestation_pin_mismatch")
+        marker = {
+            "schema_version": SCHEMA_VERSION,
+            "attestation_id": str(receipt["attestation_id"]),
+            "receipt_ref": receipt_ref,
+            "receipt_sha256": receipt_sha256,
+            "uid": uid,
+            "account_id": canonical_account,
+            "profile_id": canonical_profile,
+            "runtime_instance_id": str(receipt["runtime_instance_id"]),
+            "phase": phase,
+            "expires_at": expires_at.isoformat(),
+            "content_free": True,
+        }
+        if prior_marker is not None:
+            expected_prior = {**marker, "phase": "pool_registration"}
+            if prior_marker != expected_prior:
+                _fail("hermes_cloud_staged_attestation_replay_or_drift")
+        return {
+            "status": "ok",
+            "model": str(binding["expected_model"]),
+            "tools": sorted(set(binding.get("allowed_tools") or [])),
+            "capabilities": sorted(set(binding.get("required_capabilities") or [])),
+            "prompt_artifacts": prompt_receipt,
+            "preflight_source": "server_staged_attestation",
+            "staged_attestation": marker,
+            "content_free": True,
+        }

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -32,12 +32,14 @@ from ella.services.ai_consent import (
 )
 from ella.services.hermes_cloud import (
     HermesCloudClient,
+    HermesCloudPreflight,
     RuntimePoolAlertPublisher,
 )
 from ella.services.hermes_cloud_policy import (
     cloud_synthetic_only,
     current_cloud_authority,
 )
+from ella.services.hermes_cloud_staged_attestation import StagedAttestationVerifier
 from ella.services.runtime_errors import ProvisioningError
 
 DEFAULT_TARGET_SCHEMA_VERSION = "hermes-user-v1"
@@ -411,6 +413,7 @@ class ProvisioningCoordinator:
         honcho_client: Any = None,
         alert_publisher: Any = None,
         runtime_admission: Any = None,
+        staged_attestation_verifier: Any = None,
     ):
         self.repository = repository
         self.client = client or HermesProvisionClient()
@@ -418,6 +421,7 @@ class ProvisioningCoordinator:
         self.honcho_client = honcho_client
         self.alert_publisher = alert_publisher
         self.runtime_admission = runtime_admission
+        self.staged_attestation_verifier = staged_attestation_verifier
 
     async def ensure_job(
         self,
@@ -682,7 +686,35 @@ class ProvisioningCoordinator:
                 )
 
             await current_authority()
-            preflight = await cloud_client.preflight(binding)
+            registration_health = binding.get("health_receipt") or {}
+            if isinstance(registration_health, str):
+                try:
+                    registration_health = json.loads(registration_health)
+                except json.JSONDecodeError:
+                    registration_health = {}
+            staged_marker = (
+                registration_health.get("staged_attestation") if isinstance(registration_health, dict) else None
+            )
+            if isinstance(staged_marker, dict):
+                staged_verifier = self.staged_attestation_verifier or StagedAttestationVerifier()
+                staged_receipt = staged_verifier.preflight(
+                    binding,
+                    receipt_ref=str(staged_marker.get("receipt_ref") or ""),
+                    uid=identity.uid,
+                    account_id=str(binding.get("user_id") or ""),
+                    profile_id=str(binding.get("user_id") or ""),
+                    profile_class=str(binding.get("profile_class") or ""),
+                    phase="claim_finalization",
+                    prior_marker=staged_marker,
+                )
+                preflight = HermesCloudPreflight(
+                    model=str(staged_receipt["model"]),
+                    tools=tuple(staged_receipt["tools"]),
+                    capabilities=tuple(staged_receipt["capabilities"]),
+                    receipt=staged_receipt,
+                )
+            else:
+                preflight = await cloud_client.preflight(binding)
             final_authority = await current_authority()
             health_receipt = {
                 **preflight.receipt,

--- a/backend/scripts/hermes_cloud_pool_admin.py
+++ b/backend/scripts/hermes_cloud_pool_admin.py
@@ -46,6 +46,22 @@ async def list_pool() -> dict:
     }
 
 
+async def cleanup(*, binding_id: str, runtime_instance_id: str) -> dict:
+    repository = await EllaProvisioningRepository.create()
+    await repository.assert_cloud_schema_ready()
+    removed = await repository.cleanup_cloud_pool_binding(
+        binding_id=binding_id,
+        runtime_instance_id=runtime_instance_id,
+    )
+    return {
+        "action": "cleanup_pool_binding",
+        "binding_id": str(removed["id"]),
+        "runtime_instance_id": str(removed["runtime_instance_id"]),
+        "status": "removed",
+        "content_free": True,
+    }
+
+
 async def promote(
     *,
     uid: str,
@@ -102,6 +118,9 @@ def main() -> None:
     register_parser = subparsers.add_parser("register")
     register_parser.add_argument("--candidate", required=True)
     subparsers.add_parser("list")
+    cleanup_parser = subparsers.add_parser("cleanup")
+    cleanup_parser.add_argument("--binding-id", required=True)
+    cleanup_parser.add_argument("--runtime-instance-id", required=True)
     promote_parser = subparsers.add_parser("promote")
     promote_parser.add_argument("--uid", required=True)
     promote_parser.add_argument("--binding-id", required=True)
@@ -114,6 +133,13 @@ def main() -> None:
     args = parser.parse_args()
     if args.command == "register":
         result = asyncio.run(register(args.candidate))
+    elif args.command == "cleanup":
+        result = asyncio.run(
+            cleanup(
+                binding_id=args.binding_id,
+                runtime_instance_id=args.runtime_instance_id,
+            )
+        )
     elif args.command == "promote":
         result = asyncio.run(
             promote(

--- a/backend/tests/unit/test_authority_writer_guard.py
+++ b/backend/tests/unit/test_authority_writer_guard.py
@@ -25,6 +25,7 @@ EXPECTED_WRITERS = {
     ("database/ella_provisioning.py", "activate_runtime_binding"),
     ("database/ella_provisioning.py", "activate_user"),
     ("database/ella_provisioning.py", "claim_cloud_pool_binding"),
+    ("database/ella_provisioning.py", "cleanup_cloud_pool_binding"),
     ("database/ella_provisioning.py", "ensure_user_identity"),
     ("database/ella_provisioning.py", "finalize_cloud_pool_claim"),
     ("database/ella_provisioning.py", "promote_cloud_binding"),
@@ -43,6 +44,7 @@ EXPECTED_WRITERS = {
 }
 
 DIRECT_LOCKED_WRITERS = EXPECTED_WRITERS - {
+    ("database/ella_provisioning.py", "cleanup_cloud_pool_binding"),
     ("database/ella_provisioning.py", "register_cloud_pool_binding"),
     ("database/invitation_operator.py", "_cleanup_locked"),
     ("database/invitations.py", "_redeem_locked_invitation"),
@@ -212,6 +214,7 @@ def test_global_users_writer_inventory_is_closed_and_authority_scoped():
 
 def test_every_owner_bound_writer_is_pinned_to_real_postgres_contention_coverage():
     assert set(REAL_POSTGRES_WRITER_COVERAGE) == EXPECTED_WRITERS - {
+        ("database/ella_provisioning.py", "cleanup_cloud_pool_binding"),
         ("database/ella_provisioning.py", "register_cloud_pool_binding"),
     }
     for key, (relative_path, marker_spec) in REAL_POSTGRES_WRITER_COVERAGE.items():

--- a/backend/tests/unit/test_hermes_broker_prototype.py
+++ b/backend/tests/unit/test_hermes_broker_prototype.py
@@ -96,6 +96,11 @@ def _enable(monkeypatch, **overrides):
 class FakeResponse:
     def __init__(self, status_code: int, body: Any, *, content: Optional[bytes] = None):
         self.status_code = status_code
+        if isinstance(body, dict) and body.get("request_id"):
+            body.setdefault("callback_contract", "stock_best_effort_v1")
+            body.setdefault("terminal_proof", False)
+            body.setdefault("delivery_platform", "ella_callback_stock")
+            body.setdefault("callback_source", "hermes_stock_0_19_quiet_window")
         self._body = body
         self.content = content if content is not None else json.dumps(body).encode()
 
@@ -135,12 +140,14 @@ async def _noop_sleep(_seconds):
 
 def _completed_result(**overrides):
     body = {
-        "status": "completed",
+        "status": "writeback_completed",
         "request_id": "hwb_req1",
         "correlation_id": "hwb:corr1",
         "account_id": ACCOUNT_UUID,
         "profile_id": PROFILE_UUID,
         "lane": "chat_turn",
+        "callback_contract": "stock_best_effort_v1",
+        "terminal_proof": False,
         "outcome": "success",
         "result": {
             "answer": "proto answer",
@@ -236,6 +243,10 @@ def test_success_chat_maps_answer_with_owner_uuids(monkeypatch):
             assert body["profile_id"] == PROFILE_UUID
             assert body["account_id"] != AUTH_UID
             assert body["payload"]["message"] == "hello"
+            assert body["delivery_platform"] == "ella_callback_stock"
+            assert body["callback_source"] == "hermes_stock_0_19_quiet_window"
+            assert body["webhook_route"] == "ella-stock-synthetic"
+            assert url.endswith("/stock-canary/admit")
             assert "Authorization" in kwargs["headers"]
             return FakeResponse(
                 200,
@@ -246,7 +257,7 @@ def test_success_chat_maps_answer_with_owner_uuids(monkeypatch):
                 },
             )
         assert method == "GET"
-        assert "hwb_req1" in url
+        assert url.endswith("/stock-canary/requests/hwb_req1")
         params = kwargs.get("params") or {}
         assert params["account_id"] == ACCOUNT_UUID
         assert params["profile_id"] == PROFILE_UUID
@@ -300,6 +311,36 @@ def test_correlation_mismatch_fails_closed(monkeypatch):
             )
         )
     assert exc.value.code == "hermes_broker_prototype_correlation_mismatch"
+
+
+def test_stock_result_requires_best_effort_nonterminal_proof(monkeypatch):
+    _enable(monkeypatch)
+    cfg = proto.load_prototype_config()
+
+    def handler(method, url, kwargs):
+        if method == "POST":
+            return FakeResponse(
+                200,
+                {"status": "pending", "request_id": "hwb_req1", "correlation_id": "hwb:corr1"},
+            )
+        return FakeResponse(200, _completed_result(terminal_proof=True))
+
+    client = HermesBrokerClient(cfg, http_client_factory=FakeHttp(handler).factory, sleep=_noop_sleep)
+    with pytest.raises(ProvisioningError) as exc:
+        asyncio.run(
+            client.run_chat_turn(
+                account_id=ACCOUNT_UUID,
+                profile_id=PROFILE_UUID,
+                runtime_binding_ref=BINDING_ID,
+                consent_epoch="consent.v1",
+                message="hello",
+                session_key="sk",
+                session_id="sid",
+                source_event_id="evt-1",
+                expected_model="gpt-test",
+            )
+        )
+    assert exc.value.code == "hermes_broker_prototype_stock_semantics_mismatch"
 
 
 def test_cross_account_result_fails_closed(monkeypatch):
@@ -475,7 +516,12 @@ def test_answer_only_projection_rejected(monkeypatch):
             )
         return FakeResponse(
             200,
-            {"status": "completed", "result": {"answer": "sneaky"}},
+            {
+                "status": "writeback_completed",
+                "callback_contract": "stock_best_effort_v1",
+                "terminal_proof": False,
+                "result": {"answer": "sneaky"},
+            },
         )
 
     client = HermesBrokerClient(cfg, http_client_factory=FakeHttp(handler).factory, sleep=_noop_sleep)
@@ -706,6 +752,57 @@ def test_disallowed_host_rejected(monkeypatch):
     with pytest.raises(ProvisioningError) as exc:
         proto.load_prototype_config()
     assert exc.value.code == "hermes_broker_prototype_url_not_allowlisted"
+
+
+def test_exact_synthetic_loopback_transport_is_allowed(monkeypatch):
+    _enable(
+        monkeypatch,
+        ELLA_HERMES_BROKER_BASE_URL="http://127.0.0.1:18097",
+        ELLA_HERMES_BROKER_ALLOWED_HOST="127.0.0.1",
+    )
+    config = proto.load_prototype_config()
+    assert config is not None
+    assert config.base_url == "http://127.0.0.1:18097"
+
+
+@pytest.mark.parametrize(
+    ("base_url", "allowed_host"),
+    (
+        ("http://localhost:18097", "localhost"),
+        ("http://127.0.0.1:8097", "127.0.0.1"),
+        ("http://127.0.0.1:18098", "127.0.0.1"),
+        ("http://127.0.0.2:18097", "127.0.0.2"),
+        ("http://127.0.0.1:18097/path", "127.0.0.1"),
+        ("http://127.0.0.1:18097?target=evil", "127.0.0.1"),
+        ("http://user@127.0.0.1:18097", "127.0.0.1"),
+    ),
+)
+def test_loopback_transport_adversarial_urls_fail_closed(monkeypatch, base_url, allowed_host):
+    _enable(
+        monkeypatch,
+        ELLA_HERMES_BROKER_BASE_URL=base_url,
+        ELLA_HERMES_BROKER_ALLOWED_HOST=allowed_host,
+    )
+    with pytest.raises(ProvisioningError) as exc:
+        proto.load_prototype_config()
+    assert exc.value.code == "hermes_broker_prototype_url_not_allowlisted"
+
+
+def test_default_http_client_disables_environment_and_redirects(monkeypatch):
+    captured = {}
+
+    def fake_async_client(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(client_mod.httpx, "AsyncClient", fake_async_client)
+    _enable(monkeypatch)
+    config = proto.load_prototype_config()
+    assert config is not None
+    client = HermesBrokerClient(config)
+    client.http_client_factory(timeout=1)
+    assert captured["follow_redirects"] is False
+    assert captured["trust_env"] is False
 
 
 def test_provider_turn_uses_direct_when_not_allowlisted(monkeypatch):

--- a/backend/tests/unit/test_hermes_cloud_provider.py
+++ b/backend/tests/unit/test_hermes_cloud_provider.py
@@ -576,6 +576,98 @@ def test_pool_registration_rejects_candidate_policy_self_attestation():
     assert error.value.code == "hermes_cloud_candidate_policy_forbidden"
 
 
+def test_pool_registration_uses_exact_staged_attestation_without_direct_preflight():
+    class Repository:
+        async def get_user_identity(self, uid):
+            assert uid == "synthetic-canary"
+            return {
+                "id": "11111111-1111-4111-8111-111111111111",
+                "status": "ACTIVE",
+                "profile_class": "synthetic",
+            }
+
+        async def register_cloud_pool_binding(self, **kwargs):
+            assert kwargs["health_receipt"]["preflight_source"] == "server_staged_attestation"
+            return {
+                "id": "binding-a",
+                "runtime_instance_id": "instance-a",
+                "status": "pool_available",
+                "health_state": "healthy",
+                "_registration_idempotent": False,
+            }
+
+    class Cloud:
+        async def preflight(self, candidate):
+            raise AssertionError("direct Nous preflight must not run for the staged canary")
+
+    class Verifier:
+        def preflight(self, binding, **kwargs):
+            assert kwargs["phase"] == "pool_registration"
+            assert kwargs["account_id"] == "11111111-1111-4111-8111-111111111111"
+            return {
+                "model": binding["expected_model"],
+                "tools": list(binding["allowed_tools"]),
+                "capabilities": list(binding["required_capabilities"]),
+                "prompt_artifacts": binding["prompt_artifact_receipt"],
+                "preflight_source": "server_staged_attestation",
+                "staged_attestation": {
+                    "attestation_id": "attestation-canary",
+                    "receipt_sha256": "d" * 64,
+                    "phase": "pool_registration",
+                },
+                "content_free": True,
+            }
+
+    artifact_hash = "a" * 64
+    manifest = ApprovedRuntimeManifest(
+        policy_commit_sha="b" * 40,
+        lane_s_review_url="https://github.com/ellaaicare/ella-ai/issues/1136",
+        prompt_pack_version="prompt-v1",
+        model_policy_version="models-v1",
+        expected_model="model-a",
+        model_context_window_tokens=16384,
+        allowed_tools=(),
+        required_capabilities=("responses_api", "session_key_header"),
+        artifact_sha256={"soul": artifact_hash, "agents": artifact_hash, "model_policy": artifact_hash},
+        manifest_sha256="c" * 64,
+    )
+
+    class ManifestStore:
+        def load(self):
+            return manifest
+
+    result = asyncio.run(
+        HermesCloudPoolManager(
+            repository=Repository(),
+            cloud_client=Cloud(),
+            manifest_store=ManifestStore(),
+            staged_attestation_verifier=Verifier(),
+        ).register(
+            {
+                "synthetic_uid": "synthetic-canary",
+                "account_id": "11111111-1111-4111-8111-111111111111",
+                "profile_id": "11111111-1111-4111-8111-111111111111",
+                "staged_attestation_ref": "/var/lib/ella/hermes-cloud-attestations/canary.json",
+                "runtime_instance_id": "instance-a",
+                "profile_name": "pool-instance-a",
+                "agent_id": "hermes-cloud",
+                "api_base_url_ref": "env:ELLA_HERMES_CLOUD_API_URL_SYNTHETIC",
+                "api_key_ref": "env:ELLA_HERMES_CLOUD_API_KEY_SYNTHETIC",
+                "template_version": "hermes-cloud-user-v1",
+                "voice_policy_version": "voice-v1",
+                "observed_prompt_artifacts": {
+                    "soul_sha256": artifact_hash,
+                    "agents_sha256": artifact_hash,
+                    "model_policy_sha256": artifact_hash,
+                },
+            }
+        )
+    )
+
+    assert result["staged_attestation"]["attestation_id"] == "attestation-canary"
+    assert result["rollback"]["binding_id"] == "binding-a"
+
+
 def test_cloud_runtime_resolver_is_fail_closed_and_contains_no_local_route(cloud_env):
     binding = {
         **_binding(),

--- a/backend/tests/unit/test_hermes_cloud_provisioning.py
+++ b/backend/tests/unit/test_hermes_cloud_provisioning.py
@@ -247,6 +247,64 @@ def test_cloud_claim_preflights_vendor_without_honcho_before_atomic_publish(monk
     assert repository.delivered_alerts == ["alert-a"]
 
 
+def test_cloud_claim_finalization_revalidates_staged_receipt_without_direct_preflight(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS", "synthetic-user")
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_UIDS", "synthetic-user")
+    staged_marker = {
+        "attestation_id": "attestation-canary",
+        "receipt_ref": "/var/lib/ella/hermes-cloud-attestations/canary.json",
+        "receipt_sha256": "d" * 64,
+        "phase": "pool_registration",
+    }
+
+    class StagedRepository(FakeRepository):
+        async def claim_cloud_pool_binding(self, **kwargs):
+            binding = await super().claim_cloud_pool_binding(**kwargs)
+            binding.update(
+                {
+                    "user_id": "11111111-1111-4111-8111-111111111111",
+                    "runtime_instance_id": "instance-a",
+                    "health_receipt": {"staged_attestation": staged_marker},
+                }
+            )
+            return binding
+
+    class NoDirectCloud:
+        async def preflight(self, binding):
+            raise AssertionError("direct Nous preflight must not run for staged finalization")
+
+    class Verifier:
+        def preflight(self, binding, **kwargs):
+            assert kwargs["phase"] == "claim_finalization"
+            assert kwargs["prior_marker"] == staged_marker
+            return {
+                "model": "model-a",
+                "tools": [],
+                "capabilities": ["responses_api", "session_key_header"],
+                "preflight_source": "server_staged_attestation",
+                "staged_attestation": {**staged_marker, "phase": "claim_finalization"},
+                "content_free": True,
+            }
+
+    repository = StagedRepository()
+    coordinator = ProvisioningCoordinator(
+        repository,
+        ForbiddenLocalClient(),
+        cloud_client=NoDirectCloud(),
+        honcho_client=FakeHoncho(),
+        alert_publisher=FakeAlert(),
+        runtime_admission=allow_runtime,
+        staged_attestation_verifier=Verifier(),
+    )
+
+    asyncio.run(coordinator.process_claimed_job(job=_job(), identity=_identity()))
+
+    assert len(repository.finalized) == 1
+    health = repository.finalized[0]["health_receipt"]
+    assert health["preflight_source"] == "server_staged_attestation"
+    assert health["staged_attestation"]["phase"] == "claim_finalization"
+
+
 def test_allowlisted_real_profile_is_denied_before_claim_or_vendor_side_effect(
     monkeypatch,
 ):

--- a/backend/tests/unit/test_hermes_cloud_staged_attestation.py
+++ b/backend/tests/unit/test_hermes_cloud_staged_attestation.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from ella.services.hermes_cloud_staged_attestation import (
+    GLOBAL_FLAGS_REQUIRED_FALSE,
+    UID_SELECTORS,
+    StagedAttestationVerifier,
+)
+from ella.services.runtime_errors import ProvisioningError
+
+UID = "synthetic-hermes-canary"
+OWNER_ID = "11111111-1111-4111-8111-111111111111"
+NOW = datetime(2026, 7, 29, 22, 50, tzinfo=timezone.utc)
+ARTIFACT = "a" * 64
+
+
+def _binding():
+    return {
+        "runtime_instance_id": "nous-runtime-canary",
+        "template_version": "hermes-cloud-user-v1",
+        "voice_policy_version": "voice-v1",
+        "expected_model": "model-a",
+        "allowed_tools": [],
+        "required_capabilities": ["responses_api", "session_key_header"],
+        "prompt_pack_version": "prompt-v1",
+        "model_policy_version": "model-policy-v1",
+        "prompt_artifact_receipt": {
+            "model_context_window_tokens": 16384,
+            "policy_commit_sha": "b" * 40,
+            "approval_manifest_sha256": "c" * 64,
+            "soul_sha256": ARTIFACT,
+            "agents_sha256": ARTIFACT,
+            "model_policy_sha256": ARTIFACT,
+        },
+    }
+
+
+def _receipt():
+    return {
+        "schema_version": "ella-hermes-cloud-staged-attestation-v1",
+        "attestation_id": "attestation-hermes-canary-01",
+        "issued_at": (NOW - timedelta(minutes=1)).isoformat(),
+        "expires_at": (NOW + timedelta(hours=1)).isoformat(),
+        "uid": UID,
+        "account_id": OWNER_ID,
+        "profile_id": OWNER_ID,
+        "runtime_instance_id": "nous-runtime-canary",
+        "template_version": "hermes-cloud-user-v1",
+        "voice_policy_version": "voice-v1",
+        "expected_model": "model-a",
+        "allowed_tools": [],
+        "required_capabilities": ["responses_api", "session_key_header"],
+        "prompt_pack_version": "prompt-v1",
+        "model_policy_version": "model-policy-v1",
+        "model_context_window_tokens": 16384,
+        "policy_commit_sha": "b" * 40,
+        "approval_manifest_sha256": "c" * 64,
+        "artifact_sha256": {
+            "soul": ARTIFACT,
+            "agents": ARTIFACT,
+            "model_policy": ARTIFACT,
+        },
+        "stage": "pool_registration_and_claim_finalization",
+        "content_free": True,
+    }
+
+
+@pytest.fixture
+def staged_env(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_STAGED_ATTESTATION_ENABLED", "true")
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_ONLY", "true")
+    for name in UID_SELECTORS:
+        monkeypatch.setenv(name, UID)
+    for name in GLOBAL_FLAGS_REQUIRED_FALSE:
+        monkeypatch.setenv(name, "false")
+
+
+def _protected_receipt(tmp_path, receipt=None, *, mode=0o400):
+    root = tmp_path / "attestations"
+    root.mkdir(mode=0o700)
+    root.chmod(0o700)
+    path = root / "canary.receipt.json"
+    path.write_text(json.dumps(receipt or _receipt()), encoding="utf-8")
+    path.chmod(mode)
+    verifier = StagedAttestationVerifier(
+        approved_root=str(root),
+        expected_owner_uid=os.geteuid(),
+        clock=lambda: NOW,
+    )
+    return verifier, path
+
+
+def test_protected_receipt_covers_registration_and_exact_finalization(staged_env, tmp_path):
+    verifier, path = _protected_receipt(tmp_path)
+    registration = verifier.preflight(
+        _binding(),
+        receipt_ref=str(path),
+        uid=UID,
+        account_id=OWNER_ID,
+        profile_id=OWNER_ID,
+        profile_class="synthetic",
+        phase="pool_registration",
+    )
+    finalization = verifier.preflight(
+        _binding(),
+        receipt_ref=str(path),
+        uid=UID,
+        account_id=OWNER_ID,
+        profile_id=OWNER_ID,
+        profile_class="synthetic",
+        phase="claim_finalization",
+        prior_marker=registration["staged_attestation"],
+    )
+
+    assert registration["preflight_source"] == "server_staged_attestation"
+    assert finalization["staged_attestation"]["phase"] == "claim_finalization"
+    assert finalization["content_free"] is True
+
+
+@pytest.mark.parametrize(
+    ("mutation", "code"),
+    (
+        (lambda receipt: receipt.update(expected_model="wrong"), "hermes_cloud_staged_attestation_pin_mismatch"),
+        (
+            lambda receipt: receipt.update(expires_at=(NOW - timedelta(seconds=1)).isoformat()),
+            "hermes_cloud_staged_attestation_stale",
+        ),
+    ),
+)
+def test_staged_receipt_rejects_mismatch_and_stale(staged_env, tmp_path, mutation, code):
+    receipt = _receipt()
+    mutation(receipt)
+    verifier, path = _protected_receipt(tmp_path, receipt)
+    with pytest.raises(ProvisioningError) as exc:
+        verifier.preflight(
+            _binding(),
+            receipt_ref=str(path),
+            uid=UID,
+            account_id=OWNER_ID,
+            profile_id=OWNER_ID,
+            profile_class="synthetic",
+            phase="pool_registration",
+        )
+    assert exc.value.code == code
+
+
+def test_staged_receipt_rejects_real_profile_wrong_selector_and_insecure_file(staged_env, tmp_path, monkeypatch):
+    verifier, path = _protected_receipt(tmp_path, mode=0o644)
+    with pytest.raises(ProvisioningError) as exc:
+        verifier.preflight(
+            _binding(),
+            receipt_ref=str(path),
+            uid=UID,
+            account_id=OWNER_ID,
+            profile_id=OWNER_ID,
+            profile_class="synthetic",
+            phase="pool_registration",
+        )
+    assert exc.value.code == "hermes_cloud_staged_attestation_permissions"
+
+    path.chmod(0o400)
+    with pytest.raises(ProvisioningError) as exc:
+        verifier.preflight(
+            _binding(),
+            receipt_ref=str(path),
+            uid=UID,
+            account_id=OWNER_ID,
+            profile_id=OWNER_ID,
+            profile_class="real",
+            phase="pool_registration",
+        )
+    assert exc.value.code == "hermes_cloud_staged_attestation_identity_mismatch"
+
+    monkeypatch.setenv("ELLA_RUNTIME_BINDINGS_ENABLED_UIDS", "synthetic-other")
+    with pytest.raises(ProvisioningError) as exc:
+        verifier.preflight(
+            _binding(),
+            receipt_ref=str(path),
+            uid=UID,
+            account_id=OWNER_ID,
+            profile_id=OWNER_ID,
+            profile_class="synthetic",
+            phase="pool_registration",
+        )
+    assert exc.value.code == "hermes_cloud_staged_attestation_gate_denied"
+
+
+def test_staged_receipt_rejects_missing_and_replayed_prior_marker(staged_env, tmp_path):
+    verifier, path = _protected_receipt(tmp_path)
+    missing = path.with_name("missing.receipt.json")
+    with pytest.raises(ProvisioningError) as exc:
+        verifier.preflight(
+            _binding(),
+            receipt_ref=str(missing),
+            uid=UID,
+            account_id=OWNER_ID,
+            profile_id=OWNER_ID,
+            profile_class="synthetic",
+            phase="pool_registration",
+        )
+    assert exc.value.code == "hermes_cloud_staged_attestation_missing"
+
+    with pytest.raises(ProvisioningError) as exc:
+        verifier.preflight(
+            _binding(),
+            receipt_ref=str(path),
+            uid=UID,
+            account_id=OWNER_ID,
+            profile_id=OWNER_ID,
+            profile_class="synthetic",
+            phase="claim_finalization",
+            prior_marker={"phase": "claim_finalization"},
+        )
+    assert exc.value.code == "hermes_cloud_staged_attestation_replay_or_drift"


### PR DESCRIPTION
## Summary
- bind HermesBrokerClient to the stock-canary admit/result contract with fixed callback markers and terminal_proof=false semantics
- allow only the exact synthetic host-loopback transport at http://127.0.0.1:18097 while preserving HTTPS:443 elsewhere
- add one root-owned content-free staged-attestation path for pool registration and claim finalization, with exact-ID cleanup rollback

## Prototype boundary
Synthetic-only and default-off. No deploy, flag/allowlist mutation, vendor traffic, billing, user mutation, Plato fallback, direct-API fallback, or manual SQL.

## Verification
- 89 focused unit tests passed
- Black 24.8 check passed
- compileall and diff check passed
- commit-scoped Gitleaks: one commit scanned, no leaks found

Coordination contract: ellaaicare/ella-ai#1136 comment 5124117727.
Hardening beyond this one-account cut line remains ellaaicare/ella-ai#1157.