### PR TITLE
test(ella): persist golden profile binding in postgres

### DIFF
--- a/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
+++ b/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
@@ -275,6 +275,7 @@ async def _seed_claim(
     runtime_instance_id: str,
     daily_limit_s: int = 2700,
     profile_class: str = "synthetic",
+    profile_binding_id: str | None = None,
     allowed_tools: list[str] | None = None,
 ):
     model = "gpt-5.6-terra"
@@ -305,7 +306,7 @@ async def _seed_claim(
             """,
             user_id,
             "sha256:" + ("f" * 64),
-            uid,
+            profile_binding_id if profile_binding_id is not None else uid,
             LINEAGE.policy_version,
             LINEAGE.processor_set_hash,
             LINEAGE.scope_version,
@@ -678,6 +679,7 @@ def test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets(monk
             pool,
             uid=uid,
             runtime_instance_id=instance,
+            profile_binding_id=contract["binding"]["profile_binding_id"],
             allowed_tools=contract["binding"]["allowed_tools"],
         )
         claimed = await repository.claim_cloud_pool_binding(
@@ -716,6 +718,15 @@ def test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets(monk
                 """,
                 finalized["id"],
             )
+            persisted_profile_binding_id = await conn.fetchval(
+                """
+                SELECT profile_binding_id
+                FROM ella_managed_cloud_consent_authority
+                WHERE user_id = $1
+                """,
+                finalized["user_id"],
+            )
+        assert persisted_profile_binding_id == contract["binding"]["profile_binding_id"]
         assert [row["mode"] for row in targets] == [
             "hermes-cloud-chat",
             "hermes-cloud-guardian",


### PR DESCRIPTION
## Scope
- Test-only post-merge proof for the P2 on OMI #351.
- `_seed_claim` can seed the fixture exact `profile_binding_id` while preserving the existing default for other tests.
- The cross-repo golden PostgreSQL test passes the fixture value and asserts the persisted managed-cloud consent authority value exactly.

## Verification
- Exact base: `af7e289788833c26d7d0104417819d801d903082`
- Exact head: `23528e221ed260aa7b9289bcec5883007423a958`
- Black 24.8, `py_compile`, `git diff --check`: pass
- Golden envelope contract: 2 passed
- Focused collection guard: 434 collected; required golden/PostgreSQL IDs present
- Fixture SHA-256 unchanged: `6638880666600f0ec5c8fbc17d504fae574e8ecad9c7a54ef6dccb8aef2cad44`
- Schema SHA-256 unchanged: `61a2912501041a808f81a3715ccd24edcf7180900fbec9d26b63c22bc2521fc8`
- Exact-range Gitleaks: no findings
- Local PostgreSQL was unavailable; hosted exact-head PostgreSQL CI remains the actual-driver gate.

## Cut line
This is a non-blocking source-proof follow-up under the isolated prototype cut line. It does not authorize merge or deployment and changes no runtime code or live state.