### PR TITLE
Normalize Hermes Cloud runtime JSONB projections

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -343,7 +343,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 406
+          test "$collected" -eq 412
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -343,7 +343,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 412
+          test "$collected" -eq 428
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \

--- a/backend/ella/services/hermes_cloud.py
+++ b/backend/ella/services/hermes_cloud.py
@@ -45,6 +45,21 @@ def _content_hash(value: Any) -> str:
     return hashlib.sha256(_stable_json(value).encode("utf-8")).hexdigest()
 
 
+def normalize_cloud_json_string_list(value: Any, *, code: str) -> tuple[str, ...]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ProvisioningError(code, retryable=False) from exc
+    if (
+        not isinstance(value, list)
+        or any(not isinstance(item, str) or not item or item.strip() != item for item in value)
+        or len(value) != len(set(value))
+    ):
+        raise ProvisioningError(code, retryable=False)
+    return tuple(sorted(value))
+
+
 def validate_cloud_secret_ref(reference: Optional[str]) -> str:
     reference = str(reference or "").strip()
     if not CLOUD_SECRET_REF_RE.fullmatch(reference):
@@ -294,10 +309,18 @@ class HermesCloudClient:
         prompt_artifacts = validate_prompt_artifact_receipt(binding)
         base_url, token = self.credentials(binding)
         expected_model = str(binding.get("expected_model") or "").strip()
-        allowed_tools = {str(value) for value in (binding.get("allowed_tools") or []) if str(value).strip()}
-        required_capabilities = {
-            str(value) for value in (binding.get("required_capabilities") or []) if str(value).strip()
-        }
+        allowed_tools = set(
+            normalize_cloud_json_string_list(
+                binding.get("allowed_tools"),
+                code="cloud_allowed_tools_policy_invalid",
+            )
+        )
+        required_capabilities = set(
+            normalize_cloud_json_string_list(
+                binding.get("required_capabilities"),
+                code="cloud_required_capabilities_policy_invalid",
+            )
+        )
         if not expected_model:
             raise ProvisioningError("cloud_model_policy_missing", retryable=False)
         if "responses_api" not in required_capabilities or "session_key_header" not in required_capabilities:
@@ -443,6 +466,12 @@ class HermesCloudClient:
                 raise ProvisioningError("cloud_secret_unavailable", retryable=True)
         expected_model = str(binding.get("expected_model") or "").strip()
         model_context_window_tokens = _model_context_window_tokens(binding)
+        allowed_tools = set(
+            normalize_cloud_json_string_list(
+                binding.get("allowed_tools"),
+                code="cloud_allowed_tools_policy_invalid",
+            )
+        )
         if not expected_model:
             raise ProvisioningError("cloud_model_policy_missing", retryable=False)
         if not 1 <= int(max_output_tokens) <= 32768 or not 0 <= int(max_tool_calls) <= 32:
@@ -518,7 +547,6 @@ class HermesCloudClient:
             for item in body.get("output") or []
             if isinstance(item, dict) and item.get("type") == "function_call"
         ]
-        allowed_tools = set(binding.get("allowed_tools") or [])
         if any(name not in allowed_tools for name in unexpected_calls):
             raise ProvisioningError("hermes_cloud_unapproved_tool_call", retryable=False)
         if len(unexpected_calls) > int(max_tool_calls):

--- a/backend/ella/services/hermes_cloud.py
+++ b/backend/ella/services/hermes_cloud.py
@@ -95,6 +95,11 @@ def validate_honcho_base_url(value: str) -> str:
 def validate_prompt_artifact_receipt(binding: dict[str, Any]) -> dict[str, Any]:
     """Validate the persisted server-issued approval receipt."""
     receipt = binding.get("prompt_artifact_receipt")
