### PR TITLE
Close Hermes SSE and envelope contract gaps

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -324,6 +324,7 @@ jobs:
 
       - name: Run Hermes Cloud and isolation failure-path tests
         run: |
+          set -euo pipefail
           collected="$(
             pytest --collect-only -q \
               tests/unit/test_ella_ai_consent.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -68,6 +68,9 @@ on:
       - "backend/tests/postgres/test_authority_advisory_lock_postgres.py"
       - "backend/tests/postgres/test_invitation_redemption_postgres.py"
       - "backend/tests/postgres/test_runtime_migration_atomicity_postgres.py"
+      - "backend/tests/fixtures/hermes_binding_envelope_v1.json"
+      - "backend/tests/fixtures/hermes_binding_envelope_v1.schema.json"
+      - "backend/tests/unit/test_hermes_binding_envelope_contract.py"
       - "backend/tests/unit/test_ella_ai_consent.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
       - "backend/tests/unit/test_ella_runtime_route_isolation.py"
@@ -151,6 +154,9 @@ on:
       - "backend/tests/postgres/test_authority_advisory_lock_postgres.py"
       - "backend/tests/postgres/test_invitation_redemption_postgres.py"
       - "backend/tests/postgres/test_runtime_migration_atomicity_postgres.py"
+      - "backend/tests/fixtures/hermes_binding_envelope_v1.json"
+      - "backend/tests/fixtures/hermes_binding_envelope_v1.schema.json"
+      - "backend/tests/unit/test_hermes_binding_envelope_contract.py"
       - "backend/tests/unit/test_ella_ai_consent.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
       - "backend/tests/unit/test_ella_runtime_route_isolation.py"
@@ -213,6 +219,7 @@ jobs:
           "fastapi==0.112.0"
           "firebase-admin==6.5.0"
           "httpx==0.28.0"
+          "jsonschema==4.23.0"
           "PyJWT==2.9.0"
           "pytest==8.3.2"
           "openapi-spec-validator==0.7.1"
@@ -302,6 +309,7 @@ jobs:
           tests/unit/test_hermes_cloud_enrichment.py
           tests/unit/test_hermes_cloud_photon.py
           tests/unit/test_hermes_broker_prototype.py
+          tests/unit/test_hermes_binding_envelope_contract.py
           tests/unit/test_hermes_cloud_provider.py
           tests/unit/test_hermes_cloud_runtime.py
           tests/unit/test_hermes_cloud_staged_attestation.py
@@ -324,6 +332,7 @@ jobs:
               tests/unit/test_hermes_cloud_openapi.py \
               tests/unit/test_hermes_cloud_policy.py \
               tests/unit/test_hermes_broker_prototype.py \
+              tests/unit/test_hermes_binding_envelope_contract.py \
               tests/unit/test_hermes_cloud_photon.py \
               tests/unit/test_hermes_cloud_provider.py \
               tests/unit/test_hermes_cloud_provisioning.py \
@@ -343,7 +352,23 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 431
+          required_ids=(
+            "tests/unit/test_hermes_binding_envelope_contract.py::test_hermes_binding_envelope_v1_identity_and_content_free_shape"
+            "tests/unit/test_hermes_binding_envelope_contract.py::test_omi_request_uses_exact_stock_contract_from_shared_envelope"
+            "tests/unit/test_ella_runtime_route_isolation.py::test_cloud_chat_failure_still_emits_one_terminal_marker"
+            "tests/postgres/test_hermes_cloud_pool_postgres.py::test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets"
+          )
+          collected_ids="$(
+            pytest --collect-only -q \
+              tests/unit/test_hermes_binding_envelope_contract.py \
+              tests/unit/test_ella_runtime_route_isolation.py \
+              tests/postgres/test_hermes_cloud_pool_postgres.py |
+              sed '/^$/d'
+          )"
+          for required_id in "${required_ids[@]}"; do
+            grep -Fqx "$required_id" <<<"$collected_ids"
+          done
+          test "$collected" -ge 431
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \
@@ -351,6 +376,7 @@ jobs:
             tests/unit/test_hermes_cloud_openapi.py \
             tests/unit/test_hermes_cloud_policy.py \
             tests/unit/test_hermes_broker_prototype.py \
+            tests/unit/test_hermes_binding_envelope_contract.py \
             tests/unit/test_hermes_cloud_photon.py \
             tests/unit/test_hermes_cloud_provider.py \
             tests/unit/test_hermes_cloud_provisioning.py \
