### PR TITLE
Keep Hermes broker session identity stable across turns

### DIFF
--- a/backend/ella/services/hermes_broker_client.py
+++ b/backend/ella/services/hermes_broker_client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import time
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional
@@ -30,6 +31,15 @@ from ella.services.runtime_errors import ProvisioningError
 
 MAX_ADMISSION_BODY_BYTES = 65_536
 MAX_RESULT_BODY_BYTES = 262_144
+DIAGNOSTIC_STAGES = frozenset(
+    {
+        "broker_request",
+        "broker_dispatch",
+        "broker_callback",
+        "broker_writeback",
+    }
+)
+DIAGNOSTIC_REASON_RE = re.compile(r"^[a-z][a-z0-9_]{0,119}$")
 
 
 @dataclass(frozen=True)
@@ -43,6 +53,7 @@ class BrokerTerminalTurn:
     usage: dict[str, int]
     model: str
     duplicate: bool
+    diagnostic: Optional[dict[str, Any]] = None
 
 
 class HermesBrokerClient:
@@ -239,6 +250,7 @@ class HermesBrokerClient:
                     "hermes_broker_prototype_stock_semantics_mismatch",
                     retryable=False,
                 )
+            self._validated_diagnostic(last)
             status = str(last.get("status") or "").strip()
             if not status:
                 raise ProvisioningError(
@@ -487,6 +499,7 @@ class HermesBrokerClient:
             usage=normalized_usage,
             model=model,
             duplicate=bool(terminal.get("duplicate")) or admission_duplicate,
+            diagnostic=self._validated_diagnostic(terminal),
         )
 
     def _map_summary_result(
@@ -536,7 +549,41 @@ class HermesBrokerClient:
             usage={"input_tokens": 0, "output_tokens": 0},
             model=expected_model,
             duplicate=bool(terminal.get("duplicate")) or admission_duplicate,
+            diagnostic=self._validated_diagnostic(terminal),
         )