+    if isinstance(receipt, str):
+        try:
+            receipt = json.loads(receipt)
+        except json.JSONDecodeError:
+            receipt = None
     if not isinstance(receipt, dict):
         raise ProvisioningError("prompt_artifact_receipt_missing", retryable=False)
     prompt_pack_version = str(binding.get("prompt_pack_version") or "").strip()

--- a/backend/ella/services/runtime_resolver.py
+++ b/backend/ella/services/runtime_resolver.py
@@ -150,6 +150,21 @@ def cloud_runtime_authority_identity(runtime: IsolatedRuntime) -> CloudRuntimeAu
     )
 
 
+def _cloud_json_string_list(value, *, code: str) -> tuple[str, ...]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ProvisioningError(code, retryable=False) from exc
+    if (
+        not isinstance(value, list)
+        or any(not isinstance(item, str) or not item or item.strip() != item for item in value)
+        or len(value) != len(set(value))
+    ):
+        raise ProvisioningError(code, retryable=False)
+    return tuple(sorted(value))
+
+
 def runtime_from_binding(binding: dict, uid: str, *, allow_shadow: bool = False) -> IsolatedRuntime:
     if binding.get("omi_uid") != uid:
         raise ProvisioningError("runtime_ownership_mismatch", retryable=False)
@@ -195,6 +210,14 @@ def runtime_from_binding(binding: dict, uid: str, *, allow_shadow: bool = False)
         if str(binding.get("runtime_target_mode") or "") not in CLOUD_RUNTIME_TARGET_MODES:
             raise ProvisioningError("cloud_runtime_target_mode_missing", retryable=False)
         prompt_artifact_receipt = validate_prompt_artifact_receipt(binding)
+        allowed_tools = _cloud_json_string_list(
+            binding.get("allowed_tools"),
+            code="cloud_runtime_allowed_tools_invalid",
+        )
+        required_capabilities = _cloud_json_string_list(
+            binding.get("required_capabilities"),
+            code="cloud_runtime_required_capabilities_invalid",
+        )
         workspace_root = ""
         runtime_instance_id = str(binding.get("runtime_instance_id") or "")
         expected_model = str(binding.get("expected_model") or "")
@@ -242,6 +265,8 @@ def runtime_from_binding(binding: dict, uid: str, *, allow_shadow: bool = False)
             raise ProvisioningError("cloud_runtime_target_lineage_stale", retryable=False)
         gateway_url, gateway_token = HermesCloudClient.credentials(binding)
     else:
+        allowed_tools = tuple(sorted(str(item) for item in (binding.get("allowed_tools") or [])))
+        required_capabilities = tuple(sorted(str(item) for item in (binding.get("required_capabilities") or [])))
         workspace_root = str(binding.get("workspace_root") or "")
         profiles_root = os.getenv("ELLA_HERMES_PROFILES_ROOT", "/Users/ellaai/.hermes/profiles")
         expected_workspace = posixpath.normpath(f"{profiles_root.rstrip('/')}/{profile_name}/workspace")
@@ -296,8 +321,8 @@ def runtime_from_binding(binding: dict, uid: str, *, allow_shadow: bool = False)
         prompt_pack_version=str(binding.get("prompt_pack_version") or binding.get("template_version") or ""),
         expected_model=expected_model,
         model_context_window_tokens=model_context_window_tokens,
-        allowed_tools=tuple(sorted(str(item) for item in (binding.get("allowed_tools") or []))),
-        required_capabilities=tuple(sorted(str(item) for item in (binding.get("required_capabilities") or []))),
+        allowed_tools=allowed_tools,
+        required_capabilities=required_capabilities,
         model_policy_version=str(binding.get("model_policy_version") or ""),
         voice_policy_version=str(binding.get("voice_policy_version") or ""),
         revision=revision,

--- a/backend/ella/services/runtime_resolver.py
+++ b/backend/ella/services/runtime_resolver.py
@@ -27,6 +27,7 @@ from ella.services.ai_consent import (
 )
 from ella.services.hermes_cloud import (
     HermesCloudClient,
+    normalize_cloud_json_string_list,
     validate_prompt_artifact_receipt,
 )
 from ella.services.hermes_cloud_policy import current_cloud_authority