@@ -368,7 +394,8 @@ jobs:
             tests/postgres/test_hermes_cloud_pool_postgres.py \
             tests/postgres/test_invitation_redemption_postgres.py \
             tests/postgres/test_runtime_migration_atomicity_postgres.py \
-            -v
+            -v | tee /tmp/hermes-cloud-runtime-pytest.log
+          ! grep -Eq '[0-9]+ skipped' /tmp/hermes-cloud-runtime-pytest.log
 
       - name: Run exact reviewed boundary collections
         run: |

--- a/backend/ella/routers/chat.py
+++ b/backend/ella/routers/chat.py
@@ -990,7 +990,24 @@ async def _stream_hermes_cloud_chat(
             exc.code,
             exc.retryable,
         )
-        yield "data: Ella is temporarily unavailable. Please try again.\n\n"
+        error_text = "Ella is temporarily unavailable. Please try again."
+        yield f"data: {error_text}\n\n"
+        # OMI's SSE parser requires one terminal frame for every HTTP 200
+        # stream, including fail-closed provider admission failures.
+        message = {
+            "id": f"hermes-error:{turn_id}",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "text": error_text,
+            "sender": "ai",
+            "type": "text",
+            "plugin_id": None,
+            "from_integration": False,
+            "memories": [],
+            "files": [],
+            "ask_for_nps": False,
+        }
+        encoded = base64.b64encode(json.dumps(message).encode()).decode()
+        yield f"done: {encoded}\n\n"
 
 
 @router.post("/chat/stream")

--- a/backend/tests/fixtures/hermes_binding_envelope_v1.json
+++ b/backend/tests/fixtures/hermes_binding_envelope_v1.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "ella-hermes-binding-envelope-v1",
+  "uid": "staging-synthetic-contract-v1",
+  "account_id": "11111111-1111-4111-8111-111111111111",
+  "profile_id": "11111111-1111-4111-8111-111111111111",
+  "binding": {
+    "id": "33333333-3333-4333-8333-333333333333",
+    "provider": "hermes_cloud",
+    "status": "internal_canary",
+    "active": true,
+    "profile_class": "synthetic",
+    "profile_binding_id": "aipb_5b348159cda2e56e494e83eef28394a9",
+    "runtime_instance_id": "synthetic-contract-instance-v1",
+    "runtime_target_id": "44444444-4444-4444-8444-444444444444",
+    "runtime_target_mode": "hermes-cloud-chat",
+    "expected_model": "gpt-5.6-terra",
+    "prompt_artifact_receipt": {
+      "schema_version": "ella-hermes-cloud-approval-v1",
+      "policy_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "lane_s_review_url": "https://github.com/ellaaicare/ella-ai/pull/1138",
+      "prompt_pack_version": "ella-hermes-cloud-v1c-canary",
+      "model_policy_version": "ella-hermes-cloud-v1c-canary",
+      "expected_model": "gpt-5.6-terra",
+      "model_context_window_tokens": 16384,
+      "approval_manifest_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "content_free": true,
+      "soul_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "observed_soul_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "agents_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "observed_agents_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "model_policy_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "observed_model_policy_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    },
+    "allowed_tools": [
+      "memory"
+    ],
+    "required_capabilities": [
+      "responses_api"
+    ]
+  },
+  "authority": {
+    "consent_epoch": "55555555-5555-4555-8555-555555555555",
+    "grant_epoch": "synthetic:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "entitlement_revision": 1,
+    "content_free_receipt": {
+      "schema_version": "ella-hermes-cloud-approval-v1",
+      "policy_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "lane_s_review_url": "https://github.com/ellaaicare/ella-ai/pull/1138",
+      "prompt_pack_version": "ella-hermes-cloud-v1c-canary",
+      "model_policy_version": "ella-hermes-cloud-v1c-canary",
+      "expected_model": "gpt-5.6-terra",
+      "model_context_window_tokens": 16384,
+      "approval_manifest_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "content_free": true,
+      "soul_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "observed_soul_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "agents_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "observed_agents_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "model_policy_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "observed_model_policy_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    }
+  },
+  "request": {
+    "lane": "chat_turn",
+    "consent_epoch": "55555555-5555-4555-8555-555555555555",
+    "source_event_id": "aipb_event_111111111111111111111111",
+    "canonical_user_event_id": "aipb_event_111111111111111111111111",
+    "correlation_id": "aipb_corr_333333333333333333333333",
+    "delivery_platform": "ella_callback_stock",
+    "callback_source": "hermes_stock_0_19_quiet_window",
+    "webhook_route": "ella-stock-synthetic",
+    "callback_contract": "stock_best_effort_v1",
+    "terminal_proof": false
+  },
+  "secret_references": {
+    "broker_service_token": "env:ELLA_HERMES_BROKER_SERVICE_TOKEN",
+    "broker_ingress_hmac": "env:ELLA_HERMES_WEBHOOK_INGRESS_HMAC_SECRET",
+    "stock_callback_hmac": "env:ELLA_HERMES_STOCK_CALLBACK_HMAC_SECRET"
+  }
+}

