### PR TITLE
Fix broker consent authority epoch propagation

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -343,7 +343,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 428
+          test "$collected" -eq 431
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -2702,6 +2702,9 @@ class EllaProvisioningRepository:
                         or str(entitlement.get("consent_scope_hash") or "") != lineage.scope_hash
                     ):
                         raise RuntimePoolClaimError("runtime_cloud_entitlement_lineage_stale")
+                    consent_authority_epoch = str(entitlement.get("consent_authority_epoch") or "").strip()
+                    if not consent_authority_epoch:
+                        raise RuntimePoolClaimError("runtime_cloud_consent_authority_epoch_missing")
                     result = dict(row)
                     result["runtime_target_id"] = str(row["resolved_target_id"])
                     result["runtime_target_mode"] = str(row["resolved_target_mode"])
@@ -2709,6 +2712,7 @@ class EllaProvisioningRepository:
                     result["target_credential_ref"] = str(row["resolved_target_credential_ref"])
                     result["target_entitlement_revision"] = int(row["target_entitlement_revision"])
                     result["runtime_target_updated_at"] = str(row["resolved_target_updated_at"])
+                    result["consent_authority_epoch"] = consent_authority_epoch
                     return result
         if required_provider not in {None, "hermes"}:
             raise ValueError("invalid_runtime_provider")

--- a/backend/ella/services/hermes_cloud_runtime.py
+++ b/backend/ella/services/hermes_cloud_runtime.py
@@ -307,7 +307,6 @@ class HermesCloudRuntimeService:
         scope: Mapping[str, Any],
         claimed: Mapping[str, Any],
         budget: Mapping[str, int],
-        grant_epoch: str,
         mark_provider_send_boundary: Callable[[], Awaitable[tuple[str, str]]],
     ) -> HermesCloudTurn:
         """Direct `/v1/responses` or allowlisted broker prototype transport."""
@@ -342,6 +341,12 @@ class HermesCloudRuntimeService:
                 "hermes_broker_prototype_owner_coordinates_missing",
                 retryable=False,
             )
+        consent_authority_epoch = str(runtime.consent_authority_epoch or "").strip()
+        if not consent_authority_epoch:
+            raise ProvisioningError(
+                "hermes_broker_prototype_consent_authority_epoch_missing",
+                retryable=False,
+            )
         await mark_provider_send_boundary()
         client = self.broker_client_factory(prototype_config)
         source_event_id = str(request.client_interaction_id or request.correlation_id)
@@ -352,7 +357,7 @@ class HermesCloudRuntimeService:
                 account_id=account_user_id,
                 profile_id=profile_user_id,
                 runtime_binding_ref=str(runtime.binding_id),
-                consent_epoch=str(grant_epoch),
+                consent_epoch=consent_authority_epoch,
                 source_event_id=source_event_id,
                 transcript_segments=[
                     {"speaker": "user", "text": request.user_input[:8000]},
@@ -364,7 +369,7 @@ class HermesCloudRuntimeService:
                 account_id=account_user_id,
                 profile_id=profile_user_id,
                 runtime_binding_ref=str(runtime.binding_id),
-                consent_epoch=str(grant_epoch),
+                consent_epoch=consent_authority_epoch,
                 message=request.user_input,
                 session_key=str(scope["session_key"]),
                 session_id=str(claimed["hermes_session_id"]),
@@ -668,7 +673,6 @@ class HermesCloudRuntimeService:
                 scope=scope,
                 claimed=claimed,
                 budget=budget,
-                grant_epoch=current_grant_epoch,
                 mark_provider_send_boundary=mark_provider_send_boundary,
             )
             provider_response_ids = [turn.response_id]

--- a/backend/ella/services/runtime_resolver.py
+++ b/backend/ella/services/runtime_resolver.py
@@ -10,6 +10,7 @@ import posixpath
 from dataclasses import dataclass
 from typing import Optional
 from urllib.parse import urlparse