@@ -150,21 +151,6 @@ def cloud_runtime_authority_identity(runtime: IsolatedRuntime) -> CloudRuntimeAu
     )
 
 
-def _cloud_json_string_list(value, *, code: str) -> tuple[str, ...]:
-    if isinstance(value, str):
-        try:
-            value = json.loads(value)
-        except json.JSONDecodeError as exc:
-            raise ProvisioningError(code, retryable=False) from exc
-    if (
-        not isinstance(value, list)
-        or any(not isinstance(item, str) or not item or item.strip() != item for item in value)
-        or len(value) != len(set(value))
-    ):
-        raise ProvisioningError(code, retryable=False)
-    return tuple(sorted(value))
-
-
 def runtime_from_binding(binding: dict, uid: str, *, allow_shadow: bool = False) -> IsolatedRuntime:
     if binding.get("omi_uid") != uid:
         raise ProvisioningError("runtime_ownership_mismatch", retryable=False)
@@ -210,11 +196,11 @@ def runtime_from_binding(binding: dict, uid: str, *, allow_shadow: bool = False)
         if str(binding.get("runtime_target_mode") or "") not in CLOUD_RUNTIME_TARGET_MODES:
             raise ProvisioningError("cloud_runtime_target_mode_missing", retryable=False)
         prompt_artifact_receipt = validate_prompt_artifact_receipt(binding)
