### PR TITLE
Fix trapped iOS voice failure retry loop

### DIFF
--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -77,6 +77,10 @@ class EllaVoiceChatPage extends StatefulWidget {
   static V2VSessionScope refreshedMemoryScope(V2VSessionScope current, String? activeSummaryVersionId) =>
       current.withExpectedActiveSummaryVersionId(activeSummaryVersionId);
 
+  @visibleForTesting
+  static bool shouldCloseRouteAfterV2VFailure(V2VFailureChoice choice, {required bool modalPresentation}) =>
+      modalPresentation && choice == V2VFailureChoice.stop;
+
   @override
   State<EllaVoiceChatPage> createState() => _EllaVoiceChatPageState();
 }
@@ -759,12 +763,11 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
           await _startListening();
           break;
         case V2VFailureChoice.stop:
-          _voiceStartupGuard.cancel();
-          _usingElevenLabsFallback = false;
-          _activeV2VProvider = '';
-          setState(() {
-            _statusText = context.l10n.voiceTapToTalk;
-          });
+          await _cancelFailedVoiceAttempt();
+          if (EllaVoiceChatPage.shouldCloseRouteAfterV2VFailure(choice, modalPresentation: widget.modalPresentation) &&
+              mounted) {
+            Navigator.of(context).pop();
+          }
           break;
       }
       return;
@@ -783,6 +786,42 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
       _memoryCorrectionReceipt = null;
       _orbState = VoiceOrbState.listening;
       _statusText = context.l10n.voiceV2vActive(providerName);
+    });
+  }
+
+  Future<void> _cancelFailedVoiceAttempt() async {
+    _voiceStartupGuard.cancel();
+    final client = _v2vClient;
+    _v2vClient = null;
+    _voiceModeActive = false;
+    _isV2VMode = false;
+    _usingElevenLabsFallback = false;
+    _activeV2VProvider = '';
+    _activeSessionId = '';
+    _standardVoiceConsentLease?.stop();
+    _standardVoiceConsentLease = null;
+    _quotaClock?.cancel();
+    if (client != null) {
+      try {
+        await client.disconnect();
+      } catch (_) {}
+    }
+    if (_speech.isListening) {
+      try {
+        await _speech.stop();
+      } catch (_) {}
+    }
+    try {
+      await _audioPlayer.stop();
+    } catch (_) {}
+    try {
+      await ElevenLabsTts.stopOnDevice();
+    } catch (_) {}
+    if (!mounted) return;
+    setState(() {
+      _orbState = VoiceOrbState.idle;
+      _statusText = context.l10n.voiceTapToTalk;
+      _audioLevel = 0.0;
     });
   }
 

