### PR TITLE
Add synthetic Hermes product-fit acceptance harness

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -53,13 +53,16 @@ on:
       - "backend/migrations/013_create_managed_cloud_consent_authority.sql"
       - "backend/scripts/hermes_cloud_pool_admin.py"
       - "backend/scripts/hermes_cloud_enrichment_smoke.py"
+      - "backend/scripts/hermes_product_fit_canary.py"
       - "backend/scripts/hermes_cloud_shadow.py"
       - "backend/scripts/voice_canary_admin.py"
       - "backend/utils/ella/postprocess.py"
       - "backend/utils/ella/scanner_keyterms.py"
       - "backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md"
       - "backend/ella/docs/HERMES_CLOUD_RUNTIME_TARGETS_RUNBOOK.md"
+      - "backend/ella/docs/HERMES_PRODUCT_FIT_CANARY.md"
       - "backend/ella/docs/hermes-cloud-runtime-targets.openapi.yaml"
+      - "backend/tests/fixtures/hermes_product_fit_callback_v1.json"
       - "backend/tests/unit/test_ella_provisioning_repository.py"
       - "backend/tests/unit/test_authority_advisory_lock.py"
       - "backend/tests/unit/test_authority_writer_guard.py"
@@ -71,6 +74,7 @@ on:
       - "backend/tests/fixtures/hermes_binding_envelope_v1.json"
       - "backend/tests/fixtures/hermes_binding_envelope_v1.schema.json"
       - "backend/tests/unit/test_hermes_binding_envelope_contract.py"
+      - "backend/tests/unit/test_hermes_product_fit_canary.py"
       - "backend/tests/unit/test_ella_ai_consent.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
       - "backend/tests/unit/test_ella_runtime_route_isolation.py"
@@ -139,13 +143,16 @@ on:
       - "backend/migrations/013_create_managed_cloud_consent_authority.sql"
       - "backend/scripts/hermes_cloud_pool_admin.py"
       - "backend/scripts/hermes_cloud_enrichment_smoke.py"
+      - "backend/scripts/hermes_product_fit_canary.py"
       - "backend/scripts/hermes_cloud_shadow.py"
       - "backend/scripts/voice_canary_admin.py"
       - "backend/utils/ella/postprocess.py"
       - "backend/utils/ella/scanner_keyterms.py"
       - "backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md"
       - "backend/ella/docs/HERMES_CLOUD_RUNTIME_TARGETS_RUNBOOK.md"
+      - "backend/ella/docs/HERMES_PRODUCT_FIT_CANARY.md"
       - "backend/ella/docs/hermes-cloud-runtime-targets.openapi.yaml"
+      - "backend/tests/fixtures/hermes_product_fit_callback_v1.json"
       - "backend/tests/unit/test_ella_provisioning_repository.py"
       - "backend/tests/unit/test_authority_advisory_lock.py"
       - "backend/tests/unit/test_authority_writer_guard.py"
@@ -157,6 +164,7 @@ on:
       - "backend/tests/fixtures/hermes_binding_envelope_v1.json"
       - "backend/tests/fixtures/hermes_binding_envelope_v1.schema.json"
       - "backend/tests/unit/test_hermes_binding_envelope_contract.py"
+      - "backend/tests/unit/test_hermes_product_fit_canary.py"
       - "backend/tests/unit/test_ella_ai_consent.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
       - "backend/tests/unit/test_ella_runtime_route_isolation.py"
@@ -269,6 +277,7 @@ jobs:
           ella/services/voice_honcho.py
           scripts/hermes_cloud_pool_admin.py
           scripts/hermes_cloud_enrichment_smoke.py
+          scripts/hermes_product_fit_canary.py
           scripts/hermes_cloud_shadow.py
           scripts/voice_canary_admin.py
           utils/ella/postprocess.py
@@ -296,6 +305,7 @@ jobs:
           ella/services/provisioning.py ella/services/runtime_resolver.py
           ella/services/summary_recovery.py utils/ella/scanner_keyterms.py
           scripts/voice_canary_admin.py
+          scripts/hermes_product_fit_canary.py
           tests/unit/test_ella_callbacks_summary_update.py
           tests/unit/test_authority_advisory_lock.py
           tests/unit/test_authority_writer_guard.py
@@ -310,6 +320,7 @@ jobs:
           tests/unit/test_hermes_cloud_photon.py
           tests/unit/test_hermes_broker_prototype.py
           tests/unit/test_hermes_binding_envelope_contract.py
+          tests/unit/test_hermes_product_fit_canary.py
           tests/unit/test_hermes_cloud_provider.py
           tests/unit/test_hermes_cloud_runtime.py
           tests/unit/test_hermes_cloud_staged_attestation.py
@@ -334,6 +345,7 @@ jobs:
               tests/unit/test_hermes_cloud_policy.py \
               tests/unit/test_hermes_broker_prototype.py \
               tests/unit/test_hermes_binding_envelope_contract.py \
+              tests/unit/test_hermes_product_fit_canary.py \
               tests/unit/test_hermes_cloud_photon.py \
               tests/unit/test_hermes_cloud_provider.py \
               tests/unit/test_hermes_cloud_provisioning.py \
@@ -356,12 +368,16 @@ jobs:
           required_ids=(
             "tests/unit/test_hermes_binding_envelope_contract.py::test_hermes_binding_envelope_v1_identity_and_content_free_shape"
             "tests/unit/test_hermes_binding_envelope_contract.py::test_omi_request_uses_exact_stock_contract_from_shared_envelope"
+            "tests/unit/test_hermes_product_fit_canary.py::test_scenarios_a_to_f_pass_with_content_free_stage_tables"
+            "tests/unit/test_hermes_product_fit_canary.py::test_replay_errors_fail_closed_for_outcome_correlation_session_timeout_and_ordering"
+            "tests/unit/test_hermes_product_fit_canary.py::test_cleanup_requires_content_free_all_off_receipt_for_exact_synthetic_uid"
             "tests/unit/test_ella_runtime_route_isolation.py::test_cloud_chat_failure_still_emits_one_terminal_marker"
             "tests/postgres/test_hermes_cloud_pool_postgres.py::test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets"
           )
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_hermes_binding_envelope_contract.py \
+              tests/unit/test_hermes_product_fit_canary.py \
               tests/unit/test_ella_runtime_route_isolation.py \
               tests/postgres/test_hermes_cloud_pool_postgres.py |
               sed '/^$/d'
@@ -369,6 +385,10 @@ jobs:
           for required_id in "${required_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$collected_ids"
           done
+          test "$(
+            pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
+              grep -c '::'
+          )" -eq 15
           test "$collected" -ge 431
           pytest \
             tests/unit/test_ella_ai_consent.py \
@@ -378,6 +398,7 @@ jobs:
             tests/unit/test_hermes_cloud_policy.py \
             tests/unit/test_hermes_broker_prototype.py \
             tests/unit/test_hermes_binding_envelope_contract.py \
+            tests/unit/test_hermes_product_fit_canary.py \
             tests/unit/test_hermes_cloud_photon.py \
             tests/unit/test_hermes_cloud_provider.py \
             tests/unit/test_hermes_cloud_provisioning.py \

--- a/backend/ella/docs/HERMES_PRODUCT_FIT_CANARY.md
+++ b/backend/ella/docs/HERMES_PRODUCT_FIT_CANARY.md
@@ -1,0 +1,138 @@
+# Hermes Cloud synthetic product-fit canary
+
+This harness evaluates one disposable synthetic OMI profile without changing
+production routing. It uses the existing stock broker client, authenticated
+voice-memory scope, and authenticated enrichment route. It does not call Plato,
+Honcho, Mini, or a provider directly.
+
+## Safety boundary
+
+- Run as root with one protected JSON config at an absolute path under
+  `/var/lib/ella` or `/etc/ella`.
+- The config file must be root-owned mode `0400` or `0600`; its immediate
+  directory must be root-owned mode `0700`.
+- Put only `env:ELLA_...` secret references in the config. Load the referenced
+  values into the harness process without placing them in argv or shell history.
+- Use only a UID beginning with `synthetic-` or `staging-synthetic-`, exact
+  account/profile/binding UUIDs, and two distinct explicit session keys.
+- The backend URL is HTTPS/443 only. The broker URL retains the production
+  client's HTTPS/443 rule and permits only its reviewed synthetic loopback pin,
+  `http://127.0.0.1:18097`.
+- The harness never prints prompts, responses, tokens, memory content,
+  transcripts, or callback bodies. Reports contain hashes, equality facts,
+  counts, status names, and bounded latencies only.
+
+## Protected config contract
+
+```json
+{
+  "schema_version": "ella-hermes-product-fit-canary-v1",
+  "run_id": "synthetic-fit-YYYYMMDD",
+  "selectors": {
+    "uid": "staging-synthetic-REPLACE",
+    "account_id": "00000000-0000-4000-8000-000000000000",
+    "profile_id": "00000000-0000-4000-8000-000000000000",
+    "binding_id": "00000000-0000-4000-8000-000000000000",
+    "consent_epoch": "00000000-0000-4000-8000-000000000000",
+    "expected_model": "gpt-5.6-terra",
+    "chat_channel": "ios_chat",
+    "primary_session_key": "ella:canary:REPLACE:primary",
+    "isolated_session_key": "ella:canary:REPLACE:isolated"
+  },
+  "backend": {
+    "base_url": "https://REPLACE",
+    "auth_token_ref": "env:ELLA_CANARY_FIREBASE_ID_TOKEN",
+    "enrichment_token_ref": "env:ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN"
+  },
+  "broker": {
+    "base_url": "http://127.0.0.1:18097",
+    "allowed_host": "127.0.0.1",
+    "service_token_ref": "env:ELLA_HERMES_BROKER_SERVICE_TOKEN",
+    "poll_interval_seconds": 0.5,
+    "poll_timeout_seconds": 45,
+    "deadline_seconds": 90
+  },
+  "voice_memory": {
+    "conversation_id": "synthetic-memory-REPLACE",
+    "active_summary_version_id": "synthetic-summary-REPLACE",
+    "pack_sha256": "REPLACE_WITH_64_LOWERCASE_HEX"
+  },
+  "enrichment": {
+    "conversation_id": "synthetic-enrichment-REPLACE",
+    "transcript_sha256": "REPLACE_WITH_64_LOWERCASE_HEX"
+  },
+  "max_latency_ms": 120000
+}
+```
+
+`voice_memory.pack_sha256` is the SHA-256 of the content-free `session_scope`
+projection returned only after the server-owned full memory pack resolves. The
+exact conversation and active summary version pins prove the intended pack was
+selected without returning its content. Compute the projection hash inside an
+approved protected process; do not print or persist the memory pack. The
+enrichment transcript must already exist under the exact disposable synthetic
+profile. The harness does not seed content or fabricate database rows. It never
+calls the voice context route, so this check cannot invoke Honcho.
+
+## Run
+
+From `backend/`:
+
+```bash
+python scripts/hermes_product_fit_canary.py run \
+  --config /var/lib/ella/hermes-product-fit/canary.json
+```
+
+Exit status is `0` only when every verdict is `PASS`, `1` when any verdict is
+`FAIL`, and `2` when no verdict fails but at least one capability is
+`NOT TESTED`. Each scenario emits one content-free stage table followed by this
+matrix:
+
+- chat transport
+- full-response fidelity
+- API/SSE-like consumption
+- same-session continuity
+- cross-session isolation
+- profile memory pack
+- enrichment
+- replay safety
+
+The callback contract fixture is `ella.hermes.callback.v1` and requires the
+`outcome` field. Broker completion remains owner/request/correlation/lane pinned
+with `stock_best_effort_v1`, `terminal_proof=false`, one generation, and one
+terminal writeback.
+
+## Cleanup
+
+Cleanup is deliberately two-phase so the harness cannot mutate n8n or deployment
+configuration. First, the authorized controller restores all canary workflows,
+global flags, and exact selectors to off/empty and writes a root-owned protected
+receipt:
+
+```json
+{
+  "schema_version": "ella-hermes-canary-off-receipt-v1",
+  "uid_sha256": "REPLACE_WITH_SHA256_OF_EXACT_SYNTHETIC_UID",
+  "flags_off": true,
+  "selectors_empty": true,
+  "workflows_off": true,
+  "content_free": true
+}
+```
+
+Then invoke the existing exact-UID voice-data deletion and authenticated
+exact-account deletion paths:
+
+```bash
+python scripts/hermes_product_fit_canary.py cleanup \
+  --config /var/lib/ella/hermes-product-fit/canary.json \
+  --off-receipt /var/lib/ella/hermes-product-fit/off.receipt.json \
+  --confirm-uid staging-synthetic-REPLACE
+```
+
+Cleanup refuses UID drift, a missing or non-protected receipt, or any receipt
+that does not attest all flags, selectors, and workflows are off. The bearer
+token stays in-process; output is a content-free receipt containing only the UID
+hash, removed-row count, and cleanup facts. Invitation revocation/classification cleanup and
+unclaimed pool cleanup remain in their existing reviewed operator CLIs when
+those artifacts still exist.