-        allowed_tools = _cloud_json_string_list(
+        allowed_tools = normalize_cloud_json_string_list(
             binding.get("allowed_tools"),
             code="cloud_runtime_allowed_tools_invalid",
         )
-        required_capabilities = _cloud_json_string_list(
+        required_capabilities = normalize_cloud_json_string_list(
             binding.get("required_capabilities"),
             code="cloud_runtime_required_capabilities_invalid",
         )

--- a/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
+++ b/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
@@ -19,6 +19,8 @@ from ella.services.hermes_cloud_staged_attestation import (
     UID_SELECTORS,
     StagedAttestationVerifier,
 )
+from ella.services import runtime_resolver
+from ella.services.hermes_cloud_policy import CurrentCloudAuthority
 
 TEST_DSN = os.getenv("ELLA_TEST_POSTGRES_DSN", "").strip()
 MIGRATIONS = Path(__file__).resolve().parents[2] / "migrations"
@@ -624,7 +626,25 @@ def test_completed_usage_interleaving_consumes_no_pool_row():
     asyncio.run(_run_with_database(scenario))
 
 
-def test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets():
+def test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets(monkeypatch):
+    monkeypatch.setenv(
+        "ELLA_HERMES_CLOUD_API_URL_SYNTHETIC",
+        "https://cloud.example.test",
+    )
+    monkeypatch.setenv(
+        "ELLA_HERMES_CLOUD_API_KEY_SYNTHETIC",
+        "synthetic-test-token",
+    )
+    monkeypatch.setattr(
+        runtime_resolver,
+        "current_cloud_authority",
+        lambda uid, **_kwargs: CurrentCloudAuthority(
+            consent_receipt_id=f"receipt-{uid}",
+            profile_binding_id=f"profile-{uid}",
+            lineage=LINEAGE,
+        ),
+    )
+
     async def scenario(pool):
         uid = "synthetic-target-owner"
         instance = "synthetic-instance-target-owner"
@@ -691,6 +711,13 @@ def test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets():
         assert photon["runtime_instance_id"] == instance
         assert photon["target_endpoint_ref"] == photon["api_base_url_ref"]
         assert photon["target_credential_ref"] == photon["api_key_ref"]
+        assert isinstance(photon["prompt_artifact_receipt"], str)
+        assert isinstance(photon["allowed_tools"], str)
+        assert isinstance(photon["required_capabilities"], str)
+        runtime = runtime_resolver.runtime_from_binding(photon, uid)
+        assert runtime.model_context_window_tokens == 16384
+        assert runtime.allowed_tools == ()
+        assert runtime.required_capabilities == ("responses_api",)
 
     asyncio.run(_run_with_database(scenario))
 

--- a/backend/tests/unit/test_hermes_cloud_photon.py
+++ b/backend/tests/unit/test_hermes_cloud_photon.py
@@ -13,7 +13,7 @@ from database.ella_provisioning import RuntimePoolClaimError
 from ella.routers.photon import create_photon_router
 from ella.routers.canonical_events import CanonicalEventIn, InMemoryCanonicalEventStore
 from ella.services import ai_consent, hermes_cloud_photon
-from ella.services.hermes_cloud import HermesCloudPreflight
+from ella.services.hermes_cloud import HermesCloudClient, HermesCloudPreflight
 from ella.services.hermes_cloud_photon import (
     PHOTON_ALLOWED_REGULAR_COMMANDS,
     PHOTON_ALLOWED_TOOLS,
@@ -632,6 +632,93 @@ def test_default_resolver_uses_exact_published_photon_target_for_preflight_and_i
         HERMES_CLOUD_PHOTON_MODE,
         HERMES_CLOUD_PHOTON_MODE,
     ]
+
+
+def test_photon_preflight_accepts_real_postgres_jsonb_projection():
+    artifact_hash = "a" * 64
+
+    class Response:
+        def __init__(self, body):
+            self.status_code = 200
+            self._body = body
+
+        def json(self):
+            return self._body
+
+    class PreflightHttpClient:
+        def __init__(self):
+            self.calls = []
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def get(self, url, **kwargs):
+            self.calls.append((url, kwargs))
+            bodies = {
+                "https://cloud.example.test/health/detailed": {
+                    "status": "ok",
+                    "readiness": {"status": "ok"},
+                },
+                "https://cloud.example.test/v1/capabilities": {
+                    "session_key_header": "X-Hermes-Session-Key",
+                    "features": {"responses_api": True},
+                },
+                "https://cloud.example.test/v1/models": {
+                    "data": [{"id": "gpt-5.6-terra"}],
+                },
+                "https://cloud.example.test/v1/toolsets": [
+                    {
+                        "enabled": True,
+                        "tools": list(PHOTON_ALLOWED_TOOLS),
+                    }
+                ],
+            }
+            return Response(bodies[url])
+
+    class PreflightCloudClient(HermesCloudClient):
+        @staticmethod
+        def credentials(_binding):
+            return "https://cloud.example.test", "synthetic-test-token"
+
+    http_client = PreflightHttpClient()
+    cloud_client = PreflightCloudClient(http_client_factory=lambda **_kwargs: http_client)
+    adapter, repository, _runtime_service = _adapter(cloud=cloud_client)
+    repository.binding.update(
+        {
+            "prompt_pack_version": "prompt-v1",
+            "model_policy_version": "ella-hermes-cloud-v1",
+            "allowed_tools": json.dumps(list(PHOTON_ALLOWED_TOOLS)),
+            "required_capabilities": json.dumps(["responses_api", "session_key_header"]),
+            "prompt_artifact_receipt": json.dumps(
+                {
+                    "schema_version": "ella-hermes-cloud-approval-v1",
+                    "prompt_pack_version": "prompt-v1",
+                    "model_policy_version": "ella-hermes-cloud-v1",
+                    "expected_model": "gpt-5.6-terra",
+                    "model_context_window_tokens": 262144,
+                    "policy_commit_sha": POLICY_SHA,
+                    "lane_s_review_url": "https://github.com/ellaaicare/ella-ai/issues/1124",
+                    "approval_manifest_sha256": MANIFEST_SHA,
+                    "soul_sha256": artifact_hash,
+                    "observed_soul_sha256": artifact_hash,
+                    "agents_sha256": artifact_hash,
+                    "observed_agents_sha256": artifact_hash,
+                    "model_policy_sha256": artifact_hash,
+                    "observed_model_policy_sha256": artifact_hash,
+                },
+                sort_keys=True,
+            ),
+        }
+    )
+
+    result = asyncio.run(adapter.preflight(_preflight()))
+
+    assert result["status"] == "ok"
+    assert result["tools"] == list(PHOTON_ALLOWED_TOOLS)
+    assert len(http_client.calls) == 4
 
 
 def test_sidecar_preflight_turn_replay_and_delivery_ack_are_idempotent_and_opaque():

--- a/backend/tests/unit/test_hermes_cloud_provider.py
+++ b/backend/tests/unit/test_hermes_cloud_provider.py
@@ -1,4 +1,6 @@
 import asyncio
+import json
+
 import pytest
 
 from database.runtime_targets import RuntimeTargetLineage
@@ -164,6 +166,26 @@ def test_preflight_rejects_missing_or_mismatched_prompt_artifacts(cloud_env):
         asyncio.run(
             HermesCloudClient(http_client_factory=lambda **kwargs: FakeClient(_preflight_responses())).preflight(
                 missing
+            )
+        )
+    assert error.value.code == "prompt_artifact_receipt_missing"
+
+    malformed = _binding()
+    malformed["prompt_artifact_receipt"] = "not-json"
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(
+            HermesCloudClient(http_client_factory=lambda **kwargs: FakeClient(_preflight_responses())).preflight(
+                malformed
+            )
+        )
+    assert error.value.code == "prompt_artifact_receipt_missing"
+
+    wrong_shape = _binding()
+    wrong_shape["prompt_artifact_receipt"] = json.dumps([])
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(
+            HermesCloudClient(http_client_factory=lambda **kwargs: FakeClient(_preflight_responses())).preflight(
+                wrong_shape
             )
         )
     assert error.value.code == "prompt_artifact_receipt_missing"
@@ -716,6 +738,100 @@ def test_cloud_runtime_resolver_is_fail_closed_and_contains_no_local_route(cloud
     with pytest.raises(ProvisioningError) as profile:
         runtime_from_binding(binding, "synthetic-user")
     assert profile.value.code == "hermes_cloud_synthetic_profile_required"
+
+
+def test_cloud_runtime_resolver_normalizes_real_postgres_jsonb_projection(cloud_env):
+    binding = {
+        **_binding(),
+        "id": "binding-postgres-jsonb",
+        "omi_uid": "synthetic-user",
+        "provider": "hermes_cloud",
+        "status": "internal_canary",
+        "profile_class": "synthetic",
+        "active": True,
+        "health_state": "healthy",
+        "profile_name": "synthetic-profile",
+        "agent_id": "hermes-cloud",
+        "runtime_instance_id": "instance-postgres-jsonb",
+        "honcho_api_key_ref": None,
+        "honcho_workspace": None,
+        "observed_peer": None,
+        "observer_peer": None,
+        "target_endpoint_ref": "env:ELLA_HERMES_CLOUD_API_URL_SYNTHETIC",
+        "target_credential_ref": "env:ELLA_HERMES_CLOUD_API_KEY_SYNTHETIC",
+        "runtime_target_mode": "hermes-cloud-chat",
+        "voice_policy_version": "voice-v1",
+        "revision": 2,
+        "workspace_root": None,
+        "internal_gateway_url": None,
+        "gateway_port": None,
+        "service_label": None,
+        "credential_ref": None,
+    }
+    binding["prompt_artifact_receipt"] = json.dumps(binding["prompt_artifact_receipt"])
+    binding["allowed_tools"] = json.dumps(binding["allowed_tools"])
+    binding["required_capabilities"] = json.dumps(binding["required_capabilities"])
+
+    runtime = runtime_from_binding(binding, "synthetic-user")
+
+    assert runtime.allowed_tools == ()
+    assert runtime.required_capabilities == ("responses_api", "session_key_header")
+    assert runtime.model_context_window_tokens == 16384
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "code"),
+    (
+        ("allowed_tools", "not-json", "cloud_runtime_allowed_tools_invalid"),
+        ("allowed_tools", json.dumps({"tool": "wrong"}), "cloud_runtime_allowed_tools_invalid"),
+        ("allowed_tools", json.dumps(["tool", "tool"]), "cloud_runtime_allowed_tools_invalid"),
+        ("allowed_tools", json.dumps([" tool"]), "cloud_runtime_allowed_tools_invalid"),
+        (
+            "required_capabilities",
+            json.dumps([1]),
+            "cloud_runtime_required_capabilities_invalid",
+        ),
+    ),
+)
+def test_cloud_runtime_resolver_rejects_invalid_postgres_jsonb_lists(
+    cloud_env,
+    field,
+    value,
+    code,
+):
+    binding = {
+        **_binding(),
+        "id": "binding-invalid-postgres-jsonb",
+        "omi_uid": "synthetic-user",
+        "provider": "hermes_cloud",
+        "status": "internal_canary",
+        "profile_class": "synthetic",
+        "active": True,
+        "health_state": "healthy",
+        "profile_name": "synthetic-profile",
+        "agent_id": "hermes-cloud",
+        "runtime_instance_id": "instance-invalid-postgres-jsonb",
+        "honcho_api_key_ref": None,
+        "honcho_workspace": None,
+        "observed_peer": None,
+        "observer_peer": None,
+        "target_endpoint_ref": "env:ELLA_HERMES_CLOUD_API_URL_SYNTHETIC",
+        "target_credential_ref": "env:ELLA_HERMES_CLOUD_API_KEY_SYNTHETIC",
+        "runtime_target_mode": "hermes-cloud-chat",
+        "voice_policy_version": "voice-v1",
+        "revision": 2,
+        "workspace_root": None,
+        "internal_gateway_url": None,
+        "gateway_port": None,
+        "service_label": None,
+        "credential_ref": None,
+        field: value,
+    }
+
+    with pytest.raises(ProvisioningError) as error:
+        runtime_from_binding(binding, "synthetic-user")
+
+    assert error.value.code == code
 
 
 def test_cloud_runtime_resolver_checks_consent_before_loading_credentials(cloud_env, monkeypatch):

--- a/backend/tests/unit/test_hermes_cloud_provider.py
+++ b/backend/tests/unit/test_hermes_cloud_provider.py
@@ -102,6 +102,13 @@ def _binding():
     }
 
 
