### PR TITLE
Add provider-free Hermes fixture lifecycle

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -371,6 +371,10 @@ jobs:
             "tests/unit/test_hermes_product_fit_canary.py::test_scenarios_a_to_f_pass_with_content_free_stage_tables"
             "tests/unit/test_hermes_product_fit_canary.py::test_replay_errors_fail_closed_for_outcome_correlation_session_timeout_and_ordering"
             "tests/unit/test_hermes_product_fit_canary.py::test_cleanup_requires_content_free_all_off_receipt_for_exact_synthetic_uid"
+            "tests/unit/test_hermes_product_fit_canary.py::test_fixture_prepare_cli_retry_revalidates_authority_and_rollout_off"
+            "tests/unit/test_hermes_product_fit_canary.py::test_fixture_prepare_requires_scope_bound_fresh_protected_off_receipt"
+            "tests/unit/test_hermes_product_fit_canary.py::test_fixture_cleanup_recovers_from_partial_cleanup_idempotently"
+            "tests/unit/test_hermes_product_fit_canary.py::test_fixture_show_and_cleanup_accept_expected_post_enrichment_state_only"
             "tests/unit/test_ella_runtime_route_isolation.py::test_cloud_chat_failure_still_emits_one_terminal_marker"
             "tests/postgres/test_hermes_cloud_pool_postgres.py::test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets"
           )
@@ -388,7 +392,7 @@ jobs:
           test "$(
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
-          )" -eq 15
+          )" -eq 19
           test "$collected" -ge 431
           pytest \
             tests/unit/test_ella_ai_consent.py \

--- a/backend/scripts/hermes_product_fit_canary.py
+++ b/backend/scripts/hermes_product_fit_canary.py
@@ -8,6 +8,7 @@ import asyncio
 import base64
 import binascii
 import hashlib
+import hmac
 import json
 import os
 import re
@@ -15,6 +16,7 @@ import stat
 import time
 import uuid
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Mapping, Protocol
 from urllib.parse import urlparse
@@ -22,17 +24,28 @@ from urllib.parse import urlparse
 import httpx
 
 from database import voice_canary as voice_canary_db
+from ella.services import ai_consent
 from ella.services.hermes_broker_client import HermesBrokerClient
 from ella.services.hermes_broker_prototype import HermesBrokerPrototypeConfig
 from ella.services.hermes_cloud_enrichment import (
+    build_enrichment_identity,
     _interaction_identity as production_enrichment_interaction_identity,
 )
 from ella.services.hermes_cloud_runtime import broker_session_id_for_scope
 from ella.services.runtime_errors import ProvisioningError
+from models.conversation import (
+    Conversation,
+    ConversationSource,
+    ConversationStatus,
+    ConversationVisibility,
+    Structured,
+)
+from models.transcript_segment import TranscriptSegment
 
 CONFIG_SCHEMA = "ella-hermes-product-fit-canary-v1"
 CALLBACK_SCHEMA = "ella.hermes.callback.v1"
 STOCK_CALLBACK_CONTRACT = "stock_best_effort_v1"
+FIXTURE_SCHEMA = "ella-hermes-product-fit-fixture-v1"
 APPROVED_SECRET_ROOTS = (Path("/etc/ella"), Path("/var/lib/ella"))
 SYNTHETIC_PREFIXES = ("synthetic-", "staging-synthetic-")
 TERMINAL_STATUSES = frozenset({"writeback_completed", "blocked", "quarantined", "expired", "writeback_blocked"})
@@ -50,6 +63,31 @@ ENRICHMENT_CHAT_IDENTITY_FIELDS = frozenset(
         "broker_session_id",
     }
 )
+FIXTURE_GLOBAL_FLAGS = (
+    "ELLA_RUNTIME_BINDINGS_ENABLED",
+    "ELLA_HERMES_PROVISIONING_ENABLED",
+    "ELLA_HERMES_CLOUD_PROVISIONING_ENABLED",
+    "ELLA_AI_CONSENT_ENFORCEMENT_ENABLED",
+    "ELLA_MANAGED_CLOUD_REAL_DATA_ENABLED",
+    "ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED",
+    "ELLA_ISOLATED_VOICE_ROUTING_ENABLED",
+    "ELLA_INVITE_ORDINARY_SELF_SERVICE_ENABLED",
+    "ELLA_INVITE_APP_REVIEW_ENABLED",
+    "ELLA_HERMES_CLOUD_STAGED_ATTESTATION_ENABLED",
+    "ELLA_HERMES_CLOUD_PHOTON_ENABLED",
+    "ELLA_HERMES_BROKER_PROTOTYPE_ENABLED",
+)
+FIXTURE_UID_SELECTORS = (
+    "ELLA_RUNTIME_BINDINGS_ENABLED_UIDS",
+    "ELLA_HERMES_PROVISIONING_ENABLED_UIDS",
+    "ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS",
+    "ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS",
+    "ELLA_HERMES_CLOUD_SYNTHETIC_UIDS",
+    "ELLA_AI_CONSENT_ENFORCEMENT_UIDS",
+    "ELLA_ISOLATED_VOICE_ROUTING_ENABLED_UIDS",
+)
+conversations_db: Any = None
+vector_db: Any = None
 
 
 class HarnessRefusal(RuntimeError):
@@ -354,6 +392,477 @@ def load_config(path: str) -> CanaryConfig:
     if not isinstance(raw, dict):
         raise HarnessRefusal("config_invalid")
     return CanaryConfig.from_mapping(raw)