--- a/backend/tests/fixtures/hermes_binding_envelope_v1.schema.json
+++ b/backend/tests/fixtures/hermes_binding_envelope_v1.schema.json
@@ -1,0 +1,284 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ella-ai-care.com/contracts/hermes-binding-envelope-v1.schema.json",
+  "title": "HermesBindingEnvelope v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "uid",
+    "account_id",
+    "profile_id",
+    "binding",
+    "authority",
+    "request",
+    "secret_references"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "ella-hermes-binding-envelope-v1"
+    },
+    "uid": {
+      "type": "string",
+      "pattern": "^staging-synthetic-[a-z0-9-]+$"
+    },
+    "account_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "profile_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "provider",
+        "status",
+        "active",
+        "profile_class",
+        "profile_binding_id",
+        "runtime_instance_id",
+        "runtime_target_id",
+        "runtime_target_mode",
+        "expected_model",
+        "prompt_artifact_receipt",
+        "allowed_tools",
+        "required_capabilities"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "provider": {
+          "const": "hermes_cloud"
+        },
+        "status": {
+          "const": "internal_canary"
+        },
+        "active": {
+          "const": true
+        },
+        "profile_class": {
+          "const": "synthetic"
+        },
+        "profile_binding_id": {
+          "type": "string",
+          "pattern": "^aipb_[0-9a-f]{32}$"
+        },
+        "runtime_instance_id": {
+          "type": "string",
+          "minLength": 8
+        },
+        "runtime_target_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "runtime_target_mode": {
+          "const": "hermes-cloud-chat"
+        },
+        "expected_model": {
+          "const": "gpt-5.6-terra"
+        },
+        "prompt_artifact_receipt": {
+          "$ref": "#/$defs/contentFreeReceipt"
+        },
+        "allowed_tools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "required_capabilities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "consent_epoch",
+        "grant_epoch",
+        "entitlement_revision",
+        "content_free_receipt"
+      ],
+      "properties": {
+        "consent_epoch": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "grant_epoch": {
+          "type": "string",
+          "pattern": "^synthetic:[0-9a-f]{64}$"
+        },
+        "entitlement_revision": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "content_free_receipt": {
+          "$ref": "#/$defs/contentFreeReceipt"
+        }
+      }
+    },
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "lane",
+        "consent_epoch",
+        "source_event_id",
+        "canonical_user_event_id",
+        "correlation_id",
+        "delivery_platform",
+        "callback_source",
+        "webhook_route",
+        "callback_contract",
+        "terminal_proof"
+      ],
+      "properties": {
+        "lane": {
+          "const": "chat_turn"
+        },
+        "consent_epoch": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "source_event_id": {
+          "type": "string",
+          "pattern": "^aipb_event_[0-9a-f]{24}$"
+        },
+        "canonical_user_event_id": {
+          "type": "string",
+          "pattern": "^aipb_event_[0-9a-f]{24}$"
+        },
+        "correlation_id": {
+          "type": "string",
+          "pattern": "^aipb_corr_[0-9a-f]{24}$"
+        },
+        "delivery_platform": {
+          "const": "ella_callback_stock"
+        },
+        "callback_source": {
+          "const": "hermes_stock_0_19_quiet_window"
+        },
+        "webhook_route": {
+          "const": "ella-stock-synthetic"
+        },
+        "callback_contract": {
+          "const": "stock_best_effort_v1"
+        },
+        "terminal_proof": {
+          "const": false
+        }
+      }
+    },
+    "secret_references": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "broker_service_token",
+        "broker_ingress_hmac",
+        "stock_callback_hmac"
+      ],
+      "properties": {
+        "broker_service_token": {
+          "const": "env:ELLA_HERMES_BROKER_SERVICE_TOKEN"
+        },
+        "broker_ingress_hmac": {
+          "const": "env:ELLA_HERMES_WEBHOOK_INGRESS_HMAC_SECRET"
+        },
+        "stock_callback_hmac": {
+          "const": "env:ELLA_HERMES_STOCK_CALLBACK_HMAC_SECRET"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "contentFreeReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "policy_commit_sha",
+        "lane_s_review_url",
+        "prompt_pack_version",
+        "model_policy_version",
+        "expected_model",
+        "model_context_window_tokens",
+        "approval_manifest_sha256",
+        "content_free",
+        "soul_sha256",
+        "observed_soul_sha256",
+        "agents_sha256",
+        "observed_agents_sha256",
+        "model_policy_sha256",
+        "observed_model_policy_sha256"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "ella-hermes-cloud-approval-v1"
+        },
+        "policy_commit_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "lane_s_review_url": {
+          "type": "string",
+          "pattern": "^https://github.com/ellaaicare/ella-ai/"
+        },
+        "prompt_pack_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "model_policy_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_model": {
+          "const": "gpt-5.6-terra"
+        },
+        "model_context_window_tokens": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "approval_manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "content_free": {
+          "const": true
+        },
+        "soul_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "observed_soul_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "agents_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "observed_agents_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "model_policy_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "observed_model_policy_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
+++ b/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
@@ -24,6 +24,7 @@ from ella.services.hermes_cloud_policy import CurrentCloudAuthority
 
 TEST_DSN = os.getenv("ELLA_TEST_POSTGRES_DSN", "").strip()
 MIGRATIONS = Path(__file__).resolve().parents[2] / "migrations"
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 LINEAGE = RuntimeTargetLineage(
     policy_version="ai-data-processors-v8",
     processor_set_hash="sha256:" + ("1" * 64),
@@ -113,6 +114,10 @@ def _prompt_receipt(*, model: str = "gpt-5.6-terra") -> dict:
         "model_policy_sha256": "e" * 64,
         "observed_model_policy_sha256": "e" * 64,
     }