+def _postgres_jsonb_binding():
+    binding = _binding()
+    for field in ("prompt_artifact_receipt", "allowed_tools", "required_capabilities"):
+        binding[field] = json.dumps(binding[field], sort_keys=True)
+    return binding
+
+
 def _preflight_responses(toolsets=None):
     base = "https://cloud.example.test"
     return {
@@ -135,6 +142,51 @@ def test_preflight_requires_exact_model_capabilities_and_tools(cloud_env):
     assert receipt.capabilities == ("responses_api", "session_key_header")
     assert receipt.receipt["content_free"] is True
     assert all(call[2]["headers"]["Authorization"] == "Bearer cloud-secret" for call in fake.calls)
+
+
+def test_preflight_normalizes_real_postgres_jsonb_projection(cloud_env):
+    fake = FakeClient(_preflight_responses())
+
+    receipt = asyncio.run(
+        HermesCloudClient(http_client_factory=lambda **kwargs: fake).preflight(_postgres_jsonb_binding())
+    )
+
+    assert receipt.model == "model-a"
+    assert receipt.tools == ()
+    assert receipt.capabilities == ("responses_api", "session_key_header")
+    assert len(fake.calls) == 4
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "code"),
+    [
+        (field, value, f"cloud_{field}_policy_invalid")
+        for field in ("allowed_tools", "required_capabilities")
+        for value in (
+            "not-json",
+            json.dumps({"wrong": "shape"}),
+            json.dumps([1]),
+            json.dumps([""]),
+            json.dumps([" untrimmed"]),
+            json.dumps(["duplicate", "duplicate"]),
+        )
+    ],
+)
+def test_preflight_rejects_invalid_postgres_jsonb_policy_lists(
+    cloud_env,
+    field,
+    value,
+    code,
+):
+    binding = _postgres_jsonb_binding()
+    binding[field] = value
+    fake = FakeClient(_preflight_responses())
+
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(HermesCloudClient(http_client_factory=lambda **kwargs: fake).preflight(binding))
+
+    assert error.value.code == code
+    assert fake.calls == []
 
 
 def test_preflight_rejects_unexpected_enabled_tool(cloud_env):