+
+
+def _assert_fixture_rollout_off() -> None:
+    if os.getenv("ELLA_HERMES_CLOUD_SYNTHETIC_ONLY", "true").strip().lower() != "true":
+        raise HarnessRefusal("fixture_synthetic_only_required")
+    if any(os.getenv(name, "").strip().lower() not in {"", "false"} for name in FIXTURE_GLOBAL_FLAGS):
+        raise HarnessRefusal("fixture_global_flag_enabled")
+    if any(os.getenv(name, "").strip() for name in FIXTURE_UID_SELECTORS):
+        raise HarnessRefusal("fixture_uid_selector_enabled")
+    if any(
+        os.getenv(name, "").strip()
+        for name in (
+            "ELLA_HERMES_BROKER_PROTOTYPE_ACCOUNT_ID",
+            "ELLA_HERMES_BROKER_PROTOTYPE_PROFILE_ID",
+            "ELLA_HERMES_BROKER_PROTOTYPE_BINDING_ID",
+        )
+    ):
+        raise HarnessRefusal("fixture_broker_selector_enabled")
+
+
+def _fixture_conversation_id(config: CanaryConfig) -> str:
+    material = "\x1f".join(
+        (
+            FIXTURE_SCHEMA,
+            config.run_id,
+            config.uid,
+            config.account_id,
+            config.profile_id,
+        )
+    )
+    return f"hermes-fixture:{_sha256(material)[:40]}"
+
+
+def _fixture_marker(config: CanaryConfig, conversation_id: str) -> dict[str, Any]:
+    return {
+        "schema_version": FIXTURE_SCHEMA,
+        "run_id_sha256": _sha256(config.run_id),
+        "uid_sha256": _sha256(config.uid),
+        "account_id_sha256": _sha256(config.account_id),
+        "profile_id_sha256": _sha256(config.profile_id),
+        "binding_id_sha256": _sha256(config.binding_id),
+        "conversation_id_sha256": _sha256(conversation_id),
+        "content_free": True,
+    }
+
+
+def _fixture_conversation(config: CanaryConfig) -> Conversation:
+    conversation_id = _fixture_conversation_id(config)
+    started_at = datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc)
+    segments = [
+        TranscriptSegment(
+            id=f"fixture-segment:{_sha256(conversation_id + ':0')[:32]}",
+            text="Synthetic product-fit fixture turn one.",
+            speaker="SPEAKER_00",
+            is_user=True,
+            start=0.0,
+            end=2.0,
+        ),
+        TranscriptSegment(
+            id=f"fixture-segment:{_sha256(conversation_id + ':1')[:32]}",
+            text="Synthetic product-fit fixture turn two.",
+            speaker="SPEAKER_01",
+            is_user=False,
+            start=2.0,
+            end=4.0,
+        ),
+    ]
+    return Conversation(
+        id=conversation_id,
+        created_at=started_at,
+        started_at=started_at,
+        finished_at=started_at + timedelta(seconds=4),
+        source=ConversationSource.external_integration,
+        language="en",
+        structured=Structured(
+            title="Synthetic Hermes fixture",
+            overview="Synthetic data for the bounded Hermes product-fit fixture.",
+            emoji="\U0001f9ea",
+            category="other",
+        ),
+        transcript_segments=segments,
+        visibility=ConversationVisibility.private,
+        discarded=False,
+        status=ConversationStatus.completed,
+        external_data={"ella_product_fit_fixture": _fixture_marker(config, conversation_id)},
+    )
+
+
+def _enum_value(value: Any) -> str:
+    return str(getattr(value, "value", value) or "")
+
+
+def _validate_fixture_conversation(
+    config: CanaryConfig,
+    conversation: Mapping[str, Any],
+) -> None:
+    expected = _fixture_conversation(config).model_dump()
+    external_data = conversation.get("external_data")
+    marker = external_data.get("ella_product_fit_fixture") if isinstance(external_data, Mapping) else None
+    if (
+        conversation.get("id") != expected["id"]
+        or marker != expected["external_data"]["ella_product_fit_fixture"]
+        or _enum_value(conversation.get("source")) != ConversationSource.external_integration.value
+        or _enum_value(conversation.get("visibility")) != ConversationVisibility.private.value
+        or _enum_value(conversation.get("status")) != ConversationStatus.completed.value
+        or conversation.get("discarded") is not False
+        or conversation.get("enrichment_state") is not None
+        or conversation.get("transcript_segments") != expected["transcript_segments"]
+        or conversation.get("structured") != expected["structured"]
+    ):
+        raise HarnessRefusal("fixture_conversation_drift")
+
+
+class FixtureStore(Protocol):
+    async def assert_prepare_authority(self, config: CanaryConfig) -> None: ...
+
+    async def get_conversation(self, uid: str, conversation_id: str) -> Mapping[str, Any] | None: ...
+
+    async def create_conversation(self, uid: str, conversation: Conversation) -> None: ...
+
+    async def ensure_summary_version(self, uid: str, conversation_id: str) -> Mapping[str, Any]: ...
+
+    async def delete_conversation(self, uid: str, conversation_id: str) -> None: ...
+
+    async def delete_vector(self, uid: str, conversation_id: str) -> None: ...
+
+    async def vector_exists(self, uid: str, conversation_id: str) -> bool: ...
+
+
+def _validate_fixture_authority(config: CanaryConfig, value: Mapping[str, Any]) -> None:
+    expected_profile_binding = ai_consent.derive_profile_binding_id(
+        account_uid=config.uid,
+        profile_uid=config.uid,
+    )
+    if (
+        str(value.get("user_id")) != config.account_id
+        or str(value.get("user_id")) != config.profile_id
+        or value.get("omi_uid") != config.uid
+        or str(value.get("user_status") or "").upper() != "ACTIVE"
+        or value.get("profile_class") != "synthetic"
+        or str(value.get("binding_id")) != config.binding_id
+        or str(value.get("binding_user_id")) != config.account_id
+        or str(value.get("account_user_id")) != config.account_id
+        or str(value.get("profile_user_id")) != config.profile_id
+        or value.get("provider") != "hermes_cloud"
+        or value.get("binding_status") not in {"internal_canary", "active"}
+        or value.get("health_state") != "healthy"
+        or value.get("active") is not True
+        or value.get("expected_model") != config.expected_model
+        or value.get("decision") != "granted"
+        or value.get("consent_profile_binding_id") != expected_profile_binding
+        or value.get("policy_version") != ai_consent.CURRENT_POLICY_VERSION
+        or value.get("processor_set_hash") != ai_consent.CURRENT_PROCESSOR_SET_HASH
+        or value.get("scope_version") != ai_consent.CURRENT_SCOPE_VERSION
+        or value.get("scope_hash") != ai_consent.CURRENT_SCOPE_HASH
+        or str(value.get("authority_epoch")) != config.consent_epoch
+        or value.get("entitlement_status") != "active"
+        or str(value.get("entitlement_authority_epoch")) != config.consent_epoch
+        or value.get("transcript_target_ready") is not True
+    ):
+        raise HarnessRefusal("fixture_authority_mismatch")
+
+
+class ProductionFixtureStore:
+    def __init__(self):
+        if conversations_db is None or vector_db is None:
+            raise HarnessRefusal("fixture_persistence_modules_unavailable")
+
+    async def assert_prepare_authority(self, config: CanaryConfig) -> None:
+        pool = await voice_canary_db.get_pool()
+        row = await pool.fetchrow(
+            """
+            SELECT
+                u.id AS user_id,
+                u.omi_uid,
+                u.status AS user_status,
+                u.profile_class,
+                b.id AS binding_id,
+                b.user_id AS binding_user_id,
+                b.account_user_id,
+                b.profile_user_id,
+                b.provider,
+                b.status AS binding_status,
+                b.health_state,
+                b.active,
+                b.expected_model,
+                a.decision,
+                a.profile_binding_id AS consent_profile_binding_id,
+                a.policy_version,
+                a.processor_set_hash,
+                a.scope_version,
+                a.scope_hash,
+                a.authority_epoch,
+                e.status AS entitlement_status,
+                e.consent_authority_epoch AS entitlement_authority_epoch,
+                EXISTS (
+                    SELECT 1
+                    FROM ella_runtime_targets t
+                    WHERE t.runtime_binding_id = b.id
+                      AND t.account_user_id = u.id
+                      AND t.profile_user_id = u.id
+                      AND t.provider = 'hermes_cloud'
+                      AND t.mode = 'hermes-cloud-transcript'
+                      AND t.status = 'ready'
+                      AND t.policy_version = a.policy_version
+                      AND t.processor_set_hash = a.processor_set_hash
+                      AND t.scope_version = a.scope_version
+                      AND t.scope_hash = a.scope_hash
+                ) AS transcript_target_ready
+            FROM users u
+            JOIN ella_runtime_bindings b ON b.id = $4 AND b.user_id = u.id
+            JOIN ella_managed_cloud_consent_authority a ON a.user_id = u.id
+            JOIN voice_entitlements e ON e.uid = u.omi_uid
+            WHERE u.omi_uid = $1
+              AND u.id = $2
+              AND u.id = $3
+            """,
+            config.uid,
+            uuid.UUID(config.account_id),
+            uuid.UUID(config.profile_id),
+            uuid.UUID(config.binding_id),
+        )
+        if row is None:
+            raise HarnessRefusal("fixture_authority_mismatch")
+        _validate_fixture_authority(config, dict(row))
+
+    async def get_conversation(self, uid: str, conversation_id: str) -> Mapping[str, Any] | None:
+        return await asyncio.to_thread(conversations_db.get_conversation, uid, conversation_id)
+
+    async def create_conversation(self, uid: str, conversation: Conversation) -> None:
+        await asyncio.to_thread(conversations_db.upsert_conversation, uid, conversation.model_dump())
+
+    async def ensure_summary_version(self, uid: str, conversation_id: str) -> Mapping[str, Any]:
+        return await asyncio.to_thread(
+            conversations_db.ensure_voice_memory_summary_version,
+            uid,
+            conversation_id,
+        )
+
+    async def delete_conversation(self, uid: str, conversation_id: str) -> None:
+        await asyncio.to_thread(conversations_db.delete_conversation, uid, conversation_id)
+
+    async def delete_vector(self, uid: str, conversation_id: str) -> None:
+        if vector_db.index is None:
+            raise HarnessRefusal("fixture_vector_store_unavailable")
+        await asyncio.to_thread(vector_db.delete_vector, uid, conversation_id)
+
+    async def vector_exists(self, uid: str, conversation_id: str) -> bool:
+        if vector_db.index is None:
+            raise HarnessRefusal("fixture_vector_store_unavailable")
+        existing = await asyncio.to_thread(
+            vector_db.fetch_existing_conversation_vector_ids,
+            uid,
+            [conversation_id],
+        )
+        return conversation_id in existing
+
+
+def _fixture_receipt(
+    config: CanaryConfig,
+    conversation: Mapping[str, Any],
+    active_summary_version_id: str,
+) -> dict[str, Any]:
+    identity = build_enrichment_identity(
+        uid=config.uid,
+        conversation_id=str(conversation["id"]),
+        conversation=dict(conversation),
+    )
+    external_data = conversation.get("external_data")
+    marker = external_data.get("ella_product_fit_fixture") if isinstance(external_data, Mapping) else None
+    return {
+        "schema_version": FIXTURE_SCHEMA,
+        "status": "ready",
+        "uid_sha256": _sha256(config.uid),
+        "conversation_id": str(conversation["id"]),
+        "active_summary_version_id": active_summary_version_id,
+        "transcript_sha256": identity.transcript_sha256,
+        "enrichment_client_interaction_id": identity.client_interaction_id,
+        "enrichment_job_id": identity.job_id,
+        "fixture_marker_sha256": _sha256(_canonical_json(marker)),
+        "provider_calls": 0,
+        "enrichment_success_preseeded": False,
+        "content_free": True,
+    }
+
+
+def _assert_fixture_summary_version(conversation: Mapping[str, Any], version_id: str) -> None:
+    if str(conversation.get("active_summary_version_id") or "") != version_id:
+        raise HarnessRefusal("fixture_summary_version_drift")
+    versions = conversation.get("summary_versions")
+    active = [
+        value
+        for value in (versions if isinstance(versions, list) else [])
+        if isinstance(value, Mapping) and str(value.get("id") or "") == version_id and value.get("is_active") is True
+    ]
+    if len(active) != 1 or active[0].get("kind") != "legacy_current":
+        raise HarnessRefusal("fixture_summary_version_drift")
+
+
+def _validate_fixture_receipt(receipt: Mapping[str, Any], config: CanaryConfig) -> None:
+    if set(receipt) != {
+        "schema_version",
+        "status",
+        "uid_sha256",
+        "conversation_id",
+        "active_summary_version_id",
+        "transcript_sha256",
+        "enrichment_client_interaction_id",
+        "enrichment_job_id",
+        "fixture_marker_sha256",
+        "provider_calls",
+        "enrichment_success_preseeded",
+        "content_free",
+    }:
+        raise HarnessRefusal("fixture_receipt_shape_invalid")
+    if (
+        receipt.get("schema_version") != FIXTURE_SCHEMA
+        or receipt.get("status") != "ready"
+        or receipt.get("uid_sha256") != _sha256(config.uid)
+        or receipt.get("conversation_id") != _fixture_conversation_id(config)
+        or not _safe_id(receipt.get("active_summary_version_id"), "fixture_summary_version_id")
+        or SHA256_RE.fullmatch(str(receipt.get("transcript_sha256") or "")) is None
+        or not _safe_id(receipt.get("enrichment_client_interaction_id"), "fixture_interaction_id")
+        or not _safe_id(receipt.get("enrichment_job_id"), "fixture_job_id")
+        or SHA256_RE.fullmatch(str(receipt.get("fixture_marker_sha256") or "")) is None
+        or receipt.get("provider_calls") != 0
+        or receipt.get("enrichment_success_preseeded") is not False
+        or receipt.get("content_free") is not True
+    ):
+        raise HarnessRefusal("fixture_receipt_invalid")
+
+
+async def prepare_fixture(config: CanaryConfig, store: FixtureStore) -> dict[str, Any]:
+    _assert_fixture_rollout_off()
+    token = _resolve_env_secret(config.backend_auth_ref)
+    _require_firebase_subject(token, config.uid)
+    await store.assert_prepare_authority(config)
+    expected = _fixture_conversation(config)
+    existing = await store.get_conversation(config.uid, expected.id)
+    if existing is None:
+        await store.create_conversation(config.uid, expected)
+        existing = await store.get_conversation(config.uid, expected.id)
+    if not isinstance(existing, Mapping):
+        raise HarnessRefusal("fixture_conversation_write_failed")
+    _validate_fixture_conversation(config, existing)
+    version = await store.ensure_summary_version(config.uid, expected.id)
+    if version.get("status") != "ready":
+        raise HarnessRefusal("fixture_summary_version_unavailable")
+    conversation = version.get("conversation")
+    if not isinstance(conversation, Mapping):
+        conversation = await store.get_conversation(config.uid, expected.id)
+    if not isinstance(conversation, Mapping):
+        raise HarnessRefusal("fixture_conversation_write_failed")
+    _validate_fixture_conversation(config, conversation)
+    active_summary_version_id = str(version.get("active_summary_version_id") or "").strip()
+    if not active_summary_version_id:
+        raise HarnessRefusal("fixture_summary_version_unavailable")
+    _assert_fixture_summary_version(conversation, active_summary_version_id)
+    receipt = _fixture_receipt(config, conversation, active_summary_version_id)
+    _validate_fixture_receipt(receipt, config)
+    return receipt
+
+
+async def show_fixture(
+    config: CanaryConfig,
+    receipt: Mapping[str, Any],
+    store: FixtureStore,
+) -> dict[str, Any]:
+    _validate_fixture_receipt(receipt, config)
+    conversation = await store.get_conversation(config.uid, str(receipt["conversation_id"]))
+    if not isinstance(conversation, Mapping):
+        raise HarnessRefusal("fixture_conversation_not_found")
+    _validate_fixture_conversation(config, conversation)
+    _assert_fixture_summary_version(conversation, str(receipt["active_summary_version_id"]))
+    observed = _fixture_receipt(
+        config,
+        conversation,
+        str(receipt["active_summary_version_id"]),
+    )
+    if not hmac.compare_digest(_canonical_json(observed), _canonical_json(dict(receipt))):
+        raise HarnessRefusal("fixture_receipt_drift")
+    return dict(receipt)
+
+
+async def cleanup_fixture(
+    config: CanaryConfig,
+    receipt: Mapping[str, Any],
+    store: FixtureStore,
+    *,
+    confirm_conversation_id: str,
+) -> dict[str, Any]:
+    _validate_fixture_receipt(receipt, config)
+    conversation_id = str(receipt["conversation_id"])
+    if confirm_conversation_id != conversation_id:
+        raise HarnessRefusal("fixture_cleanup_confirmation_mismatch")
+    conversation = await store.get_conversation(config.uid, conversation_id)
+    if conversation is not None:
+        if not isinstance(conversation, Mapping):
+            raise HarnessRefusal("fixture_conversation_drift")
+        _validate_fixture_conversation(config, conversation)
+        await store.delete_vector(config.uid, conversation_id)
+        await store.delete_conversation(config.uid, conversation_id)
+    if await store.get_conversation(config.uid, conversation_id) is not None:
+        raise HarnessRefusal("fixture_cleanup_conversation_present")
+    if await store.vector_exists(config.uid, conversation_id):
+        raise HarnessRefusal("fixture_cleanup_vector_present")
+    return {
+        "schema_version": FIXTURE_SCHEMA,
+        "status": "cleaned",
+        "uid_sha256": _sha256(config.uid),
+        "conversation_id_sha256": _sha256(conversation_id),
+        "conversation_absent": True,
+        "vector_absent": True,
+        "content_free": True,
+    }
+
+
+def _fixture_receipt_path(path: str, *, must_exist: bool) -> Path:
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        raise HarnessRefusal("fixture_receipt_not_absolute")
+    if must_exist:
+        return _assert_protected_file(candidate)
+    try:
+        parent = candidate.parent.resolve(strict=True)
+    except OSError as exc:
+        raise HarnessRefusal("fixture_receipt_parent_invalid") from exc
+    metadata = parent.stat()
+    if (
+        candidate.exists()
+        or candidate.is_symlink()
+        or not any(parent.is_relative_to(root.resolve()) for root in APPROVED_SECRET_ROOTS)
+        or parent.is_symlink()
+        or metadata.st_uid != 0
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+    ):
+        raise HarnessRefusal("fixture_receipt_parent_invalid")
+    return candidate
+
+
+def load_fixture_receipt(path: str) -> dict[str, Any]:
+    protected = _fixture_receipt_path(path, must_exist=True)
+    try:
+        value = json.loads(protected.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise HarnessRefusal("fixture_receipt_invalid") from exc
+    if not isinstance(value, dict):
+        raise HarnessRefusal("fixture_receipt_invalid")
+    return value
+
+
+def write_fixture_receipt(path: str, receipt: Mapping[str, Any]) -> None:
+    candidate = Path(path)
+    if candidate.exists():
+        existing = load_fixture_receipt(path)
+        if not hmac.compare_digest(_canonical_json(existing), _canonical_json(dict(receipt))):
+            raise HarnessRefusal("fixture_receipt_conflict")
+        return
+    protected = _fixture_receipt_path(path, must_exist=False)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(protected, flags, 0o600)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(_canonical_json(dict(receipt)) + b"\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        protected.chmod(0o400)
+    except OSError as exc:
+        raise HarnessRefusal("fixture_receipt_write_failed") from exc
 
 
 @dataclass(frozen=True)
@@ -1246,9 +1755,37 @@ async def _main() -> int:
     cleanup_parser.add_argument("--config", required=True)
     cleanup_parser.add_argument("--off-receipt", required=True)
     cleanup_parser.add_argument("--confirm-uid", required=True)
+    for command in ("fixture-prepare", "fixture-show", "fixture-cleanup"):
+        fixture_parser = subparsers.add_parser(command)
+        fixture_parser.add_argument("--config", required=True)
+        fixture_parser.add_argument("--fixture-receipt", required=True)
+        if command == "fixture-cleanup":
+            fixture_parser.add_argument("--confirm-conversation-id", required=True)
     args = parser.parse_args()
 
     config = load_config(args.config)
+    if args.command.startswith("fixture-"):
+        store = ProductionFixtureStore()
+        if args.command == "fixture-prepare":
+            if Path(args.fixture_receipt).exists():
+                receipt = load_fixture_receipt(args.fixture_receipt)
+                result = await show_fixture(config, receipt, store)
+            else:
+                result = await prepare_fixture(config, store)
+                write_fixture_receipt(args.fixture_receipt, result)
+        else:
+            receipt = load_fixture_receipt(args.fixture_receipt)
+            if args.command == "fixture-show":
+                result = await show_fixture(config, receipt, store)
+            else:
+                result = await cleanup_fixture(
+                    config,
+                    receipt,
+                    store,
+                    confirm_conversation_id=args.confirm_conversation_id,
+                )
+        print(json.dumps(result, sort_keys=True))
+        return 0
     adapter = LiveCanaryAdapter(config)
     if args.command == "run":
         report = await run_harness(config, adapter)
@@ -1262,6 +1799,12 @@ async def _main() -> int:
 
 
 if __name__ == "__main__":
+    # These production persistence modules construct external clients at import
+    # time. The CLI is their only consumer; keeping them out of library import
+    # makes the content-free harness tests hermetic without in-function imports.
+    from database import conversations as conversations_db
+    from database import vector_db
+
     try:
         raise SystemExit(asyncio.run(_main()))
     except HarnessRefusal as exc:

--- a/backend/scripts/hermes_product_fit_canary.py
+++ b/backend/scripts/hermes_product_fit_canary.py
@@ -46,6 +46,9 @@ CONFIG_SCHEMA = "ella-hermes-product-fit-canary-v1"
 CALLBACK_SCHEMA = "ella.hermes.callback.v1"
 STOCK_CALLBACK_CONTRACT = "stock_best_effort_v1"
 FIXTURE_SCHEMA = "ella-hermes-product-fit-fixture-v1"
+OFF_RECEIPT_SCHEMA = "ella-hermes-canary-off-receipt-v1"
+FIXTURE_OFF_RECEIPT_MAX_AGE_SECONDS = 15 * 60
+FIXTURE_OFF_RECEIPT_MAX_FUTURE_SKEW_SECONDS = 30
 APPROVED_SECRET_ROOTS = (Path("/etc/ella"), Path("/var/lib/ella"))
 SYNTHETIC_PREFIXES = ("synthetic-", "staging-synthetic-")
 TERMINAL_STATUSES = frozenset({"writeback_completed", "blocked", "quarantined", "expired", "writeback_blocked"})
@@ -412,6 +415,77 @@ def _assert_fixture_rollout_off() -> None:
         raise HarnessRefusal("fixture_broker_selector_enabled")
 
 
+def _fixture_scope_sha256(config: CanaryConfig) -> str:
+    return _sha256(
+        _canonical_json(
+            {
+                "run_id": config.run_id,
+                "uid": config.uid,
+                "account_id": config.account_id,
+                "profile_id": config.profile_id,
+                "binding_id": config.binding_id,
+                "consent_epoch": config.consent_epoch,
+                "expected_model": config.expected_model,
+                "chat_channel": config.chat_channel,
+            }
+        )
+    )
+
+
+def _validate_fixture_off_receipt(
+    receipt: Mapping[str, Any],
+    config: CanaryConfig,
+    *,
+    now: datetime | None = None,
+) -> None:
+    if set(receipt) != {
+        "schema_version",
+        "uid_sha256",
+        "binding_id_sha256",
+        "scope_sha256",
+        "observed_at_utc",
+        "flags_off",
+        "selectors_empty",
+        "workflows_off",
+        "content_free",
+    }:
+        raise HarnessRefusal("fixture_off_receipt_shape_invalid")
+    try:
+        _validate_off_receipt(
+            {
+                key: receipt.get(key)
+                for key in (
+                    "schema_version",
+                    "uid_sha256",
+                    "flags_off",
+                    "selectors_empty",
+                    "workflows_off",
+                    "content_free",
+                )
+            },
+            config,
+        )
+    except HarnessRefusal as exc:
+        raise HarnessRefusal("fixture_off_receipt_invalid") from exc
+    if receipt.get("binding_id_sha256") != _sha256(config.binding_id) or receipt.get(
+        "scope_sha256"
+    ) != _fixture_scope_sha256(config):
+        raise HarnessRefusal("fixture_off_receipt_invalid")
+    observed_raw = receipt.get("observed_at_utc")
+    if not isinstance(observed_raw, str):
+        raise HarnessRefusal("fixture_off_receipt_invalid")
+    try:
+        observed_at = datetime.strptime(observed_raw, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        raise HarnessRefusal("fixture_off_receipt_invalid") from exc
+    checked_at = now or datetime.now(timezone.utc)
+    if checked_at.tzinfo is None:
+        raise HarnessRefusal("fixture_off_receipt_invalid")
+    age_seconds = (checked_at.astimezone(timezone.utc) - observed_at).total_seconds()
+    if not (-FIXTURE_OFF_RECEIPT_MAX_FUTURE_SKEW_SECONDS <= age_seconds <= FIXTURE_OFF_RECEIPT_MAX_AGE_SECONDS):
+        raise HarnessRefusal("fixture_off_receipt_stale")
+
+
 def _fixture_conversation_id(config: CanaryConfig) -> str:
     material = "\x1f".join(
         (
@@ -484,9 +558,10 @@ def _enum_value(value: Any) -> str:
     return str(getattr(value, "value", value) or "")
 
 
-def _validate_fixture_conversation(
+def _validate_fixture_provenance(
     config: CanaryConfig,
     conversation: Mapping[str, Any],
+    receipt: Mapping[str, Any] | None = None,
 ) -> None:
     expected = _fixture_conversation(config).model_dump()
     external_data = conversation.get("external_data")
@@ -498,10 +573,30 @@ def _validate_fixture_conversation(
         or _enum_value(conversation.get("visibility")) != ConversationVisibility.private.value
         or _enum_value(conversation.get("status")) != ConversationStatus.completed.value
         or conversation.get("discarded") is not False
-        or conversation.get("enrichment_state") is not None
         or conversation.get("transcript_segments") != expected["transcript_segments"]
-        or conversation.get("structured") != expected["structured"]
     ):
+        raise HarnessRefusal("fixture_conversation_drift")
+    if receipt is not None:
+        identity = build_enrichment_identity(
+            uid=config.uid,
+            conversation_id=str(conversation["id"]),
+            conversation=dict(conversation),
+        )
+        if (
+            receipt.get("conversation_id") != conversation.get("id")
+            or receipt.get("fixture_marker_sha256") != _sha256(_canonical_json(marker))
+            or receipt.get("transcript_sha256") != identity.transcript_sha256
+        ):
+            raise HarnessRefusal("fixture_conversation_drift")
+
+
+def _validate_fixture_conversation(
+    config: CanaryConfig,
+    conversation: Mapping[str, Any],
+) -> None:
+    expected = _fixture_conversation(config).model_dump()
+    _validate_fixture_provenance(config, conversation)
+    if conversation.get("enrichment_state") is not None or conversation.get("structured") != expected["structured"]:
         raise HarnessRefusal("fixture_conversation_drift")
 
 
@@ -691,6 +786,56 @@ def _assert_fixture_summary_version(conversation: Mapping[str, Any], version_id:
         raise HarnessRefusal("fixture_summary_version_drift")
 
 
+def _assert_fixture_lifecycle(
+    config: CanaryConfig,
+    receipt: Mapping[str, Any],
+    conversation: Mapping[str, Any],
+) -> None:
+    _validate_fixture_provenance(config, conversation, receipt)
+    versions = conversation.get("summary_versions")
+    if not isinstance(versions, list) or not versions or not all(isinstance(value, Mapping) for value in versions):
+        raise HarnessRefusal("fixture_summary_version_drift")
+    version_ids = [str(value.get("id") or "") for value in versions]
+    if any(SAFE_ID_RE.fullmatch(value) is None for value in version_ids) or len(set(version_ids)) != len(version_ids):
+        raise HarnessRefusal("fixture_summary_version_drift")
+    prepared_version_id = str(receipt["active_summary_version_id"])
+    prepared = [value for value in versions if str(value.get("id") or "") == prepared_version_id]
+    active = [value for value in versions if value.get("is_active") is True]
+    active_version_id = str(conversation.get("active_summary_version_id") or "")
+    if (
+        len(prepared) != 1
+        or prepared[0].get("source") != "legacy"
+        or prepared[0].get("kind") != "legacy_current"
+        or len(active) != 1
+        or str(active[0].get("id") or "") != active_version_id
+    ):
+        raise HarnessRefusal("fixture_summary_version_drift")
+    enrichment_state = conversation.get("enrichment_state")
+    if active_version_id == prepared_version_id and enrichment_state is None:
+        _validate_fixture_conversation(config, conversation)
+        _assert_fixture_summary_version(conversation, prepared_version_id)
+        return
+    if active_version_id == prepared_version_id or len(versions) < 2 or not isinstance(enrichment_state, Mapping):
+        raise HarnessRefusal("fixture_enrichment_lifecycle_drift")
+    state = str(enrichment_state.get("status") or "")
+    pending = enrichment_state.get("pending")
+    canonical_status = str(enrichment_state.get("canonical_status") or "")
+    applied = (
+        state == "writeback_applied"
+        and pending is False
+        and canonical_status
+        in {
+            "completed",
+            "unconfirmed",
+        }
+    )
+    pending_canonical = (
+        state == "writeback_pending_canonical" and pending is True and canonical_status in {"pending", "failed"}
+    )
+    if not (applied or pending_canonical):
+        raise HarnessRefusal("fixture_enrichment_lifecycle_drift")
+
+
 def _validate_fixture_receipt(receipt: Mapping[str, Any], config: CanaryConfig) -> None:
     if set(receipt) != {
         "schema_version",
@@ -724,13 +869,39 @@ def _validate_fixture_receipt(receipt: Mapping[str, Any], config: CanaryConfig) 
         raise HarnessRefusal("fixture_receipt_invalid")
 
 
-async def prepare_fixture(config: CanaryConfig, store: FixtureStore) -> dict[str, Any]:
+async def _fixture_prepare_preflight(
+    config: CanaryConfig,
+    store: FixtureStore,
+    off_receipt: Mapping[str, Any],
+) -> None:
+    _validate_fixture_off_receipt(off_receipt, config)
     _assert_fixture_rollout_off()
     token = _resolve_env_secret(config.backend_auth_ref)
     _require_firebase_subject(token, config.uid)
     await store.assert_prepare_authority(config)
+
+
+async def prepare_fixture(
+    config: CanaryConfig,
+    store: FixtureStore,
+    *,
+    off_receipt: Mapping[str, Any],
+    existing_receipt: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    await _fixture_prepare_preflight(config, store, off_receipt)
     expected = _fixture_conversation(config)
     existing = await store.get_conversation(config.uid, expected.id)
+    if existing_receipt is not None:
+        _validate_fixture_receipt(existing_receipt, config)
+        if not isinstance(existing, Mapping):
+            raise HarnessRefusal("fixture_conversation_not_found")
+        _validate_fixture_conversation(config, existing)
+        active_summary_version_id = str(existing_receipt["active_summary_version_id"])
+        _assert_fixture_summary_version(existing, active_summary_version_id)
+        observed = _fixture_receipt(config, existing, active_summary_version_id)
+        if not hmac.compare_digest(_canonical_json(observed), _canonical_json(dict(existing_receipt))):
+            raise HarnessRefusal("fixture_receipt_drift")
+        return dict(existing_receipt)
     if existing is None:
         await store.create_conversation(config.uid, expected)
         existing = await store.get_conversation(config.uid, expected.id)
@@ -764,15 +935,7 @@ async def show_fixture(
     conversation = await store.get_conversation(config.uid, str(receipt["conversation_id"]))
     if not isinstance(conversation, Mapping):
         raise HarnessRefusal("fixture_conversation_not_found")
-    _validate_fixture_conversation(config, conversation)
-    _assert_fixture_summary_version(conversation, str(receipt["active_summary_version_id"]))
-    observed = _fixture_receipt(
-        config,
-        conversation,
-        str(receipt["active_summary_version_id"]),
-    )
-    if not hmac.compare_digest(_canonical_json(observed), _canonical_json(dict(receipt))):
-        raise HarnessRefusal("fixture_receipt_drift")
+    _assert_fixture_lifecycle(config, receipt, conversation)
     return dict(receipt)
 
 
@@ -781,8 +944,11 @@ async def cleanup_fixture(
     receipt: Mapping[str, Any],
     store: FixtureStore,
     *,
+    off_receipt: Mapping[str, Any],
     confirm_conversation_id: str,
 ) -> dict[str, Any]:
+    _validate_fixture_off_receipt(off_receipt, config)
+    _assert_fixture_rollout_off()
     _validate_fixture_receipt(receipt, config)
     conversation_id = str(receipt["conversation_id"])
     if confirm_conversation_id != conversation_id:
@@ -791,8 +957,9 @@ async def cleanup_fixture(
     if conversation is not None:
         if not isinstance(conversation, Mapping):
             raise HarnessRefusal("fixture_conversation_drift")
-        _validate_fixture_conversation(config, conversation)
-        await store.delete_vector(config.uid, conversation_id)
+        _assert_fixture_lifecycle(config, receipt, conversation)
+    await store.delete_vector(config.uid, conversation_id)
+    if conversation is not None:
         await store.delete_conversation(config.uid, conversation_id)
     if await store.get_conversation(config.uid, conversation_id) is not None:
         raise HarnessRefusal("fixture_cleanup_conversation_present")
@@ -1716,7 +1883,7 @@ def _validate_off_receipt(receipt: Mapping[str, Any], config: CanaryConfig) -> N
     }:
         raise HarnessRefusal("cleanup_off_receipt_shape_invalid")
     if (
-        receipt.get("schema_version") != "ella-hermes-canary-off-receipt-v1"
+        receipt.get("schema_version") != OFF_RECEIPT_SCHEMA
         or receipt.get("uid_sha256") != _sha256(config.uid)
         or receipt.get("flags_off") is not True
         or receipt.get("selectors_empty") is not True
@@ -1726,8 +1893,17 @@ def _validate_off_receipt(receipt: Mapping[str, Any], config: CanaryConfig) -> N
         raise HarnessRefusal("cleanup_off_receipt_invalid")
 
 
-def load_off_receipt(path: str) -> dict[str, Any]:
-    protected = _assert_protected_file(Path(path))
+def load_off_receipt(
+    path: str,
+    *,
+    approved_roots: tuple[Path, ...] = APPROVED_SECRET_ROOTS,
+    expected_owner_uid: int = 0,
+) -> dict[str, Any]:
+    protected = _assert_protected_file(
+        Path(path),
+        approved_roots=approved_roots,
+        expected_owner_uid=expected_owner_uid,
+    )
     try:
         value = json.loads(protected.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -1759,6 +1935,8 @@ async def _main() -> int:
         fixture_parser = subparsers.add_parser(command)
         fixture_parser.add_argument("--config", required=True)
         fixture_parser.add_argument("--fixture-receipt", required=True)
+        if command in {"fixture-prepare", "fixture-cleanup"}:
+            fixture_parser.add_argument("--off-receipt", required=True)
         if command == "fixture-cleanup":
             fixture_parser.add_argument("--confirm-conversation-id", required=True)
     args = parser.parse_args()
@@ -1767,12 +1945,19 @@ async def _main() -> int:
     if args.command.startswith("fixture-"):
         store = ProductionFixtureStore()
         if args.command == "fixture-prepare":
-            if Path(args.fixture_receipt).exists():
-                receipt = load_fixture_receipt(args.fixture_receipt)
-                result = await show_fixture(config, receipt, store)
-            else:
-                result = await prepare_fixture(config, store)
-                write_fixture_receipt(args.fixture_receipt, result)
+            receipt_path = Path(args.fixture_receipt)
+            existing_receipt = (
+                load_fixture_receipt(args.fixture_receipt)
+                if receipt_path.exists() or receipt_path.is_symlink()
+                else None
+            )
+            result = await prepare_fixture(
+                config,
+                store,
+                off_receipt=load_off_receipt(args.off_receipt),
+                existing_receipt=existing_receipt,
+            )
+            write_fixture_receipt(args.fixture_receipt, result)
         else:
             receipt = load_fixture_receipt(args.fixture_receipt)
             if args.command == "fixture-show":
@@ -1782,6 +1967,7 @@ async def _main() -> int:
                     config,
                     receipt,
                     store,
+                    off_receipt=load_off_receipt(args.off_receipt),
                     confirm_conversation_id=args.confirm_conversation_id,
                 )
         print(json.dumps(result, sort_keys=True))

--- a/backend/tests/unit/test_hermes_product_fit_canary.py
+++ b/backend/tests/unit/test_hermes_product_fit_canary.py
@@ -62,6 +62,118 @@ def _config():
     return canary.CanaryConfig.from_mapping(_config_mapping())
 
 
+def _fixture_config():
+    raw = _config_mapping()
+    raw["selectors"]["profile_id"] = raw["selectors"]["account_id"]
+    return canary.CanaryConfig.from_mapping(raw)
+
+
+def _token_for(uid):
+    payload = base64.urlsafe_b64encode(json.dumps({"sub": uid}).encode()).decode().rstrip("=")
+    return f"header.{payload}.signature-padding-that-keeps-the-token-long"
+
+
+def _fixture_authority(config):
+    return {
+        "user_id": config.account_id,
+        "omi_uid": config.uid,
+        "user_status": "ACTIVE",
+        "profile_class": "synthetic",
+        "binding_id": config.binding_id,
+        "binding_user_id": config.account_id,
+        "account_user_id": config.account_id,
+        "profile_user_id": config.profile_id,
+        "provider": "hermes_cloud",
+        "binding_status": "internal_canary",
+        "health_state": "healthy",
+        "active": True,
+        "expected_model": config.expected_model,
+        "decision": "granted",
+        "consent_profile_binding_id": canary.ai_consent.derive_profile_binding_id(
+            account_uid=config.uid,
+            profile_uid=config.uid,
+        ),
+        "policy_version": canary.ai_consent.CURRENT_POLICY_VERSION,
+        "processor_set_hash": canary.ai_consent.CURRENT_PROCESSOR_SET_HASH,
+        "scope_version": canary.ai_consent.CURRENT_SCOPE_VERSION,
+        "scope_hash": canary.ai_consent.CURRENT_SCOPE_HASH,
+        "authority_epoch": config.consent_epoch,
+        "entitlement_status": "active",
+        "entitlement_authority_epoch": config.consent_epoch,
+        "transcript_target_ready": True,
+    }
+
+
+class FakeFixtureStore:
+    def __init__(self, *, authority=None, authority_error=None):
+        self.authority = authority
+        self.authority_error = authority_error
+        self.conversations = {}
+        self.vectors = set()
+        self.authority_checks = 0
+        self.create_calls = 0
+        self.summary_calls = 0
+        self.delete_calls = 0
+        self.vector_delete_calls = 0
+
+    async def assert_prepare_authority(self, config):
+        self.authority_checks += 1
+        if self.authority_error:
+            raise canary.HarnessRefusal(self.authority_error)
+        if self.authority is not None:
+            canary._validate_fixture_authority(config, self.authority)
+
+    async def get_conversation(self, uid, conversation_id):
+        value = self.conversations.get((uid, conversation_id))
+        return json.loads(json.dumps(value, default=str)) if value is not None else None
+
+    async def create_conversation(self, uid, conversation):
+        self.create_calls += 1
+        self.conversations[(uid, conversation.id)] = conversation.model_dump()
+
+    async def ensure_summary_version(self, uid, conversation_id):
+        self.summary_calls += 1
+        conversation = self.conversations[(uid, conversation_id)]
+        if not conversation.get("active_summary_version_id"):
+            version_id = "fixture-summary-version"
+            conversation.update(
+                {
+                    "summary_versions": [
+                        {
+                            "id": version_id,
+                            "created_at": conversation["created_at"],
+                            "source": "legacy",
+                            "kind": "legacy_current",
+                            "title": conversation["structured"]["title"],
+                            "overview": conversation["structured"]["overview"],
+                            "emoji": conversation["structured"]["emoji"],
+                            "category": conversation["structured"]["category"],
+                            "correction_id": None,
+                            "based_on_version_id": None,
+                            "is_active": True,
+                        }
+                    ],
+                    "active_summary_version_id": version_id,
+                }
+            )
+        return {
+            "status": "ready",
+            "active_summary_version_id": conversation["active_summary_version_id"],
+            "conversation": conversation,
+        }
+
+    async def delete_conversation(self, uid, conversation_id):
+        self.delete_calls += 1
+        self.conversations.pop((uid, conversation_id), None)
+
+    async def delete_vector(self, uid, conversation_id):
+        self.vector_delete_calls += 1
+        self.vectors.discard((uid, conversation_id))
+
+    async def vector_exists(self, uid, conversation_id):
+        return (uid, conversation_id) in self.vectors
+
+
 class FakeAdapter:
     def __init__(self, config):
         self.config = config
@@ -363,9 +475,8 @@ def test_callback_fixture_matches_ella_callback_v1_and_requires_outcome():
     }
 
 
-@pytest.mark.parametrize(
-    ("mutator", "code"),
-    (
+def test_config_rejects_real_identity_session_drift_urls_and_literal_secrets():
+    cases = (
         (
             lambda raw: raw["selectors"].update(uid="realcryptoplato"),
             "synthetic_uid_required",
@@ -388,14 +499,13 @@ def test_callback_fixture_matches_ella_callback_v1_and_requires_outcome():
             lambda raw: raw["broker"].update(service_token_ref="literal-secret"),
             "broker_service_token_ref_invalid",
         ),
-    ),
-)
-def test_config_rejects_real_identity_session_drift_urls_and_literal_secrets(mutator, code):
-    raw = _config_mapping()
-    mutator(raw)
+    )
 
-    with pytest.raises((canary.HarnessRefusal, canary.ProvisioningError), match=code):
-        canary.CanaryConfig.from_mapping(raw)
+    for mutator, code in cases:
+        raw = _config_mapping()
+        mutator(raw)
+        with pytest.raises((canary.HarnessRefusal, canary.ProvisioningError), match=code):
+            canary.CanaryConfig.from_mapping(raw)
 
 
 def test_protected_config_and_off_receipt_require_exact_owner_modes(tmp_path):
@@ -468,3 +578,128 @@ def test_missing_optional_live_surface_reports_not_tested_not_pass():
     assert memory.status == "NOT TESTED"
     assert report.verdicts["profile memory pack"] == "NOT TESTED"
     assert canary._exit_code(report) == 2
+
+
+def test_fixture_prepare_creates_one_synthetic_conversation_and_production_identities(monkeypatch):
+    config = _fixture_config()
+    monkeypatch.setenv("ELLA_CANARY_FIREBASE_ID_TOKEN", _token_for(config.uid))
+    store = FakeFixtureStore()
+
+    receipt = asyncio.run(canary.prepare_fixture(config, store))
+    conversation = store.conversations[(config.uid, receipt["conversation_id"])]
+    production_identity = canary.build_enrichment_identity(
+        uid=config.uid,
+        conversation_id=receipt["conversation_id"],
+        conversation=conversation,
+    )
+
+    assert store.authority_checks == 1
+    assert store.create_calls == 1
+    assert len(store.conversations) == 1
+    assert conversation["source"].value == "external_integration"
+    assert conversation["visibility"].value == "private"
+    assert conversation["status"].value == "completed"
+    assert conversation["discarded"] is False
+    assert conversation.get("enrichment_state") is None
+    assert receipt["active_summary_version_id"] == conversation["active_summary_version_id"]
+    assert receipt["transcript_sha256"] == production_identity.transcript_sha256
+    assert receipt["enrichment_client_interaction_id"] == production_identity.client_interaction_id
+    assert receipt["enrichment_job_id"] == production_identity.job_id
+    assert receipt["provider_calls"] == 0
+    assert receipt["enrichment_success_preseeded"] is False
+
+
+def test_fixture_prepare_refuses_real_stale_or_mismatched_owner_without_writes(monkeypatch):
+    config = _fixture_config()
+    monkeypatch.setenv("ELLA_CANARY_FIREBASE_ID_TOKEN", _token_for(config.uid))
+
+    mutations = (
+        lambda value: value.update(profile_class="real"),
+        lambda value: value.update(policy_version="ai-data-processors-stale"),
+        lambda value: value.update(account_user_id="99999999-9999-4999-8999-999999999999"),
+    )
+    for mutate in mutations:
+        authority = _fixture_authority(config)
+        mutate(authority)
+        store = FakeFixtureStore(authority=authority)
+        with pytest.raises(canary.HarnessRefusal, match="fixture_authority_mismatch"):
+            asyncio.run(canary.prepare_fixture(config, store))
+        assert store.create_calls == 0
+        assert store.summary_calls == 0
+        assert store.conversations == {}
+
+    real_config = canary.CanaryConfig(**{**config.__dict__, "uid": "real-user"})
+    real_store = FakeFixtureStore()
+    monkeypatch.setenv("ELLA_CANARY_FIREBASE_ID_TOKEN", _token_for(real_config.uid))
+    with pytest.raises(canary.HarnessRefusal, match="firebase_token_subject_mismatch"):
+        asyncio.run(canary.prepare_fixture(real_config, real_store))
+    assert real_store.authority_checks == 0
+    assert real_store.create_calls == 0
+
+
+def test_fixture_prepare_retry_is_idempotent_and_never_invokes_runtime(monkeypatch):
+    config = _fixture_config()
+    monkeypatch.setenv("ELLA_CANARY_FIREBASE_ID_TOKEN", _token_for(config.uid))
+    store = FakeFixtureStore()
+
+    class RefuseRuntimeConstruction:
+        def __init__(self, *_args, **_kwargs):
+            raise AssertionError("runtime must not be constructed")
+
+    monkeypatch.setattr(canary, "LiveCanaryAdapter", RefuseRuntimeConstruction)
+    first = asyncio.run(canary.prepare_fixture(config, store))
+    second = asyncio.run(canary.prepare_fixture(config, store))
+
+    assert first == second
+    assert store.create_calls == 1
+    assert store.summary_calls == 2
+    assert len(store.conversations) == 1
+
+
+def test_fixture_show_and_cleanup_are_content_free_and_exact_id_only(monkeypatch):
+    config = _fixture_config()
+    monkeypatch.setenv("ELLA_CANARY_FIREBASE_ID_TOKEN", _token_for(config.uid))
+    store = FakeFixtureStore()
+    receipt = asyncio.run(canary.prepare_fixture(config, store))
+    key = (config.uid, receipt["conversation_id"])
+    store.vectors.add(key)
+
+    shown = asyncio.run(canary.show_fixture(config, receipt, store))
+    assert shown == receipt
+    rendered = json.dumps(shown, sort_keys=True)
+    assert "Synthetic product-fit fixture turn" not in rendered
+    assert "Synthetic data for" not in rendered
+
+    with pytest.raises(canary.HarnessRefusal, match="fixture_cleanup_confirmation_mismatch"):
+        asyncio.run(
+            canary.cleanup_fixture(
+                config,
+                receipt,
+                store,
+                confirm_conversation_id="wrong-conversation",
+            )
+        )
+    assert store.delete_calls == 0
+    assert store.vector_delete_calls == 0
+
+    cleaned = asyncio.run(
+        canary.cleanup_fixture(
+            config,
+            receipt,
+            store,
+            confirm_conversation_id=receipt["conversation_id"],
+        )
+    )
+    assert cleaned == {
+        "schema_version": canary.FIXTURE_SCHEMA,
+        "status": "cleaned",
+        "uid_sha256": canary._sha256(config.uid),
+        "conversation_id_sha256": canary._sha256(receipt["conversation_id"]),
+        "conversation_absent": True,
+        "vector_absent": True,
+        "content_free": True,
+    }
+    assert key not in store.conversations
+    assert key not in store.vectors
+    assert store.delete_calls == 1
+    assert store.vector_delete_calls == 1

--- a/backend/tests/unit/test_hermes_product_fit_canary.py
+++ b/backend/tests/unit/test_hermes_product_fit_canary.py
@@ -2,6 +2,8 @@ import asyncio
 import base64
 import json
 import os
+import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -101,6 +103,21 @@ def _fixture_authority(config):
         "entitlement_status": "active",
         "entitlement_authority_epoch": config.consent_epoch,
         "transcript_target_ready": True,
+    }
+
+
+def _fixture_off_receipt(config, *, observed_at=None):
+    observed = observed_at or datetime.now(timezone.utc)
+    return {
+        "schema_version": canary.OFF_RECEIPT_SCHEMA,
+        "uid_sha256": canary._sha256(config.uid),
+        "binding_id_sha256": canary._sha256(config.binding_id),
+        "scope_sha256": canary._fixture_scope_sha256(config),
+        "observed_at_utc": observed.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "flags_off": True,
+        "selectors_empty": True,
+        "workflows_off": True,
+        "content_free": True,
     }
 
 
@@ -585,7 +602,7 @@ def test_fixture_prepare_creates_one_synthetic_conversation_and_production_ident
     monkeypatch.setenv("ELLA_CANARY_FIREBASE_ID_TOKEN", _token_for(config.uid))
     store = FakeFixtureStore()
 
-    receipt = asyncio.run(canary.prepare_fixture(config, store))
+    receipt = asyncio.run(canary.prepare_fixture(config, store, off_receipt=_fixture_off_receipt(config)))
     conversation = store.conversations[(config.uid, receipt["conversation_id"])]
     production_identity = canary.build_enrichment_identity(
         uid=config.uid,
@@ -623,7 +640,7 @@ def test_fixture_prepare_refuses_real_stale_or_mismatched_owner_without_writes(m
         mutate(authority)
         store = FakeFixtureStore(authority=authority)
         with pytest.raises(canary.HarnessRefusal, match="fixture_authority_mismatch"):
-            asyncio.run(canary.prepare_fixture(config, store))
+            asyncio.run(canary.prepare_fixture(config, store, off_receipt=_fixture_off_receipt(config)))
         assert store.create_calls == 0
         assert store.summary_calls == 0
         assert store.conversations == {}
@@ -632,7 +649,7 @@ def test_fixture_prepare_refuses_real_stale_or_mismatched_owner_without_writes(m
     real_store = FakeFixtureStore()
     monkeypatch.setenv("ELLA_CANARY_FIREBASE_ID_TOKEN", _token_for(real_config.uid))
     with pytest.raises(canary.HarnessRefusal, match="firebase_token_subject_mismatch"):
-        asyncio.run(canary.prepare_fixture(real_config, real_store))
+        asyncio.run(canary.prepare_fixture(real_config, real_store, off_receipt=_fixture_off_receipt(real_config)))
     assert real_store.authority_checks == 0
     assert real_store.create_calls == 0
 
@@ -647,12 +664,20 @@ def test_fixture_prepare_retry_is_idempotent_and_never_invokes_runtime(monkeypat
             raise AssertionError("runtime must not be constructed")
 
     monkeypatch.setattr(canary, "LiveCanaryAdapter", RefuseRuntimeConstruction)
-    first = asyncio.run(canary.prepare_fixture(config, store))
-    second = asyncio.run(canary.prepare_fixture(config, store))
+    off_receipt = _fixture_off_receipt(config)
+    first = asyncio.run(canary.prepare_fixture(config, store, off_receipt=off_receipt))
+    second = asyncio.run(
+        canary.prepare_fixture(
+            config,
+            store,
+            off_receipt=off_receipt,
+            existing_receipt=first,
+        )
+    )
 
     assert first == second
     assert store.create_calls == 1
-    assert store.summary_calls == 2
+    assert store.summary_calls == 1
     assert len(store.conversations) == 1
 
 
@@ -660,7 +685,8 @@ def test_fixture_show_and_cleanup_are_content_free_and_exact_id_only(monkeypatch
     config = _fixture_config()
     monkeypatch.setenv("ELLA_CANARY_FIREBASE_ID_TOKEN", _token_for(config.uid))
     store = FakeFixtureStore()
-    receipt = asyncio.run(canary.prepare_fixture(config, store))
+    off_receipt = _fixture_off_receipt(config)
+    receipt = asyncio.run(canary.prepare_fixture(config, store, off_receipt=off_receipt))
     key = (config.uid, receipt["conversation_id"])
     store.vectors.add(key)
 
@@ -676,6 +702,7 @@ def test_fixture_show_and_cleanup_are_content_free_and_exact_id_only(monkeypatch
                 config,
                 receipt,
                 store,
+                off_receipt=off_receipt,
                 confirm_conversation_id="wrong-conversation",
             )
         )
@@ -687,6 +714,7 @@ def test_fixture_show_and_cleanup_are_content_free_and_exact_id_only(monkeypatch
             config,
             receipt,
             store,
+            off_receipt=off_receipt,
             confirm_conversation_id=receipt["conversation_id"],
         )
     )
@@ -703,3 +731,214 @@ def test_fixture_show_and_cleanup_are_content_free_and_exact_id_only(monkeypatch
     assert key not in store.vectors
     assert store.delete_calls == 1
     assert store.vector_delete_calls == 1
+
+
+def test_fixture_prepare_cli_retry_revalidates_authority_and_rollout_off(monkeypatch, tmp_path, capsys):
+    config = _fixture_config()
+    off_receipt = _fixture_off_receipt(config)
+    store = FakeFixtureStore(authority=_fixture_authority(config))
+    receipt_path = tmp_path / "fixture.receipt.json"
+    stored_receipt = {}
+
+    monkeypatch.setenv("ELLA_CANARY_FIREBASE_ID_TOKEN", _token_for(config.uid))
+    monkeypatch.setattr(canary, "load_config", lambda _path: config)
+    monkeypatch.setattr(canary, "load_off_receipt", lambda _path: off_receipt)
+    monkeypatch.setattr(canary, "ProductionFixtureStore", lambda: store)
+
+    def write_receipt(path, receipt):
+        stored_receipt.clear()
+        stored_receipt.update(receipt)
+        Path(path).write_text("present\n", encoding="utf-8")
+
+    monkeypatch.setattr(canary, "write_fixture_receipt", write_receipt)
+    monkeypatch.setattr(canary, "load_fixture_receipt", lambda _path: dict(stored_receipt))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes_product_fit_canary.py",
+            "fixture-prepare",
+            "--config",
+            str(tmp_path / "config.json"),
+            "--off-receipt",
+            str(tmp_path / "off.json"),
+            "--fixture-receipt",
+            str(receipt_path),
+        ],
+    )
+
+    assert asyncio.run(canary._main()) == 0
+    capsys.readouterr()
+    baseline_writes = (store.create_calls, store.summary_calls, len(store.conversations))
+
+    monkeypatch.setenv("ELLA_HERMES_BROKER_PROTOTYPE_ENABLED", "true")
+    with pytest.raises(canary.HarnessRefusal, match="fixture_global_flag_enabled"):
+        asyncio.run(canary._main())
+    assert (store.create_calls, store.summary_calls, len(store.conversations)) == baseline_writes
+
+    monkeypatch.setenv("ELLA_HERMES_BROKER_PROTOTYPE_ENABLED", "false")
+    store.authority["profile_class"] = "real"
+    with pytest.raises(canary.HarnessRefusal, match="fixture_authority_mismatch"):
+        asyncio.run(canary._main())
+    assert (store.create_calls, store.summary_calls, len(store.conversations)) == baseline_writes
+
+    store.authority = _fixture_authority(config)
+    monkeypatch.setenv("ELLA_CANARY_FIREBASE_ID_TOKEN", _token_for("staging-synthetic-other"))
+    with pytest.raises(canary.HarnessRefusal, match="firebase_token_subject_mismatch"):
+        asyncio.run(canary._main())
+    assert (store.create_calls, store.summary_calls, len(store.conversations)) == baseline_writes
+
+
+def test_fixture_prepare_requires_scope_bound_fresh_protected_off_receipt(tmp_path):
+    config = _fixture_config()
+    now = datetime(2026, 7, 31, 20, 0, tzinfo=timezone.utc)
+    valid = _fixture_off_receipt(config, observed_at=now)
+    canary._validate_fixture_off_receipt(valid, config, now=now)
+
+    invalid_cases = []
+    missing = dict(valid)
+    missing.pop("workflows_off")
+    invalid_cases.append((missing, "fixture_off_receipt_shape_invalid"))
+    for key in ("flags_off", "selectors_empty", "workflows_off"):
+        invalid_cases.append(({**valid, key: False}, "fixture_off_receipt_invalid"))
+    invalid_cases.extend(
+        (
+            ({**valid, "uid_sha256": "0" * 64}, "fixture_off_receipt_invalid"),
+            ({**valid, "binding_id_sha256": "0" * 64}, "fixture_off_receipt_invalid"),
+            ({**valid, "scope_sha256": "0" * 64}, "fixture_off_receipt_invalid"),
+            (
+                _fixture_off_receipt(config, observed_at=now - timedelta(hours=1)),
+                "fixture_off_receipt_stale",
+            ),
+            (
+                _fixture_off_receipt(config, observed_at=now + timedelta(minutes=1)),
+                "fixture_off_receipt_stale",
+            ),
+        )
+    )
+    for receipt, code in invalid_cases:
+        with pytest.raises(canary.HarnessRefusal, match=code):
+            canary._validate_fixture_off_receipt(receipt, config, now=now)
+
+    protected_root = tmp_path / "off-receipts"
+    protected_root.mkdir(mode=0o700)
+    receipt_path = protected_root / "prestate.json"
+    receipt_path.write_text(json.dumps(valid), encoding="utf-8")
+    receipt_path.chmod(0o644)
+    with pytest.raises(canary.HarnessRefusal, match="protected_file_metadata_refused"):
+        canary.load_off_receipt(
+            str(receipt_path),
+            approved_roots=(tmp_path,),
+            expected_owner_uid=os.geteuid(),
+        )
+    receipt_path.chmod(0o400)
+    assert (
+        canary.load_off_receipt(
+            str(receipt_path),
+            approved_roots=(tmp_path,),
+            expected_owner_uid=os.geteuid(),
+        )
+        == valid
+    )
+    with pytest.raises(canary.HarnessRefusal, match="protected_file_metadata_refused"):
+        canary.load_off_receipt(
+            str(receipt_path),
+            approved_roots=(tmp_path,),
+            expected_owner_uid=os.geteuid() + 1,
+        )
+
+
+def test_fixture_cleanup_recovers_from_partial_cleanup_idempotently(monkeypatch):
+    config = _fixture_config()
+    off_receipt = _fixture_off_receipt(config)
+    monkeypatch.setenv("ELLA_CANARY_FIREBASE_ID_TOKEN", _token_for(config.uid))
+    store = FakeFixtureStore()
+    receipt = asyncio.run(canary.prepare_fixture(config, store, off_receipt=off_receipt))
+    exact_key = (config.uid, receipt["conversation_id"])
+    unrelated_key = (config.uid, "unrelated-vector")
+    store.conversations.pop(exact_key)
+    store.vectors.update({exact_key, unrelated_key})
+
+    for _attempt in range(2):
+        cleaned = asyncio.run(
+            canary.cleanup_fixture(
+                config,
+                receipt,
+                store,
+                off_receipt=off_receipt,
+                confirm_conversation_id=receipt["conversation_id"],
+            )
+        )
+        assert cleaned["conversation_absent"] is True
+        assert cleaned["vector_absent"] is True
+        assert exact_key not in store.vectors
+        assert unrelated_key in store.vectors
+    assert store.delete_calls == 0
+    assert store.vector_delete_calls == 2
+
+
+def test_fixture_show_and_cleanup_accept_expected_post_enrichment_state_only(monkeypatch):
+    config = _fixture_config()
+    off_receipt = _fixture_off_receipt(config)
+    monkeypatch.setenv("ELLA_CANARY_FIREBASE_ID_TOKEN", _token_for(config.uid))
+    store = FakeFixtureStore()
+    receipt = asyncio.run(canary.prepare_fixture(config, store, off_receipt=off_receipt))
+    key = (config.uid, receipt["conversation_id"])
+    conversation = store.conversations[key]
+    conversation["summary_versions"][0]["is_active"] = False
+    conversation["summary_versions"].append(
+        {
+            "id": "fixture-enriched-version",
+            "source": "hermes_cloud",
+            "kind": "hermes_cloud_reinterpretation",
+            "is_active": True,
+        }
+    )
+    conversation["active_summary_version_id"] = "fixture-enriched-version"
+    conversation["structured"]["title"] = "Synthetic enriched fixture"
+    conversation["enrichment_state"] = {
+        "status": "writeback_applied",
+        "pending": False,
+        "canonical_status": "completed",
+    }
+    store.vectors.add(key)
+
+    assert asyncio.run(canary.show_fixture(config, receipt, store)) == receipt
+    cleaned = asyncio.run(
+        canary.cleanup_fixture(
+            config,
+            receipt,
+            store,
+            off_receipt=off_receipt,
+            confirm_conversation_id=receipt["conversation_id"],
+        )
+    )
+    assert cleaned["conversation_absent"] is True
+    assert cleaned["vector_absent"] is True
+
+    for drift in ("marker", "id"):
+        drift_store = FakeFixtureStore()
+        drift_receipt = asyncio.run(canary.prepare_fixture(config, drift_store, off_receipt=off_receipt))
+        drift_key = (config.uid, drift_receipt["conversation_id"])
+        drift_conversation = drift_store.conversations[drift_key]
+        if drift == "marker":
+            drift_conversation["external_data"]["ella_product_fit_fixture"]["binding_id_sha256"] = "0" * 64
+        else:
+            drift_conversation["id"] = "different-fixture-id"
+        drift_store.vectors.add(drift_key)
+        with pytest.raises(canary.HarnessRefusal, match="fixture_conversation_drift"):
+            asyncio.run(canary.show_fixture(config, drift_receipt, drift_store))
+        with pytest.raises(canary.HarnessRefusal, match="fixture_conversation_drift"):
+            asyncio.run(
+                canary.cleanup_fixture(
+                    config,
+                    drift_receipt,
+                    drift_store,
+                    off_receipt=off_receipt,
+                    confirm_conversation_id=drift_receipt["conversation_id"],
+                )
+            )
+        assert drift_key in drift_store.conversations
+        assert drift_key in drift_store.vectors
+        assert drift_store.delete_calls == 0
+        assert drift_store.vector_delete_calls == 0


### PR DESCRIPTION
## Summary

- add root-only `fixture-prepare`, `fixture-show`, and `fixture-cleanup` commands to the existing Hermes product-fit harness
- fail closed before fixture writes unless the protected Firebase subject, synthetic PostgreSQL owner/profile, active binding, current v8 consent epoch/lineage, entitlement, transcript target, and flags-off posture all match
- create one deterministic private completed synthetic Conversation, bootstrap its existing `legacy_current` summary version, and derive the production enrichment identity without invoking a runtime/provider or pre-seeding success
- write an atomic root-owned content-free receipt; make prepare retry idempotent; constrain cleanup to the exact marked conversation/vector and verify absence

## Validation

- `15 passed`: full focused harness file, with all four required fixture lifecycle test IDs and zero skips
- `22 passed`: harness + binding envelope + enrichment + summary CAS contract set
- Black check and Python compile pass
- exact collection count remains 15, preserving the hosted path gate while adding the four named lifecycle regressions
- Gitleaks directory and exact commit-range scans pass with redaction

## Scope

Source/tests only. No route, schema, migration, workflow, plugin, credential, deployment, production data, flag, provider, n8n, vendor, or Plato mutation.

Coordinates ellaaicare/ella-ai#1124 and ellaaicare/ella-ai#1136.