### PR TITLE
fix(device): preserve firmware and WAL safeguards

### DIFF
--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -373,6 +373,10 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     }
 
     var device = pairedDevice!;
+    if (device.firmwareRevision.isEmpty) {
+      return ('Unable to determine current firmware version', false, '', {});
+    }
+
     var latestFirmwareDetails = await getLatestFirmwareVersion(
       deviceModelNumber: device.modelNumber,
       firmwareRevision: device.firmwareRevision,

--- a/app/lib/services/devices/omi_connection.dart
+++ b/app/lib/services/devices/omi_connection.dart
@@ -623,9 +623,11 @@ class OmiDeviceConnection extends DeviceConnection {
       Logger.debug('OmiDeviceConnection: Error getting device info: $e');
     }
 
-    // Set defaults if values are empty
+    // Set defaults if values are empty. Keep firmwareRevision empty when the
+    // BLE read fails so callers can distinguish "unknown" from a real legacy
+    // firmware version.
     deviceInfo['modelNumber'] ??= 'Omi Device';
-    deviceInfo['firmwareRevision'] ??= '1.0.2';
+    deviceInfo['firmwareRevision'] ??= '';
     deviceInfo['hardwareRevision'] ??= 'Seeed Xiao BLE Sense';
     deviceInfo['manufacturerName'] ??= 'Based Hardware';
     deviceInfo['hasImageStream'] ??= 'false';

--- a/app/lib/services/wals/sdcard_wal_sync.dart
+++ b/app/lib/services/wals/sdcard_wal_sync.dart
@@ -175,6 +175,10 @@ class SDCardWalSyncImpl implements SDCardWalSync {
       var timerStart = DateTime.now().millisecondsSinceEpoch ~/ 1000 - seconds;
 
       var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+      if (connection == null) {
+        Logger.debug("SDCard: Failed to establish connection for device info");
+        return wals;
+      }
       var pd = await _device!.getDeviceInfo(connection);
       String deviceModel = pd.modelNumber.isNotEmpty ? pd.modelNumber : "Omi";
 
@@ -563,7 +567,11 @@ class SDCardWalSyncImpl implements SDCardWalSync {
     IWalSyncProgressListener? progress,
     IWifiConnectionListener? connectionListener,
   }) async {
-    var walToSync = _wals.where((w) => w == wal).toList().first;
+    var walToSync = _wals.where((w) => w == wal).firstOrNull;
+    if (walToSync == null) {
+      Logger.debug("SDCardWalSync: WAL not found in _wals, skipping sync");
+      return null;
+    }
 
     _resetSyncState();
     _isSyncing = true;

--- a/app/lib/utils/device.dart
+++ b/app/lib/utils/device.dart
@@ -11,9 +11,8 @@ class DeviceUtils {
     required String currentFirmware,
     required Map latestFirmwareDetails,
   }) async {
-    Version currentVersion = Version.parse(currentFirmware);
-    if (latestFirmwareDetails.isEmpty) {
-      return ('Latest Version Not Available', false, '');
+    if (currentFirmware.isEmpty) {
+      return ('Unable to determine current firmware version', false, '');
     }
     if (latestFirmwareDetails.isEmpty || latestFirmwareDetails['version'] == null) {
       return ('Latest Version Not Available', false, '');
@@ -22,6 +21,7 @@ class DeviceUtils {
       return ('Latest Version Not Available', false, '');
     }
 
+    Version currentVersion = Version.parse(currentFirmware);
     String latestVersionStr = latestFirmwareDetails['version'];
     Version latestVersion = Version.parse(latestVersionStr);
     Version minVersion = Version.parse(latestFirmwareDetails['min_version']);

--- a/app/test/utils/device_utils_test.dart
+++ b/app/test/utils/device_utils_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/utils/device.dart';
+
+void main() {
+  group('DeviceUtils.shouldUpdateFirmware', () {
+    test('short-circuits when current firmware is unknown', () async {
+      final result = await DeviceUtils.shouldUpdateFirmware(
+        currentFirmware: '',
+        latestFirmwareDetails: {
+          'version': '3.0.19',
+          'draft': false,
+          'min_version': '3.0.6',
+        },
+      );
+
+      expect(result.$1, 'Unable to determine current firmware version');
+      expect(result.$2, false);
+      expect(result.$3, '');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- preserve previously uncommitted firmware-version fallback safeguards
- avoid SD-card WAL sync crashes when connection or queued WAL state is absent
- add a focused unknown-firmware regression test

## Validation
- `git diff --cached --check` passed before commit
- `detect-secrets` found no secrets in the five changed files
- Dart/Flutter tests were not run because the Dart executable is unavailable in this worktree environment

## Provenance
Rescued during the 2026-07-30 registered-worktree safety audit from the otherwise superseded `omi-1026-upstream` worktree. No canonical checkout or production infrastructure was modified.