@@ -266,9 +318,11 @@ def test_responses_api_uses_distinct_session_headers_and_idempotency(cloud_env):
             )
         }
     )
+    binding = _binding()
+    binding["allowed_tools"] = json.dumps(binding["allowed_tools"])
     turn = asyncio.run(
         HermesCloudClient(http_client_factory=lambda **kwargs: fake).create_response(
-            _binding(),
+            binding,
             session_key="stable-memory-key",
             hermes_session_id="single-interaction-id",
             idempotency_key="request-id",
@@ -314,6 +368,35 @@ def test_responses_api_validation_failure_does_not_cross_provider_boundary(cloud
         )
 
     assert error.value.code == "hermes_cloud_turn_budget_invalid"
+    assert boundary == []
+
+
+def test_responses_api_rejects_invalid_jsonb_tool_policy_before_provider_boundary(cloud_env):
+    boundary = []
+    binding = _binding()
+    binding["allowed_tools"] = json.dumps([" untrimmed"])
+
+    async def mark_boundary():
+        boundary.append("provider_send")
+
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(
+            HermesCloudClient(
+                http_client_factory=lambda **_kwargs: pytest.fail("client must not be created for invalid tool policy")
+            ).create_response(
+                binding,
+                session_key="scope",
+                hermes_session_id="interaction",
+                idempotency_key="request",
+                user_input="Synthetic",
+                instructions="Synthetic",
+                max_output_tokens=128,
+                max_tool_calls=0,
+                before_provider_send=mark_boundary,
+            )
+        )
+
+    assert error.value.code == "cloud_allowed_tools_policy_invalid"
     assert boundary == []
 
 

--- a/backend/tests/unit/test_hermes_cloud_provisioning.py
+++ b/backend/tests/unit/test_hermes_cloud_provisioning.py
@@ -1,11 +1,12 @@
 import asyncio
+import json
 from types import SimpleNamespace
 
 import pytest
 
 from database.runtime_targets import RuntimeTargetLineage
 from ella.services import provisioning
-from ella.services.hermes_cloud import HermesCloudPreflight
+from ella.services.hermes_cloud import HermesCloudClient, HermesCloudPreflight
 from ella.services.hermes_cloud_policy import CurrentCloudAuthority
 from ella.services.provisioning import (
     HermesProvisionClient,
@@ -245,6 +246,98 @@ def test_cloud_claim_preflights_vendor_without_honcho_before_atomic_publish(monk
     assert repository.jobs[-1]["state"] == "ready"
     assert alert.calls[0]["available"] == 1
     assert repository.delivered_alerts == ["alert-a"]
+
+
+def test_nonstaged_finalization_accepts_real_postgres_jsonb_projection(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS", "synthetic-user")
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_SYNTHETIC_UIDS", "synthetic-user")
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_API_URL_SYNTHETIC", "https://cloud.example.test")
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_API_KEY_SYNTHETIC", "synthetic-test-token")
+    artifact_hash = "a" * 64
+
+    class AsyncpgProjectionRepository(FakeRepository):
+        async def claim_cloud_pool_binding(self, **kwargs):
+            binding = await super().claim_cloud_pool_binding(**kwargs)
+            binding.update(
+                {
+                    "prompt_pack_version": "prompt-v1",
+                    "model_policy_version": "models-v1",
+                    "allowed_tools": json.dumps([]),
+                    "required_capabilities": json.dumps(["responses_api", "session_key_header"]),
+                    "prompt_artifact_receipt": json.dumps(
+                        {
+                            "schema_version": "ella-hermes-cloud-approval-v1",
+                            "prompt_pack_version": "prompt-v1",
+                            "model_policy_version": "models-v1",
+                            "expected_model": "model-a",
+                            "model_context_window_tokens": 16384,
+                            "policy_commit_sha": "b" * 40,
+                            "lane_s_review_url": "https://github.com/ellaaicare/ella-ai/issues/1124",
+                            "approval_manifest_sha256": "c" * 64,
+                            "soul_sha256": artifact_hash,
+                            "observed_soul_sha256": artifact_hash,
+                            "agents_sha256": artifact_hash,
+                            "observed_agents_sha256": artifact_hash,
+                            "model_policy_sha256": artifact_hash,
+                            "observed_model_policy_sha256": artifact_hash,
+                        },
+                        sort_keys=True,
+                    ),
+                }
+            )
+            return binding
+
+    class Response:
+        def __init__(self, body):
+            self.status_code = 200
+            self._body = body
+
+        def json(self):
+            return self._body
+
+    class PreflightHttpClient:
+        def __init__(self):
+            self.calls = []
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def get(self, url, **kwargs):
+            self.calls.append((url, kwargs))
+            bodies = {
+                "https://cloud.example.test/health/detailed": {
+                    "status": "ok",
+                    "readiness": {"status": "ok"},
+                },
+                "https://cloud.example.test/v1/capabilities": {
+                    "session_key_header": "X-Hermes-Session-Key",
+                    "features": {"responses_api": True},
+                },
+                "https://cloud.example.test/v1/models": {"data": [{"id": "model-a"}]},
+                "https://cloud.example.test/v1/toolsets": [],
+            }
+            return Response(bodies[url])
+
+    repository = AsyncpgProjectionRepository()
+    http_client = PreflightHttpClient()
+    coordinator = ProvisioningCoordinator(
+        repository,
+        ForbiddenLocalClient(),
+        cloud_client=HermesCloudClient(http_client_factory=lambda **_kwargs: http_client),
+        honcho_client=FakeHoncho(),
+        alert_publisher=FakeAlert(),
+        runtime_admission=allow_runtime,
+    )
+
+    asyncio.run(coordinator.process_claimed_job(job=_job(), identity=_identity()))
+
+    assert len(http_client.calls) == 4
+    assert len(repository.finalized) == 1
+    assert repository.jobs[-1]["state"] == "ready"
+    assert repository.quarantined == []
 
 
 def test_cloud_claim_finalization_revalidates_staged_receipt_without_direct_preflight(monkeypatch):


### PR DESCRIPTION
## Summary
- decode PostgreSQL JSONB projections for prompt receipts, allowed tools, and required capabilities at the cloud runtime boundary
- fail closed on malformed, wrong-shape, non-canonical, or duplicate list values
- exercise the real asyncpg string projection through runtime resolution and raise the focused CI inventory to 412

## Validation
- 80 focused unit tests passed
- full local CI-shaped suite: 373 passed, 39 PostgreSQL tests skipped because the Mini container snapshot volume is full
- exact collection: 412
- Black 24.8.0, compileall, git diff --check passed
- Gitleaks: no leaks in the commit

Hosted PostgreSQL CI is required before merge and deployment. This is the minimal follow-up for the fail-closed canary finding recorded on ellaaicare/ella-ai#1124.