--- a/app/lib/ella/widgets/v2v_fallback_dialog.dart
+++ b/app/lib/ella/widgets/v2v_fallback_dialog.dart
@@ -38,13 +38,20 @@ class V2VFallbackDialog extends StatelessWidget {
         style: EllaTextStyles.body,
       ),
       actions: [
-        TextButton(onPressed: () => Navigator.of(context).pop(V2VFailureChoice.stop), child: Text(context.l10n.notNow)),
+        OutlinedButton.icon(
+          key: const ValueKey('v2v-failure-cancel'),
+          onPressed: () => Navigator.of(context).pop(V2VFailureChoice.stop),
+          icon: const Icon(Icons.close),
+          label: Text(context.l10n.cancel),
+        ),
         if (allowStandardFallback)
           TextButton(
+            key: const ValueKey('v2v-failure-elevenlabs'),
             onPressed: () => Navigator.of(context).pop(V2VFailureChoice.useElevenLabs),
             child: Text(context.l10n.voiceUseElevenLabs),
           ),
         FilledButton(
+          key: const ValueKey('v2v-failure-retry'),
           onPressed: () => Navigator.of(context).pop(V2VFailureChoice.retry),
           child: Text(context.l10n.retry),
         ),
@@ -60,7 +67,7 @@ Future<V2VFailureChoice> showV2VFallbackDialog(
 }) async {
   return await showDialog<V2VFailureChoice>(
         context: context,
-        barrierDismissible: false,
+        barrierDismissible: true,
         builder: (_) => V2VFallbackDialog(receipt: receipt, allowStandardFallback: allowStandardFallback),
       ) ??
       V2VFailureChoice.stop;

--- a/app/test/ella/widgets/v2v_fallback_dialog_test.dart
+++ b/app/test/ella/widgets/v2v_fallback_dialog_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:omi/ella/pages/ella_voice_chat_page.dart';
 import 'package:omi/ella/services/v2v_client.dart';
 import 'package:omi/ella/widgets/v2v_fallback_dialog.dart';
 import 'package:omi/l10n/app_localizations.dart';
@@ -31,7 +32,8 @@ void main() {
     expect(find.textContaining('isolated_voice_not_ready'), findsOneWidget);
     expect(find.text('Retry'), findsOneWidget);
     expect(find.text('Use ElevenLabs'), findsOneWidget);
-    expect(find.text('Not now'), findsOneWidget);
+    expect(find.text('Cancel'), findsOneWidget);
+    expect(find.byKey(const ValueKey('v2v-failure-cancel')), findsOneWidget);
   });
 
   testWidgets('memory-scoped failures offer retry or stop without an unscoped fallback', (tester) async {
@@ -39,18 +41,47 @@ void main() {
       const MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: Scaffold(
-          body: V2VFallbackDialog(
-            receipt: receipt,
-            allowStandardFallback: false,
-          ),
-        ),
+        home: Scaffold(body: V2VFallbackDialog(receipt: receipt, allowStandardFallback: false)),
       ),
     );
     await tester.pumpAndSettle();
 
     expect(find.text('Use ElevenLabs'), findsNothing);
     expect(find.text('Retry'), findsOneWidget);
-    expect(find.text('Not now'), findsOneWidget);
+    expect(find.text('Cancel'), findsOneWidget);
+  });
+
+  testWidgets('explicit cancel returns stop instead of forcing another retry', (tester) async {
+    V2VFailureChoice? choice;
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              onPressed: () async {
+                choice = await showV2VFallbackDialog(context, receipt, allowStandardFallback: false);
+              },
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('v2v-failure-cancel')));
+    await tester.pumpAndSettle();
+
+    expect(choice, V2VFailureChoice.stop);
+    expect(find.byType(V2VFallbackDialog), findsNothing);
+  });
+
+  test('cancel closes only memory voice modals after teardown', () {
+    expect(EllaVoiceChatPage.shouldCloseRouteAfterV2VFailure(V2VFailureChoice.stop, modalPresentation: true), isTrue);
+    expect(EllaVoiceChatPage.shouldCloseRouteAfterV2VFailure(V2VFailureChoice.stop, modalPresentation: false), isFalse);
+    expect(EllaVoiceChatPage.shouldCloseRouteAfterV2VFailure(V2VFailureChoice.retry, modalPresentation: true), isFalse);
   });
 }


### PR DESCRIPTION
## Summary
- replace the low-visibility `Not now` action with an explicit outlined `Cancel` control
- treat barrier dismissal as cancellation instead of forcing another retry
- tear down V2V, microphone, audio, consent lease, and quota state on cancel
- close the `Talk about this` voice modal after cancellation while leaving the main Voice tab idle and usable

## Validation
- focused voice/modal/V2V tests: 47/47 passed
- full Flutter suite: 293/293 passed
- `ELLA_TEST_NO_PUB=true ./test.sh`: passed
- targeted dialog/test analysis: no issues
- voice page analysis: no errors or warnings; six pre-existing `speech_to_text` deprecation infos remain

## Scope
Ella iOS app only. No backend, auth, signing, TestFlight, App Store Connect, or AlphaRange changes.