+
+    @staticmethod
+    def _validated_diagnostic(body: Mapping[str, Any]) -> dict[str, Any]:
+        diagnostic = body.get("diagnostic")
+        if not isinstance(diagnostic, dict) or set(diagnostic) != {
+            "stage",
+            "reason",
+            "generation",
+        }:
+            raise ProvisioningError(
+                "hermes_broker_prototype_diagnostic_invalid",
+                retryable=False,
+            )
+        stage = diagnostic.get("stage")
+        reason = diagnostic.get("reason")
+        generation = diagnostic.get("generation")
+        if (
+            stage not in DIAGNOSTIC_STAGES
+            or not isinstance(reason, str)
+            or DIAGNOSTIC_REASON_RE.fullmatch(reason) is None
+            or isinstance(generation, bool)
+            or not isinstance(generation, int)
+            or generation < 1
+        ):
+            raise ProvisioningError(
+                "hermes_broker_prototype_diagnostic_invalid",
+                retryable=False,
+            )
+        return {
+            "stage": stage,
+            "reason": reason,
+            "generation": generation,
+        }
 
     @staticmethod
     def _require_exact_field(

--- a/backend/ella/services/hermes_broker_prototype.py
+++ b/backend/ella/services/hermes_broker_prototype.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 import hmac
 import os
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 from urllib.parse import urlparse
 
 from ella.services.runtime_errors import ProvisioningError
-from ella.services.runtime_resolver import IsolatedRuntime
+
+if TYPE_CHECKING:
+    from ella.services.runtime_resolver import IsolatedRuntime
 
 # Exact lowercase only — no permissive truthy aliases.
 _TRUE = "true"

--- a/backend/ella/services/hermes_cloud.py
+++ b/backend/ella/services/hermes_cloud.py
@@ -289,6 +289,7 @@ class HermesCloudTurn:
     usage: dict[str, Any]
     model: str
     tool_calls: int
+    diagnostic: Optional[dict[str, Any]] = None
 
 
 class HermesCloudClient:

--- a/backend/ella/services/hermes_cloud_runtime.py
+++ b/backend/ella/services/hermes_cloud_runtime.py
@@ -47,6 +47,7 @@ DEFAULT_MAX_INPUT_TOKENS = 8192
 DEFAULT_MAX_OUTPUT_TOKENS = 1024
 DEFAULT_MAX_TOOL_CALLS = 2
 INVALID_OUTPUT_ERROR = "hermes_cloud_enrichment_output_invalid"
+BROKER_SESSION_ID_DOMAIN = "ella-hermes-broker-session-v1"
 
 
 def assert_runtime_managed_consent(runtime: IsolatedRuntime) -> str:
@@ -62,6 +63,32 @@ def assert_runtime_managed_consent(runtime: IsolatedRuntime) -> str:
     if not authority.grant_epoch:
         raise ProvisioningError("managed_cloud_consent_stale", retryable=False)
     return authority.grant_epoch
+
+
+def broker_session_id_for_scope(
+    *,
+    account_id: str,
+    profile_id: str,
+    runtime_binding_ref: str,
+    channel: str,
+    session_key: str,
+) -> str:
+    """Derive one opaque broker-only session id for a persisted runtime scope."""
+    values = (
+        BROKER_SESSION_ID_DOMAIN,
+        account_id,
+        profile_id,
+        runtime_binding_ref,
+        channel,
+        session_key,
+    )
+    if any(not isinstance(value, str) or not value.strip() for value in values):
+        raise ProvisioningError(
+            "hermes_broker_prototype_session_identity_invalid",
+            retryable=False,
+        )
+    digest = hashlib.sha256("\x1f".join(values).encode("utf-8")).hexdigest()
+    return f"ella:broker-session:v1:{digest[:48]}"
 
 
 def _bounded_env_int(name: str, default: int, minimum: int, maximum: int) -> int:
@@ -241,6 +268,7 @@ def _event(
     role: str,
     text: str,
     provider_response_id: Optional[str] = None,
+    provider_diagnostic: Optional[Mapping[str, Any]] = None,
 ) -> CanonicalEventIn:
     now = datetime.now(timezone.utc)
     started_at = request.started_at if role == "user" else now
@@ -267,6 +295,7 @@ def _event(
             "correlation_id": request.correlation_id,
             "client": request.client_metadata,
             "event_revision": 1,
+            **({"broker_diagnostic": dict(provider_diagnostic)} if provider_diagnostic else {}),
         },
     )
 
@@ -365,6 +394,13 @@ class HermesCloudRuntimeService:
                 expected_model=runtime.expected_model,
             )
         else:
+            broker_session_id = broker_session_id_for_scope(
+                account_id=account_user_id,
+                profile_id=profile_user_id,
+                runtime_binding_ref=str(runtime.binding_id),
+                channel=str(request.channel),
+                session_key=str(scope["session_key"]),
+            )
             terminal = await client.run_chat_turn(
                 account_id=account_user_id,
                 profile_id=profile_user_id,
@@ -372,7 +408,7 @@ class HermesCloudRuntimeService:
                 consent_epoch=consent_authority_epoch,
                 message=request.user_input,
                 session_key=str(scope["session_key"]),
-                session_id=str(claimed["hermes_session_id"]),
+                session_id=broker_session_id,
                 source_event_id=source_event_id,
                 expected_model=runtime.expected_model,
                 context={"instructions": request.instructions[:4000]},
@@ -383,6 +419,7 @@ class HermesCloudRuntimeService:
             usage=dict(terminal.usage),
             model=terminal.model,
             tool_calls=0,
+            diagnostic=terminal.diagnostic,
         )
 
     async def run_turn(
@@ -729,6 +766,7 @@ class HermesCloudRuntimeService:
                 role="assistant",
                 text=turn.text,
                 provider_response_id=turn.response_id,
+                provider_diagnostic=turn.diagnostic,
             )
             assistant_write = await self.event_store.write_batch([assistant_event])
             assistant_receipt = await self.repository.claim_runtime_ingestion(

--- a/backend/tests/fixtures/hermes_binding_envelope_v1.json
+++ b/backend/tests/fixtures/hermes_binding_envelope_v1.json
@@ -60,6 +60,11 @@
       "observed_model_policy_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
     }
   },