+from uuid import UUID
 
 from database.ella_provisioning import (
     EllaProvisioningRepository,
@@ -86,6 +87,7 @@ class IsolatedRuntime:
     target_endpoint_ref: str = ""
     target_credential_ref: str = ""
     target_entitlement_revision: int = 0
+    consent_authority_epoch: str = ""
     # Canonical broker/authority owner coordinates (users.id UUIDs), not omi_uid.
     account_user_id: str = ""
     profile_user_id: str = ""
@@ -110,6 +112,7 @@ def cloud_runtime_authority_identity(runtime: IsolatedRuntime) -> CloudRuntimeAu
         or not runtime.target_endpoint_ref
         or not runtime.target_credential_ref
         or runtime.target_entitlement_revision < 1
+        or not runtime.consent_authority_epoch
     ):
         raise ProvisioningError("hermes_cloud_runtime_target_identity_missing", retryable=False)
     material = {
@@ -123,6 +126,7 @@ def cloud_runtime_authority_identity(runtime: IsolatedRuntime) -> CloudRuntimeAu
         "target_endpoint_ref": runtime.target_endpoint_ref,
         "target_credential_ref": runtime.target_credential_ref,
         "target_entitlement_revision": runtime.target_entitlement_revision,
+        "consent_authority_epoch": runtime.consent_authority_epoch,
         "endpoint_sha256": hashlib.sha256(runtime.gateway_url.encode("utf-8")).hexdigest(),
         "credential_sha256": hashlib.sha256(runtime.gateway_token.encode("utf-8")).hexdigest(),
         "profile_class": runtime.profile_class,
@@ -249,6 +253,13 @@ def runtime_from_binding(binding: dict, uid: str, *, allow_shadow: bool = False)
         )
         if stored_lineage.validate() != authority.lineage:
             raise ProvisioningError("cloud_runtime_target_lineage_stale", retryable=False)
+        try:
+            consent_authority_epoch = str(UUID(str(binding.get("consent_authority_epoch") or "").strip()))
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise ProvisioningError(
+                "cloud_runtime_consent_authority_epoch_invalid",
+                retryable=False,
+            ) from exc
         gateway_url, gateway_token = HermesCloudClient.credentials(binding)
     else:
         allowed_tools = tuple(sorted(str(item) for item in (binding.get("allowed_tools") or [])))
@@ -270,6 +281,7 @@ def runtime_from_binding(binding: dict, uid: str, *, allow_shadow: bool = False)
         runtime_instance_id = ""
         expected_model = str(binding.get("agent_id") or "")
         model_context_window_tokens = 0
+        consent_authority_epoch = ""
 
     honcho_workspace = str(binding.get("honcho_workspace") or "")
     observed_peer = str(binding.get("observed_peer") or "")
@@ -325,6 +337,7 @@ def runtime_from_binding(binding: dict, uid: str, *, allow_shadow: bool = False)
         target_endpoint_ref=str(binding.get("target_endpoint_ref") or ""),
         target_credential_ref=str(binding.get("target_credential_ref") or ""),
         target_entitlement_revision=int(binding.get("target_entitlement_revision") or 0),
+        consent_authority_epoch=consent_authority_epoch,
         account_user_id=account_user_id,
         profile_user_id=profile_user_id,
     )