+
+
+def _binding_contract() -> dict:
+    return json.loads((FIXTURES / "hermes_binding_envelope_v1.json").read_text(encoding="utf-8"))
 
 
 async def _run_with_database(scenario):
@@ -646,6 +651,7 @@ def test_completed_usage_interleaving_consumes_no_pool_row():
 
 
 def test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets(monkeypatch):
+    contract = _binding_contract()
     monkeypatch.setenv(
         "ELLA_HERMES_CLOUD_API_URL_SYNTHETIC",
         "https://cloud.example.test",
@@ -659,14 +665,14 @@ def test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets(monk
         "current_cloud_authority",
         lambda uid, **_kwargs: CurrentCloudAuthority(
             consent_receipt_id=f"receipt-{uid}",
-            profile_binding_id=f"profile-{uid}",
+            profile_binding_id=contract["binding"]["profile_binding_id"],
             lineage=LINEAGE,
         ),
     )
 
     async def scenario(pool):
-        uid = "synthetic-target-owner"
-        instance = "synthetic-instance-target-owner"
+        uid = contract["uid"]
+        instance = contract["binding"]["runtime_instance_id"]
         repository, job_id, model, revision = await _seed_claim(
             pool,
             uid=uid,
@@ -733,7 +739,19 @@ def test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets(monk
         assert isinstance(photon["prompt_artifact_receipt"], str)
         assert isinstance(photon["allowed_tools"], str)
         assert isinstance(photon["required_capabilities"], str)
+        assert isinstance(photon["id"], uuid.UUID)
+        assert isinstance(photon["user_id"], uuid.UUID)
+        assert isinstance(photon["account_user_id"], uuid.UUID)
+        assert isinstance(photon["profile_user_id"], uuid.UUID)
         runtime = runtime_resolver.runtime_from_binding(photon, uid)
+        assert runtime.provider == contract["binding"]["provider"]
+        assert runtime.status == contract["binding"]["status"]
+        assert runtime.profile_class == contract["binding"]["profile_class"]
+        assert runtime.runtime_instance_id == instance
+        assert runtime.expected_model == contract["binding"]["expected_model"]
+        assert runtime.account_user_id == str(photon["account_user_id"])
+        assert runtime.profile_user_id == str(photon["profile_user_id"])
+        assert runtime.consent_authority_epoch == str(uuid.UUID(runtime.consent_authority_epoch))
         assert runtime.model_context_window_tokens == 16384
         assert runtime.allowed_tools == ()
         assert runtime.required_capabilities == ("responses_api",)

--- a/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
+++ b/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
@@ -144,8 +144,7 @@ async def _run_with_database(scenario):
                 "013_create_managed_cloud_consent_authority.sql",
             ):
                 await conn.execute((MIGRATIONS / name).read_text(encoding="utf-8"))
-            assert await conn.fetchval(
-                """
+            assert await conn.fetchval("""
                 SELECT EXISTS (
                     SELECT 1
                     FROM information_schema.columns
@@ -155,18 +154,15 @@ async def _run_with_database(scenario):
                       AND is_nullable = 'NO'
                       AND column_default = '''real''::text'
                 )
-                """
-            )
-            assert await conn.fetchval(
-                """
+                """)
+            assert await conn.fetchval("""
                 SELECT EXISTS (
                     SELECT 1
                     FROM pg_constraint
                     WHERE connamespace = current_schema()::regnamespace
                       AND conname = 'users_profile_class_check'
                 )
-                """
-            )
+                """)
         await scenario(pool)
     finally:
         voice_canary._pool = previous_voice_pool
@@ -249,15 +245,11 @@ def test_revoke_between_admission_and_claim_consumes_no_pool_row():
 
         assert error.value.code == "runtime_admission_revoked"
         async with pool.acquire() as conn:
-            pool_row = dict(
-                await conn.fetchrow(
-                    """
+            pool_row = dict(await conn.fetchrow("""
                     SELECT status, user_id, claim_job_id, claim_token
                     FROM ella_runtime_bindings
                     WHERE runtime_instance_id = 'synthetic-instance-a'
-                    """
-                )
-            )
+                    """))
         assert pool_row == {
             "status": "pool_available",
             "user_id": None,
@@ -275,6 +267,7 @@ async def _seed_claim(
     runtime_instance_id: str,
     daily_limit_s: int = 2700,
     profile_class: str = "synthetic",
+    allowed_tools: list[str] | None = None,
 ):
     model = "gpt-5.6-terra"
     async with pool.acquire() as conn:
@@ -350,7 +343,7 @@ async def _seed_claim(
         model_policy_version="model-policy-v1",
         voice_policy_version="voice-policy-v1",
         expected_model=model,
-        allowed_tools=[],
+        allowed_tools=allowed_tools or [],
         required_capabilities=["responses_api"],
         health_receipt={"status": "ok", "content_free": True},
     )
@@ -503,6 +496,7 @@ def test_real_profile_cannot_consume_synthetic_pool_capacity():
             pool,
             uid=uid,
             runtime_instance_id=instance,
+            allowed_tools=contract["binding"]["allowed_tools"],
             profile_class="real",
         )
 
@@ -753,7 +747,7 @@ def test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets(monk
         assert runtime.profile_user_id == str(photon["profile_user_id"])
         assert runtime.consent_authority_epoch == str(uuid.UUID(runtime.consent_authority_epoch))
         assert runtime.model_context_window_tokens == 16384
-        assert runtime.allowed_tools == ()
+        assert runtime.allowed_tools == tuple(contract["binding"]["allowed_tools"])
         assert runtime.required_capabilities == ("responses_api",)
 
     asyncio.run(_run_with_database(scenario))
@@ -804,16 +798,12 @@ def test_plato_retained_binding_never_claims_hermes_cloud_pool():
 
         assert claimed["provider"] == "hermes_cloud"
         async with pool.acquire() as conn:
-            plato = dict(
-                await conn.fetchrow(
-                    """
+            plato = dict(await conn.fetchrow("""
                     SELECT provider, profile_name, active, workspace_root, internal_gateway_url,
                            credential_ref, honcho_workspace, observed_peer, observer_peer
                     FROM ella_runtime_bindings
                     WHERE profile_name = 'plato-eval'
-                    """
-                )
-            )
+                    """))
         assert plato == {
             "provider": "hermes",
             "profile_name": "plato-eval",
@@ -1055,15 +1045,11 @@ def test_post_publication_rollback_revokes_cloud_targets_and_preserves_retained_
                 """,
                 claimed["id"],
             )
-            retained = dict(
-                await conn.fetchrow(
-                    """
+            retained = dict(await conn.fetchrow("""
                     SELECT provider, status, active, profile_name
                     FROM ella_runtime_bindings
                     WHERE profile_name = 'plato-retained-rollback'
-                    """
-                )
-            )
+                    """))
         assert [dict(row) for row in target_states] == [{"status": "revoked", "count": 5}]
         assert retained == {
             "provider": "hermes",

--- a/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
+++ b/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
@@ -144,7 +144,8 @@ async def _run_with_database(scenario):
                 "013_create_managed_cloud_consent_authority.sql",
             ):
                 await conn.execute((MIGRATIONS / name).read_text(encoding="utf-8"))
-            assert await conn.fetchval("""
+            assert await conn.fetchval(
+                """
                 SELECT EXISTS (
                     SELECT 1
                     FROM information_schema.columns
@@ -154,15 +155,18 @@ async def _run_with_database(scenario):
                       AND is_nullable = 'NO'
                       AND column_default = '''real''::text'
                 )
-                """)
-            assert await conn.fetchval("""
+                """
+            )
+            assert await conn.fetchval(
+                """
                 SELECT EXISTS (
                     SELECT 1
                     FROM pg_constraint
                     WHERE connamespace = current_schema()::regnamespace
                       AND conname = 'users_profile_class_check'
                 )
-                """)
+                """
+            )
         await scenario(pool)
     finally:
         voice_canary._pool = previous_voice_pool
@@ -245,11 +249,15 @@ def test_revoke_between_admission_and_claim_consumes_no_pool_row():
 
         assert error.value.code == "runtime_admission_revoked"
         async with pool.acquire() as conn:
-            pool_row = dict(await conn.fetchrow("""
+            pool_row = dict(
+                await conn.fetchrow(
+                    """
                     SELECT status, user_id, claim_job_id, claim_token
                     FROM ella_runtime_bindings
                     WHERE runtime_instance_id = 'synthetic-instance-a'
-                    """))
+                    """
+                )
+            )
         assert pool_row == {
             "status": "pool_available",
             "user_id": None,
@@ -798,12 +806,16 @@ def test_plato_retained_binding_never_claims_hermes_cloud_pool():
 
         assert claimed["provider"] == "hermes_cloud"
         async with pool.acquire() as conn:
-            plato = dict(await conn.fetchrow("""
+            plato = dict(
+                await conn.fetchrow(
+                    """
                     SELECT provider, profile_name, active, workspace_root, internal_gateway_url,
                            credential_ref, honcho_workspace, observed_peer, observer_peer
                     FROM ella_runtime_bindings
                     WHERE profile_name = 'plato-eval'
-                    """))
+                    """
+                )
+            )
         assert plato == {
             "provider": "hermes",
             "profile_name": "plato-eval",
@@ -1045,11 +1057,15 @@ def test_post_publication_rollback_revokes_cloud_targets_and_preserves_retained_
                 """,
                 claimed["id"],
             )
-            retained = dict(await conn.fetchrow("""
+            retained = dict(
+                await conn.fetchrow(
+                    """
                     SELECT provider, status, active, profile_name
                     FROM ella_runtime_bindings
                     WHERE profile_name = 'plato-retained-rollback'
-                    """))
+                    """
+                )
+            )
         assert [dict(row) for row in target_states] == [{"status": "revoked", "count": 5}]
         assert retained == {
             "provider": "hermes",

--- a/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
+++ b/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
@@ -504,7 +504,6 @@ def test_real_profile_cannot_consume_synthetic_pool_capacity():
             pool,
             uid=uid,
             runtime_instance_id=instance,
-            allowed_tools=contract["binding"]["allowed_tools"],
             profile_class="real",
         )
 
@@ -679,6 +678,7 @@ def test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets(monk
             pool,
             uid=uid,
             runtime_instance_id=instance,
+            allowed_tools=contract["binding"]["allowed_tools"],
         )
         claimed = await repository.claim_cloud_pool_binding(
             uid=uid,

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -650,3 +650,49 @@ def test_cloud_chat_path_does_not_call_openclaw_or_mini(monkeypatch):
     output = asyncio.run(collect())
     assert output[0] == "data: Cloud response\n\n"
     assert output[1].startswith("done: ")
+
+
+def test_cloud_chat_failure_still_emits_one_terminal_marker(monkeypatch):
+    class Repository:
+        @classmethod
+        async def create(cls):
+            return object()
+
+    class Service:
+        def __init__(self, **kwargs):
+            pass
+
+        async def run_turn(self, runtime, request):
+            raise ProvisioningError(
+                "hermes_broker_prototype_auth_failed",
+                retryable=False,
+            )
+
+    async def no_context(*args, **kwargs):
+        return []
+
+    async def no_temporal(*args, **kwargs):
+        return ("requested window", [])
+
+    runtime = SimpleNamespace(provider="hermes_cloud", binding_id="binding-a")
+    monkeypatch.setattr(chat, "EllaProvisioningRepository", Repository)
+    monkeypatch.setattr(chat, "HermesCloudRuntimeService", Service)
+    monkeypatch.setattr(chat, "_fetch_chat_canonical_events", no_context)
+    monkeypatch.setattr(chat, "_fetch_temporal_chat_context", no_temporal)
+
+    async def collect():
+        return [
+            item
+            async for item in chat._stream_hermes_cloud_chat(
+                "Synthetic hello",
+                "user-a",
+                {"synthetic": True},
+                turn_id="turn-error-a",
+                client_sent_at=chat.datetime.now(chat.timezone.utc),
+                runtime=runtime,
+            )
+        ]
+
+    output = asyncio.run(collect())
+    assert output[0] == ("data: Ella is temporarily unavailable. Please try again.\n\n")
+    assert len([item for item in output if item.startswith("done: ")]) == 1

--- a/backend/tests/unit/test_hermes_binding_envelope_contract.py
+++ b/backend/tests/unit/test_hermes_binding_envelope_contract.py
@@ -15,6 +15,8 @@ from ella.services.hermes_broker_prototype import HermesBrokerPrototypeConfig
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 ENVELOPE_PATH = FIXTURES / "hermes_binding_envelope_v1.json"
 SCHEMA_PATH = FIXTURES / "hermes_binding_envelope_v1.schema.json"
+ENVELOPE_SHA256 = "6638880666600f0ec5c8fbc17d504fae574e8ecad9c7a54ef6dccb8aef2cad44"
+SCHEMA_SHA256 = "61a2912501041a808f81a3715ccd24edcf7180900fbec9d26b63c22bc2521fc8"
 
 
 class _Response:
@@ -65,6 +67,8 @@ def _load_contract():
 
 
 def test_hermes_binding_envelope_v1_identity_and_content_free_shape():
+    assert hashlib.sha256(ENVELOPE_PATH.read_bytes()).hexdigest() == ENVELOPE_SHA256
+    assert hashlib.sha256(SCHEMA_PATH.read_bytes()).hexdigest() == SCHEMA_SHA256
     envelope = _load_contract()
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
     jsonschema.Draft202012Validator(

--- a/backend/tests/unit/test_hermes_binding_envelope_contract.py
+++ b/backend/tests/unit/test_hermes_binding_envelope_contract.py
@@ -1,0 +1,143 @@
+"""Cross-repository HermesBindingEnvelope v1 contract checks."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+
+import jsonschema
+
+from ella.services.hermes_broker_client import HermesBrokerClient
+from ella.services.hermes_broker_prototype import HermesBrokerPrototypeConfig
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+ENVELOPE_PATH = FIXTURES / "hermes_binding_envelope_v1.json"
+SCHEMA_PATH = FIXTURES / "hermes_binding_envelope_v1.schema.json"
+
+
+class _Response:
+    status_code = 200
+
+    def __init__(self, body):
+        self._body = body
+        self.content = json.dumps(body, separators=(",", ":")).encode()
+
+    def json(self):
+        return self._body
+
+
+class _CaptureHttp:
+    def __init__(self):
+        self.call = None
+
+    def factory(self, timeout):
+        del timeout
+        parent = self
+
+        class _Client:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            async def post(self, url, **kwargs):
+                parent.call = ("POST", url, kwargs)
+                return _Response(
+                    {
+                        "status": "pending",
+                        "request_id": "hwb_contract_request",
+                        "correlation_id": "hwb:contract-correlation",
+                        "delivery_platform": "ella_callback_stock",
+                        "callback_source": "hermes_stock_0_19_quiet_window",
+                        "callback_contract": "stock_best_effort_v1",
+                        "terminal_proof": False,
+                    }
+                )
+
+        return _Client()
+
+
+def _load_contract():
+    return json.loads(ENVELOPE_PATH.read_text(encoding="utf-8"))
+
+
+def test_hermes_binding_envelope_v1_identity_and_content_free_shape():
+    envelope = _load_contract()
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator(
+        schema,
+        format_checker=jsonschema.FormatChecker(),
+    ).validate(envelope)
+    assert schema["title"] == "HermesBindingEnvelope v1"
+    assert envelope["schema_version"] == "ella-hermes-binding-envelope-v1"
+    assert envelope["account_id"] == envelope["profile_id"]
+    uid = envelope["uid"]
+    expected = hashlib.sha256(f"ella-managed-cloud-profile-v1\x1f{uid}\x1f{uid}".encode()).hexdigest()
+    assert envelope["binding"]["profile_binding_id"] == f"aipb_{expected[:32]}"
+    assert envelope["binding"]["profile_class"] == "synthetic"
+    assert envelope["authority"]["content_free_receipt"] == envelope["binding"]["prompt_artifact_receipt"]
+    assert envelope["authority"]["content_free_receipt"]["content_free"] is True
+    assert envelope["request"]["consent_epoch"] == envelope["authority"]["consent_epoch"]
+    assert envelope["request"]["canonical_user_event_id"] == envelope["request"]["source_event_id"]
+    assert envelope["request"]["callback_contract"] == "stock_best_effort_v1"
+    assert envelope["request"]["terminal_proof"] is False
+    assert envelope["secret_references"] == {
+        "broker_service_token": "env:ELLA_HERMES_BROKER_SERVICE_TOKEN",
+        "broker_ingress_hmac": "env:ELLA_HERMES_WEBHOOK_INGRESS_HMAC_SECRET",
+        "stock_callback_hmac": "env:ELLA_HERMES_STOCK_CALLBACK_HMAC_SECRET",
+    }
+
+
+def test_omi_request_uses_exact_stock_contract_from_shared_envelope(monkeypatch):
+    envelope = _load_contract()
+    monkeypatch.setenv(
+        "ELLA_HERMES_BROKER_SERVICE_TOKEN",
+        "synthetic-test-token",
+    )
+    capture = _CaptureHttp()
+    config = HermesBrokerPrototypeConfig(
+        enabled=True,
+        account_id=envelope["account_id"],
+        profile_id=envelope["profile_id"],
+        binding_id=envelope["binding"]["id"],
+        base_url="https://broker.ella.test",
+        allowed_host="broker.ella.test",
+        service_token_ref=envelope["secret_references"]["broker_service_token"],
+        poll_interval_seconds=0.1,
+        poll_timeout_seconds=1.0,
+        deadline_seconds=30,
+    )
+    client = HermesBrokerClient(config, http_client_factory=capture.factory)
+    request = envelope["request"]
+    asyncio.run(
+        client.admit(
+            account_id=envelope["account_id"],
+            profile_id=envelope["profile_id"],
+            runtime_binding_ref=envelope["binding"]["id"],
+            lane=request["lane"],
+            source_event_id=request["source_event_id"],
+            consent_epoch=request["consent_epoch"],
+            payload={
+                "message": "synthetic-contract-payload",
+                "session_key": "synthetic-contract-session",
+                "session_id": "synthetic-contract-session-1",
+                "canonical_user_event_id": request["canonical_user_event_id"],
+            },
+            deadline_at=1_900_000_000,
+        )
+    )
+
+    method, url, kwargs = capture.call
+    assert method == "POST"
+    assert url.endswith("/stock-canary/admit")
+    assert "/hermes-webhook-broker/admit" not in url
+    assert kwargs["json"]["delivery_platform"] == request["delivery_platform"]
+    assert kwargs["json"]["callback_source"] == request["callback_source"]
+    assert kwargs["json"]["webhook_route"] == request["webhook_route"]
+    assert kwargs["json"]["runtime_binding_ref"] == envelope["binding"]["id"]
+    assert kwargs["json"]["consent_epoch"] == envelope["authority"]["consent_epoch"]
+    assert kwargs["json"]["source_event_id"] == kwargs["json"]["payload"]["canonical_user_event_id"]
+    assert kwargs["headers"]["Authorization"].startswith("Bearer ")


### PR DESCRIPTION
Completes the bounded synthetic golden-sweep work after merged PR #350.

- emits one terminal `done:` frame for fail-closed Hermes provisioning errors
- pins a shared, content-free `HermesBindingEnvelope` v1 schema/fixture
- proves actual asyncpg JSONB/UUID projection and exact stock request identity
- replaces count-only CI dependence with required-test-ID and zero-skip checks

Local receipts: 117 focused tests passed; 434 exact focused tests collected; Black 24.8, compile, YAML, diff, and changed-range Gitleaks passed. The PostgreSQL path is included in hosted CI; no provider call, deployment, flags, user data, credential, n8n, vendor, or Plato mutation.

Coordinates with ellaaicare/ella-ai#1124 and ellaaicare/ella-ai#1136.