### PR TITLE
Scope self-hosted rollout to invitation authority

### DIFF
--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -510,7 +510,7 @@ class EllaProvisioningRepository:
                     WHERE NOT EXISTS (
                         SELECT 1
                         FROM information_schema.columns
-                        WHERE table_schema = 'public'
+                        WHERE table_schema = current_schema()
                           AND table_name = required.table_name
                           AND column_name = required.column_name
                     )
@@ -521,7 +521,7 @@ class EllaProvisioningRepository:
                     FROM unnest($3::text[]) AS required(constraint_name)
                     WHERE NOT EXISTS (
                         SELECT 1 FROM pg_constraint
-                        WHERE connamespace = 'public'::regnamespace
+                        WHERE connamespace = current_schema()::regnamespace
                           AND conname = required.constraint_name
                     )
                     ORDER BY required.constraint_name
@@ -531,7 +531,7 @@ class EllaProvisioningRepository:
                     FROM unnest($4::text[]) AS required(index_name)
                     WHERE NOT EXISTS (
                         SELECT 1 FROM pg_indexes
-                        WHERE schemaname = 'public'
+                        WHERE schemaname = current_schema()
                           AND indexname = required.index_name
                     )
                     ORDER BY required.index_name
@@ -643,24 +643,18 @@ class EllaProvisioningRepository:
         return _row_dict(row)
 
     async def has_invitation_owned_self_hosted_runtime(self, uid: str) -> bool:
-        """Return whether this UID is bound to any invitation-owned Hermes target."""
+        """Return sticky invitation ownership even after authority or owner drift."""
         return bool(
             await self.pool.fetchval(
                 """
                 SELECT EXISTS (
                     SELECT 1
                     FROM users app_user
-                    JOIN voice_entitlements entitlement
-                      ON entitlement.uid = app_user.omi_uid
-                     AND entitlement.invitation_id IS NOT NULL
                     JOIN ella_invitation_redemptions redemption
-                      ON redemption.invitation_id = entitlement.invitation_id
-                     AND redemption.user_id = app_user.id
+                      ON redemption.user_id = app_user.id
                      AND redemption.user_mapping_state = 'mapped'
                     JOIN ella_runtime_targets target
                       ON target.invitation_target_id = redemption.invitation_target_id
-                     AND target.account_user_id = app_user.id
-                     AND target.profile_user_id = app_user.id
                      AND target.provider = $2
                     WHERE app_user.omi_uid = $1
                 )

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -564,6 +564,7 @@ class EllaProvisioningRepository:
                 authority.decision AS consent_decision,
                 authority.authority_epoch AS current_authority_epoch,
                 app_user.id AS user_id,
+                app_user.omi_uid,
                 app_user.profile_class
             FROM users app_user
             JOIN voice_entitlements entitlement ON entitlement.uid = app_user.omi_uid
@@ -640,6 +641,34 @@ class EllaProvisioningRepository:
             list(SELF_HOSTED_RUNTIME_TARGET_MODES),
         )
         return _row_dict(row)
+
+    async def has_invitation_owned_self_hosted_runtime(self, uid: str) -> bool:
+        """Return whether this UID is bound to any invitation-owned Hermes target."""
+        return bool(
+            await self.pool.fetchval(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM users app_user
+                    JOIN voice_entitlements entitlement
+                      ON entitlement.uid = app_user.omi_uid
+                     AND entitlement.invitation_id IS NOT NULL
+                    JOIN ella_invitation_redemptions redemption
+                      ON redemption.invitation_id = entitlement.invitation_id
+                     AND redemption.user_id = app_user.id
+                     AND redemption.user_mapping_state = 'mapped'
+                    JOIN ella_runtime_targets target
+                      ON target.invitation_target_id = redemption.invitation_target_id
+                     AND target.account_user_id = app_user.id
+                     AND target.profile_user_id = app_user.id
+                     AND target.provider = $2
+                    WHERE app_user.omi_uid = $1
+                )
+                """,
+                uid,
+                SELF_HOSTED_RUNTIME_PROVIDER,
+            )
+        )
 
     async def ensure_user_identity(
         self,

--- a/backend/ella/routers/auto_provision.py
+++ b/backend/ella/routers/auto_provision.py
@@ -158,7 +158,7 @@ async def validate_isolated_listen_runtime(uid: str, omi_user_exists=None) -> di
 
 async def listen_runtime_gate(uid: str, omi_user_exists=None) -> dict:
     """Apply the same isolated-runtime gate to every authenticated listen surface."""
-    required = runtime_resolver.runtime_authority_enabled(uid)
+    required = await runtime_resolver.runtime_authority_enabled(uid)
     if not required:
         return {"required": False, "success": True}
     result = await validate_isolated_listen_runtime(uid, omi_user_exists)
@@ -183,7 +183,7 @@ async def auto_provision_user(uid: str, name: str = "User") -> dict:
             - error: str (if success=False)
             - cluster: dict (if success=True)
     """
-    if runtime_resolver.runtime_authority_enabled(uid):
+    if await runtime_resolver.runtime_authority_enabled(uid):
         return {
             "success": False,
             "error": "isolated_runtime_auto_provision_forbidden",

--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -274,7 +274,7 @@ async def _resolve_agent_id_for_uid(uid: str) -> Optional[str]:
 
 
 async def _resolve_workspace_target_for_uid(uid: str) -> Optional[tuple[str, str, str]]:
-    if runtime_authority_enabled(uid):
+    if await runtime_authority_enabled(uid):
         runtime = await resolve_isolated_runtime(uid, target_mode="hermes-cloud-transcript")
         if runtime is None:
             return None

--- a/backend/ella/routers/chat.py
+++ b/backend/ella/routers/chat.py
@@ -732,7 +732,7 @@ async def _stream_hermes_chat(
     import time as _time
 
     _start = _time.time()
-    if runtime is None and runtime_authority_enabled(uid):
+    if runtime is None and await runtime_authority_enabled(uid):
         yield "data: Error: isolated runtime required\n\n"
         return
 
@@ -1211,7 +1211,7 @@ async def ella_chat_history(
     if uid and uid != authenticated_uid:
         raise HTTPException(status_code=403, detail={"code": "ownership_mismatch"})
     uid = authenticated_uid
-    runtime_bound = runtime_authority_enabled(authenticated_uid)
+    runtime_bound = await runtime_authority_enabled(authenticated_uid)
     if runtime_bound:
         try:
             await resolve_isolated_runtime(authenticated_uid, target_mode="hermes-cloud-chat")

--- a/backend/ella/routers/chat.py
+++ b/backend/ella/routers/chat.py
@@ -46,7 +46,9 @@ from ella.services.ai_consent import require_current_ai_consent
 from ella.services.provisioning import ProvisioningError
 from ella.services.runtime_resolver import (
     IsolatedRuntime,
+    revalidate_runtime_authority,
     resolve_isolated_runtime,
+    runtime_authority_identity,
     runtime_authority_enabled,
 )
 from utils.ella.canonical_context import (
@@ -736,11 +738,14 @@ async def _stream_hermes_chat(
         yield "data: Error: isolated runtime required\n\n"
         return
 
-    gateway_url = runtime.gateway_url if runtime else HERMES_GATEWAY_URL
-    gateway_token = runtime.gateway_token if runtime else HERMES_GATEWAY_TOKEN
-    agent_id = runtime.agent_id if runtime else HERMES_MODEL
-
-    if not gateway_token:
+    runtime_identity = None
+    if runtime is not None:
+        try:
+            runtime_identity = runtime_authority_identity(runtime)
+        except ProvisioningError as exc:
+            yield f"data: Error: {exc.code}\n\n"
+            return
+    elif not HERMES_GATEWAY_TOKEN:
         print(f"[FLOW:CHAT-HERMES] ERROR token_missing=true uid={uid}", flush=True)
         yield "data: Error: HERMES_API_SERVER_KEY not configured\n\n"
         return
@@ -805,6 +810,16 @@ async def _stream_hermes_chat(
     )
 
     try:
+        send_runtime = runtime
+        if runtime_identity is not None:
+            send_runtime = await revalidate_runtime_authority(runtime_identity)
+            if send_runtime.provider != "hermes":
+                raise ProvisioningError("self_hosted_runtime_required", retryable=False)
+        gateway_url = send_runtime.gateway_url if send_runtime else HERMES_GATEWAY_URL
+        gateway_token = send_runtime.gateway_token if send_runtime else HERMES_GATEWAY_TOKEN
+        agent_id = send_runtime.agent_id if send_runtime else HERMES_MODEL
+        if not gateway_token:
+            raise ProvisioningError("hermes_runtime_credential_missing", retryable=False)
         async with httpx.AsyncClient(timeout=None) as client:
             async with client.stream(
                 "POST",
@@ -847,13 +862,18 @@ async def _stream_hermes_chat(
 
         full_text = "".join(text).strip()
         if not full_text:
+            recovery_runtime = send_runtime
+            if runtime_identity is not None:
+                recovery_runtime = await revalidate_runtime_authority(runtime_identity)
+                if recovery_runtime.provider != "hermes":
+                    raise ProvisioningError("self_hosted_runtime_required", retryable=False)
             recovery_text = await _hermes_nonstream_completion(
                 messages,
                 session_key,
                 memory_key,
-                gateway_url=gateway_url,
-                gateway_token=gateway_token,
-                agent_id=agent_id,
+                gateway_url=recovery_runtime.gateway_url if recovery_runtime else HERMES_GATEWAY_URL,
+                gateway_token=recovery_runtime.gateway_token if recovery_runtime else HERMES_GATEWAY_TOKEN,
+                agent_id=recovery_runtime.agent_id if recovery_runtime else HERMES_MODEL,
             )
             if recovery_text:
                 text.append(recovery_text)
@@ -902,6 +922,10 @@ async def _stream_hermes_chat(
             flush=True,
         )
 
+    except ProvisioningError as exc:
+        _elapsed = int((_time.time() - _start) * 1000)
+        print(f"[FLOW:CHAT-HERMES] AUTHORITY_ERROR uid={uid} code={exc.code} latency={_elapsed}ms", flush=True)
+        yield f"data: Error: {exc.code}\n\n"
     except httpx.TimeoutException:
         _elapsed = int((_time.time() - _start) * 1000)
         print(f"[FLOW:CHAT-HERMES] TIMEOUT uid={uid} latency={_elapsed}ms", flush=True)

--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -1056,7 +1056,7 @@ async def _get_recent_chat_turns(uid: str, limit: int = 5) -> list[dict]:
             flush=True,
         )
 
-    if runtime_authority_enabled(uid):
+    if await runtime_authority_enabled(uid):
         print(
             f"[FLOW:GUARDIAN-CONTEXT] uid={uid} isolated=true canonical_empty=true fallback=disabled",
             flush=True,
@@ -1125,7 +1125,7 @@ async def _consolidate_queue(
     """
     assert_current_ai_consent(uid)
     runtime = None
-    if runtime_authority_enabled(uid):
+    if await runtime_authority_enabled(uid):
         runtime = await resolve_isolated_runtime(
             uid,
             target_mode=_GUARDIAN_CLOUD_TARGET_MODE,

--- a/backend/ella/routers/onboarding.py
+++ b/backend/ella/routers/onboarding.py
@@ -15,7 +15,7 @@ from database.ella_provisioning import (
     IdentityConflictError,
     ProvisioningSchemaNotReadyError,
 )
-from database.runtime_targets import CLOUD_RUNTIME_MODEL, CLOUD_RUNTIME_PROVIDER
+from database.runtime_targets import CLOUD_RUNTIME_MODEL, CLOUD_RUNTIME_PROVIDER, SELF_HOSTED_RUNTIME_MODEL
 from ella.services.ai_consent import (
     MANAGED_CLOUD_MEMORY_PROVIDER,
     MANAGED_CLOUD_PHOTON_SCOPE,
@@ -30,6 +30,7 @@ from ella.services.provisioning import (
     VerifiedIdentity,
     any_provisioning_enabled,
     cloud_provisioning_enabled,
+    current_self_hosted_runtime_lineage,
     effective_target_schema_version,
     provisioning_enabled,
     public_receipt,
@@ -37,6 +38,7 @@ from ella.services.provisioning import (
     self_hosted_invitation_admission,
     self_hosted_provisioning_configured,
     self_hosted_provisioning_enabled,
+    self_hosted_runtime_authority_required,
 )
 from ella.services.runtime_resolver import runtime_bindings_enabled
 from utils.other import endpoints as auth
@@ -138,15 +140,30 @@ async def ensure_onboarding(
             raise HTTPException(status_code=409, detail={"code": exc.code}) from exc
     coordinator = None
     invitation_admission = None
-    if self_hosted_configured:
-        coordinator = await _coordinator()
+    invitation_owned = False
+    if not cloud_provisioning_enabled(uid):
         try:
-            invitation_admission = await self_hosted_invitation_admission(
+            coordinator = await _coordinator()
+            invitation_owned = await self_hosted_runtime_authority_required(
                 uid,
                 repository=coordinator.repository,
             )
+            if invitation_owned and not self_hosted_configured:
+                raise ProvisioningError("self_hosted_invitation_runtime_disabled", retryable=True)
+            if self_hosted_configured:
+                invitation_admission = await self_hosted_invitation_admission(
+                    uid,
+                    repository=coordinator.repository,
+                )
+            if invitation_owned and not self_hosted_provisioning_enabled(uid, admission=invitation_admission):
+                raise ProvisioningError("invitation_authority_required", retryable=False)
         except ProvisioningError as exc:
             raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
+        except Exception as exc:
+            raise HTTPException(
+                status_code=503,
+                detail={"code": "self_hosted_invitation_authority_unavailable"},
+            ) from exc
     if not any_provisioning_enabled(uid, self_hosted_admission=invitation_admission):
         receipt = await _retained_receipt(uid, payload.target_schema_version)
         if receipt:
@@ -218,23 +235,46 @@ async def onboarding_status(
         target_schema_version = effective_target_schema_version(uid, target_schema_version)
     except ProvisioningError as exc:
         raise HTTPException(status_code=409, detail={"code": exc.code}) from exc
-    if not any_provisioning_enabled(uid):
+    cloud_required = cloud_provisioning_enabled(uid)
+    self_hosted_configured = self_hosted_provisioning_configured() and not cloud_required
+    try:
+        repository = await EllaProvisioningRepository.create()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "self_hosted_invitation_authority_unavailable"},
+        ) from exc
+    invitation_admission = None
+    invitation_owned = False
+    if not cloud_required:
+        try:
+            invitation_owned = await self_hosted_runtime_authority_required(uid, repository=repository)
+            if invitation_owned and not self_hosted_configured:
+                raise ProvisioningError("self_hosted_invitation_runtime_disabled", retryable=True)
+            if self_hosted_configured:
+                invitation_admission = await self_hosted_invitation_admission(uid, repository=repository)
+            if invitation_owned and not self_hosted_provisioning_enabled(uid, admission=invitation_admission):
+                raise ProvisioningError("invitation_authority_required", retryable=False)
+        except ProvisioningError as exc:
+            raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
+    if not any_provisioning_enabled(uid, self_hosted_admission=invitation_admission):
         receipt = await _retained_receipt(uid, target_schema_version)
         if receipt:
             return receipt
         raise HTTPException(status_code=503, detail={"code": "provisioning_disabled"})
-    repository = await EllaProvisioningRepository.create()
     try:
         await repository.assert_schema_ready()
-        if cloud_provisioning_enabled(uid):
+        if cloud_required:
             await repository.assert_cloud_schema_ready()
+        elif self_hosted_provisioning_enabled(uid, admission=invitation_admission):
+            await repository.assert_self_hosted_invite_schema_ready()
     except ProvisioningSchemaNotReadyError as exc:
         logger.error("Ella provisioning status schema is incomplete: %s", ", ".join(exc.missing))
         raise HTTPException(status_code=503, detail={"code": "provisioning_schema_not_ready"}) from exc
     job = await repository.get_job(uid, target_schema_version)
     if not job:
         raise HTTPException(status_code=404, detail={"code": "setup_not_started"})
-    if cloud_provisioning_enabled(uid):
+    if cloud_required:
         profile_class = await repository.get_cloud_profile_class(uid)
         authority = current_cloud_authority(
             uid,
@@ -254,11 +294,15 @@ async def onboarding_status(
             model=CLOUD_RUNTIME_MODEL,
         )
     else:
+        self_hosted_required = self_hosted_provisioning_enabled(uid, admission=invitation_admission)
         binding = await repository.resolve_active_runtime(
             uid,
             template_version=target_schema_version,
+            target_mode="hermes-chat" if self_hosted_required else None,
             required_provider="hermes",
+            authority_lineage=current_self_hosted_runtime_lineage() if self_hosted_required else None,
+            model=SELF_HOSTED_RUNTIME_MODEL if self_hosted_required else CLOUD_RUNTIME_MODEL,
         )
-    if not binding and cloud_provisioning_enabled(uid):
+    if not binding and cloud_required:
         binding = await repository.resolve_cloud_binding_state(uid)
     return public_receipt(job, binding)

--- a/backend/ella/routers/onboarding.py
+++ b/backend/ella/routers/onboarding.py
@@ -34,6 +34,8 @@ from ella.services.provisioning import (
     provisioning_enabled,
     public_receipt,
     retained_compatibility_receipt,
+    self_hosted_invitation_admission,
+    self_hosted_provisioning_configured,
     self_hosted_provisioning_enabled,
 )
 from ella.services.runtime_resolver import runtime_bindings_enabled
@@ -127,16 +129,33 @@ async def ensure_onboarding(
         target_schema_version = effective_target_schema_version(uid, payload.target_schema_version)
     except ProvisioningError as exc:
         raise HTTPException(status_code=409, detail={"code": exc.code}) from exc
-    if not any_provisioning_enabled(uid):
+    self_hosted_configured = self_hosted_provisioning_configured() and not cloud_provisioning_enabled(uid)
+    authority_snapshot = None
+    if self_hosted_configured:
+        try:
+            authority_snapshot = HermesProvisionClient.snapshot_authority()
+        except ProvisioningError as exc:
+            raise HTTPException(status_code=409, detail={"code": exc.code}) from exc
+    coordinator = None
+    invitation_admission = None
+    if self_hosted_configured:
+        coordinator = await _coordinator()
+        try:
+            invitation_admission = await self_hosted_invitation_admission(
+                uid,
+                repository=coordinator.repository,
+            )
+        except ProvisioningError as exc:
+            raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
+    if not any_provisioning_enabled(uid, self_hosted_admission=invitation_admission):
         receipt = await _retained_receipt(uid, payload.target_schema_version)
         if receipt:
             return receipt
         raise HTTPException(status_code=503, detail={"code": "provisioning_disabled"})
     hermes_required = not cloud_provisioning_enabled(uid) and (
-        self_hosted_provisioning_enabled(uid) or provisioning_enabled(uid)
+        self_hosted_provisioning_enabled(uid, admission=invitation_admission) or provisioning_enabled(uid)
     )
-    authority_snapshot = None
-    if hermes_required:
+    if hermes_required and authority_snapshot is None:
         try:
             authority_snapshot = HermesProvisionClient.snapshot_authority()
         except ProvisioningError as exc:
@@ -147,7 +166,7 @@ async def ensure_onboarding(
             HermesProvisionClient.snapshot_authority(authority_snapshot)
         except ProvisioningError as exc:
             raise HTTPException(status_code=409, detail={"code": exc.code}) from exc
-    coordinator = await _coordinator()
+    coordinator = coordinator or await _coordinator()
     try:
         job, binding, claimed = await coordinator.ensure_job(
             identity=identity,

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -51,12 +51,10 @@ from ella.services.ai_consent import (
 from ella.services.provisioning import (
     ProvisioningError,
     cloud_provisioning_enabled,
-    rollout_enabled,
-    self_hosted_provisioning_enabled,
+    self_hosted_runtime_authority_required,
 )
 from ella.services.runtime_resolver import (
     resolve_isolated_runtime,
-    runtime_authority_enabled,
     runtime_authority_identity,
     runtime_bindings_enabled,
 )
@@ -133,12 +131,27 @@ _VOICE_HONCHO_PROFILE_NEGATIVE_CACHE: dict[str, float] = {}
 
 
 def isolated_voice_routing_enabled(uid: Optional[str] = None) -> bool:
-    """Keep isolated users off the legacy OpenClaw voice proxy until cutover."""
-    return rollout_enabled(
-        "ELLA_ISOLATED_VOICE_ROUTING_ENABLED",
-        "ELLA_ISOLATED_VOICE_ROUTING_ENABLED_UIDS",
-        uid,
-    )
+    """Require the voice master switch before honoring any exact UID selector."""
+    if os.getenv("ELLA_ISOLATED_VOICE_ROUTING_ENABLED", "false").strip().lower() not in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        return False
+    allowed_uids = {
+        value.strip() for value in os.getenv("ELLA_ISOLATED_VOICE_ROUTING_ENABLED_UIDS", "").split(",") if value.strip()
+    }
+    return not allowed_uids or bool(uid and uid in allowed_uids)
+
+
+async def _self_hosted_voice_required(uid: str) -> bool:
+    if cloud_provisioning_enabled(uid):
+        return False
+    try:
+        return await self_hosted_runtime_authority_required(uid)
+    except ProvisioningError as exc:
+        raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
 
 
 @dataclass(frozen=True)
@@ -303,18 +316,15 @@ def authenticate_voice_proxy_request(request: Request, requested_uid: str) -> Vo
 
 async def _resolve_voice_runtime(principal: VoiceProxyPrincipal):
     """Resolve an isolated session to the exact active Hermes receipt."""
-    self_hosted_required = self_hosted_provisioning_enabled(principal.uid) and not cloud_provisioning_enabled(
-        principal.uid
-    )
+    self_hosted_required = await _self_hosted_voice_required(principal.uid)
     authority_enabled = (
-        runtime_authority_enabled(principal.uid)
-        or runtime_bindings_enabled(principal.uid)
-        or cloud_provisioning_enabled(principal.uid)
-        or self_hosted_required
+        runtime_bindings_enabled(principal.uid) or cloud_provisioning_enabled(principal.uid) or self_hosted_required
     )
-    voice_enabled = isolated_voice_routing_enabled(principal.uid) or self_hosted_required
+    voice_enabled = isolated_voice_routing_enabled(principal.uid)
     if voice_enabled and not authority_enabled:
         raise HTTPException(status_code=409, detail={"code": "voice_runtime_claim_stale"})
+    if authority_enabled and not voice_enabled:
+        raise HTTPException(status_code=503, detail={"code": "isolated_voice_not_ready"})
     isolated_required = authority_enabled and voice_enabled
     if principal.isolated_runtime != isolated_required:
         raise HTTPException(status_code=409, detail={"code": "voice_runtime_claim_stale"})
@@ -1021,17 +1031,19 @@ async def create_voice_session(
     requested_scope = body.session_scope if body else None
 
     cloud_required = cloud_provisioning_enabled(uid)
-    self_hosted_required = self_hosted_provisioning_enabled(uid) and not cloud_required
-    runtime_bound = (
-        runtime_authority_enabled(uid) or runtime_bindings_enabled(uid) or cloud_required or self_hosted_required
-    )
-    voice_rollout_enabled = isolated_voice_routing_enabled(uid) or self_hosted_required
+    self_hosted_required = await _self_hosted_voice_required(uid)
+    runtime_bound = runtime_bindings_enabled(uid) or cloud_required or self_hosted_required
+    voice_rollout_enabled = isolated_voice_routing_enabled(uid)
     if voice_rollout_enabled and not runtime_bound:
         raise HTTPException(status_code=503, detail={"code": "isolated_voice_runtime_required"})
     isolated_runtime = runtime_bound and voice_rollout_enabled
     runtime = None
     runtime_authority_digest = ""
     if runtime_bound:
+        if not isolated_runtime:
+            # Invitation-owned users remain authority-bound even while voice is
+            # disabled; they cannot enter the legacy provider registry.
+            raise HTTPException(status_code=503, detail={"code": "isolated_voice_not_ready"})
         try:
             runtime = await resolve_isolated_runtime(
                 uid,
@@ -1039,10 +1051,6 @@ async def create_voice_session(
             )
         except ProvisioningError as exc:
             raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
-        if not isolated_runtime:
-            # Runtime-bound users must never fall through to legacy voice while
-            # their explicit isolated-voice rollout gate remains disabled.
-            raise HTTPException(status_code=503, detail={"code": "isolated_voice_not_ready"})
         if not runtime:
             raise HTTPException(status_code=503, detail={"code": "isolated_voice_runtime_required"})
         if self_hosted_required:

--- a/backend/ella/services/observer_extractor.py
+++ b/backend/ella/services/observer_extractor.py
@@ -432,7 +432,7 @@ async def build_extraction_result(
     heuristic = _heuristic_extraction_result(events)
     hermes_kwargs: dict[str, Any] = {}
     if uid:
-        if runtime_resolver.runtime_authority_enabled(uid):
+        if await runtime_resolver.runtime_authority_enabled(uid):
             runtime = await runtime_resolver.resolve_isolated_runtime(uid, target_mode="hermes-cloud-guardian")
             if runtime is None:
                 return ExtractionResult(

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import ipaddress
 import json
 import logging
@@ -108,13 +109,73 @@ def cloud_provisioning_enabled(uid: Optional[str] = None) -> bool:
     )
 
 
-def self_hosted_provisioning_enabled(uid: Optional[str] = None) -> bool:
-    del uid
+def self_hosted_provisioning_configured() -> bool:
+    """Return the operator master switch without granting any account access."""
     return os.getenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "false").strip().lower() in TRUE_VALUES
 
 
-def any_provisioning_enabled(uid: Optional[str] = None) -> bool:
-    return cloud_provisioning_enabled(uid) or provisioning_enabled(uid) or self_hosted_provisioning_enabled(uid)
+def self_hosted_provisioning_enabled(
+    uid: Optional[str] = None,
+    *,
+    admission: Optional[dict[str, Any]] = None,
+) -> bool:
+    """Admit only the exact UID backed by current invitation authority."""
+    if not self_hosted_provisioning_configured() or not uid or not admission:
+        return False
+    return hmac.compare_digest(str(admission.get("omi_uid") or ""), uid) and _self_hosted_invitation_matches(admission)
+
+
+async def self_hosted_invitation_admission(
+    uid: str,
+    *,
+    repository: Optional[EllaProvisioningRepository] = None,
+) -> Optional[dict[str, Any]]:
+    """Load current account-scoped invitation authority without caching revocable state."""
+    if not self_hosted_provisioning_configured() or not uid:
+        return None
+    try:
+        repository = repository or await EllaProvisioningRepository.create()
+        admission = await repository.get_self_hosted_invitation_admission(uid)
+    except ProvisioningSchemaNotReadyError as exc:
+        raise ProvisioningError("provisioning_schema_not_ready", retryable=True) from exc
+    except ProvisioningError:
+        raise
+    except Exception as exc:
+        raise ProvisioningError("self_hosted_invitation_authority_unavailable", retryable=True) from exc
+    if not self_hosted_provisioning_enabled(uid, admission=admission):
+        return None
+    return admission
+
+
+async def self_hosted_runtime_authority_required(
+    uid: str,
+    *,
+    repository: Optional[EllaProvisioningRepository] = None,
+) -> bool:
+    """Keep invitation-owned UIDs on the fail-closed runtime path during rollout."""
+    if not self_hosted_provisioning_configured() or not uid:
+        return False
+    try:
+        repository = repository or await EllaProvisioningRepository.create()
+        return await repository.has_invitation_owned_self_hosted_runtime(uid)
+    except ProvisioningSchemaNotReadyError as exc:
+        raise ProvisioningError("provisioning_schema_not_ready", retryable=True) from exc
+    except ProvisioningError:
+        raise
+    except Exception as exc:
+        raise ProvisioningError("self_hosted_invitation_authority_unavailable", retryable=True) from exc
+
+
+def any_provisioning_enabled(
+    uid: Optional[str] = None,
+    *,
+    self_hosted_admission: Optional[dict[str, Any]] = None,
+) -> bool:
+    return (
+        cloud_provisioning_enabled(uid)
+        or provisioning_enabled(uid)
+        or self_hosted_provisioning_enabled(uid, admission=self_hosted_admission)
+    )
 
 
 def _self_hosted_invitation_matches(admission: Optional[dict[str, Any]]) -> bool:
@@ -525,10 +586,11 @@ class ProvisioningCoordinator:
         authority_snapshot: ProvisionAuthoritySnapshot | None = None,
     ) -> tuple[dict[str, Any], Optional[dict[str, Any]], bool]:
         cloud_required = cloud_provisioning_enabled(identity.uid)
-        self_hosted_required = self_hosted_provisioning_enabled(identity.uid) and not cloud_required
+        self_hosted_configured = self_hosted_provisioning_configured() and not cloud_required
+        invitation_admission = None
         if (
             not cloud_required
-            and (self_hosted_required or provisioning_enabled(identity.uid))
+            and (self_hosted_configured or provisioning_enabled(identity.uid))
             and isinstance(self.client, HermesProvisionClient)
         ):
             authority_snapshot = self._authority_snapshot(authority_snapshot)
@@ -538,7 +600,7 @@ class ProvisioningCoordinator:
             await self._repository_call(authority_snapshot, self.repository.assert_schema_ready)
             if cloud_required:
                 await self.repository.assert_cloud_schema_ready()
-            elif self_hosted_required:
+            elif self_hosted_configured:
                 await self._repository_call(
                     authority_snapshot,
                     self.repository.assert_self_hosted_invite_schema_ready,
@@ -547,18 +609,28 @@ class ProvisioningCoordinator:
             logger.error("Ella provisioning schema is incomplete: %s", ", ".join(exc.missing))
             raise ProvisioningError("provisioning_schema_not_ready", retryable=True) from exc
 
-        invitation_admission = None
+        if self_hosted_configured:
+            try:
+                invitation_admission = await self._repository_call(
+                    authority_snapshot,
+                    self.repository.get_self_hosted_invitation_admission,
+                    identity.uid,
+                )
+            except Exception as exc:
+                if isinstance(exc, ProvisioningError):
+                    raise
+                raise ProvisioningError("self_hosted_invitation_authority_unavailable", retryable=True) from exc
+
+        self_hosted_required = self_hosted_provisioning_enabled(
+            identity.uid,
+            admission=invitation_admission,
+        )
+        if self_hosted_configured and not self_hosted_required and not provisioning_enabled(identity.uid):
+            raise ProvisioningError("invitation_authority_required", retryable=False)
         if self_hosted_required:
-            # Invitation mode is itself authoritative. Even an already active
-            # binding must still resolve through the exact current invitation,
-            # entitlement, consent epoch, and lineage chain.
-            invitation_admission = await self._repository_call(
-                authority_snapshot,
-                self.repository.get_self_hosted_invitation_admission,
-                identity.uid,
-            )
-            if not _self_hosted_invitation_matches(invitation_admission):
-                raise ProvisioningError("invitation_authority_required", retryable=False)
+            # The current invitation, entitlement, consent epoch, and target
+            # chain were resolved before identity, job, or provider side effects.
+            assert invitation_admission is not None
 
         await self._repository_call(
             authority_snapshot,
@@ -685,15 +757,28 @@ class ProvisioningCoordinator:
             return
         authority_snapshot = self._authority_snapshot(authority_snapshot)
         try:
-            self_hosted_required = self_hosted_provisioning_enabled(identity.uid)
-            if self_hosted_required:
-                invitation_admission = await self._repository_call(
-                    authority_snapshot,
-                    self.repository.get_self_hosted_invitation_admission,
-                    identity.uid,
-                )
-                if not _self_hosted_invitation_matches(invitation_admission):
-                    raise ProvisioningError("invitation_authority_required", retryable=False)
+            invitation_admission = None
+            if self_hosted_provisioning_configured():
+                try:
+                    invitation_admission = await self._repository_call(
+                        authority_snapshot,
+                        self.repository.get_self_hosted_invitation_admission,
+                        identity.uid,
+                    )
+                except Exception as exc:
+                    if isinstance(exc, ProvisioningError):
+                        raise
+                    raise ProvisioningError("self_hosted_invitation_authority_unavailable", retryable=True) from exc
+            self_hosted_required = self_hosted_provisioning_enabled(
+                identity.uid,
+                admission=invitation_admission,
+            )
+            if (
+                self_hosted_provisioning_configured()
+                and not self_hosted_required
+                and not provisioning_enabled(identity.uid)
+            ):
+                raise ProvisioningError("invitation_authority_required", retryable=False)
             if isinstance(self.client, HermesProvisionClient):
                 result = await self.client.provision(
                     identity,

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -114,6 +114,16 @@ def self_hosted_provisioning_configured() -> bool:
     return os.getenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "false").strip().lower() in TRUE_VALUES
 
 
+def current_self_hosted_runtime_lineage() -> RuntimeTargetLineage:
+    """Return the exact invitation consent lineage required by local Hermes."""
+    return RuntimeTargetLineage(
+        policy_version=CURRENT_POLICY_VERSION,
+        processor_set_hash=CURRENT_PROCESSOR_SET_HASH,
+        scope_version=CURRENT_SCOPE_VERSION,
+        scope_hash=CURRENT_SCOPE_HASH,
+    ).validate()
+
+
 def self_hosted_provisioning_enabled(
     uid: Optional[str] = None,
     *,
@@ -152,8 +162,8 @@ async def self_hosted_runtime_authority_required(
     *,
     repository: Optional[EllaProvisioningRepository] = None,
 ) -> bool:
-    """Keep invitation-owned UIDs on the fail-closed runtime path during rollout."""
-    if not self_hosted_provisioning_configured() or not uid:
+    """Detect sticky invitation ownership independently of rollout switches."""
+    if not uid:
         return False
     try:
         repository = repository or await EllaProvisioningRepository.create()
@@ -586,11 +596,13 @@ class ProvisioningCoordinator:
         authority_snapshot: ProvisionAuthoritySnapshot | None = None,
     ) -> tuple[dict[str, Any], Optional[dict[str, Any]], bool]:
         cloud_required = cloud_provisioning_enabled(identity.uid)
+        legacy_required = provisioning_enabled(identity.uid)
         self_hosted_configured = self_hosted_provisioning_configured() and not cloud_required
         invitation_admission = None
+        invitation_owned = False
         if (
             not cloud_required
-            and (self_hosted_configured or provisioning_enabled(identity.uid))
+            and (self_hosted_configured or legacy_required)
             and isinstance(self.client, HermesProvisionClient)
         ):
             authority_snapshot = self._authority_snapshot(authority_snapshot)
@@ -600,7 +612,7 @@ class ProvisioningCoordinator:
             await self._repository_call(authority_snapshot, self.repository.assert_schema_ready)
             if cloud_required:
                 await self.repository.assert_cloud_schema_ready()
-            elif self_hosted_configured:
+            elif self_hosted_configured or legacy_required:
                 await self._repository_call(
                     authority_snapshot,
                     self.repository.assert_self_hosted_invite_schema_ready,
@@ -609,13 +621,19 @@ class ProvisioningCoordinator:
             logger.error("Ella provisioning schema is incomplete: %s", ", ".join(exc.missing))
             raise ProvisioningError("provisioning_schema_not_ready", retryable=True) from exc
 
-        if self_hosted_configured:
+        if not cloud_required and (self_hosted_configured or legacy_required):
             try:
-                invitation_admission = await self._repository_call(
+                invitation_owned = await self._repository_call(
                     authority_snapshot,
-                    self.repository.get_self_hosted_invitation_admission,
+                    self.repository.has_invitation_owned_self_hosted_runtime,
                     identity.uid,
                 )
+                if self_hosted_configured:
+                    invitation_admission = await self._repository_call(
+                        authority_snapshot,
+                        self.repository.get_self_hosted_invitation_admission,
+                        identity.uid,
+                    )
             except Exception as exc:
                 if isinstance(exc, ProvisioningError):
                     raise
@@ -625,7 +643,12 @@ class ProvisioningCoordinator:
             identity.uid,
             admission=invitation_admission,
         )
-        if self_hosted_configured and not self_hosted_required and not provisioning_enabled(identity.uid):
+        invitation_owned = invitation_owned or invitation_admission is not None
+        if invitation_owned and not self_hosted_configured:
+            raise ProvisioningError("self_hosted_invitation_runtime_disabled", retryable=True)
+        if invitation_owned and not self_hosted_required:
+            raise ProvisioningError("invitation_authority_required", retryable=False)
+        if self_hosted_configured and not self_hosted_required and not legacy_required:
             raise ProvisioningError("invitation_authority_required", retryable=False)
         if self_hosted_required:
             # The current invitation, entitlement, consent epoch, and target
@@ -699,16 +722,7 @@ class ProvisioningCoordinator:
                 template_version=target_schema_version,
                 target_mode="hermes-chat" if self_hosted_required else None,
                 required_provider="hermes",
-                authority_lineage=(
-                    RuntimeTargetLineage(
-                        policy_version=CURRENT_POLICY_VERSION,
-                        processor_set_hash=CURRENT_PROCESSOR_SET_HASH,
-                        scope_version=CURRENT_SCOPE_VERSION,
-                        scope_hash=CURRENT_SCOPE_HASH,
-                    )
-                    if self_hosted_required
-                    else None
-                ),
+                authority_lineage=(current_self_hosted_runtime_lineage() if self_hosted_required else None),
                 model=SELF_HOSTED_RUNTIME_MODEL if self_hosted_required else CLOUD_RUNTIME_MODEL,
             )
         if binding:
@@ -727,7 +741,7 @@ class ProvisioningCoordinator:
                     receipt={"type": "active_binding_reconciled", "binding_revision": binding["revision"]},
                 )
             return job, binding, False
-        if not cloud_required and not provisioning_enabled(identity.uid) and not self_hosted_required:
+        if not cloud_required and not legacy_required and not self_hosted_required:
             job = await self._repository_call(
                 authority_snapshot,
                 self.repository.update_job,
@@ -758,6 +772,22 @@ class ProvisioningCoordinator:
         authority_snapshot = self._authority_snapshot(authority_snapshot)
         try:
             invitation_admission = None
+            invitation_owned = False
+            legacy_required = provisioning_enabled(identity.uid)
+            await self._repository_call(
+                authority_snapshot,
+                self.repository.assert_self_hosted_invite_schema_ready,
+            )
+            try:
+                invitation_owned = await self._repository_call(
+                    authority_snapshot,
+                    self.repository.has_invitation_owned_self_hosted_runtime,
+                    identity.uid,
+                )
+            except Exception as exc:
+                if isinstance(exc, ProvisioningError):
+                    raise
+                raise ProvisioningError("self_hosted_invitation_authority_unavailable", retryable=True) from exc
             if self_hosted_provisioning_configured():
                 try:
                     invitation_admission = await self._repository_call(
@@ -773,12 +803,15 @@ class ProvisioningCoordinator:
                 identity.uid,
                 admission=invitation_admission,
             )
-            if (
-                self_hosted_provisioning_configured()
-                and not self_hosted_required
-                and not provisioning_enabled(identity.uid)
-            ):
+            invitation_owned = invitation_owned or invitation_admission is not None
+            if invitation_owned and not self_hosted_provisioning_configured():
+                raise ProvisioningError("self_hosted_invitation_runtime_disabled", retryable=True)
+            if invitation_owned and not self_hosted_required:
                 raise ProvisioningError("invitation_authority_required", retryable=False)
+            if self_hosted_provisioning_configured() and not self_hosted_required and not legacy_required:
+                raise ProvisioningError("invitation_authority_required", retryable=False)
+            if not self_hosted_required and not legacy_required:
+                raise ProvisioningError("provisioning_disabled", retryable=False)
             if isinstance(self.client, HermesProvisionClient):
                 result = await self.client.provision(
                     identity,
@@ -818,16 +851,7 @@ class ProvisioningCoordinator:
                 uid=identity.uid,
                 provider="hermes",
                 require_invitation_target=self_hosted_required,
-                authority_lineage=(
-                    RuntimeTargetLineage(
-                        policy_version=CURRENT_POLICY_VERSION,
-                        processor_set_hash=CURRENT_PROCESSOR_SET_HASH,
-                        scope_version=CURRENT_SCOPE_VERSION,
-                        scope_hash=CURRENT_SCOPE_HASH,
-                    )
-                    if self_hosted_required
-                    else None
-                ),
+                authority_lineage=(current_self_hosted_runtime_lineage() if self_hosted_required else None),
                 model=SELF_HOSTED_RUNTIME_MODEL,
             )
             await self._repository_call(

--- a/backend/ella/services/runtime_resolver.py
+++ b/backend/ella/services/runtime_resolver.py
@@ -45,7 +45,10 @@ from ella.services.provisioning import (
     cloud_provisioning_enabled,
     resolve_gateway_credential,
     rollout_enabled,
+    self_hosted_invitation_admission,
+    self_hosted_provisioning_configured,
     self_hosted_provisioning_enabled,
+    self_hosted_runtime_authority_required,
     validate_internal_gateway_url,
 )
 
@@ -58,9 +61,17 @@ def runtime_bindings_enabled(uid: Optional[str] = None) -> bool:
     )
 
 
-def runtime_authority_enabled(uid: Optional[str] = None) -> bool:
+async def runtime_authority_enabled(
+    uid: Optional[str] = None,
+    *,
+    repository: Optional[EllaProvisioningRepository] = None,
+) -> bool:
     """Return whether this user must resolve through persisted runtime authority."""
-    return runtime_bindings_enabled(uid) or cloud_provisioning_enabled(uid) or self_hosted_provisioning_enabled(uid)
+    if runtime_bindings_enabled(uid) or cloud_provisioning_enabled(uid):
+        return True
+    if not uid:
+        return False
+    return await self_hosted_runtime_authority_required(uid, repository=repository)
 
 
 def _current_self_hosted_lineage() -> RuntimeTargetLineage:
@@ -432,11 +443,21 @@ async def resolve_isolated_runtime(
 ) -> Optional[IsolatedRuntime]:
     """Resolve the one authoritative persisted runtime; never fall through modes."""
     cloud_required = cloud_provisioning_enabled(uid)
-    self_hosted_required = self_hosted_provisioning_enabled(uid) and not cloud_required
     retained_required = runtime_bindings_enabled(uid)
-    if not cloud_required and not self_hosted_required and not retained_required:
+    self_hosted_configured = self_hosted_provisioning_configured() and not cloud_required
+    if not cloud_required and not retained_required and not self_hosted_configured:
         return None
     repository = repository or await EllaProvisioningRepository.create()
+    invitation_admission = None
+    self_hosted_owned = False
+    if self_hosted_configured:
+        self_hosted_owned = await self_hosted_runtime_authority_required(uid, repository=repository)
+        invitation_admission = await self_hosted_invitation_admission(uid, repository=repository)
+    self_hosted_required = self_hosted_provisioning_enabled(uid, admission=invitation_admission)
+    if self_hosted_owned and not self_hosted_required:
+        raise ProvisioningError("self_hosted_invitation_runtime_not_provisioned", retryable=False)
+    if not cloud_required and not self_hosted_required and not retained_required:
+        return None
     try:
         if cloud_required:
             if target_mode not in CLOUD_RUNTIME_TARGET_MODES:

--- a/backend/ella/services/runtime_resolver.py
+++ b/backend/ella/services/runtime_resolver.py
@@ -26,10 +26,6 @@ from database.runtime_targets import (
     SELF_HOSTED_RUNTIME_TARGET_MODES,
 )
 from ella.services.ai_consent import (
-    CURRENT_POLICY_VERSION,
-    CURRENT_PROCESSOR_SET_HASH,
-    CURRENT_SCOPE_HASH,
-    CURRENT_SCOPE_VERSION,
     MANAGED_CLOUD_MEMORY_PROVIDER,
     MANAGED_CLOUD_PHOTON_SCOPE,
 )
@@ -43,6 +39,7 @@ from ella.services.provisioning import (
     PROFILE_NAME_RE,
     ProvisioningError,
     cloud_provisioning_enabled,
+    current_self_hosted_runtime_lineage,
     resolve_gateway_credential,
     rollout_enabled,
     self_hosted_invitation_admission,
@@ -71,16 +68,13 @@ async def runtime_authority_enabled(
         return True
     if not uid:
         return False
-    return await self_hosted_runtime_authority_required(uid, repository=repository)
+    if await self_hosted_runtime_authority_required(uid, repository=repository):
+        return True
+    return False
 
 
 def _current_self_hosted_lineage() -> RuntimeTargetLineage:
-    return RuntimeTargetLineage(
-        policy_version=CURRENT_POLICY_VERSION,
-        processor_set_hash=CURRENT_PROCESSOR_SET_HASH,
-        scope_version=CURRENT_SCOPE_VERSION,
-        scope_hash=CURRENT_SCOPE_HASH,
-    ).validate()
+    return current_self_hosted_runtime_lineage()
 
 
 def _self_hosted_target_mode(target_mode: Optional[str]) -> str:
@@ -445,14 +439,18 @@ async def resolve_isolated_runtime(
     cloud_required = cloud_provisioning_enabled(uid)
     retained_required = runtime_bindings_enabled(uid)
     self_hosted_configured = self_hosted_provisioning_configured() and not cloud_required
-    if not cloud_required and not retained_required and not self_hosted_configured:
-        return None
-    repository = repository or await EllaProvisioningRepository.create()
+    try:
+        repository = repository or await EllaProvisioningRepository.create()
+    except Exception as exc:
+        raise ProvisioningError("self_hosted_invitation_authority_unavailable", retryable=True) from exc
     invitation_admission = None
     self_hosted_owned = False
-    if self_hosted_configured:
+    if not cloud_required:
         self_hosted_owned = await self_hosted_runtime_authority_required(uid, repository=repository)
-        invitation_admission = await self_hosted_invitation_admission(uid, repository=repository)
+        if self_hosted_owned and not self_hosted_configured:
+            raise ProvisioningError("self_hosted_invitation_runtime_disabled", retryable=True)
+        if self_hosted_configured:
+            invitation_admission = await self_hosted_invitation_admission(uid, repository=repository)
     self_hosted_required = self_hosted_provisioning_enabled(uid, admission=invitation_admission)
     if self_hosted_owned and not self_hosted_required:
         raise ProvisioningError("self_hosted_invitation_runtime_not_provisioned", retryable=False)
@@ -518,6 +516,24 @@ async def resolve_isolated_runtime(
     if retained_required:
         raise ProvisioningError("hermes_not_provisioned", retryable=True)
     return None
+
+
+async def revalidate_runtime_authority(
+    identity: CloudRuntimeAuthorityIdentity,
+    repository: Optional[EllaProvisioningRepository] = None,
+) -> IsolatedRuntime:
+    """Re-resolve and compare the exact runtime target immediately before use."""
+    current = await resolve_isolated_runtime(
+        identity.uid,
+        repository=repository,
+        target_mode=identity.target_mode,
+    )
+    if current is None:
+        raise ProvisioningError("hermes_runtime_required", retryable=False)
+    current_identity = runtime_authority_identity(current)
+    if not hmac.compare_digest(current_identity.digest, identity.digest):
+        raise ProvisioningError("hermes_runtime_authority_changed", retryable=False)
+    return current
 
 
 async def revalidate_cloud_runtime_authority(

--- a/backend/tests/postgres/test_invitation_redemption_postgres.py
+++ b/backend/tests/postgres/test_invitation_redemption_postgres.py
@@ -1156,6 +1156,16 @@ def test_self_hosted_runtime_resolution_is_invitation_authoritative_and_exact(mo
             authority_lineage=_self_hosted_lineage(),
             model=SELF_HOSTED_RUNTIME_MODEL,
         )
+        assert await runtime_authority_enabled(uid, repository=repository) is True
+        assert await runtime_authority_enabled("any-public-user", repository=repository) is False
+        assert (
+            await resolve_isolated_runtime(
+                "any-public-user",
+                repository=repository,
+                target_mode="hermes-cloud-chat",
+            )
+            is None
+        )
 
         runtime = await resolve_isolated_runtime(
             uid,
@@ -1350,7 +1360,6 @@ def test_self_hosted_runtime_resolution_is_invitation_authoritative_and_exact(mo
     monkeypatch.setenv("ELLA_HERMES_CLOUD_PROVISIONING_ENABLED", "false")
     monkeypatch.setenv("ELLA_RUNTIME_BINDINGS_ENABLED", "false")
     monkeypatch.setenv("HERMES_API_SERVER_KEY", "unit-test-gateway-secret")
-    assert runtime_authority_enabled("any-public-user") is True
     asyncio.run(_run_with_database(scenario))
 
 

--- a/backend/tests/postgres/test_invitation_redemption_postgres.py
+++ b/backend/tests/postgres/test_invitation_redemption_postgres.py
@@ -1167,6 +1167,18 @@ def test_self_hosted_runtime_resolution_is_invitation_authoritative_and_exact(mo
             is None
         )
 
+        monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "false")
+        assert await runtime_authority_enabled(uid, repository=repository) is True
+        with pytest.raises(ProvisioningError) as disabled:
+            await resolve_isolated_runtime(
+                uid,
+                repository=repository,
+                target_mode="hermes-cloud-chat",
+            )
+        assert disabled.value.code == "self_hosted_invitation_runtime_disabled"
+        assert await runtime_authority_enabled("any-public-user", repository=repository) is False
+        monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "true")
+
         runtime = await resolve_isolated_runtime(
             uid,
             repository=repository,
@@ -1694,7 +1706,15 @@ def test_self_hosted_post_provider_revoke_race_cannot_publish_or_retry(monkeypat
                 identity=VerifiedIdentity(uid, email, "Race User", "UTC"),
             )
         )
-        await client.started.wait()
+        provider_started = asyncio.create_task(client.started.wait())
+        completed, _ = await asyncio.wait(
+            {task, provider_started},
+            timeout=5,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if task in completed:
+            await task
+        assert provider_started in completed, "provider boundary did not become reachable"
         await pilot_invite_admin._revoke_invitation(
             receipt_id=issued["receipt_id"],
             expected_version=version,

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -383,6 +383,9 @@ def test_isolated_internal_assessment_uses_active_hermes_runtime(monkeypatch):
     async def fail_legacy(_uid):
         raise AssertionError("isolated summary metadata must not use OpenClaw routing")
 
+    async def authority_enabled(uid=None):
+        return uid == "uid-isolated"
+
     class FakeResponse:
         status_code = 200
 
@@ -403,7 +406,7 @@ def test_isolated_internal_assessment_uses_active_hermes_runtime(monkeypatch):
             requests.append((url, headers))
             return FakeResponse()
 
-    monkeypatch.setattr(callbacks, "runtime_authority_enabled", lambda uid=None: uid == "uid-isolated")
+    monkeypatch.setattr(callbacks, "runtime_authority_enabled", authority_enabled)
     monkeypatch.setattr(callbacks, "resolve_isolated_runtime", fake_runtime)
     monkeypatch.setattr(callbacks, "_resolve_agent_id_for_uid", fail_legacy)
     monkeypatch.setattr(callbacks.httpx, "AsyncClient", FakeClient)
@@ -432,11 +435,14 @@ def test_cloud_internal_assessment_never_calls_mini_or_openclaw(monkeypatch):
     async def fail_legacy(_uid):
         raise AssertionError("Cloud callback must not resolve a process-global Plato agent")
 
+    async def authority_enabled(uid=None):
+        return uid == "uid-cloud"
+
     class ForbiddenClient:
         def __init__(self, **_kwargs):
             raise AssertionError("Cloud callback must not call a Mini workspace endpoint")
 
-    monkeypatch.setattr(callbacks, "runtime_authority_enabled", lambda uid=None: uid == "uid-cloud")
+    monkeypatch.setattr(callbacks, "runtime_authority_enabled", authority_enabled)
     monkeypatch.setattr(callbacks, "resolve_isolated_runtime", fake_runtime)
     monkeypatch.setattr(callbacks, "_resolve_agent_id_for_uid", fail_legacy)
     monkeypatch.setattr(callbacks.httpx, "AsyncClient", ForbiddenClient)

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -45,9 +45,14 @@ def _disable_external_observer_side_effects(monkeypatch):
     async def noop_propagate(**kwargs):
         return None
 
+    async def retained_runtime(_uid, *, target_mode=None):
+        del target_mode
+        return None
+
     monkeypatch.setattr(corrections, "_emit_canonical_correction_event", noop_emit)
     monkeypatch.setattr(corrections, "_run_correction_propagation_for_submission", noop_propagate)
     monkeypatch.setattr(summary_recovery, "_conversation_vector_present", lambda uid, cid: False)
+    monkeypatch.setattr(summary_recovery, "resolve_isolated_runtime", retained_runtime)
 
 
 def _conversation():

--- a/backend/tests/unit/test_ella_guardian_delivery.py
+++ b/backend/tests/unit/test_ella_guardian_delivery.py
@@ -61,7 +61,13 @@ sys.modules["ella.services.runtime_errors"] = runtime_errors_module
 
 runtime_resolver_module = types.ModuleType("ella.services.runtime_resolver")
 runtime_resolver_module.runtime_bindings_enabled = lambda _uid: False
-runtime_resolver_module.runtime_authority_enabled = lambda _uid: False
+
+
+async def _runtime_authority_disabled(_uid):
+    return False
+
+
+runtime_resolver_module.runtime_authority_enabled = _runtime_authority_disabled
 runtime_resolver_module.resolve_isolated_runtime = lambda *_args, **_kwargs: None
 runtime_resolver_module.cloud_runtime_authority_identity = lambda runtime: runtime
 runtime_resolver_module.revalidate_cloud_runtime_authority = lambda identity: identity
@@ -641,6 +647,9 @@ def test_guardian_cloud_consolidation_uses_exact_target_without_global_provider(
         requested_modes.append(target_mode)
         return runtime
 
+    async def authority_enabled(uid):
+        return uid == "auth-uid"
+
     class CloudClient:
         provider_posts = 0
 
@@ -656,7 +665,7 @@ def test_guardian_cloud_consolidation_uses_exact_target_without_global_provider(
             type(self).provider_posts += 1
             return types.SimpleNamespace(text="One safe consolidated alert.")
 
-    monkeypatch.setattr(guardian, "runtime_authority_enabled", lambda uid: uid == "auth-uid")
+    monkeypatch.setattr(guardian, "runtime_authority_enabled", authority_enabled)
     monkeypatch.setattr(guardian, "resolve_isolated_runtime", resolve)
     monkeypatch.setattr(guardian, "cloud_runtime_authority_identity", lambda selected: authority)
 
@@ -702,6 +711,9 @@ def test_guardian_cloud_target_revoked_at_provider_boundary_blocks_send(monkeypa
             raise _ProvisioningError("runtime_admission_revoked", retryable=False)
         return runtime
 
+    async def authority_enabled(uid):
+        return uid == "auth-uid"
+
     class CloudClient:
         provider_posts = 0
 
@@ -710,7 +722,7 @@ def test_guardian_cloud_target_revoked_at_provider_boundary_blocks_send(monkeypa
             type(self).provider_posts += 1
             return types.SimpleNamespace(text="must not send")
 
-    monkeypatch.setattr(guardian, "runtime_authority_enabled", lambda uid: uid == "auth-uid")
+    monkeypatch.setattr(guardian, "runtime_authority_enabled", authority_enabled)
     monkeypatch.setattr(guardian, "resolve_isolated_runtime", resolve)
     monkeypatch.setattr(guardian, "cloud_runtime_authority_identity", lambda selected: authority)
 

--- a/backend/tests/unit/test_ella_listen_runtime_gate.py
+++ b/backend/tests/unit/test_ella_listen_runtime_gate.py
@@ -45,7 +45,10 @@ def test_isolated_listen_requires_omi_identity(monkeypatch):
 
 
 def test_listen_runtime_gate_skips_legacy_users(monkeypatch):
-    monkeypatch.setattr(auto_provision.runtime_resolver, "runtime_bindings_enabled", lambda _uid: False)
+    async def authority_disabled(_uid):
+        return False
+
+    monkeypatch.setattr(auto_provision.runtime_resolver, "runtime_authority_enabled", authority_disabled)
     monkeypatch.setattr(
         auto_provision,
         "validate_isolated_listen_runtime",

--- a/backend/tests/unit/test_ella_listen_runtime_gate.py
+++ b/backend/tests/unit/test_ella_listen_runtime_gate.py
@@ -80,7 +80,10 @@ def test_cloud_authority_forbids_direct_mini_auto_provision(monkeypatch):
     async def forbidden_pool():
         raise AssertionError("Cloud authority must be rejected before any Mini provisioning lookup")
 
-    monkeypatch.setattr(auto_provision.runtime_resolver, "runtime_authority_enabled", lambda _uid: True)
+    async def authority_enabled(_uid):
+        return True
+
+    monkeypatch.setattr(auto_provision.runtime_resolver, "runtime_authority_enabled", authority_enabled)
     monkeypatch.setattr(auto_provision, "_get_pool", forbidden_pool)
 
     result = asyncio.run(auto_provision.auto_provision_user("cloud-user"))

--- a/backend/tests/unit/test_ella_observer.py
+++ b/backend/tests/unit/test_ella_observer.py
@@ -442,10 +442,13 @@ def test_observer_extractor_uses_isolated_runtime_for_hermes(monkeypatch):
         captured.update(kwargs)
         return extractor_module.ExtractionResult(metadata={"extractor": "hermes"})
 
+    async def authority_enabled(uid=None):
+        return uid == "uid-isolated"
+
     monkeypatch.setattr(
         extractor_module.runtime_resolver,
         "runtime_authority_enabled",
-        lambda uid=None: uid == "uid-isolated",
+        authority_enabled,
     )
     monkeypatch.setattr(extractor_module.runtime_resolver, "resolve_isolated_runtime", fake_runtime)
     authority = extractor_module.runtime_resolver.CloudRuntimeAuthorityIdentity(

--- a/backend/tests/unit/test_ella_onboarding_contract.py
+++ b/backend/tests/unit/test_ella_onboarding_contract.py
@@ -11,6 +11,11 @@ from ella.services.provisioning import ProvisioningError
 from ella.utils.provision_authority import APPROVED_HERMES_PROVISION_URL, _authority_binding_value
 
 
+class _NonInvitationRepository:
+    async def has_invitation_owned_self_hosted_runtime(self, _uid):
+        return False
+
+
 def _configure_hermes_authority(monkeypatch):
     token = "onboarding-hermes-test-token"
     binding_env = "ELLA_TEST_ONBOARDING_AUTHORITY_BINDING"
@@ -67,6 +72,8 @@ def test_ensure_schedules_only_authenticated_subject(monkeypatch):
     captured = {}
 
     class FakeCoordinator:
+        repository = _NonInvitationRepository()
+
         async def ensure_job(self, **kwargs):
             captured.update(kwargs)
             return (
@@ -117,12 +124,12 @@ def test_ensure_schedules_only_authenticated_subject(monkeypatch):
 
 
 def test_disabled_endpoint_returns_without_touching_database(monkeypatch):
-    async def forbidden_coordinator():
-        raise AssertionError("disabled onboarding must not touch provisioning storage")
+    async def coordinator():
+        return SimpleNamespace(repository=_NonInvitationRepository())
 
     monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
     monkeypatch.delenv("ELLA_HERMES_PROVISIONING_ENABLED_UIDS", raising=False)
-    monkeypatch.setattr(onboarding, "_coordinator", forbidden_coordinator)
+    monkeypatch.setattr(onboarding, "_coordinator", coordinator)
 
     async def no_retained_receipt(_uid, _target_schema_version):
         return None
@@ -143,8 +150,8 @@ def test_disabled_endpoint_returns_without_touching_database(monkeypatch):
 
 
 def test_disabled_endpoint_allows_existing_retained_account_without_provisioning(monkeypatch):
-    async def forbidden_coordinator():
-        raise AssertionError("retained onboarding must not start Hermes provisioning")
+    async def coordinator():
+        return SimpleNamespace(repository=_NonInvitationRepository())
 
     async def retained_receipt(uid, target_schema_version):
         assert uid == "retained-user"
@@ -159,7 +166,7 @@ def test_disabled_endpoint_allows_existing_retained_account_without_provisioning
 
     monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
     monkeypatch.delenv("ELLA_HERMES_PROVISIONING_ENABLED_UIDS", raising=False)
-    monkeypatch.setattr(onboarding, "_coordinator", forbidden_coordinator)
+    monkeypatch.setattr(onboarding, "_coordinator", coordinator)
     monkeypatch.setattr(onboarding, "_retained_receipt", retained_receipt)
     monkeypatch.setattr(
         onboarding.auth,
@@ -181,6 +188,14 @@ def test_disabled_endpoint_allows_existing_retained_account_without_provisioning
 
 
 def test_disabled_status_allows_existing_retained_account(monkeypatch):
+    class RetainedRepository:
+        async def has_invitation_owned_self_hosted_runtime(self, uid):
+            assert uid == "retained-user"
+            return False
+
+    async def retained_repository(**_kwargs):
+        return RetainedRepository()
+
     async def retained_receipt(uid, target_schema_version):
         assert uid == "retained-user"
         assert target_schema_version == "hermes-user-v1"
@@ -188,11 +203,86 @@ def test_disabled_status_allows_existing_retained_account(monkeypatch):
 
     monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
     monkeypatch.delenv("ELLA_HERMES_PROVISIONING_ENABLED_UIDS", raising=False)
+    monkeypatch.setattr(onboarding.EllaProvisioningRepository, "create", retained_repository)
     monkeypatch.setattr(onboarding, "_retained_receipt", retained_receipt)
 
     result = asyncio.run(onboarding.onboarding_status(uid="retained-user"))
 
     assert result == {"state": "ready", "binding_state": "active", "binding_revision": 1}
+
+    class InvitationRepository:
+        async def assert_schema_ready(self):
+            return None
+
+        async def assert_self_hosted_invite_schema_ready(self):
+            return None
+
+        async def has_invitation_owned_self_hosted_runtime(self, uid):
+            assert uid == "invited-user"
+            return True
+
+        async def get_self_hosted_invitation_admission(self, uid):
+            return {
+                "omi_uid": uid,
+                "consent_policy_version": provisioning.CURRENT_POLICY_VERSION,
+                "consent_processor_set_hash": provisioning.CURRENT_PROCESSOR_SET_HASH,
+                "consent_scope_version": provisioning.CURRENT_SCOPE_VERSION,
+                "consent_scope_hash": provisioning.CURRENT_SCOPE_HASH,
+                "provider_allowlist": [provisioning.SELF_HOSTED_RUNTIME_PROVIDER],
+                "model_allowlist": [provisioning.SELF_HOSTED_RUNTIME_MODEL],
+                "mode_allowlist": list(provisioning.SELF_HOSTED_RUNTIME_TARGET_MODES),
+                "fallback_policy": {"enabled": False, "order": []},
+            }
+
+        async def get_job(self, uid, target_schema_version):
+            assert (uid, target_schema_version) == ("invited-user", "hermes-user-v1")
+            return {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "target_schema_version": target_schema_version,
+                "state": "ready",
+                "stage": "active",
+                "retryable": False,
+            }
+
+        async def resolve_active_runtime(self, uid, **kwargs):
+            assert uid == "invited-user"
+            assert kwargs["target_mode"] == "hermes-chat"
+            assert kwargs["required_provider"] == provisioning.SELF_HOSTED_RUNTIME_PROVIDER
+            assert kwargs["model"] == provisioning.SELF_HOSTED_RUNTIME_MODEL
+            assert kwargs["authority_lineage"].policy_version == provisioning.CURRENT_POLICY_VERSION
+            return {
+                "active": True,
+                "revision": 7,
+                "model_policy_version": "frontier-v1",
+                "voice_policy_version": "ella-voice-v1",
+                "provider": "hermes",
+                "status": "active",
+            }
+
+    repository = InvitationRepository()
+
+    async def invitation_repository(**_kwargs):
+        return repository
+
+    async def forbidden_retained(_uid, _target_schema_version):
+        raise AssertionError("invitation-owned status must not use retained compatibility")
+
+    monkeypatch.setattr(onboarding.EllaProvisioningRepository, "create", invitation_repository)
+    monkeypatch.setattr(onboarding, "_retained_receipt", forbidden_retained)
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "true")
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_PROVISIONING_ENABLED", "false")
+
+    invited = asyncio.run(onboarding.onboarding_status(uid="invited-user"))
+    assert invited["state"] == "ready"
+    assert invited["runtime_provider"] == "hermes"
+    assert invited["binding_revision"] == 7
+
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "false")
+    with pytest.raises(onboarding.HTTPException) as disabled:
+        asyncio.run(onboarding.onboarding_status(uid="invited-user"))
+    assert disabled.value.status_code == 503
+    assert disabled.value.detail == {"code": "self_hosted_invitation_runtime_disabled"}
 
 
 def test_retained_receipt_uses_authenticated_uid_and_public_contract(monkeypatch):
@@ -239,12 +329,12 @@ def test_retained_receipt_rejects_uid_in_isolated_runtime_cutover(monkeypatch):
 
 
 def test_disabled_endpoint_does_not_claim_future_schema_for_retained_account(monkeypatch):
-    async def forbidden_create(**_kwargs):
-        raise AssertionError("future schemas must not use retained compatibility")
+    async def retained_repository(**_kwargs):
+        return _NonInvitationRepository()
 
     monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
     monkeypatch.delenv("ELLA_HERMES_PROVISIONING_ENABLED_UIDS", raising=False)
-    monkeypatch.setattr(onboarding.EllaProvisioningRepository, "create", forbidden_create)
+    monkeypatch.setattr(onboarding.EllaProvisioningRepository, "create", retained_repository)
 
     with pytest.raises(onboarding.HTTPException) as error:
         asyncio.run(
@@ -265,6 +355,8 @@ def test_uid_allowlist_canaries_onboarding_without_global_cutover(monkeypatch):
     captured = {}
 
     class FakeCoordinator:
+        repository = _NonInvitationRepository()
+
         async def ensure_job(self, **kwargs):
             captured.update(kwargs)
             return (
@@ -312,6 +404,8 @@ def test_schema_not_ready_returns_retryable_service_unavailable(monkeypatch):
     _configure_hermes_authority(monkeypatch)
 
     class FakeCoordinator:
+        repository = _NonInvitationRepository()
+
         async def ensure_job(self, **_kwargs):
             raise ProvisioningError("provisioning_schema_not_ready", retryable=True)
 
@@ -385,6 +479,9 @@ def test_authority_rejection_precedes_identity_and_repository_side_effects(monke
 
     class Repository:
         admission = None
+
+        async def has_invitation_owned_self_hosted_runtime(self, uid):
+            return bool(self.admission and self.admission["omi_uid"] == uid)
 
         async def get_self_hosted_invitation_admission(self, uid):
             return self.admission if self.admission and self.admission["omi_uid"] == uid else None
@@ -484,6 +581,8 @@ def test_onboarding_rechecks_before_background_job_creation(monkeypatch):
     )
 
     class FakeCoordinator:
+        repository = _NonInvitationRepository()
+
         async def ensure_job(self, **kwargs):
             assert "<opaque>" in repr(kwargs["authority_snapshot"])
             replacement_ref = "ELLA_TEST_ONBOARDING_ROTATED_BINDING"

--- a/backend/tests/unit/test_ella_onboarding_contract.py
+++ b/backend/tests/unit/test_ella_onboarding_contract.py
@@ -6,6 +6,7 @@ from fastapi import BackgroundTasks, Response
 from pydantic import ValidationError
 
 from ella.routers import onboarding
+from ella.services import provisioning
 from ella.services.provisioning import ProvisioningError
 from ella.utils.provision_authority import APPROVED_HERMES_PROVISION_URL, _authority_binding_value
 
@@ -372,6 +373,101 @@ def test_authority_rejection_precedes_identity_and_repository_side_effects(monke
     assert error.value.status_code == 409
     assert error.value.detail == {"code": "hermes_provision_authority_incomplete"}
     assert side_effects == []
+
+    # With valid authority config, the real route still admits only the exact
+    # current invitation UID before identity or provisioning writes.
+    _configure_hermes_authority(monkeypatch)
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "true")
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
+    monkeypatch.delenv("ELLA_HERMES_PROVISIONING_ENABLED_UIDS", raising=False)
+    identity_calls = []
+    ensure_calls = []
+
+    class Repository:
+        admission = None
+
+        async def get_self_hosted_invitation_admission(self, uid):
+            return self.admission if self.admission and self.admission["omi_uid"] == uid else None
+
+    repository = Repository()
+
+    class Coordinator:
+        def __init__(self):
+            self.repository = repository
+
+        async def ensure_job(self, **kwargs):
+            ensure_calls.append(kwargs)
+            return (
+                {
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "target_schema_version": "hermes-user-v1",
+                    "state": "provisioning",
+                    "stage": "profile_ready",
+                    "retryable": True,
+                },
+                None,
+                False,
+            )
+
+    coordinator = Coordinator()
+
+    async def fake_coordinator():
+        return coordinator
+
+    async def no_retained_receipt(_uid, _target_schema_version):
+        return None
+
+    monkeypatch.setattr(onboarding, "_coordinator", fake_coordinator)
+    monkeypatch.setattr(onboarding, "_retained_receipt", no_retained_receipt)
+    monkeypatch.setattr(
+        onboarding.auth,
+        "get_user",
+        lambda uid: identity_calls.append(uid)
+        or SimpleNamespace(
+            email="invited@example.test",
+            email_verified=True,
+            display_name="Invited User",
+        ),
+    )
+
+    with pytest.raises(onboarding.HTTPException) as uninvited:
+        asyncio.run(
+            onboarding.ensure_onboarding(
+                onboarding.OnboardingEnsureRequest(),
+                BackgroundTasks(),
+                Response(),
+                uid="arbitrary-user",
+            )
+        )
+    assert uninvited.value.status_code == 503
+    assert uninvited.value.detail == {"code": "provisioning_disabled"}
+    assert identity_calls == []
+    assert ensure_calls == []
+
+    repository.admission = {
+        "omi_uid": "invited-user",
+        "consent_policy_version": provisioning.CURRENT_POLICY_VERSION,
+        "consent_processor_set_hash": provisioning.CURRENT_PROCESSOR_SET_HASH,
+        "consent_scope_version": provisioning.CURRENT_SCOPE_VERSION,
+        "consent_scope_hash": provisioning.CURRENT_SCOPE_HASH,
+        "provider_allowlist": [provisioning.SELF_HOSTED_RUNTIME_PROVIDER],
+        "model_allowlist": [provisioning.SELF_HOSTED_RUNTIME_MODEL],
+        "mode_allowlist": list(provisioning.SELF_HOSTED_RUNTIME_TARGET_MODES),
+        "fallback_policy": {"enabled": False, "order": []},
+    }
+    response = Response()
+    result = asyncio.run(
+        onboarding.ensure_onboarding(
+            onboarding.OnboardingEnsureRequest(),
+            BackgroundTasks(),
+            response,
+            uid="invited-user",
+        )
+    )
+
+    assert result["state"] == "provisioning"
+    assert identity_calls == ["invited-user"]
+    assert ensure_calls[0]["identity"].uid == "invited-user"
 
 
 def test_onboarding_rechecks_before_background_job_creation(monkeypatch):

--- a/backend/tests/unit/test_ella_provision_authority_split.py
+++ b/backend/tests/unit/test_ella_provision_authority_split.py
@@ -718,6 +718,7 @@ class _RecordingRepository:
     async def get_self_hosted_invitation_admission(self, _uid):
         self._record("get_self_hosted_invitation_admission")
         return {
+            "omi_uid": _uid,
             "consent_policy_version": provisioning.CURRENT_POLICY_VERSION,
             "consent_processor_set_hash": provisioning.CURRENT_PROCESSOR_SET_HASH,
             "consent_scope_version": provisioning.CURRENT_SCOPE_VERSION,

--- a/backend/tests/unit/test_ella_provision_authority_split.py
+++ b/backend/tests/unit/test_ella_provision_authority_split.py
@@ -694,9 +694,10 @@ def _runtime_receipt():
 
 
 class _RecordingRepository:
-    def __init__(self, *, binding=None):
+    def __init__(self, *, binding=None, invitation_owned=False):
         self.calls = []
         self.binding = binding
+        self.invitation_owned = invitation_owned
         self.job = {
             "id": "11111111-1111-1111-1111-111111111111",
             "target_schema_version": "hermes-user-v1",
@@ -714,6 +715,10 @@ class _RecordingRepository:
 
     async def assert_self_hosted_invite_schema_ready(self):
         self._record("assert_self_hosted_invite_schema_ready")
+
+    async def has_invitation_owned_self_hosted_runtime(self, _uid):
+        self._record("has_invitation_owned_self_hosted_runtime")
+        return self.invitation_owned
 
     async def get_self_hosted_invitation_admission(self, _uid):
         self._record("get_self_hosted_invitation_admission")
@@ -853,7 +858,10 @@ def test_real_claimed_worker_stops_after_inflight_http_authority_drift(monkeypat
         pass
 
     assert sends == ["http"]
-    assert repository.calls == []
+    assert repository.calls == [
+        "assert_self_hosted_invite_schema_ready",
+        "has_invitation_owned_self_hosted_runtime",
+    ]
 
 
 @pytest.mark.parametrize("case", DRIFT_CASES)
@@ -936,7 +944,7 @@ def test_coordinator_rechecks_before_each_schema_identity_firebase_and_job_bound
     _configure_distinct_authorities(monkeypatch)
     monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
     monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "true")
-    repository = _RecordingRepository()
+    repository = _RecordingRepository(invitation_owned=True)
     coordinator = _DriftBeforeCoordinator(
         repository,
         monkeypatch=monkeypatch,
@@ -969,7 +977,8 @@ def test_coordinator_rechecks_before_existing_binding_activation_and_job_receipt
             "user_status": "PENDING",
             "active": True,
             "template_version": "hermes-user-v1",
-        }
+        },
+        invitation_owned=True,
     )
     coordinator = _DriftBeforeCoordinator(
         repository,

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -75,8 +75,9 @@ def _runtime_receipt(profile_name="omi-user-a"):
     }
 
 
-def _self_hosted_admission():
+def _self_hosted_admission(uid: str):
     return {
+        "omi_uid": uid,
         "consent_policy_version": CURRENT_POLICY_VERSION,
         "consent_processor_set_hash": CURRENT_PROCESSOR_SET_HASH,
         "consent_scope_version": CURRENT_SCOPE_VERSION,
@@ -376,7 +377,7 @@ def test_self_hosted_invitation_admission_precedes_identity_and_job_writes(monke
     assert repository.identity_calls == []
     assert repository.job_calls == []
 
-    repository.self_hosted_admission = _self_hosted_admission()
+    repository.self_hosted_admission = _self_hosted_admission(identity.uid)
     job, binding, claimed = asyncio.run(
         coordinator.ensure_job(
             identity=identity,
@@ -394,7 +395,7 @@ def test_self_hosted_invitation_admission_precedes_identity_and_job_writes(monke
 
 def test_self_hosted_authority_drift_blocks_before_provider_call(monkeypatch):
     monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "true")
-    repository = FakeRepository(self_hosted_admission=_self_hosted_admission())
+    repository = FakeRepository(self_hosted_admission=_self_hosted_admission("invited-user"))
     client = FakeProvisionClient(_runtime_receipt())
     coordinator = ProvisioningCoordinator(repository, client)
     identity = VerifiedIdentity("invited-user", "user@example.test", "User", "UTC")

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -32,7 +32,12 @@ from ella.services.provisioning import (
     stable_payload_hash,
     validate_internal_gateway_url,
 )
-from ella.services.runtime_resolver import runtime_bindings_enabled, runtime_from_binding
+from ella.services.runtime_resolver import (
+    resolve_isolated_runtime,
+    runtime_authority_enabled,
+    runtime_bindings_enabled,
+    runtime_from_binding,
+)
 
 
 def _job(**overrides):
@@ -97,6 +102,7 @@ class FakeRepository:
         omi_identity_error=None,
         schema_error=None,
         self_hosted_admission=None,
+        self_hosted_owned=None,
     ):
         self.job = _job()
         self.binding = binding
@@ -109,6 +115,9 @@ class FakeRepository:
         self.schema_checks = 0
         self.self_hosted_schema_checks = 0
         self.self_hosted_admission = self_hosted_admission
+        self.self_hosted_owned = (
+            self_hosted_admission is not None if self_hosted_owned is None else bool(self_hosted_owned)
+        )
         self.job_calls = []
 
     async def assert_schema_ready(self):
@@ -129,6 +138,9 @@ class FakeRepository:
 
     async def get_self_hosted_invitation_admission(self, _uid):
         return self.self_hosted_admission
+
+    async def has_invitation_owned_self_hosted_runtime(self, _uid):
+        return self.self_hosted_owned
 
     async def ensure_omi_user_document(self, **kwargs):
         if self.omi_identity_error:
@@ -395,26 +407,48 @@ def test_self_hosted_invitation_admission_precedes_identity_and_job_writes(monke
 
 def test_self_hosted_authority_drift_blocks_before_provider_call(monkeypatch):
     monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "true")
-    repository = FakeRepository(self_hosted_admission=_self_hosted_admission("invited-user"))
-    client = FakeProvisionClient(_runtime_receipt())
-    coordinator = ProvisioningCoordinator(repository, client)
     identity = VerifiedIdentity("invited-user", "user@example.test", "User", "UTC")
-    job, _, claimed = asyncio.run(
-        coordinator.ensure_job(
-            identity=identity,
-            target_schema_version="hermes-user-v1",
-            client_request_id="request-invited",
-            request_payload={"client": "ios"},
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED_UIDS", identity.uid)
+
+    for drift in ("revoked", "target", "consent"):
+        repository = FakeRepository(self_hosted_admission=None, self_hosted_owned=True)
+        repository.authority_drift = drift
+        client = FakeProvisionClient(_runtime_receipt())
+        coordinator = ProvisioningCoordinator(repository, client)
+
+        with pytest.raises(ProvisioningError, match="invitation_authority_required"):
+            asyncio.run(
+                coordinator.ensure_job(
+                    identity=identity,
+                    target_schema_version="hermes-user-v1",
+                    client_request_id=f"request-{drift}",
+                    request_payload={"client": "ios", "drift": drift},
+                )
+            )
+        assert repository.identity_calls == []
+        assert repository.job_calls == []
+
+        repository.job = _job(state="provisioning", stage="profile_ready")
+        asyncio.run(coordinator.process_claimed_job(job=dict(repository.job), identity=identity))
+        assert client.calls == []
+        assert repository.job["state"] == "blocked"
+        assert repository.job["error_code"] == "invitation_authority_required"
+
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "false")
+    monkeypatch.delenv("ELLA_HERMES_PROVISIONING_ENABLED_UIDS", raising=False)
+    repository = FakeRepository(self_hosted_admission=None, self_hosted_owned=True)
+
+    assert asyncio.run(runtime_authority_enabled(identity.uid, repository=repository)) is True
+    with pytest.raises(ProvisioningError, match="self_hosted_invitation_runtime_disabled") as disabled:
+        asyncio.run(
+            resolve_isolated_runtime(
+                identity.uid,
+                repository=repository,
+                target_mode="hermes-chat",
+            )
         )
-    )
-    assert claimed is True
-
-    repository.self_hosted_admission = None
-    asyncio.run(coordinator.process_claimed_job(job=job, identity=identity))
-
-    assert client.calls == []
-    assert repository.job["state"] == "blocked"
-    assert repository.job["error_code"] == "invitation_authority_required"
+    assert disabled.value.retryable is True
 
 
 def test_public_receipt_does_not_expose_runtime_secrets():

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -19,8 +19,11 @@ RUNTIME_AUTHORITY_DIGEST = "a" * 64
 
 @pytest.fixture(autouse=True)
 def voice_authority_defaults(monkeypatch):
+    async def self_hosted_disabled(_uid):
+        return False
+
     monkeypatch.setattr(voice, "VOICE_CANARY_ENFORCEMENT_ENABLED", False)
-    monkeypatch.setattr(voice, "self_hosted_provisioning_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "_self_hosted_voice_required", self_hosted_disabled)
     monkeypatch.setattr(
         voice,
         "runtime_authority_identity",
@@ -30,6 +33,10 @@ def voice_authority_defaults(monkeypatch):
 
 def _request():
     return Request({"type": "http", "method": "POST", "path": "/v1/ella/chat/stream", "headers": []})
+
+
+async def _runtime_authority_enabled(_uid=None):
+    return True
 
 
 def test_chat_rejects_body_uid_that_differs_from_firebase_subject():
@@ -62,7 +69,7 @@ def test_isolated_history_never_uses_openclaw_fallback(monkeypatch):
     async def forbidden_legacy(uid):
         raise AssertionError("OpenClaw fallback must not run in isolated mode")
 
-    monkeypatch.setattr(chat, "runtime_authority_enabled", lambda uid=None: True)
+    monkeypatch.setattr(chat, "runtime_authority_enabled", _runtime_authority_enabled)
     monkeypatch.setattr(chat, "resolve_isolated_runtime", fake_runtime)
     monkeypatch.setattr(chat, "_fetch_chat_canonical_events", no_events)
     monkeypatch.setattr(chat, "resolve_user_routing", forbidden_legacy)
@@ -88,7 +95,7 @@ def test_cloud_history_never_uses_openclaw_fallback(monkeypatch):
     async def forbidden_legacy(uid):
         raise AssertionError("OpenClaw fallback must not run for a cloud-bound user")
 
-    monkeypatch.setattr(chat, "runtime_authority_enabled", lambda uid=None: True)
+    monkeypatch.setattr(chat, "runtime_authority_enabled", _runtime_authority_enabled)
     monkeypatch.setattr(chat, "resolve_isolated_runtime", fake_runtime)
     monkeypatch.setattr(chat, "_fetch_chat_canonical_events", no_events)
     monkeypatch.setattr(chat, "resolve_user_routing", forbidden_legacy)
@@ -107,7 +114,7 @@ def test_isolated_history_fails_closed_without_binding(monkeypatch):
     async def missing_runtime(uid, **kwargs):
         raise ProvisioningError("hermes_not_provisioned", retryable=True)
 
-    monkeypatch.setattr(chat, "runtime_authority_enabled", lambda uid=None: True)
+    monkeypatch.setattr(chat, "runtime_authority_enabled", _runtime_authority_enabled)
     monkeypatch.setattr(chat, "resolve_isolated_runtime", missing_runtime)
 
     with pytest.raises(HTTPException) as error:
@@ -176,6 +183,7 @@ def test_voice_session_requires_active_runtime_when_isolation_enabled(monkeypatc
         raise ProvisioningError("hermes_not_provisioned", retryable=True)
 
     monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: True)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid: True)
     monkeypatch.setattr(voice, "resolve_isolated_runtime", missing_runtime)
 
     with pytest.raises(HTTPException) as error:
@@ -190,22 +198,35 @@ def test_voice_session_requires_active_runtime_when_isolation_enabled(monkeypatc
 
 
 def test_voice_session_stays_closed_while_isolated_voice_flag_is_disabled(monkeypatch):
-    async def ready_runtime(uid, **kwargs):
-        return object()
+    async def self_hosted_required(uid):
+        return uid == "invited-user"
 
-    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: True)
-    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
-    monkeypatch.setattr(voice, "resolve_isolated_runtime", ready_runtime)
+    async def forbidden_runtime(*_args, **_kwargs):
+        raise AssertionError("voice-off account must stop before runtime/provider resolution")
 
-    with pytest.raises(HTTPException) as error:
-        asyncio.run(
-            voice.create_voice_session(
-                body=voice.VoiceSessionRequest(uid="user-a", provider="grok-voice"),
-                authenticated_uid="user-a",
+    stale_uid = "test-pr835-dryrun-20260504000956"
+    monkeypatch.setenv("ELLA_ISOLATED_VOICE_ROUTING_ENABLED", "false")
+    monkeypatch.setenv("ELLA_ISOLATED_VOICE_ROUTING_ENABLED_UIDS", f"invited-user,{stale_uid}")
+    monkeypatch.setattr(voice, "_self_hosted_voice_required", self_hosted_required)
+    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: uid == stale_uid)
+    monkeypatch.setattr(voice, "resolve_isolated_runtime", forbidden_runtime)
+    monkeypatch.setattr(
+        voice,
+        "resolve_processor",
+        lambda _provider: (_ for _ in ()).throw(AssertionError("legacy provider lookup must not run")),
+    )
+
+    for uid in ("invited-user", stale_uid):
+        with pytest.raises(HTTPException) as error:
+            asyncio.run(
+                voice.create_voice_session(
+                    body=voice.VoiceSessionRequest(uid=uid, provider="grok-voice"),
+                    authenticated_uid=uid,
+                )
             )
-        )
-    assert error.value.status_code == 503
-    assert error.value.detail == {"code": "isolated_voice_not_ready"}
+        assert voice.isolated_voice_routing_enabled(uid) is False
+        assert error.value.status_code == 503
+        assert error.value.detail == {"code": "isolated_voice_not_ready"}
 
 
 def test_voice_session_issues_isolated_token_for_enabled_uid_canary(monkeypatch):
@@ -273,13 +294,15 @@ def test_self_hosted_voice_session_uses_exact_invitation_authority_without_legac
     async def pool():
         return Pool()
 
+    async def self_hosted_required(uid):
+        return uid == "invited-user"
+
     monkeypatch.setattr(voice, "ELLA_SESSION_SECRET", "test-session-secret-at-least-32-bytes")
     monkeypatch.setattr(voice, "VOICE_CANARY_ENFORCEMENT_ENABLED", True)
-    monkeypatch.setattr(voice, "self_hosted_provisioning_enabled", lambda uid=None: uid == "invited-user")
-    monkeypatch.setattr(voice, "runtime_authority_enabled", lambda uid=None: uid == "invited-user")
+    monkeypatch.setattr(voice, "_self_hosted_voice_required", self_hosted_required)
     monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
     monkeypatch.setattr(voice, "cloud_provisioning_enabled", lambda uid=None: False)
-    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: uid == "invited-user")
     monkeypatch.setattr(voice, "resolve_isolated_runtime", resolve_runtime)
     monkeypatch.setattr(voice.voice_canary_db, "evaluate_issuance", evaluate_issuance)
     monkeypatch.setattr(voice, "resolve_processor", lambda _provider: (_ for _ in ()).throw(AssertionError("legacy")))
@@ -344,12 +367,14 @@ def test_self_hosted_voice_session_activation_race_drift_fails_before_token_or_p
     async def pool():
         return Pool()
 
+    async def self_hosted_required(_uid):
+        return True
+
     monkeypatch.setattr(voice, "VOICE_CANARY_ENFORCEMENT_ENABLED", True)
-    monkeypatch.setattr(voice, "self_hosted_provisioning_enabled", lambda uid=None: True)
-    monkeypatch.setattr(voice, "runtime_authority_enabled", lambda uid=None: True)
+    monkeypatch.setattr(voice, "_self_hosted_voice_required", self_hosted_required)
     monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
     monkeypatch.setattr(voice, "cloud_provisioning_enabled", lambda uid=None: False)
-    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: True)
     monkeypatch.setattr(voice, "resolve_isolated_runtime", resolve_runtime)
     monkeypatch.setattr(
         voice,
@@ -402,11 +427,13 @@ def test_self_hosted_voice_session_authority_denials_precede_provider_setup(monk
         provider_calls.append(kwargs)
         raise AssertionError("policy/provider setup must not run after authority denial")
 
-    monkeypatch.setattr(voice, "self_hosted_provisioning_enabled", lambda uid=None: True)
-    monkeypatch.setattr(voice, "runtime_authority_enabled", lambda uid=None: True)
+    async def self_hosted_required(_uid):
+        return True
+
+    monkeypatch.setattr(voice, "_self_hosted_voice_required", self_hosted_required)
     monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
     monkeypatch.setattr(voice, "cloud_provisioning_enabled", lambda uid=None: False)
-    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: True)
     monkeypatch.setattr(voice, "resolve_isolated_runtime", deny_runtime)
     monkeypatch.setattr(voice.voice_canary_db, "evaluate_issuance", forbidden_policy)
     monkeypatch.setattr(voice, "V2V_PROVIDERS", {})

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+from dataclasses import replace
 from types import ModuleType
 from types import SimpleNamespace
 
@@ -12,6 +13,7 @@ conversations_module._decrypt_conversation_data = lambda value: value
 sys.modules.setdefault("database.conversations", conversations_module)
 
 from ella.routers import chat, resolve, voice
+from ella.services import runtime_resolver
 from ella.services.provisioning import ProvisioningError
 
 RUNTIME_AUTHORITY_DIGEST = "a" * 64
@@ -35,11 +37,53 @@ def _request():
     return Request({"type": "http", "method": "POST", "path": "/v1/ella/chat/stream", "headers": []})
 
 
+def _invitation_chat_runtime(**overrides):
+    values = {
+        "uid": "invited-user",
+        "binding_id": "binding-1",
+        "provider": "hermes",
+        "status": "active",
+        "profile_name": "omi-invited-user",
+        "agent_id": "hermes",
+        "runtime_instance_id": "instance-1",
+        "gateway_url": "http://hermes.internal.test:8642",
+        "gateway_token": "test-hermes-token",
+        "workspace_root": "/srv/ella/invited-user",
+        "honcho_workspace": "honcho-invited-user",
+        "observed_peer": "invited-user",
+        "observer_peer": "ella-invited-user",
+        "prompt_pack_version": "hermes-user-v1",
+        "expected_model": "gpt-5.6-terra",
+        "model_context_window_tokens": 128000,
+        "allowed_tools": (),
+        "required_capabilities": (),
+        "model_policy_version": "frontier-v1",
+        "voice_policy_version": "ella-voice-v1",
+        "revision": 7,
+        "profile_class": "real",
+        "runtime_target_id": "target-chat-1",
+        "runtime_target_mode": "hermes-chat",
+        "runtime_target_updated_at": "2026-08-02T18:00:00+00:00",
+        "target_endpoint_ref": "",
+        "target_credential_ref": "",
+        "target_entitlement_revision": 11,
+        "consent_authority_epoch": "authority-epoch-1",
+        "account_user_id": "account-1",
+        "profile_user_id": "account-1",
+    }
+    values.update(overrides)
+    return chat.IsolatedRuntime(**values)
+
+
+async def _collect_stream(stream):
+    return [chunk async for chunk in stream]
+
+
 async def _runtime_authority_enabled(_uid=None):
     return True
 
 
-def test_chat_rejects_body_uid_that_differs_from_firebase_subject():
+def test_chat_rejects_body_uid_that_differs_from_firebase_subject(monkeypatch):
     with pytest.raises(HTTPException) as error:
         asyncio.run(
             chat.ella_chat_stream(
@@ -50,6 +94,110 @@ def test_chat_rejects_body_uid_that_differs_from_firebase_subject():
         )
     assert error.value.status_code == 403
     assert error.value.detail == {"code": "ownership_mismatch"}
+
+    async def no_events(*_args, **_kwargs):
+        return []
+
+    async def no_temporal(*_args, **_kwargs):
+        return "recent context", []
+
+    async def canonical_write(*_args, **_kwargs):
+        return None
+
+    class ForbiddenProviderClient:
+        def __init__(self, *_args, **_kwargs):
+            raise AssertionError("authority drift must fail before any provider HTTP client is created")
+
+    monkeypatch.setattr(chat, "_fetch_chat_canonical_events", no_events)
+    monkeypatch.setattr(chat, "_fetch_temporal_chat_context", no_temporal)
+    monkeypatch.setattr(chat, "_write_ios_chat_canonical_event", canonical_write)
+    monkeypatch.setattr(chat.httpx, "AsyncClient", ForbiddenProviderClient)
+    admitted = _invitation_chat_runtime()
+    drifted = (
+        ProvisioningError("self_hosted_invitation_runtime_not_provisioned", retryable=False),
+        replace(admitted, target_entitlement_revision=12),
+        replace(admitted, runtime_target_id="target-chat-drifted"),
+        replace(admitted, consent_authority_epoch="authority-epoch-drifted"),
+        replace(admitted, account_user_id="account-drifted", profile_user_id="profile-drifted"),
+    )
+    for current in drifted:
+
+        async def resolve_current(*_args, _current=current, **_kwargs):
+            if isinstance(_current, Exception):
+                raise _current
+            return _current
+
+        monkeypatch.setattr(runtime_resolver, "resolve_isolated_runtime", resolve_current)
+        chunks = asyncio.run(
+            _collect_stream(
+                chat._stream_hermes_chat(
+                    "content-free test",
+                    admitted.uid,
+                    runtime=admitted,
+                )
+            )
+        )
+        assert any(
+            code in "".join(chunks)
+            for code in (
+                "self_hosted_invitation_runtime_not_provisioned",
+                "hermes_runtime_authority_changed",
+            )
+        )
+
+    provider_effects = []
+    revalidation_calls = []
+
+    class EmptyStreamResponse:
+        status_code = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def aiter_lines(self):
+            yield "data: [DONE]"
+
+    class EmptyStreamClient:
+        def __init__(self, *_args, **_kwargs):
+            return None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        def stream(self, *_args, **_kwargs):
+            provider_effects.append("initial_stream")
+            return EmptyStreamResponse()
+
+        async def post(self, *_args, **_kwargs):
+            provider_effects.append("recovery_send")
+            raise AssertionError("recovery provider call must be denied after authority drift")
+
+    async def revalidate_for_recovery(_identity):
+        revalidation_calls.append("revalidate")
+        if len(revalidation_calls) == 1:
+            return admitted
+        raise ProvisioningError("hermes_runtime_authority_changed", retryable=False)
+
+    monkeypatch.setattr(chat, "revalidate_runtime_authority", revalidate_for_recovery)
+    monkeypatch.setattr(chat.httpx, "AsyncClient", EmptyStreamClient)
+    recovery_chunks = asyncio.run(
+        _collect_stream(
+            chat._stream_hermes_chat(
+                "content-free recovery test",
+                admitted.uid,
+                runtime=admitted,
+            )
+        )
+    )
+    assert revalidation_calls == ["revalidate", "revalidate"]
+    assert provider_effects == ["initial_stream"]
+    assert "hermes_runtime_authority_changed" in "".join(recovery_chunks)
 
 
 def test_chat_history_rejects_query_uid_that_differs_from_firebase_subject():
@@ -121,6 +269,37 @@ def test_isolated_history_fails_closed_without_binding(monkeypatch):
         asyncio.run(chat.ella_chat_history("user-a", authenticated_uid="user-a"))
     assert error.value.status_code == 503
     assert error.value.detail == {"code": "hermes_not_provisioned"}
+
+    class InvitationOwnedRepository:
+        async def has_invitation_owned_self_hosted_runtime(self, uid):
+            assert uid == "invited-user"
+            return True
+
+        async def get_self_hosted_invitation_admission(self, _uid):
+            raise AssertionError("master-off quarantine must not treat invitation authority as enabled")
+
+    repository = InvitationOwnedRepository()
+
+    async def actual_authority(uid):
+        return await runtime_resolver.runtime_authority_enabled(uid, repository=repository)
+
+    async def actual_runtime(uid, **kwargs):
+        return await runtime_resolver.resolve_isolated_runtime(uid, repository=repository, **kwargs)
+
+    async def forbidden_legacy(_uid):
+        raise AssertionError("master-off invitation owner must never reach OpenClaw fallback")
+
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "false")
+    monkeypatch.setenv("ELLA_RUNTIME_BINDINGS_ENABLED", "false")
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_PROVISIONING_ENABLED", "false")
+    monkeypatch.setattr(chat, "runtime_authority_enabled", actual_authority)
+    monkeypatch.setattr(chat, "resolve_isolated_runtime", actual_runtime)
+    monkeypatch.setattr(chat, "resolve_user_routing", forbidden_legacy)
+
+    with pytest.raises(HTTPException) as disabled:
+        asyncio.run(chat.ella_chat_history("invited-user", authenticated_uid="invited-user"))
+    assert disabled.value.status_code == 503
+    assert disabled.value.detail == {"code": "self_hosted_invitation_runtime_disabled"}
 
 
 def test_public_resolver_is_authenticated_and_redacts_internal_runtime(monkeypatch):

--- a/backend/tests/unit/test_scanner_keyterms.py
+++ b/backend/tests/unit/test_scanner_keyterms.py
@@ -2,6 +2,8 @@ import asyncio
 import time
 from types import SimpleNamespace
 
+import pytest
+
 from utils.ella import scanner_keyterms
 
 SCANNER_TUNING = """
@@ -44,6 +46,14 @@ SCANNER_TUNING = """
 
 def setup_function():
     scanner_keyterms.clear_scanner_keyterm_cache()
+
+
+@pytest.fixture(autouse=True)
+def retained_runtime_not_invitation_owned(monkeypatch):
+    async def authority_disabled(_uid):
+        return False
+
+    monkeypatch.setattr(scanner_keyterms, "runtime_authority_enabled", authority_disabled)
 
 
 def test_parse_scanner_tuning_keyterms_prioritizes_active_wake_and_learned_terms():
@@ -194,6 +204,9 @@ def test_refresh_scanner_keyterms_fetches_provision_file(monkeypatch):
 def test_isolated_scanner_uses_hermes_workspace_and_drops_legacy_cache(monkeypatch):
     requests = []
 
+    async def authority_enabled(_uid):
+        return True
+
     async def fake_runtime(uid, *, target_mode=None):
         assert uid == "uid-isolated"
         assert target_mode == "hermes-cloud-guardian"
@@ -235,6 +248,7 @@ def test_isolated_scanner_uses_hermes_workspace_and_drops_legacy_cache(monkeypat
     monkeypatch.setenv("ELLA_HERMES_PROVISION_API_URL", "http://hermes-provision")
     monkeypatch.setenv("ELLA_HERMES_PROVISION_API_TOKEN", "hermes-token")
     monkeypatch.setenv("ELLA_SCANNER_KEYTERMS_ALLOW_SHARED_FALLBACK", "true")
+    monkeypatch.setattr(scanner_keyterms, "runtime_authority_enabled", authority_enabled)
     monkeypatch.setattr(scanner_keyterms, "resolve_isolated_runtime", fake_runtime)
     monkeypatch.setattr(scanner_keyterms.httpx, "AsyncClient", FakeClient)
 

--- a/backend/tests/unit/test_scanner_keyterms.py
+++ b/backend/tests/unit/test_scanner_keyterms.py
@@ -252,6 +252,9 @@ def test_isolated_scanner_uses_hermes_workspace_and_drops_legacy_cache(monkeypat
 
 
 def test_cloud_scanner_never_calls_mini_or_returns_retained_cache(monkeypatch):
+    async def authority_enabled(uid=None):
+        return uid == "uid-cloud"
+
     async def fake_runtime(uid, *, target_mode=None):
         assert uid == "uid-cloud"
         assert target_mode == "hermes-cloud-guardian"
@@ -267,7 +270,7 @@ def test_cloud_scanner_never_calls_mini_or_returns_retained_cache(monkeypatch):
         fetched_at=time.time(),
         source="isolated:hermes",
     )
-    monkeypatch.setattr(scanner_keyterms, "runtime_authority_enabled", lambda uid=None: uid == "uid-cloud")
+    monkeypatch.setattr(scanner_keyterms, "runtime_authority_enabled", authority_enabled)
     monkeypatch.setattr(scanner_keyterms, "resolve_isolated_runtime", fake_runtime)
     monkeypatch.setattr(scanner_keyterms.httpx, "AsyncClient", ForbiddenClient)
 

--- a/backend/tests/unit/test_voice_canary.py
+++ b/backend/tests/unit/test_voice_canary.py
@@ -18,6 +18,14 @@ from ella.routers import voice
 from scripts import voice_canary_admin
 
 
+@pytest.fixture(autouse=True)
+def retained_runtime_not_invitation_owned(monkeypatch):
+    async def authority_disabled(_uid):
+        return False
+
+    monkeypatch.setattr(voice, "self_hosted_runtime_authority_required", authority_disabled)
+
+
 def _entitlement(**overrides):
     value = {
         "revision": 7,

--- a/backend/tests/unit/test_voice_proxy_auth.py
+++ b/backend/tests/unit/test_voice_proxy_auth.py
@@ -360,11 +360,13 @@ def test_self_hosted_voice_proxy_re_resolves_exact_voice_target(monkeypatch):
         resolved.append((uid, kwargs))
         return runtime
 
-    monkeypatch.setattr(voice, "self_hosted_provisioning_enabled", lambda uid=None: True)
+    async def self_hosted_required(_uid):
+        return True
+
+    monkeypatch.setattr(voice, "_self_hosted_voice_required", self_hosted_required)
     monkeypatch.setattr(voice, "cloud_provisioning_enabled", lambda uid=None: False)
-    monkeypatch.setattr(voice, "runtime_authority_enabled", lambda uid=None: True)
     monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
-    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: True)
     monkeypatch.setattr(voice, "resolve_isolated_runtime", resolve)
 
     with pytest.raises(HTTPException) as unpinned:
@@ -487,6 +489,9 @@ def test_self_hosted_voice_accept_drift_fails_before_session_or_provider_call(mo
         accept_calls.append(kwargs)
         raise AssertionError("provider/session acceptance must not run")
 
+    async def self_hosted_required(_uid):
+        return True
+
     provider = "gemini-live" if drift == "provider" else "hermes"
     mode = "v4" if drift == "mode" else "hermes-voice"
     model = "drifted-model" if drift == "model" else voice.SELF_HOSTED_RUNTIME_MODEL
@@ -497,11 +502,10 @@ def test_self_hosted_voice_accept_drift_fails_before_session_or_provider_call(mo
             lambda _runtime: SimpleNamespace(digest="b" * 64),
         )
     monkeypatch.setattr(voice, "VOICE_CANARY_ENFORCEMENT_ENABLED", True)
-    monkeypatch.setattr(voice, "self_hosted_provisioning_enabled", lambda uid=None: True)
+    monkeypatch.setattr(voice, "_self_hosted_voice_required", self_hosted_required)
     monkeypatch.setattr(voice, "cloud_provisioning_enabled", lambda uid=None: False)
-    monkeypatch.setattr(voice, "runtime_authority_enabled", lambda uid=None: True)
     monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
-    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: True)
     monkeypatch.setattr(voice, "resolve_isolated_runtime", resolve)
     monkeypatch.setattr(voice.voice_canary_db, "accept_session", forbidden_accept)
 
@@ -623,19 +627,25 @@ def test_voice_proxy_legacy_bridge_is_bounded_to_nonisolated_tokens(monkeypatch)
 
 
 @pytest.mark.parametrize(
-    ("bindings_enabled", "voice_enabled", "isolated_claim"),
+    ("self_hosted_required", "voice_enabled", "isolated_claim", "status_code", "error_code"),
     [
-        (True, False, True),
-        (False, True, False),
+        (True, False, True, 503, "isolated_voice_not_ready"),
+        (False, True, False, 409, "voice_runtime_claim_stale"),
     ],
 )
 def test_voice_runtime_rechecks_rollout_gate_on_every_request(
     monkeypatch,
-    bindings_enabled,
+    self_hosted_required,
     voice_enabled,
     isolated_claim,
+    status_code,
+    error_code,
 ):
-    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: bindings_enabled)
+    async def invitation_authority(_uid):
+        return self_hosted_required
+
+    monkeypatch.setattr(voice, "_self_hosted_voice_required", invitation_authority)
+    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
     monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: voice_enabled)
     principal = voice.VoiceProxyPrincipal(
         uid="uid-a",
@@ -648,8 +658,8 @@ def test_voice_runtime_rechecks_rollout_gate_on_every_request(
     with pytest.raises(HTTPException) as error:
         asyncio.run(voice._resolve_voice_runtime(principal))
 
-    assert error.value.status_code == 409
-    assert error.value.detail == {"code": "voice_runtime_claim_stale"}
+    assert error.value.status_code == status_code
+    assert error.value.detail == {"code": error_code}
 
 
 def test_isolated_context_uses_active_8210_agent_and_redacts_credentials(monkeypatch):

--- a/backend/tests/unit/test_voice_proxy_auth.py
+++ b/backend/tests/unit/test_voice_proxy_auth.py
@@ -110,6 +110,15 @@ def voice_auth(monkeypatch):
         lambda _runtime: SimpleNamespace(digest=RUNTIME_AUTHORITY_DIGEST),
     )
 
+    async def retained_runtime_not_invitation_owned(_uid):
+        return False
+
+    monkeypatch.setattr(
+        voice,
+        "self_hosted_runtime_authority_required",
+        retained_runtime_not_invitation_owned,
+    )
+
 
 def test_voice_session_token_has_firebase_subject_and_proxy_audience():
     encoded = voice.create_session_token(

--- a/backend/utils/ella/scanner_keyterms.py
+++ b/backend/utils/ella/scanner_keyterms.py
@@ -68,8 +68,8 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-def _provision_url(uid: str = "") -> str:
-    if uid and runtime_authority_enabled(uid):
+def _provision_url(uid: str = "", *, isolated: bool = False) -> str:
+    if uid and isolated:
         return os.getenv("ELLA_HERMES_PROVISION_API_URL", "http://100.76.138.56:8210").rstrip("/")
     return (
         os.getenv("ELLA_PROVISION_API_URL")
@@ -79,8 +79,8 @@ def _provision_url(uid: str = "") -> str:
     ).rstrip("/")
 
 
-def _provision_token(uid: str = "") -> str:
-    if uid and runtime_authority_enabled(uid):
+def _provision_token(uid: str = "", *, isolated: bool = False) -> str:
+    if uid and isolated:
         return os.getenv("ELLA_HERMES_PROVISION_API_TOKEN", "")
     return (
         os.getenv("ELLA_PROVISION_API_TOKEN")
@@ -118,8 +118,8 @@ def _enabled() -> bool:
     return os.getenv("ELLA_SCANNER_KEYTERMS_ENABLED", "true").lower() not in {"0", "false", "no", "off"}
 
 
-def _allow_shared_fallback(uid: str = "") -> bool:
-    if uid and runtime_authority_enabled(uid):
+def _allow_shared_fallback(uid: str = "", *, isolated: bool = False) -> bool:
+    if uid and isolated:
         return False
     return os.getenv("ELLA_SCANNER_KEYTERMS_ALLOW_SHARED_FALLBACK", "false").lower() in {"1", "true", "yes", "on"}
 
@@ -143,7 +143,7 @@ async def _resolve_agent_id(uid: str) -> str:
     if not uid:
         return ""
 
-    if runtime_authority_enabled(uid):
+    if await runtime_authority_enabled(uid):
         runtime = await resolve_isolated_runtime(uid, target_mode="hermes-cloud-guardian")
         if runtime is None:
             return ""
@@ -391,13 +391,15 @@ async def _fetch_scanner_tuning(agent_id: str, uid: str = "") -> str:
             "hermes_cloud_scanner_keyterms_unavailable",
             retryable=False,
         )
-    token = _provision_token(uid)
+    isolated = await runtime_authority_enabled(uid) if uid else False
+    token = _provision_token(uid, isolated=isolated)
     headers = {"Authorization": f"Bearer {token}"} if token else {}
-    url = f"{_provision_url(uid)}/workspace/{agent_id}/files/scanner-tuning.md"
+    provision_url = _provision_url(uid, isolated=isolated)
+    url = f"{provision_url}/workspace/{agent_id}/files/scanner-tuning.md"
     async with httpx.AsyncClient(timeout=_timeout_seconds()) as client:
         response = await client.get(url, headers=headers)
-        if response.status_code == 404 and _allow_shared_fallback(uid):
-            shared = f"{_provision_url(uid)}/workspace/shared/files/scanner-tuning.md"
+        if response.status_code == 404 and _allow_shared_fallback(uid, isolated=isolated):
+            shared = f"{provision_url}/workspace/shared/files/scanner-tuning.md"
             response = await client.get(shared, headers=headers)
         response.raise_for_status()
         try:
@@ -414,7 +416,7 @@ async def refresh_scanner_keyterms(uid: str, agent_id: Optional[str] = None) -> 
     if not _enabled() or not uid:
         return []
 
-    isolated = runtime_authority_enabled(uid)
+    isolated = await runtime_authority_enabled(uid)
     resolved_agent_id = await _resolve_agent_id(uid) if isolated else agent_id or await _resolve_agent_id(uid)
     key = resolved_agent_id or uid
     runtime_provider = _uid_runtime_providers.get(uid, "") if isolated else ""
@@ -477,7 +479,7 @@ async def get_scanner_keyterms(uid: str, agent_id: Optional[str] = None) -> list
 
     resolved_key = agent_id or _uid_agent_ids.get(uid) or uid
     entry = _cache.get(resolved_key) or _cache.get(uid)
-    if runtime_authority_enabled(uid):
+    if await runtime_authority_enabled(uid):
         runtime_provider = _uid_runtime_providers.get(uid, "")
         if not runtime_provider or runtime_provider == "hermes_cloud":
             entry = None


### PR DESCRIPTION
## Summary
- make the self-hosted provisioning master switch necessary but insufficient: `/v1/ella/onboarding/ensure`, coordinator admission, workers, and runtime resolution require the exact current invitation UID/entitlement/target/consent lineage
- retain a separate invitation-owned routing predicate so authority drift fails closed instead of falling through to retained Plato/OpenClaw behavior
- make isolated voice eligibility depend only on the voice master switch; a false master makes the UID selector inert, while invitation-owned or otherwise isolated users receive typed `isolated_voice_not_ready` before legacy provider/context calls
- preserve existing destination/token authority preflight before repository, identity, HTTP, or provider effects

## Validation
- Hermes Cloud Runtime collection: 490 tests, zero skips; full local PostgreSQL-backed run green before the test scenarios were folded into existing required IDs
- Invite Redemption: 139 tests, zero skips
- Voice Canary: 54 tests, zero skips
- focused unit surfaces: 614 tests across primary/callback/Guardian suites, green
- Black (120, skip string normalization), compile, YAML validation, `git diff --check`, and commit-range Gitleaks: green / zero findings

## Deployed selector receipt
Read-only production inspection found `ELLA_ISOLATED_VOICE_ROUTING_ENABLED=false` and one stale selector UID. The UID is an ACTIVE `profile_class=real` test account with an active runtime binding, no invitation ownership, and no entitlement. No configuration or production state was changed.

Tracks ellaaicare/ella-ai#1174. Source only: no merge, deploy, migration, flag change, provider traffic, or invitation issuance.