--- a/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
+++ b/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
@@ -287,13 +287,31 @@ async def _seed_claim(
             """,
             user_id,
         )
+        consent_authority_epoch = await conn.fetchval(
+            """
+            INSERT INTO ella_managed_cloud_consent_authority (
+                user_id, decision, consent_receipt_ref, profile_binding_id,
+                policy_version, processor_set_hash, scope_version, scope_hash
+            ) VALUES (
+                $1, 'granted', $2, $3, $4, $5, $6, $7
+            )
+            RETURNING authority_epoch
+            """,
+            user_id,
+            "sha256:" + ("f" * 64),
+            uid,
+            LINEAGE.policy_version,
+            LINEAGE.processor_set_hash,
+            LINEAGE.scope_version,
+            LINEAGE.scope_hash,
+        )
         await conn.execute(
             """
             INSERT INTO voice_entitlements (
                 uid, status, provider_allowlist, model_allowlist, mode_allowlist,
                 daily_limit_s, consent_policy_version,
                 consent_processor_set_hash, consent_scope_version,
-                consent_scope_hash
+                consent_scope_hash, consent_authority_epoch
             ) VALUES (
                 $1, 'active', ARRAY['hermes_cloud'], ARRAY[$2],
                 ARRAY[
@@ -301,7 +319,7 @@ async def _seed_claim(
                     'hermes-cloud-transcript', 'hermes-cloud-guardian',
                     'hermes-cloud-photon'
                 ],
-                $3, $4, $5, $6, $7
+                $3, $4, $5, $6, $7, $8
             )
             """,
             uid,
@@ -311,6 +329,7 @@ async def _seed_claim(
             LINEAGE.processor_set_hash,
             LINEAGE.scope_version,
             LINEAGE.scope_hash,
+            consent_authority_epoch,
         )
     repository = EllaProvisioningRepository(pool)
     await repository.register_cloud_pool_binding(
@@ -1083,6 +1102,16 @@ def test_resolution_rechecks_kill_switch_and_never_returns_retained_binding():
         assert resolved["target_endpoint_ref"] == resolved["api_base_url_ref"]
         assert resolved["target_credential_ref"] == resolved["api_key_ref"]
         assert resolved["target_entitlement_revision"] == revision
+        async with pool.acquire() as conn:
+            consent_authority_epoch = await conn.fetchval(
+                """
+                SELECT consent_authority_epoch
+                FROM voice_entitlements
+                WHERE uid = $1
+                """,
+                uid,
+            )
+        assert resolved["consent_authority_epoch"] == str(consent_authority_epoch)
 
         async with pool.acquire() as conn:
             await voice_canary.set_kill_switch_on_connection(

--- a/backend/tests/unit/test_hermes_broker_prototype.py
+++ b/backend/tests/unit/test_hermes_broker_prototype.py
@@ -28,6 +28,7 @@ AUTH_UID = "omi-auth-uid-synth-01"
 ACCOUNT_UUID = "11111111-1111-4111-8111-111111111111"
 PROFILE_UUID = "22222222-2222-4222-8222-222222222222"
 BINDING_ID = "33333333-3333-4333-8333-333333333333"
+CONSENT_AUTHORITY_EPOCH = "44444444-4444-4444-8444-444444444444"
 
 
 def _runtime(
@@ -36,6 +37,7 @@ def _runtime(
     account_user_id: str = ACCOUNT_UUID,
     profile_user_id: str = PROFILE_UUID,
     binding_id: str = BINDING_ID,
+    consent_authority_epoch: str = CONSENT_AUTHORITY_EPOCH,
     profile_class: str = "synthetic",
     provider: str = "hermes_cloud",
     mode: str = HERMES_CLOUD_CHAT_MODE,
@@ -69,6 +71,7 @@ def _runtime(
         target_endpoint_ref="env:URL",
         target_credential_ref="env:KEY",
         target_entitlement_revision=1,
+        consent_authority_epoch=consent_authority_epoch,
         account_user_id=account_user_id,
         profile_user_id=profile_user_id,
     )
@@ -845,7 +848,6 @@ def test_provider_turn_uses_direct_when_not_allowlisted(monkeypatch):
             scope={"session_key": "sk"},
             claimed={"hermes_session_id": "sid", "idempotency_key": "ik"},
             budget={"max_output_tokens": 64, "max_tool_calls": 0},
-            grant_epoch="ge",
             mark_provider_send_boundary=boundary,
         )
     )
@@ -903,7 +905,6 @@ def test_provider_turn_submits_owner_uuids_not_auth_uid(monkeypatch):
             scope={"session_key": "sk"},
             claimed={"hermes_session_id": "sid", "idempotency_key": "ik"},
             budget={"max_output_tokens": 64, "max_tool_calls": 0},
-            grant_epoch="ge",
             mark_provider_send_boundary=boundary,
         )
     )
@@ -912,6 +913,41 @@ def test_provider_turn_submits_owner_uuids_not_auth_uid(monkeypatch):
     assert seen["profile_id"] == PROFILE_UUID
     assert seen["account_id"] != AUTH_UID
     assert seen["runtime_binding_ref"] == BINDING_ID
+    assert seen["consent_epoch"] == CONSENT_AUTHORITY_EPOCH
+
+
+def test_provider_turn_rejects_missing_persisted_consent_authority_epoch(monkeypatch):
+    _enable(monkeypatch)
+    service = HermesCloudRuntimeService(
+        repository=object(),  # type: ignore[arg-type]
+        event_store=object(),  # type: ignore[arg-type]
+    )
+
+    async def boundary():
+        raise AssertionError("provider boundary must not run")
+
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(
+            service._provider_turn(
+                runtime=_runtime(consent_authority_epoch=""),
+                request=HermesCloudTurnRequest(
+                    uid=AUTH_UID,
+                    client_interaction_id="evt-1",
+                    correlation_id="c1",
+                    channel="ios_chat",
+                    user_input="hi",
+                    instructions="sys",
+                    started_at=datetime.now(timezone.utc),
+                    client_metadata={},
+                ),
+                scope={"session_key": "sk"},
+                claimed={"hermes_session_id": "sid", "idempotency_key": "ik"},
+                budget={"max_output_tokens": 64, "max_tool_calls": 0},
+                mark_provider_send_boundary=boundary,
+            )
+        )
+
+    assert error.value.code == "hermes_broker_prototype_consent_authority_epoch_missing"
 
 
 def test_enrichment_channel_uses_transcript_lane(monkeypatch):
@@ -963,7 +999,6 @@ def test_enrichment_channel_uses_transcript_lane(monkeypatch):
             scope={"session_key": "sk"},
             claimed={"hermes_session_id": "sid", "idempotency_key": "ik"},
             budget={"max_output_tokens": 64, "max_tool_calls": 0},
-            grant_epoch="ge",
             mark_provider_send_boundary=boundary,
         )
     )

--- a/backend/tests/unit/test_hermes_cloud_photon.py
+++ b/backend/tests/unit/test_hermes_cloud_photon.py
@@ -157,6 +157,7 @@ def _runtime(**updates) -> IsolatedRuntime:
         target_endpoint_ref="secret://hermes-cloud/api-base",
         target_credential_ref="secret://hermes-cloud/api-key",
         target_entitlement_revision=1,
+        consent_authority_epoch="44444444-4444-4444-8444-444444444444",
     )
     values.update(updates)
     return IsolatedRuntime(**values)

--- a/backend/tests/unit/test_hermes_cloud_provider.py
+++ b/backend/tests/unit/test_hermes_cloud_provider.py
@@ -74,6 +74,7 @@ def _binding():
         "id": "binding-a",
         "account_user_id": "11111111-1111-4111-8111-111111111111",
         "profile_user_id": "11111111-1111-4111-8111-111111111111",
+        "consent_authority_epoch": "44444444-4444-4444-8444-444444444444",
         "api_base_url_ref": "env:ELLA_HERMES_CLOUD_API_URL_SYNTHETIC",
         "api_key_ref": "env:ELLA_HERMES_CLOUD_API_KEY_SYNTHETIC",
         "honcho_api_key_ref": "env:ELLA_HONCHO_CLOUD_API_KEY_SYNTHETIC",
@@ -810,6 +811,7 @@ def test_cloud_runtime_resolver_is_fail_closed_and_contains_no_local_route(cloud
     assert runtime.gateway_url == "https://cloud.example.test"
     assert runtime.workspace_root == ""
     assert runtime.model_context_window_tokens == 16384
+    assert runtime.consent_authority_epoch == "44444444-4444-4444-8444-444444444444"
 
     binding["workspace_root"] = "/Users/ellaai/.hermes/profiles/legacy"
     with pytest.raises(ProvisioningError) as error:
@@ -821,6 +823,42 @@ def test_cloud_runtime_resolver_is_fail_closed_and_contains_no_local_route(cloud
     with pytest.raises(ProvisioningError) as profile:
         runtime_from_binding(binding, "synthetic-user")
     assert profile.value.code == "hermes_cloud_synthetic_profile_required"
+
+
+def test_cloud_runtime_resolver_requires_persisted_consent_authority_epoch(cloud_env):
+    binding = {
+        **_binding(),
+        "id": "binding-missing-consent-authority",
+        "omi_uid": "synthetic-user",
+        "provider": "hermes_cloud",
+        "status": "internal_canary",
+        "profile_class": "synthetic",
+        "active": True,
+        "health_state": "healthy",
+        "profile_name": "synthetic-profile",
+        "agent_id": "hermes-cloud",
+        "runtime_instance_id": "instance-missing-consent-authority",
+        "honcho_api_key_ref": None,
+        "honcho_workspace": None,
+        "observed_peer": None,
+        "observer_peer": None,
+        "target_endpoint_ref": "env:ELLA_HERMES_CLOUD_API_URL_SYNTHETIC",
+        "target_credential_ref": "env:ELLA_HERMES_CLOUD_API_KEY_SYNTHETIC",
+        "runtime_target_mode": "hermes-cloud-chat",
+        "voice_policy_version": "voice-v1",
+        "revision": 2,
+        "workspace_root": None,
+        "internal_gateway_url": None,
+        "gateway_port": None,
+        "service_label": None,
+        "credential_ref": None,
+        "consent_authority_epoch": None,
+    }
+
+    with pytest.raises(ProvisioningError) as error:
+        runtime_from_binding(binding, "synthetic-user")
+
+    assert error.value.code == "cloud_runtime_consent_authority_epoch_invalid"
 
 
 def test_cloud_runtime_resolver_normalizes_real_postgres_jsonb_projection(cloud_env):

--- a/backend/tests/unit/test_hermes_cloud_runtime.py
+++ b/backend/tests/unit/test_hermes_cloud_runtime.py
@@ -79,6 +79,7 @@ def _runtime(**updates) -> IsolatedRuntime:
         target_endpoint_ref="env:ELLA_HERMES_CLOUD_API_URL_SYNTHETIC",
         target_credential_ref="env:ELLA_HERMES_CLOUD_API_KEY_SYNTHETIC",
         target_entitlement_revision=3,
+        consent_authority_epoch="44444444-4444-4444-8444-444444444444",
     )
     values.update(updates)
     return IsolatedRuntime(**values)
@@ -744,6 +745,7 @@ def test_synthetic_consent_revoked_at_provider_boundary_hook_blocks_send(monkeyp
         ("endpoint", "hermes_cloud_runtime_authority_changed"),
         ("credential", "hermes_cloud_runtime_authority_changed"),
         ("entitlement_revision", "hermes_cloud_runtime_authority_changed"),
+        ("consent_authority_epoch", "hermes_cloud_runtime_authority_changed"),
     ),
 )
 def test_runtime_authority_change_at_provider_boundary_blocks_send(
@@ -797,6 +799,7 @@ def test_runtime_authority_change_at_provider_boundary_blocks_send(
             "endpoint": {"gateway_url": "https://replacement.example.test"},
             "credential": {"gateway_token": "replacement-secret"},
             "entitlement_revision": {"target_entitlement_revision": 4},
+            "consent_authority_epoch": {"consent_authority_epoch": "55555555-5555-4555-8555-555555555555"},
         }
         if change in updates:
             current = _runtime(**updates[change])


### PR DESCRIPTION
Closes the observed isolated canary refusal on ellaaicare/ella-ai#1124 without changing global rollout behavior.

The Hermes broker correctly requires the PostgreSQL managed-cloud consent authority epoch, while OMI was sending its Firestore policy grant epoch. This change projects the locked entitlement authority epoch into the resolved runtime, binds it into runtime revalidation, and submits it only on the allowlisted broker path. Missing, invalid, or rotated epochs fail closed before provider send.

Evidence:
- exact base: `66b6c4e81a54704ab21bf7f477f67304750f6235`
- exact head: `c47c3e09b4f9eb5a816b48a30fa04dff2a2fcfff`
- hosted collection sentinel: 431
- local focused gate: 431 passed; no skips/deselections
- PostgreSQL Hermes pool: 14 passed
- supporting unit suites: 151 + 38 passed
- Black 24.8.0, compile, YAML, diff check, and Gitleaks green

No deployment, flag, vendor, billing, credential, user, route, Plato, or traffic mutation is part of this PR.