--- a/backend/ella/docs/HERMES_PRODUCT_FIT_CANARY.md
+++ b/backend/ella/docs/HERMES_PRODUCT_FIT_CANARY.md
@@ -102,6 +102,14 @@ The callback contract fixture is `ella.hermes.callback.v1` and requires the
 with `stock_best_effort_v1`, `terminal_proof=false`, one generation, and one
 terminal writeback.
 
+Scenario E obtains its `client_interaction_id` from the production enrichment
+identity boundary. That boundary binds UID, conversation ID, transcript SHA-256,
+the current enrichment policy version, and the SHA-256 of the current policy
+instructions. The canary `run_id` is not part of this canonical identity, so an
+exact retry reaches the production duplicate-safe path. Successful enrichment
+receipts may include canonical user and assistant event IDs. Chat session
+key/ID fields remain forbidden and cause the contamination check to fail.
+
 ## Cleanup
 
 Cleanup is deliberately two-phase so the harness cannot mutate n8n or deployment

--- a/backend/scripts/hermes_product_fit_canary.py
+++ b/backend/scripts/hermes_product_fit_canary.py
@@ -1,0 +1,1248 @@
+#!/usr/bin/env python3
+"""Content-free acceptance harness for one synthetic Hermes Cloud profile."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import binascii
+import hashlib
+import json
+import os
+import re
+import stat
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Protocol
+from urllib.parse import urlparse
+
+import httpx
+
+from database import voice_canary as voice_canary_db
+from ella.services.hermes_broker_client import HermesBrokerClient
+from ella.services.hermes_broker_prototype import HermesBrokerPrototypeConfig
+from ella.services.hermes_cloud_runtime import broker_session_id_for_scope
+from ella.services.runtime_errors import ProvisioningError
+
+CONFIG_SCHEMA = "ella-hermes-product-fit-canary-v1"
+CALLBACK_SCHEMA = "ella.hermes.callback.v1"
+STOCK_CALLBACK_CONTRACT = "stock_best_effort_v1"
+APPROVED_SECRET_ROOTS = (Path("/etc/ella"), Path("/var/lib/ella"))
+SYNTHETIC_PREFIXES = ("synthetic-", "staging-synthetic-")
+TERMINAL_STATUSES = frozenset({"writeback_completed", "blocked", "quarantined", "expired", "writeback_blocked"})
+SECRET_REF_RE = re.compile(r"^env:(ELLA_[A-Z0-9_]{3,120})$")
+SAFE_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,256}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class HarnessRefusal(RuntimeError):
+    """Fail-closed harness refusal carrying only a content-free code."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+class ScenarioNotTested(RuntimeError):
+    """A deployed optional observation surface is unavailable."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+def _sha256(value: str | bytes) -> str:
+    raw = value.encode("utf-8") if isinstance(value, str) else value
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _exact_uuid(value: Any, field_name: str) -> str:
+    try:
+        parsed = uuid.UUID(str(value))
+    except (ValueError, TypeError, AttributeError) as exc:
+        raise HarnessRefusal(f"{field_name}_invalid") from exc
+    if str(parsed) != str(value):
+        raise HarnessRefusal(f"{field_name}_invalid")
+    return str(parsed)
+
+
+def _safe_id(value: Any, field_name: str) -> str:
+    candidate = str(value or "").strip()
+    if SAFE_ID_RE.fullmatch(candidate) is None:
+        raise HarnessRefusal(f"{field_name}_invalid")
+    return candidate
+
+
+def _approved_https_base_url(value: Any) -> str:
+    candidate = str(value or "").strip().rstrip("/")
+    parsed = urlparse(candidate)
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.port not in (None, 443)
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        raise HarnessRefusal("backend_base_url_not_allowlisted")
+    return candidate
+
+
+def _secret_ref(value: Any, field_name: str) -> str:
+    candidate = str(value or "").strip()
+    if SECRET_REF_RE.fullmatch(candidate) is None:
+        raise HarnessRefusal(f"{field_name}_invalid")
+    return candidate
+
+
+def _resolve_env_secret(ref: str) -> str:
+    match = SECRET_REF_RE.fullmatch(ref)
+    if match is None:
+        raise HarnessRefusal("secret_ref_invalid")
+    value = os.getenv(match.group(1), "")
+    if len(value) < 32:
+        raise HarnessRefusal("secret_ref_unavailable")
+    return value
+
+
+def _require_firebase_subject(token: str, expected_uid: str) -> None:
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise HarnessRefusal("firebase_token_shape_invalid")
+    try:
+        padding = "=" * (-len(parts[1]) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(parts[1] + padding).decode("utf-8"))
+    except (ValueError, binascii.Error, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise HarnessRefusal("firebase_token_shape_invalid") from exc
+    if not isinstance(claims, dict):
+        raise HarnessRefusal("firebase_token_shape_invalid")
+    subject = str(claims.get("user_id") or claims.get("sub") or "")
+    if subject != expected_uid or not subject.startswith(SYNTHETIC_PREFIXES):
+        raise HarnessRefusal("firebase_token_subject_mismatch")
+
+
+def _assert_protected_file(
+    path: Path,
+    *,
+    approved_roots: tuple[Path, ...] = APPROVED_SECRET_ROOTS,
+    expected_owner_uid: int = 0,
+) -> Path:
+    if not path.is_absolute():
+        raise HarnessRefusal("protected_file_not_absolute")
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError as exc:
+        raise HarnessRefusal("protected_file_invalid") from exc
+    if path.is_symlink() or not resolved.is_file():
+        raise HarnessRefusal("protected_file_invalid")
+    if not any(resolved.is_relative_to(root.resolve()) for root in approved_roots):
+        raise HarnessRefusal("protected_file_root_refused")
+    metadata = resolved.stat()
+    if metadata.st_uid != expected_owner_uid or stat.S_IMODE(metadata.st_mode) not in {0o400, 0o600}:
+        raise HarnessRefusal("protected_file_metadata_refused")
+    parent = resolved.parent
+    parent_metadata = parent.stat()
+    if (
+        parent.is_symlink()
+        or parent_metadata.st_uid != expected_owner_uid
+        or stat.S_IMODE(parent_metadata.st_mode) != 0o700
+    ):
+        raise HarnessRefusal("protected_parent_metadata_refused")
+    return resolved
+
+
+@dataclass(frozen=True)
+class CanaryConfig:
+    run_id: str
+    uid: str
+    account_id: str
+    profile_id: str
+    binding_id: str
+    consent_epoch: str
+    expected_model: str
+    chat_channel: str
+    primary_session_key: str
+    isolated_session_key: str
+    backend_base_url: str
+    backend_auth_ref: str
+    enrichment_token_ref: str
+    broker: HermesBrokerPrototypeConfig
+    voice_conversation_id: str
+    voice_summary_version_id: str
+    memory_pack_sha256: str
+    enrichment_conversation_id: str
+    enrichment_transcript_sha256: str
+    max_latency_ms: int
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> "CanaryConfig":
+        if raw.get("schema_version") != CONFIG_SCHEMA or set(raw) != {
+            "schema_version",
+            "run_id",
+            "selectors",
+            "backend",
+            "broker",
+            "voice_memory",
+            "enrichment",
+            "max_latency_ms",
+        }:
+            raise HarnessRefusal("config_shape_invalid")
+        selectors = raw.get("selectors")
+        backend = raw.get("backend")
+        broker = raw.get("broker")
+        voice_memory = raw.get("voice_memory")
+        enrichment = raw.get("enrichment")
+        if not all(isinstance(item, dict) for item in (selectors, backend, broker, voice_memory, enrichment)):
+            raise HarnessRefusal("config_shape_invalid")
+        if set(selectors) != {
+            "uid",
+            "account_id",
+            "profile_id",
+            "binding_id",
+            "consent_epoch",
+            "expected_model",
+            "chat_channel",
+            "primary_session_key",
+            "isolated_session_key",
+        }:
+            raise HarnessRefusal("selector_shape_invalid")
+        if set(backend) != {
+            "base_url",
+            "auth_token_ref",
+            "enrichment_token_ref",
+        }:
+            raise HarnessRefusal("backend_shape_invalid")
+        if set(broker) != {
+            "base_url",
+            "allowed_host",
+            "service_token_ref",
+            "poll_interval_seconds",
+            "poll_timeout_seconds",
+            "deadline_seconds",
+        }:
+            raise HarnessRefusal("broker_shape_invalid")
+        if set(voice_memory) != {
+            "conversation_id",
+            "active_summary_version_id",
+            "pack_sha256",
+        }:
+            raise HarnessRefusal("voice_memory_shape_invalid")
+        if set(enrichment) != {
+            "conversation_id",
+            "transcript_sha256",
+        }:
+            raise HarnessRefusal("enrichment_shape_invalid")
+
+        uid = _safe_id(selectors["uid"], "uid")
+        if not uid.startswith(SYNTHETIC_PREFIXES) or uid in {"realcryptoplato", "plato_eval", "plato-eval"}:
+            raise HarnessRefusal("synthetic_uid_required")
+        account_id = _exact_uuid(selectors["account_id"], "account_id")
+        profile_id = _exact_uuid(selectors["profile_id"], "profile_id")
+        binding_id = _exact_uuid(selectors["binding_id"], "binding_id")
+        consent_epoch = _exact_uuid(selectors["consent_epoch"], "consent_epoch")
+        primary_session_key = _safe_id(selectors["primary_session_key"], "primary_session_key")
+        isolated_session_key = _safe_id(selectors["isolated_session_key"], "isolated_session_key")
+        if primary_session_key == isolated_session_key:
+            raise HarnessRefusal("distinct_sessions_required")
+        expected_model = _safe_id(selectors["expected_model"], "expected_model")
+        chat_channel = _safe_id(selectors["chat_channel"], "chat_channel")
+
+        try:
+            broker_config = HermesBrokerPrototypeConfig(
+                enabled=True,
+                account_id=account_id,
+                profile_id=profile_id,
+                binding_id=binding_id,
+                base_url=str(broker["base_url"] or "").strip().rstrip("/"),
+                allowed_host=str(broker["allowed_host"] or "").strip(),
+                service_token_ref=_secret_ref(broker["service_token_ref"], "broker_service_token_ref"),
+                poll_interval_seconds=float(broker["poll_interval_seconds"]),
+                poll_timeout_seconds=float(broker["poll_timeout_seconds"]),
+                deadline_seconds=int(broker["deadline_seconds"]),
+            )
+        except (TypeError, ValueError) as exc:
+            raise HarnessRefusal("broker_timing_invalid") from exc
+        # Reuse the production client's exact URL gate before any network work.
+        try:
+            HermesBrokerClient(broker_config)._assert_url(
+                f"{broker_config.base_url}/v1/ella/internal/hermes-webhook-broker/stock-canary/admit",
+                expected_path_prefix="/v1/ella/internal/hermes-webhook-broker/stock-canary/admit",
+            )
+        except ProvisioningError as exc:
+            raise HarnessRefusal(exc.code) from exc
+        if broker_config.allowed_host == "127.0.0.1" and broker_config.base_url != "http://127.0.0.1:18097":
+            raise HarnessRefusal("broker_loopback_pin_invalid")
+        if not (0.1 <= broker_config.poll_interval_seconds <= 5.0):
+            raise HarnessRefusal("broker_poll_interval_invalid")
+        if not (1.0 <= broker_config.poll_timeout_seconds <= 120.0):
+            raise HarnessRefusal("broker_poll_timeout_invalid")
+        if not (10 <= broker_config.deadline_seconds <= 600):
+            raise HarnessRefusal("broker_deadline_invalid")
+
+        memory_pack_sha256 = str(voice_memory["pack_sha256"] or "").strip()
+        transcript_sha256 = str(enrichment["transcript_sha256"] or "").strip()
+        if SHA256_RE.fullmatch(memory_pack_sha256) is None or SHA256_RE.fullmatch(transcript_sha256) is None:
+            raise HarnessRefusal("expected_digest_invalid")
+        try:
+            max_latency_ms = int(raw["max_latency_ms"])
+        except (TypeError, ValueError) as exc:
+            raise HarnessRefusal("max_latency_invalid") from exc
+        if not (1000 <= max_latency_ms <= 600_000):
+            raise HarnessRefusal("max_latency_invalid")
+
+        return cls(
+            run_id=_safe_id(raw["run_id"], "run_id"),
+            uid=uid,
+            account_id=account_id,
+            profile_id=profile_id,
+            binding_id=binding_id,
+            consent_epoch=consent_epoch,
+            expected_model=expected_model,
+            chat_channel=chat_channel,
+            primary_session_key=primary_session_key,
+            isolated_session_key=isolated_session_key,
+            backend_base_url=_approved_https_base_url(backend["base_url"]),
+            backend_auth_ref=_secret_ref(backend["auth_token_ref"], "backend_auth_token_ref"),
+            enrichment_token_ref=_secret_ref(backend["enrichment_token_ref"], "enrichment_token_ref"),
+            broker=broker_config,
+            voice_conversation_id=_safe_id(voice_memory["conversation_id"], "voice_conversation_id"),
+            voice_summary_version_id=_safe_id(
+                voice_memory["active_summary_version_id"],
+                "voice_summary_version_id",
+            ),
+            memory_pack_sha256=memory_pack_sha256,
+            enrichment_conversation_id=_safe_id(
+                enrichment["conversation_id"],
+                "enrichment_conversation_id",
+            ),
+            enrichment_transcript_sha256=transcript_sha256,
+            max_latency_ms=max_latency_ms,
+        )
+
+
+def load_config(path: str) -> CanaryConfig:
+    if os.geteuid() != 0:
+        raise HarnessRefusal("root_required")
+    protected = _assert_protected_file(Path(path))
+    try:
+        raw = json.loads(protected.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise HarnessRefusal("config_invalid") from exc
+    if not isinstance(raw, dict):
+        raise HarnessRefusal("config_invalid")
+    return CanaryConfig.from_mapping(raw)
+
+
+@dataclass(frozen=True)
+class ChatObservation:
+    text: str
+    response_id: str
+    request_id: str
+    correlation_id: str
+    duplicate: bool
+    statuses: tuple[str, ...]
+    terminal_frames: int
+    admission_posts: int
+    callback_outcomes: int
+    generation: int
+    latency_ms: int
+
+
+@dataclass(frozen=True)
+class MemoryObservation:
+    scoped_pack_sha256: str
+    conversation_id_matches: bool
+    summary_version_matches: bool
+    unscoped_memory_absent: bool
+    latency_ms: int
+
+
+@dataclass(frozen=True)
+class EnrichmentObservation:
+    status: str
+    correlation_matches: bool
+    transcript_hash_matches: bool
+    duplicate_replay: bool
+    chat_identity_absent: bool
+    latency_ms: int
+
+
+@dataclass(frozen=True)
+class ReplayObservation:
+    duplicate_ingress: bool
+    same_response_hash: bool
+    same_response_id: bool
+    missing_outcome_refused: bool
+    wrong_correlation_refused: bool
+    wrong_session_refused: bool
+    timeout_refused: bool
+    partial_after_terminal_refused: bool
+    latency_ms: int
+
+
+class CanaryAdapter(Protocol):
+    async def chat(self, *, session_key: str, source_event_id: str, prompt: str) -> ChatObservation: ...
+
+    async def memory_pack(self) -> MemoryObservation: ...
+
+    async def enrichment(self) -> EnrichmentObservation: ...
+
+    async def replay(self, original: ChatObservation, *, source_event_id: str, prompt: str) -> ReplayObservation: ...
+
+    async def cleanup(self, *, off_receipt: Mapping[str, Any]) -> dict[str, Any]: ...
+
+
+class _RecordingHttpFactory:
+    def __init__(self):
+        self.posts = 0
+        self.statuses: list[str] = []
+        self.terminal_frames = 0
+        self.callback_outcomes = 0
+        self.generation = 0
+
+    def __call__(self, timeout: float):
+        recorder = self
+
+        class RecordingClient:
+            def __init__(self):
+                self.client = httpx.AsyncClient(
+                    timeout=timeout,
+                    follow_redirects=False,
+                    trust_env=False,
+                )
+
+            async def __aenter__(self):
+                await self.client.__aenter__()
+                return self
+
+            async def __aexit__(self, *args):
+                return await self.client.__aexit__(*args)
+
+            async def post(self, url: str, **kwargs):
+                recorder.posts += 1
+                return await self.client.post(url, **kwargs)
+
+            async def get(self, url: str, **kwargs):
+                response = await self.client.get(url, **kwargs)
+                try:
+                    body = response.json()
+                except (ValueError, json.JSONDecodeError):
+                    return response
+                if isinstance(body, dict):
+                    status_value = str(body.get("status") or "").strip()
+                    if status_value:
+                        recorder.statuses.append(status_value)
+                    if status_value in TERMINAL_STATUSES:
+                        recorder.terminal_frames += 1
+                    if body.get("outcome") in {"success", "error"}:
+                        recorder.callback_outcomes += 1
+                    diagnostic = body.get("diagnostic")
+                    if isinstance(diagnostic, dict) and isinstance(diagnostic.get("generation"), int):
+                        recorder.generation = int(diagnostic["generation"])
+                return response
+
+        return RecordingClient()
+
+
+class LiveCanaryAdapter:
+    """Use only the existing OMI broker and authenticated first-party APIs."""
+
+    def __init__(self, config: CanaryConfig):
+        self.config = config
+
+    async def chat(self, *, session_key: str, source_event_id: str, prompt: str) -> ChatObservation:
+        recorder = _RecordingHttpFactory()
+        client = HermesBrokerClient(self.config.broker, http_client_factory=recorder)
+        started = time.monotonic()
+        session_id = _session_id(self.config, session_key)
+        try:
+            result = await client.run_chat_turn(
+                account_id=self.config.account_id,
+                profile_id=self.config.profile_id,
+                runtime_binding_ref=self.config.binding_id,
+                consent_epoch=self.config.consent_epoch,
+                message=prompt,
+                session_key=session_key,
+                session_id=session_id,
+                source_event_id=source_event_id,
+                expected_model=self.config.expected_model,
+            )
+        except ProvisioningError as exc:
+            raise HarnessRefusal(exc.code) from exc
+        return ChatObservation(
+            text=result.text,
+            response_id=result.response_id,
+            request_id=result.request_id,
+            correlation_id=result.correlation_id,
+            duplicate=result.duplicate,
+            statuses=tuple(recorder.statuses),
+            terminal_frames=recorder.terminal_frames,
+            admission_posts=recorder.posts,
+            callback_outcomes=recorder.callback_outcomes,
+            generation=recorder.generation,
+            latency_ms=int((time.monotonic() - started) * 1000),
+        )
+
+    async def memory_pack(self) -> MemoryObservation:
+        started = time.monotonic()
+        auth_token = _resolve_env_secret(self.config.backend_auth_ref)
+        _require_firebase_subject(auth_token, self.config.uid)
+        async with httpx.AsyncClient(timeout=60.0, follow_redirects=False, trust_env=False) as client:
+            scoped_body = await _request_json(
+                client,
+                "POST",
+                f"{self.config.backend_base_url}/v1/voice/session",
+                surface="voice_session",
+                headers={"Authorization": f"Bearer {auth_token}"},
+                json={
+                    "uid": self.config.uid,
+                    "provider": "grok-voice",
+                    "voice_mode": "v4",
+                    "session_scope": {
+                        "kind": "memory",
+                        "conversation_id": self.config.voice_conversation_id,
+                        "expected_active_summary_version_id": self.config.voice_summary_version_id,
+                    },
+                },
+            )
+            if len(str(scoped_body.get("session_token") or "")) < 32:
+                raise HarnessRefusal("voice_session_token_missing")
+            scoped_identity = scoped_body.get("session_scope")
+            if not isinstance(scoped_identity, dict):
+                raise HarnessRefusal("voice_memory_scope_missing")
+
+            unscoped_body = await _request_json(
+                client,
+                "POST",
+                f"{self.config.backend_base_url}/v1/voice/session",
+                surface="voice_session",
+                headers={"Authorization": f"Bearer {auth_token}"},
+                json={"uid": self.config.uid, "provider": "grok-voice", "voice_mode": "v4"},
+            )
+            if len(str(unscoped_body.get("session_token") or "")) < 32:
+                raise HarnessRefusal("voice_session_token_missing")
+
+        return MemoryObservation(
+            # The session route returns this content-free projection only after
+            # the server-owned full memory pack has resolved successfully.
+            scoped_pack_sha256=_sha256(_canonical_json(scoped_identity)),
+            conversation_id_matches=(str(scoped_identity.get("conversation_id")) == self.config.voice_conversation_id),
+            summary_version_matches=(
+                str(scoped_identity.get("active_summary_version_id")) == self.config.voice_summary_version_id
+            ),
+            unscoped_memory_absent=unscoped_body.get("session_scope") is None,
+            latency_ms=int((time.monotonic() - started) * 1000),
+        )
+
+    async def enrichment(self) -> EnrichmentObservation:
+        started = time.monotonic()
+        token = _resolve_env_secret(self.config.enrichment_token_ref)
+        digest = _sha256(f"{self.config.run_id}|{self.config.uid}|{self.config.enrichment_conversation_id}|enrichment")
+        client_interaction_id = f"omi-enrichment:{digest}"
+        payload = {
+            "uid": self.config.uid,
+            "conversation_id": self.config.enrichment_conversation_id,
+            "client_interaction_id": client_interaction_id,
+            "transcript_sha256": self.config.enrichment_transcript_sha256,
+        }
+        headers = {"X-Ella-Hermes-Cloud-Enrichment-Token": token}
+        async with httpx.AsyncClient(timeout=120.0, follow_redirects=False, trust_env=False) as client:
+            first = await _request_json(
+                client,
+                "POST",
+                f"{self.config.backend_base_url}/v1/ella/internal/hermes-cloud/enrichment/run",
+                surface="enrichment",
+                headers=headers,
+                json=payload,
+            )
+            replay = await _request_json(
+                client,
+                "POST",
+                f"{self.config.backend_base_url}/v1/ella/internal/hermes-cloud/enrichment/run",
+                surface="enrichment",
+                headers=headers,
+                json=payload,
+            )
+        forbidden_chat_keys = {"session_key", "session_id", "canonical_user_event_id"}
+        return EnrichmentObservation(
+            status=str(first.get("status") or ""),
+            correlation_matches=(
+                first.get("client_interaction_id") == client_interaction_id
+                and replay.get("client_interaction_id") == client_interaction_id
+            ),
+            transcript_hash_matches=(
+                first.get("transcript_sha256") == self.config.enrichment_transcript_sha256
+                and replay.get("transcript_sha256") == self.config.enrichment_transcript_sha256
+            ),
+            duplicate_replay=first.get("duplicate") is False and replay.get("duplicate") is True,
+            chat_identity_absent=forbidden_chat_keys.isdisjoint(first) and forbidden_chat_keys.isdisjoint(replay),
+            latency_ms=int((time.monotonic() - started) * 1000),
+        )
+
+    async def replay(self, original: ChatObservation, *, source_event_id: str, prompt: str) -> ReplayObservation:
+        started = time.monotonic()
+        replay = await self.chat(
+            session_key=self.config.primary_session_key,
+            source_event_id=source_event_id,
+            prompt=prompt,
+        )
+        contract_checks = await _contract_failure_checks(self.config, source_event_id)
+        return ReplayObservation(
+            duplicate_ingress=replay.duplicate,
+            same_response_hash=_sha256(replay.text) == _sha256(original.text),
+            same_response_id=replay.response_id == original.response_id,
+            missing_outcome_refused=contract_checks["missing_outcome"],
+            wrong_correlation_refused=contract_checks["wrong_correlation"],
+            wrong_session_refused=contract_checks["wrong_session"],
+            timeout_refused=contract_checks["timeout"],
+            partial_after_terminal_refused=_status_sequence_valid(
+                ("pending", "writeback_completed", "writeback_pending")
+            )
+            is False,
+            latency_ms=int((time.monotonic() - started) * 1000),
+        )
+
+    async def cleanup(self, *, off_receipt: Mapping[str, Any]) -> dict[str, Any]:
+        _validate_off_receipt(off_receipt, self.config)
+        auth_token = _resolve_env_secret(self.config.backend_auth_ref)
+        _require_firebase_subject(auth_token, self.config.uid)
+        voice_counts = await voice_canary_db.delete_user_voice_data(self.config.uid)
+        async with httpx.AsyncClient(timeout=60.0, follow_redirects=False, trust_env=False) as client:
+            body = await _request_json(
+                client,
+                "DELETE",
+                f"{self.config.backend_base_url}/v1/users/delete-account",
+                surface="account_cleanup",
+                unavailable_is_not_tested=False,
+                headers={"Authorization": f"Bearer {auth_token}"},
+            )
+        if body.get("status") != "ok":
+            raise HarnessRefusal("account_cleanup_refused")
+        return {
+            "status": "cleaned",
+            "uid_sha256": _sha256(self.config.uid),
+            "flags_off": True,
+            "selectors_empty": True,
+            "workflows_off": True,
+            "exact_account_delete": True,
+            "voice_rows_removed": sum(int(value) for value in voice_counts.values()),
+            "content_free": True,
+        }
+
+
+def _response_json(response: httpx.Response, surface: str) -> dict[str, Any]:
+    if response.status_code >= 400:
+        if response.status_code in {404, 501, 503}:
+            raise ScenarioNotTested(f"{surface}_unavailable")
+        raise HarnessRefusal(f"{surface}_http_refused")
+    try:
+        body = response.json()
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise HarnessRefusal(f"{surface}_response_invalid") from exc
+    if not isinstance(body, dict):
+        raise HarnessRefusal(f"{surface}_response_invalid")
+    return body
+
+
+async def _request_json(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    *,
+    surface: str,
+    unavailable_is_not_tested: bool = True,
+    **kwargs,
+) -> dict[str, Any]:
+    try:
+        response = await client.request(method, url, **kwargs)
+    except httpx.HTTPError as exc:
+        if unavailable_is_not_tested:
+            raise ScenarioNotTested(f"{surface}_transport_unavailable") from exc
+        raise HarnessRefusal(f"{surface}_transport_refused") from exc
+    try:
+        return _response_json(response, surface)
+    except ScenarioNotTested as exc:
+        if unavailable_is_not_tested:
+            raise
+        raise HarnessRefusal(f"{surface}_unavailable") from exc
+
+
+def _session_id(config: CanaryConfig, session_key: str) -> str:
+    return broker_session_id_for_scope(
+        account_id=config.account_id,
+        profile_id=config.profile_id,
+        runtime_binding_ref=config.binding_id,
+        channel=config.chat_channel,
+        session_key=session_key,
+    )
+
+
+def _source_event_id(config: CanaryConfig, label: str) -> str:
+    return f"canary-event:{_sha256(f'{config.run_id}|{label}')[:48]}"
+
+
+def _marker(config: CanaryConfig, label: str) -> str:
+    return f"CANARY-{label.upper()}-{_sha256(f'{config.run_id}|{label}')[:24]}"
+
+
+def _status_sequence_valid(statuses: tuple[str, ...]) -> bool:
+    terminal_seen = False
+    terminal_count = 0
+    for status_value in statuses:
+        if status_value in TERMINAL_STATUSES:
+            terminal_count += 1
+            terminal_seen = True
+        elif terminal_seen:
+            return False
+    return terminal_count == 1
+
+
+def _sse_contract(text: str, response_id: str) -> tuple[str, ...]:
+    payload = {
+        "id": response_id,
+        "text": text,
+        "sender": "ai",
+        "type": "text",
+    }
+    return (
+        f"data: {text.replace(chr(10), '__CRLF__')}",
+        f"done: {base64.b64encode(json.dumps(payload).encode()).decode()}",
+    )
+
+
+def _sse_contract_valid(frames: tuple[str, ...]) -> bool:
+    if len(frames) != 2 or not frames[0].startswith("data: ") or not frames[1].startswith("done: "):
+        return False
+    try:
+        decoded = json.loads(base64.b64decode(frames[1][6:]).decode("utf-8"))
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    data_text = frames[0][6:].replace("__CRLF__", "\n")
+    return decoded.get("text") == data_text and decoded.get("sender") == "ai"
+
+
+async def _contract_failure_checks(config: CanaryConfig, source_event_id: str) -> dict[str, bool]:
+    client = HermesBrokerClient(config.broker)
+    session_key = config.primary_session_key
+    session_id = _session_id(config, session_key)
+    result = {
+        "answer": "CANARY-CONTENT-SAFE",
+        "session_key": session_key,
+        "session_id": session_id,
+        "canonical_user_event_id": source_event_id,
+        "model": config.expected_model,
+    }
+    terminal = {
+        "outcome": "success",
+        "result": result,
+        "diagnostic": {
+            "stage": "broker_writeback",
+            "reason": "writeback_completed",
+            "generation": 1,
+        },
+    }
+    checks: dict[str, bool] = {}
+    for label, mutated in (
+        ("missing_outcome", {**terminal, "outcome": None}),
+        ("wrong_session", {**terminal, "result": {**result, "session_id": f"{session_id}-wrong"}}),
+    ):
+        try:
+            client._map_chat_result(
+                mutated,
+                request_id="canary-request",
+                correlation_id="canary-correlation",
+                expected_model=config.expected_model,
+                session_key=session_key,
+                session_id=session_id,
+                source_event_id=source_event_id,
+                admission_duplicate=False,
+            )
+        except ProvisioningError:
+            checks[label] = True
+        else:
+            checks[label] = False
+    envelope = {
+        "request_id": "canary-request",
+        "correlation_id": "canary-correlation-wrong",
+        "account_id": config.account_id,
+        "profile_id": config.profile_id,
+        "lane": "chat_turn",
+    }
+    try:
+        client._assert_terminal_envelope(
+            envelope,
+            request_id="canary-request",
+            correlation_id="canary-correlation",
+            account_id=config.account_id,
+            profile_id=config.profile_id,
+            lane="chat_turn",
+            require_terminal_identity=True,
+        )
+    except ProvisioningError:
+        checks["wrong_correlation"] = True
+    else:
+        checks["wrong_correlation"] = False
+
+    class PendingResponse:
+        status_code = 200
+        content = b"{}"
+
+        @staticmethod
+        def json():
+            return {
+                "status": "pending",
+                "request_id": "canary-request",
+                "account_id": config.account_id,
+                "profile_id": config.profile_id,
+                "lane": "chat_turn",
+                "callback_contract": STOCK_CALLBACK_CONTRACT,
+                "terminal_proof": False,
+                "outcome": None,
+                "diagnostic": {
+                    "stage": "broker_request",
+                    "reason": "pending",
+                    "generation": 1,
+                },
+            }
+
+    class PendingHttp:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def get(self, _url, **_kwargs):
+            return PendingResponse()
+
+    clock_values = iter((0.0, 0.0, config.broker.poll_timeout_seconds + 1.0))
+    timeout_client = HermesBrokerClient(
+        config.broker,
+        http_client_factory=lambda timeout: PendingHttp(),
+        sleep=lambda _seconds: asyncio.sleep(0),
+        clock=lambda: next(clock_values),
+    )
+    timeout_client._headers = lambda: {
+        "Authorization": "Bearer content-safe-contract-test",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "Host": config.broker.allowed_host,
+    }
+    try:
+        await timeout_client.wait_for_terminal(
+            request_id="canary-request",
+            account_id=config.account_id,
+            profile_id=config.profile_id,
+            lane="chat_turn",
+        )
+    except ProvisioningError as exc:
+        checks["timeout"] = exc.code == "hermes_broker_prototype_wait_timeout"
+    else:
+        checks["timeout"] = False
+    return checks
+
+
+@dataclass
+class Stage:
+    scenario: str
+    name: str
+    status: str
+    latency_ms: int
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class HarnessReport:
+    stages: list[Stage]
+    verdicts: dict[str, str]
+
+    def render(self) -> str:
+        lines: list[str] = []
+        for scenario in "ABCDEF":
+            lines.extend(
+                (
+                    f"Scenario {scenario}",
+                    "",
+                    "| Stage | Status | Latency ms | Content-free evidence |",
+                    "|---|---:|---:|---|",
+                )
+            )
+            rows = [stage for stage in self.stages if stage.scenario == scenario]
+            if not rows:
+                rows = [Stage(scenario, "scenario", "NOT TESTED", 0, {"reason": "not_run"})]
+            for stage in rows:
+                evidence = "; ".join(f"{key}={str(value).lower()}" for key, value in sorted(stage.evidence.items()))
+                lines.append(f"| {stage.name} | {stage.status} | {stage.latency_ms} | {evidence} |")
+            lines.append("")
+        lines.extend(
+            (
+                "Final verdict matrix",
+                "",
+                "| Capability | Verdict |",
+                "|---|---:|",
+            )
+        )
+        for capability, verdict in self.verdicts.items():
+            lines.append(f"| {capability} | {verdict} |")
+        return "\n".join(lines) + "\n"
+
+
+def _pass_or_fail(condition: bool) -> str:
+    return "PASS" if condition else "FAIL"
+
+
+def _scenario_verdict(stages: list[Stage], scenario: str) -> str:
+    statuses = [stage.status for stage in stages if stage.scenario == scenario]
+    if not statuses or "NOT TESTED" in statuses:
+        return "NOT TESTED"
+    return "FAIL" if "FAIL" in statuses else "PASS"
+
+
+async def run_harness(config: CanaryConfig, adapter: CanaryAdapter) -> HarnessReport:
+    stages: list[Stage] = []
+    observations: dict[str, ChatObservation] = {}
+
+    async def run_chat(label: str, session_key: str, prompt: str) -> ChatObservation:
+        return await adapter.chat(
+            session_key=session_key,
+            source_event_id=_source_event_id(config, label),
+            prompt=prompt,
+        )
+
+    full_response = _marker(config, "full-response")
+    try:
+        observation = await run_chat(
+            "full-response",
+            config.primary_session_key,
+            f"Return exactly this synthetic marker and nothing else: {full_response}",
+        )
+        observations["full-response"] = observation
+        fidelity = observation.text == full_response
+        transport_ok = (
+            observation.admission_posts == 1
+            and observation.callback_outcomes == 1
+            and observation.terminal_frames == 1
+            and observation.generation == 1
+            and _status_sequence_valid(observation.statuses)
+            and observation.latency_ms <= config.max_latency_ms
+            and not observation.duplicate
+        )
+        sse_ok = _sse_contract_valid(_sse_contract(observation.text, observation.response_id))
+        stages.extend(
+            (
+                Stage(
+                    "A",
+                    "broker_transport",
+                    _pass_or_fail(transport_ok),
+                    observation.latency_ms,
+                    {
+                        "admissions": observation.admission_posts,
+                        "callbacks": observation.callback_outcomes,
+                        "generation": observation.generation,
+                        "provider_turns": 1 if observation.generation == 1 and not observation.duplicate else 0,
+                        "terminal_frames": observation.terminal_frames,
+                        "writebacks": observation.terminal_frames,
+                    },
+                ),
+                Stage(
+                    "A",
+                    "full_response_fidelity",
+                    _pass_or_fail(fidelity),
+                    observation.latency_ms,
+                    {
+                        "hash_equal": fidelity,
+                        "response_sha256": _sha256(observation.text),
+                    },
+                ),
+                Stage(
+                    "A",
+                    "sse_projection",
+                    _pass_or_fail(sse_ok),
+                    0,
+                    {"event_sequence": "data>done", "duplicate_terminal": False},
+                ),
+            )
+        )
+    except ScenarioNotTested as exc:
+        stages.append(Stage("A", "broker_transport", "NOT TESTED", 0, {"reason": exc.code}))
+    except (HarnessRefusal, ProvisioningError) as exc:
+        stages.append(Stage("A", "broker_transport", "FAIL", 0, {"reason": getattr(exc, "code", "refused")}))
+
+    continuity_nonce = _marker(config, "same-session-nonce")
+    try:
+        first = await run_chat(
+            "continuity-first",
+            config.primary_session_key,
+            f"Remember this turn-local synthetic nonce: {continuity_nonce}. Reply exactly ACK.",
+        )
+        second = await run_chat(
+            "continuity-second",
+            config.primary_session_key,
+            "Return exactly the synthetic nonce from the previous turn and nothing else.",
+        )
+        stable_identity = _session_id(config, config.primary_session_key) == _session_id(
+            config,
+            config.primary_session_key,
+        )
+        continuity_ok = (
+            second.text == continuity_nonce and stable_identity and not first.duplicate and not second.duplicate
+        )
+        stages.append(
+            Stage(
+                "B",
+                "fixed_session_continuity",
+                _pass_or_fail(continuity_ok),
+                first.latency_ms + second.latency_ms,
+                {
+                    "nonce_hash_equal": second.text == continuity_nonce,
+                    "stable_session_id": stable_identity,
+                    "turns": 2,
+                },
+            )
+        )
+    except ScenarioNotTested as exc:
+        stages.append(Stage("B", "fixed_session_continuity", "NOT TESTED", 0, {"reason": exc.code}))
+    except (HarnessRefusal, ProvisioningError) as exc:
+        stages.append(Stage("B", "fixed_session_continuity", "FAIL", 0, {"reason": getattr(exc, "code", "refused")}))
+
+    try:
+        isolated = await run_chat(
+            "isolation-second-session",
+            config.isolated_session_key,
+            "If a turn-local synthetic nonce exists in this session, return it. Otherwise return exactly NO-NONCE.",
+        )
+        retained = await run_chat(
+            "isolation-original-session",
+            config.primary_session_key,
+            "Return exactly the synthetic nonce retained in this session and nothing else.",
+        )
+        isolated_ok = (
+            isolated.text == "NO-NONCE"
+            and retained.text == continuity_nonce
+            and _session_id(config, config.primary_session_key) != _session_id(config, config.isolated_session_key)
+        )
+        stages.append(
+            Stage(
+                "C",
+                "cross_session_isolation",
+                _pass_or_fail(isolated_ok),
+                isolated.latency_ms + retained.latency_ms,
+                {
+                    "isolated_absent": isolated.text == "NO-NONCE",
+                    "original_retained": retained.text == continuity_nonce,
+                    "session_ids_distinct": True,
+                },
+            )
+        )
+    except ScenarioNotTested as exc:
+        stages.append(Stage("C", "cross_session_isolation", "NOT TESTED", 0, {"reason": exc.code}))
+    except (HarnessRefusal, ProvisioningError) as exc:
+        stages.append(Stage("C", "cross_session_isolation", "FAIL", 0, {"reason": getattr(exc, "code", "refused")}))
+
+    try:
+        memory = await adapter.memory_pack()
+        memory_ok = (
+            memory.scoped_pack_sha256 == config.memory_pack_sha256
+            and memory.conversation_id_matches
+            and memory.summary_version_matches
+            and memory.unscoped_memory_absent
+            and memory.latency_ms <= config.max_latency_ms
+        )
+        stages.append(
+            Stage(
+                "D",
+                "profile_memory_pack",
+                _pass_or_fail(memory_ok),
+                memory.latency_ms,
+                {
+                    "conversation_pinned": memory.conversation_id_matches,
+                    "pack_hash_equal": memory.scoped_pack_sha256 == config.memory_pack_sha256,
+                    "unscoped_absent": memory.unscoped_memory_absent,
+                    "version_pinned": memory.summary_version_matches,
+                },
+            )
+        )
+    except ScenarioNotTested as exc:
+        stages.append(Stage("D", "profile_memory_pack", "NOT TESTED", 0, {"reason": exc.code}))
+    except (HarnessRefusal, ProvisioningError) as exc:
+        stages.append(Stage("D", "profile_memory_pack", "FAIL", 0, {"reason": getattr(exc, "code", "refused")}))
+
+    try:
+        enrichment = await adapter.enrichment()
+        post_enrichment_chat = await run_chat(
+            "enrichment-chat-isolation",
+            config.primary_session_key,
+            "Return exactly the synthetic nonce retained in this chat session and nothing else.",
+        )
+        chat_session_retained = post_enrichment_chat.text == continuity_nonce
+        enrichment_ok = (
+            enrichment.status == "applied"
+            and enrichment.correlation_matches
+            and enrichment.transcript_hash_matches
+            and enrichment.duplicate_replay
+            and enrichment.chat_identity_absent
+            and chat_session_retained
+            and enrichment.latency_ms <= config.max_latency_ms
+        )
+        stages.append(
+            Stage(
+                "E",
+                "transcript_enrichment",
+                _pass_or_fail(enrichment_ok),
+                enrichment.latency_ms,
+                {
+                    "chat_identity_absent": enrichment.chat_identity_absent,
+                    "chat_session_retained": chat_session_retained,
+                    "correlation_pinned": enrichment.correlation_matches,
+                    "one_canonical_result": enrichment.duplicate_replay,
+                    "transcript_hash_equal": enrichment.transcript_hash_matches,
+                },
+            )
+        )
+    except ScenarioNotTested as exc:
+        stages.append(Stage("E", "transcript_enrichment", "NOT TESTED", 0, {"reason": exc.code}))
+    except (HarnessRefusal, ProvisioningError) as exc:
+        stages.append(Stage("E", "transcript_enrichment", "FAIL", 0, {"reason": getattr(exc, "code", "refused")}))
+
+    try:
+        original = observations.get("full-response")
+        if original is None:
+            raise ScenarioNotTested("full_response_prerequisite_unavailable")
+        replay = await adapter.replay(
+            original,
+            source_event_id=_source_event_id(config, "full-response"),
+            prompt=f"Return exactly this synthetic marker and nothing else: {full_response}",
+        )
+        replay_ok = all(
+            (
+                replay.duplicate_ingress,
+                replay.same_response_hash,
+                replay.same_response_id,
+                replay.missing_outcome_refused,
+                replay.wrong_correlation_refused,
+                replay.wrong_session_refused,
+                replay.timeout_refused,
+                replay.partial_after_terminal_refused,
+            )
+        )
+        stages.append(
+            Stage(
+                "F",
+                "error_and_replay",
+                _pass_or_fail(replay_ok),
+                replay.latency_ms,
+                {
+                    "callback_contract": CALLBACK_SCHEMA,
+                    "duplicate_ingress_suppressed": replay.duplicate_ingress,
+                    "missing_outcome_refused": replay.missing_outcome_refused,
+                    "partial_after_terminal_refused": replay.partial_after_terminal_refused,
+                    "same_canonical_write": replay.same_response_id,
+                    "timeout_refused": replay.timeout_refused,
+                    "wrong_correlation_refused": replay.wrong_correlation_refused,
+                    "wrong_session_refused": replay.wrong_session_refused,
+                },
+            )
+        )
+    except ScenarioNotTested as exc:
+        stages.append(Stage("F", "error_and_replay", "NOT TESTED", 0, {"reason": exc.code}))
+    except (HarnessRefusal, ProvisioningError) as exc:
+        stages.append(Stage("F", "error_and_replay", "FAIL", 0, {"reason": getattr(exc, "code", "refused")}))
+
+    verdicts = {
+        "chat transport": _scenario_verdict(stages, "A"),
+        "full-response fidelity": next(
+            (stage.status for stage in stages if stage.name == "full_response_fidelity"),
+            "NOT TESTED",
+        ),
+        "API/SSE-like consumption": next(
+            (stage.status for stage in stages if stage.name == "sse_projection"),
+            "NOT TESTED",
+        ),
+        "same-session continuity": _scenario_verdict(stages, "B"),
+        "cross-session isolation": _scenario_verdict(stages, "C"),
+        "profile memory pack": _scenario_verdict(stages, "D"),
+        "enrichment": _scenario_verdict(stages, "E"),
+        "replay safety": _scenario_verdict(stages, "F"),
+    }
+    return HarnessReport(stages=stages, verdicts=verdicts)
+
+
+def _validate_off_receipt(receipt: Mapping[str, Any], config: CanaryConfig) -> None:
+    if set(receipt) != {
+        "schema_version",
+        "uid_sha256",
+        "flags_off",
+        "selectors_empty",
+        "workflows_off",
+        "content_free",
+    }:
+        raise HarnessRefusal("cleanup_off_receipt_shape_invalid")
+    if (
+        receipt.get("schema_version") != "ella-hermes-canary-off-receipt-v1"
+        or receipt.get("uid_sha256") != _sha256(config.uid)
+        or receipt.get("flags_off") is not True
+        or receipt.get("selectors_empty") is not True
+        or receipt.get("workflows_off") is not True
+        or receipt.get("content_free") is not True
+    ):
+        raise HarnessRefusal("cleanup_off_receipt_invalid")
+
+
+def load_off_receipt(path: str) -> dict[str, Any]:
+    protected = _assert_protected_file(Path(path))
+    try:
+        value = json.loads(protected.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise HarnessRefusal("cleanup_off_receipt_invalid") from exc
+    if not isinstance(value, dict):
+        raise HarnessRefusal("cleanup_off_receipt_invalid")
+    return value
+
+
+def _exit_code(report: HarnessReport) -> int:
+    values = set(report.verdicts.values())
+    if "FAIL" in values:
+        return 1
+    if "NOT TESTED" in values:
+        return 2
+    return 0
+
+
+async def _main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    run_parser = subparsers.add_parser("run")
+    run_parser.add_argument("--config", required=True)
+    cleanup_parser = subparsers.add_parser("cleanup")
+    cleanup_parser.add_argument("--config", required=True)
+    cleanup_parser.add_argument("--off-receipt", required=True)
+    cleanup_parser.add_argument("--confirm-uid", required=True)
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+    adapter = LiveCanaryAdapter(config)
+    if args.command == "run":
+        report = await run_harness(config, adapter)
+        print(report.render(), end="")
+        return _exit_code(report)
+    if args.confirm_uid != config.uid:
+        raise HarnessRefusal("cleanup_confirmation_mismatch")
+    result = await adapter.cleanup(off_receipt=load_off_receipt(args.off_receipt))
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(asyncio.run(_main()))
+    except HarnessRefusal as exc:
+        raise SystemExit(f"harness_refused:{exc.code}") from None

--- a/backend/scripts/hermes_product_fit_canary.py
+++ b/backend/scripts/hermes_product_fit_canary.py
@@ -24,6 +24,9 @@ import httpx
 from database import voice_canary as voice_canary_db
 from ella.services.hermes_broker_client import HermesBrokerClient
 from ella.services.hermes_broker_prototype import HermesBrokerPrototypeConfig
+from ella.services.hermes_cloud_enrichment import (
+    _interaction_identity as production_enrichment_interaction_identity,
+)
 from ella.services.hermes_cloud_runtime import broker_session_id_for_scope
 from ella.services.runtime_errors import ProvisioningError
 
@@ -36,6 +39,17 @@ TERMINAL_STATUSES = frozenset({"writeback_completed", "blocked", "quarantined", 
 SECRET_REF_RE = re.compile(r"^env:(ELLA_[A-Z0-9_]{3,120})$")
 SAFE_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,256}$")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+ENRICHMENT_CHAT_IDENTITY_FIELDS = frozenset(
+    {
+        "session_key",
+        "session_id",
+        "chat_session_key",
+        "chat_session_id",
+        "hermes_session_key",
+        "hermes_session_id",
+        "broker_session_id",
+    }
+)
 
 
 class HarnessRefusal(RuntimeError):
@@ -546,8 +560,11 @@ class LiveCanaryAdapter:
     async def enrichment(self) -> EnrichmentObservation:
         started = time.monotonic()
         token = _resolve_env_secret(self.config.enrichment_token_ref)
-        digest = _sha256(f"{self.config.run_id}|{self.config.uid}|{self.config.enrichment_conversation_id}|enrichment")
-        client_interaction_id = f"omi-enrichment:{digest}"
+        client_interaction_id, _ = production_enrichment_interaction_identity(
+            self.config.uid,
+            self.config.enrichment_conversation_id,
+            self.config.enrichment_transcript_sha256,
+        )
         payload = {
             "uid": self.config.uid,
             "conversation_id": self.config.enrichment_conversation_id,
@@ -572,7 +589,6 @@ class LiveCanaryAdapter:
                 headers=headers,
                 json=payload,
             )
-        forbidden_chat_keys = {"session_key", "session_id", "canonical_user_event_id"}
         return EnrichmentObservation(
             status=str(first.get("status") or ""),
             correlation_matches=(
@@ -584,7 +600,7 @@ class LiveCanaryAdapter:
                 and replay.get("transcript_sha256") == self.config.enrichment_transcript_sha256
             ),
             duplicate_replay=first.get("duplicate") is False and replay.get("duplicate") is True,
-            chat_identity_absent=forbidden_chat_keys.isdisjoint(first) and forbidden_chat_keys.isdisjoint(replay),
+            chat_identity_absent=_enrichment_chat_identity_absent(first, replay),
             latency_ms=int((time.monotonic() - started) * 1000),
         )
 
@@ -684,6 +700,10 @@ def _session_id(config: CanaryConfig, session_key: str) -> str:
         channel=config.chat_channel,
         session_key=session_key,
     )
+
+
+def _enrichment_chat_identity_absent(*results: Mapping[str, Any]) -> bool:
+    return all(ENRICHMENT_CHAT_IDENTITY_FIELDS.isdisjoint(result) for result in results)
 
 
 def _source_event_id(config: CanaryConfig, label: str) -> str:

--- a/backend/tests/fixtures/hermes_product_fit_callback_v1.json
+++ b/backend/tests/fixtures/hermes_product_fit_callback_v1.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "ella.hermes.callback.v1",
+  "correlation_id": "canary-correlation-111111111111111111111111",
+  "delivery_id": "canary-delivery-222222222222222222222222",
+  "outcome": "success",
+  "response": {
+    "answer": "CANARY-CONTENT-SAFE",
+    "session_key": "ella:canary:primary",
+    "session_id": "ella:broker-session:v1:d79db7e7a916852093a06d69a3e73531a235548deedffb81",
+    "canonical_user_event_id": "canary-event:444444444444444444444444444444444444444444444444",
+    "model": "gpt-5.6-terra",
+    "usage": {
+      "input_tokens": 1,
+      "output_tokens": 1
+    }
+  },
+  "sent_at": "2026-07-30T00:00:00Z"
+}

--- a/backend/tests/unit/test_hermes_product_fit_canary.py
+++ b/backend/tests/unit/test_hermes_product_fit_canary.py
@@ -3,8 +3,14 @@ import base64
 import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+from fastapi import FastAPI
+
+from ella.routers.hermes_cloud_enrichment import (
+    create_hermes_cloud_enrichment_router,
+)
 
 from scripts import hermes_product_fit_canary as canary
 
@@ -212,23 +218,85 @@ def test_voice_memory_pack_is_hash_only_and_unscoped_session_isolated():
     assert report.verdicts["profile memory pack"] == "FAIL"
 
 
-def test_enrichment_requires_one_correlated_duplicate_safe_result_without_chat_identity():
+def test_enrichment_requires_one_correlated_duplicate_safe_result_without_chat_identity(monkeypatch):
     config = _config()
+    token = "e" * 32
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN", token)
+    expected_interaction_id, _ = canary.production_enrichment_interaction_identity(
+        config.uid,
+        config.enrichment_conversation_id,
+        config.enrichment_transcript_sha256,
+    )
+    old_run_id_digest = canary._sha256(f"{config.run_id}|{config.uid}|{config.enrichment_conversation_id}|enrichment")
+    assert expected_interaction_id != f"omi-enrichment:{old_run_id_digest}"
 
-    class ContaminatedEnrichmentAdapter(FakeAdapter):
-        async def enrichment(self):
-            observed = await super().enrichment()
-            return canary.EnrichmentObservation(
-                **{
-                    **observed.__dict__,
-                    "chat_identity_absent": False,
-                }
+    class ContractService:
+        def __init__(self):
+            self.calls = []
+
+        async def enrich(self, **kwargs):
+            assert kwargs["expected_client_interaction_id"] == expected_interaction_id
+            assert kwargs["expected_transcript_sha256"] == config.enrichment_transcript_sha256
+            self.calls.append(kwargs)
+            return SimpleNamespace(
+                conversation_id=kwargs["conversation_id"],
+                runtime_binding_id=config.binding_id,
+                runtime_interaction_id="55555555-5555-4555-8555-555555555555",
+                active_summary_version_id=config.voice_summary_version_id,
+                canonical_user_event_id="canonical-user-event",
+                canonical_assistant_event_id="canonical-assistant-event",
+                transcript_sha256=config.enrichment_transcript_sha256,
+                summary_sha256="c" * 64,
+                provider_response_present=True,
+                duplicate=len(self.calls) > 1,
+                client_interaction_id=kwargs["expected_client_interaction_id"],
             )
 
-    report = asyncio.run(canary.run_harness(config, ContaminatedEnrichmentAdapter(config)))
-    enrichment = next(stage for stage in report.stages if stage.scenario == "E")
-    assert enrichment.status == "FAIL"
-    assert report.verdicts["enrichment"] == "FAIL"
+    service = ContractService()
+
+    async def service_factory():
+        return service
+
+    app = FastAPI()
+    app.include_router(create_hermes_cloud_enrichment_router(service_factory))
+    original_async_client = canary.httpx.AsyncClient
+
+    def asgi_client(*_args, **kwargs):
+        return original_async_client(
+            transport=canary.httpx.ASGITransport(app=app),
+            base_url=config.backend_base_url,
+            timeout=kwargs.get("timeout"),
+            follow_redirects=False,
+            trust_env=False,
+        )
+
+    monkeypatch.setattr(canary.httpx, "AsyncClient", asgi_client)
+    observed = asyncio.run(canary.LiveCanaryAdapter(config).enrichment())
+
+    assert observed.status == "applied"
+    assert observed.correlation_matches is True
+    assert observed.transcript_hash_matches is True
+    assert observed.duplicate_replay is True
+    assert observed.chat_identity_absent is True
+    assert [call["expected_client_interaction_id"] for call in service.calls] == [
+        expected_interaction_id,
+        expected_interaction_id,
+    ]
+    assert [call["expected_transcript_sha256"] for call in service.calls] == [
+        config.enrichment_transcript_sha256,
+        config.enrichment_transcript_sha256,
+    ]
+    canonical_result = {
+        "canonical_user_event_id": "canonical-user-event",
+        "canonical_assistant_event_id": "canonical-assistant-event",
+    }
+    assert canary._enrichment_chat_identity_absent(canonical_result)
+    assert not canary._enrichment_chat_identity_absent(
+        {
+            **canonical_result,
+            "session_id": "ella:broker-session:v1:leaked",
+        }
+    )
 
 
 def test_replay_errors_fail_closed_for_outcome_correlation_session_timeout_and_ordering():

--- a/backend/tests/unit/test_hermes_product_fit_canary.py
+++ b/backend/tests/unit/test_hermes_product_fit_canary.py
@@ -1,0 +1,402 @@
+import asyncio
+import base64
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts import hermes_product_fit_canary as canary
+
+FIXTURE_PATH = Path(__file__).parents[1] / "fixtures" / "hermes_product_fit_callback_v1.json"
+
+
+def _config_mapping():
+    return {
+        "schema_version": canary.CONFIG_SCHEMA,
+        "run_id": "synthetic-fit-20260730",
+        "selectors": {
+            "uid": "staging-synthetic-product-fit",
+            "account_id": "11111111-1111-4111-8111-111111111111",
+            "profile_id": "22222222-2222-4222-8222-222222222222",
+            "binding_id": "33333333-3333-4333-8333-333333333333",
+            "consent_epoch": "44444444-4444-4444-8444-444444444444",
+            "expected_model": "gpt-5.6-terra",
+            "chat_channel": "ios_chat",
+            "primary_session_key": "ella:canary:primary",
+            "isolated_session_key": "ella:canary:isolated",
+        },
+        "backend": {
+            "base_url": "https://omi.example.test",
+            "auth_token_ref": "env:ELLA_CANARY_FIREBASE_ID_TOKEN",
+            "enrichment_token_ref": "env:ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN",
+        },
+        "broker": {
+            "base_url": "http://127.0.0.1:18097",
+            "allowed_host": "127.0.0.1",
+            "service_token_ref": "env:ELLA_HERMES_BROKER_SERVICE_TOKEN",
+            "poll_interval_seconds": 0.1,
+            "poll_timeout_seconds": 5.0,
+            "deadline_seconds": 30,
+        },
+        "voice_memory": {
+            "conversation_id": "synthetic-memory-conversation",
+            "active_summary_version_id": "synthetic-summary-version",
+            "pack_sha256": "a" * 64,
+        },
+        "enrichment": {
+            "conversation_id": "synthetic-enrichment-conversation",
+            "transcript_sha256": "b" * 64,
+        },
+        "max_latency_ms": 120_000,
+    }
+
+
+def _config():
+    return canary.CanaryConfig.from_mapping(_config_mapping())
+
+
+class FakeAdapter:
+    def __init__(self, config):
+        self.config = config
+        self.nonce = ""
+        self.responses = {}
+        self.cleaned = False
+
+    async def chat(self, *, session_key, source_event_id, prompt):
+        if "Remember this turn-local synthetic nonce:" in prompt:
+            self.nonce = prompt.split("nonce: ", 1)[1].split(".", 1)[0]
+            text = "ACK"
+        elif "previous turn" in prompt or "retained in this" in prompt:
+            text = self.nonce
+        elif "If a turn-local synthetic nonce exists" in prompt:
+            text = "NO-NONCE"
+        else:
+            text = prompt.rsplit(": ", 1)[1]
+        response_id = f"response:{canary._sha256(source_event_id)[:24]}"
+        self.responses[source_event_id] = (text, response_id)
+        return canary.ChatObservation(
+            text=text,
+            response_id=response_id,
+            request_id=f"request:{canary._sha256(source_event_id)[:24]}",
+            correlation_id=f"correlation:{canary._sha256(source_event_id)[:24]}",
+            duplicate=False,
+            statuses=("pending", "dispatching", "awaiting_callback", "writeback_completed"),
+            terminal_frames=1,
+            admission_posts=1,
+            callback_outcomes=1,
+            generation=1,
+            latency_ms=25,
+        )
+
+    async def memory_pack(self):
+        return canary.MemoryObservation(
+            scoped_pack_sha256=self.config.memory_pack_sha256,
+            conversation_id_matches=True,
+            summary_version_matches=True,
+            unscoped_memory_absent=True,
+            latency_ms=20,
+        )
+
+    async def enrichment(self):
+        return canary.EnrichmentObservation(
+            status="applied",
+            correlation_matches=True,
+            transcript_hash_matches=True,
+            duplicate_replay=True,
+            chat_identity_absent=True,
+            latency_ms=30,
+        )
+
+    async def replay(self, original, *, source_event_id, prompt):
+        text, response_id = self.responses[source_event_id]
+        return canary.ReplayObservation(
+            duplicate_ingress=True,
+            same_response_hash=canary._sha256(text) == canary._sha256(original.text),
+            same_response_id=response_id == original.response_id,
+            missing_outcome_refused=True,
+            wrong_correlation_refused=True,
+            wrong_session_refused=True,
+            timeout_refused=True,
+            partial_after_terminal_refused=True,
+            latency_ms=10,
+        )
+
+    async def cleanup(self, *, off_receipt):
+        canary._validate_off_receipt(off_receipt, self.config)
+        self.cleaned = True
+        return {
+            "status": "cleaned",
+            "uid_sha256": canary._sha256(self.config.uid),
+            "content_free": True,
+        }
+
+
+def test_scenarios_a_to_f_pass_with_content_free_stage_tables():
+    config = _config()
+    report = asyncio.run(canary.run_harness(config, FakeAdapter(config)))
+    rendered = report.render()
+
+    assert set(report.verdicts.values()) == {"PASS"}
+    assert [f"Scenario {letter}" for letter in "ABCDEF"] == [
+        line for line in rendered.splitlines() if line.startswith("Scenario ")
+    ]
+    assert "data: " not in rendered
+    assert "done: " not in rendered
+    for label in ("full-response", "same-session-nonce"):
+        assert canary._marker(config, label) not in rendered
+    assert "response_sha256=" in rendered
+    assert "event_sequence=data>done" in rendered
+
+
+def test_scenario_a_requires_one_terminal_callback_and_lossless_hash():
+    config = _config()
+
+    class DuplicateTerminalAdapter(FakeAdapter):
+        async def chat(self, **kwargs):
+            observed = await super().chat(**kwargs)
+            if "full-response" in kwargs["prompt"].lower():
+                return canary.ChatObservation(
+                    **{
+                        **observed.__dict__,
+                        "statuses": ("pending", "writeback_completed", "writeback_completed"),
+                        "terminal_frames": 2,
+                        "callback_outcomes": 2,
+                    }
+                )
+            return observed
+
+    report = asyncio.run(canary.run_harness(config, DuplicateTerminalAdapter(config)))
+
+    transport = next(stage for stage in report.stages if stage.name == "broker_transport")
+    assert transport.status == "FAIL"
+    assert report.verdicts["chat transport"] == "FAIL"
+
+
+def test_session_continuity_and_isolation_use_distinct_stable_projections():
+    config = _config()
+
+    assert canary._session_id(config, config.primary_session_key) == canary._session_id(
+        config,
+        config.primary_session_key,
+    )
+    assert canary._session_id(config, config.primary_session_key) != canary._session_id(
+        config,
+        config.isolated_session_key,
+    )
+
+    report = asyncio.run(canary.run_harness(config, FakeAdapter(config)))
+    continuity = next(stage for stage in report.stages if stage.scenario == "B")
+    isolation = next(stage for stage in report.stages if stage.scenario == "C")
+    assert continuity.status == "PASS"
+    assert isolation.status == "PASS"
+
+
+def test_voice_memory_pack_is_hash_only_and_unscoped_session_isolated():
+    config = _config()
+
+    class LeakingMemoryAdapter(FakeAdapter):
+        async def memory_pack(self):
+            observed = await super().memory_pack()
+            return canary.MemoryObservation(
+                **{
+                    **observed.__dict__,
+                    "unscoped_memory_absent": False,
+                }
+            )
+
+    report = asyncio.run(canary.run_harness(config, LeakingMemoryAdapter(config)))
+    memory = next(stage for stage in report.stages if stage.scenario == "D")
+    assert memory.status == "FAIL"
+    assert "synthetic-memory-conversation" not in report.render()
+    assert report.verdicts["profile memory pack"] == "FAIL"
+
+
+def test_enrichment_requires_one_correlated_duplicate_safe_result_without_chat_identity():
+    config = _config()
+
+    class ContaminatedEnrichmentAdapter(FakeAdapter):
+        async def enrichment(self):
+            observed = await super().enrichment()
+            return canary.EnrichmentObservation(
+                **{
+                    **observed.__dict__,
+                    "chat_identity_absent": False,
+                }
+            )
+
+    report = asyncio.run(canary.run_harness(config, ContaminatedEnrichmentAdapter(config)))
+    enrichment = next(stage for stage in report.stages if stage.scenario == "E")
+    assert enrichment.status == "FAIL"
+    assert report.verdicts["enrichment"] == "FAIL"
+
+
+def test_replay_errors_fail_closed_for_outcome_correlation_session_timeout_and_ordering():
+    config = _config()
+    checks = asyncio.run(
+        canary._contract_failure_checks(
+            config,
+            canary._source_event_id(config, "contract"),
+        )
+    )
+
+    assert checks == {
+        "missing_outcome": True,
+        "wrong_session": True,
+        "wrong_correlation": True,
+        "timeout": True,
+    }
+    assert canary._status_sequence_valid(("pending", "dispatching", "writeback_completed"))
+    assert not canary._status_sequence_valid(("pending", "writeback_completed", "writeback_pending"))
+    assert not canary._status_sequence_valid(("pending", "writeback_completed", "writeback_completed"))
+
+
+def test_callback_fixture_matches_ella_callback_v1_and_requires_outcome():
+    fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    config = _config()
+
+    assert fixture["schema_version"] == canary.CALLBACK_SCHEMA
+    assert fixture["outcome"] == "success"
+    assert set(fixture) == {
+        "schema_version",
+        "correlation_id",
+        "delivery_id",
+        "outcome",
+        "response",
+        "sent_at",
+    }
+    assert fixture["response"]["session_key"] == "ella:canary:primary"
+    assert fixture["response"]["canonical_user_event_id"].startswith("canary-event:")
+    assert fixture["response"]["session_id"] == canary._session_id(config, config.primary_session_key)
+
+    mapped = canary.HermesBrokerClient(config.broker)._map_chat_result(
+        {
+            "outcome": fixture["outcome"],
+            "result": fixture["response"],
+            "diagnostic": {
+                "stage": "broker_writeback",
+                "reason": "writeback_completed",
+                "generation": 1,
+            },
+        },
+        request_id="canary-request",
+        correlation_id=fixture["correlation_id"],
+        expected_model=config.expected_model,
+        session_key=config.primary_session_key,
+        session_id=fixture["response"]["session_id"],
+        source_event_id=fixture["response"]["canonical_user_event_id"],
+        admission_duplicate=False,
+    )
+    assert mapped.text == "CANARY-CONTENT-SAFE"
+    assert mapped.diagnostic == {
+        "stage": "broker_writeback",
+        "reason": "writeback_completed",
+        "generation": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutator", "code"),
+    (
+        (
+            lambda raw: raw["selectors"].update(uid="realcryptoplato"),
+            "synthetic_uid_required",
+        ),
+        (
+            lambda raw: raw["selectors"].update(
+                isolated_session_key=raw["selectors"]["primary_session_key"],
+            ),
+            "distinct_sessions_required",
+        ),
+        (
+            lambda raw: raw["backend"].update(base_url="http://127.0.0.1:8000"),
+            "backend_base_url_not_allowlisted",
+        ),
+        (
+            lambda raw: raw["broker"].update(base_url="http://127.0.0.1:18098"),
+            "hermes_broker_prototype_url_not_allowlisted",
+        ),
+        (
+            lambda raw: raw["broker"].update(service_token_ref="literal-secret"),
+            "broker_service_token_ref_invalid",
+        ),
+    ),
+)
+def test_config_rejects_real_identity_session_drift_urls_and_literal_secrets(mutator, code):
+    raw = _config_mapping()
+    mutator(raw)
+
+    with pytest.raises((canary.HarnessRefusal, canary.ProvisioningError), match=code):
+        canary.CanaryConfig.from_mapping(raw)
+
+
+def test_protected_config_and_off_receipt_require_exact_owner_modes(tmp_path):
+    protected_root = tmp_path / "ella"
+    protected_root.mkdir(mode=0o700)
+    protected = protected_root / "config.json"
+    protected.write_text("{}\n", encoding="utf-8")
+    protected.chmod(0o400)
+
+    assert (
+        canary._assert_protected_file(
+            protected,
+            approved_roots=(tmp_path,),
+            expected_owner_uid=os.geteuid(),
+        )
+        == protected.resolve()
+    )
+    protected.chmod(0o644)
+    with pytest.raises(canary.HarnessRefusal, match="protected_file_metadata_refused"):
+        canary._assert_protected_file(
+            protected,
+            approved_roots=(tmp_path,),
+            expected_owner_uid=os.geteuid(),
+        )
+
+    def token_for(uid):
+        payload = base64.urlsafe_b64encode(json.dumps({"sub": uid}).encode()).decode().rstrip("=")
+        return f"header.{payload}.signature"
+
+    canary._require_firebase_subject(
+        token_for("staging-synthetic-product-fit"),
+        "staging-synthetic-product-fit",
+    )
+    with pytest.raises(canary.HarnessRefusal, match="firebase_token_subject_mismatch"):
+        canary._require_firebase_subject(
+            token_for("real-user"),
+            "staging-synthetic-product-fit",
+        )
+
+
+def test_cleanup_requires_content_free_all_off_receipt_for_exact_synthetic_uid():
+    config = _config()
+    adapter = FakeAdapter(config)
+    receipt = {
+        "schema_version": "ella-hermes-canary-off-receipt-v1",
+        "uid_sha256": canary._sha256(config.uid),
+        "flags_off": True,
+        "selectors_empty": True,
+        "workflows_off": True,
+        "content_free": True,
+    }
+
+    result = asyncio.run(adapter.cleanup(off_receipt=receipt))
+    assert adapter.cleaned is True
+    assert result["content_free"] is True
+    with pytest.raises(canary.HarnessRefusal, match="cleanup_off_receipt_invalid"):
+        canary._validate_off_receipt({**receipt, "workflows_off": False}, config)
+
+
+def test_missing_optional_live_surface_reports_not_tested_not_pass():
+    config = _config()
+
+    class MissingSurfaceAdapter(FakeAdapter):
+        async def memory_pack(self):
+            raise canary.ScenarioNotTested("voice_context_unavailable")
+
+    report = asyncio.run(canary.run_harness(config, MissingSurfaceAdapter(config)))
+
+    memory = next(stage for stage in report.stages if stage.scenario == "D")
+    assert memory.status == "NOT TESTED"
+    assert report.verdicts["profile memory pack"] == "NOT TESTED"
+    assert canary._exit_code(report) == 2


### PR DESCRIPTION
## Summary

- add one deterministic, content-free synthetic Hermes product-fit canary covering chat transport/fidelity, fixed-session continuity, cross-session isolation, voice memory scope, transcript enrichment, and fail-closed replay/error behavior
- reuse the existing stock broker client, current broker session projection, authenticated voice session boundary, enrichment route, and exact-account cleanup path without changing production routing semantics
- require root-owned protected config/off receipts and env-only secret references; never print prompts, responses, tokens, memory content, transcripts, or callback bodies
- add a shared `ella.hermes.callback.v1` fixture with required `outcome`, exact test collection/required IDs, and an operator runbook

## Validation

- Black check and Python compile passed
- exact harness collection: 15 tests, zero skips
- focused suite: 59 passed (`hermes_product_fit_canary`, broker prototype, enrichment router, voice memory scope)
- commit-scoped Gitleaks: no leaks

## Boundaries

No deployment, provider call, vendor/n8n mutation, live user/data access, flags/selectors, Plato path, production routing, schema, or migration change. Base lineage: `faa022eca968b8001cf445969453cb7a0564b727`.