### PR TITLE
Fix staged attestation JSONB pin validation

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -343,7 +343,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 396
+          test "$collected" -eq 406
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \

--- a/backend/ella/services/hermes_cloud_staged_attestation.py
+++ b/backend/ella/services/hermes_cloud_staged_attestation.py
@@ -91,6 +91,21 @@ def _json_object(value: Any) -> dict[str, Any]:
     return {}
 
 
+def _normalized_string_list(value: Any, *, allow_json_string: bool) -> Optional[list[str]]:
+    if isinstance(value, str):
+        if not allow_json_string:
+            return None
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(value, (list, tuple)):
+        return None
+    if any(not isinstance(item, str) or not item or item.strip() != item for item in value):
+        return None
+    return sorted(set(value))
+
+
 class StagedAttestationVerifier:
     """Read and pin one root-owned content-free receipt without network access."""
 
@@ -210,6 +225,22 @@ class StagedAttestationVerifier:
         expected_artifacts = {
             name: str(prompt_receipt.get(f"{name}_sha256") or "") for name in ("soul", "agents", "model_policy")
         }
+        binding_allowed_tools = _normalized_string_list(
+            binding.get("allowed_tools"),
+            allow_json_string=True,
+        )
+        binding_required_capabilities = _normalized_string_list(
+            binding.get("required_capabilities"),
+            allow_json_string=True,
+        )
+        receipt_allowed_tools = _normalized_string_list(
+            receipt.get("allowed_tools"),
+            allow_json_string=False,
+        )
+        receipt_required_capabilities = _normalized_string_list(
+            receipt.get("required_capabilities"),
+            allow_json_string=False,
+        )
         if (
             receipt.get("schema_version") != SCHEMA_VERSION
             or receipt.get("content_free") is not True
@@ -222,8 +253,14 @@ class StagedAttestationVerifier:
             or receipt.get("template_version") != str(binding.get("template_version") or "")
             or receipt.get("voice_policy_version") != str(binding.get("voice_policy_version") or "")
             or receipt.get("expected_model") != str(binding.get("expected_model") or "")
-            or receipt.get("allowed_tools") != sorted(set(binding.get("allowed_tools") or []))
-            or receipt.get("required_capabilities") != sorted(set(binding.get("required_capabilities") or []))
+            or binding_allowed_tools is None
+            or binding_required_capabilities is None
+            or receipt_allowed_tools is None
+            or receipt_required_capabilities is None
+            or receipt.get("allowed_tools") != receipt_allowed_tools
+            or receipt.get("required_capabilities") != receipt_required_capabilities
+            or receipt_allowed_tools != binding_allowed_tools
+            or receipt_required_capabilities != binding_required_capabilities
             or receipt.get("prompt_pack_version") != str(binding.get("prompt_pack_version") or "")
             or receipt.get("model_policy_version") != str(binding.get("model_policy_version") or "")
             or receipt.get("model_context_window_tokens")
@@ -257,11 +294,13 @@ class StagedAttestationVerifier:
             expected_prior = {**marker, "phase": "pool_registration"}
             if prior_marker != expected_prior:
                 _fail("hermes_cloud_staged_attestation_replay_or_drift")
+        assert binding_allowed_tools is not None
+        assert binding_required_capabilities is not None
         return {
             "status": "ok",
             "model": str(binding["expected_model"]),
-            "tools": sorted(set(binding.get("allowed_tools") or [])),
-            "capabilities": sorted(set(binding.get("required_capabilities") or [])),
+            "tools": binding_allowed_tools,
+            "capabilities": binding_required_capabilities,
             "prompt_artifacts": prompt_receipt,
             "preflight_source": "server_staged_attestation",
             "staged_attestation": marker,

--- a/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
+++ b/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
@@ -1,7 +1,8 @@
 import asyncio
+import json
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import asyncpg
@@ -13,6 +14,11 @@ from database.ella_provisioning import (
     RuntimePoolClaimError,
 )
 from database.runtime_targets import RuntimeTargetLineage
+from ella.services.hermes_cloud_staged_attestation import (
+    GLOBAL_FLAGS_REQUIRED_FALSE,
+    UID_SELECTORS,
+    StagedAttestationVerifier,
+)
 
 TEST_DSN = os.getenv("ELLA_TEST_POSTGRES_DSN", "").strip()
 MIGRATIONS = Path(__file__).resolve().parents[2] / "migrations"
@@ -329,6 +335,118 @@ async def _seed_claim(
     )
     assert admitted.allowed
     return repository, str(job_id), model, int(admitted.entitlement["revision"])
+
+
+def test_real_postgres_claim_revalidates_jsonb_string_pins(tmp_path, monkeypatch):
+    uid = "synthetic-staged-jsonb-revalidation"
+    instance = "synthetic-instance-staged-jsonb"
+    model = "gpt-5.6-terra"
+    now = datetime(2026, 7, 30, 1, 0, tzinfo=timezone.utc)
+    root = tmp_path / "attestations"
+    root.mkdir(mode=0o700)
+    root.chmod(0o700)
+    receipt_path = root / "staged-jsonb.receipt.json"
+    verifier = StagedAttestationVerifier(
+        approved_root=str(root),
+        expected_owner_uid=os.geteuid(),
+        clock=lambda: now,
+    )
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_STAGED_ATTESTATION_ENABLED", "true")
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_ONLY", "true")
+    for name in UID_SELECTORS:
+        monkeypatch.setenv(name, uid)
+    for name in GLOBAL_FLAGS_REQUIRED_FALSE:
+        monkeypatch.setenv(name, "false")
+
+    async def scenario(pool):
+        repository, job_id, claimed_model, revision = await _seed_claim(
+            pool,
+            uid=uid,
+            runtime_instance_id=instance,
+        )
+        assert claimed_model == model
+        async with pool.acquire() as conn:
+            user_id = await conn.fetchval("SELECT id FROM users WHERE omi_uid = $1", uid)
+
+        receipt = {
+            "schema_version": "ella-hermes-cloud-staged-attestation-v1",
+            "attestation_id": "attestation-staged-jsonb-01",
+            "issued_at": (now - timedelta(minutes=1)).isoformat(),
+            "expires_at": (now + timedelta(hours=1)).isoformat(),
+            "uid": uid,
+            "account_id": str(user_id),
+            "profile_id": str(user_id),
+            "runtime_instance_id": instance,
+            "template_version": "template-v1",
+            "voice_policy_version": "voice-policy-v1",
+            "expected_model": model,
+            "allowed_tools": [],
+            "required_capabilities": ["responses_api"],
+            "prompt_pack_version": "prompt-v1",
+            "model_policy_version": "model-policy-v1",
+            "model_context_window_tokens": 16384,
+            "policy_commit_sha": "a" * 40,
+            "approval_manifest_sha256": "b" * 64,
+            "artifact_sha256": {
+                "soul": "c" * 64,
+                "agents": "d" * 64,
+                "model_policy": "e" * 64,
+            },
+            "stage": "pool_registration_and_claim_finalization",
+            "content_free": True,
+        }
+        receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+        receipt_path.chmod(0o400)
+        registration = verifier.preflight(
+            {
+                "runtime_instance_id": instance,
+                "template_version": "template-v1",
+                "voice_policy_version": "voice-policy-v1",
+                "expected_model": model,
+                "allowed_tools": [],
+                "required_capabilities": ["responses_api"],
+                "prompt_pack_version": "prompt-v1",
+                "model_policy_version": "model-policy-v1",
+                "prompt_artifact_receipt": _prompt_receipt(model=model),
+            },
+            receipt_ref=str(receipt_path),
+            uid=uid,
+            account_id=str(user_id),
+            profile_id=str(user_id),
+            profile_class="synthetic",
+            phase="pool_registration",
+        )
+
+        claimed = await repository.claim_cloud_pool_binding(
+            uid=uid,
+            job_id=job_id,
+            lease_seconds=120,
+            admitted_entitlement_revision=revision,
+            provider="hermes_cloud",
+            model=model,
+            required_profile_class="synthetic",
+        )
+        assert isinstance(claimed["allowed_tools"], str)
+        assert isinstance(claimed["required_capabilities"], str)
+        assert json.loads(claimed["allowed_tools"]) == []
+        assert json.loads(claimed["required_capabilities"]) == ["responses_api"]
+
+        finalization = verifier.preflight(
+            claimed,
+            receipt_ref=str(receipt_path),
+            uid=uid,
+            account_id=str(user_id),
+            profile_id=str(user_id),
+            profile_class="synthetic",
+            phase="claim_finalization",
+            prior_marker=registration["staged_attestation"],
+        )
+
+        assert finalization["tools"] == []
+        assert finalization["capabilities"] == ["responses_api"]
+        assert finalization["staged_attestation"]["phase"] == "claim_finalization"
+
+    asyncio.run(_run_with_database(scenario))
 
 
 async def _assert_pool_available(pool, runtime_instance_id: str):

--- a/backend/tests/unit/test_hermes_cloud_staged_attestation.py
+++ b/backend/tests/unit/test_hermes_cloud_staged_attestation.py
@@ -106,8 +106,11 @@ def test_protected_receipt_covers_registration_and_exact_finalization(staged_env
         profile_class="synthetic",
         phase="pool_registration",
     )
+    database_binding = _binding()
+    database_binding["allowed_tools"] = json.dumps(database_binding["allowed_tools"])
+    database_binding["required_capabilities"] = json.dumps(database_binding["required_capabilities"])
     finalization = verifier.preflight(
-        _binding(),
+        database_binding,
         receipt_ref=str(path),
         uid=UID,
         account_id=OWNER_ID,
@@ -119,7 +122,66 @@ def test_protected_receipt_covers_registration_and_exact_finalization(staged_env
 
     assert registration["preflight_source"] == "server_staged_attestation"
     assert finalization["staged_attestation"]["phase"] == "claim_finalization"
+    assert finalization["tools"] == []
+    assert finalization["capabilities"] == ["responses_api", "session_key_header"]
     assert finalization["content_free"] is True
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("allowed_tools", "not-json"),
+        ("allowed_tools", json.dumps({"tool": "wrong-shape"})),
+        ("allowed_tools", json.dumps([1])),
+        ("required_capabilities", json.dumps("responses_api")),
+        ("required_capabilities", json.dumps(["responses_api", " "])),
+    ),
+)
+def test_staged_receipt_rejects_malformed_database_string_lists(staged_env, tmp_path, field, value):
+    verifier, path = _protected_receipt(tmp_path)
+    binding = _binding()
+    binding[field] = value
+
+    with pytest.raises(ProvisioningError) as exc:
+        verifier.preflight(
+            binding,
+            receipt_ref=str(path),
+            uid=UID,
+            account_id=OWNER_ID,
+            profile_id=OWNER_ID,
+            profile_class="synthetic",
+            phase="claim_finalization",
+        )
+
+    assert exc.value.code == "hermes_cloud_staged_attestation_pin_mismatch"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("allowed_tools", "[]"),
+        ("allowed_tools", ["tool-b", "tool-a"]),
+        ("required_capabilities", ["responses_api", "responses_api"]),
+        ("required_capabilities", ["responses_api", 1]),
+    ),
+)
+def test_staged_receipt_rejects_noncanonical_pin_arrays(staged_env, tmp_path, field, value):
+    receipt = _receipt()
+    receipt[field] = value
+    verifier, path = _protected_receipt(tmp_path, receipt)
+
+    with pytest.raises(ProvisioningError) as exc:
+        verifier.preflight(
+            _binding(),
+            receipt_ref=str(path),
+            uid=UID,
+            account_id=OWNER_ID,
+            profile_id=OWNER_ID,
+            profile_class="synthetic",
+            phase="pool_registration",
+        )
+
+    assert exc.value.code == "hermes_cloud_staged_attestation_pin_mismatch"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- decode PostgreSQL JSON strings for staged `allowed_tools` and `required_capabilities` pins before comparison
- require attestation pins to remain canonical sorted unique string arrays
- reject malformed JSON, wrong shapes, non-string entries, whitespace-only entries, duplicates, and unsorted receipt arrays
- add a real PostgreSQL claim-to-finalization regression using the actual asyncpg row representation

## Scope

This closes the fail-closed synthetic canary blocker recorded in ellaaicare/ella-ai#1124. It does not change migrations, runtime authority, Plato/Mini routing, flags, secrets, or non-synthetic behavior.

## Validation

- staged attestation plus provider/provisioning/repository unit suite: `64 passed`
- complete Hermes Cloud pool PostgreSQL suite against isolated PostgreSQL 16: `14 passed`
- exact PostgreSQL JSONB regression: passed and proved both fields arrive as strings before verifier normalization
- Black `24.8.0` check: passed
- Python compile: passed
- `git diff --check`: passed
- commit-scoped Gitleaks: no leaks

## Deployment

No deployment or live-state mutation is included. Deployment remains a separate flags-off gate after hosted CI and independent exact-head review.

Closes the source blocker in ellaaicare/ella-ai#1124.