+  "broker_session": {
+    "channel": "chat",
+    "session_key": "ella:scope:22222222-2222-4222-8222-222222222222",
+    "session_id": "ella:broker-session:v1:df513ec5261a4cd673e5fda22a46dec18ac5606b589a98b3"
+  },
   "request": {
     "lane": "chat_turn",
     "consent_epoch": "55555555-5555-4555-8555-555555555555",
@@ -71,6 +76,16 @@
     "webhook_route": "ella-stock-synthetic",
     "callback_contract": "stock_best_effort_v1",
     "terminal_proof": false
+  },
+  "result_contract": {
+    "success_status": "writeback_completed",
+    "callback_contract": "stock_best_effort_v1",
+    "terminal_proof": false,
+    "diagnostic_fields": [
+      "stage",
+      "reason",
+      "generation"
+    ]
   },
   "secret_references": {
     "broker_service_token": "env:ELLA_HERMES_BROKER_SERVICE_TOKEN",

--- a/backend/tests/fixtures/hermes_binding_envelope_v1.schema.json
+++ b/backend/tests/fixtures/hermes_binding_envelope_v1.schema.json
@@ -11,7 +11,9 @@
     "profile_id",
     "binding",
     "authority",
+    "broker_session",
     "request",
+    "result_contract",
     "secret_references"
   ],
   "properties": {
@@ -129,6 +131,28 @@
         }
       }
     },
+    "broker_session": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "channel",
+        "session_key",
+        "session_id"
+      ],
+      "properties": {
+        "channel": {
+          "const": "chat"
+        },
+        "session_key": {
+          "type": "string",
+          "pattern": "^ella:scope:[0-9a-f-]{36}$"
+        },
+        "session_id": {
+          "type": "string",
+          "pattern": "^ella:broker-session:v1:[0-9a-f]{48}$"
+        }
+      }
+    },
     "request": {
       "type": "object",
       "additionalProperties": false,
@@ -178,6 +202,44 @@
         },
         "terminal_proof": {
           "const": false
+        }
+      }
+    },
+    "result_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "success_status",
+        "callback_contract",
+        "terminal_proof",
+        "diagnostic_fields"
+      ],
+      "properties": {
+        "success_status": {
+          "const": "writeback_completed"
+        },
+        "callback_contract": {
+          "const": "stock_best_effort_v1"
+        },
+        "terminal_proof": {
+          "const": false
+        },
+        "diagnostic_fields": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "stage"
+            },
+            {
+              "const": "reason"
+            },
+            {
+              "const": "generation"
+            }
+          ],
+          "items": false,
+          "minItems": 3,
+          "maxItems": 3
         }
       }
     },

--- a/backend/tests/unit/test_hermes_binding_envelope_contract.py
+++ b/backend/tests/unit/test_hermes_binding_envelope_contract.py
@@ -11,12 +11,13 @@ import jsonschema
 
 from ella.services.hermes_broker_client import HermesBrokerClient
 from ella.services.hermes_broker_prototype import HermesBrokerPrototypeConfig
+from ella.services.hermes_cloud_runtime import broker_session_id_for_scope
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 ENVELOPE_PATH = FIXTURES / "hermes_binding_envelope_v1.json"
 SCHEMA_PATH = FIXTURES / "hermes_binding_envelope_v1.schema.json"
-ENVELOPE_SHA256 = "6638880666600f0ec5c8fbc17d504fae574e8ecad9c7a54ef6dccb8aef2cad44"
-SCHEMA_SHA256 = "61a2912501041a808f81a3715ccd24edcf7180900fbec9d26b63c22bc2521fc8"
+ENVELOPE_SHA256 = "e4140b26a9ea0b9e7110fd092884913fa10556d63e689eb44c95e55171f577b3"
+SCHEMA_SHA256 = "b57c94b6a2a116f166b7662afa83fc5b8b75f984c7c29802ec1b45f35d0ecfeb"
 
 
 class _Response:
@@ -88,6 +89,20 @@ def test_hermes_binding_envelope_v1_identity_and_content_free_shape():
     assert envelope["request"]["canonical_user_event_id"] == envelope["request"]["source_event_id"]
     assert envelope["request"]["callback_contract"] == "stock_best_effort_v1"
     assert envelope["request"]["terminal_proof"] is False
+    assert envelope["result_contract"] == {
+        "success_status": "writeback_completed",
+        "callback_contract": "stock_best_effort_v1",
+        "terminal_proof": False,
+        "diagnostic_fields": ["stage", "reason", "generation"],
+    }
+    broker_session = envelope["broker_session"]
+    assert broker_session["session_id"] == broker_session_id_for_scope(
+        account_id=envelope["account_id"],
+        profile_id=envelope["profile_id"],
+        runtime_binding_ref=envelope["binding"]["id"],
+        channel=broker_session["channel"],
+        session_key=broker_session["session_key"],
+    )
     assert envelope["secret_references"] == {
         "broker_service_token": "env:ELLA_HERMES_BROKER_SERVICE_TOKEN",
         "broker_ingress_hmac": "env:ELLA_HERMES_WEBHOOK_INGRESS_HMAC_SECRET",
@@ -126,8 +141,8 @@ def test_omi_request_uses_exact_stock_contract_from_shared_envelope(monkeypatch)
             consent_epoch=request["consent_epoch"],
             payload={
                 "message": "synthetic-contract-payload",
-                "session_key": "synthetic-contract-session",
-                "session_id": "synthetic-contract-session-1",
+                "session_key": envelope["broker_session"]["session_key"],
+                "session_id": envelope["broker_session"]["session_id"],
                 "canonical_user_event_id": request["canonical_user_event_id"],
             },
             deadline_at=1_900_000_000,

--- a/backend/tests/unit/test_hermes_broker_prototype.py
+++ b/backend/tests/unit/test_hermes_broker_prototype.py
@@ -19,6 +19,7 @@ from ella.services.hermes_cloud_runtime import (
     HERMES_CLOUD_ENRICHMENT_MODE,
     HermesCloudRuntimeService,
     HermesCloudTurnRequest,
+    broker_session_id_for_scope,
 )
 from ella.services.runtime_errors import ProvisioningError
 from ella.services.runtime_resolver import IsolatedRuntime
@@ -104,6 +105,14 @@ class FakeResponse:
             body.setdefault("terminal_proof", False)
             body.setdefault("delivery_platform", "ella_callback_stock")
             body.setdefault("callback_source", "hermes_stock_0_19_quiet_window")
+            body.setdefault(
+                "diagnostic",
+                {
+                    "stage": ("broker_writeback" if body.get("status") == "writeback_completed" else "broker_request"),
+                    "reason": str(body.get("status") or "pending"),
+                    "generation": 1,
+                },
+            )
         self._body = body
         self.content = content if content is not None else json.dumps(body).encode()
 
@@ -152,6 +161,11 @@ def _completed_result(**overrides):
         "callback_contract": "stock_best_effort_v1",
         "terminal_proof": False,
         "outcome": "success",
+        "diagnostic": {
+            "stage": "broker_writeback",
+            "reason": "writeback_completed",
+            "generation": 1,
+        },
         "result": {
             "answer": "proto answer",
             "session_key": "sk",
@@ -548,6 +562,7 @@ def test_answer_only_projection_rejected(monkeypatch):
         "hermes_broker_prototype_profile_omitted",
         "hermes_broker_prototype_correlation_omitted",
         "hermes_broker_prototype_lane_omitted",
+        "hermes_broker_prototype_diagnostic_invalid",
     }
 
 
@@ -914,6 +929,80 @@ def test_provider_turn_submits_owner_uuids_not_auth_uid(monkeypatch):
     assert seen["account_id"] != AUTH_UID
     assert seen["runtime_binding_ref"] == BINDING_ID
     assert seen["consent_epoch"] == CONSENT_AUTHORITY_EPOCH
+
+
+def test_three_broker_turns_keep_one_scope_session_identity(monkeypatch):
+    _enable(
+        monkeypatch,
+        ELLA_HERMES_BROKER_PROTOTYPE_PROFILE_ID=("11111111-1111-4111-8111-111111111111"),
+    )
+    seen = []
+
+    class FakeBroker(HermesBrokerClient):
+        def __init__(self, config):
+            super().__init__(config, sleep=_noop_sleep)
+
+        async def run_chat_turn(self, **kwargs):
+            seen.append(kwargs)
+            return client_mod.BrokerTerminalTurn(
+                text="via-broker",
+                request_id=f"hwb_{len(seen)}",
+                correlation_id=f"hwb:{len(seen)}",
+                response_id=f"resp-{len(seen)}",
+                usage={"input_tokens": 1, "output_tokens": 1},
+                model="gpt-test",
+                duplicate=False,
+            )
+
+    service = HermesCloudRuntimeService(
+        repository=object(),  # type: ignore[arg-type]
+        event_store=object(),  # type: ignore[arg-type]
+    )
+    service.broker_client_factory = FakeBroker
+
+    async def boundary():
+        return ("https://h", "t")
+
+    scope = {"session_key": "ella:scope:22222222-2222-4222-8222-222222222222"}
+    for turn in range(1, 4):
+        asyncio.run(
+            service._provider_turn(
+                runtime=_runtime(
+                    account_user_id="11111111-1111-4111-8111-111111111111",
+                    profile_user_id="11111111-1111-4111-8111-111111111111",
+                ),
+                request=HermesCloudTurnRequest(
+                    uid=AUTH_UID,
+                    client_interaction_id=f"evt-{turn}",
+                    correlation_id=f"c-{turn}",
+                    channel="chat",
+                    user_input=f"synthetic-{turn}",
+                    instructions="sys",
+                    started_at=datetime.now(timezone.utc),
+                    client_metadata={},
+                ),
+                scope=scope,
+                claimed={
+                    "hermes_session_id": f"rotating-interaction-{turn}",
+                    "idempotency_key": f"ik-{turn}",
+                },
+                budget={"max_output_tokens": 64, "max_tool_calls": 0},
+                mark_provider_send_boundary=boundary,
+            )
+        )
+
+    assert {call["session_key"] for call in seen} == {scope["session_key"]}
+    assert {call["session_id"] for call in seen} == {
+        "ella:broker-session:v1:" "df513ec5261a4cd673e5fda22a46dec18ac5606b589a98b3"
+    }
+    assert all(call["session_id"] != f"rotating-interaction-{index}" for index, call in enumerate(seen, start=1))
+    assert seen[0]["session_id"] == broker_session_id_for_scope(
+        account_id="11111111-1111-4111-8111-111111111111",
+        profile_id="11111111-1111-4111-8111-111111111111",
+        runtime_binding_ref=BINDING_ID,
+        channel="chat",
+        session_key=scope["session_key"],
+    )
 
 
 def test_provider_turn_rejects_missing_persisted_consent_authority_epoch(monkeypatch):


### PR DESCRIPTION
## Summary
- derive one broker-only Hermes session ID from account/profile/runtime binding/channel/session scope and reuse it across interaction rows
- preserve canonical account/profile and `aipb_*` event authority while preventing per-turn broker session rotation
- validate and propagate only content-free broker `stage`/`reason`/`generation` diagnostics
- extend the shared versioned `HermesBindingEnvelope` with the broker session and result contract

## Cross-repo pin
- companion Ella PR: ellaaicare/ella-ai#1164
- companion exact head: `c24d172165b9d262d663546aa2a93e18468d699f`
- shared envelope SHA-256: `e4140b26a9ea0b9e7110fd092884913fa10556d63e689eb44c95e55171f577b3`
- shared schema SHA-256: `b57c94b6a2a116f166b7662afa83fc5b8b75f984c7c29802ec1b45f35d0ecfeb`

## Validation
- focused OMI runtime suite: 70 passed, zero skips
- required test IDs include stable three-turn scope identity and exact diagnostic validation
- Black, py_compile, JSON/schema checks, diff check: passed
- exact-range redacted Gitleaks: no findings
- hosted `hermes-cloud-runtime`: green on exact head

Source and synthetic tests only. No deployment, flags, workflow, n8n, vendor, provider traffic, or real data.