### PR TITLE
Fix resumable account deletion

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -12,6 +12,7 @@ on:
       - "backend/database/content_write_recovery_authority.py"
       - "backend/database/content_writer_owner.py"
       - "backend/database/firestore_account_deletion.py"
+      - "backend/database/redis_db.py"
       - "backend/database/memory_reinterpretations.py"
       - "backend/routers/action_items.py"
       - "backend/routers/apps.py"
@@ -153,6 +154,7 @@ on:
       - "backend/database/content_write_recovery_authority.py"
       - "backend/database/content_writer_owner.py"
       - "backend/database/firestore_account_deletion.py"
+      - "backend/database/redis_db.py"
       - "backend/database/memory_reinterpretations.py"
       - "backend/routers/action_items.py"
       - "backend/routers/apps.py"
@@ -350,6 +352,7 @@ jobs:
           database/content_write_recovery_authority.py
           database/content_writer_owner.py
           database/firestore_account_deletion.py
+          database/redis_db.py
           database/memory_reinterpretations.py
           routers/action_items.py
           routers/apps.py
@@ -437,6 +440,7 @@ jobs:
           database/content_write_recovery_authority.py
           database/content_writer_owner.py
           database/firestore_account_deletion.py
+          database/redis_db.py
           database/memory_reinterpretations.py
           routers/action_items.py
           routers/apps.py routers/integration.py
@@ -615,7 +619,13 @@ jobs:
             "tests/unit/test_account_deletion.py::test_deletion_service_never_reports_success_when_routing_trace_purge_is_unavailable"
             "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[True]"
             "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[False]"
-            "tests/unit/test_account_deletion.py::test_firestore_delete_removes_only_owned_top_level_jobs_and_retries"
+            "tests/unit/test_account_deletion.py::test_firestore_inventory_snapshot_covers_every_repository_owned_root"
+            "tests/unit/test_account_deletion.py::test_production_firestore_cleanup_removes_seeded_inventory_and_retains_other_uid"
+            "tests/unit/test_account_deletion.py::test_firestore_owned_collection_purge_is_bounded_across_multiple_batches"
+            "tests/unit/test_account_deletion.py::test_firestore_gate_fails_closed_when_known_inventory_entry_is_omitted[analytics]"
+            "tests/unit/test_account_deletion.py::test_firestore_gate_fails_closed_when_known_inventory_entry_is_omitted[tasks]"
+            "tests/unit/test_account_deletion.py::test_firestore_gate_positive_control_detects_new_uid_linked_top_level_collection"
+            "tests/unit/test_account_deletion.py::test_firestore_api_key_cache_failure_preserves_resumable_key_record"
             "tests/unit/test_account_deletion.py::test_deletion_service_retains_firebase_when_memory_work_purge_is_unavailable"
             "tests/unit/test_account_deletion.py::test_canonical_ledger_purge_is_resumable_and_precedes_firebase_last"
             "tests/unit/test_content_write_fence.py::test_expired_registration_never_proves_a_live_writer_absent"
@@ -681,10 +691,12 @@ jobs:
             "tests/unit/test_voice_proxy_auth.py::test_self_hosted_voice_accept_drift_fails_before_session_or_provider_call[session-voice_session_claim_mismatch]"
             "tests/postgres/test_invitation_redemption_postgres.py::test_self_hosted_runtime_resolution_is_invitation_authoritative_and_exact"
             "tests/postgres/test_invitation_redemption_postgres.py::test_lost_provider_ack_persists_unproven_attempt_blocks_firebase_and_retry_converges"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_provider_attempt_tombstone_trigger_allows_only_monotonic_terminal_proof"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_provider_attempt_direct_writer_cannot_cross_finalization_count_read"
             "tests/postgres/test_invitation_redemption_postgres.py::test_deletion_tombstone_serializes_inflight_provider_writer_and_quarantines_photon_immediately"
             "tests/postgres/test_hermes_cloud_pool_postgres.py::test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets"
           )
-          test "${#required_ids[@]}" -eq 76
+          test "${#required_ids[@]}" -eq 84
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_account_deletion.py \
@@ -708,7 +720,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 574
+          test "$collected" -eq 582
           pytest \
             tests/unit/test_account_deletion.py \
             tests/unit/test_content_write_fence.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -7,6 +7,11 @@ on:
       - "backend/contracts/README.md"
       - "backend/database/account_deletion.py"
       - "backend/database/authority_advisory_lock.py"
+      - "backend/database/content_write_fence.py"
+      - "backend/routers/apps.py"
+      - "backend/routers/integration.py"
+      - "backend/routers/mcp_sse.py"
+      - "backend/routers/workflow.py"
       - "backend/database/ella_provisioning.py"
       - "backend/database/hermes_cloud_enrichment_outbox.py"
       - "backend/database/invitations.py"
@@ -91,6 +96,7 @@ on:
       - "backend/tests/unit/test_hermes_product_fit_canary.py"
       - "backend/tests/unit/test_ella_ai_consent.py"
       - "backend/tests/unit/test_account_deletion.py"
+      - "backend/tests/unit/test_content_write_fence.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
       - "backend/tests/unit/test_ella_runtime_route_isolation.py"
       - "backend/tests/unit/test_hermes_cloud_*.py"
@@ -116,6 +122,11 @@ on:
       - "backend/contracts/README.md"
       - "backend/database/account_deletion.py"
       - "backend/database/authority_advisory_lock.py"
+      - "backend/database/content_write_fence.py"
+      - "backend/routers/apps.py"
+      - "backend/routers/integration.py"
+      - "backend/routers/mcp_sse.py"
+      - "backend/routers/workflow.py"
       - "backend/database/ella_provisioning.py"
       - "backend/database/hermes_cloud_enrichment_outbox.py"
       - "backend/database/invitations.py"
@@ -200,6 +211,7 @@ on:
       - "backend/tests/unit/test_hermes_product_fit_canary.py"
       - "backend/tests/unit/test_ella_ai_consent.py"
       - "backend/tests/unit/test_account_deletion.py"
+      - "backend/tests/unit/test_content_write_fence.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
       - "backend/tests/unit/test_ella_runtime_route_isolation.py"
       - "backend/tests/unit/test_hermes_cloud_*.py"
@@ -278,6 +290,11 @@ jobs:
           python -m py_compile
           database/account_deletion.py
           database/authority_advisory_lock.py
+          database/content_write_fence.py
+          routers/apps.py
+          routers/integration.py
+          routers/mcp_sse.py
+          routers/workflow.py
           database/firestore_account_deletion.py
           database/users.py
           database/ella_provisioning.py
@@ -337,6 +354,9 @@ jobs:
           black --check --line-length 120 --skip-string-normalization
           database/account_deletion.py
           database/authority_advisory_lock.py
+          database/content_write_fence.py
+          routers/apps.py routers/integration.py
+          routers/mcp_sse.py routers/workflow.py
           database/firestore_account_deletion.py
           database/ella_provisioning.py database/invitations.py
           database/managed_cloud_consent.py
@@ -365,6 +385,7 @@ jobs:
           tests/unit/test_authority_advisory_lock.py
           tests/unit/test_authority_writer_guard.py
           tests/unit/test_account_deletion.py
+          tests/unit/test_content_write_fence.py
           tests/unit/test_ella_ai_consent.py
           tests/unit/test_ella_conversation_corrections.py
           tests/unit/test_ella_guardian_delivery.py
@@ -399,6 +420,7 @@ jobs:
           collected="$(
             pytest --collect-only -q \
               tests/unit/test_account_deletion.py \
+              tests/unit/test_content_write_fence.py \
               tests/unit/test_ella_ai_consent.py \
               tests/unit/test_ella_ai_consent_route_gates.py \
               tests/unit/test_hermes_cloud_migration.py \
@@ -432,6 +454,10 @@ jobs:
             "tests/unit/test_account_deletion.py::test_production_route_uses_legacy_resumable_deletion_when_ella_authority_is_explicitly_disabled"
             "tests/unit/test_account_deletion.py::test_production_route_fails_closed_before_destructive_work_when_enabled_authority_is_unavailable"
             "tests/unit/test_account_deletion.py::test_retained_firebase_subject_is_fenced_from_authenticated_content_writes"
+            "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[True]"
+            "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[False]"
+            "tests/unit/test_content_write_fence.py::test_mounted_authenticated_writer_inventory_uses_scope_holding_dependencies"
+            "tests/unit/test_content_write_fence.py::test_request_fence_covers_streamed_commit_after_route_returns"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_mid_transaction_failure_rolls_back_every_authority_and_capacity_write"
             "tests/unit/test_hermes_binding_envelope_contract.py::test_omi_request_uses_exact_stock_contract_from_shared_envelope"
             "tests/unit/test_hermes_product_fit_canary.py::test_scenarios_a_to_f_pass_with_content_free_stage_tables"
@@ -456,6 +482,7 @@ jobs:
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_account_deletion.py \
+              tests/unit/test_content_write_fence.py \
               tests/unit/test_hermes_binding_envelope_contract.py \
               tests/unit/test_hermes_product_fit_canary.py \
               tests/unit/test_ella_runtime_route_isolation.py \
@@ -471,9 +498,10 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 506
+          test "$collected" -eq 515
           pytest \
             tests/unit/test_account_deletion.py \
+            tests/unit/test_content_write_fence.py \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \
             tests/unit/test_hermes_cloud_migration.py \
@@ -546,13 +574,17 @@ jobs:
             tests/unit/test_ella_provision_authority_split.py \
             tests/unit/test_ella_plato_mcp.py \
             -v
-          test "$(
+          advisory_ids="$(
             pytest --collect-only -q \
               tests/unit/test_authority_advisory_lock.py \
               tests/unit/test_authority_writer_guard.py \
               tests/postgres/test_authority_advisory_lock_postgres.py |
-              grep -c '::'
-          )" -eq 65
+              sed '/^$/d'
+          )"
+          test "$(grep -c '::' <<<"$advisory_ids")" -eq 66
+          grep -Fqx \
+            "tests/postgres/test_authority_advisory_lock_postgres.py::test_content_request_holds_owner_lock_across_real_commit_and_releases_on_cancellation" \
+            <<<"$advisory_ids"
           pytest \
             tests/unit/test_authority_advisory_lock.py \
             tests/unit/test_authority_writer_guard.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -9,6 +9,7 @@ on:
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/content_write_fence.py"
       - "backend/database/firestore_account_deletion.py"
+      - "backend/database/memory_reinterpretations.py"
       - "backend/routers/action_items.py"
       - "backend/routers/apps.py"
       - "backend/routers/chat.py"
@@ -86,8 +87,10 @@ on:
       - "backend/scripts/hermes_cloud_enrichment_smoke.py"
       - "backend/scripts/hermes_product_fit_canary.py"
       - "backend/scripts/hermes_cloud_shadow.py"
+      - "backend/scripts/ella_memory_e2e_smoke.py"
       - "backend/scripts/voice_canary_admin.py"
       - "backend/utils/ella/postprocess.py"
+      - "backend/utils/ella/canonical_omi.py"
       - "backend/utils/ella/scanner_keyterms.py"
       - "backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md"
       - "backend/ella/docs/HERMES_CLOUD_RUNTIME_TARGETS_RUNBOOK.md"
@@ -109,6 +112,7 @@ on:
       - "backend/tests/unit/test_ella_ai_consent.py"
       - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_content_write_fence.py"
+      - "backend/tests/unit/test_durable_worker_deletion_finality.py"
       - "backend/tests/unit/test_trace_deletion_finality.py"
       - "backend/tests/unit/test_conversation_processing_failures.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
@@ -138,6 +142,7 @@ on:
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/content_write_fence.py"
       - "backend/database/firestore_account_deletion.py"
+      - "backend/database/memory_reinterpretations.py"
       - "backend/routers/action_items.py"
       - "backend/routers/apps.py"
       - "backend/routers/chat.py"
@@ -215,8 +220,10 @@ on:
       - "backend/scripts/hermes_cloud_enrichment_smoke.py"
       - "backend/scripts/hermes_product_fit_canary.py"
       - "backend/scripts/hermes_cloud_shadow.py"
+      - "backend/scripts/ella_memory_e2e_smoke.py"
       - "backend/scripts/voice_canary_admin.py"
       - "backend/utils/ella/postprocess.py"
+      - "backend/utils/ella/canonical_omi.py"
       - "backend/utils/ella/scanner_keyterms.py"
       - "backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md"
       - "backend/ella/docs/HERMES_CLOUD_RUNTIME_TARGETS_RUNBOOK.md"
@@ -238,6 +245,7 @@ on:
       - "backend/tests/unit/test_ella_ai_consent.py"
       - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_content_write_fence.py"
+      - "backend/tests/unit/test_durable_worker_deletion_finality.py"
       - "backend/tests/unit/test_trace_deletion_finality.py"
       - "backend/tests/unit/test_conversation_processing_failures.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
@@ -323,6 +331,7 @@ jobs:
           database/authority_advisory_lock.py
           database/content_write_fence.py
           database/firestore_account_deletion.py
+          database/memory_reinterpretations.py
           routers/action_items.py
           routers/apps.py
           routers/chat.py
@@ -351,6 +360,7 @@ jobs:
           ella/routers/auto_provision.py
           ella/routers/callbacks.py
           ella/routers/ai_consent.py
+          ella/routers/canonical_events.py
           ella/routers/hermes_cloud_enrichment.py
           ella/routers/guardian.py
           ella/routers/invites.py
@@ -383,12 +393,14 @@ jobs:
           ella/utils/identity_sync.py
           ella/utils/provision_authority.py
           scripts/hermes_cloud_pool_admin.py
+          scripts/ella_memory_e2e_smoke.py
           scripts/hermes_cloud_enrichment_smoke.py
           scripts/hermes_product_fit_canary.py
           scripts/pilot_invite_admin.py
           scripts/hermes_cloud_shadow.py
           scripts/voice_canary_admin.py
           utils/ella/postprocess.py
+          utils/ella/canonical_omi.py
           utils/ella/scanner_keyterms.py
           utils/other/endpoints.py
 
@@ -399,6 +411,7 @@ jobs:
           database/authority_advisory_lock.py
           database/content_write_fence.py
           database/firestore_account_deletion.py
+          database/memory_reinterpretations.py
           routers/action_items.py
           routers/apps.py routers/integration.py
           routers/chat.py routers/developer.py routers/imports.py
@@ -412,6 +425,7 @@ jobs:
           database/runtime_targets.py database/voice_canary.py
           ella/routers/auto_provision.py ella/routers/callbacks.py
           ella/routers/ai_consent.py ella/routers/chat.py
+          ella/routers/canonical_events.py
           ella/routers/guardian.py ella/routers/invites.py
           ella/routers/onboarding.py ella/routers/plato_mcp.py
           ella/services/hermes_cloud_policy.py
@@ -421,6 +435,8 @@ jobs:
           ella/services/hermes_cloud_staged_attestation.py
           ella/services/hermes_cloud_runtime.py
           ella/services/account_deletion.py
+          ella/services/ai_consent.py
+          ella/services/hermes_cloud_enrichment_outbox.py
           ella/services/consent_authority.py ella/services/invitation_authority.py
           ella/services/memory_reinterpretation.py
           ella/services/observer_extractor.py
@@ -428,6 +444,8 @@ jobs:
           ella/services/summary_recovery.py
           ella/utils/auto_provision.py ella/utils/identity_sync.py
           ella/utils/provision_authority.py utils/ella/scanner_keyterms.py
+          utils/ella/canonical_omi.py
+          scripts/ella_memory_e2e_smoke.py
           scripts/voice_canary_admin.py
           scripts/hermes_product_fit_canary.py
           tests/unit/test_ella_callbacks_summary_update.py
@@ -435,6 +453,8 @@ jobs:
           tests/unit/test_authority_writer_guard.py
           tests/unit/test_account_deletion.py
           tests/unit/test_content_write_fence.py
+          tests/unit/test_durable_worker_deletion_finality.py
+          tests/unit/test_trace_deletion_finality.py
           tests/unit/test_ella_ai_consent.py
           tests/unit/test_ella_conversation_corrections.py
           tests/unit/test_ella_guardian_delivery.py
@@ -470,6 +490,7 @@ jobs:
             pytest --collect-only -q \
               tests/unit/test_account_deletion.py \
               tests/unit/test_content_write_fence.py \
+              tests/unit/test_durable_worker_deletion_finality.py \
               tests/unit/test_trace_deletion_finality.py \
               tests/unit/test_conversation_processing_failures.py \
               tests/unit/test_ella_ai_consent.py \
@@ -510,6 +531,7 @@ jobs:
             "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[False]"
             "tests/unit/test_account_deletion.py::test_firestore_delete_removes_only_owned_top_level_jobs_and_retries"
             "tests/unit/test_account_deletion.py::test_deletion_service_retains_firebase_when_memory_work_purge_is_unavailable"
+            "tests/unit/test_account_deletion.py::test_canonical_ledger_purge_is_resumable_and_precedes_firebase_last"
             "tests/unit/test_content_write_fence.py::test_expired_registration_never_proves_a_live_writer_absent"
             "tests/unit/test_content_write_fence.py::test_detached_writer_transfers_child_registration_before_parent_release"
             "tests/unit/test_content_write_fence.py::test_mounted_limitless_worker_transfers_fence_until_actual_upsert_finishes"
@@ -518,6 +540,13 @@ jobs:
             "tests/unit/test_content_write_fence.py::test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact"
             "tests/unit/test_content_write_fence.py::test_backend_mutation_and_raw_launch_inventory_covers_startup_services_and_utilities"
             "tests/unit/test_content_write_fence.py::test_backend_inventory_positive_controls_reject_startup_raw_task_and_unfenced_uid_writer"
+            "tests/unit/test_content_write_fence.py::test_threaded_mutation_stale_token_is_joined_before_failure"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_positive_control_legacy_mounted_canonical_route_writes_after_tombstone"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_mounted_canonical_auth_drain_exact_purge_firebase_last_and_retry"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[success]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[error]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[timeout]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_memory_proposal_thread_before_deletion"
             "tests/unit/test_hermes_cloud_enrichment_outbox.py::test_stale_claim_fails_closed_at_external_delivery_boundary"
             "tests/unit/test_hermes_cloud_enrichment_outbox.py::test_firestore_repository_rejects_post_tombstone_claim_complete_fail_and_retry"
             "tests/unit/test_hermes_cloud_enrichment_outbox.py::test_firestore_repository_rejects_post_tombstone_enqueue"
@@ -530,6 +559,7 @@ jobs:
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_mid_transaction_failure_rolls_back_every_authority_and_capacity_write"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_routing_trace_purge_is_exact_repeatable_and_retains_other_users"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_memory_reinterpretation_purge_removes_attempts_and_retains_other_users"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_canonical_ledger_positive_control_exact_purge_rollback_and_retry"
             "tests/unit/test_hermes_binding_envelope_contract.py::test_omi_request_uses_exact_stock_contract_from_shared_envelope"
             "tests/unit/test_hermes_product_fit_canary.py::test_scenarios_a_to_f_pass_with_content_free_stage_tables"
             "tests/unit/test_hermes_product_fit_canary.py::test_replay_errors_fail_closed_for_outcome_correlation_session_timeout_and_ordering"
@@ -550,10 +580,12 @@ jobs:
             "tests/postgres/test_invitation_redemption_postgres.py::test_deletion_tombstone_serializes_inflight_provider_writer_and_quarantines_photon_immediately"
             "tests/postgres/test_hermes_cloud_pool_postgres.py::test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets"
           )
+          test "${#required_ids[@]}" -eq 58
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_account_deletion.py \
               tests/unit/test_content_write_fence.py \
+              tests/unit/test_durable_worker_deletion_finality.py \
               tests/unit/test_trace_deletion_finality.py \
               tests/unit/test_conversation_processing_failures.py \
               tests/unit/test_hermes_cloud_enrichment_outbox.py \
@@ -572,10 +604,11 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 543
+          test "$collected" -eq 556
           pytest \
             tests/unit/test_account_deletion.py \
             tests/unit/test_content_write_fence.py \
+            tests/unit/test_durable_worker_deletion_finality.py \
             tests/unit/test_trace_deletion_finality.py \
             tests/unit/test_conversation_processing_failures.py \
             tests/unit/test_ella_ai_consent.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "backend/contracts/authority_advisory_lock_v1.json"
       - "backend/contracts/README.md"
+      - "backend/database/account_deletion.py"
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/ella_provisioning.py"
       - "backend/database/hermes_cloud_enrichment_outbox.py"
@@ -13,6 +14,9 @@ on:
       - "backend/database/runtime_targets.py"
       - "backend/database/voice_canary.py"
       - "backend/routers/transcribe.py"
+      - "backend/routers/users.py"
+      - "backend/database/users.py"
+      - "backend/utils/other/endpoints.py"
       - "backend/ella/__init__.py"
       - "backend/ella/routers/auto_provision.py"
       - "backend/ella/routers/callbacks.py"
@@ -35,6 +39,8 @@ on:
       - "backend/ella/services/hermes_cloud_enrichment_outbox.py"
       - "backend/ella/services/hermes_cloud_enrichment_dependencies.py"
       - "backend/ella/services/ai_consent.py"
+      - "backend/ella/services/account_deletion.py"
+      - "backend/database/firestore_account_deletion.py"
       - "backend/ella/services/consent_authority.py"
       - "backend/ella/services/hermes_cloud_policy.py"
       - "backend/ella/services/invitation_authority.py"
@@ -83,6 +89,7 @@ on:
       - "backend/tests/unit/test_hermes_binding_envelope_contract.py"
       - "backend/tests/unit/test_hermes_product_fit_canary.py"
       - "backend/tests/unit/test_ella_ai_consent.py"
+      - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
       - "backend/tests/unit/test_ella_runtime_route_isolation.py"
       - "backend/tests/unit/test_hermes_cloud_*.py"
@@ -106,6 +113,7 @@ on:
     paths:
       - "backend/contracts/authority_advisory_lock_v1.json"
       - "backend/contracts/README.md"
+      - "backend/database/account_deletion.py"
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/ella_provisioning.py"
       - "backend/database/hermes_cloud_enrichment_outbox.py"
@@ -114,6 +122,9 @@ on:
       - "backend/database/runtime_targets.py"
       - "backend/database/voice_canary.py"
       - "backend/routers/transcribe.py"
+      - "backend/routers/users.py"
+      - "backend/database/users.py"
+      - "backend/utils/other/endpoints.py"
       - "backend/ella/__init__.py"
       - "backend/ella/routers/auto_provision.py"
       - "backend/ella/routers/callbacks.py"
@@ -136,6 +147,8 @@ on:
       - "backend/ella/services/hermes_cloud_enrichment_outbox.py"
       - "backend/ella/services/hermes_cloud_enrichment_dependencies.py"
       - "backend/ella/services/ai_consent.py"
+      - "backend/ella/services/account_deletion.py"
+      - "backend/database/firestore_account_deletion.py"
       - "backend/ella/services/consent_authority.py"
       - "backend/ella/services/hermes_cloud_policy.py"
       - "backend/ella/services/invitation_authority.py"
@@ -184,6 +197,7 @@ on:
       - "backend/tests/unit/test_hermes_binding_envelope_contract.py"
       - "backend/tests/unit/test_hermes_product_fit_canary.py"
       - "backend/tests/unit/test_ella_ai_consent.py"
+      - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
       - "backend/tests/unit/test_ella_runtime_route_isolation.py"
       - "backend/tests/unit/test_hermes_cloud_*.py"
@@ -260,7 +274,10 @@ jobs:
       - name: Compile Hermes Cloud runtime modules
         run: >-
           python -m py_compile
+          database/account_deletion.py
           database/authority_advisory_lock.py
+          database/firestore_account_deletion.py
+          database/users.py
           database/ella_provisioning.py
           database/hermes_cloud_enrichment_outbox.py
           database/invitations.py
@@ -268,6 +285,7 @@ jobs:
           database/runtime_targets.py
           database/voice_canary.py
           routers/transcribe.py
+          routers/users.py
           ella/routers/auto_provision.py
           ella/routers/callbacks.py
           ella/routers/ai_consent.py
@@ -277,6 +295,7 @@ jobs:
           ella/routers/onboarding.py
           ella/routers/observer.py
           ella/routers/plato_mcp.py
+          ella/services/account_deletion.py
           ella/services/ai_consent.py
           ella/services/consent_authority.py
           ella/services/hermes_broker_client.py
@@ -309,11 +328,14 @@ jobs:
           scripts/voice_canary_admin.py
           utils/ella/postprocess.py
           utils/ella/scanner_keyterms.py
+          utils/other/endpoints.py
 
       - name: Validate formatting and OpenAPI contract
         run: >-
           black --check --line-length 120 --skip-string-normalization
+          database/account_deletion.py
           database/authority_advisory_lock.py
+          database/firestore_account_deletion.py
           database/ella_provisioning.py database/invitations.py
           database/managed_cloud_consent.py
           database/runtime_targets.py database/voice_canary.py
@@ -327,6 +349,7 @@ jobs:
           ella/services/hermes_cloud.py ella/services/hermes_cloud_enrichment.py
           ella/services/hermes_cloud_staged_attestation.py
           ella/services/hermes_cloud_runtime.py
+          ella/services/account_deletion.py
           ella/services/consent_authority.py ella/services/invitation_authority.py
           ella/services/memory_reinterpretation.py
           ella/services/observer_extractor.py
@@ -339,6 +362,7 @@ jobs:
           tests/unit/test_ella_callbacks_summary_update.py
           tests/unit/test_authority_advisory_lock.py
           tests/unit/test_authority_writer_guard.py
+          tests/unit/test_account_deletion.py
           tests/unit/test_ella_ai_consent.py
           tests/unit/test_ella_conversation_corrections.py
           tests/unit/test_ella_guardian_delivery.py
@@ -372,6 +396,7 @@ jobs:
           set -euo pipefail
           collected="$(
             pytest --collect-only -q \
+              tests/unit/test_account_deletion.py \
               tests/unit/test_ella_ai_consent.py \
               tests/unit/test_ella_ai_consent_route_gates.py \
               tests/unit/test_hermes_cloud_migration.py \
@@ -401,6 +426,8 @@ jobs:
           )"
           required_ids=(
             "tests/unit/test_hermes_binding_envelope_contract.py::test_hermes_binding_envelope_v1_identity_and_content_free_shape"
+            "tests/unit/test_account_deletion.py::test_authenticated_route_delegates_to_the_resumable_deletion_service"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_mid_transaction_failure_rolls_back_every_authority_and_capacity_write"
             "tests/unit/test_hermes_binding_envelope_contract.py::test_omi_request_uses_exact_stock_contract_from_shared_envelope"
             "tests/unit/test_hermes_product_fit_canary.py::test_scenarios_a_to_f_pass_with_content_free_stage_tables"
             "tests/unit/test_hermes_product_fit_canary.py::test_replay_errors_fail_closed_for_outcome_correlation_session_timeout_and_ordering"
@@ -421,6 +448,7 @@ jobs:
           )
           collected_ids="$(
             pytest --collect-only -q \
+              tests/unit/test_account_deletion.py \
               tests/unit/test_hermes_binding_envelope_contract.py \
               tests/unit/test_hermes_product_fit_canary.py \
               tests/unit/test_ella_runtime_route_isolation.py \
@@ -436,8 +464,9 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 490
+          test "$collected" -eq 499
           pytest \
+            tests/unit/test_account_deletion.py \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \
             tests/unit/test_hermes_cloud_migration.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -63,6 +63,7 @@ on:
       - "backend/migrations/013_create_managed_cloud_consent_authority.sql"
       - "backend/migrations/014_add_synthetic_invitation_operator_audit.sql"
       - "backend/migrations/015_add_invitation_allowed_email_hash.sql"
+      - "backend/migrations/017_add_provider_attempt_deletion_fence.sql"
       - "backend/scripts/pilot_invite_admin.py"
       - "backend/scripts/hermes_cloud_pool_admin.py"
       - "backend/scripts/hermes_cloud_enrichment_smoke.py"
@@ -171,6 +172,7 @@ on:
       - "backend/migrations/013_create_managed_cloud_consent_authority.sql"
       - "backend/migrations/014_add_synthetic_invitation_operator_audit.sql"
       - "backend/migrations/015_add_invitation_allowed_email_hash.sql"
+      - "backend/migrations/017_add_provider_attempt_deletion_fence.sql"
       - "backend/scripts/pilot_invite_admin.py"
       - "backend/scripts/hermes_cloud_pool_admin.py"
       - "backend/scripts/hermes_cloud_enrichment_smoke.py"
@@ -427,6 +429,9 @@ jobs:
           required_ids=(
             "tests/unit/test_hermes_binding_envelope_contract.py::test_hermes_binding_envelope_v1_identity_and_content_free_shape"
             "tests/unit/test_account_deletion.py::test_authenticated_route_delegates_to_the_resumable_deletion_service"
+            "tests/unit/test_account_deletion.py::test_production_route_uses_legacy_resumable_deletion_when_ella_authority_is_explicitly_disabled"
+            "tests/unit/test_account_deletion.py::test_production_route_fails_closed_before_destructive_work_when_enabled_authority_is_unavailable"
+            "tests/unit/test_account_deletion.py::test_retained_firebase_subject_is_fenced_from_authenticated_content_writes"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_mid_transaction_failure_rolls_back_every_authority_and_capacity_write"
             "tests/unit/test_hermes_binding_envelope_contract.py::test_omi_request_uses_exact_stock_contract_from_shared_envelope"
             "tests/unit/test_hermes_product_fit_canary.py::test_scenarios_a_to_f_pass_with_content_free_stage_tables"
@@ -444,6 +449,8 @@ jobs:
             "tests/unit/test_voice_proxy_auth.py::test_self_hosted_voice_accept_drift_fails_before_session_or_provider_call[authority_digest-voice_runtime_authority_changed]"
             "tests/unit/test_voice_proxy_auth.py::test_self_hosted_voice_accept_drift_fails_before_session_or_provider_call[session-voice_session_claim_mismatch]"
             "tests/postgres/test_invitation_redemption_postgres.py::test_self_hosted_runtime_resolution_is_invitation_authoritative_and_exact"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_lost_provider_ack_persists_unproven_attempt_blocks_firebase_and_retry_converges"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_deletion_tombstone_serializes_inflight_provider_writer_and_quarantines_photon_immediately"
             "tests/postgres/test_hermes_cloud_pool_postgres.py::test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets"
           )
           collected_ids="$(
@@ -464,7 +471,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 499
+          test "$collected" -eq 506
           pytest \
             tests/unit/test_account_deletion.py \
             tests/unit/test_ella_ai_consent.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -562,7 +562,7 @@ jobs:
           pytest tests/unit/test_ella_callbacks_summary_update.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_conversation_corrections.py | grep -c '::')" -eq 64
           pytest tests/unit/test_ella_conversation_corrections.py -v
-          test "$(pytest --collect-only -q tests/unit/test_ella_guardian_delivery.py | grep -c '::')" -eq 18
+          test "$(pytest --collect-only -q tests/unit/test_ella_guardian_delivery.py | grep -c '::')" -eq 19
           pytest tests/unit/test_ella_guardian_delivery.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_listen_runtime_gate.py | grep -c '::')" -eq 7
           pytest tests/unit/test_ella_listen_runtime_gate.py -v

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -9,6 +9,7 @@ on:
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/content_write_fence.py"
       - "backend/database/content_write_recovery.py"
+      - "backend/database/content_write_recovery_authority.py"
       - "backend/database/content_writer_owner.py"
       - "backend/database/firestore_account_deletion.py"
       - "backend/database/memory_reinterpretations.py"
@@ -117,6 +118,9 @@ on:
       - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_content_write_fence.py"
       - "backend/tests/unit/test_durable_worker_deletion_finality.py"
+      - "backend/tests/conftest.py"
+      - "backend/tests/support/__init__.py"
+      - "backend/tests/support/content_writer_owner_nonlinux.py"
       - "backend/tests/unit/test_trace_deletion_finality.py"
       - "backend/tests/unit/test_conversation_processing_failures.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
@@ -146,6 +150,7 @@ on:
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/content_write_fence.py"
       - "backend/database/content_write_recovery.py"
+      - "backend/database/content_write_recovery_authority.py"
       - "backend/database/content_writer_owner.py"
       - "backend/database/firestore_account_deletion.py"
       - "backend/database/memory_reinterpretations.py"
@@ -254,6 +259,9 @@ on:
       - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_content_write_fence.py"
       - "backend/tests/unit/test_durable_worker_deletion_finality.py"
+      - "backend/tests/conftest.py"
+      - "backend/tests/support/__init__.py"
+      - "backend/tests/support/content_writer_owner_nonlinux.py"
       - "backend/tests/unit/test_trace_deletion_finality.py"
       - "backend/tests/unit/test_conversation_processing_failures.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
@@ -339,6 +347,7 @@ jobs:
           database/authority_advisory_lock.py
           database/content_write_fence.py
           database/content_write_recovery.py
+          database/content_write_recovery_authority.py
           database/content_writer_owner.py
           database/firestore_account_deletion.py
           database/memory_reinterpretations.py
@@ -410,6 +419,9 @@ jobs:
           scripts/hermes_cloud_shadow.py
           scripts/voice_canary_admin.py
           scripts/content_writer_recovery.py
+          tests/conftest.py
+          tests/support/__init__.py
+          tests/support/content_writer_owner_nonlinux.py
           utils/ella/postprocess.py
           utils/ella/canonical_omi.py
           utils/ella/scanner_keyterms.py
@@ -422,6 +434,7 @@ jobs:
           database/authority_advisory_lock.py
           database/content_write_fence.py
           database/content_write_recovery.py
+          database/content_write_recovery_authority.py
           database/content_writer_owner.py
           database/firestore_account_deletion.py
           database/memory_reinterpretations.py
@@ -461,6 +474,9 @@ jobs:
           scripts/ella_memory_e2e_smoke.py
           scripts/voice_canary_admin.py
           scripts/content_writer_recovery.py
+          tests/conftest.py
+          tests/support/__init__.py
+          tests/support/content_writer_owner_nonlinux.py
           scripts/hermes_product_fit_canary.py
           tests/unit/test_ella_callbacks_summary_update.py
           tests/unit/test_authority_advisory_lock.py
@@ -496,6 +512,62 @@ jobs:
           tests/postgres/test_runtime_migration_atomicity_postgres.py
           &&
           python -c "import yaml; from openapi_spec_validator import validate; validate(yaml.safe_load(open('ella/docs/hermes-cloud-runtime-targets.openapi.yaml', encoding='utf-8')))"
+
+      - name: Prove container root refuses before imports or writes
+        run: |
+          set -euo pipefail
+          docker run --rm -v "$PWD:/source:ro" python:3.12-slim sh -ceu '
+            mkdir -p /opt/omi-recovery /tmp/hostile/database /tmp/recovery-cwd
+            cp -a /source /opt/omi-recovery/backend
+            chown -R 0:0 /opt/omi-recovery
+            chmod -R go-w /opt/omi-recovery
+            printf "%s\n" "from pathlib import Path" "Path(\"/tmp/hostile-marker\").write_text(\"loaded\")" > /tmp/hostile/database/__init__.py
+            ln -s /tmp/credential-target /tmp/recovery-cwd/google-credentials.json
+            set +e
+            cd /tmp/recovery-cwd
+            env \
+              PYTHONPATH=/tmp/hostile \
+              SERVICE_ACCOUNT_JSON="{\"private_key\":\"fake-control\"}" \
+              FIRESTORE_EMULATOR_HOST=127.0.0.1:65530 \
+              GCLOUD_PROJECT=wrong-project \
+              GOOGLE_CLOUD_PROJECT=wrong-project \
+              /usr/local/bin/python -I \
+              /opt/omi-recovery/backend/scripts/content_writer_recovery.py \
+              --subject-hash aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+              --token-hash bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            status=$?
+            set -e
+            test "$status" -eq 77
+            test ! -e /tmp/credential-target
+            test ! -e /tmp/hostile-marker
+            test "$(find /tmp/recovery-cwd -mindepth 1 -maxdepth 1 | wc -l)" -eq 1
+          '
+          docker run --rm --privileged --pid=host -v "$PWD:/source:ro" python:3.12-slim sh -ceu '
+            mkdir -p /opt/omi-recovery /tmp/hostile/database /tmp/recovery-cwd
+            cp -a /source /opt/omi-recovery/backend
+            chown -R 0:0 /opt/omi-recovery
+            chmod -R go-w /opt/omi-recovery
+            printf "%s\n" "from pathlib import Path" "Path(\"/tmp/hostile-marker\").write_text(\"loaded\")" > /tmp/hostile/database/__init__.py
+            ln -s /tmp/credential-target /tmp/recovery-cwd/google-credentials.json
+            set +e
+            cd /tmp/recovery-cwd
+            env \
+              PYTHONPATH=/tmp/hostile \
+              SERVICE_ACCOUNT_JSON="{\"private_key\":\"fake-control\"}" \
+              FIRESTORE_EMULATOR_HOST=127.0.0.1:65530 \
+              GCLOUD_PROJECT=wrong-project \
+              GOOGLE_CLOUD_PROJECT=wrong-project \
+              /usr/local/bin/python -I \
+              /opt/omi-recovery/backend/scripts/content_writer_recovery.py \
+              --subject-hash aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+              --token-hash bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            status=$?
+            set -e
+            test "$status" -eq 77
+            test ! -e /tmp/credential-target
+            test ! -e /tmp/hostile-marker
+            test "$(find /tmp/recovery-cwd -mindepth 1 -maxdepth 1 | wc -l)" -eq 1
+          '
 
       - name: Run Hermes Cloud and isolation failure-path tests
         run: |
@@ -567,6 +639,13 @@ jobs:
             "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_surface_rejects_stale_cross_uid_ownerless_and_actual_unprivileged_invocation"
             "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_surface_rejects_cross_generation_replacement_after_real_terminal_proof"
             "tests/unit/test_durable_worker_deletion_finality.py::test_concurrent_recovery_surface_is_exact_and_idempotent"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_concurrent_different_token_compaction_keeps_only_latest_retry_authority"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_receipt_is_strictly_bounded_across_five_thousand_cycles_and_deletion_converges"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_stale_receipt_or_hash_collision_never_releases_a_different_writer"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_pinned_recovery_authority_ignores_hostile_ambient_project_and_credentials"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_authority_rejects_emulator_mismatch_and_symlink_before_credentials"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_authority_wrong_receipt_or_credential_project_loads_no_credentials"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_production_recovery_modules_refuse_darwin_before_firestore_calls"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[success]"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[error]"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[timeout]"
@@ -605,7 +684,7 @@ jobs:
             "tests/postgres/test_invitation_redemption_postgres.py::test_deletion_tombstone_serializes_inflight_provider_writer_and_quarantines_photon_immediately"
             "tests/postgres/test_hermes_cloud_pool_postgres.py::test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets"
           )
-          test "${#required_ids[@]}" -eq 69
+          test "${#required_ids[@]}" -eq 76
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_account_deletion.py \
@@ -629,7 +708,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 567
+          test "$collected" -eq 574
           pytest \
             tests/unit/test_account_deletion.py \
             tests/unit/test_content_write_fence.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -541,12 +541,16 @@ jobs:
             "tests/unit/test_content_write_fence.py::test_backend_mutation_and_raw_launch_inventory_covers_startup_services_and_utilities"
             "tests/unit/test_content_write_fence.py::test_backend_inventory_positive_controls_reject_startup_raw_task_and_unfenced_uid_writer"
             "tests/unit/test_content_write_fence.py::test_threaded_mutation_stale_token_is_joined_before_failure"
+            "tests/unit/test_content_write_fence.py::test_threaded_mutation_survives_repeated_cancellation_until_thread_terminal"
             "tests/unit/test_durable_worker_deletion_finality.py::test_positive_control_legacy_mounted_canonical_route_writes_after_tombstone"
             "tests/unit/test_durable_worker_deletion_finality.py::test_mounted_canonical_auth_drain_exact_purge_firebase_last_and_retry"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_positive_control_legacy_two_stops_release_enrichment_writer_before_thread_terminal"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_process_restart_retains_orphan_token_until_exact_terminal_proof_recovery"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[success]"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[error]"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[timeout]"
-            "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_memory_proposal_thread_before_deletion"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_memory_thread_before_deletion[proposal]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_memory_thread_before_deletion[correction]"
             "tests/unit/test_hermes_cloud_enrichment_outbox.py::test_stale_claim_fails_closed_at_external_delivery_boundary"
             "tests/unit/test_hermes_cloud_enrichment_outbox.py::test_firestore_repository_rejects_post_tombstone_claim_complete_fail_and_retry"
             "tests/unit/test_hermes_cloud_enrichment_outbox.py::test_firestore_repository_rejects_post_tombstone_enqueue"
@@ -580,7 +584,7 @@ jobs:
             "tests/postgres/test_invitation_redemption_postgres.py::test_deletion_tombstone_serializes_inflight_provider_writer_and_quarantines_photon_immediately"
             "tests/postgres/test_hermes_cloud_pool_postgres.py::test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets"
           )
-          test "${#required_ids[@]}" -eq 58
+          test "${#required_ids[@]}" -eq 62
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_account_deletion.py \
@@ -604,7 +608,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 556
+          test "$collected" -eq 560
           pytest \
             tests/unit/test_account_deletion.py \
             tests/unit/test_content_write_fence.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -109,6 +109,7 @@ on:
       - "backend/tests/unit/test_ella_ai_consent.py"
       - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_content_write_fence.py"
+      - "backend/tests/unit/test_trace_deletion_finality.py"
       - "backend/tests/unit/test_conversation_processing_failures.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
       - "backend/tests/unit/test_ella_runtime_route_isolation.py"
@@ -237,6 +238,7 @@ on:
       - "backend/tests/unit/test_ella_ai_consent.py"
       - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_content_write_fence.py"
+      - "backend/tests/unit/test_trace_deletion_finality.py"
       - "backend/tests/unit/test_conversation_processing_failures.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
       - "backend/tests/unit/test_ella_runtime_route_isolation.py"
@@ -468,6 +470,7 @@ jobs:
             pytest --collect-only -q \
               tests/unit/test_account_deletion.py \
               tests/unit/test_content_write_fence.py \
+              tests/unit/test_trace_deletion_finality.py \
               tests/unit/test_conversation_processing_failures.py \
               tests/unit/test_ella_ai_consent.py \
               tests/unit/test_ella_ai_consent_route_gates.py \
@@ -502,6 +505,7 @@ jobs:
             "tests/unit/test_account_deletion.py::test_production_route_uses_legacy_resumable_deletion_when_ella_authority_is_explicitly_disabled"
             "tests/unit/test_account_deletion.py::test_production_route_fails_closed_before_destructive_work_when_enabled_authority_is_unavailable"
             "tests/unit/test_account_deletion.py::test_retained_firebase_subject_is_fenced_from_authenticated_content_writes"
+            "tests/unit/test_account_deletion.py::test_deletion_service_never_reports_success_when_routing_trace_purge_is_unavailable"
             "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[True]"
             "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[False]"
             "tests/unit/test_account_deletion.py::test_firestore_delete_removes_only_owned_top_level_import_jobs_and_retries"
@@ -513,7 +517,12 @@ jobs:
             "tests/unit/test_content_write_fence.py::test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact"
             "tests/unit/test_conversation_processing_failures.py::test_process_conversation_provider_failure_persists_retryable_payload"
             "tests/unit/test_content_write_fence.py::test_request_fence_covers_streamed_commit_after_route_returns"
+            "tests/unit/test_trace_deletion_finality.py::test_trace_probe_positive_control_reproduces_old_mounted_escape"
+            "tests/unit/test_trace_deletion_finality.py::test_mounted_trace_persistence_is_drained_purged_and_tombstoned"
+            "tests/unit/test_trace_deletion_finality.py::test_trace_reads_require_exact_authenticated_subject"
+            "tests/unit/test_trace_deletion_finality.py::test_concurrent_trace_requests_release_request_lifetimes_before_bounded_pool_progress"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_mid_transaction_failure_rolls_back_every_authority_and_capacity_write"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_routing_trace_purge_is_exact_repeatable_and_retains_other_users"
             "tests/unit/test_hermes_binding_envelope_contract.py::test_omi_request_uses_exact_stock_contract_from_shared_envelope"
             "tests/unit/test_hermes_product_fit_canary.py::test_scenarios_a_to_f_pass_with_content_free_stage_tables"
             "tests/unit/test_hermes_product_fit_canary.py::test_replay_errors_fail_closed_for_outcome_correlation_session_timeout_and_ordering"
@@ -538,6 +547,7 @@ jobs:
             pytest --collect-only -q \
               tests/unit/test_account_deletion.py \
               tests/unit/test_content_write_fence.py \
+              tests/unit/test_trace_deletion_finality.py \
               tests/unit/test_conversation_processing_failures.py \
               tests/unit/test_hermes_binding_envelope_contract.py \
               tests/unit/test_hermes_product_fit_canary.py \
@@ -554,10 +564,11 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 530
+          test "$collected" -eq 536
           pytest \
             tests/unit/test_account_deletion.py \
             tests/unit/test_content_write_fence.py \
+            tests/unit/test_trace_deletion_finality.py \
             tests/unit/test_conversation_processing_failures.py \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -8,6 +8,8 @@ on:
       - "backend/database/account_deletion.py"
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/content_write_fence.py"
+      - "backend/database/content_write_recovery.py"
+      - "backend/database/content_writer_owner.py"
       - "backend/database/firestore_account_deletion.py"
       - "backend/database/memory_reinterpretations.py"
       - "backend/routers/action_items.py"
@@ -89,12 +91,14 @@ on:
       - "backend/scripts/hermes_cloud_shadow.py"
       - "backend/scripts/ella_memory_e2e_smoke.py"
       - "backend/scripts/voice_canary_admin.py"
+      - "backend/scripts/content_writer_recovery.py"
       - "backend/utils/ella/postprocess.py"
       - "backend/utils/ella/canonical_omi.py"
       - "backend/utils/ella/scanner_keyterms.py"
       - "backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md"
       - "backend/ella/docs/HERMES_CLOUD_RUNTIME_TARGETS_RUNBOOK.md"
       - "backend/ella/docs/HERMES_PRODUCT_FIT_CANARY.md"
+      - "backend/ella/docs/CONTENT_WRITER_RECOVERY.md"
       - "backend/ella/docs/hermes-cloud-runtime-targets.openapi.yaml"
       - "backend/tests/fixtures/hermes_product_fit_callback_v1.json"
       - "backend/tests/unit/test_ella_provisioning_repository.py"
@@ -141,6 +145,8 @@ on:
       - "backend/database/account_deletion.py"
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/content_write_fence.py"
+      - "backend/database/content_write_recovery.py"
+      - "backend/database/content_writer_owner.py"
       - "backend/database/firestore_account_deletion.py"
       - "backend/database/memory_reinterpretations.py"
       - "backend/routers/action_items.py"
@@ -222,12 +228,14 @@ on:
       - "backend/scripts/hermes_cloud_shadow.py"
       - "backend/scripts/ella_memory_e2e_smoke.py"
       - "backend/scripts/voice_canary_admin.py"
+      - "backend/scripts/content_writer_recovery.py"
       - "backend/utils/ella/postprocess.py"
       - "backend/utils/ella/canonical_omi.py"
       - "backend/utils/ella/scanner_keyterms.py"
       - "backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md"
       - "backend/ella/docs/HERMES_CLOUD_RUNTIME_TARGETS_RUNBOOK.md"
       - "backend/ella/docs/HERMES_PRODUCT_FIT_CANARY.md"
+      - "backend/ella/docs/CONTENT_WRITER_RECOVERY.md"
       - "backend/ella/docs/hermes-cloud-runtime-targets.openapi.yaml"
       - "backend/tests/fixtures/hermes_product_fit_callback_v1.json"
       - "backend/tests/unit/test_ella_provisioning_repository.py"
@@ -330,6 +338,8 @@ jobs:
           database/account_deletion.py
           database/authority_advisory_lock.py
           database/content_write_fence.py
+          database/content_write_recovery.py
+          database/content_writer_owner.py
           database/firestore_account_deletion.py
           database/memory_reinterpretations.py
           routers/action_items.py
@@ -399,6 +409,7 @@ jobs:
           scripts/pilot_invite_admin.py
           scripts/hermes_cloud_shadow.py
           scripts/voice_canary_admin.py
+          scripts/content_writer_recovery.py
           utils/ella/postprocess.py
           utils/ella/canonical_omi.py
           utils/ella/scanner_keyterms.py
@@ -410,6 +421,8 @@ jobs:
           database/account_deletion.py
           database/authority_advisory_lock.py
           database/content_write_fence.py
+          database/content_write_recovery.py
+          database/content_writer_owner.py
           database/firestore_account_deletion.py
           database/memory_reinterpretations.py
           routers/action_items.py
@@ -447,6 +460,7 @@ jobs:
           utils/ella/canonical_omi.py
           scripts/ella_memory_e2e_smoke.py
           scripts/voice_canary_admin.py
+          scripts/content_writer_recovery.py
           scripts/hermes_product_fit_canary.py
           tests/unit/test_ella_callbacks_summary_update.py
           tests/unit/test_authority_advisory_lock.py
@@ -545,7 +559,14 @@ jobs:
             "tests/unit/test_durable_worker_deletion_finality.py::test_positive_control_legacy_mounted_canonical_route_writes_after_tombstone"
             "tests/unit/test_durable_worker_deletion_finality.py::test_mounted_canonical_auth_drain_exact_purge_firebase_last_and_retry"
             "tests/unit/test_durable_worker_deletion_finality.py::test_positive_control_legacy_two_stops_release_enrichment_writer_before_thread_terminal"
-            "tests/unit/test_durable_worker_deletion_finality.py::test_process_restart_retains_orphan_token_until_exact_terminal_proof_recovery"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_process_restart_uses_root_cli_and_real_kernel_terminal_proof_before_firebase_last"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_surface_rejects_other_boundary_and_pid_reuse[host-account_writer_recovery_host_mismatch]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_surface_rejects_other_boundary_and_pid_reuse[boot-account_writer_recovery_boot_mismatch]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_surface_rejects_other_boundary_and_pid_reuse[namespace-account_writer_recovery_pid_namespace_mismatch]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_surface_rejects_other_boundary_and_pid_reuse[start-account_writer_recovery_pid_reused]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_surface_rejects_stale_cross_uid_ownerless_and_actual_unprivileged_invocation"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_surface_rejects_cross_generation_replacement_after_real_terminal_proof"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_concurrent_recovery_surface_is_exact_and_idempotent"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[success]"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[error]"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[timeout]"
@@ -584,7 +605,7 @@ jobs:
             "tests/postgres/test_invitation_redemption_postgres.py::test_deletion_tombstone_serializes_inflight_provider_writer_and_quarantines_photon_immediately"
             "tests/postgres/test_hermes_cloud_pool_postgres.py::test_finalize_ready_cloud_claim_publishes_exact_account_profile_targets"
           )
-          test "${#required_ids[@]}" -eq 62
+          test "${#required_ids[@]}" -eq 69
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_account_deletion.py \
@@ -608,7 +629,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 560
+          test "$collected" -eq 567
           pytest \
             tests/unit/test_account_deletion.py \
             tests/unit/test_content_write_fence.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -8,17 +8,30 @@ on:
       - "backend/database/account_deletion.py"
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/content_write_fence.py"
+      - "backend/database/firestore_account_deletion.py"
+      - "backend/routers/action_items.py"
       - "backend/routers/apps.py"
+      - "backend/routers/chat.py"
+      - "backend/routers/developer.py"
+      - "backend/routers/imports.py"
       - "backend/routers/integration.py"
+      - "backend/routers/mcp.py"
       - "backend/routers/mcp_sse.py"
+      - "backend/routers/memories.py"
+      - "backend/routers/pusher.py"
+      - "backend/routers/sync.py"
+      - "backend/routers/transcribe.py"
+      - "backend/routers/wrapped.py"
       - "backend/routers/workflow.py"
+      - "backend/utils/imports/limitless.py"
+      - "backend/utils/conversations/process_conversation.py"
+      - "backend/utils/other/storage.py"
       - "backend/database/ella_provisioning.py"
       - "backend/database/hermes_cloud_enrichment_outbox.py"
       - "backend/database/invitations.py"
       - "backend/database/managed_cloud_consent.py"
       - "backend/database/runtime_targets.py"
       - "backend/database/voice_canary.py"
-      - "backend/routers/transcribe.py"
       - "backend/routers/users.py"
       - "backend/database/users.py"
       - "backend/utils/other/endpoints.py"
@@ -45,7 +58,6 @@ on:
       - "backend/ella/services/hermes_cloud_enrichment_dependencies.py"
       - "backend/ella/services/ai_consent.py"
       - "backend/ella/services/account_deletion.py"
-      - "backend/database/firestore_account_deletion.py"
       - "backend/ella/services/consent_authority.py"
       - "backend/ella/services/hermes_cloud_policy.py"
       - "backend/ella/services/invitation_authority.py"
@@ -97,6 +109,7 @@ on:
       - "backend/tests/unit/test_ella_ai_consent.py"
       - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_content_write_fence.py"
+      - "backend/tests/unit/test_conversation_processing_failures.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
       - "backend/tests/unit/test_ella_runtime_route_isolation.py"
       - "backend/tests/unit/test_hermes_cloud_*.py"
@@ -123,17 +136,30 @@ on:
       - "backend/database/account_deletion.py"
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/content_write_fence.py"
+      - "backend/database/firestore_account_deletion.py"
+      - "backend/routers/action_items.py"
       - "backend/routers/apps.py"
+      - "backend/routers/chat.py"
+      - "backend/routers/developer.py"
+      - "backend/routers/imports.py"
       - "backend/routers/integration.py"
+      - "backend/routers/mcp.py"
       - "backend/routers/mcp_sse.py"
+      - "backend/routers/memories.py"
+      - "backend/routers/pusher.py"
+      - "backend/routers/sync.py"
+      - "backend/routers/transcribe.py"
+      - "backend/routers/wrapped.py"
       - "backend/routers/workflow.py"
+      - "backend/utils/imports/limitless.py"
+      - "backend/utils/conversations/process_conversation.py"
+      - "backend/utils/other/storage.py"
       - "backend/database/ella_provisioning.py"
       - "backend/database/hermes_cloud_enrichment_outbox.py"
       - "backend/database/invitations.py"
       - "backend/database/managed_cloud_consent.py"
       - "backend/database/runtime_targets.py"
       - "backend/database/voice_canary.py"
-      - "backend/routers/transcribe.py"
       - "backend/routers/users.py"
       - "backend/database/users.py"
       - "backend/utils/other/endpoints.py"
@@ -160,7 +186,6 @@ on:
       - "backend/ella/services/hermes_cloud_enrichment_dependencies.py"
       - "backend/ella/services/ai_consent.py"
       - "backend/ella/services/account_deletion.py"
-      - "backend/database/firestore_account_deletion.py"
       - "backend/ella/services/consent_authority.py"
       - "backend/ella/services/hermes_cloud_policy.py"
       - "backend/ella/services/invitation_authority.py"
@@ -212,6 +237,7 @@ on:
       - "backend/tests/unit/test_ella_ai_consent.py"
       - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_content_write_fence.py"
+      - "backend/tests/unit/test_conversation_processing_failures.py"
       - "backend/tests/unit/test_ella_ai_consent_route_gates.py"
       - "backend/tests/unit/test_ella_runtime_route_isolation.py"
       - "backend/tests/unit/test_hermes_cloud_*.py"
@@ -252,6 +278,7 @@ jobs:
       ELLA_VOICE_CANARY_ENFORCEMENT_ENABLED: "false"
       ELLA_TEST_POSTGRES_DSN: postgresql://postgres:postgres@127.0.0.1:5432/hermes_cloud_test
       FIRESTORE_EMULATOR_HOST: localhost:9999
+      STORAGE_EMULATOR_HOST: http://localhost:4443
       GCLOUD_PROJECT: omi-ci
       GOOGLE_CLOUD_PROJECT: omi-ci
       ENCRYPTION_SECRET: omi_ci_hermes_cloud_test_only_32_bytes
@@ -283,6 +310,8 @@ jobs:
           "openapi-spec-validator==0.7.1"
           "PyYAML==6.0.2"
           "python-multipart==0.0.9"
+          "redis==5.0.8"
+          "stripe==11.3.0"
           "websockets==12.0"
 
       - name: Compile Hermes Cloud runtime modules
@@ -291,11 +320,24 @@ jobs:
           database/account_deletion.py
           database/authority_advisory_lock.py
           database/content_write_fence.py
-          routers/apps.py
-          routers/integration.py
-          routers/mcp_sse.py
-          routers/workflow.py
           database/firestore_account_deletion.py
+          routers/action_items.py
+          routers/apps.py
+          routers/chat.py
+          routers/developer.py
+          routers/imports.py
+          routers/integration.py
+          routers/mcp.py
+          routers/mcp_sse.py
+          routers/memories.py
+          routers/pusher.py
+          routers/sync.py
+          routers/transcribe.py
+          routers/wrapped.py
+          routers/workflow.py
+          utils/imports/limitless.py
+          utils/conversations/process_conversation.py
+          utils/other/storage.py
           database/users.py
           database/ella_provisioning.py
           database/hermes_cloud_enrichment_outbox.py
@@ -303,7 +345,6 @@ jobs:
           database/managed_cloud_consent.py
           database/runtime_targets.py
           database/voice_canary.py
-          routers/transcribe.py
           routers/users.py
           ella/routers/auto_provision.py
           ella/routers/callbacks.py
@@ -355,9 +396,15 @@ jobs:
           database/account_deletion.py
           database/authority_advisory_lock.py
           database/content_write_fence.py
-          routers/apps.py routers/integration.py
-          routers/mcp_sse.py routers/workflow.py
           database/firestore_account_deletion.py
+          routers/action_items.py
+          routers/apps.py routers/integration.py
+          routers/chat.py routers/developer.py routers/imports.py
+          routers/mcp.py routers/mcp_sse.py routers/memories.py
+          routers/pusher.py
+          routers/sync.py routers/transcribe.py routers/wrapped.py routers/workflow.py
+          utils/imports/limitless.py
+          utils/conversations/process_conversation.py utils/other/storage.py
           database/ella_provisioning.py database/invitations.py
           database/managed_cloud_consent.py
           database/runtime_targets.py database/voice_canary.py
@@ -421,6 +468,7 @@ jobs:
             pytest --collect-only -q \
               tests/unit/test_account_deletion.py \
               tests/unit/test_content_write_fence.py \
+              tests/unit/test_conversation_processing_failures.py \
               tests/unit/test_ella_ai_consent.py \
               tests/unit/test_ella_ai_consent_route_gates.py \
               tests/unit/test_hermes_cloud_migration.py \
@@ -456,7 +504,14 @@ jobs:
             "tests/unit/test_account_deletion.py::test_retained_firebase_subject_is_fenced_from_authenticated_content_writes"
             "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[True]"
             "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[False]"
-            "tests/unit/test_content_write_fence.py::test_mounted_authenticated_writer_inventory_uses_scope_holding_dependencies"
+            "tests/unit/test_account_deletion.py::test_firestore_delete_removes_only_owned_top_level_import_jobs_and_retries"
+            "tests/unit/test_content_write_fence.py::test_expired_registration_never_proves_a_live_writer_absent"
+            "tests/unit/test_content_write_fence.py::test_detached_writer_transfers_child_registration_before_parent_release"
+            "tests/unit/test_content_write_fence.py::test_mounted_limitless_worker_transfers_fence_until_actual_upsert_finishes"
+            "tests/unit/test_content_write_fence.py::test_mounted_nested_database_routes_release_admission_connection_before_handler[consent]"
+            "tests/unit/test_content_write_fence.py::test_mounted_nested_database_routes_release_admission_connection_before_handler[entitlement]"
+            "tests/unit/test_content_write_fence.py::test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact"
+            "tests/unit/test_conversation_processing_failures.py::test_process_conversation_provider_failure_persists_retryable_payload"
             "tests/unit/test_content_write_fence.py::test_request_fence_covers_streamed_commit_after_route_returns"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_mid_transaction_failure_rolls_back_every_authority_and_capacity_write"
             "tests/unit/test_hermes_binding_envelope_contract.py::test_omi_request_uses_exact_stock_contract_from_shared_envelope"
@@ -483,6 +538,7 @@ jobs:
             pytest --collect-only -q \
               tests/unit/test_account_deletion.py \
               tests/unit/test_content_write_fence.py \
+              tests/unit/test_conversation_processing_failures.py \
               tests/unit/test_hermes_binding_envelope_contract.py \
               tests/unit/test_hermes_product_fit_canary.py \
               tests/unit/test_ella_runtime_route_isolation.py \
@@ -498,10 +554,11 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 515
+          test "$collected" -eq 530
           pytest \
             tests/unit/test_account_deletion.py \
             tests/unit/test_content_write_fence.py \
+            tests/unit/test_conversation_processing_failures.py \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \
             tests/unit/test_hermes_cloud_migration.py \
@@ -583,7 +640,7 @@ jobs:
           )"
           test "$(grep -c '::' <<<"$advisory_ids")" -eq 66
           grep -Fqx \
-            "tests/postgres/test_authority_advisory_lock_postgres.py::test_content_request_holds_owner_lock_across_real_commit_and_releases_on_cancellation" \
+            "tests/postgres/test_authority_advisory_lock_postgres.py::test_content_admission_releases_pool_before_same_owner_nested_writers_at_full_capacity" \
             <<<"$advisory_ids"
           pytest \
             tests/unit/test_authority_advisory_lock.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -508,13 +508,19 @@ jobs:
             "tests/unit/test_account_deletion.py::test_deletion_service_never_reports_success_when_routing_trace_purge_is_unavailable"
             "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[True]"
             "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[False]"
-            "tests/unit/test_account_deletion.py::test_firestore_delete_removes_only_owned_top_level_import_jobs_and_retries"
+            "tests/unit/test_account_deletion.py::test_firestore_delete_removes_only_owned_top_level_jobs_and_retries"
+            "tests/unit/test_account_deletion.py::test_deletion_service_retains_firebase_when_memory_work_purge_is_unavailable"
             "tests/unit/test_content_write_fence.py::test_expired_registration_never_proves_a_live_writer_absent"
             "tests/unit/test_content_write_fence.py::test_detached_writer_transfers_child_registration_before_parent_release"
             "tests/unit/test_content_write_fence.py::test_mounted_limitless_worker_transfers_fence_until_actual_upsert_finishes"
             "tests/unit/test_content_write_fence.py::test_mounted_nested_database_routes_release_admission_connection_before_handler[consent]"
             "tests/unit/test_content_write_fence.py::test_mounted_nested_database_routes_release_admission_connection_before_handler[entitlement]"
             "tests/unit/test_content_write_fence.py::test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact"
+            "tests/unit/test_content_write_fence.py::test_backend_mutation_and_raw_launch_inventory_covers_startup_services_and_utilities"
+            "tests/unit/test_content_write_fence.py::test_backend_inventory_positive_controls_reject_startup_raw_task_and_unfenced_uid_writer"
+            "tests/unit/test_hermes_cloud_enrichment_outbox.py::test_stale_claim_fails_closed_at_external_delivery_boundary"
+            "tests/unit/test_hermes_cloud_enrichment_outbox.py::test_firestore_repository_rejects_post_tombstone_claim_complete_fail_and_retry"
+            "tests/unit/test_hermes_cloud_enrichment_outbox.py::test_firestore_repository_rejects_post_tombstone_enqueue"
             "tests/unit/test_conversation_processing_failures.py::test_process_conversation_provider_failure_persists_retryable_payload"
             "tests/unit/test_content_write_fence.py::test_request_fence_covers_streamed_commit_after_route_returns"
             "tests/unit/test_trace_deletion_finality.py::test_trace_probe_positive_control_reproduces_old_mounted_escape"
@@ -523,6 +529,7 @@ jobs:
             "tests/unit/test_trace_deletion_finality.py::test_concurrent_trace_requests_release_request_lifetimes_before_bounded_pool_progress"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_mid_transaction_failure_rolls_back_every_authority_and_capacity_write"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_routing_trace_purge_is_exact_repeatable_and_retains_other_users"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_memory_reinterpretation_purge_removes_attempts_and_retains_other_users"
             "tests/unit/test_hermes_binding_envelope_contract.py::test_omi_request_uses_exact_stock_contract_from_shared_envelope"
             "tests/unit/test_hermes_product_fit_canary.py::test_scenarios_a_to_f_pass_with_content_free_stage_tables"
             "tests/unit/test_hermes_product_fit_canary.py::test_replay_errors_fail_closed_for_outcome_correlation_session_timeout_and_ordering"
@@ -549,6 +556,7 @@ jobs:
               tests/unit/test_content_write_fence.py \
               tests/unit/test_trace_deletion_finality.py \
               tests/unit/test_conversation_processing_failures.py \
+              tests/unit/test_hermes_cloud_enrichment_outbox.py \
               tests/unit/test_hermes_binding_envelope_contract.py \
               tests/unit/test_hermes_product_fit_canary.py \
               tests/unit/test_ella_runtime_route_isolation.py \
@@ -564,7 +572,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 536
+          test "$collected" -eq 543
           pytest \
             tests/unit/test_account_deletion.py \
             tests/unit/test_content_write_fence.py \
@@ -670,7 +678,17 @@ jobs:
           pytest tests/unit/test_ella_observer.py -v
           test "$(pytest --collect-only -q tests/unit/test_invitation_redemption.py | grep -c '::')" -eq 19
           pytest tests/unit/test_invitation_redemption.py -v
-          test "$(pytest --collect-only -q tests/unit/test_memory_reinterpretation_outbox.py | grep -c '::')" -eq 28
+          memory_reinterpretation_ids="$(
+            pytest --collect-only -q tests/unit/test_memory_reinterpretation_outbox.py |
+              sed '/^$/d'
+          )"
+          test "$(grep -c '::' <<<"$memory_reinterpretation_ids")" -eq 30
+          grep -Fqx \
+            "tests/unit/test_memory_reinterpretation_outbox.py::test_reinterpretation_completion_rejects_post_tombstone_enqueue" \
+            <<<"$memory_reinterpretation_ids"
+          grep -Fqx \
+            "tests/unit/test_memory_reinterpretation_outbox.py::test_stale_claim_fails_closed_before_hermes_delivery_or_durable_retry" \
+            <<<"$memory_reinterpretation_ids"
           pytest tests/unit/test_memory_reinterpretation_outbox.py -v
           test "$(pytest --collect-only -q tests/unit/test_scanner_keyterms.py | grep -c '::')" -eq 10
           pytest tests/unit/test_scanner_keyterms.py -v

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -60,6 +60,7 @@ on:
       - "backend/tests/unit/test_invitation_redemption.py"
       - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_content_write_fence.py"
+      - "backend/tests/unit/test_trace_deletion_finality.py"
       - "backend/tests/unit/test_pilot_invite_admin.py"
       - "backend/tests/unit/test_authority_writer_guard.py"
       - "backend/tests/unit/test_ella_onboarding_contract.py"
@@ -128,6 +129,7 @@ on:
       - "backend/tests/unit/test_invitation_redemption.py"
       - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_content_write_fence.py"
+      - "backend/tests/unit/test_trace_deletion_finality.py"
       - "backend/tests/unit/test_pilot_invite_admin.py"
       - "backend/tests/unit/test_authority_writer_guard.py"
       - "backend/tests/unit/test_ella_onboarding_contract.py"
@@ -243,6 +245,7 @@ jobs:
               tests/unit/test_invitation_redemption.py \
               tests/unit/test_account_deletion.py \
               tests/unit/test_content_write_fence.py \
+              tests/unit/test_trace_deletion_finality.py \
               tests/unit/test_synthetic_invite_admin.py \
               tests/unit/test_pilot_invite_admin.py \
               tests/unit/test_authority_writer_guard.py \
@@ -253,12 +256,13 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 171
+          test "$collected" -eq 177
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
               tests/unit/test_account_deletion.py \
               tests/unit/test_content_write_fence.py \
+              tests/unit/test_trace_deletion_finality.py \
               tests/unit/test_pilot_invite_admin.py \
               tests/unit/test_authority_writer_guard.py \
               tests/unit/test_ella_onboarding_contract.py \
@@ -274,6 +278,7 @@ jobs:
             "tests/unit/test_account_deletion.py::test_deletion_service_returns_typed_pending_and_preserves_auth_retry"
             "tests/unit/test_account_deletion.py::test_deletion_service_completes_missing_external_profile_and_is_repeatable"
             "tests/unit/test_account_deletion.py::test_deletion_service_converts_firestore_and_firebase_failures_to_resumable_state"
+            "tests/unit/test_account_deletion.py::test_deletion_service_never_reports_success_when_routing_trace_purge_is_unavailable"
             "tests/unit/test_account_deletion.py::test_firebase_delete_lost_ack_converges_only_after_authoritative_absence"
             "tests/unit/test_account_deletion.py::test_production_route_uses_legacy_resumable_deletion_when_ella_authority_is_explicitly_disabled"
             "tests/unit/test_account_deletion.py::test_production_route_fails_closed_before_destructive_work_when_enabled_authority_is_unavailable"
@@ -289,6 +294,10 @@ jobs:
             "tests/unit/test_content_write_fence.py::test_mounted_nested_database_routes_release_admission_connection_before_handler[entitlement]"
             "tests/unit/test_content_write_fence.py::test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact"
             "tests/unit/test_content_write_fence.py::test_request_fence_covers_streamed_commit_after_route_returns"
+            "tests/unit/test_trace_deletion_finality.py::test_trace_probe_positive_control_reproduces_old_mounted_escape"
+            "tests/unit/test_trace_deletion_finality.py::test_mounted_trace_persistence_is_drained_purged_and_tombstoned"
+            "tests/unit/test_trace_deletion_finality.py::test_trace_reads_require_exact_authenticated_subject"
+            "tests/unit/test_trace_deletion_finality.py::test_concurrent_trace_requests_release_request_lifetimes_before_bounded_pool_progress"
             "tests/unit/test_ella_onboarding_contract.py::test_authority_rejection_precedes_identity_and_repository_side_effects"
             "tests/unit/test_pilot_invite_admin.py::test_self_hosted_admission_uses_verified_email_and_current_policy_without_uid_allowlist"
             "tests/unit/test_pilot_invite_admin.py::test_scoped_email_interface_keeps_plaintext_out_of_argv_receipts_logs_and_errors"
@@ -306,6 +315,7 @@ jobs:
             "tests/postgres/test_invitation_redemption_postgres.py::test_self_hosted_revoke_invalidates_authority_and_blocks_reactivation"
             "tests/postgres/test_invitation_redemption_postgres.py::test_self_hosted_post_provider_revoke_race_cannot_publish_or_retry"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_atomically_quarantines_authority_releases_capacity_and_retries"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_routing_trace_purge_is_exact_repeatable_and_retains_other_users"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_mid_transaction_failure_rolls_back_every_authority_and_capacity_write"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_service_handles_partial_provision_and_repeat_without_operator"
             "tests/postgres/test_invitation_redemption_postgres.py::test_lost_provider_ack_persists_unproven_attempt_blocks_firebase_and_retry_converges"
@@ -320,6 +330,7 @@ jobs:
             tests/unit/test_invitation_redemption.py \
             tests/unit/test_account_deletion.py \
             tests/unit/test_content_write_fence.py \
+            tests/unit/test_trace_deletion_finality.py \
             tests/unit/test_synthetic_invite_admin.py \
             tests/unit/test_pilot_invite_admin.py \
             tests/unit/test_authority_writer_guard.py \

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -189,7 +189,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 155
+          test "$collected" -eq 156
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "backend/contracts/authority_advisory_lock_v1.json"
+      - "backend/database/account_deletion.py"
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/ella_provisioning.py"
       - "backend/database/invitation_operator.py"
@@ -21,6 +22,12 @@ on:
       - "backend/ella/services/hermes_cloud_policy.py"
       - "backend/ella/utils/provision_authority.py"
       - "backend/ella/routers/voice.py"
+      - "backend/ella/services/account_deletion.py"
+      - "backend/database/firestore_account_deletion.py"
+      - "backend/ella/services/ai_consent.py"
+      - "backend/database/users.py"
+      - "backend/routers/users.py"
+      - "backend/utils/other/endpoints.py"
       - "backend/ella/__init__.py"
       - "backend/migrations/011_create_invitation_redemption.sql"
       - "backend/migrations/012_create_account_profile_runtime_targets.sql"
@@ -32,6 +39,7 @@ on:
       - "backend/ella/docs/INVITE_REDEMPTION_CONTROL_PLANE.md"
       - "backend/ella/docs/SYNTHETIC_INVITE_OPERATOR.md"
       - "backend/tests/unit/test_invitation_redemption.py"
+      - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_pilot_invite_admin.py"
       - "backend/tests/unit/test_authority_writer_guard.py"
       - "backend/tests/unit/test_ella_onboarding_contract.py"
@@ -44,6 +52,7 @@ on:
     branches: [main]
     paths:
       - "backend/contracts/authority_advisory_lock_v1.json"
+      - "backend/database/account_deletion.py"
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/ella_provisioning.py"
       - "backend/database/invitation_operator.py"
@@ -61,6 +70,12 @@ on:
       - "backend/ella/services/hermes_cloud_policy.py"
       - "backend/ella/utils/provision_authority.py"
       - "backend/ella/routers/voice.py"
+      - "backend/ella/services/account_deletion.py"
+      - "backend/database/firestore_account_deletion.py"
+      - "backend/ella/services/ai_consent.py"
+      - "backend/database/users.py"
+      - "backend/routers/users.py"
+      - "backend/utils/other/endpoints.py"
       - "backend/ella/__init__.py"
       - "backend/migrations/011_create_invitation_redemption.sql"
       - "backend/migrations/012_create_account_profile_runtime_targets.sql"
@@ -72,6 +87,7 @@ on:
       - "backend/ella/docs/INVITE_REDEMPTION_CONTROL_PLANE.md"
       - "backend/ella/docs/SYNTHETIC_INVITE_OPERATOR.md"
       - "backend/tests/unit/test_invitation_redemption.py"
+      - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_pilot_invite_admin.py"
       - "backend/tests/unit/test_authority_writer_guard.py"
       - "backend/tests/unit/test_ella_onboarding_contract.py"
@@ -130,7 +146,10 @@ jobs:
       - name: Compile invite and entitlement modules
         run: >-
           python -m py_compile
+          database/account_deletion.py
           database/authority_advisory_lock.py
+          database/firestore_account_deletion.py
+          database/users.py
           database/ella_provisioning.py
           database/invitation_operator.py
           database/invitations.py
@@ -140,12 +159,15 @@ jobs:
           ella/routers/invites.py
           ella/routers/onboarding.py
           ella/routers/ai_consent.py
+          ella/services/account_deletion.py
           ella/services/consent_authority.py
           ella/services/invitation_authority.py
           ella/services/provisioning.py
           ella/services/runtime_resolver.py
           ella/services/hermes_cloud_policy.py
           ella/utils/provision_authority.py
+          routers/users.py
+          utils/other/endpoints.py
           scripts/synthetic_invite_admin.py
           scripts/pilot_invite_admin.py
 
@@ -154,6 +176,7 @@ jobs:
           collected="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
+              tests/unit/test_account_deletion.py \
               tests/unit/test_synthetic_invite_admin.py \
               tests/unit/test_pilot_invite_admin.py \
               tests/unit/test_authority_writer_guard.py \
@@ -164,10 +187,11 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 139
+          test "$collected" -eq 148
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
+              tests/unit/test_account_deletion.py \
               tests/unit/test_pilot_invite_admin.py \
               tests/unit/test_authority_writer_guard.py \
               tests/unit/test_ella_onboarding_contract.py \
@@ -178,6 +202,12 @@ jobs:
           )"
           required_ids=(
             "tests/unit/test_invitation_redemption.py::test_redeem_rejects_unverified_firebase_email_before_authority_or_database"
+            "tests/unit/test_account_deletion.py::test_firestore_delete_is_idempotent_and_resumes_after_partial_failure"
+            "tests/unit/test_account_deletion.py::test_authenticated_route_delegates_to_the_resumable_deletion_service"
+            "tests/unit/test_account_deletion.py::test_deletion_service_returns_typed_pending_and_preserves_auth_retry"
+            "tests/unit/test_account_deletion.py::test_deletion_service_completes_missing_external_profile_and_is_repeatable"
+            "tests/unit/test_account_deletion.py::test_deletion_service_converts_firestore_and_firebase_failures_to_resumable_state"
+            "tests/unit/test_account_deletion.py::test_firebase_delete_lost_ack_converges_only_after_authoritative_absence"
             "tests/unit/test_ella_onboarding_contract.py::test_authority_rejection_precedes_identity_and_repository_side_effects"
             "tests/unit/test_pilot_invite_admin.py::test_self_hosted_admission_uses_verified_email_and_current_policy_without_uid_allowlist"
             "tests/unit/test_pilot_invite_admin.py::test_scoped_email_interface_keeps_plaintext_out_of_argv_receipts_logs_and_errors"
@@ -194,6 +224,9 @@ jobs:
             "tests/postgres/test_invitation_redemption_postgres.py::test_self_hosted_runtime_resolution_is_invitation_authoritative_and_exact"
             "tests/postgres/test_invitation_redemption_postgres.py::test_self_hosted_revoke_invalidates_authority_and_blocks_reactivation"
             "tests/postgres/test_invitation_redemption_postgres.py::test_self_hosted_post_provider_revoke_race_cannot_publish_or_retry"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_atomically_quarantines_authority_releases_capacity_and_retries"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_mid_transaction_failure_rolls_back_every_authority_and_capacity_write"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_service_handles_partial_provision_and_repeat_without_operator"
             "tests/postgres/test_runtime_migration_atomicity_postgres.py::test_migration_015_upgrades_multi_redemption_app_review_history_atomically"
           )
           for required_id in "${required_ids[@]}"; do
@@ -201,6 +234,7 @@ jobs:
           done
           pytest \
             tests/unit/test_invitation_redemption.py \
+            tests/unit/test_account_deletion.py \
             tests/unit/test_synthetic_invite_admin.py \
             tests/unit/test_pilot_invite_admin.py \
             tests/unit/test_authority_writer_guard.py \

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -8,6 +8,7 @@ on:
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/content_write_fence.py"
       - "backend/database/firestore_account_deletion.py"
+      - "backend/database/memory_reinterpretations.py"
       - "backend/routers/action_items.py"
       - "backend/routers/apps.py"
       - "backend/routers/chat.py"
@@ -34,6 +35,7 @@ on:
       - "backend/ella/routers/invites.py"
       - "backend/ella/routers/onboarding.py"
       - "backend/ella/routers/ai_consent.py"
+      - "backend/ella/routers/canonical_events.py"
       - "backend/ella/services/consent_authority.py"
       - "backend/ella/services/invitation_authority.py"
       - "backend/ella/services/provisioning.py"
@@ -43,9 +45,13 @@ on:
       - "backend/ella/routers/voice.py"
       - "backend/ella/services/account_deletion.py"
       - "backend/ella/services/ai_consent.py"
+      - "backend/ella/services/hermes_cloud_enrichment_outbox.py"
+      - "backend/ella/services/memory_reinterpretation.py"
       - "backend/database/users.py"
       - "backend/routers/users.py"
       - "backend/utils/other/endpoints.py"
+      - "backend/utils/ella/canonical_omi.py"
+      - "backend/scripts/ella_memory_e2e_smoke.py"
       - "backend/ella/__init__.py"
       - "backend/migrations/011_create_invitation_redemption.sql"
       - "backend/migrations/012_create_account_profile_runtime_targets.sql"
@@ -78,6 +84,7 @@ on:
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/content_write_fence.py"
       - "backend/database/firestore_account_deletion.py"
+      - "backend/database/memory_reinterpretations.py"
       - "backend/routers/action_items.py"
       - "backend/routers/apps.py"
       - "backend/routers/chat.py"
@@ -104,6 +111,7 @@ on:
       - "backend/ella/routers/invites.py"
       - "backend/ella/routers/onboarding.py"
       - "backend/ella/routers/ai_consent.py"
+      - "backend/ella/routers/canonical_events.py"
       - "backend/ella/services/consent_authority.py"
       - "backend/ella/services/invitation_authority.py"
       - "backend/ella/services/provisioning.py"
@@ -113,9 +121,13 @@ on:
       - "backend/ella/routers/voice.py"
       - "backend/ella/services/account_deletion.py"
       - "backend/ella/services/ai_consent.py"
+      - "backend/ella/services/hermes_cloud_enrichment_outbox.py"
+      - "backend/ella/services/memory_reinterpretation.py"
       - "backend/database/users.py"
       - "backend/routers/users.py"
       - "backend/utils/other/endpoints.py"
+      - "backend/utils/ella/canonical_omi.py"
+      - "backend/scripts/ella_memory_e2e_smoke.py"
       - "backend/ella/__init__.py"
       - "backend/migrations/011_create_invitation_redemption.sql"
       - "backend/migrations/012_create_account_profile_runtime_targets.sql"
@@ -183,6 +195,7 @@ jobs:
         run: >-
           python -m pip install
           "asyncpg==0.31.0"
+          "black==24.8.0"
           "fastapi==0.112.0"
           "firebase-admin==6.5.0"
           "httpx==0.28.0"
@@ -201,6 +214,7 @@ jobs:
           database/authority_advisory_lock.py
           database/content_write_fence.py
           database/firestore_account_deletion.py
+          database/memory_reinterpretations.py
           routers/action_items.py
           routers/apps.py
           routers/chat.py
@@ -228,7 +242,11 @@ jobs:
           ella/routers/invites.py
           ella/routers/onboarding.py
           ella/routers/ai_consent.py
+          ella/routers/canonical_events.py
           ella/services/account_deletion.py
+          ella/services/ai_consent.py
+          ella/services/hermes_cloud_enrichment_outbox.py
+          ella/services/memory_reinterpretation.py
           ella/services/consent_authority.py
           ella/services/invitation_authority.py
           ella/services/provisioning.py
@@ -237,8 +255,30 @@ jobs:
           ella/utils/provision_authority.py
           routers/users.py
           utils/other/endpoints.py
+          utils/ella/canonical_omi.py
+          scripts/ella_memory_e2e_smoke.py
           scripts/synthetic_invite_admin.py
           scripts/pilot_invite_admin.py
+
+      - name: Validate exact changed Python formatting
+        run: >-
+          black --check --line-length 120 --skip-string-normalization
+          database/account_deletion.py
+          database/content_write_fence.py
+          database/memory_reinterpretations.py
+          ella/routers/canonical_events.py
+          ella/services/account_deletion.py
+          ella/services/ai_consent.py
+          ella/services/hermes_cloud_enrichment_outbox.py
+          ella/services/memory_reinterpretation.py
+          scripts/ella_memory_e2e_smoke.py
+          utils/ella/canonical_omi.py
+          tests/unit/test_account_deletion.py
+          tests/unit/test_content_write_fence.py
+          tests/unit/test_durable_worker_deletion_finality.py
+          tests/unit/test_trace_deletion_finality.py
+          tests/unit/test_hermes_cloud_enrichment_outbox.py
+          tests/postgres/test_invitation_redemption_postgres.py
 
       - name: Run unit and PostgreSQL security tests
         run: |
@@ -259,7 +299,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 185
+          test "$collected" -eq 194
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
@@ -283,6 +323,7 @@ jobs:
             "tests/unit/test_account_deletion.py::test_deletion_service_completes_missing_external_profile_and_is_repeatable"
             "tests/unit/test_account_deletion.py::test_deletion_service_converts_firestore_and_firebase_failures_to_resumable_state"
             "tests/unit/test_account_deletion.py::test_deletion_service_never_reports_success_when_routing_trace_purge_is_unavailable"
+            "tests/unit/test_account_deletion.py::test_canonical_ledger_purge_is_resumable_and_precedes_firebase_last"
             "tests/unit/test_account_deletion.py::test_firebase_delete_lost_ack_converges_only_after_authoritative_absence"
             "tests/unit/test_account_deletion.py::test_production_route_uses_legacy_resumable_deletion_when_ella_authority_is_explicitly_disabled"
             "tests/unit/test_account_deletion.py::test_production_route_fails_closed_before_destructive_work_when_enabled_authority_is_unavailable"
@@ -299,6 +340,13 @@ jobs:
             "tests/unit/test_content_write_fence.py::test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact"
             "tests/unit/test_content_write_fence.py::test_backend_mutation_and_raw_launch_inventory_covers_startup_services_and_utilities"
             "tests/unit/test_content_write_fence.py::test_backend_inventory_positive_controls_reject_startup_raw_task_and_unfenced_uid_writer"
+            "tests/unit/test_content_write_fence.py::test_threaded_mutation_stale_token_is_joined_before_failure"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_positive_control_legacy_mounted_canonical_route_writes_after_tombstone"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_mounted_canonical_auth_drain_exact_purge_firebase_last_and_retry"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[success]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[error]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[timeout]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_memory_proposal_thread_before_deletion"
             "tests/unit/test_durable_worker_deletion_finality.py::test_startup_enrichment_worker_is_drained_purged_and_tombstone_denied[True]"
             "tests/unit/test_durable_worker_deletion_finality.py::test_startup_enrichment_worker_is_drained_purged_and_tombstone_denied[False]"
             "tests/unit/test_durable_worker_deletion_finality.py::test_startup_memory_worker_is_drained_purged_and_tombstone_denied[True]"
@@ -326,6 +374,7 @@ jobs:
             "tests/postgres/test_invitation_redemption_postgres.py::test_self_hosted_post_provider_revoke_race_cannot_publish_or_retry"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_atomically_quarantines_authority_releases_capacity_and_retries"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_routing_trace_purge_is_exact_repeatable_and_retains_other_users"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_canonical_ledger_positive_control_exact_purge_rollback_and_retry"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_mid_transaction_failure_rolls_back_every_authority_and_capacity_write"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_service_handles_partial_provision_and_repeat_without_operator"
             "tests/postgres/test_invitation_redemption_postgres.py::test_lost_provider_ack_persists_unproven_attempt_blocks_firebase_and_retry_converges"
@@ -333,6 +382,7 @@ jobs:
             "tests/postgres/test_runtime_migration_atomicity_postgres.py::test_migration_prerequisite_failure_is_atomic[017_add_provider_attempt_deletion_fence.sql-leaked_relations4]"
             "tests/postgres/test_runtime_migration_atomicity_postgres.py::test_migration_015_upgrades_multi_redemption_app_review_history_atomically"
           )
+          test "${#required_ids[@]}" -eq 65
           for required_id in "${required_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$collected_ids"
           done

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -299,7 +299,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 194
+          test "$collected" -eq 198
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
@@ -341,12 +341,16 @@ jobs:
             "tests/unit/test_content_write_fence.py::test_backend_mutation_and_raw_launch_inventory_covers_startup_services_and_utilities"
             "tests/unit/test_content_write_fence.py::test_backend_inventory_positive_controls_reject_startup_raw_task_and_unfenced_uid_writer"
             "tests/unit/test_content_write_fence.py::test_threaded_mutation_stale_token_is_joined_before_failure"
+            "tests/unit/test_content_write_fence.py::test_threaded_mutation_survives_repeated_cancellation_until_thread_terminal"
             "tests/unit/test_durable_worker_deletion_finality.py::test_positive_control_legacy_mounted_canonical_route_writes_after_tombstone"
             "tests/unit/test_durable_worker_deletion_finality.py::test_mounted_canonical_auth_drain_exact_purge_firebase_last_and_retry"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_positive_control_legacy_two_stops_release_enrichment_writer_before_thread_terminal"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_process_restart_retains_orphan_token_until_exact_terminal_proof_recovery"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[success]"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[error]"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[timeout]"
-            "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_memory_proposal_thread_before_deletion"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_memory_thread_before_deletion[proposal]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_memory_thread_before_deletion[correction]"
             "tests/unit/test_durable_worker_deletion_finality.py::test_startup_enrichment_worker_is_drained_purged_and_tombstone_denied[True]"
             "tests/unit/test_durable_worker_deletion_finality.py::test_startup_enrichment_worker_is_drained_purged_and_tombstone_denied[False]"
             "tests/unit/test_durable_worker_deletion_finality.py::test_startup_memory_worker_is_drained_purged_and_tombstone_denied[True]"
@@ -382,7 +386,7 @@ jobs:
             "tests/postgres/test_runtime_migration_atomicity_postgres.py::test_migration_prerequisite_failure_is_atomic[017_add_provider_attempt_deletion_fence.sql-leaked_relations4]"
             "tests/postgres/test_runtime_migration_atomicity_postgres.py::test_migration_015_upgrades_multi_redemption_app_review_history_atomically"
           )
-          test "${#required_ids[@]}" -eq 65
+          test "${#required_ids[@]}" -eq 69
           for required_id in "${required_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$collected_ids"
           done

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -34,6 +34,7 @@ on:
       - "backend/migrations/013_create_managed_cloud_consent_authority.sql"
       - "backend/migrations/014_add_synthetic_invitation_operator_audit.sql"
       - "backend/migrations/015_add_invitation_allowed_email_hash.sql"
+      - "backend/migrations/017_add_provider_attempt_deletion_fence.sql"
       - "backend/scripts/pilot_invite_admin.py"
       - "backend/scripts/synthetic_invite_admin.py"
       - "backend/ella/docs/INVITE_REDEMPTION_CONTROL_PLANE.md"
@@ -82,6 +83,7 @@ on:
       - "backend/migrations/013_create_managed_cloud_consent_authority.sql"
       - "backend/migrations/014_add_synthetic_invitation_operator_audit.sql"
       - "backend/migrations/015_add_invitation_allowed_email_hash.sql"
+      - "backend/migrations/017_add_provider_attempt_deletion_fence.sql"
       - "backend/scripts/pilot_invite_admin.py"
       - "backend/scripts/synthetic_invite_admin.py"
       - "backend/ella/docs/INVITE_REDEMPTION_CONTROL_PLANE.md"
@@ -187,7 +189,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 148
+          test "$collected" -eq 155
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
@@ -208,6 +210,10 @@ jobs:
             "tests/unit/test_account_deletion.py::test_deletion_service_completes_missing_external_profile_and_is_repeatable"
             "tests/unit/test_account_deletion.py::test_deletion_service_converts_firestore_and_firebase_failures_to_resumable_state"
             "tests/unit/test_account_deletion.py::test_firebase_delete_lost_ack_converges_only_after_authoritative_absence"
+            "tests/unit/test_account_deletion.py::test_production_route_uses_legacy_resumable_deletion_when_ella_authority_is_explicitly_disabled"
+            "tests/unit/test_account_deletion.py::test_production_route_fails_closed_before_destructive_work_when_enabled_authority_is_unavailable"
+            "tests/unit/test_account_deletion.py::test_retained_firebase_subject_is_fenced_from_authenticated_content_writes"
+            "tests/unit/test_account_deletion.py::test_explicit_legacy_mode_does_not_probe_optional_ella_authority_for_content_writes"
             "tests/unit/test_ella_onboarding_contract.py::test_authority_rejection_precedes_identity_and_repository_side_effects"
             "tests/unit/test_pilot_invite_admin.py::test_self_hosted_admission_uses_verified_email_and_current_policy_without_uid_allowlist"
             "tests/unit/test_pilot_invite_admin.py::test_scoped_email_interface_keeps_plaintext_out_of_argv_receipts_logs_and_errors"
@@ -227,6 +233,9 @@ jobs:
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_atomically_quarantines_authority_releases_capacity_and_retries"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_mid_transaction_failure_rolls_back_every_authority_and_capacity_write"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_service_handles_partial_provision_and_repeat_without_operator"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_lost_provider_ack_persists_unproven_attempt_blocks_firebase_and_retry_converges"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_deletion_tombstone_serializes_inflight_provider_writer_and_quarantines_photon_immediately"
+            "tests/postgres/test_runtime_migration_atomicity_postgres.py::test_migration_prerequisite_failure_is_atomic[017_add_provider_attempt_deletion_fence.sql-leaked_relations4]"
             "tests/postgres/test_runtime_migration_atomicity_postgres.py::test_migration_015_upgrades_multi_redemption_app_review_history_atomically"
           )
           for required_id in "${required_ids[@]}"; do

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -8,6 +8,7 @@ on:
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/content_write_fence.py"
       - "backend/database/content_write_recovery.py"
+      - "backend/database/content_write_recovery_authority.py"
       - "backend/database/content_writer_owner.py"
       - "backend/database/firestore_account_deletion.py"
       - "backend/database/memory_reinterpretations.py"
@@ -71,6 +72,9 @@ on:
       - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_content_write_fence.py"
       - "backend/tests/unit/test_durable_worker_deletion_finality.py"
+      - "backend/tests/conftest.py"
+      - "backend/tests/support/__init__.py"
+      - "backend/tests/support/content_writer_owner_nonlinux.py"
       - "backend/tests/unit/test_hermes_cloud_enrichment_outbox.py"
       - "backend/tests/unit/test_trace_deletion_finality.py"
       - "backend/tests/unit/test_pilot_invite_admin.py"
@@ -89,6 +93,7 @@ on:
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/content_write_fence.py"
       - "backend/database/content_write_recovery.py"
+      - "backend/database/content_write_recovery_authority.py"
       - "backend/database/content_writer_owner.py"
       - "backend/database/firestore_account_deletion.py"
       - "backend/database/memory_reinterpretations.py"
@@ -152,6 +157,9 @@ on:
       - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_content_write_fence.py"
       - "backend/tests/unit/test_durable_worker_deletion_finality.py"
+      - "backend/tests/conftest.py"
+      - "backend/tests/support/__init__.py"
+      - "backend/tests/support/content_writer_owner_nonlinux.py"
       - "backend/tests/unit/test_hermes_cloud_enrichment_outbox.py"
       - "backend/tests/unit/test_trace_deletion_finality.py"
       - "backend/tests/unit/test_pilot_invite_admin.py"
@@ -224,6 +232,7 @@ jobs:
           database/authority_advisory_lock.py
           database/content_write_fence.py
           database/content_write_recovery.py
+          database/content_write_recovery_authority.py
           database/content_writer_owner.py
           database/firestore_account_deletion.py
           database/memory_reinterpretations.py
@@ -272,6 +281,9 @@ jobs:
           scripts/synthetic_invite_admin.py
           scripts/pilot_invite_admin.py
           scripts/content_writer_recovery.py
+          tests/conftest.py
+          tests/support/__init__.py
+          tests/support/content_writer_owner_nonlinux.py
 
       - name: Validate exact changed Python formatting
         run: >-
@@ -279,6 +291,7 @@ jobs:
           database/account_deletion.py
           database/content_write_fence.py
           database/content_write_recovery.py
+          database/content_write_recovery_authority.py
           database/content_writer_owner.py
           database/memory_reinterpretations.py
           ella/routers/canonical_events.py
@@ -295,6 +308,9 @@ jobs:
           tests/unit/test_hermes_cloud_enrichment_outbox.py
           tests/postgres/test_invitation_redemption_postgres.py
           scripts/content_writer_recovery.py
+          tests/conftest.py
+          tests/support/__init__.py
+          tests/support/content_writer_owner_nonlinux.py
 
       - name: Run unit and PostgreSQL security tests
         run: |
@@ -316,7 +332,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 215
+          test "$collected" -eq 222
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
@@ -371,6 +387,13 @@ jobs:
             "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_surface_rejects_stale_cross_uid_ownerless_and_actual_unprivileged_invocation"
             "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_surface_rejects_cross_generation_replacement_after_real_terminal_proof"
             "tests/unit/test_durable_worker_deletion_finality.py::test_concurrent_recovery_surface_is_exact_and_idempotent"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_concurrent_different_token_compaction_keeps_only_latest_retry_authority"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_receipt_is_strictly_bounded_across_five_thousand_cycles_and_deletion_converges"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_stale_receipt_or_hash_collision_never_releases_a_different_writer"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_pinned_recovery_authority_ignores_hostile_ambient_project_and_credentials"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_authority_rejects_emulator_mismatch_and_symlink_before_credentials"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_authority_wrong_receipt_or_credential_project_loads_no_credentials"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_production_recovery_modules_refuse_darwin_before_firestore_calls"
             "tests/unit/test_hermes_cloud_enrichment_outbox.py::test_firestore_repository_rejects_post_tombstone_claim_complete_fail_and_retry"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[success]"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[error]"
@@ -412,7 +435,7 @@ jobs:
             "tests/postgres/test_runtime_migration_atomicity_postgres.py::test_migration_prerequisite_failure_is_atomic[017_add_provider_attempt_deletion_fence.sql-leaked_relations4]"
             "tests/postgres/test_runtime_migration_atomicity_postgres.py::test_migration_015_upgrades_multi_redemption_app_review_history_atomically"
           )
-          test "${#required_ids[@]}" -eq 77
+          test "${#required_ids[@]}" -eq 84
           for required_id in "${required_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$collected_ids"
           done

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -7,6 +7,8 @@ on:
       - "backend/database/account_deletion.py"
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/content_write_fence.py"
+      - "backend/database/content_write_recovery.py"
+      - "backend/database/content_writer_owner.py"
       - "backend/database/firestore_account_deletion.py"
       - "backend/database/memory_reinterpretations.py"
       - "backend/routers/action_items.py"
@@ -61,12 +63,15 @@ on:
       - "backend/migrations/017_add_provider_attempt_deletion_fence.sql"
       - "backend/scripts/pilot_invite_admin.py"
       - "backend/scripts/synthetic_invite_admin.py"
+      - "backend/scripts/content_writer_recovery.py"
+      - "backend/ella/docs/CONTENT_WRITER_RECOVERY.md"
       - "backend/ella/docs/INVITE_REDEMPTION_CONTROL_PLANE.md"
       - "backend/ella/docs/SYNTHETIC_INVITE_OPERATOR.md"
       - "backend/tests/unit/test_invitation_redemption.py"
       - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_content_write_fence.py"
       - "backend/tests/unit/test_durable_worker_deletion_finality.py"
+      - "backend/tests/unit/test_hermes_cloud_enrichment_outbox.py"
       - "backend/tests/unit/test_trace_deletion_finality.py"
       - "backend/tests/unit/test_pilot_invite_admin.py"
       - "backend/tests/unit/test_authority_writer_guard.py"
@@ -83,6 +88,8 @@ on:
       - "backend/database/account_deletion.py"
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/content_write_fence.py"
+      - "backend/database/content_write_recovery.py"
+      - "backend/database/content_writer_owner.py"
       - "backend/database/firestore_account_deletion.py"
       - "backend/database/memory_reinterpretations.py"
       - "backend/routers/action_items.py"
@@ -137,12 +144,15 @@ on:
       - "backend/migrations/017_add_provider_attempt_deletion_fence.sql"
       - "backend/scripts/pilot_invite_admin.py"
       - "backend/scripts/synthetic_invite_admin.py"
+      - "backend/scripts/content_writer_recovery.py"
+      - "backend/ella/docs/CONTENT_WRITER_RECOVERY.md"
       - "backend/ella/docs/INVITE_REDEMPTION_CONTROL_PLANE.md"
       - "backend/ella/docs/SYNTHETIC_INVITE_OPERATOR.md"
       - "backend/tests/unit/test_invitation_redemption.py"
       - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_content_write_fence.py"
       - "backend/tests/unit/test_durable_worker_deletion_finality.py"
+      - "backend/tests/unit/test_hermes_cloud_enrichment_outbox.py"
       - "backend/tests/unit/test_trace_deletion_finality.py"
       - "backend/tests/unit/test_pilot_invite_admin.py"
       - "backend/tests/unit/test_authority_writer_guard.py"
@@ -213,6 +223,8 @@ jobs:
           database/account_deletion.py
           database/authority_advisory_lock.py
           database/content_write_fence.py
+          database/content_write_recovery.py
+          database/content_writer_owner.py
           database/firestore_account_deletion.py
           database/memory_reinterpretations.py
           routers/action_items.py
@@ -259,12 +271,15 @@ jobs:
           scripts/ella_memory_e2e_smoke.py
           scripts/synthetic_invite_admin.py
           scripts/pilot_invite_admin.py
+          scripts/content_writer_recovery.py
 
       - name: Validate exact changed Python formatting
         run: >-
           black --check --line-length 120 --skip-string-normalization
           database/account_deletion.py
           database/content_write_fence.py
+          database/content_write_recovery.py
+          database/content_writer_owner.py
           database/memory_reinterpretations.py
           ella/routers/canonical_events.py
           ella/services/account_deletion.py
@@ -279,6 +294,7 @@ jobs:
           tests/unit/test_trace_deletion_finality.py
           tests/unit/test_hermes_cloud_enrichment_outbox.py
           tests/postgres/test_invitation_redemption_postgres.py
+          scripts/content_writer_recovery.py
 
       - name: Run unit and PostgreSQL security tests
         run: |
@@ -288,6 +304,7 @@ jobs:
               tests/unit/test_account_deletion.py \
               tests/unit/test_content_write_fence.py \
               tests/unit/test_durable_worker_deletion_finality.py \
+              tests/unit/test_hermes_cloud_enrichment_outbox.py \
               tests/unit/test_trace_deletion_finality.py \
               tests/unit/test_synthetic_invite_admin.py \
               tests/unit/test_pilot_invite_admin.py \
@@ -299,13 +316,14 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 198
+          test "$collected" -eq 215
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
               tests/unit/test_account_deletion.py \
               tests/unit/test_content_write_fence.py \
               tests/unit/test_durable_worker_deletion_finality.py \
+              tests/unit/test_hermes_cloud_enrichment_outbox.py \
               tests/unit/test_trace_deletion_finality.py \
               tests/unit/test_pilot_invite_admin.py \
               tests/unit/test_authority_writer_guard.py \
@@ -345,7 +363,15 @@ jobs:
             "tests/unit/test_durable_worker_deletion_finality.py::test_positive_control_legacy_mounted_canonical_route_writes_after_tombstone"
             "tests/unit/test_durable_worker_deletion_finality.py::test_mounted_canonical_auth_drain_exact_purge_firebase_last_and_retry"
             "tests/unit/test_durable_worker_deletion_finality.py::test_positive_control_legacy_two_stops_release_enrichment_writer_before_thread_terminal"
-            "tests/unit/test_durable_worker_deletion_finality.py::test_process_restart_retains_orphan_token_until_exact_terminal_proof_recovery"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_process_restart_uses_root_cli_and_real_kernel_terminal_proof_before_firebase_last"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_surface_rejects_other_boundary_and_pid_reuse[host-account_writer_recovery_host_mismatch]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_surface_rejects_other_boundary_and_pid_reuse[boot-account_writer_recovery_boot_mismatch]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_surface_rejects_other_boundary_and_pid_reuse[namespace-account_writer_recovery_pid_namespace_mismatch]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_surface_rejects_other_boundary_and_pid_reuse[start-account_writer_recovery_pid_reused]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_surface_rejects_stale_cross_uid_ownerless_and_actual_unprivileged_invocation"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_recovery_surface_rejects_cross_generation_replacement_after_real_terminal_proof"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_concurrent_recovery_surface_is_exact_and_idempotent"
+            "tests/unit/test_hermes_cloud_enrichment_outbox.py::test_firestore_repository_rejects_post_tombstone_claim_complete_fail_and_retry"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[success]"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[error]"
             "tests/unit/test_durable_worker_deletion_finality.py::test_stop_worker_joins_actual_enrichment_thread_before_deletion[timeout]"
@@ -386,7 +412,7 @@ jobs:
             "tests/postgres/test_runtime_migration_atomicity_postgres.py::test_migration_prerequisite_failure_is_atomic[017_add_provider_attempt_deletion_fence.sql-leaked_relations4]"
             "tests/postgres/test_runtime_migration_atomicity_postgres.py::test_migration_015_upgrades_multi_redemption_app_review_history_atomically"
           )
-          test "${#required_ids[@]}" -eq 69
+          test "${#required_ids[@]}" -eq 77
           for required_id in "${required_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$collected_ids"
           done
@@ -395,6 +421,7 @@ jobs:
             tests/unit/test_account_deletion.py \
             tests/unit/test_content_write_fence.py \
             tests/unit/test_durable_worker_deletion_finality.py \
+            tests/unit/test_hermes_cloud_enrichment_outbox.py \
             tests/unit/test_trace_deletion_finality.py \
             tests/unit/test_synthetic_invite_admin.py \
             tests/unit/test_pilot_invite_admin.py \

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -60,6 +60,7 @@ on:
       - "backend/tests/unit/test_invitation_redemption.py"
       - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_content_write_fence.py"
+      - "backend/tests/unit/test_durable_worker_deletion_finality.py"
       - "backend/tests/unit/test_trace_deletion_finality.py"
       - "backend/tests/unit/test_pilot_invite_admin.py"
       - "backend/tests/unit/test_authority_writer_guard.py"
@@ -129,6 +130,7 @@ on:
       - "backend/tests/unit/test_invitation_redemption.py"
       - "backend/tests/unit/test_account_deletion.py"
       - "backend/tests/unit/test_content_write_fence.py"
+      - "backend/tests/unit/test_durable_worker_deletion_finality.py"
       - "backend/tests/unit/test_trace_deletion_finality.py"
       - "backend/tests/unit/test_pilot_invite_admin.py"
       - "backend/tests/unit/test_authority_writer_guard.py"
@@ -245,6 +247,7 @@ jobs:
               tests/unit/test_invitation_redemption.py \
               tests/unit/test_account_deletion.py \
               tests/unit/test_content_write_fence.py \
+              tests/unit/test_durable_worker_deletion_finality.py \
               tests/unit/test_trace_deletion_finality.py \
               tests/unit/test_synthetic_invite_admin.py \
               tests/unit/test_pilot_invite_admin.py \
@@ -256,12 +259,13 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 177
+          test "$collected" -eq 185
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
               tests/unit/test_account_deletion.py \
               tests/unit/test_content_write_fence.py \
+              tests/unit/test_durable_worker_deletion_finality.py \
               tests/unit/test_trace_deletion_finality.py \
               tests/unit/test_pilot_invite_admin.py \
               tests/unit/test_authority_writer_guard.py \
@@ -286,13 +290,19 @@ jobs:
             "tests/unit/test_account_deletion.py::test_explicit_legacy_mode_does_not_probe_optional_ella_authority_for_content_writes"
             "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[True]"
             "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[False]"
-            "tests/unit/test_account_deletion.py::test_firestore_delete_removes_only_owned_top_level_import_jobs_and_retries"
+            "tests/unit/test_account_deletion.py::test_firestore_delete_removes_only_owned_top_level_jobs_and_retries"
             "tests/unit/test_content_write_fence.py::test_expired_registration_never_proves_a_live_writer_absent"
             "tests/unit/test_content_write_fence.py::test_detached_writer_transfers_child_registration_before_parent_release"
             "tests/unit/test_content_write_fence.py::test_mounted_limitless_worker_transfers_fence_until_actual_upsert_finishes"
             "tests/unit/test_content_write_fence.py::test_mounted_nested_database_routes_release_admission_connection_before_handler[consent]"
             "tests/unit/test_content_write_fence.py::test_mounted_nested_database_routes_release_admission_connection_before_handler[entitlement]"
             "tests/unit/test_content_write_fence.py::test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact"
+            "tests/unit/test_content_write_fence.py::test_backend_mutation_and_raw_launch_inventory_covers_startup_services_and_utilities"
+            "tests/unit/test_content_write_fence.py::test_backend_inventory_positive_controls_reject_startup_raw_task_and_unfenced_uid_writer"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_startup_enrichment_worker_is_drained_purged_and_tombstone_denied[True]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_startup_enrichment_worker_is_drained_purged_and_tombstone_denied[False]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_startup_memory_worker_is_drained_purged_and_tombstone_denied[True]"
+            "tests/unit/test_durable_worker_deletion_finality.py::test_startup_memory_worker_is_drained_purged_and_tombstone_denied[False]"
             "tests/unit/test_content_write_fence.py::test_request_fence_covers_streamed_commit_after_route_returns"
             "tests/unit/test_trace_deletion_finality.py::test_trace_probe_positive_control_reproduces_old_mounted_escape"
             "tests/unit/test_trace_deletion_finality.py::test_mounted_trace_persistence_is_drained_purged_and_tombstoned"
@@ -330,6 +340,7 @@ jobs:
             tests/unit/test_invitation_redemption.py \
             tests/unit/test_account_deletion.py \
             tests/unit/test_content_write_fence.py \
+            tests/unit/test_durable_worker_deletion_finality.py \
             tests/unit/test_trace_deletion_finality.py \
             tests/unit/test_synthetic_invite_admin.py \
             tests/unit/test_pilot_invite_admin.py \

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -11,6 +11,7 @@ on:
       - "backend/database/content_write_recovery_authority.py"
       - "backend/database/content_writer_owner.py"
       - "backend/database/firestore_account_deletion.py"
+      - "backend/database/redis_db.py"
       - "backend/database/memory_reinterpretations.py"
       - "backend/routers/action_items.py"
       - "backend/routers/apps.py"
@@ -96,6 +97,7 @@ on:
       - "backend/database/content_write_recovery_authority.py"
       - "backend/database/content_writer_owner.py"
       - "backend/database/firestore_account_deletion.py"
+      - "backend/database/redis_db.py"
       - "backend/database/memory_reinterpretations.py"
       - "backend/routers/action_items.py"
       - "backend/routers/apps.py"
@@ -235,6 +237,7 @@ jobs:
           database/content_write_recovery_authority.py
           database/content_writer_owner.py
           database/firestore_account_deletion.py
+          database/redis_db.py
           database/memory_reinterpretations.py
           routers/action_items.py
           routers/apps.py
@@ -289,6 +292,8 @@ jobs:
         run: >-
           black --check --line-length 120 --skip-string-normalization
           database/account_deletion.py
+          database/firestore_account_deletion.py
+          database/redis_db.py
           database/content_write_fence.py
           database/content_write_recovery.py
           database/content_write_recovery_authority.py
@@ -332,7 +337,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 222
+          test "$collected" -eq 230
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
@@ -365,7 +370,13 @@ jobs:
             "tests/unit/test_account_deletion.py::test_explicit_legacy_mode_does_not_probe_optional_ella_authority_for_content_writes"
             "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[True]"
             "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[False]"
-            "tests/unit/test_account_deletion.py::test_firestore_delete_removes_only_owned_top_level_jobs_and_retries"
+            "tests/unit/test_account_deletion.py::test_firestore_inventory_snapshot_covers_every_repository_owned_root"
+            "tests/unit/test_account_deletion.py::test_production_firestore_cleanup_removes_seeded_inventory_and_retains_other_uid"
+            "tests/unit/test_account_deletion.py::test_firestore_owned_collection_purge_is_bounded_across_multiple_batches"
+            "tests/unit/test_account_deletion.py::test_firestore_gate_fails_closed_when_known_inventory_entry_is_omitted[analytics]"
+            "tests/unit/test_account_deletion.py::test_firestore_gate_fails_closed_when_known_inventory_entry_is_omitted[tasks]"
+            "tests/unit/test_account_deletion.py::test_firestore_gate_positive_control_detects_new_uid_linked_top_level_collection"
+            "tests/unit/test_account_deletion.py::test_firestore_api_key_cache_failure_preserves_resumable_key_record"
             "tests/unit/test_content_write_fence.py::test_expired_registration_never_proves_a_live_writer_absent"
             "tests/unit/test_content_write_fence.py::test_detached_writer_transfers_child_registration_before_parent_release"
             "tests/unit/test_content_write_fence.py::test_mounted_limitless_worker_transfers_fence_until_actual_upsert_finishes"
@@ -431,11 +442,13 @@ jobs:
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_mid_transaction_failure_rolls_back_every_authority_and_capacity_write"
             "tests/postgres/test_invitation_redemption_postgres.py::test_account_deletion_service_handles_partial_provision_and_repeat_without_operator"
             "tests/postgres/test_invitation_redemption_postgres.py::test_lost_provider_ack_persists_unproven_attempt_blocks_firebase_and_retry_converges"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_provider_attempt_tombstone_trigger_allows_only_monotonic_terminal_proof"
+            "tests/postgres/test_invitation_redemption_postgres.py::test_provider_attempt_direct_writer_cannot_cross_finalization_count_read"
             "tests/postgres/test_invitation_redemption_postgres.py::test_deletion_tombstone_serializes_inflight_provider_writer_and_quarantines_photon_immediately"
             "tests/postgres/test_runtime_migration_atomicity_postgres.py::test_migration_prerequisite_failure_is_atomic[017_add_provider_attempt_deletion_fence.sql-leaked_relations4]"
             "tests/postgres/test_runtime_migration_atomicity_postgres.py::test_migration_015_upgrades_multi_redemption_app_review_history_atomically"
           )
-          test "${#required_ids[@]}" -eq 84
+          test "${#required_ids[@]}" -eq 92
           for required_id in "${required_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$collected_ids"
           done

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -7,10 +7,24 @@ on:
       - "backend/database/account_deletion.py"
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/content_write_fence.py"
+      - "backend/database/firestore_account_deletion.py"
+      - "backend/routers/action_items.py"
       - "backend/routers/apps.py"
+      - "backend/routers/chat.py"
+      - "backend/routers/developer.py"
+      - "backend/routers/imports.py"
       - "backend/routers/integration.py"
+      - "backend/routers/mcp.py"
       - "backend/routers/mcp_sse.py"
+      - "backend/routers/memories.py"
+      - "backend/routers/pusher.py"
+      - "backend/routers/sync.py"
+      - "backend/routers/transcribe.py"
+      - "backend/routers/wrapped.py"
       - "backend/routers/workflow.py"
+      - "backend/utils/imports/limitless.py"
+      - "backend/utils/conversations/process_conversation.py"
+      - "backend/utils/other/storage.py"
       - "backend/database/ella_provisioning.py"
       - "backend/database/invitation_operator.py"
       - "backend/database/invitations.py"
@@ -28,7 +42,6 @@ on:
       - "backend/ella/utils/provision_authority.py"
       - "backend/ella/routers/voice.py"
       - "backend/ella/services/account_deletion.py"
-      - "backend/database/firestore_account_deletion.py"
       - "backend/ella/services/ai_consent.py"
       - "backend/database/users.py"
       - "backend/routers/users.py"
@@ -62,10 +75,24 @@ on:
       - "backend/database/account_deletion.py"
       - "backend/database/authority_advisory_lock.py"
       - "backend/database/content_write_fence.py"
+      - "backend/database/firestore_account_deletion.py"
+      - "backend/routers/action_items.py"
       - "backend/routers/apps.py"
+      - "backend/routers/chat.py"
+      - "backend/routers/developer.py"
+      - "backend/routers/imports.py"
       - "backend/routers/integration.py"
+      - "backend/routers/mcp.py"
       - "backend/routers/mcp_sse.py"
+      - "backend/routers/memories.py"
+      - "backend/routers/pusher.py"
+      - "backend/routers/sync.py"
+      - "backend/routers/transcribe.py"
+      - "backend/routers/wrapped.py"
       - "backend/routers/workflow.py"
+      - "backend/utils/imports/limitless.py"
+      - "backend/utils/conversations/process_conversation.py"
+      - "backend/utils/other/storage.py"
       - "backend/database/ella_provisioning.py"
       - "backend/database/invitation_operator.py"
       - "backend/database/invitations.py"
@@ -83,7 +110,6 @@ on:
       - "backend/ella/utils/provision_authority.py"
       - "backend/ella/routers/voice.py"
       - "backend/ella/services/account_deletion.py"
-      - "backend/database/firestore_account_deletion.py"
       - "backend/ella/services/ai_consent.py"
       - "backend/database/users.py"
       - "backend/routers/users.py"
@@ -131,6 +157,10 @@ jobs:
     env:
       ELLA_TEST_POSTGRES_DSN: postgresql://postgres:postgres@127.0.0.1:5432/invite_redemption_test
       ENCRYPTION_SECRET: omi_ci_invite_redemption_only
+      FIRESTORE_EMULATOR_HOST: localhost:9999
+      GCLOUD_PROJECT: omi-ci
+      GOOGLE_CLOUD_PROJECT: omi-ci
+      STORAGE_EMULATOR_HOST: http://localhost:4443
     defaults:
       run:
         working-directory: backend
@@ -154,7 +184,10 @@ jobs:
           "httpx==0.28.0"
           "PyJWT==2.9.0"
           "pydantic==2.8.2"
+          "python-multipart==0.0.9"
           "pytest==8.3.2"
+          "redis==5.0.8"
+          "stripe==11.3.0"
           "websockets==12.0"
 
       - name: Compile invite and entitlement modules
@@ -163,11 +196,24 @@ jobs:
           database/account_deletion.py
           database/authority_advisory_lock.py
           database/content_write_fence.py
-          routers/apps.py
-          routers/integration.py
-          routers/mcp_sse.py
-          routers/workflow.py
           database/firestore_account_deletion.py
+          routers/action_items.py
+          routers/apps.py
+          routers/chat.py
+          routers/developer.py
+          routers/imports.py
+          routers/integration.py
+          routers/mcp.py
+          routers/mcp_sse.py
+          routers/memories.py
+          routers/pusher.py
+          routers/sync.py
+          routers/transcribe.py
+          routers/wrapped.py
+          routers/workflow.py
+          utils/imports/limitless.py
+          utils/conversations/process_conversation.py
+          utils/other/storage.py
           database/users.py
           database/ella_provisioning.py
           database/invitation_operator.py
@@ -207,7 +253,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 165
+          test "$collected" -eq 171
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
@@ -235,7 +281,13 @@ jobs:
             "tests/unit/test_account_deletion.py::test_explicit_legacy_mode_does_not_probe_optional_ella_authority_for_content_writes"
             "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[True]"
             "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[False]"
-            "tests/unit/test_content_write_fence.py::test_mounted_authenticated_writer_inventory_uses_scope_holding_dependencies"
+            "tests/unit/test_account_deletion.py::test_firestore_delete_removes_only_owned_top_level_import_jobs_and_retries"
+            "tests/unit/test_content_write_fence.py::test_expired_registration_never_proves_a_live_writer_absent"
+            "tests/unit/test_content_write_fence.py::test_detached_writer_transfers_child_registration_before_parent_release"
+            "tests/unit/test_content_write_fence.py::test_mounted_limitless_worker_transfers_fence_until_actual_upsert_finishes"
+            "tests/unit/test_content_write_fence.py::test_mounted_nested_database_routes_release_admission_connection_before_handler[consent]"
+            "tests/unit/test_content_write_fence.py::test_mounted_nested_database_routes_release_admission_connection_before_handler[entitlement]"
+            "tests/unit/test_content_write_fence.py::test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact"
             "tests/unit/test_content_write_fence.py::test_request_fence_covers_streamed_commit_after_route_returns"
             "tests/unit/test_ella_onboarding_contract.py::test_authority_rejection_precedes_identity_and_repository_side_effects"
             "tests/unit/test_pilot_invite_admin.py::test_self_hosted_admission_uses_verified_email_and_current_policy_without_uid_allowlist"

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -6,6 +6,11 @@ on:
       - "backend/contracts/authority_advisory_lock_v1.json"
       - "backend/database/account_deletion.py"
       - "backend/database/authority_advisory_lock.py"
+      - "backend/database/content_write_fence.py"
+      - "backend/routers/apps.py"
+      - "backend/routers/integration.py"
+      - "backend/routers/mcp_sse.py"
+      - "backend/routers/workflow.py"
       - "backend/database/ella_provisioning.py"
       - "backend/database/invitation_operator.py"
       - "backend/database/invitations.py"
@@ -41,6 +46,7 @@ on:
       - "backend/ella/docs/SYNTHETIC_INVITE_OPERATOR.md"
       - "backend/tests/unit/test_invitation_redemption.py"
       - "backend/tests/unit/test_account_deletion.py"
+      - "backend/tests/unit/test_content_write_fence.py"
       - "backend/tests/unit/test_pilot_invite_admin.py"
       - "backend/tests/unit/test_authority_writer_guard.py"
       - "backend/tests/unit/test_ella_onboarding_contract.py"
@@ -55,6 +61,11 @@ on:
       - "backend/contracts/authority_advisory_lock_v1.json"
       - "backend/database/account_deletion.py"
       - "backend/database/authority_advisory_lock.py"
+      - "backend/database/content_write_fence.py"
+      - "backend/routers/apps.py"
+      - "backend/routers/integration.py"
+      - "backend/routers/mcp_sse.py"
+      - "backend/routers/workflow.py"
       - "backend/database/ella_provisioning.py"
       - "backend/database/invitation_operator.py"
       - "backend/database/invitations.py"
@@ -90,6 +101,7 @@ on:
       - "backend/ella/docs/SYNTHETIC_INVITE_OPERATOR.md"
       - "backend/tests/unit/test_invitation_redemption.py"
       - "backend/tests/unit/test_account_deletion.py"
+      - "backend/tests/unit/test_content_write_fence.py"
       - "backend/tests/unit/test_pilot_invite_admin.py"
       - "backend/tests/unit/test_authority_writer_guard.py"
       - "backend/tests/unit/test_ella_onboarding_contract.py"
@@ -150,6 +162,11 @@ jobs:
           python -m py_compile
           database/account_deletion.py
           database/authority_advisory_lock.py
+          database/content_write_fence.py
+          routers/apps.py
+          routers/integration.py
+          routers/mcp_sse.py
+          routers/workflow.py
           database/firestore_account_deletion.py
           database/users.py
           database/ella_provisioning.py
@@ -179,6 +196,7 @@ jobs:
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
               tests/unit/test_account_deletion.py \
+              tests/unit/test_content_write_fence.py \
               tests/unit/test_synthetic_invite_admin.py \
               tests/unit/test_pilot_invite_admin.py \
               tests/unit/test_authority_writer_guard.py \
@@ -189,11 +207,12 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 156
+          test "$collected" -eq 165
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
               tests/unit/test_account_deletion.py \
+              tests/unit/test_content_write_fence.py \
               tests/unit/test_pilot_invite_admin.py \
               tests/unit/test_authority_writer_guard.py \
               tests/unit/test_ella_onboarding_contract.py \
@@ -214,6 +233,10 @@ jobs:
             "tests/unit/test_account_deletion.py::test_production_route_fails_closed_before_destructive_work_when_enabled_authority_is_unavailable"
             "tests/unit/test_account_deletion.py::test_retained_firebase_subject_is_fenced_from_authenticated_content_writes"
             "tests/unit/test_account_deletion.py::test_explicit_legacy_mode_does_not_probe_optional_ella_authority_for_content_writes"
+            "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[True]"
+            "tests/unit/test_content_write_fence.py::test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete[False]"
+            "tests/unit/test_content_write_fence.py::test_mounted_authenticated_writer_inventory_uses_scope_holding_dependencies"
+            "tests/unit/test_content_write_fence.py::test_request_fence_covers_streamed_commit_after_route_returns"
             "tests/unit/test_ella_onboarding_contract.py::test_authority_rejection_precedes_identity_and_repository_side_effects"
             "tests/unit/test_pilot_invite_admin.py::test_self_hosted_admission_uses_verified_email_and_current_policy_without_uid_allowlist"
             "tests/unit/test_pilot_invite_admin.py::test_scoped_email_interface_keeps_plaintext_out_of_argv_receipts_logs_and_errors"
@@ -244,6 +267,7 @@ jobs:
           pytest \
             tests/unit/test_invitation_redemption.py \
             tests/unit/test_account_deletion.py \
+            tests/unit/test_content_write_fence.py \
             tests/unit/test_synthetic_invite_admin.py \
             tests/unit/test_pilot_invite_admin.py \
             tests/unit/test_authority_writer_guard.py \

--- a/.github/workflows/voice-canary-tests.yml
+++ b/.github/workflows/voice-canary-tests.yml
@@ -4,10 +4,17 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - "backend/database/content_write_fence.py"
+      - "backend/database/content_write_recovery.py"
+      - "backend/database/content_writer_owner.py"
       - "backend/database/voice_canary.py"
       - "backend/ella/routers/voice.py"
       - "backend/migrations/008_create_voice_canary_controls.sql"
       - "backend/scripts/voice_canary_admin.py"
+      - "backend/scripts/content_writer_recovery.py"
+      - "backend/ella/docs/CONTENT_WRITER_RECOVERY.md"
+      - "backend/tests/unit/test_durable_worker_deletion_finality.py"
+      - "backend/tests/unit/test_hermes_cloud_enrichment_outbox.py"
       - "backend/tests/postgres/test_voice_canary_postgres.py"
       - "backend/tests/unit/test_voice_canary.py"
       - "backend/tests/unit/test_voice_proxy_auth.py"
@@ -16,10 +23,17 @@ on:
   push:
     branches: [main]
     paths:
+      - "backend/database/content_write_fence.py"
+      - "backend/database/content_write_recovery.py"
+      - "backend/database/content_writer_owner.py"
       - "backend/database/voice_canary.py"
       - "backend/ella/routers/voice.py"
       - "backend/migrations/008_create_voice_canary_controls.sql"
       - "backend/scripts/voice_canary_admin.py"
+      - "backend/scripts/content_writer_recovery.py"
+      - "backend/ella/docs/CONTENT_WRITER_RECOVERY.md"
+      - "backend/tests/unit/test_durable_worker_deletion_finality.py"
+      - "backend/tests/unit/test_hermes_cloud_enrichment_outbox.py"
       - "backend/tests/postgres/test_voice_canary_postgres.py"
       - "backend/tests/unit/test_voice_canary.py"
       - "backend/tests/unit/test_voice_proxy_auth.py"
@@ -72,9 +86,35 @@ jobs:
           "websockets==12.0"
 
       - name: Run voice canary unit and PostgreSQL failure-path tests
-        run: >-
-          pytest
-          tests/unit/test_voice_canary.py
-          tests/unit/test_voice_proxy_auth.py
-          tests/postgres/test_voice_canary_postgres.py
-          -v
+        run: |
+          collected="$(
+            pytest --collect-only -q \
+              tests/unit/test_voice_canary.py \
+              tests/unit/test_voice_proxy_auth.py \
+              tests/postgres/test_voice_canary_postgres.py |
+              grep -c '::'
+          )"
+          test "$collected" -eq 55
+          collected_ids="$(
+            pytest --collect-only -q \
+              tests/unit/test_voice_canary.py \
+              tests/unit/test_voice_proxy_auth.py \
+              tests/postgres/test_voice_canary_postgres.py |
+              sed '/^$/d'
+          )"
+          required_ids=(
+            "tests/unit/test_voice_canary.py::test_entitled_session_has_bounded_jwt_and_quota_contract"
+            "tests/unit/test_voice_proxy_auth.py::test_self_hosted_voice_proxy_re_resolves_exact_voice_target"
+            "tests/postgres/test_voice_canary_postgres.py::test_cost_reservation_is_atomic_at_hard_boundary_and_settles"
+            "tests/postgres/test_voice_canary_postgres.py::test_cost_reservation_rejects_revocation_between_accept_and_reserve"
+          )
+          test "${#required_ids[@]}" -eq 4
+          for required_id in "${required_ids[@]}"; do
+            grep -Fqx "$required_id" <<<"$collected_ids"
+          done
+          pytest \
+            tests/unit/test_voice_canary.py \
+            tests/unit/test_voice_proxy_auth.py \
+            tests/postgres/test_voice_canary_postgres.py \
+            -v | tee /tmp/voice-canary-pytest.log
+          ! grep -Eq '[0-9]+ skipped' /tmp/voice-canary-pytest.log

--- a/.github/workflows/voice-canary-tests.yml
+++ b/.github/workflows/voice-canary-tests.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "backend/database/content_write_fence.py"
       - "backend/database/content_write_recovery.py"
+      - "backend/database/content_write_recovery_authority.py"
       - "backend/database/content_writer_owner.py"
       - "backend/database/voice_canary.py"
       - "backend/ella/routers/voice.py"
@@ -14,6 +15,9 @@ on:
       - "backend/scripts/content_writer_recovery.py"
       - "backend/ella/docs/CONTENT_WRITER_RECOVERY.md"
       - "backend/tests/unit/test_durable_worker_deletion_finality.py"
+      - "backend/tests/conftest.py"
+      - "backend/tests/support/__init__.py"
+      - "backend/tests/support/content_writer_owner_nonlinux.py"
       - "backend/tests/unit/test_hermes_cloud_enrichment_outbox.py"
       - "backend/tests/postgres/test_voice_canary_postgres.py"
       - "backend/tests/unit/test_voice_canary.py"
@@ -25,6 +29,7 @@ on:
     paths:
       - "backend/database/content_write_fence.py"
       - "backend/database/content_write_recovery.py"
+      - "backend/database/content_write_recovery_authority.py"
       - "backend/database/content_writer_owner.py"
       - "backend/database/voice_canary.py"
       - "backend/ella/routers/voice.py"
@@ -33,6 +38,9 @@ on:
       - "backend/scripts/content_writer_recovery.py"
       - "backend/ella/docs/CONTENT_WRITER_RECOVERY.md"
       - "backend/tests/unit/test_durable_worker_deletion_finality.py"
+      - "backend/tests/conftest.py"
+      - "backend/tests/support/__init__.py"
+      - "backend/tests/support/content_writer_owner_nonlinux.py"
       - "backend/tests/unit/test_hermes_cloud_enrichment_outbox.py"
       - "backend/tests/postgres/test_voice_canary_postgres.py"
       - "backend/tests/unit/test_voice_canary.py"
@@ -78,12 +86,37 @@ jobs:
         run: >-
           python -m pip install
           "asyncpg==0.31.0"
+          "black==24.8.0"
           "fastapi==0.112.0"
           "firebase-admin==6.5.0"
           "httpx==0.28.0"
           "PyJWT==2.9.0"
           "pytest==8.3.2"
           "websockets==12.0"
+
+      - name: Compile and format exact recovery surfaces
+        run: >-
+          python -m py_compile
+          database/content_write_fence.py
+          database/content_write_recovery.py
+          database/content_write_recovery_authority.py
+          database/content_writer_owner.py
+          scripts/content_writer_recovery.py
+          tests/conftest.py
+          tests/support/__init__.py
+          tests/support/content_writer_owner_nonlinux.py
+          tests/unit/test_durable_worker_deletion_finality.py
+          &&
+          black --check --line-length 120 --skip-string-normalization
+          database/content_write_fence.py
+          database/content_write_recovery.py
+          database/content_write_recovery_authority.py
+          database/content_writer_owner.py
+          scripts/content_writer_recovery.py
+          tests/conftest.py
+          tests/support/__init__.py
+          tests/support/content_writer_owner_nonlinux.py
+          tests/unit/test_durable_worker_deletion_finality.py
 
       - name: Run voice canary unit and PostgreSQL failure-path tests
         run: |

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -87,6 +87,9 @@ ELLA_HERMES_PROVISIONING_ENABLED=false
 ELLA_HERMES_PROVISIONING_ENABLED_UIDS=
 ELLA_HERMES_CLOUD_PROVISIONING_ENABLED=false
 ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS=
+# Account deletion uses Ella PostgreSQL authority whenever this is true.
+# Set false only for the documented vanilla/rollback deployment with no Ella schema.
+ELLA_POSTGRES_AUTHORITY_ENABLED=true
 ELLA_RUNTIME_BINDINGS_ENABLED=false
 ELLA_RUNTIME_BINDINGS_ENABLED_UIDS=
 # Root-only invitation redemption. Ordinary/App Review admission stays off for

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -90,7 +90,8 @@ ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS=
 # Account deletion uses Ella PostgreSQL authority whenever this is true.
 # Set false only for the documented vanilla/rollback deployment with no Ella schema.
 ELLA_POSTGRES_AUTHORITY_ENABLED=true
-# Distributed content-writer fence. Values are bounded in production code.
+# Distributed content-writer fence. Registration expiry is diagnostic only;
+# deletion requires explicit writer release and otherwise remains pending.
 ELLA_CONTENT_WRITE_FENCE_LEASE_SECONDS=900
 ELLA_CONTENT_WRITE_FENCE_ACQUIRE_SECONDS=15
 ELLA_CONTENT_WRITE_FENCE_DRAIN_SECONDS=15

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -90,6 +90,10 @@ ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS=
 # Account deletion uses Ella PostgreSQL authority whenever this is true.
 # Set false only for the documented vanilla/rollback deployment with no Ella schema.
 ELLA_POSTGRES_AUTHORITY_ENABLED=true
+# Distributed content-writer fence. Values are bounded in production code.
+ELLA_CONTENT_WRITE_FENCE_LEASE_SECONDS=900
+ELLA_CONTENT_WRITE_FENCE_ACQUIRE_SECONDS=15
+ELLA_CONTENT_WRITE_FENCE_DRAIN_SECONDS=15
 ELLA_RUNTIME_BINDINGS_ENABLED=false
 ELLA_RUNTIME_BINDINGS_ENABLED_UIDS=
 # Root-only invitation redemption. Ordinary/App Review admission stays off for

--- a/backend/database/account_deletion.py
+++ b/backend/database/account_deletion.py
@@ -305,6 +305,58 @@ async def purge_memory_reinterpretation_work(uid: str) -> int:
         raise AccountDeletionUnavailable("account_deletion_memory_reinterpretation_unavailable") from exc
 
 
+async def purge_canonical_event_ledger(uid: str) -> int:
+    """Transactionally prove the exact UID absent from both canonical tables."""
+    code = "account_deletion_canonical_event_ledger_unavailable"
+    try:
+        pool = await voice_canary.get_pool()
+        async with pool.acquire() as connection:
+            async with connection.transaction():
+                events_exists = await connection.fetchval("SELECT to_regclass('canonical_events') IS NOT NULL")
+                sessions_exists = await connection.fetchval(
+                    "SELECT to_regclass('canonical_event_sessions') IS NOT NULL"
+                )
+                if not events_exists or not sessions_exists:
+                    raise AccountDeletionUnavailable(code)
+
+                event_count = int(
+                    await connection.fetchval("SELECT COUNT(*) FROM canonical_events WHERE uid = $1", uid) or 0
+                )
+                session_count = int(
+                    await connection.fetchval("SELECT COUNT(*) FROM canonical_event_sessions WHERE uid = $1", uid) or 0
+                )
+                session_result = await connection.execute(
+                    "DELETE FROM canonical_event_sessions WHERE uid = $1",
+                    uid,
+                )
+                event_result = await connection.execute(
+                    "DELETE FROM canonical_events WHERE uid = $1",
+                    uid,
+                )
+                affected_sessions = _affected(session_result)
+                affected_events = _affected(event_result)
+                remaining = await connection.fetchrow(
+                    """
+                    SELECT
+                        (SELECT COUNT(*) FROM canonical_events WHERE uid = $1) AS events,
+                        (SELECT COUNT(*) FROM canonical_event_sessions WHERE uid = $1) AS sessions
+                    """,
+                    uid,
+                )
+                if (
+                    affected_events != event_count
+                    or affected_sessions != session_count
+                    or int(remaining["events"] or 0) != 0
+                    or int(remaining["sessions"] or 0) != 0
+                ):
+                    raise AccountDeletionUnavailable(code)
+                return affected_events + affected_sessions
+    except AccountDeletionUnavailable:
+        raise
+    except Exception as exc:
+        raise AccountDeletionUnavailable(code) from exc
+
+
 async def finalize_account_deletion(uid: str) -> bool:
     """Mark a quarantined identity complete only after external state is absent."""
     try:

--- a/backend/database/account_deletion.py
+++ b/backend/database/account_deletion.py
@@ -1,0 +1,266 @@
+"""Transactional authority quarantine for resumable account deletion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import asyncpg
+
+from database import authority_advisory_lock, managed_cloud_consent, voice_canary
+
+
+class AccountDeletionUnavailable(RuntimeError):
+    """The durable account deletion state could not be advanced safely."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True)
+class AccountDeletionState:
+    user_found: bool
+    capacity_released: bool
+    authority_quarantined: bool
+    external_cleanup_required: tuple[str, ...]
+    counts: dict[str, int]
+
+
+def _affected(command_tag: str) -> int:
+    return int(command_tag.rsplit(" ", 1)[-1])
+
+
+async def quarantine_account_for_deletion(uid: str) -> AccountDeletionState:
+    """Quarantine all database authority and release ordinary pilot capacity.
+
+    The shared account/profile advisory lock is acquired before any protected
+    row lock or mutation. External Hermes/Honcho artifacts are deliberately not
+    reported deleted: the current self-hosted authority has no authenticated
+    deprovision operation that can issue an authoritative completion receipt.
+    """
+    try:
+        pool = await voice_canary.get_pool()
+        async with pool.acquire() as connection:
+            try:
+                owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+                    connection,
+                    uid=uid,
+                )
+            except authority_advisory_lock.AuthorityLockError as exc:
+                if exc.code == "authority_lock_owner_missing":
+                    return AccountDeletionState(
+                        user_found=False,
+                        capacity_released=True,
+                        authority_quarantined=True,
+                        external_cleanup_required=(),
+                        counts={},
+                    )
+                raise
+
+            async with connection.transaction():
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(
+                    connection,
+                    owner=owner,
+                )
+                user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=uid,
+                    owner=owner,
+                    proof=owner_lock,
+                )
+                await voice_canary.lock_runtime_authority_on_connection(
+                    connection,
+                    uid=uid,
+                )
+
+                invitation_rows = await connection.fetch(
+                    """
+                    SELECT invitation.id, invitation.kind,
+                           invitation.capacity_reservation_id
+                    FROM ella_invitation_redemptions redemption
+                    JOIN ella_invitations invitation
+                      ON invitation.id = redemption.invitation_id
+                    JOIN ella_invitation_capacity_reservations reservation
+                      ON reservation.id = invitation.capacity_reservation_id
+                    WHERE redemption.user_id = $1
+                    ORDER BY invitation.id
+                    FOR UPDATE OF redemption, invitation, reservation
+                    """,
+                    user_id,
+                )
+
+                await managed_cloud_consent._quarantine_on_connection(
+                    connection,
+                    uid=uid,
+                    user_id=user_id,
+                    reason="account_deletion_requested",
+                    owner_lock=owner_lock,
+                )
+                consent_result = await connection.execute(
+                    """
+                    UPDATE ella_managed_cloud_consent_authority
+                    SET decision = 'revoked',
+                        consent_receipt_ref = NULL,
+                        profile_binding_id = NULL,
+                        policy_version = NULL,
+                        processor_set_hash = NULL,
+                        scope_version = NULL,
+                        scope_hash = NULL,
+                        authority_epoch = gen_random_uuid(),
+                        revision = revision + 1,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE user_id = $1
+                      AND decision <> 'revoked'
+                    """,
+                    user_id,
+                )
+
+                invitation_ids = [row["id"] for row in invitation_rows if row["kind"] == "ordinary"]
+                reservation_ids = [
+                    row["capacity_reservation_id"] for row in invitation_rows if row["kind"] == "ordinary"
+                ]
+                invitation_result = "UPDATE 0"
+                capacity_result = "UPDATE 0"
+                if invitation_ids:
+                    invitation_result = await connection.execute(
+                        """
+                        UPDATE ella_invitations
+                        SET state = 'revoked',
+                            delivery_state = 'suppressed',
+                            revoked_at = COALESCE(revoked_at, CURRENT_TIMESTAMP),
+                            version = CASE WHEN state = 'revoked' THEN version ELSE version + 1 END,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE id = ANY($1::uuid[])
+                          AND state <> 'revoked'
+                        """,
+                        invitation_ids,
+                    )
+                    capacity_result = await connection.execute(
+                        """
+                        UPDATE ella_invitation_capacity_reservations
+                        SET state = 'released',
+                            released_at = COALESCE(released_at, CURRENT_TIMESTAMP),
+                            version = version + 1,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE id = ANY($1::uuid[])
+                          AND state IN ('reserved', 'consumed')
+                        """,
+                        reservation_ids,
+                    )
+
+                cluster_result = "UPDATE 0"
+                if await connection.fetchval("SELECT to_regclass('agent_clusters') IS NOT NULL"):
+                    cluster_result = await connection.execute(
+                        """
+                        UPDATE agent_clusters
+                        SET status = 'INACTIVE', agents = '{}'::jsonb
+                        WHERE user_id = $1
+                          AND (status <> 'INACTIVE' OR agents <> '{}'::jsonb)
+                        """,
+                        user_id,
+                    )
+
+                user_result = await connection.execute(
+                    """
+                    UPDATE users
+                    SET status = 'DELETION_PENDING',
+                        email = 'deleted+' || replace(id::text, '-', '') || '@invalid.ella',
+                        name = 'Deleted User',
+                        identities = '{}'::jsonb,
+                        settings = '{}'::jsonb,
+                        tags = ARRAY[]::text[],
+                        conditions = ARRAY[]::text[],
+                        medications = ARRAY[]::text[],
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = $1
+                      AND status <> 'DELETED'
+                    """,
+                    user_id,
+                )
+
+                provider_rows = await connection.fetch(
+                    """
+                    SELECT DISTINCT provider
+                    FROM ella_runtime_bindings
+                    WHERE user_id = $1
+                      AND provider IN ('hermes', 'hermes_cloud')
+                    ORDER BY provider
+                    """,
+                    user_id,
+                )
+                external_cleanup_required: tuple[str, ...] = ()
+                if provider_rows:
+                    external_cleanup_required = (
+                        "hermes_profile",
+                        "honcho_tenancy",
+                        "runtime_registry",
+                    )
+
+                return AccountDeletionState(
+                    user_found=True,
+                    capacity_released=True,
+                    authority_quarantined=True,
+                    external_cleanup_required=external_cleanup_required,
+                    counts={
+                        "consent_authorities": _affected(consent_result),
+                        "invitations": _affected(invitation_result),
+                        "capacity_reservations": _affected(capacity_result),
+                        "agent_clusters": _affected(cluster_result),
+                        "users": _affected(user_result),
+                    },
+                )
+    except AccountDeletionUnavailable:
+        raise
+    except Exception as exc:
+        raise AccountDeletionUnavailable("account_deletion_authority_unavailable") from exc
+
+
+async def finalize_account_deletion(uid: str) -> bool:
+    """Mark a quarantined identity complete only after external state is absent."""
+    try:
+        pool = await voice_canary.get_pool()
+        async with pool.acquire() as connection:
+            try:
+                owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+                    connection,
+                    uid=uid,
+                )
+            except authority_advisory_lock.AuthorityLockError as exc:
+                if exc.code == "authority_lock_owner_missing":
+                    return False
+                raise
+            async with connection.transaction():
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(
+                    connection,
+                    owner=owner,
+                )
+                user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=uid,
+                    owner=owner,
+                    proof=owner_lock,
+                )
+                external_count = await connection.fetchval(
+                    """
+                    SELECT COUNT(*)
+                    FROM ella_runtime_bindings
+                    WHERE user_id = $1
+                      AND provider IN ('hermes', 'hermes_cloud')
+                    """,
+                    user_id,
+                )
+                if int(external_count or 0) != 0:
+                    raise AccountDeletionUnavailable("account_deletion_external_cleanup_incomplete")
+                result = await connection.execute(
+                    """
+                    UPDATE users
+                    SET status = 'DELETED', updated_at = CURRENT_TIMESTAMP
+                    WHERE id = $1 AND status <> 'DELETED'
+                    """,
+                    user_id,
+                )
+                return _affected(result) == 1
+    except AccountDeletionUnavailable:
+        raise
+    except Exception as exc:
+        raise AccountDeletionUnavailable("account_deletion_finalize_unavailable") from exc

--- a/backend/database/account_deletion.py
+++ b/backend/database/account_deletion.py
@@ -263,6 +263,48 @@ async def purge_routing_traces(uid: str) -> int:
         raise AccountDeletionUnavailable("account_deletion_routing_traces_unavailable") from exc
 
 
+async def purge_memory_reinterpretation_work(uid: str) -> int:
+    """Delete exact-UID reinterpretation jobs and their cascading attempts."""
+    try:
+        pool = await voice_canary.get_pool()
+        async with pool.acquire() as connection:
+            async with connection.transaction():
+                jobs_exists = await connection.fetchval(
+                    "SELECT to_regclass('memory_reinterpretation_jobs') IS NOT NULL"
+                )
+                attempts_exists = await connection.fetchval(
+                    "SELECT to_regclass('memory_reinterpretation_attempts') IS NOT NULL"
+                )
+                if not jobs_exists and not attempts_exists:
+                    return 0
+                if not jobs_exists or not attempts_exists:
+                    raise AccountDeletionUnavailable("account_deletion_memory_reinterpretation_unavailable")
+                attempt_result = await connection.execute(
+                    """
+                    DELETE FROM memory_reinterpretation_attempts attempt
+                    USING memory_reinterpretation_jobs job
+                    WHERE attempt.job_id = job.id
+                      AND job.uid = $1
+                    """,
+                    uid,
+                )
+                result = await connection.execute(
+                    "DELETE FROM memory_reinterpretation_jobs WHERE uid = $1",
+                    uid,
+                )
+                remaining = await connection.fetchval(
+                    "SELECT COUNT(*) FROM memory_reinterpretation_jobs WHERE uid = $1",
+                    uid,
+                )
+                if int(remaining or 0) != 0:
+                    raise AccountDeletionUnavailable("account_deletion_memory_reinterpretation_unavailable")
+                return _affected(result) + _affected(attempt_result)
+    except AccountDeletionUnavailable:
+        raise
+    except Exception as exc:
+        raise AccountDeletionUnavailable("account_deletion_memory_reinterpretation_unavailable") from exc
+
+
 async def finalize_account_deletion(uid: str) -> bool:
     """Mark a quarantined identity complete only after external state is absent."""
     try:

--- a/backend/database/account_deletion.py
+++ b/backend/database/account_deletion.py
@@ -246,6 +246,23 @@ async def quarantine_account_for_deletion(uid: str) -> AccountDeletionState:
         raise AccountDeletionUnavailable("account_deletion_authority_unavailable") from exc
 
 
+async def purge_routing_traces(uid: str) -> int:
+    """Delete all durable UID-linked routing telemetry after writers drain."""
+    try:
+        pool = await voice_canary.get_pool()
+        async with pool.acquire() as connection:
+            async with connection.transaction():
+                if not await connection.fetchval("SELECT to_regclass('routing_traces') IS NOT NULL"):
+                    return 0
+                result = await connection.execute(
+                    "DELETE FROM routing_traces WHERE uid = $1",
+                    uid,
+                )
+                return _affected(result)
+    except Exception as exc:
+        raise AccountDeletionUnavailable("account_deletion_routing_traces_unavailable") from exc
+
+
 async def finalize_account_deletion(uid: str) -> bool:
     """Mark a quarantined identity complete only after external state is absent."""
     try:

--- a/backend/database/account_deletion.py
+++ b/backend/database/account_deletion.py
@@ -23,6 +23,7 @@ class AccountDeletionState:
     capacity_released: bool
     authority_quarantined: bool
     external_cleanup_required: tuple[str, ...]
+    external_cleanup_references: tuple[str, ...]
     counts: dict[str, int]
 
 
@@ -53,6 +54,7 @@ async def quarantine_account_for_deletion(uid: str) -> AccountDeletionState:
                         capacity_released=True,
                         authority_quarantined=True,
                         external_cleanup_required=(),
+                        external_cleanup_references=(),
                         counts={},
                     )
                 raise
@@ -160,6 +162,22 @@ async def quarantine_account_for_deletion(uid: str) -> AccountDeletionState:
                         user_id,
                     )
 
+                photon_result = await connection.execute(
+                    """
+                    UPDATE ella_photon_channel_bindings
+                    SET status = 'quarantined',
+                        quarantined_at = COALESCE(quarantined_at, CURRENT_TIMESTAMP),
+                        quarantine_reason = 'account_deletion_requested',
+                        sidecar_connection_key = NULL,
+                        sidecar_connected_at = NULL,
+                        oauth_expires_at = NULL,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE user_id = $1
+                      AND status <> 'quarantined'
+                    """,
+                    user_id,
+                )
+
                 user_result = await connection.execute(
                     """
                     UPDATE users
@@ -188,24 +206,37 @@ async def quarantine_account_for_deletion(uid: str) -> AccountDeletionState:
                     """,
                     user_id,
                 )
+                attempt_rows = await connection.fetch(
+                    """
+                    SELECT correlation_ref
+                    FROM ella_provider_attempts
+                    WHERE user_id = $1
+                      AND proof_state = 'unproven'
+                    ORDER BY correlation_ref
+                    """,
+                    user_id,
+                )
                 external_cleanup_required: tuple[str, ...] = ()
-                if provider_rows:
+                if provider_rows or attempt_rows:
                     external_cleanup_required = (
                         "hermes_profile",
                         "honcho_tenancy",
                         "runtime_registry",
                     )
+                external_cleanup_references = tuple(str(row["correlation_ref"]) for row in attempt_rows)
 
                 return AccountDeletionState(
                     user_found=True,
                     capacity_released=True,
                     authority_quarantined=True,
                     external_cleanup_required=external_cleanup_required,
+                    external_cleanup_references=external_cleanup_references,
                     counts={
                         "consent_authorities": _affected(consent_result),
                         "invitations": _affected(invitation_result),
                         "capacity_reservations": _affected(capacity_result),
                         "agent_clusters": _affected(cluster_result),
+                        "photon_bindings": _affected(photon_result),
                         "users": _affected(user_result),
                     },
                 )
@@ -242,10 +273,15 @@ async def finalize_account_deletion(uid: str) -> bool:
                 )
                 external_count = await connection.fetchval(
                     """
-                    SELECT COUNT(*)
-                    FROM ella_runtime_bindings
-                    WHERE user_id = $1
-                      AND provider IN ('hermes', 'hermes_cloud')
+                    SELECT
+                        (SELECT COUNT(*)
+                         FROM ella_runtime_bindings
+                         WHERE user_id = $1
+                           AND provider IN ('hermes', 'hermes_cloud'))
+                      + (SELECT COUNT(*)
+                         FROM ella_provider_attempts
+                         WHERE user_id = $1
+                           AND proof_state = 'unproven')
                     """,
                     user_id,
                 )

--- a/backend/database/authority_advisory_lock.py
+++ b/backend/database/authority_advisory_lock.py
@@ -278,6 +278,37 @@ async def require_self_owner_lock(
     )
 
 
+async def require_user_write_status(
+    connection: asyncpg.Connection,
+    proof: AuthorityLockProof,
+    *,
+    user_id: Any,
+    allowed_statuses: tuple[str, ...] = ("ACTIVE",),
+) -> str:
+    """Fence authority writes after the owner lock has been proven.
+
+    PENDING is allowed only at explicitly named bootstrap/activation call sites.
+    Tombstoned accounts are never writable through this helper.
+    """
+    await require_self_owner_lock(
+        connection,
+        proof,
+        user_id=user_id,
+    )
+    if not allowed_statuses or any(status in {"DELETION_PENDING", "DELETED"} for status in allowed_statuses):
+        raise AuthorityLockError("authority_write_status_policy_invalid")
+    status = await connection.fetchval(
+        "SELECT status FROM users WHERE id = $1 FOR UPDATE",
+        _validated_database_uuid(user_id, field="user_id"),
+    )
+    if status is None:
+        raise AuthorityLockError("authority_write_owner_missing")
+    normalized = str(status)
+    if normalized not in allowed_statuses:
+        raise AuthorityLockError("authority_write_user_not_active")
+    return normalized
+
+
 async def resolve_self_owner_unlocked(
     connection: asyncpg.Connection,
     *,

--- a/backend/database/content_write_fence.py
+++ b/backend/database/content_write_fence.py
@@ -53,11 +53,13 @@ class WriterRegistration:
 
 @dataclass(frozen=True)
 class WriterRecovery:
+    token_hash: str
     owner: content_writer_owner.ProcessOwner
     recovered_at: datetime
 
     def to_storage(self) -> dict[str, Any]:
         return {
+            "token_hash": self.token_hash,
             "owner": self.owner.to_storage(),
             "recovered_at": self.recovered_at,
         }
@@ -218,37 +220,52 @@ def _registered_writers(data: dict[str, Any]) -> dict[str, WriterRegistration]:
     return registered
 
 
-def _registered_recoveries(data: dict[str, Any]) -> dict[str, WriterRecovery]:
-    recoveries = data.get("writer_recoveries")
-    if recoveries is None:
-        return {}
-    if not isinstance(recoveries, dict):
+def _registered_recovery(data: dict[str, Any]) -> WriterRecovery | None:
+    """Return the one bounded idempotency receipt for the latest recovery.
+
+    Recovery history is intentionally not retained. One exact token/owner
+    receipt is sufficient to converge concurrent retries of the transaction
+    that removed that token. An absent or different receipt never authorizes
+    recovery and ordinary ACTIVE cleanup or tombstoning removes it.
+    """
+    if "writer_recovery" in data and "writer_recoveries" in data:
         raise ContentWriteFenceError("account_content_fence_corrupt")
-    registered: dict[str, WriterRecovery] = {}
-    for token_hash, value in recoveries.items():
+    legacy = data.get("writer_recoveries")
+    values = legacy.items() if isinstance(legacy, dict) else ((None, data.get("writer_recovery")),)
+    if legacy is not None and not isinstance(legacy, dict):
+        raise ContentWriteFenceError("account_content_fence_corrupt")
+    registered: list[WriterRecovery] = []
+    for legacy_token_hash, value in values:
+        if value is None:
+            continue
+        if not isinstance(value, dict):
+            raise ContentWriteFenceError("account_content_fence_corrupt")
+        expected = (
+            {"owner", "recovered_at"} if legacy_token_hash is not None else {"token_hash", "owner", "recovered_at"}
+        )
+        if set(value) != expected:
+            raise ContentWriteFenceError("account_content_fence_corrupt")
+        token_hash = legacy_token_hash if legacy_token_hash is not None else value["token_hash"]
         if (
             not isinstance(token_hash, str)
             or len(token_hash) != 64
             or not all(character in "0123456789abcdef" for character in token_hash)
-            or not isinstance(value, dict)
+            or not isinstance(value["recovered_at"], datetime)
         ):
-            raise ContentWriteFenceError("account_content_fence_corrupt")
-        if set(value) != {"owner", "recovered_at"} or not isinstance(value["recovered_at"], datetime):
             raise ContentWriteFenceError("account_content_fence_corrupt")
         try:
             owner = content_writer_owner.ProcessOwner.from_storage(value["owner"])
         except content_writer_owner.ProcessOwnerError as exc:
             raise ContentWriteFenceError(exc.code) from exc
-        registered[token_hash] = WriterRecovery(owner=owner, recovered_at=value["recovered_at"])
-    return registered
+        registered.append(WriterRecovery(token_hash=token_hash, owner=owner, recovered_at=value["recovered_at"]))
+    try:
+        return max(registered, key=lambda recovery: (recovery.recovered_at, recovery.token_hash), default=None)
+    except TypeError as exc:
+        raise ContentWriteFenceError("account_content_fence_corrupt") from exc
 
 
 def _writers_to_storage(writers: dict[str, WriterRegistration]) -> dict[str, Any]:
     return {token: registration.to_storage() for token, registration in writers.items()}
-
-
-def _recoveries_to_storage(recoveries: dict[str, WriterRecovery]) -> dict[str, Any]:
-    return {token: recovery.to_storage() for token, recovery in recoveries.items()}
 
 
 def _acquire_firestore_writer(db: Any, uid: str, token: str, lease_seconds: int) -> None:
@@ -262,10 +279,12 @@ def _acquire_firestore_writer(db: Any, uid: str, token: str, lease_seconds: int)
         if data.get("state", ACTIVE) != ACTIVE:
             raise ContentWriteFenceError("account_write_forbidden")
         writers = _registered_writers(data)
-        recoveries = _registered_recoveries(data)
+        recovery = _registered_recovery(data)
         existing = writers.get(token)
         token_hash = hashlib.sha256(token.encode("utf-8")).hexdigest()
-        if (existing is not None and existing.owner != owner) or token_hash in recoveries:
+        if (existing is not None and existing.owner != owner) or (
+            recovery is not None and recovery.token_hash == token_hash
+        ):
             raise ContentWriteFenceError("account_writer_owner_mismatch")
         writers[token] = WriterRegistration(
             expires_at=now + timedelta(seconds=lease_seconds),
@@ -276,7 +295,7 @@ def _acquire_firestore_writer(db: Any, uid: str, token: str, lease_seconds: int)
             {
                 "state": ACTIVE,
                 "writers": _writers_to_storage(writers),
-                "writer_recoveries": _recoveries_to_storage(recoveries),
+                "writer_recovery": recovery.to_storage() if recovery is not None else None,
                 "updated_at": now,
             },
         )
@@ -315,9 +334,9 @@ def _release_firestore_writer(db: Any, uid: str, token: str) -> None:
         if registration.owner != owner:
             raise ContentWriteFenceError("account_writer_owner_mismatch")
         writers.pop(token)
-        recoveries = _registered_recoveries(data)
+        recovery = _registered_recovery(data)
         state = data.get("state", ACTIVE)
-        if state == ACTIVE and not writers and not recoveries:
+        if state == ACTIVE and not writers:
             if getattr(snapshot, "exists", False):
                 transaction.delete(reference)
             return
@@ -326,7 +345,7 @@ def _release_firestore_writer(db: Any, uid: str, token: str) -> None:
             {
                 "state": state,
                 "writers": _writers_to_storage(writers),
-                "writer_recoveries": _recoveries_to_storage(recoveries),
+                "writer_recovery": recovery.to_storage() if recovery is not None else None,
                 "updated_at": now,
             },
         )
@@ -342,22 +361,26 @@ def _advance_firestore_tombstone(db: Any, uid: str) -> bool:
     @firestore.transactional
     def advance(transaction: Any) -> bool:
         data = _snapshot_data(reference.get(transaction=transaction))
+        recovery = _registered_recovery(data)
         if data.get("state") == TOMBSTONED:
+            if recovery is not None or "writer_recoveries" in data or "writer_recovery" in data:
+                cleaned = dict(data)
+                cleaned.pop("writer_recovery", None)
+                cleaned.pop("writer_recoveries", None)
+                transaction.set(reference, cleaned)
             return True
         writers = _registered_writers(data)
-        recoveries = _registered_recoveries(data)
         state = DRAINING if writers else TOMBSTONED
-        transaction.set(
-            reference,
-            {
-                "state": state,
-                "writers": _writers_to_storage(writers),
-                "writer_recoveries": _recoveries_to_storage(recoveries),
-                "deletion_requested_at": data.get("deletion_requested_at") or now,
-                "tombstoned_at": now if state == TOMBSTONED else None,
-                "updated_at": now,
-            },
-        )
+        updated = {
+            "state": state,
+            "writers": _writers_to_storage(writers),
+            "deletion_requested_at": data.get("deletion_requested_at") or now,
+            "tombstoned_at": now if state == TOMBSTONED else None,
+            "updated_at": now,
+        }
+        if state == DRAINING and recovery is not None:
+            updated["writer_recovery"] = recovery.to_storage()
+        transaction.set(reference, updated)
         return state == TOMBSTONED
 
     return bool(advance(db.transaction()))

--- a/backend/database/content_write_fence.py
+++ b/backend/database/content_write_fence.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import asyncio
 from contextlib import asynccontextmanager
 from contextvars import ContextVar, Token
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import hashlib
 import os
+import threading
 import time
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Awaitable, Callable
 import uuid
 
 from google.cloud import firestore
@@ -27,6 +29,10 @@ DEFAULT_DRAIN_SECONDS = 15.0
 _firestore_db: Any = None
 _request_fence_registry: ContextVar[dict[str, Any] | None] = ContextVar(
     "content_write_fence_registry",
+    default=None,
+)
+_detached_writer: ContextVar["DetachedContentWriter | None"] = ContextVar(
+    "detached_content_writer",
     default=None,
 )
 
@@ -110,15 +116,24 @@ def _snapshot_data(snapshot: Any) -> dict[str, Any]:
     return dict(snapshot.to_dict() or {})
 
 
-def _active_writers(data: dict[str, Any], now: datetime) -> dict[str, datetime]:
+def _registered_writers(data: dict[str, Any]) -> dict[str, datetime]:
+    """Return every unreleased writer; timestamps never prove absence.
+
+    A process crash or missed heartbeat must leave deletion pending. Expiry is
+    diagnostic metadata only because a live writer can stall its event loop
+    longer than the configured interval and still reach its datastore commit.
+    """
     writers = data.get("writers")
-    if not isinstance(writers, dict):
+    if writers is None:
         return {}
-    return {
-        token: expires_at
-        for token, expires_at in writers.items()
-        if isinstance(token, str) and isinstance(expires_at, datetime) and expires_at > now
-    }
+    if not isinstance(writers, dict):
+        raise ContentWriteFenceError("account_content_fence_corrupt")
+    registered: dict[str, datetime] = {}
+    for token, expires_at in writers.items():
+        if not isinstance(token, str) or not token or not isinstance(expires_at, datetime):
+            raise ContentWriteFenceError("account_content_fence_corrupt")
+        registered[token] = expires_at
+    return registered
 
 
 def _acquire_firestore_writer(db: Any, uid: str, token: str, lease_seconds: int) -> None:
@@ -130,7 +145,7 @@ def _acquire_firestore_writer(db: Any, uid: str, token: str, lease_seconds: int)
         data = _snapshot_data(reference.get(transaction=transaction))
         if data.get("state", ACTIVE) != ACTIVE:
             raise ContentWriteFenceError("account_write_forbidden")
-        writers = _active_writers(data, now)
+        writers = _registered_writers(data)
         writers[token] = now + timedelta(seconds=lease_seconds)
         transaction.set(
             reference,
@@ -144,28 +159,17 @@ def _acquire_firestore_writer(db: Any, uid: str, token: str, lease_seconds: int)
     acquire(db.transaction())
 
 
-def _renew_firestore_writer(db: Any, uid: str, token: str, lease_seconds: int) -> bool:
+def _assert_firestore_writer_current(db: Any, uid: str, token: str) -> None:
     reference = _fence_reference(db, uid)
-    now = datetime.now(timezone.utc)
 
     @firestore.transactional
-    def renew(transaction: Any) -> bool:
+    def assert_current(transaction: Any) -> None:
         data = _snapshot_data(reference.get(transaction=transaction))
-        writers = _active_writers(data, now)
-        if token not in writers or data.get("state", ACTIVE) == TOMBSTONED:
-            return False
-        writers[token] = now + timedelta(seconds=lease_seconds)
-        transaction.set(
-            reference,
-            {
-                "state": data.get("state", ACTIVE),
-                "writers": writers,
-                "updated_at": now,
-            },
-        )
-        return True
+        writers = _registered_writers(data)
+        if token not in writers or data.get("state", ACTIVE) not in {ACTIVE, DRAINING}:
+            raise ContentWriteFenceError("account_write_forbidden")
 
-    return bool(renew(db.transaction()))
+    assert_current(db.transaction())
 
 
 def _release_firestore_writer(db: Any, uid: str, token: str) -> None:
@@ -176,7 +180,7 @@ def _release_firestore_writer(db: Any, uid: str, token: str) -> None:
     def release(transaction: Any) -> None:
         snapshot = reference.get(transaction=transaction)
         data = _snapshot_data(snapshot)
-        writers = _active_writers(data, now)
+        writers = _registered_writers(data)
         writers.pop(token, None)
         state = data.get("state", ACTIVE)
         if state == ACTIVE and not writers:
@@ -205,7 +209,7 @@ def _advance_firestore_tombstone(db: Any, uid: str) -> bool:
         data = _snapshot_data(reference.get(transaction=transaction))
         if data.get("state") == TOMBSTONED:
             return True
-        writers = _active_writers(data, now)
+        writers = _registered_writers(data)
         state = DRAINING if writers else TOMBSTONED
         transaction.set(
             reference,
@@ -231,9 +235,14 @@ async def _finish_even_if_cancelled(awaitable: Any) -> None:
         raise
 
 
-@asynccontextmanager
-async def _postgres_owner_fence(uid: str) -> AsyncIterator[None]:
-    """Hold the shared owner advisory lock and ACTIVE proof through the write."""
+async def _assert_postgres_owner_active(uid: str) -> None:
+    """Briefly serialize admission with deletion, then release the pool slot.
+
+    The Firestore writer registration is acquired only after this check. That
+    ordering means deletion either observes the writer registration and drains
+    it, or tombstones first and makes registration fail. No PostgreSQL
+    connection or advisory lock is held across arbitrary route code.
+    """
     try:
         pool = await voice_canary.get_pool()
         owner_missing = False
@@ -260,27 +269,17 @@ async def _postgres_owner_fence(uid: str) -> AsyncIterator[None]:
                         proof=proof,
                     )
                     status = await connection.fetchval("SELECT status FROM users WHERE id = $1", user_id)
-                    if str(status or "") in {"DELETION_PENDING", "DELETED"}:
+                    if str(status or "") != ACTIVE:
                         raise ContentWriteFenceError("account_write_forbidden")
-                    yield
                 finally:
                     await _finish_even_if_cancelled(transaction.rollback())
                 return
         if owner_missing:
-            yield
+            return
     except ContentWriteFenceError:
         raise
     except Exception as exc:
         raise ContentWriteFenceError("account_authority_unavailable") from exc
-
-
-async def _renew_until_released(db: Any, uid: str, token: str, lease_seconds: int) -> None:
-    interval = max(1.0, lease_seconds / 3)
-    while True:
-        await asyncio.sleep(interval)
-        renewed = await asyncio.to_thread(_renew_firestore_writer, db, uid, token, lease_seconds)
-        if not renewed:
-            return
 
 
 @asynccontextmanager
@@ -302,24 +301,139 @@ async def content_write_fence(uid: str, *, db: Any = None) -> AsyncIterator[str]
         except Exception as exc:
             raise ContentWriteFenceError("account_content_fence_unavailable") from exc
 
-        renew_task = asyncio.create_task(_renew_until_released(firestore_db, uid, token, lease_seconds))
         try:
             yield
         finally:
-            renew_task.cancel()
-            try:
-                await renew_task
-            except asyncio.CancelledError:
-                pass
             await _finish_even_if_cancelled(asyncio.to_thread(_release_firestore_writer, firestore_db, uid, token))
 
     if _authority_enabled():
-        async with _postgres_owner_fence(uid):
-            async with firestore_fence():
-                yield uid
-    else:
-        async with firestore_fence():
-            yield uid
+        await _assert_postgres_owner_active(uid)
+    async with firestore_fence():
+        yield uid
+
+
+@dataclass(frozen=True)
+class DetachedContentWriter:
+    """A writer registration transferred from a request to detached work."""
+
+    uid: str
+    token: str
+    firestore_db: Any
+
+    def assert_current(self) -> None:
+        _assert_firestore_writer_current(self.firestore_db, self.uid, self.token)
+
+    def release(self) -> None:
+        _release_firestore_writer(self.firestore_db, self.uid, self.token)
+
+
+@asynccontextmanager
+async def detached_content_write_fence(uid: str, *, db: Any = None) -> AsyncIterator[DetachedContentWriter]:
+    """Own and bind one writer registration inside a detached async task."""
+    firestore_db = _configured_firestore_db(db)
+    if _authority_enabled():
+        await _assert_postgres_owner_active(uid)
+    writer = DetachedContentWriter(uid=uid, token=uuid.uuid4().hex, firestore_db=firestore_db)
+    try:
+        await asyncio.wait_for(
+            asyncio.to_thread(
+                _acquire_firestore_writer,
+                firestore_db,
+                uid,
+                writer.token,
+                _lease_seconds(),
+            ),
+            timeout=_acquire_seconds(),
+        )
+    except ContentWriteFenceError:
+        raise
+    except Exception as exc:
+        raise ContentWriteFenceError("account_content_fence_unavailable") from exc
+
+    context_token = _detached_writer.set(writer)
+    try:
+        yield writer
+    finally:
+        _detached_writer.reset(context_token)
+        await _finish_even_if_cancelled(asyncio.to_thread(writer.release))
+
+
+def _prepare_detached_content_writer(uid: str) -> DetachedContentWriter:
+    registry = _request_fence_registry.get()
+    if registry is None or uid not in registry:
+        parent = _detached_writer.get()
+        if parent is None or parent.uid != uid:
+            raise ContentWriteFenceError("account_content_fence_unavailable")
+        parent.assert_current()
+    firestore_db = _configured_firestore_db(None)
+    token = uuid.uuid4().hex
+    _acquire_firestore_writer(firestore_db, uid, token, _lease_seconds())
+    return DetachedContentWriter(uid=uid, token=token, firestore_db=firestore_db)
+
+
+def assert_detached_content_writer_current(uid: str) -> None:
+    """Fail a detached worker at its datastore commit boundary if ownership is lost."""
+    writer = _detached_writer.get()
+    if writer is None or writer.uid != uid:
+        raise ContentWriteFenceError("account_content_fence_unavailable")
+    writer.assert_current()
+
+
+def start_content_writer_thread(
+    uid: str,
+    target: Callable[..., Any],
+    *,
+    args: tuple[Any, ...] = (),
+    kwargs: dict[str, Any] | None = None,
+    name: str | None = None,
+    daemon: bool = True,
+) -> threading.Thread:
+    """Transfer a durable writer registration before starting a raw thread."""
+    writer = _prepare_detached_content_writer(uid)
+
+    def run() -> None:
+        context_token = _detached_writer.set(writer)
+        try:
+            target(*args, **(kwargs or {}))
+        finally:
+            try:
+                writer.release()
+            finally:
+                _detached_writer.reset(context_token)
+
+    thread = threading.Thread(target=run, name=name, daemon=daemon)
+    try:
+        thread.start()
+    except Exception:
+        writer.release()
+        raise
+    return thread
+
+
+async def start_content_writer_task(
+    uid: str,
+    factory: Callable[[], Awaitable[Any]],
+    *,
+    name: str | None = None,
+) -> asyncio.Task[Any]:
+    """Transfer a durable writer registration before starting an async task."""
+    writer = await asyncio.to_thread(_prepare_detached_content_writer, uid)
+
+    async def run() -> Any:
+        context_token = _detached_writer.set(writer)
+        try:
+            return await factory()
+        finally:
+            try:
+                await _finish_even_if_cancelled(asyncio.to_thread(writer.release))
+            finally:
+                _detached_writer.reset(context_token)
+
+    try:
+        return asyncio.create_task(run(), name=name)
+    except Exception:
+        await asyncio.to_thread(writer.release)
+        raise
 
 
 @asynccontextmanager
@@ -366,6 +480,7 @@ class ContentWriteFenceMiddleware:
             try:
                 for manager in reversed(tuple(registry.values())):
                     await _finish_even_if_cancelled(manager.__aexit__(None, None, None))
+                registry.clear()
             finally:
                 _request_fence_registry.reset(context_token)
 

--- a/backend/database/content_write_fence.py
+++ b/backend/database/content_write_fence.py
@@ -110,6 +110,32 @@ def _fence_reference(db: Any, uid: str) -> Any:
     return db.collection(FENCE_COLLECTION).document(subject_hash)
 
 
+def content_writes_active(uid: str, *, db: Any = None) -> bool:
+    """Return whether new UID-scoped durable work may be admitted.
+
+    This is only a queue-selection hint. Callers must still acquire a durable
+    writer registration before claiming or mutating work because deletion can
+    begin immediately after this read.
+    """
+    firestore_db = _configured_firestore_db(db)
+    data = _snapshot_data(_fence_reference(firestore_db, uid).get())
+    return data.get("state", ACTIVE) == ACTIVE
+
+
+def transaction_content_writer_current(
+    transaction: Any,
+    firestore_db: Any,
+    uid: str,
+    writer_token: str,
+    *,
+    allow_draining: bool,
+) -> bool:
+    """Check one durable writer token inside another Firestore transaction."""
+    data = _snapshot_data(_fence_reference(firestore_db, uid).get(transaction=transaction))
+    allowed_states = {ACTIVE, DRAINING} if allow_draining else {ACTIVE}
+    return data.get("state", ACTIVE) in allowed_states and writer_token in _registered_writers(data)
+
+
 def _snapshot_data(snapshot: Any) -> dict[str, Any]:
     if not getattr(snapshot, "exists", False):
         return {}

--- a/backend/database/content_write_fence.py
+++ b/backend/database/content_write_fence.py
@@ -1,0 +1,386 @@
+"""Distributed serialization between authenticated content writes and deletion."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from contextvars import ContextVar, Token
+from datetime import datetime, timedelta, timezone
+import hashlib
+import os
+import time
+from typing import Any, AsyncIterator
+import uuid
+
+from google.cloud import firestore
+
+from database import authority_advisory_lock, voice_canary
+
+FENCE_COLLECTION = "_ella_account_deletion_fences"
+ACTIVE = "ACTIVE"
+DRAINING = "DRAINING"
+TOMBSTONED = "TOMBSTONED"
+DEFAULT_LEASE_SECONDS = 900
+MAX_LEASE_SECONDS = 900
+DEFAULT_ACQUIRE_SECONDS = 15.0
+DEFAULT_DRAIN_SECONDS = 15.0
+_firestore_db: Any = None
+_request_fence_registry: ContextVar[dict[str, Any] | None] = ContextVar(
+    "content_write_fence_registry",
+    default=None,
+)
+
+
+class ContentWriteFenceError(RuntimeError):
+    """A content mutation could not safely cross the deletion fence."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def configure_firestore_db(db: Any) -> None:
+    """Inject the production Firestore client without import-time credentials."""
+    global _firestore_db
+    _firestore_db = db
+
+
+def _configured_firestore_db(db: Any) -> Any:
+    configured = db if db is not None else _firestore_db
+    if configured is None:
+        raise ContentWriteFenceError("account_content_fence_unavailable")
+    return configured
+
+
+def _configured_seconds(name: str, default: float, *, maximum: float) -> float:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return min(max(value, 0.1), maximum)
+
+
+def _lease_seconds() -> int:
+    return max(
+        1,
+        int(
+            _configured_seconds(
+                "ELLA_CONTENT_WRITE_FENCE_LEASE_SECONDS",
+                DEFAULT_LEASE_SECONDS,
+                maximum=MAX_LEASE_SECONDS,
+            )
+        ),
+    )
+
+
+def _acquire_seconds() -> float:
+    return _configured_seconds(
+        "ELLA_CONTENT_WRITE_FENCE_ACQUIRE_SECONDS",
+        DEFAULT_ACQUIRE_SECONDS,
+        maximum=60.0,
+    )
+
+
+def _drain_seconds() -> float:
+    return _configured_seconds(
+        "ELLA_CONTENT_WRITE_FENCE_DRAIN_SECONDS",
+        DEFAULT_DRAIN_SECONDS,
+        maximum=60.0,
+    )
+
+
+def _authority_enabled() -> bool:
+    configured = os.getenv("ELLA_POSTGRES_AUTHORITY_ENABLED")
+    if configured is not None:
+        return configured.strip().lower() != "false"
+    return os.getenv("ELLA_ENABLED", "true").strip().lower() != "false"
+
+
+def _fence_reference(db: Any, uid: str) -> Any:
+    subject_hash = hashlib.sha256(uid.encode("utf-8")).hexdigest()
+    return db.collection(FENCE_COLLECTION).document(subject_hash)
+
+
+def _snapshot_data(snapshot: Any) -> dict[str, Any]:
+    if not getattr(snapshot, "exists", False):
+        return {}
+    return dict(snapshot.to_dict() or {})
+
+
+def _active_writers(data: dict[str, Any], now: datetime) -> dict[str, datetime]:
+    writers = data.get("writers")
+    if not isinstance(writers, dict):
+        return {}
+    return {
+        token: expires_at
+        for token, expires_at in writers.items()
+        if isinstance(token, str) and isinstance(expires_at, datetime) and expires_at > now
+    }
+
+
+def _acquire_firestore_writer(db: Any, uid: str, token: str, lease_seconds: int) -> None:
+    reference = _fence_reference(db, uid)
+    now = datetime.now(timezone.utc)
+
+    @firestore.transactional
+    def acquire(transaction: Any) -> None:
+        data = _snapshot_data(reference.get(transaction=transaction))
+        if data.get("state", ACTIVE) != ACTIVE:
+            raise ContentWriteFenceError("account_write_forbidden")
+        writers = _active_writers(data, now)
+        writers[token] = now + timedelta(seconds=lease_seconds)
+        transaction.set(
+            reference,
+            {
+                "state": ACTIVE,
+                "writers": writers,
+                "updated_at": now,
+            },
+        )
+
+    acquire(db.transaction())
+
+
+def _renew_firestore_writer(db: Any, uid: str, token: str, lease_seconds: int) -> bool:
+    reference = _fence_reference(db, uid)
+    now = datetime.now(timezone.utc)
+
+    @firestore.transactional
+    def renew(transaction: Any) -> bool:
+        data = _snapshot_data(reference.get(transaction=transaction))
+        writers = _active_writers(data, now)
+        if token not in writers or data.get("state", ACTIVE) == TOMBSTONED:
+            return False
+        writers[token] = now + timedelta(seconds=lease_seconds)
+        transaction.set(
+            reference,
+            {
+                "state": data.get("state", ACTIVE),
+                "writers": writers,
+                "updated_at": now,
+            },
+        )
+        return True
+
+    return bool(renew(db.transaction()))
+
+
+def _release_firestore_writer(db: Any, uid: str, token: str) -> None:
+    reference = _fence_reference(db, uid)
+    now = datetime.now(timezone.utc)
+
+    @firestore.transactional
+    def release(transaction: Any) -> None:
+        snapshot = reference.get(transaction=transaction)
+        data = _snapshot_data(snapshot)
+        writers = _active_writers(data, now)
+        writers.pop(token, None)
+        state = data.get("state", ACTIVE)
+        if state == ACTIVE and not writers:
+            if getattr(snapshot, "exists", False):
+                transaction.delete(reference)
+            return
+        transaction.set(
+            reference,
+            {
+                "state": state,
+                "writers": writers,
+                "updated_at": now,
+            },
+        )
+
+    release(db.transaction())
+
+
+def _advance_firestore_tombstone(db: Any, uid: str) -> bool:
+    """Block new writers and tombstone once every admitted writer is absent."""
+    reference = _fence_reference(db, uid)
+    now = datetime.now(timezone.utc)
+
+    @firestore.transactional
+    def advance(transaction: Any) -> bool:
+        data = _snapshot_data(reference.get(transaction=transaction))
+        if data.get("state") == TOMBSTONED:
+            return True
+        writers = _active_writers(data, now)
+        state = DRAINING if writers else TOMBSTONED
+        transaction.set(
+            reference,
+            {
+                "state": state,
+                "writers": writers,
+                "deletion_requested_at": data.get("deletion_requested_at") or now,
+                "tombstoned_at": now if state == TOMBSTONED else None,
+                "updated_at": now,
+            },
+        )
+        return state == TOMBSTONED
+
+    return bool(advance(db.transaction()))
+
+
+async def _finish_even_if_cancelled(awaitable: Any) -> None:
+    task = asyncio.create_task(awaitable)
+    try:
+        await asyncio.shield(task)
+    except asyncio.CancelledError:
+        await task
+        raise
+
+
+@asynccontextmanager
+async def _postgres_owner_fence(uid: str) -> AsyncIterator[None]:
+    """Hold the shared owner advisory lock and ACTIVE proof through the write."""
+    try:
+        pool = await voice_canary.get_pool()
+        owner_missing = False
+        async with pool.acquire() as connection:
+            try:
+                owner = await authority_advisory_lock.resolve_self_owner_unlocked(connection, uid=uid)
+            except authority_advisory_lock.AuthorityLockError as exc:
+                if exc.code == "authority_lock_owner_missing":
+                    owner_missing = True
+                else:
+                    raise
+            if not owner_missing:
+                transaction = connection.transaction()
+                await transaction.start()
+                try:
+                    proof = await asyncio.wait_for(
+                        authority_advisory_lock.acquire_authority_lock(connection, owner=owner),
+                        timeout=_acquire_seconds(),
+                    )
+                    user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+                        connection,
+                        uid=uid,
+                        owner=owner,
+                        proof=proof,
+                    )
+                    status = await connection.fetchval("SELECT status FROM users WHERE id = $1", user_id)
+                    if str(status or "") in {"DELETION_PENDING", "DELETED"}:
+                        raise ContentWriteFenceError("account_write_forbidden")
+                    yield
+                finally:
+                    await _finish_even_if_cancelled(transaction.rollback())
+                return
+        if owner_missing:
+            yield
+    except ContentWriteFenceError:
+        raise
+    except Exception as exc:
+        raise ContentWriteFenceError("account_authority_unavailable") from exc
+
+
+async def _renew_until_released(db: Any, uid: str, token: str, lease_seconds: int) -> None:
+    interval = max(1.0, lease_seconds / 3)
+    while True:
+        await asyncio.sleep(interval)
+        renewed = await asyncio.to_thread(_renew_firestore_writer, db, uid, token, lease_seconds)
+        if not renewed:
+            return
+
+
+@asynccontextmanager
+async def content_write_fence(uid: str, *, db: Any = None) -> AsyncIterator[str]:
+    """Hold every distributed deletion fence through the caller's mutation."""
+    firestore_db = _configured_firestore_db(db)
+    lease_seconds = _lease_seconds()
+    token = uuid.uuid4().hex
+
+    @asynccontextmanager
+    async def firestore_fence() -> AsyncIterator[None]:
+        try:
+            await asyncio.wait_for(
+                asyncio.to_thread(_acquire_firestore_writer, firestore_db, uid, token, lease_seconds),
+                timeout=_acquire_seconds(),
+            )
+        except ContentWriteFenceError:
+            raise
+        except Exception as exc:
+            raise ContentWriteFenceError("account_content_fence_unavailable") from exc
+
+        renew_task = asyncio.create_task(_renew_until_released(firestore_db, uid, token, lease_seconds))
+        try:
+            yield
+        finally:
+            renew_task.cancel()
+            try:
+                await renew_task
+            except asyncio.CancelledError:
+                pass
+            await _finish_even_if_cancelled(asyncio.to_thread(_release_firestore_writer, firestore_db, uid, token))
+
+    if _authority_enabled():
+        async with _postgres_owner_fence(uid):
+            async with firestore_fence():
+                yield uid
+    else:
+        async with firestore_fence():
+            yield uid
+
+
+@asynccontextmanager
+async def request_content_write_fence(uid: str) -> AsyncIterator[str]:
+    """Hold one fence per UID until the entire ASGI request has completed."""
+    registry = _request_fence_registry.get()
+    if registry is None:
+        async with content_write_fence(uid):
+            yield uid
+        return
+
+    await admit_request_content_writer(uid)
+    yield uid
+
+
+async def admit_request_content_writer(uid: str) -> str:
+    """Register a post-authentication writer with the request-lifetime fence."""
+    registry = _request_fence_registry.get()
+    if registry is None:
+        raise ContentWriteFenceError("account_content_fence_unavailable")
+    if uid not in registry:
+        manager = content_write_fence(uid)
+        await manager.__aenter__()
+        registry[uid] = manager
+    return uid
+
+
+class ContentWriteFenceMiddleware:
+    """Release registered fences after response streams and background tasks."""
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        if scope.get("type") not in {"http", "websocket"}:
+            await self.app(scope, receive, send)
+            return
+
+        registry: dict[str, Any] = {}
+        context_token: Token[dict[str, Any] | None] = _request_fence_registry.set(registry)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            try:
+                for manager in reversed(tuple(registry.values())):
+                    await _finish_even_if_cancelled(manager.__aexit__(None, None, None))
+            finally:
+                _request_fence_registry.reset(context_token)
+
+
+async def tombstone_content_writes(uid: str, *, db: Any = None) -> bool:
+    """Drain admitted writers, deny new writers, and durably tombstone the UID."""
+    firestore_db = _configured_firestore_db(db)
+    deadline = time.monotonic() + _drain_seconds()
+    while True:
+        try:
+            tombstoned = await asyncio.to_thread(_advance_firestore_tombstone, firestore_db, uid)
+        except Exception as exc:
+            raise ContentWriteFenceError("account_content_fence_unavailable") from exc
+        if tombstoned:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        await asyncio.sleep(0.05)

--- a/backend/database/content_write_fence.py
+++ b/backend/database/content_write_fence.py
@@ -16,7 +16,7 @@ import uuid
 
 from google.cloud import firestore
 
-from database import authority_advisory_lock, voice_canary
+from database import authority_advisory_lock, content_writer_owner, voice_canary
 
 FENCE_COLLECTION = "_ella_account_deletion_fences"
 ACTIVE = "ACTIVE"
@@ -37,6 +37,32 @@ _detached_writer: ContextVar["DetachedContentWriter | None"] = ContextVar(
 )
 
 
+@dataclass(frozen=True)
+class WriterRegistration:
+    expires_at: datetime
+    owner: content_writer_owner.ProcessOwner | None
+
+    def to_storage(self) -> Any:
+        if self.owner is None:
+            return self.expires_at
+        return {
+            "expires_at": self.expires_at,
+            "owner": self.owner.to_storage(),
+        }
+
+
+@dataclass(frozen=True)
+class WriterRecovery:
+    owner: content_writer_owner.ProcessOwner
+    recovered_at: datetime
+
+    def to_storage(self) -> dict[str, Any]:
+        return {
+            "owner": self.owner.to_storage(),
+            "recovered_at": self.recovered_at,
+        }
+
+
 class ContentWriteFenceError(RuntimeError):
     """A content mutation could not safely cross the deletion fence."""
 
@@ -48,6 +74,7 @@ class ContentWriteFenceError(RuntimeError):
 def configure_firestore_db(db: Any) -> None:
     """Inject the production Firestore client without import-time credentials."""
     global _firestore_db
+    _current_process_owner()
     _firestore_db = db
 
 
@@ -133,7 +160,12 @@ def transaction_content_writer_current(
     """Check one durable writer token inside another Firestore transaction."""
     data = _snapshot_data(_fence_reference(firestore_db, uid).get(transaction=transaction))
     allowed_states = {ACTIVE, DRAINING} if allow_draining else {ACTIVE}
-    return data.get("state", ACTIVE) in allowed_states and writer_token in _registered_writers(data)
+    registration = _registered_writers(data).get(writer_token)
+    return (
+        data.get("state", ACTIVE) in allowed_states
+        and registration is not None
+        and registration.owner == _current_process_owner()
+    )
 
 
 def _snapshot_data(snapshot: Any) -> dict[str, Any]:
@@ -142,7 +174,14 @@ def _snapshot_data(snapshot: Any) -> dict[str, Any]:
     return dict(snapshot.to_dict() or {})
 
 
-def _registered_writers(data: dict[str, Any]) -> dict[str, datetime]:
+def _current_process_owner() -> content_writer_owner.ProcessOwner:
+    try:
+        return content_writer_owner.current_process_owner()
+    except content_writer_owner.ProcessOwnerError as exc:
+        raise ContentWriteFenceError(exc.code) from exc
+
+
+def _registered_writers(data: dict[str, Any]) -> dict[str, WriterRegistration]:
     """Return every unreleased writer; timestamps never prove absence.
 
     A process crash or missed heartbeat must leave deletion pending. Expiry is
@@ -159,17 +198,63 @@ def _registered_writers(data: dict[str, Any]) -> dict[str, datetime]:
         return {}
     if not isinstance(writers, dict):
         raise ContentWriteFenceError("account_content_fence_corrupt")
-    registered: dict[str, datetime] = {}
-    for token, expires_at in writers.items():
-        if not isinstance(token, str) or not token or not isinstance(expires_at, datetime):
+    registered: dict[str, WriterRegistration] = {}
+    for token, value in writers.items():
+        if not isinstance(token, str) or not token:
             raise ContentWriteFenceError("account_content_fence_corrupt")
-        registered[token] = expires_at
+        if isinstance(value, datetime):
+            registered[token] = WriterRegistration(expires_at=value, owner=None)
+            continue
+        if not isinstance(value, dict) or set(value) != {"expires_at", "owner"}:
+            raise ContentWriteFenceError("account_content_fence_corrupt")
+        expires_at = value["expires_at"]
+        if not isinstance(expires_at, datetime):
+            raise ContentWriteFenceError("account_content_fence_corrupt")
+        try:
+            owner = content_writer_owner.ProcessOwner.from_storage(value["owner"])
+        except content_writer_owner.ProcessOwnerError as exc:
+            raise ContentWriteFenceError(exc.code) from exc
+        registered[token] = WriterRegistration(expires_at=expires_at, owner=owner)
     return registered
+
+
+def _registered_recoveries(data: dict[str, Any]) -> dict[str, WriterRecovery]:
+    recoveries = data.get("writer_recoveries")
+    if recoveries is None:
+        return {}
+    if not isinstance(recoveries, dict):
+        raise ContentWriteFenceError("account_content_fence_corrupt")
+    registered: dict[str, WriterRecovery] = {}
+    for token_hash, value in recoveries.items():
+        if (
+            not isinstance(token_hash, str)
+            or len(token_hash) != 64
+            or not all(character in "0123456789abcdef" for character in token_hash)
+            or not isinstance(value, dict)
+        ):
+            raise ContentWriteFenceError("account_content_fence_corrupt")
+        if set(value) != {"owner", "recovered_at"} or not isinstance(value["recovered_at"], datetime):
+            raise ContentWriteFenceError("account_content_fence_corrupt")
+        try:
+            owner = content_writer_owner.ProcessOwner.from_storage(value["owner"])
+        except content_writer_owner.ProcessOwnerError as exc:
+            raise ContentWriteFenceError(exc.code) from exc
+        registered[token_hash] = WriterRecovery(owner=owner, recovered_at=value["recovered_at"])
+    return registered
+
+
+def _writers_to_storage(writers: dict[str, WriterRegistration]) -> dict[str, Any]:
+    return {token: registration.to_storage() for token, registration in writers.items()}
+
+
+def _recoveries_to_storage(recoveries: dict[str, WriterRecovery]) -> dict[str, Any]:
+    return {token: recovery.to_storage() for token, recovery in recoveries.items()}
 
 
 def _acquire_firestore_writer(db: Any, uid: str, token: str, lease_seconds: int) -> None:
     reference = _fence_reference(db, uid)
     now = datetime.now(timezone.utc)
+    owner = _current_process_owner()
 
     @firestore.transactional
     def acquire(transaction: Any) -> None:
@@ -177,12 +262,21 @@ def _acquire_firestore_writer(db: Any, uid: str, token: str, lease_seconds: int)
         if data.get("state", ACTIVE) != ACTIVE:
             raise ContentWriteFenceError("account_write_forbidden")
         writers = _registered_writers(data)
-        writers[token] = now + timedelta(seconds=lease_seconds)
+        recoveries = _registered_recoveries(data)
+        existing = writers.get(token)
+        token_hash = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        if (existing is not None and existing.owner != owner) or token_hash in recoveries:
+            raise ContentWriteFenceError("account_writer_owner_mismatch")
+        writers[token] = WriterRegistration(
+            expires_at=now + timedelta(seconds=lease_seconds),
+            owner=owner,
+        )
         transaction.set(
             reference,
             {
                 "state": ACTIVE,
-                "writers": writers,
+                "writers": _writers_to_storage(writers),
+                "writer_recoveries": _recoveries_to_storage(recoveries),
                 "updated_at": now,
             },
         )
@@ -192,12 +286,14 @@ def _acquire_firestore_writer(db: Any, uid: str, token: str, lease_seconds: int)
 
 def _assert_firestore_writer_current(db: Any, uid: str, token: str) -> None:
     reference = _fence_reference(db, uid)
+    owner = _current_process_owner()
 
     @firestore.transactional
     def assert_current(transaction: Any) -> None:
         data = _snapshot_data(reference.get(transaction=transaction))
         writers = _registered_writers(data)
-        if token not in writers or data.get("state", ACTIVE) not in {ACTIVE, DRAINING}:
+        registration = writers.get(token)
+        if registration is None or registration.owner != owner or data.get("state", ACTIVE) not in {ACTIVE, DRAINING}:
             raise ContentWriteFenceError("account_write_forbidden")
 
     assert_current(db.transaction())
@@ -206,15 +302,22 @@ def _assert_firestore_writer_current(db: Any, uid: str, token: str) -> None:
 def _release_firestore_writer(db: Any, uid: str, token: str) -> None:
     reference = _fence_reference(db, uid)
     now = datetime.now(timezone.utc)
+    owner = _current_process_owner()
 
     @firestore.transactional
     def release(transaction: Any) -> None:
         snapshot = reference.get(transaction=transaction)
         data = _snapshot_data(snapshot)
         writers = _registered_writers(data)
-        writers.pop(token, None)
+        registration = writers.get(token)
+        if registration is None:
+            return
+        if registration.owner != owner:
+            raise ContentWriteFenceError("account_writer_owner_mismatch")
+        writers.pop(token)
+        recoveries = _registered_recoveries(data)
         state = data.get("state", ACTIVE)
-        if state == ACTIVE and not writers:
+        if state == ACTIVE and not writers and not recoveries:
             if getattr(snapshot, "exists", False):
                 transaction.delete(reference)
             return
@@ -222,7 +325,8 @@ def _release_firestore_writer(db: Any, uid: str, token: str) -> None:
             reference,
             {
                 "state": state,
-                "writers": writers,
+                "writers": _writers_to_storage(writers),
+                "writer_recoveries": _recoveries_to_storage(recoveries),
                 "updated_at": now,
             },
         )
@@ -241,12 +345,14 @@ def _advance_firestore_tombstone(db: Any, uid: str) -> bool:
         if data.get("state") == TOMBSTONED:
             return True
         writers = _registered_writers(data)
+        recoveries = _registered_recoveries(data)
         state = DRAINING if writers else TOMBSTONED
         transaction.set(
             reference,
             {
                 "state": state,
-                "writers": writers,
+                "writers": _writers_to_storage(writers),
+                "writer_recoveries": _recoveries_to_storage(recoveries),
                 "deletion_requested_at": data.get("deletion_requested_at") or now,
                 "tombstoned_at": now if state == TOMBSTONED else None,
                 "updated_at": now,

--- a/backend/database/content_write_fence.py
+++ b/backend/database/content_write_fence.py
@@ -416,6 +416,39 @@ def assert_content_writer_admitted(uid: str) -> None:
     writer.assert_current()
 
 
+async def finish_admitted_content_mutation(uid: str, awaitable: Awaitable[Any]) -> Any:
+    """Shield an admitted mutation and join it before propagating cancellation.
+
+    Cancellation is a request to stop waiting, not proof that an external
+    mutation stopped. The durable writer therefore remains owned until the
+    submitted operation has a known terminal outcome.
+    """
+    assert_content_writer_admitted(uid)
+    task = asyncio.create_task(awaitable)
+    try:
+        result = await asyncio.shield(task)
+    except asyncio.CancelledError:
+        try:
+            await task
+        except Exception:
+            # The durable job/lease remains the resumable outcome. Shutdown
+            # cancellation is still propagated only after the mutation ended.
+            pass
+        raise
+    assert_content_writer_admitted(uid)
+    return result
+
+
+async def run_admitted_threaded_mutation(
+    subject_uid: str,
+    target: Callable[..., Any],
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """Run a synchronous mutation without orphaning its actual thread."""
+    return await finish_admitted_content_mutation(subject_uid, asyncio.to_thread(target, *args, **kwargs))
+
+
 def start_content_writer_thread(
     uid: str,
     target: Callable[..., Any],

--- a/backend/database/content_write_fence.py
+++ b/backend/database/content_write_fence.py
@@ -379,6 +379,17 @@ def assert_detached_content_writer_current(uid: str) -> None:
     writer.assert_current()
 
 
+def assert_content_writer_admitted(uid: str) -> None:
+    """Require a live request or detached registration for a UID-linked write."""
+    registry = _request_fence_registry.get()
+    if registry is not None and uid in registry:
+        return
+    writer = _detached_writer.get()
+    if writer is None or writer.uid != uid:
+        raise ContentWriteFenceError("account_content_fence_unavailable")
+    writer.assert_current()
+
+
 def start_content_writer_thread(
     uid: str,
     target: Callable[..., Any],

--- a/backend/database/content_write_fence.py
+++ b/backend/database/content_write_fence.py
@@ -148,6 +148,11 @@ def _registered_writers(data: dict[str, Any]) -> dict[str, datetime]:
     A process crash or missed heartbeat must leave deletion pending. Expiry is
     diagnostic metadata only because a live writer can stall its event loop
     longer than the configured interval and still reach its datastore commit.
+    Orphan recovery is exact-token and out-of-band: only after the process
+    supervisor proves the owning process has exited may its recorded tokens be
+    released transactionally, followed by the ordinary deletion retry. A
+    process exit is terminal proof because its ``to_thread`` threads cannot
+    survive it; a lease timestamp alone is never that proof.
     """
     writers = data.get("writers")
     if writers is None:
@@ -252,13 +257,45 @@ def _advance_firestore_tombstone(db: Any, uid: str) -> bool:
     return bool(advance(db.transaction()))
 
 
+async def _await_task_terminal(task: asyncio.Task[Any]) -> Any:
+    """Join one task without allowing caller cancellation to cancel it.
+
+    ``asyncio.shield`` only protects the await during which it is used.  A
+    caller may be cancelled repeatedly while a synchronous ``to_thread``
+    operation is still running, so every wait must remain shielded.  The first
+    caller cancellation is propagated only after the child has a terminal
+    result and its exception (if any) has been retrieved.
+    """
+    caller = asyncio.current_task()
+    cancellation: asyncio.CancelledError | None = None
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError as exc:
+            if caller is not None and caller.cancelling():
+                cancellation = cancellation or exc
+                continue
+            # The shielded child cancelled itself and is therefore terminal.
+            break
+        except BaseException:
+            # The child is terminal. Retrieve and propagate its exact outcome
+            # below, unless caller cancellation has precedence.
+            break
+
+    try:
+        result = task.result()
+    except BaseException:
+        if cancellation is not None:
+            raise cancellation
+        raise
+    if cancellation is not None:
+        raise cancellation
+    return result
+
+
 async def _finish_even_if_cancelled(awaitable: Any) -> None:
     task = asyncio.create_task(awaitable)
-    try:
-        await asyncio.shield(task)
-    except asyncio.CancelledError:
-        await task
-        raise
+    await _await_task_terminal(task)
 
 
 async def _assert_postgres_owner_active(uid: str) -> None:
@@ -425,16 +462,7 @@ async def finish_admitted_content_mutation(uid: str, awaitable: Awaitable[Any]) 
     """
     assert_content_writer_admitted(uid)
     task = asyncio.create_task(awaitable)
-    try:
-        result = await asyncio.shield(task)
-    except asyncio.CancelledError:
-        try:
-            await task
-        except Exception:
-            # The durable job/lease remains the resumable outcome. Shutdown
-            # cancellation is still propagated only after the mutation ended.
-            pass
-        raise
+    result = await _await_task_terminal(task)
     assert_content_writer_admitted(uid)
     return result
 

--- a/backend/database/content_write_recovery.py
+++ b/backend/database/content_write_recovery.py
@@ -1,0 +1,212 @@
+"""Fail-closed, OS-verified recovery for orphaned durable content writers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import hmac
+import re
+from typing import Any
+
+from google.cloud import firestore
+
+from database import content_write_fence, content_writer_owner
+
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ContentWriterRecoveryError(RuntimeError):
+    """Recovery could not prove that the exact recorded owner is terminal."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True)
+class TerminalProcessProof:
+    owner: content_writer_owner.ProcessOwner
+    proof_kind: str
+
+
+@dataclass(frozen=True)
+class ContentWriterRecoveryReceipt:
+    subject_hash: str
+    token_hash: str
+    owner_fingerprint: str
+    result: str
+    proof_kind: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": "content_writer_recovery",
+            "content_free": True,
+            "owner_fingerprint": self.owner_fingerprint,
+            "proof_kind": self.proof_kind,
+            "result": self.result,
+            "subject_hash": self.subject_hash,
+            "token_hash": self.token_hash,
+        }
+
+
+def hash_selector(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _validate_selector(value: str, *, code: str) -> str:
+    normalized = value.strip().lower()
+    if not SHA256_RE.fullmatch(normalized):
+        raise ContentWriterRecoveryError(code)
+    return normalized
+
+
+def _reference(db: Any, subject_hash: str) -> Any:
+    return db.collection(content_write_fence.FENCE_COLLECTION).document(subject_hash)
+
+
+def _matching_token(values: dict[str, Any], token_hash: str) -> str | None:
+    matches = [token for token in values if hmac.compare_digest(hash_selector(token), token_hash)]
+    if len(matches) > 1:
+        raise ContentWriterRecoveryError("account_writer_recovery_selector_ambiguous")
+    return matches[0] if matches else None
+
+
+def prove_recorded_owner_terminal(owner: content_writer_owner.ProcessOwner) -> TerminalProcessProof:
+    """Use only the local kernel boundary; no caller-supplied claim is accepted."""
+    try:
+        boundary = content_writer_owner.current_process_boundary()
+    except content_writer_owner.ProcessOwnerError as exc:
+        raise ContentWriterRecoveryError(exc.code) from exc
+    if owner.system != boundary.system:
+        raise ContentWriterRecoveryError("account_writer_recovery_system_mismatch")
+    if owner.host_id != boundary.host_id:
+        raise ContentWriterRecoveryError("account_writer_recovery_host_mismatch")
+    if owner.boot_id != boundary.boot_id:
+        raise ContentWriterRecoveryError("account_writer_recovery_boot_mismatch")
+    try:
+        namespace_seen = True
+        if owner.pid_namespace == boundary.pid_namespace:
+            snapshot = content_writer_owner.process_snapshot(owner.system, owner.pid)
+        elif owner.system == "Linux":
+            snapshot, namespace_seen = content_writer_owner.linux_supervisor_process_snapshot(
+                owner.pid_namespace,
+                owner.pid,
+            )
+        else:
+            raise ContentWriterRecoveryError("account_writer_recovery_pid_namespace_mismatch")
+    except content_writer_owner.ProcessOwnerError as exc:
+        if exc.code == "account_writer_supervisor_authority_required":
+            raise ContentWriterRecoveryError("account_writer_recovery_pid_namespace_mismatch") from exc
+        raise ContentWriterRecoveryError(exc.code) from exc
+    if snapshot is None:
+        proof_kind = "kernel_process_absent" if namespace_seen else "kernel_pid_namespace_absent"
+        return TerminalProcessProof(owner=owner, proof_kind=proof_kind)
+    if snapshot.start_id != owner.start_id:
+        # A reused PID proves the recorded owner is not the visible process,
+        # but recovery still refuses so an operator cannot normalize a
+        # namespace/start mismatch into release authority.
+        raise ContentWriterRecoveryError("account_writer_recovery_pid_reused")
+    if snapshot.state == "Z":
+        return TerminalProcessProof(owner=owner, proof_kind="kernel_process_zombie")
+    raise ContentWriterRecoveryError("account_writer_recovery_owner_live")
+
+
+def _receipt(
+    *,
+    subject_hash: str,
+    token_hash: str,
+    owner: content_writer_owner.ProcessOwner,
+    result: str,
+    proof_kind: str,
+) -> ContentWriterRecoveryReceipt:
+    return ContentWriterRecoveryReceipt(
+        subject_hash=subject_hash,
+        token_hash=token_hash,
+        owner_fingerprint=owner.fingerprint(),
+        result=result,
+        proof_kind=proof_kind,
+    )
+
+
+def recover_orphaned_writer(
+    db: Any,
+    *,
+    subject_hash: str,
+    token_hash: str,
+) -> ContentWriterRecoveryReceipt:
+    """Recover one exact record after OS proof and a transactional owner CAS."""
+    subject_hash = _validate_selector(subject_hash, code="account_writer_recovery_subject_selector_invalid")
+    token_hash = _validate_selector(token_hash, code="account_writer_recovery_token_selector_invalid")
+    reference = _reference(db, subject_hash)
+    try:
+        initial = content_write_fence._snapshot_data(reference.get())
+        writers = content_write_fence._registered_writers(initial)
+        recoveries = content_write_fence._registered_recoveries(initial)
+    except content_write_fence.ContentWriteFenceError as exc:
+        raise ContentWriterRecoveryError(exc.code) from exc
+
+    token = _matching_token(writers, token_hash)
+    if token is None:
+        recovery = recoveries.get(token_hash)
+        if recovery is None:
+            raise ContentWriterRecoveryError("account_writer_recovery_stale_token")
+        return _receipt(
+            subject_hash=subject_hash,
+            token_hash=token_hash,
+            owner=recovery.owner,
+            result="already_recovered",
+            proof_kind="durable_recovery_receipt",
+        )
+    registration = writers[token]
+    if registration.owner is None:
+        raise ContentWriterRecoveryError("account_writer_recovery_owner_unknown")
+    proof = prove_recorded_owner_terminal(registration.owner)
+    now = datetime.now(timezone.utc)
+
+    @firestore.transactional
+    def compare_and_set(transaction: Any) -> str:
+        try:
+            snapshot = reference.get(transaction=transaction)
+            data = content_write_fence._snapshot_data(snapshot)
+            current_writers = content_write_fence._registered_writers(data)
+            current_recoveries = content_write_fence._registered_recoveries(data)
+        except content_write_fence.ContentWriteFenceError as exc:
+            raise ContentWriterRecoveryError(exc.code) from exc
+        current = current_writers.get(token)
+        if current is None:
+            recovered = current_recoveries.get(token_hash)
+            if recovered is not None and recovered.owner == proof.owner:
+                return "already_recovered"
+            raise ContentWriterRecoveryError("account_writer_recovery_record_replaced")
+        if current.owner != proof.owner:
+            raise ContentWriterRecoveryError("account_writer_recovery_record_replaced")
+        current_writers.pop(token)
+        current_recoveries[token_hash] = content_write_fence.WriterRecovery(
+            owner=proof.owner,
+            recovered_at=now,
+        )
+        updated = dict(data)
+        updated.update(
+            {
+                "writers": content_write_fence._writers_to_storage(current_writers),
+                "writer_recoveries": content_write_fence._recoveries_to_storage(current_recoveries),
+                "updated_at": now,
+            }
+        )
+        transaction.set(reference, updated)
+        return "recovered"
+
+    try:
+        result = compare_and_set(db.transaction())
+    except ContentWriterRecoveryError:
+        raise
+    except Exception as exc:
+        raise ContentWriterRecoveryError("account_writer_recovery_transaction_unavailable") from exc
+    return _receipt(
+        subject_hash=subject_hash,
+        token_hash=token_hash,
+        owner=proof.owner,
+        result=result,
+        proof_kind=proof.proof_kind,
+    )

--- a/backend/database/content_write_recovery.py
+++ b/backend/database/content_write_recovery.py
@@ -6,10 +6,9 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 import hashlib
 import hmac
+import platform
 import re
-from typing import Any
-
-from google.cloud import firestore
+from typing import Any, Callable
 
 from database import content_write_fence, content_writer_owner
 
@@ -134,22 +133,26 @@ def recover_orphaned_writer(
     *,
     subject_hash: str,
     token_hash: str,
+    transactional: Callable[[Callable[..., Any]], Callable[..., Any]],
 ) -> ContentWriterRecoveryReceipt:
     """Recover one exact record after OS proof and a transactional owner CAS."""
+    if platform.system() != "Linux":
+        raise ContentWriterRecoveryError("account_writer_recovery_system_unsupported")
     subject_hash = _validate_selector(subject_hash, code="account_writer_recovery_subject_selector_invalid")
     token_hash = _validate_selector(token_hash, code="account_writer_recovery_token_selector_invalid")
     reference = _reference(db, subject_hash)
     try:
         initial = content_write_fence._snapshot_data(reference.get())
         writers = content_write_fence._registered_writers(initial)
-        recoveries = content_write_fence._registered_recoveries(initial)
+        recovery = content_write_fence._registered_recovery(initial)
     except content_write_fence.ContentWriteFenceError as exc:
         raise ContentWriterRecoveryError(exc.code) from exc
 
     token = _matching_token(writers, token_hash)
+    if token is not None and recovery is not None and hmac.compare_digest(recovery.token_hash, token_hash):
+        raise ContentWriterRecoveryError("account_writer_recovery_selector_ambiguous")
     if token is None:
-        recovery = recoveries.get(token_hash)
-        if recovery is None:
+        if recovery is None or not hmac.compare_digest(recovery.token_hash, token_hash):
             raise ContentWriterRecoveryError("account_writer_recovery_stale_token")
         return _receipt(
             subject_hash=subject_hash,
@@ -164,33 +167,38 @@ def recover_orphaned_writer(
     proof = prove_recorded_owner_terminal(registration.owner)
     now = datetime.now(timezone.utc)
 
-    @firestore.transactional
+    @transactional
     def compare_and_set(transaction: Any) -> str:
         try:
             snapshot = reference.get(transaction=transaction)
             data = content_write_fence._snapshot_data(snapshot)
             current_writers = content_write_fence._registered_writers(data)
-            current_recoveries = content_write_fence._registered_recoveries(data)
+            current_recovery = content_write_fence._registered_recovery(data)
         except content_write_fence.ContentWriteFenceError as exc:
             raise ContentWriterRecoveryError(exc.code) from exc
         current = current_writers.get(token)
         if current is None:
-            recovered = current_recoveries.get(token_hash)
-            if recovered is not None and recovered.owner == proof.owner:
+            if (
+                current_recovery is not None
+                and hmac.compare_digest(current_recovery.token_hash, token_hash)
+                and current_recovery.owner == proof.owner
+            ):
                 return "already_recovered"
             raise ContentWriterRecoveryError("account_writer_recovery_record_replaced")
         if current.owner != proof.owner:
             raise ContentWriterRecoveryError("account_writer_recovery_record_replaced")
         current_writers.pop(token)
-        current_recoveries[token_hash] = content_write_fence.WriterRecovery(
+        current_recovery = content_write_fence.WriterRecovery(
+            token_hash=token_hash,
             owner=proof.owner,
             recovered_at=now,
         )
         updated = dict(data)
+        updated.pop("writer_recoveries", None)
         updated.update(
             {
                 "writers": content_write_fence._writers_to_storage(current_writers),
-                "writer_recoveries": content_write_fence._recoveries_to_storage(current_recoveries),
+                "writer_recovery": current_recovery.to_storage(),
                 "updated_at": now,
             }
         )

--- a/backend/database/content_write_recovery_authority.py
+++ b/backend/database/content_write_recovery_authority.py
@@ -1,0 +1,230 @@
+"""Pinned, protected Firestore authority for host-supervisor recovery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import stat
+from typing import Any, Callable
+
+RECOVERY_CONFIG_PATH = Path("/etc/omi/content-writer-recovery.json")
+CONFIG_SCHEMA_VERSION = 1
+RECEIPT_SCHEMA_VERSION = 1
+MAX_CONFIG_BYTES = 16 * 1024
+MAX_RECEIPT_BYTES = 16 * 1024
+MAX_CREDENTIAL_BYTES = 128 * 1024
+PROJECT_ID_RE = re.compile(r"^[a-z][a-z0-9-]{4,28}[a-z0-9]$")
+DATABASE_ID_RE = re.compile(r"^(?:\(default\)|[a-z][a-z0-9_-]{0,61}[a-z0-9])$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class RecoveryAuthorityError(RuntimeError):
+    """The protected recovery authority could not be proven exactly."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True)
+class RecoveryAuthority:
+    project_id: str
+    database_id: str
+    credential_sha256: str
+
+
+def _protected_parent_chain(path: Path) -> None:
+    if not path.is_absolute():
+        raise RecoveryAuthorityError("account_writer_recovery_authority_path_invalid")
+    current = path.parent
+    while True:
+        try:
+            metadata = current.lstat()
+        except OSError as exc:
+            raise RecoveryAuthorityError("account_writer_recovery_authority_path_unavailable") from exc
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or metadata.st_uid != 0
+            or metadata.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+        ):
+            raise RecoveryAuthorityError("account_writer_recovery_authority_path_unprotected")
+        if current == current.parent:
+            return
+        current = current.parent
+
+
+def _read_protected_file(path: Path, *, maximum: int, code: str) -> bytes:
+    _protected_parent_chain(path)
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise RecoveryAuthorityError(code) from exc
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != 0
+            or metadata.st_mode & (stat.S_IXUSR | stat.S_IRWXG | stat.S_IRWXO)
+            or metadata.st_size > maximum
+        ):
+            raise RecoveryAuthorityError("account_writer_recovery_authority_file_unprotected")
+        chunks: list[bytes] = []
+        length = 0
+        while True:
+            chunk = os.read(descriptor, min(16 * 1024, maximum + 1 - length))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            length += len(chunk)
+            if length > maximum:
+                raise RecoveryAuthorityError("account_writer_recovery_authority_file_oversized")
+        return b"".join(chunks)
+    finally:
+        os.close(descriptor)
+
+
+def _decode_object(payload: bytes, *, code: str) -> dict[str, Any]:
+    try:
+        value = json.loads(payload.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise RecoveryAuthorityError(code) from exc
+    if not isinstance(value, dict):
+        raise RecoveryAuthorityError(code)
+    return value
+
+
+def _validated_config(config_path: Path) -> tuple[str, str, Path, Path]:
+    config = _decode_object(
+        _read_protected_file(
+            config_path,
+            maximum=MAX_CONFIG_BYTES,
+            code="account_writer_recovery_config_unavailable",
+        ),
+        code="account_writer_recovery_config_invalid",
+    )
+    if set(config) != {
+        "schema_version",
+        "project_id",
+        "database_id",
+        "credential_file",
+        "deployment_receipt_file",
+    }:
+        raise RecoveryAuthorityError("account_writer_recovery_config_invalid")
+    project_id = config["project_id"]
+    database_id = config["database_id"]
+    credential_file = config["credential_file"]
+    receipt_file = config["deployment_receipt_file"]
+    if (
+        not isinstance(config["schema_version"], int)
+        or isinstance(config["schema_version"], bool)
+        or config["schema_version"] != CONFIG_SCHEMA_VERSION
+        or not isinstance(project_id, str)
+        or PROJECT_ID_RE.fullmatch(project_id) is None
+        or not isinstance(database_id, str)
+        or DATABASE_ID_RE.fullmatch(database_id) is None
+        or not isinstance(credential_file, str)
+        or not isinstance(receipt_file, str)
+    ):
+        raise RecoveryAuthorityError("account_writer_recovery_config_invalid")
+    credential_path = Path(credential_file)
+    receipt_path = Path(receipt_file)
+    if not credential_path.is_absolute() or not receipt_path.is_absolute():
+        raise RecoveryAuthorityError("account_writer_recovery_config_invalid")
+    return project_id, database_id, credential_path, receipt_path
+
+
+def _validated_receipt(
+    path: Path,
+    *,
+    project_id: str,
+    database_id: str,
+    credential_sha256: str,
+) -> None:
+    receipt = _decode_object(
+        _read_protected_file(
+            path,
+            maximum=MAX_RECEIPT_BYTES,
+            code="account_writer_recovery_deployment_receipt_unavailable",
+        ),
+        code="account_writer_recovery_deployment_receipt_invalid",
+    )
+    if set(receipt) != {"schema_version", "project_id", "database_id", "credential_sha256"}:
+        raise RecoveryAuthorityError("account_writer_recovery_deployment_receipt_invalid")
+    if (
+        not isinstance(receipt["schema_version"], int)
+        or isinstance(receipt["schema_version"], bool)
+        or receipt["schema_version"] != RECEIPT_SCHEMA_VERSION
+        or receipt["project_id"] != project_id
+        or receipt["database_id"] != database_id
+        or not isinstance(receipt["credential_sha256"], str)
+        or SHA256_RE.fullmatch(receipt["credential_sha256"]) is None
+        or receipt["credential_sha256"] != credential_sha256
+    ):
+        raise RecoveryAuthorityError("account_writer_recovery_deployment_receipt_mismatch")
+
+
+def _load_recovery_firestore_client(
+    config_path: Path,
+    *,
+    credentials_factory: Callable[[dict[str, Any]], Any],
+    client_factory: Callable[..., Any],
+) -> tuple[Any, RecoveryAuthority]:
+    if os.environ.get("FIRESTORE_EMULATOR_HOST") is not None:
+        raise RecoveryAuthorityError("account_writer_recovery_emulator_forbidden")
+    project_id, database_id, credential_path, receipt_path = _validated_config(config_path)
+    credential_payload = _read_protected_file(
+        credential_path,
+        maximum=MAX_CREDENTIAL_BYTES,
+        code="account_writer_recovery_credentials_unavailable",
+    )
+    credential_sha256 = hashlib.sha256(credential_payload).hexdigest()
+    _validated_receipt(
+        receipt_path,
+        project_id=project_id,
+        database_id=database_id,
+        credential_sha256=credential_sha256,
+    )
+    credential_info = _decode_object(
+        credential_payload,
+        code="account_writer_recovery_credentials_invalid",
+    )
+    if credential_info.get("type") != "service_account" or credential_info.get("project_id") != project_id:
+        raise RecoveryAuthorityError("account_writer_recovery_credentials_mismatch")
+    try:
+        credentials = credentials_factory(credential_info)
+        del credential_info, credential_payload
+        client = client_factory(project=project_id, database=database_id, credentials=credentials)
+    except Exception as exc:
+        raise RecoveryAuthorityError("account_writer_recovery_client_unavailable") from exc
+    selected_project = getattr(client, "project", getattr(client, "_project", None))
+    selected_database = getattr(client, "database", getattr(client, "_database", None))
+    if selected_project != project_id or selected_database != database_id:
+        raise RecoveryAuthorityError("account_writer_recovery_client_mismatch")
+    return client, RecoveryAuthority(
+        project_id=project_id,
+        database_id=database_id,
+        credential_sha256=credential_sha256,
+    )
+
+
+def load_production_recovery_firestore_client() -> tuple[Any, RecoveryAuthority, Callable[..., Any]]:
+    """Load the only production recovery authority; callers cannot select it."""
+    if platform.system() != "Linux":
+        raise RecoveryAuthorityError("account_writer_recovery_system_unsupported")
+    # Delayed imports are mandatory here: the production bootstrap proves the
+    # initial-host supervisor before this function can load Google code.
+    from google.cloud import firestore
+    from google.oauth2 import service_account
+
+    client, authority = _load_recovery_firestore_client(
+        RECOVERY_CONFIG_PATH,
+        credentials_factory=service_account.Credentials.from_service_account_info,
+        client_factory=firestore.Client,
+    )
+    return client, authority, firestore.transactional

--- a/backend/database/content_writer_owner.py
+++ b/backend/database/content_writer_owner.py
@@ -1,0 +1,331 @@
+"""Immutable process ownership and kernel-backed terminal proof for writers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import errno
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import socket
+import subprocess
+import threading
+from typing import Any
+import uuid
+
+OWNER_SCHEMA_VERSION = 1
+SUPPORTED_RECOVERY_SYSTEMS = {"Linux", "Darwin"}
+LINUX_CAP_SYS_ADMIN = 21
+LINUX_NS_GET_PARENT = 0xB702
+_owner_lock = threading.Lock()
+_process_owner: "ProcessOwner | None" = None
+
+
+class ProcessOwnerError(RuntimeError):
+    """The local kernel boundary could not authoritatively identify a process."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True)
+class ProcessBoundary:
+    system: str
+    host_id: str
+    boot_id: str
+    pid_namespace: str
+
+
+@dataclass(frozen=True)
+class ProcessSnapshot:
+    start_id: str
+    state: str
+
+
+@dataclass(frozen=True)
+class ProcessOwner:
+    schema_version: int
+    generation: str
+    system: str
+    host_id: str
+    boot_id: str
+    pid_namespace: str
+    pid: int
+    start_id: str
+
+    def to_storage(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "generation": self.generation,
+            "system": self.system,
+            "host_id": self.host_id,
+            "boot_id": self.boot_id,
+            "pid_namespace": self.pid_namespace,
+            "pid": self.pid,
+            "start_id": self.start_id,
+        }
+
+    @classmethod
+    def from_storage(cls, value: Any) -> "ProcessOwner":
+        if not isinstance(value, dict) or set(value) != {
+            "schema_version",
+            "generation",
+            "system",
+            "host_id",
+            "boot_id",
+            "pid_namespace",
+            "pid",
+            "start_id",
+        }:
+            raise ProcessOwnerError("account_writer_owner_corrupt")
+        owner = cls(
+            schema_version=value["schema_version"],
+            generation=value["generation"],
+            system=value["system"],
+            host_id=value["host_id"],
+            boot_id=value["boot_id"],
+            pid_namespace=value["pid_namespace"],
+            pid=value["pid"],
+            start_id=value["start_id"],
+        )
+        if (
+            not isinstance(owner.schema_version, int)
+            or isinstance(owner.schema_version, bool)
+            or owner.schema_version != OWNER_SCHEMA_VERSION
+            or not isinstance(owner.generation, str)
+            or len(owner.generation) != 32
+            or not all(character in "0123456789abcdef" for character in owner.generation)
+            or not isinstance(owner.system, str)
+            or owner.system not in SUPPORTED_RECOVERY_SYSTEMS
+            or not isinstance(owner.host_id, str)
+            or len(owner.host_id) != 64
+            or not all(character in "0123456789abcdef" for character in owner.host_id)
+            or not isinstance(owner.boot_id, str)
+            or not owner.boot_id
+            or not isinstance(owner.pid_namespace, str)
+            or not owner.pid_namespace
+            or not isinstance(owner.pid, int)
+            or isinstance(owner.pid, bool)
+            or owner.pid <= 0
+            or not isinstance(owner.start_id, str)
+            or not owner.start_id
+        ):
+            raise ProcessOwnerError("account_writer_owner_corrupt")
+        return owner
+
+    def fingerprint(self) -> str:
+        encoded = json.dumps(self.to_storage(), sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+
+def _read_required_text(path: Path, *, code: str) -> str:
+    try:
+        value = path.read_text(encoding="ascii").strip()
+    except (OSError, UnicodeError) as exc:
+        raise ProcessOwnerError(code) from exc
+    if not value:
+        raise ProcessOwnerError(code)
+    return value
+
+
+def _linux_boundary() -> ProcessBoundary:
+    boot_id = _read_required_text(Path("/proc/sys/kernel/random/boot_id"), code="account_writer_boot_unknown")
+    try:
+        pid_namespace = os.readlink("/proc/self/ns/pid")
+    except OSError as exc:
+        raise ProcessOwnerError("account_writer_pid_namespace_unknown") from exc
+    host_material = f"linux-host-boot:{boot_id}"
+    return ProcessBoundary(
+        system="Linux",
+        host_id=hashlib.sha256(host_material.encode("ascii")).hexdigest(),
+        boot_id=boot_id,
+        pid_namespace=pid_namespace,
+    )
+
+
+def _darwin_boundary() -> ProcessBoundary:
+    try:
+        completed = subprocess.run(
+            ["sysctl", "-n", "kern.boottime"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise ProcessOwnerError("account_writer_boot_unknown") from exc
+    boot_id = completed.stdout.strip()
+    hostname = socket.gethostname().strip()
+    if not boot_id or not hostname:
+        raise ProcessOwnerError("account_writer_host_unknown")
+    return ProcessBoundary(
+        system="Darwin",
+        host_id=hashlib.sha256(hostname.encode("utf-8")).hexdigest(),
+        boot_id=boot_id,
+        pid_namespace="darwin-host-process-table",
+    )
+
+
+def current_process_boundary() -> ProcessBoundary:
+    system = platform.system()
+    if system == "Linux":
+        return _linux_boundary()
+    if system == "Darwin":
+        return _darwin_boundary()
+    raise ProcessOwnerError("account_writer_os_boundary_unsupported")
+
+
+def _linux_process_snapshot(pid: int) -> ProcessSnapshot | None:
+    return _linux_process_snapshot_path(Path(f"/proc/{pid}/stat"))
+
+
+def _linux_process_snapshot_path(path: Path) -> ProcessSnapshot | None:
+    try:
+        raw = path.read_text(encoding="ascii")
+    except FileNotFoundError:
+        return None
+    except (OSError, UnicodeError) as exc:
+        raise ProcessOwnerError("account_writer_process_state_unknown") from exc
+    closing_parenthesis = raw.rfind(")")
+    fields = raw[closing_parenthesis + 2 :].split() if closing_parenthesis >= 0 else []
+    if len(fields) <= 19:
+        raise ProcessOwnerError("account_writer_process_state_unknown")
+    return ProcessSnapshot(start_id=f"linux-proc-start:{fields[19]}", state=fields[0])
+
+
+def _linux_has_supervisor_authority() -> bool:
+    try:
+        status = Path("/proc/self/status").read_text(encoding="ascii")
+    except (OSError, UnicodeError) as exc:
+        raise ProcessOwnerError("account_writer_supervisor_authority_unknown") from exc
+    cap_eff = next((line.split(":", 1)[1].strip() for line in status.splitlines() if line.startswith("CapEff:")), None)
+    if cap_eff is None:
+        raise ProcessOwnerError("account_writer_supervisor_authority_unknown")
+    try:
+        capabilities = int(cap_eff, 16)
+    except ValueError as exc:
+        raise ProcessOwnerError("account_writer_supervisor_authority_unknown") from exc
+    if not capabilities & (1 << LINUX_CAP_SYS_ADMIN):
+        return False
+    try:
+        namespace_fd = os.open("/proc/self/ns/pid", os.O_RDONLY)
+    except OSError as exc:
+        raise ProcessOwnerError("account_writer_supervisor_authority_unknown") from exc
+    try:
+        try:
+            parent_fd = fcntl.ioctl(namespace_fd, LINUX_NS_GET_PARENT)
+        except OSError as exc:
+            if exc.errno == errno.EINVAL:
+                return True
+            if exc.errno in {errno.EPERM, errno.EACCES}:
+                return False
+            raise ProcessOwnerError("account_writer_supervisor_authority_unknown") from exc
+        else:
+            os.close(parent_fd)
+            return False
+    finally:
+        os.close(namespace_fd)
+
+
+def linux_supervisor_process_snapshot(pid_namespace: str, namespace_pid: int) -> tuple[ProcessSnapshot | None, bool]:
+    """Read an exact container PID from a host-supervisor process table."""
+    if platform.system() != "Linux" or not _linux_has_supervisor_authority():
+        raise ProcessOwnerError("account_writer_supervisor_authority_required")
+    namespace_seen = False
+    try:
+        process_paths = tuple(Path("/proc").iterdir())
+    except OSError as exc:
+        raise ProcessOwnerError("account_writer_process_state_unknown") from exc
+    for process_path in process_paths:
+        if not process_path.name.isdigit():
+            continue
+        try:
+            visible_namespace = os.readlink(process_path / "ns" / "pid")
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise ProcessOwnerError("account_writer_process_state_unknown") from exc
+        if visible_namespace != pid_namespace:
+            continue
+        namespace_seen = True
+        try:
+            status = (process_path / "status").read_text(encoding="ascii")
+        except FileNotFoundError:
+            continue
+        except (OSError, UnicodeError) as exc:
+            raise ProcessOwnerError("account_writer_process_state_unknown") from exc
+        nspid = next((line.split(":", 1)[1].split() for line in status.splitlines() if line.startswith("NSpid:")), None)
+        if nspid is None:
+            raise ProcessOwnerError("account_writer_process_state_unknown")
+        try:
+            visible_pid = int(nspid[-1])
+        except (IndexError, ValueError) as exc:
+            raise ProcessOwnerError("account_writer_process_state_unknown") from exc
+        if visible_pid != namespace_pid:
+            continue
+        return _linux_process_snapshot_path(process_path / "stat"), namespace_seen
+    return None, namespace_seen
+
+
+def _darwin_ps_value(pid: int, field: str) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["ps", "-o", f"{field}=", "-p", str(pid)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise ProcessOwnerError("account_writer_process_state_unknown") from exc
+    if completed.returncode != 0:
+        return None
+    value = completed.stdout.strip()
+    return value or None
+
+
+def _darwin_process_snapshot(pid: int) -> ProcessSnapshot | None:
+    first_start = _darwin_ps_value(pid, "lstart")
+    if first_start is None:
+        return None
+    state = _darwin_ps_value(pid, "state")
+    second_start = _darwin_ps_value(pid, "lstart")
+    if state is None or second_start is None or first_start != second_start:
+        raise ProcessOwnerError("account_writer_process_state_unknown")
+    return ProcessSnapshot(start_id=f"darwin-ps-start:{first_start}", state=state[:1])
+
+
+def process_snapshot(system: str, pid: int) -> ProcessSnapshot | None:
+    if system == "Linux":
+        return _linux_process_snapshot(pid)
+    if system == "Darwin":
+        return _darwin_process_snapshot(pid)
+    raise ProcessOwnerError("account_writer_os_boundary_unsupported")
+
+
+def current_process_owner() -> ProcessOwner:
+    """Return one immutable generation, regenerating safely after ``fork``."""
+    global _process_owner
+    pid = os.getpid()
+    with _owner_lock:
+        if _process_owner is not None and _process_owner.pid == pid:
+            return _process_owner
+        boundary = current_process_boundary()
+        snapshot = process_snapshot(boundary.system, pid)
+        if snapshot is None or snapshot.state == "Z":
+            raise ProcessOwnerError("account_writer_process_state_unknown")
+        _process_owner = ProcessOwner(
+            schema_version=OWNER_SCHEMA_VERSION,
+            generation=uuid.uuid4().hex,
+            system=boundary.system,
+            host_id=boundary.host_id,
+            boot_id=boundary.boot_id,
+            pid_namespace=boundary.pid_namespace,
+            pid=pid,
+            start_id=snapshot.start_id,
+        )
+        return _process_owner

--- a/backend/database/content_writer_owner.py
+++ b/backend/database/content_writer_owner.py
@@ -10,14 +10,12 @@ import json
 import os
 from pathlib import Path
 import platform
-import socket
-import subprocess
 import threading
 from typing import Any
 import uuid
 
 OWNER_SCHEMA_VERSION = 1
-SUPPORTED_RECOVERY_SYSTEMS = {"Linux", "Darwin"}
+SUPPORTED_RECOVERY_SYSTEMS = {"Linux"}
 LINUX_CAP_SYS_ADMIN = 21
 LINUX_NS_GET_PARENT = 0xB702
 _owner_lock = threading.Lock()
@@ -147,36 +145,10 @@ def _linux_boundary() -> ProcessBoundary:
     )
 
 
-def _darwin_boundary() -> ProcessBoundary:
-    try:
-        completed = subprocess.run(
-            ["sysctl", "-n", "kern.boottime"],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=2,
-        )
-    except (OSError, subprocess.SubprocessError) as exc:
-        raise ProcessOwnerError("account_writer_boot_unknown") from exc
-    boot_id = completed.stdout.strip()
-    hostname = socket.gethostname().strip()
-    if not boot_id or not hostname:
-        raise ProcessOwnerError("account_writer_host_unknown")
-    return ProcessBoundary(
-        system="Darwin",
-        host_id=hashlib.sha256(hostname.encode("utf-8")).hexdigest(),
-        boot_id=boot_id,
-        pid_namespace="darwin-host-process-table",
-    )
-
-
 def current_process_boundary() -> ProcessBoundary:
-    system = platform.system()
-    if system == "Linux":
-        return _linux_boundary()
-    if system == "Darwin":
-        return _darwin_boundary()
-    raise ProcessOwnerError("account_writer_os_boundary_unsupported")
+    if platform.system() != "Linux":
+        raise ProcessOwnerError("account_writer_os_boundary_unsupported")
+    return _linux_boundary()
 
 
 def _linux_process_snapshot(pid: int) -> ProcessSnapshot | None:
@@ -271,40 +243,10 @@ def linux_supervisor_process_snapshot(pid_namespace: str, namespace_pid: int) ->
     return None, namespace_seen
 
 
-def _darwin_ps_value(pid: int, field: str) -> str | None:
-    try:
-        completed = subprocess.run(
-            ["ps", "-o", f"{field}=", "-p", str(pid)],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=2,
-        )
-    except (OSError, subprocess.SubprocessError) as exc:
-        raise ProcessOwnerError("account_writer_process_state_unknown") from exc
-    if completed.returncode != 0:
-        return None
-    value = completed.stdout.strip()
-    return value or None
-
-
-def _darwin_process_snapshot(pid: int) -> ProcessSnapshot | None:
-    first_start = _darwin_ps_value(pid, "lstart")
-    if first_start is None:
-        return None
-    state = _darwin_ps_value(pid, "state")
-    second_start = _darwin_ps_value(pid, "lstart")
-    if state is None or second_start is None or first_start != second_start:
-        raise ProcessOwnerError("account_writer_process_state_unknown")
-    return ProcessSnapshot(start_id=f"darwin-ps-start:{first_start}", state=state[:1])
-
-
 def process_snapshot(system: str, pid: int) -> ProcessSnapshot | None:
-    if system == "Linux":
-        return _linux_process_snapshot(pid)
-    if system == "Darwin":
-        return _darwin_process_snapshot(pid)
-    raise ProcessOwnerError("account_writer_os_boundary_unsupported")
+    if system != "Linux" or platform.system() != "Linux":
+        raise ProcessOwnerError("account_writer_os_boundary_unsupported")
+    return _linux_process_snapshot(pid)
 
 
 def current_process_owner() -> ProcessOwner:

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -24,6 +24,7 @@ from database.runtime_targets import (
 )
 
 _pool: Optional[asyncpg.Pool] = None
+PROVIDER_ATTEMPT_NAMESPACE = uuid.UUID("48f8770f-c801-5ba7-8be1-aaafaf68480d")
 REQUIRED_PROVISIONING_INDEXES = (
     "ella_provisioning_jobs_user_schema_key",
     "ella_provisioning_jobs_state_updated_idx",
@@ -37,6 +38,10 @@ REQUIRED_PROVISIONING_INDEXES = (
     "ella_runtime_bindings_one_active_role_key",
     "ella_runtime_bindings_user_role_active_idx",
     "ella_runtime_bindings_health_updated_idx",
+    "ella_provider_attempts_idempotency_key",
+    "ella_provider_attempts_job_operation_key",
+    "ella_provider_attempts_correlation_ref_key",
+    "ella_provider_attempts_user_pending_idx",
 )
 REQUIRED_CLOUD_RUNTIME_INDEXES = (
     "users_profile_class_idx",
@@ -343,6 +348,54 @@ def _json_object(value: Any) -> Any:
     return value
 
 
+def ensure_omi_user_document_contents(
+    firestore_db: Any,
+    *,
+    uid: str,
+    email: str,
+    name: str,
+    timezone_name: str,
+    private_cloud_sync_default: bool = False,
+) -> bool:
+    """Apply the content-only Firestore mutation after the SQL write fence."""
+    user_ref = firestore_db.collection("users").document(uid)
+    snapshot = user_ref.get()
+    if snapshot.exists:
+        data = snapshot.to_dict() or {}
+        missing_defaults = {
+            key: value
+            for key, value in {
+                "uid": uid,
+                "email": email,
+                "name": name,
+                "time_zone": timezone_name,
+                "private_cloud_sync_enabled": private_cloud_sync_default,
+                "store_recording_permission": False,
+            }.items()
+            if key not in data
+        }
+        if missing_defaults:
+            missing_defaults["updated_at"] = datetime.now(timezone.utc)
+            user_ref.set(missing_defaults, merge=True)
+            return True
+        return False
+    now = datetime.now(timezone.utc)
+    user_ref.set(
+        {
+            "uid": uid,
+            "email": email,
+            "name": name,
+            "time_zone": timezone_name,
+            "created_at": now,
+            "updated_at": now,
+            "private_cloud_sync_enabled": private_cloud_sync_default,
+            "store_recording_permission": False,
+        },
+        merge=False,
+    )
+    return True
+
+
 class EllaProvisioningRepository:
     def __init__(self, pool: asyncpg.Pool, *, firestore_db: Any = None):
         self.pool = pool
@@ -359,6 +412,7 @@ class EllaProvisioningRepository:
             SELECT
                 to_regclass('public.ella_provisioning_jobs') IS NOT NULL AS jobs_table,
                 to_regclass('public.ella_runtime_bindings') IS NOT NULL AS bindings_table,
+                to_regclass('public.ella_provider_attempts') IS NOT NULL AS provider_attempts_table,
                 ARRAY(
                     SELECT required.index_name
                     FROM unnest($1::text[]) AS required(index_name)
@@ -378,6 +432,8 @@ class EllaProvisioningRepository:
             missing.append("table:ella_provisioning_jobs")
         if not row or not row["bindings_table"]:
             missing.append("table:ella_runtime_bindings")
+        if not row or not row["provider_attempts_table"]:
+            missing.append("table:ella_provider_attempts")
         if row:
             missing.extend(f"index:{name}" for name in (row["missing_indexes"] or []))
         if missing:
@@ -499,7 +555,7 @@ class EllaProvisioningRepository:
             raise ProvisioningSchemaNotReadyError(missing)
 
     async def assert_self_hosted_invite_schema_ready(self) -> None:
-        """Require migration 015 before any invited self-hosted side effect."""
+        """Require migrations 015 and 017 before a self-hosted side effect."""
         row = await self.pool.fetchrow(
             """
             SELECT
@@ -536,6 +592,8 @@ class EllaProvisioningRepository:
                     )
                     ORDER BY required.index_name
                 ) AS missing_indexes
+                ,to_regclass(current_schema() || '.ella_provider_attempts') IS NOT NULL
+                    AS provider_attempts_table
             """,
             [table for table, _column in REQUIRED_SELF_HOSTED_INVITE_COLUMNS],
             [column for _table, column in REQUIRED_SELF_HOSTED_INVITE_COLUMNS],
@@ -549,6 +607,8 @@ class EllaProvisioningRepository:
             missing.extend(f"column:{value}" for value in (row["missing_columns"] or []))
             missing.extend(f"constraint:{value}" for value in (row["missing_constraints"] or []))
             missing.extend(f"index:{value}" for value in (row["missing_indexes"] or []))
+            if not row["provider_attempts_table"]:
+                missing.append("table:ella_provider_attempts")
         if missing:
             raise ProvisioningSchemaNotReadyError(missing)
 
@@ -700,6 +760,14 @@ class EllaProvisioningRepository:
                 if by_uid:
                     if str(by_uid["email"]).lower() != email.lower():
                         raise IdentityConflictError("uid_email_mismatch")
+                    status = str(by_uid["status"])
+                    if status == "PENDING":
+                        return dict(by_uid)
+                    await authority_advisory_lock.require_user_write_status(
+                        connection,
+                        owner_lock,
+                        user_id=by_uid["id"],
+                    )
                     updated = await connection.fetchrow(
                         """
                         UPDATE users
@@ -725,6 +793,11 @@ class EllaProvisioningRepository:
                     existing_uid = by_email["omi_uid"]
                     if existing_uid and existing_uid != uid:
                         raise IdentityConflictError("email_owned_by_different_uid")
+                    await authority_advisory_lock.require_user_write_status(
+                        connection,
+                        owner_lock,
+                        user_id=by_email["id"],
+                    )
                     updated = await connection.fetchrow(
                         """
                         UPDATE users
@@ -790,45 +863,37 @@ class EllaProvisioningRepository:
         if self.firestore_db is None:
             raise RuntimeError("firestore_client_unavailable")
 
-        def _ensure() -> bool:
-            user_ref = self.firestore_db.collection("users").document(uid)
-            snapshot = user_ref.get()
-            if snapshot.exists:
-                data = snapshot.to_dict() or {}
-                missing_defaults = {
-                    key: value
-                    for key, value in {
-                        "uid": uid,
-                        "email": email,
-                        "name": name,
-                        "time_zone": timezone_name,
-                        "private_cloud_sync_enabled": private_cloud_sync_default,
-                        "store_recording_permission": False,
-                    }.items()
-                    if key not in data
-                }
-                if missing_defaults:
-                    missing_defaults["updated_at"] = datetime.now(timezone.utc)
-                    user_ref.set(missing_defaults, merge=True)
-                    return True
-                return False
-            now = datetime.now(timezone.utc)
-            user_ref.set(
-                {
-                    "uid": uid,
-                    "email": email,
-                    "name": name,
-                    "time_zone": timezone_name,
-                    "created_at": now,
-                    "updated_at": now,
-                    "private_cloud_sync_enabled": private_cloud_sync_default,
-                    "store_recording_permission": False,
-                },
-                merge=False,
+        async with self.pool.acquire() as connection:
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+                connection,
+                uid=uid,
             )
-            return True
-
-        return await asyncio.to_thread(_ensure)
+            async with connection.transaction():
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(
+                    connection,
+                    owner=owner,
+                )
+                user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=uid,
+                    owner=owner,
+                    proof=owner_lock,
+                )
+                await authority_advisory_lock.require_user_write_status(
+                    connection,
+                    owner_lock,
+                    user_id=user_id,
+                    allowed_statuses=("PENDING", "ACTIVE"),
+                )
+                return await asyncio.to_thread(
+                    ensure_omi_user_document_contents,
+                    self.firestore_db,
+                    uid=uid,
+                    email=email,
+                    name=name,
+                    timezone_name=timezone_name,
+                    private_cloud_sync_default=private_cloud_sync_default,
+                )
 
     async def acquire_job(
         self,
@@ -838,25 +903,38 @@ class EllaProvisioningRepository:
         client_request_id: Optional[str],
         request_payload_hash: str,
     ) -> dict[str, Any]:
-        row = await self.pool.fetchrow(
-            """
-            INSERT INTO ella_provisioning_jobs (
-                id, user_id, target_schema_version, client_request_id,
-                request_payload_hash, state, stage, retryable
-            )
-            SELECT $1, u.id, $3, $4, $5, 'pending', 'identity_ready', true
-            FROM users u
-            WHERE u.omi_uid = $2
-            ON CONFLICT (user_id, target_schema_version) DO UPDATE
-            SET client_request_id = EXCLUDED.client_request_id
-            RETURNING *
-            """,
-            uuid.uuid4(),
-            uid,
-            target_schema_version,
-            client_request_id,
-            request_payload_hash,
-        )
+        async with self.pool.acquire() as connection:
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked(connection, uid=uid)
+            async with connection.transaction():
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(connection, owner=owner)
+                user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=uid,
+                    owner=owner,
+                    proof=owner_lock,
+                )
+                await authority_advisory_lock.require_user_write_status(
+                    connection,
+                    owner_lock,
+                    user_id=user_id,
+                    allowed_statuses=("PENDING", "ACTIVE"),
+                )
+                row = await connection.fetchrow(
+                    """
+                    INSERT INTO ella_provisioning_jobs (
+                        id, user_id, target_schema_version, client_request_id,
+                        request_payload_hash, state, stage, retryable
+                    ) VALUES ($1, $2, $3, $4, $5, 'pending', 'identity_ready', true)
+                    ON CONFLICT (user_id, target_schema_version) DO UPDATE
+                    SET client_request_id = EXCLUDED.client_request_id
+                    RETURNING *
+                    """,
+                    uuid.uuid4(),
+                    user_id,
+                    target_schema_version,
+                    client_request_id,
+                    request_payload_hash,
+                )
         if not row:
             raise LookupError("user_not_found")
         return dict(row)
@@ -875,26 +953,56 @@ class EllaProvisioningRepository:
         return _row_dict(row)
 
     async def claim_job(self, job_id: str) -> Optional[dict[str, Any]]:
-        row = await self.pool.fetchrow(
-            """
-            UPDATE ella_provisioning_jobs
-            SET state = 'provisioning',
-                stage = 'profile_ready',
-                attempts = attempts + 1,
-                retryable = true,
-                error_code = NULL,
-                error_detail = '{}'::jsonb,
-                updated_at = CURRENT_TIMESTAMP
-            WHERE id = $1
-              AND state NOT IN ('ready', 'blocked', 'rolling_back', 'manual_intervention')
-              AND (
-                    state NOT IN ('provisioning', 'retryable')
-                    OR updated_at < CURRENT_TIMESTAMP - INTERVAL '2 minutes'
-                  )
-            RETURNING *
-            """,
-            uuid.UUID(str(job_id)),
-        )
+        job_uuid = uuid.UUID(str(job_id))
+        async with self.pool.acquire() as connection:
+            owner_row = await connection.fetchrow(
+                """
+                SELECT u.id, u.omi_uid
+                FROM ella_provisioning_jobs job
+                JOIN users u ON u.id = job.user_id
+                WHERE job.id = $1
+                """,
+                job_uuid,
+            )
+            if not owner_row:
+                return None
+            owner = authority_advisory_lock.AuthorityOwner.from_values(owner_row["id"], owner_row["id"])
+            async with connection.transaction():
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(connection, owner=owner)
+                user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=str(owner_row["omi_uid"]),
+                    owner=owner,
+                    proof=owner_lock,
+                )
+                await authority_advisory_lock.require_user_write_status(
+                    connection,
+                    owner_lock,
+                    user_id=user_id,
+                    allowed_statuses=("PENDING", "ACTIVE"),
+                )
+                row = await connection.fetchrow(
+                    """
+                    UPDATE ella_provisioning_jobs
+                    SET state = 'provisioning',
+                        stage = 'profile_ready',
+                        attempts = attempts + 1,
+                        retryable = true,
+                        error_code = NULL,
+                        error_detail = '{}'::jsonb,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = $1
+                      AND user_id = $2
+                      AND state NOT IN ('ready', 'blocked', 'rolling_back', 'manual_intervention')
+                      AND (
+                            state NOT IN ('provisioning', 'retryable')
+                            OR updated_at < CURRENT_TIMESTAMP - INTERVAL '2 minutes'
+                          )
+                    RETURNING *
+                    """,
+                    job_uuid,
+                    user_id,
+                )
         return _row_dict(row)
 
     async def get_cloud_pool_admission_policy(self) -> Optional[dict[str, Any]]:
@@ -1096,6 +1204,11 @@ class EllaProvisioningRepository:
                     owner=owner,
                     proof=owner_lock,
                 )
+                await authority_advisory_lock.require_user_write_status(
+                    connection,
+                    owner_lock,
+                    user_id=owner.account_id,
+                )
                 existing = await connection.fetchrow(
                     """
                     SELECT b.*, u.omi_uid, u.profile_class
@@ -1255,6 +1368,11 @@ class EllaProvisioningRepository:
                     owner=owner,
                     proof=owner_lock,
                 )
+                await authority_advisory_lock.require_user_write_status(
+                    connection,
+                    owner_lock,
+                    user_id=owner.account_id,
+                )
                 entitlement = admission.entitlement or {}
                 if (
                     str(entitlement.get("consent_policy_version") or "") != lineage.policy_version
@@ -1407,7 +1525,20 @@ class EllaProvisioningRepository:
     ) -> dict[str, Any]:
         """Append one receipt-owned external artifact before the next side effect."""
         async with self.pool.acquire() as connection:
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked(connection, uid=uid)
             async with connection.transaction():
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(connection, owner=owner)
+                user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=uid,
+                    owner=owner,
+                    proof=owner_lock,
+                )
+                await authority_advisory_lock.require_user_write_status(
+                    connection,
+                    owner_lock,
+                    user_id=user_id,
+                )
                 binding = await connection.fetchrow(
                     """
                     SELECT b.id
@@ -1458,28 +1589,56 @@ class EllaProvisioningRepository:
     ) -> dict[str, Any]:
         if state not in {"retryable", "blocked", "manual_intervention"}:
             raise ValueError("invalid_cloud_rollback_state")
-        row = await self.pool.fetchrow(
-            """
-            UPDATE ella_provisioning_jobs
-            SET state = $2,
-                stage = 'runtime_ready',
-                retryable = $3,
-                error_code = $4,
-                rollback_receipt = $5::jsonb,
-                manual_intervention_at = CASE
-                    WHEN $2 = 'manual_intervention' THEN CURRENT_TIMESTAMP
-                    ELSE manual_intervention_at
-                END,
-                updated_at = CURRENT_TIMESTAMP
-            WHERE id = $1
-            RETURNING *
-            """,
-            uuid.UUID(str(job_id)),
-            state,
-            retryable,
-            error_code[:120],
-            json.dumps(rollback_receipt),
-        )
+        job_uuid = uuid.UUID(str(job_id))
+        async with self.pool.acquire() as connection:
+            owner_row = await connection.fetchrow(
+                """
+                SELECT u.id, u.omi_uid
+                FROM ella_provisioning_jobs job
+                JOIN users u ON u.id = job.user_id
+                WHERE job.id = $1
+                """,
+                job_uuid,
+            )
+            if not owner_row:
+                raise RuntimePoolClaimError("runtime_pool_job_lost")
+            owner = authority_advisory_lock.AuthorityOwner.from_values(owner_row["id"], owner_row["id"])
+            async with connection.transaction():
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(connection, owner=owner)
+                user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=str(owner_row["omi_uid"]),
+                    owner=owner,
+                    proof=owner_lock,
+                )
+                await authority_advisory_lock.require_user_write_status(
+                    connection,
+                    owner_lock,
+                    user_id=user_id,
+                )
+                row = await connection.fetchrow(
+                    """
+                    UPDATE ella_provisioning_jobs
+                    SET state = $3,
+                        stage = 'runtime_ready',
+                        retryable = $4,
+                        error_code = $5,
+                        rollback_receipt = $6::jsonb,
+                        manual_intervention_at = CASE
+                            WHEN $3 = 'manual_intervention' THEN CURRENT_TIMESTAMP
+                            ELSE manual_intervention_at
+                        END,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = $1 AND user_id = $2
+                    RETURNING *
+                    """,
+                    job_uuid,
+                    user_id,
+                    state,
+                    retryable,
+                    error_code[:120],
+                    json.dumps(rollback_receipt),
+                )
         if not row:
             raise RuntimePoolClaimError("runtime_pool_job_lost")
         return dict(row)
@@ -1508,6 +1667,11 @@ class EllaProvisioningRepository:
                     uid=uid,
                     owner=owner,
                     proof=owner_lock,
+                )
+                await authority_advisory_lock.require_user_write_status(
+                    connection,
+                    owner_lock,
+                    user_id=owner.account_id,
                 )
                 selected = await connection.fetchrow(
                     """
@@ -1719,6 +1883,11 @@ class EllaProvisioningRepository:
                     uid=uid,
                     owner=owner,
                     proof=owner_lock,
+                )
+                await authority_advisory_lock.require_user_write_status(
+                    connection,
+                    owner_lock,
+                    user_id=owner.account_id,
                 )
                 entitlement = admission.entitlement or {}
                 if (
@@ -2202,6 +2371,15 @@ class EllaProvisioningRepository:
             WHERE p.line_identity_key = $1
               AND p.contact_identity_key = $2
               AND p.status = 'enabled'
+              AND u.status = 'ACTIVE'
+              AND b.active = true
+              AND b.status IN ('internal_canary', 'active')
+              AND b.health_state = 'healthy'
+              AND b.account_user_id = u.id
+              AND b.profile_user_id = u.id
+              AND b.runtime_target_mode = 'hermes-cloud-photon'
+              AND b.target_endpoint_ref IS NOT NULL
+              AND b.target_credential_ref IS NOT NULL
             ORDER BY p.id
             LIMIT 2
             """,
@@ -2220,26 +2398,64 @@ class EllaProvisioningRepository:
         oauth_expires_at: datetime,
         receipt: dict[str, Any],
     ) -> dict[str, Any]:
-        row = await self.pool.fetchrow(
-            """
-            UPDATE ella_photon_channel_bindings
-            SET sidecar_connection_key = $2,
-                sidecar_connected_at = CURRENT_TIMESTAMP,
-                oauth_expires_at = $3,
-                preflight_receipt = $4::jsonb,
-                updated_at = CURRENT_TIMESTAMP
-            WHERE id = $1
-              AND status = 'enabled'
-              AND allow_all = false
-              AND attachments_enabled = false
-              AND caregiver_delivery_enabled = false
-            RETURNING *
-            """,
-            uuid.UUID(str(photon_binding_id)),
-            connection_key,
-            oauth_expires_at,
-            json.dumps(receipt),
-        )
+        binding_uuid = uuid.UUID(str(photon_binding_id))
+        async with self.pool.acquire() as connection:
+            owner_row = await connection.fetchrow(
+                """
+                SELECT u.id, u.omi_uid
+                FROM ella_photon_channel_bindings p
+                JOIN users u ON u.id = p.user_id
+                WHERE p.id = $1
+                """,
+                binding_uuid,
+            )
+            if not owner_row:
+                raise RuntimePoolClaimError("photon_binding_not_ready")
+            owner = authority_advisory_lock.AuthorityOwner.from_values(owner_row["id"], owner_row["id"])
+            async with connection.transaction():
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(connection, owner=owner)
+                user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=str(owner_row["omi_uid"]),
+                    owner=owner,
+                    proof=owner_lock,
+                )
+                await authority_advisory_lock.require_user_write_status(
+                    connection,
+                    owner_lock,
+                    user_id=user_id,
+                )
+                row = await connection.fetchrow(
+                    """
+                    UPDATE ella_photon_channel_bindings p
+                    SET sidecar_connection_key = $2,
+                        sidecar_connected_at = CURRENT_TIMESTAMP,
+                        oauth_expires_at = $3,
+                        preflight_receipt = $4::jsonb,
+                        updated_at = CURRENT_TIMESTAMP
+                    FROM ella_runtime_bindings b
+                    WHERE p.id = $1
+                      AND p.status = 'enabled'
+                      AND p.allow_all = false
+                      AND p.attachments_enabled = false
+                      AND p.caregiver_delivery_enabled = false
+                      AND b.id = p.runtime_binding_id
+                      AND b.user_id = p.user_id
+                      AND b.active = true
+                      AND b.status IN ('internal_canary', 'active')
+                      AND b.health_state = 'healthy'
+                      AND b.account_user_id = p.user_id
+                      AND b.profile_user_id = p.user_id
+                      AND b.runtime_target_mode = 'hermes-cloud-photon'
+                      AND b.target_endpoint_ref IS NOT NULL
+                      AND b.target_credential_ref IS NOT NULL
+                    RETURNING p.*
+                    """,
+                    binding_uuid,
+                    connection_key,
+                    oauth_expires_at,
+                    json.dumps(receipt),
+                )
         if not row:
             raise RuntimePoolClaimError("photon_binding_not_ready")
         return dict(row)
@@ -2712,33 +2928,116 @@ class EllaProvisioningRepository:
         error_detail: Optional[dict[str, Any]] = None,
         receipt: Optional[dict[str, Any]] = None,
     ) -> dict[str, Any]:
-        row = await self.pool.fetchrow(
-            """
-            UPDATE ella_provisioning_jobs
-            SET state = $2,
-                stage = $3,
-                retryable = $4,
-                error_code = $5,
-                error_detail = $6::jsonb,
-                receipts = CASE
-                    WHEN $7::jsonb = '{}'::jsonb THEN receipts
-                    ELSE COALESCE(receipts, '[]'::jsonb) || jsonb_build_array($7::jsonb)
-                END,
-                updated_at = CURRENT_TIMESTAMP
-            WHERE id = $1
-            RETURNING *
-            """,
-            uuid.UUID(str(job_id)),
-            state,
-            stage,
-            retryable,
-            error_code,
-            json.dumps(error_detail or {}),
-            json.dumps(receipt or {}),
-        )
+        job_uuid = uuid.UUID(str(job_id))
+        async with self.pool.acquire() as connection:
+            owner_row = await connection.fetchrow(
+                """
+                SELECT u.id, u.omi_uid
+                FROM ella_provisioning_jobs job
+                JOIN users u ON u.id = job.user_id
+                WHERE job.id = $1
+                """,
+                job_uuid,
+            )
+            if not owner_row:
+                raise LookupError("provisioning_job_not_found")
+            owner = authority_advisory_lock.AuthorityOwner.from_values(owner_row["id"], owner_row["id"])
+            async with connection.transaction():
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(connection, owner=owner)
+                user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=str(owner_row["omi_uid"]),
+                    owner=owner,
+                    proof=owner_lock,
+                )
+                await authority_advisory_lock.require_user_write_status(
+                    connection,
+                    owner_lock,
+                    user_id=user_id,
+                    allowed_statuses=("PENDING", "ACTIVE"),
+                )
+                row = await connection.fetchrow(
+                    """
+                    UPDATE ella_provisioning_jobs
+                    SET state = $3,
+                        stage = $4,
+                        retryable = $5,
+                        error_code = $6,
+                        error_detail = $7::jsonb,
+                        receipts = CASE
+                            WHEN $8::jsonb = '{}'::jsonb THEN receipts
+                            ELSE COALESCE(receipts, '[]'::jsonb) || jsonb_build_array($8::jsonb)
+                        END,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = $1 AND user_id = $2
+                    RETURNING *
+                    """,
+                    job_uuid,
+                    user_id,
+                    state,
+                    stage,
+                    retryable,
+                    error_code,
+                    json.dumps(error_detail or {}),
+                    json.dumps(receipt or {}),
+                )
         if not row:
             raise LookupError("provisioning_job_not_found")
         return dict(row)
+
+    async def begin_provider_attempt(
+        self,
+        *,
+        uid: str,
+        job_id: str,
+        provider: str = "hermes",
+        operation: str = "provision",
+    ) -> dict[str, Any]:
+        """Persist the durable marker before an external provider call."""
+        if provider != "hermes" or operation != "provision":
+            raise ValueError("provider_attempt_contract_invalid")
+        job_uuid = uuid.UUID(str(job_id))
+        idempotency_key = uuid.uuid5(PROVIDER_ATTEMPT_NAMESPACE, f"{job_uuid}:{provider}:{operation}")
+        correlation_ref = f"ella-ext-{uuid.uuid4().hex[:16]}"
+        async with self.pool.acquire() as connection:
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked(connection, uid=uid)
+            async with connection.transaction():
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(connection, owner=owner)
+                user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=uid,
+                    owner=owner,
+                    proof=owner_lock,
+                )
+                await authority_advisory_lock.require_user_write_status(
+                    connection,
+                    owner_lock,
+                    user_id=user_id,
+                    allowed_statuses=("PENDING", "ACTIVE"),
+                )
+                row = await connection.fetchrow(
+                    """
+                    INSERT INTO ella_provider_attempts (
+                        user_id, provisioning_job_id, provider, operation,
+                        idempotency_key, correlation_ref
+                    )
+                    SELECT $1, job.id, $3, $4, $5, $6
+                    FROM ella_provisioning_jobs job
+                    WHERE job.id = $2 AND job.user_id = $1
+                    ON CONFLICT (provisioning_job_id, provider, operation)
+                    DO UPDATE SET updated_at = CURRENT_TIMESTAMP
+                    RETURNING *
+                    """,
+                    user_id,
+                    job_uuid,
+                    provider,
+                    operation,
+                    idempotency_key,
+                    correlation_ref,
+                )
+                if not row:
+                    raise LookupError("provisioning_job_not_found")
+                return dict(row)
 
     async def stage_runtime_binding(self, *, uid: str, binding: dict[str, Any]) -> dict[str, Any]:
         async with self.pool.acquire() as connection:
@@ -2757,6 +3056,12 @@ class EllaProvisioningRepository:
                     owner=owner,
                     proof=owner_lock,
                 )
+                await authority_advisory_lock.require_user_write_status(
+                    connection,
+                    owner_lock,
+                    user_id=owner.account_id,
+                    allowed_statuses=("PENDING", "ACTIVE"),
+                )
                 row = await connection.fetchrow(
                     """
                     INSERT INTO ella_runtime_bindings (
@@ -2772,6 +3077,7 @@ class EllaProvisioningRepository:
                         $12, $13, $14, $15, $16, $17, $18, $19::jsonb, 1, false
                     FROM users u
                     WHERE u.omi_uid = $2
+                      AND u.status IN ('PENDING', 'ACTIVE')
                     ON CONFLICT (user_id, role, provider)
                     WHERE provider <> 'hermes_cloud'
                     DO UPDATE
@@ -2856,6 +3162,12 @@ class EllaProvisioningRepository:
                     owner=owner,
                     proof=owner_lock,
                 )
+                await authority_advisory_lock.require_user_write_status(
+                    connection,
+                    owner_lock,
+                    user_id=owner.account_id,
+                    allowed_statuses=("PENDING", "ACTIVE"),
+                )
                 await voice_canary_db.lock_runtime_authority_on_connection(
                     connection,
                     uid=uid,
@@ -2867,7 +3179,9 @@ class EllaProvisioningRepository:
                     SELECT b.*
                     FROM ella_runtime_bindings b
                     JOIN users u ON u.id = b.user_id
-                    WHERE u.omi_uid = $1 AND b.provider = $2 AND b.role = $3
+                    WHERE u.omi_uid = $1
+                      AND u.status IN ('PENDING', 'ACTIVE')
+                      AND b.provider = $2 AND b.role = $3
                     FOR UPDATE
                     """,
                     uid,
@@ -3065,6 +3379,7 @@ class EllaProvisioningRepository:
                     UPDATE users
                     SET status = 'ACTIVE', updated_at = CURRENT_TIMESTAMP
                     WHERE id = $1
+                      AND status IN ('PENDING', 'ACTIVE')
                     """,
                     selected["user_id"],
                 )
@@ -3081,17 +3396,24 @@ class EllaProvisioningRepository:
                     connection,
                     owner=owner,
                 )
-                await authority_advisory_lock.verify_self_owner_after_lock(
+                user_id = await authority_advisory_lock.verify_self_owner_after_lock(
                     connection,
                     uid=uid,
                     owner=owner,
                     proof=owner_lock,
+                )
+                await authority_advisory_lock.require_user_write_status(
+                    connection,
+                    owner_lock,
+                    user_id=user_id,
+                    allowed_statuses=("PENDING", "ACTIVE"),
                 )
                 result = await connection.execute(
                     """
                     UPDATE users
                     SET status = 'ACTIVE', updated_at = CURRENT_TIMESTAMP
                     WHERE omi_uid = $1
+                      AND status IN ('PENDING', 'ACTIVE')
                     """,
                     uid,
                 )

--- a/backend/database/firestore_account_deletion.py
+++ b/backend/database/firestore_account_deletion.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from google.cloud.firestore_v1 import FieldFilter
+
 
 def _delete_collection(
     firestore: Any,
@@ -37,8 +39,12 @@ def delete_firestore_user_data(
     batch_size: int = 450,
 ) -> dict[str, Any]:
     """Delete a full document tree; missing/partially deleted trees are success."""
+    deleted = _delete_collection(
+        firestore,
+        firestore.collection("import_jobs").where(filter=FieldFilter("uid", "==", uid)),
+        batch_size=batch_size,
+    )
     user_ref = firestore.collection("users").document(uid)
-    deleted = 0
     for collection_ref in user_ref.collections():
         deleted += _delete_collection(
             firestore,

--- a/backend/database/firestore_account_deletion.py
+++ b/backend/database/firestore_account_deletion.py
@@ -39,11 +39,16 @@ def delete_firestore_user_data(
     batch_size: int = 450,
 ) -> dict[str, Any]:
     """Delete a full document tree; missing/partially deleted trees are success."""
-    deleted = _delete_collection(
-        firestore,
-        firestore.collection("import_jobs").where(filter=FieldFilter("uid", "==", uid)),
-        batch_size=batch_size,
-    )
+    deleted = 0
+    for collection_name in (
+        "import_jobs",
+        "ella_hermes_cloud_enrichment_outbox",
+    ):
+        deleted += _delete_collection(
+            firestore,
+            firestore.collection(collection_name).where(filter=FieldFilter("uid", "==", uid)),
+            batch_size=batch_size,
+        )
     user_ref = firestore.collection("users").document(uid)
     for collection_ref in user_ref.collections():
         deleted += _delete_collection(

--- a/backend/database/firestore_account_deletion.py
+++ b/backend/database/firestore_account_deletion.py
@@ -2,9 +2,71 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+import os
 from typing import Any
 
 from google.cloud.firestore_v1 import FieldFilter
+
+
+@dataclass(frozen=True)
+class OwnedCollection:
+    name: str
+    owner_field: str
+    api_key_cache: str | None = None
+
+
+OWNED_TOP_LEVEL_COLLECTIONS = (
+    OwnedCollection("analytics", "uid"),
+    OwnedCollection("dev_api_keys", "user_id", "developer"),
+    OwnedCollection("mcp_api_keys", "user_id", "mcp"),
+    OwnedCollection("tasks", "user_uid"),
+    OwnedCollection("import_jobs", "uid"),
+    OwnedCollection("ella_hermes_cloud_enrichment_outbox", "uid"),
+    OwnedCollection("plugins_data", "uid"),
+    OwnedCollection("mcp_identity_grants", "profile_uid"),
+)
+OWNED_COLLECTION_GROUPS = (
+    OwnedCollection("reviews", "uid"),
+    OwnedCollection("usage_history", "uid"),
+)
+DIRECT_UID_DOCUMENT_COLLECTIONS = ("testers",)
+OWNERSHIP_PROBE_FIELDS = ("uid", "user_id", "user_uid", "profile_uid")
+
+
+class FirestoreAccountDeletionIncomplete(RuntimeError):
+    """The bounded purge could not prove that Firestore authority is absent."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def _owned_top_level_collections() -> tuple[OwnedCollection, ...]:
+    configured_grants = os.getenv("ELLA_MCP_IDENTITY_GRANTS_COLLECTION", "mcp_identity_grants").strip()
+    if not configured_grants or configured_grants == "mcp_identity_grants":
+        return OWNED_TOP_LEVEL_COLLECTIONS
+    return (*OWNED_TOP_LEVEL_COLLECTIONS, OwnedCollection(configured_grants, "profile_uid"))
+
+
+def _snapshot_data(document: Any) -> dict[str, Any]:
+    data = document.to_dict()
+    return dict(data or {})
+
+
+def _invalidate_api_key_cache(cache_authority: Any, cache_kind: str, hashed_key: Any) -> None:
+    if cache_authority is None:
+        raise FirestoreAccountDeletionIncomplete("account_deletion_api_key_cache_unavailable")
+    if not isinstance(hashed_key, str) or not hashed_key:
+        raise FirestoreAccountDeletionIncomplete("account_deletion_api_key_cache_identity_missing")
+    if cache_kind == "developer":
+        absent = cache_authority.invalidate_cached_dev_api_key(hashed_key)
+    elif cache_kind == "mcp":
+        absent = cache_authority.invalidate_cached_mcp_api_key(hashed_key)
+    else:  # pragma: no cover - inventory constants are closed above
+        raise FirestoreAccountDeletionIncomplete("account_deletion_api_key_cache_inventory_invalid")
+    if absent is not True:
+        raise FirestoreAccountDeletionIncomplete("account_deletion_api_key_cache_retained")
 
 
 def _delete_collection(
@@ -12,24 +74,78 @@ def _delete_collection(
     collection_ref: Any,
     *,
     batch_size: int,
+    api_key_cache: str | None = None,
+    cache_authority: Any = None,
 ) -> int:
     deleted = 0
     while True:
         docs = list(collection_ref.limit(batch_size).stream())
         if not docs:
             return deleted
+        cache_hashes: list[str] = []
         for document in docs:
+            if api_key_cache is not None:
+                hashed_key = _snapshot_data(document).get("hashed_key")
+                _invalidate_api_key_cache(cache_authority, api_key_cache, hashed_key)
+                cache_hashes.append(hashed_key)
             for child_collection in document.reference.collections():
                 deleted += _delete_collection(
                     firestore,
                     child_collection,
                     batch_size=batch_size,
+                    cache_authority=cache_authority,
                 )
         batch = firestore.batch()
         for document in docs:
             batch.delete(document.reference)
         batch.commit()
         deleted += len(docs)
+        for hashed_key in cache_hashes:
+            _invalidate_api_key_cache(cache_authority, api_key_cache, hashed_key)
+        cache_hashes.clear()
+        del docs
+
+
+def _query_has_documents(query: Any) -> bool:
+    return bool(list(query.limit(1).stream()))
+
+
+def _verify_user_tree_absent(user_ref: Any) -> None:
+    if user_ref.get().exists:
+        raise FirestoreAccountDeletionIncomplete("account_deletion_firestore_user_retained")
+    for collection_ref in user_ref.collections():
+        if _query_has_documents(collection_ref):
+            raise FirestoreAccountDeletionIncomplete("account_deletion_firestore_user_descendant_retained")
+
+
+def _verify_known_inventory_absent(
+    firestore: Any,
+    uid: str,
+    *,
+    owned_collections: tuple[OwnedCollection, ...],
+) -> None:
+    for owned in owned_collections:
+        query = firestore.collection(owned.name).where(filter=FieldFilter(owned.owner_field, "==", uid))
+        if _query_has_documents(query):
+            raise FirestoreAccountDeletionIncomplete("account_deletion_firestore_owned_document_retained")
+    for owned in OWNED_COLLECTION_GROUPS:
+        query = firestore.collection_group(owned.name).where(filter=FieldFilter(owned.owner_field, "==", uid))
+        if _query_has_documents(query):
+            raise FirestoreAccountDeletionIncomplete("account_deletion_firestore_owned_descendant_retained")
+    for collection_name in DIRECT_UID_DOCUMENT_COLLECTIONS:
+        if firestore.collection(collection_name).document(uid).get().exists:
+            raise FirestoreAccountDeletionIncomplete("account_deletion_firestore_direct_document_retained")
+
+
+def _verify_no_uninventoried_top_level_ownership(firestore: Any, uid: str) -> None:
+    """Fail closed when a top-level collection retains a recognized UID field."""
+    for collection_ref in firestore.collections():
+        if collection_ref.id == "users":
+            continue
+        for owner_field in OWNERSHIP_PROBE_FIELDS:
+            query = collection_ref.where(filter=FieldFilter(owner_field, "==", uid))
+            if _query_has_documents(query):
+                raise FirestoreAccountDeletionIncomplete("account_deletion_firestore_inventory_incomplete")
 
 
 def delete_firestore_user_data(
@@ -37,28 +153,54 @@ def delete_firestore_user_data(
     uid: str,
     *,
     batch_size: int = 450,
+    cache_authority: Any = None,
 ) -> dict[str, Any]:
-    """Delete a full document tree; missing/partially deleted trees are success."""
+    """Delete and verify the complete known Firestore ownership inventory."""
+    if batch_size < 1 or batch_size > 450:
+        raise ValueError("batch_size must be between 1 and 450")
     deleted = 0
-    for collection_name in (
-        "import_jobs",
-        "ella_hermes_cloud_enrichment_outbox",
-    ):
+    owned_collections = _owned_top_level_collections()
+    for owned in owned_collections:
         deleted += _delete_collection(
             firestore,
-            firestore.collection(collection_name).where(filter=FieldFilter("uid", "==", uid)),
+            firestore.collection(owned.name).where(filter=FieldFilter(owned.owner_field, "==", uid)),
             batch_size=batch_size,
+            api_key_cache=owned.api_key_cache,
+            cache_authority=cache_authority,
         )
+    for owned in OWNED_COLLECTION_GROUPS:
+        deleted += _delete_collection(
+            firestore,
+            firestore.collection_group(owned.name).where(filter=FieldFilter(owned.owner_field, "==", uid)),
+            batch_size=batch_size,
+            cache_authority=cache_authority,
+        )
+    for collection_name in DIRECT_UID_DOCUMENT_COLLECTIONS:
+        document_ref = firestore.collection(collection_name).document(uid)
+        for child_collection in document_ref.collections():
+            deleted += _delete_collection(
+                firestore,
+                child_collection,
+                batch_size=batch_size,
+                cache_authority=cache_authority,
+            )
+        if document_ref.get().exists:
+            document_ref.delete()
+            deleted += 1
     user_ref = firestore.collection("users").document(uid)
     for collection_ref in user_ref.collections():
         deleted += _delete_collection(
             firestore,
             collection_ref,
             batch_size=batch_size,
+            cache_authority=cache_authority,
         )
     if user_ref.get().exists:
         user_ref.delete()
         deleted += 1
+    _verify_user_tree_absent(user_ref)
+    _verify_known_inventory_absent(firestore, uid, owned_collections=owned_collections)
+    _verify_no_uninventoried_top_level_ownership(firestore, uid)
     return {
         "status": "ok",
         "message": "Account data deleted successfully",

--- a/backend/database/firestore_account_deletion.py
+++ b/backend/database/firestore_account_deletion.py
@@ -1,0 +1,55 @@
+"""Idempotent recursive Firestore deletion for one authenticated account."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _delete_collection(
+    firestore: Any,
+    collection_ref: Any,
+    *,
+    batch_size: int,
+) -> int:
+    deleted = 0
+    while True:
+        docs = list(collection_ref.limit(batch_size).stream())
+        if not docs:
+            return deleted
+        for document in docs:
+            for child_collection in document.reference.collections():
+                deleted += _delete_collection(
+                    firestore,
+                    child_collection,
+                    batch_size=batch_size,
+                )
+        batch = firestore.batch()
+        for document in docs:
+            batch.delete(document.reference)
+        batch.commit()
+        deleted += len(docs)
+
+
+def delete_firestore_user_data(
+    firestore: Any,
+    uid: str,
+    *,
+    batch_size: int = 450,
+) -> dict[str, Any]:
+    """Delete a full document tree; missing/partially deleted trees are success."""
+    user_ref = firestore.collection("users").document(uid)
+    deleted = 0
+    for collection_ref in user_ref.collections():
+        deleted += _delete_collection(
+            firestore,
+            collection_ref,
+            batch_size=batch_size,
+        )
+    if user_ref.get().exists:
+        user_ref.delete()
+        deleted += 1
+    return {
+        "status": "ok",
+        "message": "Account data deleted successfully",
+        "documents_deleted": deleted,
+    }

--- a/backend/database/hermes_cloud_enrichment_outbox.py
+++ b/backend/database/hermes_cloud_enrichment_outbox.py
@@ -8,6 +8,7 @@ from typing import Any, Optional
 
 from google.cloud.firestore_v1 import FieldFilter, transactional
 
+from database import content_write_fence
 from database._client import db
 
 COLLECTION = "ella_hermes_cloud_enrichment_outbox"
@@ -49,15 +50,24 @@ def _enqueue_transaction(
 @transactional
 def _claim_transaction(
     transaction,
+    firestore_db,
     reference,
     *,
+    writer_token: str,
     now: datetime,
     lease_seconds: int,
 ) -> Optional[dict[str, Any]]:
     snapshot = reference.get(transaction=transaction)
-    if not snapshot.exists:
+    current = snapshot.to_dict() if snapshot.exists else {}
+    uid = str(current.get("uid") or "")
+    if not current or not content_write_fence.transaction_content_writer_current(
+        transaction,
+        firestore_db,
+        uid,
+        writer_token,
+        allow_draining=False,
+    ):
         return None
-    current = snapshot.to_dict() or {}
     status = current.get("status")
     next_attempt_at = _aware(current.get("next_attempt_at"))
     lease_expires_at = _aware(current.get("lease_expires_at"))
@@ -72,6 +82,7 @@ def _claim_transaction(
         "status": "running",
         "lease_token": lease_token,
         "lease_expires_at": now + timedelta(seconds=lease_seconds),
+        "content_writer_token": writer_token,
         "attempt_count": int(current.get("attempt_count") or 0) + 1,
         "updated_at": now,
     }
@@ -81,6 +92,7 @@ def _claim_transaction(
             "status": claimed["status"],
             "lease_token": claimed["lease_token"],
             "lease_expires_at": claimed["lease_expires_at"],
+            "content_writer_token": claimed["content_writer_token"],
             "attempt_count": claimed["attempt_count"],
             "updated_at": claimed["updated_at"],
         },
@@ -91,6 +103,7 @@ def _claim_transaction(
 @transactional
 def _complete_transaction(
     transaction,
+    firestore_db,
     reference,
     *,
     lease_token: str,
@@ -101,6 +114,14 @@ def _complete_transaction(
     current = snapshot.to_dict() if snapshot.exists else {}
     if not current or current.get("status") != "running" or current.get("lease_token") != lease_token:
         return False
+    if not content_write_fence.transaction_content_writer_current(
+        transaction,
+        firestore_db,
+        str(current.get("uid") or ""),
+        str(current.get("content_writer_token") or ""),
+        allow_draining=True,
+    ):
+        return False
     transaction.update(
         reference,
         {
@@ -109,6 +130,7 @@ def _complete_transaction(
             "last_error_code": None,
             "lease_token": None,
             "lease_expires_at": None,
+            "content_writer_token": None,
             "completed_at": now,
             "updated_at": now,
         },
@@ -119,6 +141,7 @@ def _complete_transaction(
 @transactional
 def _fail_transaction(
     transaction,
+    firestore_db,
     reference,
     *,
     lease_token: str,
@@ -131,6 +154,14 @@ def _fail_transaction(
     current = snapshot.to_dict() if snapshot.exists else {}
     if not current or current.get("status") != "running" or current.get("lease_token") != lease_token:
         return False
+    if not content_write_fence.transaction_content_writer_current(
+        transaction,
+        firestore_db,
+        str(current.get("uid") or ""),
+        str(current.get("content_writer_token") or ""),
+        allow_draining=True,
+    ):
+        return False
     transaction.update(
         reference,
         {
@@ -139,6 +170,7 @@ def _fail_transaction(
             "next_attempt_at": next_attempt_at if retryable else None,
             "lease_token": None,
             "lease_expires_at": None,
+            "content_writer_token": None,
             "updated_at": now,
         },
     )
@@ -159,6 +191,7 @@ class FirestoreHermesCloudEnrichmentOutbox:
         transcript_sha256: str,
         policy_version: str,
     ) -> dict[str, Any]:
+        content_write_fence.assert_content_writer_admitted(uid)
         now = _utcnow()
         payload = {
             "job_id": job_id,
@@ -172,6 +205,7 @@ class FirestoreHermesCloudEnrichmentOutbox:
             "next_attempt_at": now,
             "lease_token": None,
             "lease_expires_at": None,
+            "content_writer_token": None,
             "last_error_code": None,
             "receipt": None,
             "created_at": now,
@@ -180,9 +214,23 @@ class FirestoreHermesCloudEnrichmentOutbox:
         reference = self.db.collection(COLLECTION).document(job_id)
         return _enqueue_transaction(self.db.transaction(), reference, payload)
 
+    def peek_next_uid(self, *, scan_limit: int = 50) -> Optional[str]:
+        query = (
+            self.db.collection(COLLECTION)
+            .where(filter=FieldFilter("status", "in", list(PENDING_STATUSES)))
+            .limit(scan_limit)
+        )
+        for snapshot in query.stream():
+            uid = str((snapshot.to_dict() or {}).get("uid") or "")
+            if uid and content_write_fence.content_writes_active(uid, db=self.db):
+                return uid
+        return None
+
     def claim_next(
         self,
         *,
+        uid: str,
+        writer_token: str,
         lease_seconds: int,
         scan_limit: int = 50,
     ) -> Optional[dict[str, Any]]:
@@ -193,9 +241,13 @@ class FirestoreHermesCloudEnrichmentOutbox:
             .limit(scan_limit)
         )
         for snapshot in query.stream():
+            if str((snapshot.to_dict() or {}).get("uid") or "") != uid:
+                continue
             claimed = _claim_transaction(
                 self.db.transaction(),
+                self.db,
                 snapshot.reference,
+                writer_token=writer_token,
                 now=now,
                 lease_seconds=lease_seconds,
             )
@@ -212,6 +264,7 @@ class FirestoreHermesCloudEnrichmentOutbox:
     ) -> bool:
         return _complete_transaction(
             self.db.transaction(),
+            self.db,
             self.db.collection(COLLECTION).document(job_id),
             lease_token=lease_token,
             receipt=receipt,
@@ -230,6 +283,7 @@ class FirestoreHermesCloudEnrichmentOutbox:
         now = _utcnow()
         return _fail_transaction(
             self.db.transaction(),
+            self.db,
             self.db.collection(COLLECTION).document(job_id),
             lease_token=lease_token,
             error_code=error_code,

--- a/backend/database/invitations.py
+++ b/backend/database/invitations.py
@@ -594,6 +594,12 @@ async def _bind_verified_identity_on_connection(
     if by_email:
         if by_email["omi_uid"] not in (None, "", uid):
             raise InvitePilotGateDenied("invite_identity_mismatch")
+        await authority_advisory_lock.require_user_write_status(
+            conn,
+            owner_lock,
+            user_id=by_email["id"],
+            allowed_statuses=("PENDING", "ACTIVE"),
+        )
         row = await conn.fetchrow(
             """
             UPDATE users

--- a/backend/database/managed_cloud_consent.py
+++ b/backend/database/managed_cloud_consent.py
@@ -205,6 +205,12 @@ async def lock_or_bootstrap_grant_on_connection(
         owner=owner,
         proof=owner_lock,
     )
+    await authority_advisory_lock.require_user_write_status(
+        conn,
+        owner_lock,
+        user_id=user_id,
+        allowed_statuses=("PENDING", "ACTIVE"),
+    )
     await authority_advisory_lock.require_self_owner_lock(
         conn,
         owner_lock,
@@ -268,6 +274,12 @@ async def synchronize_grant(
                     uid=grant.account_uid,
                     owner=owner,
                     proof=owner_lock,
+                )
+                await authority_advisory_lock.require_user_write_status(
+                    conn,
+                    owner_lock,
+                    user_id=user_id,
+                    allowed_statuses=("PENDING", "ACTIVE"),
                 )
                 row = await conn.fetchrow(
                     """
@@ -448,6 +460,12 @@ async def synchronize_denial(
                     uid=uid,
                     owner=owner,
                     proof=owner_lock,
+                )
+                await authority_advisory_lock.require_user_write_status(
+                    conn,
+                    owner_lock,
+                    user_id=user_id,
+                    allowed_statuses=("PENDING", "ACTIVE"),
                 )
                 row = await conn.fetchrow(
                     """

--- a/backend/database/memory_reinterpretations.py
+++ b/backend/database/memory_reinterpretations.py
@@ -384,7 +384,8 @@ class PostgresMemoryReinterpretationRepository:
 
     async def next_due_uid(self) -> Optional[str]:
         pool = await self._pool()
-        uid = await pool.fetchval("""
+        uid = await pool.fetchval(
+            """
             SELECT uid
             FROM memory_reinterpretation_jobs
             WHERE (
@@ -397,7 +398,8 @@ class PostgresMemoryReinterpretationRepository:
                   )
             ORDER BY not_before ASC, created_at ASC
             LIMIT 1
-            """)
+            """
+        )
         return str(uid) if uid else None
 
     async def claim_due(
@@ -772,16 +774,20 @@ class PostgresMemoryReinterpretationRepository:
 
     async def metrics(self) -> dict[str, Any]:
         pool = await self._pool()
-        rows = await pool.fetch("""
+        rows = await pool.fetch(
+            """
             SELECT status, COUNT(*) AS count
             FROM memory_reinterpretation_jobs
             GROUP BY status
-            """)
-        oldest_due_seconds = await pool.fetchval("""
+            """
+        )
+        oldest_due_seconds = await pool.fetchval(
+            """
             SELECT EXTRACT(EPOCH FROM (NOW() - MIN(not_before)))
             FROM memory_reinterpretation_jobs
             WHERE status IN ('pending', 'retry') AND not_before <= NOW()
-            """)
+            """
+        )
         return {
             "jobs_by_status": {str(_row_value(row, "status")): int(_row_value(row, "count", 0) or 0) for row in rows},
             "oldest_due_seconds": float(oldest_due_seconds or 0),

--- a/backend/database/memory_reinterpretations.py
+++ b/backend/database/memory_reinterpretations.py
@@ -382,27 +382,55 @@ class PostgresMemoryReinterpretationRepository:
         )
         return row_to_job(row) if row else existing
 
-    async def claim_due(self, worker_id: str, *, lease_seconds: int = 120) -> Optional[dict[str, Any]]:
+    async def next_due_uid(self) -> Optional[str]:
+        pool = await self._pool()
+        uid = await pool.fetchval("""
+            SELECT uid
+            FROM memory_reinterpretation_jobs
+            WHERE (
+                    status IN ('pending', 'retry')
+                    AND not_before <= NOW()
+                  )
+               OR (
+                    status = 'running'
+                    AND lease_expires_at < NOW()
+                  )
+            ORDER BY not_before ASC, created_at ASC
+            LIMIT 1
+            """)
+        return str(uid) if uid else None
+
+    async def claim_due(
+        self,
+        worker_id: str,
+        *,
+        lease_seconds: int = 120,
+        uid: Optional[str] = None,
+    ) -> Optional[dict[str, Any]]:
         pool = await self._pool()
         lease_token = str(uuid.uuid4())
+        uid_filter = "AND uid = $1" if uid is not None else ""
+        candidate_args = (uid,) if uid is not None else ()
         async with pool.acquire() as conn:
             async with conn.transaction():
                 candidate_row = await conn.fetchrow(
-                    """
+                    f"""
                     SELECT *
                     FROM memory_reinterpretation_jobs
-                    WHERE (
+                    WHERE ((
                             status IN ('pending', 'retry')
                             AND not_before <= NOW()
                           )
                        OR (
                             status = 'running'
                             AND lease_expires_at < NOW()
-                          )
+                          ))
+                      {uid_filter}
                     ORDER BY not_before ASC, created_at ASC
                     LIMIT 1
                     FOR UPDATE SKIP LOCKED
                     """,
+                    *candidate_args,
                 )
                 if candidate_row is None:
                     return None
@@ -919,12 +947,33 @@ class InMemoryMemoryReinterpretationRepository:
         current["updated_at"] = self.now
         return True
 
-    async def claim_due(self, worker_id: str, *, lease_seconds: int = 120) -> Optional[dict[str, Any]]:
+    async def next_due_uid(self) -> Optional[str]:
         candidates = [
             job
             for job in self.jobs.values()
             if (job["status"] in RUNNABLE_STATUSES and job["not_before"] <= self.now)
             or (job["status"] == "running" and job["lease_expires_at"] and job["lease_expires_at"] < self.now)
+        ]
+        if not candidates:
+            return None
+        job = sorted(candidates, key=lambda item: (item["not_before"], item["created_at"]))[0]
+        return str(job["uid"])
+
+    async def claim_due(
+        self,
+        worker_id: str,
+        *,
+        lease_seconds: int = 120,
+        uid: Optional[str] = None,
+    ) -> Optional[dict[str, Any]]:
+        candidates = [
+            job
+            for job in self.jobs.values()
+            if (uid is None or job["uid"] == uid)
+            and (
+                (job["status"] in RUNNABLE_STATUSES and job["not_before"] <= self.now)
+                or (job["status"] == "running" and job["lease_expires_at"] and job["lease_expires_at"] < self.now)
+            )
         ]
         if not candidates:
             return None

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -540,23 +540,34 @@ def get_user_data_protection_level(uid: str) -> Optional[str]:
 # ******************************************************
 
 
+def _mcp_api_key_cache_key(hashed_key: str) -> str:
+    return f'mcp_api_key:{hashed_key}'
+
+
 @try_catch_decorator
 def cache_mcp_api_key(hashed_key: str, user_id: str, ttl: int = 3600):
     """Caches the user_id for a given hashed MCP API key."""
-    r.set(f'mcp_api_key:{hashed_key}', user_id, ex=ttl)
+    r.set(_mcp_api_key_cache_key(hashed_key), user_id, ex=ttl)
 
 
 @try_catch_decorator
 def get_cached_mcp_api_key_user_id(hashed_key: str) -> Optional[str]:
     """Retrieves the user_id for a given hashed MCP API key from cache."""
-    user_id = r.get(f'mcp_api_key:{hashed_key}')
+    user_id = r.get(_mcp_api_key_cache_key(hashed_key))
     return user_id.decode() if user_id else None
 
 
 @try_catch_decorator
 def delete_cached_mcp_api_key(hashed_key: str):
     """Deletes a cached MCP API key."""
-    r.delete(f'mcp_api_key:{hashed_key}')
+    r.delete(_mcp_api_key_cache_key(hashed_key))
+
+
+def invalidate_cached_mcp_api_key(hashed_key: str) -> bool:
+    """Delete and prove absence of one exact MCP API-key cache entry."""
+    cache_key = _mcp_api_key_cache_key(hashed_key)
+    r.delete(cache_key)
+    return not bool(r.exists(cache_key))
 
 
 # ******************************************************
@@ -564,16 +575,20 @@ def delete_cached_mcp_api_key(hashed_key: str):
 # ******************************************************
 
 
+def _dev_api_key_cache_key(hashed_key: str) -> str:
+    return f'dev_api_key:{hashed_key}'
+
+
 def cache_dev_api_key(hashed_key: str, user_id: str, scopes: Optional[List[str]] = None, ttl: int = 3600):
     """Caches the user_id and scopes for a given hashed Developer API key."""
     cache_data = {"user_id": user_id, "scopes": scopes}
-    r.set(f'dev_api_key:{hashed_key}', json.dumps(cache_data), ex=ttl)
+    r.set(_dev_api_key_cache_key(hashed_key), json.dumps(cache_data), ex=ttl)
 
 
 @try_catch_decorator
 def get_cached_dev_api_key_user_id(hashed_key: str) -> Optional[str]:
     """Retrieves the user_id for a given hashed Developer API key from cache."""
-    cached = r.get(f'dev_api_key:{hashed_key}')
+    cached = r.get(_dev_api_key_cache_key(hashed_key))
     if not cached:
         return None
     data = json.loads(cached.decode())
@@ -583,7 +598,7 @@ def get_cached_dev_api_key_user_id(hashed_key: str) -> Optional[str]:
 @try_catch_decorator
 def get_cached_dev_api_key_data(hashed_key: str) -> Optional[dict]:
     """Retrieves the user_id and scopes for a given hashed Developer API key from cache."""
-    cached = r.get(f'dev_api_key:{hashed_key}')
+    cached = r.get(_dev_api_key_cache_key(hashed_key))
     if not cached:
         return None
     return json.loads(cached.decode())
@@ -592,7 +607,14 @@ def get_cached_dev_api_key_data(hashed_key: str) -> Optional[dict]:
 @try_catch_decorator
 def delete_cached_dev_api_key(hashed_key: str):
     """Deletes a cached Developer API key."""
-    r.delete(f'dev_api_key:{hashed_key}')
+    r.delete(_dev_api_key_cache_key(hashed_key))
+
+
+def invalidate_cached_dev_api_key(hashed_key: str) -> bool:
+    """Delete and prove absence of one exact developer API-key cache entry."""
+    cache_key = _dev_api_key_cache_key(hashed_key)
+    r.delete(cache_key)
+    return not bool(r.exists(cache_key))
 
 
 # ******************************************************

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -5,6 +5,7 @@ from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter, transactional
 
 from ._client import db, document_id_from_seed
+from .firestore_account_deletion import delete_firestore_user_data
 from models.users import Subscription, PlanLimits, PlanType, SubscriptionStatus
 from utils.subscription import get_default_basic_subscription
 
@@ -408,48 +409,8 @@ def update_person_speech_samples_version(uid: str, person_id: str, version: int)
 
 
 def delete_user_data(uid: str):
-    user_ref = db.collection('users').document(uid)
-    if not user_ref.get().exists:
-        return {'status': 'error', 'message': 'User not found'}
-
-    subcollections_to_delete = [
-        'conversations',
-        'messages',
-        'chat_sessions',
-        'people',
-        'memories',
-        'files',
-        'ai_consent_receipts',
-    ]
-    batch_size = 450
-
-    for cname in subcollections_to_delete:
-        print(f"Deleting subcollection: {cname} for user {uid}")
-        collection_ref = user_ref.collection(cname)
-
-        while True:
-            docs_query = collection_ref.limit(batch_size)
-            docs = list(docs_query.stream())
-
-            if not docs:
-                # docs might not exists, try using {parent path / id}
-                print(f"No more documents to delete in {collection_ref.parent.path}/{collection_ref.id}")
-                break
-
-            batch = db.batch()
-            for doc in docs:
-                print(f"Deleting document: {doc.reference.path}")
-                batch.delete(doc.reference)
-            batch.commit()
-
-            if len(docs) < batch_size:
-                print(f"Processed all documents in {collection_ref.path}")
-                break
-
-    # delete the user document itself
-    print(f"Deleting user document: {uid}")
-    user_ref.delete()
-    return {'status': 'ok', 'message': 'Account deleted successfully'}
+    """Idempotently remove a user's complete Firestore document tree."""
+    return delete_firestore_user_data(db, uid)
 
 
 # **************************************

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -4,6 +4,7 @@ from typing import Optional
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter, transactional
 
+from database import redis_db
 from ._client import db, document_id_from_seed
 from .firestore_account_deletion import delete_firestore_user_data
 from models.users import Subscription, PlanLimits, PlanType, SubscriptionStatus
@@ -410,7 +411,7 @@ def update_person_speech_samples_version(uid: str, person_id: str, version: int)
 
 def delete_user_data(uid: str):
     """Idempotently remove a user's complete Firestore document tree."""
-    return delete_firestore_user_data(db, uid)
+    return delete_firestore_user_data(db, uid, cache_authority=redis_db)
 
 
 # **************************************
@@ -1026,18 +1027,14 @@ def set_user_conversation_lifecycle_preferences(
     update_data = {}
 
     if update_enabled:
-        update_data[
-            'conversation_lifecycle_preferences.conversation_max_duration_enabled'
-        ] = (
+        update_data['conversation_lifecycle_preferences.conversation_max_duration_enabled'] = (
             conversation_max_duration_enabled
             if conversation_max_duration_enabled is not None
             else firestore.DELETE_FIELD
         )
 
     if update_seconds:
-        update_data[
-            'conversation_lifecycle_preferences.conversation_max_duration_seconds'
-        ] = (
+        update_data['conversation_lifecycle_preferences.conversation_max_duration_seconds'] = (
             conversation_max_duration_seconds
             if conversation_max_duration_seconds is not None
             else firestore.DELETE_FIELD

--- a/backend/database/voice_canary.py
+++ b/backend/database/voice_canary.py
@@ -500,11 +500,16 @@ async def upsert_entitlement(
         async with conn.transaction():
             owner_lock = await authority_advisory_lock.acquire_authority_lock(conn, owner=owner)
             await lock_runtime_authority_on_connection(conn, uid=uid)
-            await authority_advisory_lock.verify_self_owner_after_lock(
+            user_id = await authority_advisory_lock.verify_self_owner_after_lock(
                 conn,
                 uid=uid,
                 owner=owner,
                 proof=owner_lock,
+            )
+            await authority_advisory_lock.require_user_write_status(
+                conn,
+                owner_lock,
+                user_id=user_id,
             )
             row = await conn.fetchrow(
                 """
@@ -562,11 +567,16 @@ async def update_entitlement_status(
         async with conn.transaction():
             owner_lock = await authority_advisory_lock.acquire_authority_lock(conn, owner=owner)
             await lock_runtime_authority_on_connection(conn, uid=uid)
-            await authority_advisory_lock.verify_self_owner_after_lock(
+            user_id = await authority_advisory_lock.verify_self_owner_after_lock(
                 conn,
                 uid=uid,
                 owner=owner,
                 proof=owner_lock,
+            )
+            await authority_advisory_lock.require_user_write_status(
+                conn,
+                owner_lock,
+                user_id=user_id,
             )
             row = await conn.fetchrow(
                 """

--- a/backend/database/voice_canary.py
+++ b/backend/database/voice_canary.py
@@ -4,6 +4,8 @@ The billing/operations ledger is deliberately content-free. Transcript text and
 audio never enter these tables.
 """
 
+from __future__ import annotations
+
 import hashlib
 import json
 import os

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -1,4 +1,5 @@
-from typing import List, Optional
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, List, Optional
 
 from fastapi import Depends, HTTPException, Security
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
@@ -6,6 +7,7 @@ from firebase_admin import auth
 
 import database.mcp_api_key as mcp_api_key_db
 import database.dev_api_key as dev_api_key_db
+from database import content_write_fence
 from utils.scopes import Scopes, has_scope
 
 bearer_scheme = HTTPBearer()
@@ -13,22 +15,24 @@ bearer_scheme = HTTPBearer()
 
 async def get_current_user_id(
     credentials: HTTPAuthorizationCredentials = Security(bearer_scheme),
-) -> str:
+) -> AsyncIterator[str]:
     if not credentials:
         raise HTTPException(status_code=401, detail="Not authenticated")
     try:
         id_token = credentials.credentials
         decoded_token = auth.verify_id_token(id_token)
-        return decoded_token["uid"]
+        uid = decoded_token["uid"]
     except Exception as e:
         print(f"Error verifying Firebase ID token: {e}")
         raise HTTPException(status_code=401, detail="Invalid authentication credentials")
+    async with _content_fence(uid):
+        yield uid
 
 
 api_key_header = APIKeyHeader(name="Authorization", auto_error=False)
 
 
-async def get_uid_from_mcp_api_key(api_key: str = Security(api_key_header)) -> str:
+async def get_uid_from_mcp_api_key(api_key: str = Security(api_key_header)) -> AsyncIterator[str]:
     if not api_key or not api_key.startswith("Bearer "):
         raise HTTPException(
             status_code=401,
@@ -39,7 +43,8 @@ async def get_uid_from_mcp_api_key(api_key: str = Security(api_key_header)) -> s
     user_id = mcp_api_key_db.get_user_id_by_api_key(token)
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid API Key")
-    return user_id
+    async with _content_fence(user_id):
+        yield user_id
 
 
 # Data structure to return from auth
@@ -72,6 +77,23 @@ async def get_uid_from_dev_api_key(api_key: str = Security(api_key_header)) -> s
     return auth_data.uid
 
 
+@asynccontextmanager
+async def _content_fence(uid: str) -> AsyncIterator[None]:
+    try:
+        async with content_write_fence.request_content_write_fence(uid):
+            yield
+    except content_write_fence.ContentWriteFenceError as exc:
+        if exc.code == "account_write_forbidden":
+            raise HTTPException(
+                status_code=403,
+                detail={"code": "account_write_forbidden", "retryable": False},
+            ) from exc
+        raise HTTPException(
+            status_code=503,
+            detail={"code": exc.code, "retryable": True},
+        ) from exc
+
+
 # Scope-specific dependencies
 async def get_uid_with_conversations_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
     if not has_scope(auth.scopes, Scopes.CONVERSATIONS_READ):
@@ -81,12 +103,15 @@ async def get_uid_with_conversations_read(auth: ApiKeyAuth = Depends(get_api_key
     return auth.uid
 
 
-async def get_uid_with_conversations_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
+async def get_uid_with_conversations_write(
+    auth: ApiKeyAuth = Depends(get_api_key_auth),
+) -> AsyncIterator[str]:
     if not has_scope(auth.scopes, Scopes.CONVERSATIONS_WRITE):
         raise HTTPException(
             status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.CONVERSATIONS_WRITE}"
         )
-    return auth.uid
+    async with _content_fence(auth.uid):
+        yield auth.uid
 
 
 async def get_uid_with_memories_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
@@ -95,12 +120,13 @@ async def get_uid_with_memories_read(auth: ApiKeyAuth = Depends(get_api_key_auth
     return auth.uid
 
 
-async def get_uid_with_memories_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
+async def get_uid_with_memories_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> AsyncIterator[str]:
     if not has_scope(auth.scopes, Scopes.MEMORIES_WRITE):
         raise HTTPException(
             status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.MEMORIES_WRITE}"
         )
-    return auth.uid
+    async with _content_fence(auth.uid):
+        yield auth.uid
 
 
 async def get_uid_with_action_items_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
@@ -111,9 +137,12 @@ async def get_uid_with_action_items_read(auth: ApiKeyAuth = Depends(get_api_key_
     return auth.uid
 
 
-async def get_uid_with_action_items_write(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> str:
+async def get_uid_with_action_items_write(
+    auth: ApiKeyAuth = Depends(get_api_key_auth),
+) -> AsyncIterator[str]:
     if not has_scope(auth.scopes, Scopes.ACTION_ITEMS_WRITE):
         raise HTTPException(
             status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.ACTION_ITEMS_WRITE}"
         )
-    return auth.uid
+    async with _content_fence(auth.uid):
+        yield auth.uid

--- a/backend/ella/README.md
+++ b/backend/ella/README.md
@@ -249,8 +249,8 @@ print('Adapters:', list(get_all_adapters().keys()))
 |----------|---------|-------------|
 | `ELLA_ENABLED` | `true` | Master switch for all Ella features |
 | `ELLA_POSTGRES_AUTHORITY_ENABLED` | follows `ELLA_ENABLED` | Explicit account-deletion authority boundary. Set `false` only when Ella PostgreSQL persistence/schema is intentionally absent; enabled database failures remain fail-closed. |
-| `ELLA_CONTENT_WRITE_FENCE_LEASE_SECONDS` | `900` | Renewable Firestore writer lease; bounded to 900 seconds and removed on every request exit. |
-| `ELLA_CONTENT_WRITE_FENCE_ACQUIRE_SECONDS` | `15` | Bounded wait for the distributed content/owner fence. |
+| `ELLA_CONTENT_WRITE_FENCE_LEASE_SECONDS` | `900` | Diagnostic writer-registration horizon. Expiry never proves absence; only explicit release permits deletion completion. |
+| `ELLA_CONTENT_WRITE_FENCE_ACQUIRE_SECONDS` | `15` | Bounded wait for short PostgreSQL admission proof and Firestore writer registration. No pool connection is held across route code. |
 | `ELLA_CONTENT_WRITE_FENCE_DRAIN_SECONDS` | `15` | Bounded deletion drain wait before returning truthful HTTP 202 for pending Firestore cleanup. |
 | `ELLA_N8N_BASE_URL` | `https://n8n.ella-ai-care.com` | n8n webhook base URL |
 | `ELLA_SUMMARY_ENABLED` | `true` | Use n8n for summary generation |
@@ -310,7 +310,13 @@ receipt subcollection; callers cannot submit or select another UID.
   binding, and OMI identity authority and releases any ordinary invitation
   capacity. Firestore cleanup is recursive and retry-safe. A fully completed
   deletion returns a non-identifying receipt; `202 deletion_pending` names only
-  the remaining artifact classes when cleanup must resume. The self-hosted
+  the remaining artifact classes when cleanup must resume. The content fence
+  transfers a separate durable registration to detached import,
+  conversation-processing, persona, vector, and cache workers before their
+  caller returns. Top-level Limitless import-job records are deleted by exact
+  UID with the recursive user tree. Registration timestamps are diagnostic;
+  an unreleased worker keeps deletion pending instead of being assumed dead.
+  The self-hosted
   `:8210` authority currently has no authenticated deprovision operation, so a
   provisioned Hermes profile/Honcho tenancy/registry entry remains disabled and
   requires an operator until that authority can issue a trusted deletion

--- a/backend/ella/README.md
+++ b/backend/ella/README.md
@@ -248,6 +248,7 @@ print('Adapters:', list(get_all_adapters().keys()))
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ELLA_ENABLED` | `true` | Master switch for all Ella features |
+| `ELLA_POSTGRES_AUTHORITY_ENABLED` | follows `ELLA_ENABLED` | Explicit account-deletion authority boundary. Set `false` only when Ella PostgreSQL persistence/schema is intentionally absent; enabled database failures remain fail-closed. |
 | `ELLA_N8N_BASE_URL` | `https://n8n.ella-ai-care.com` | n8n webhook base URL |
 | `ELLA_SUMMARY_ENABLED` | `true` | Use n8n for summary generation |
 | `ELLA_MEMORY_ENABLED` | `true` | Use n8n for memory extraction |
@@ -312,6 +313,12 @@ receipt subcollection; callers cannot submit or select another UID.
   requires an operator until that authority can issue a trusted deletion
   receipt. Firebase Auth is retained while deletion is pending so the same
   authenticated caller can retry.
+
+The deletion proof schema in this release applies in executable order
+`011 -> 012 -> 013 -> 014 -> 015 -> 017_add_provider_attempt_deletion_fence.sql`.
+Migration `016_create_today_cards.sql` is reserved by open `ellaaicare/omi#360`, is not part
+of account deletion, and is not modified here. On a fresh database containing
+both changes, apply `016` before `017`; `017` has no dependency on `016`.
 
 Exact-policy grants are required at the Ella chat stream, Hermes onboarding
 ensure, voice-session issuance, necklace/web transcription sockets, direct TTS,

--- a/backend/ella/README.md
+++ b/backend/ella/README.md
@@ -301,10 +301,17 @@ receipt subcollection; callers cannot submit or select another UID.
   idempotent; reuse with different metadata fails with `409`.
 - `GET /v1/users/ai-consent/receipts/{receipt_id}` verifies a receipt only
   within the authenticated user's path.
-- Account/data deletion remains `DELETE /v1/users/delete-account`; deletion
-  also removes the user's consent receipt subcollection and returns a
-  non-identifying synchronous completion receipt with request ID and server
-  completion time.
+- Account/data deletion remains `DELETE /v1/users/delete-account`. The route
+  first atomically quarantines PostgreSQL consent, entitlement, target,
+  binding, and OMI identity authority and releases any ordinary invitation
+  capacity. Firestore cleanup is recursive and retry-safe. A fully completed
+  deletion returns a non-identifying receipt; `202 deletion_pending` names only
+  the remaining artifact classes when cleanup must resume. The self-hosted
+  `:8210` authority currently has no authenticated deprovision operation, so a
+  provisioned Hermes profile/Honcho tenancy/registry entry remains disabled and
+  requires an operator until that authority can issue a trusted deletion
+  receipt. Firebase Auth is retained while deletion is pending so the same
+  authenticated caller can retry.
 
 Exact-policy grants are required at the Ella chat stream, Hermes onboarding
 ensure, voice-session issuance, necklace/web transcription sockets, direct TTS,

--- a/backend/ella/README.md
+++ b/backend/ella/README.md
@@ -249,6 +249,9 @@ print('Adapters:', list(get_all_adapters().keys()))
 |----------|---------|-------------|
 | `ELLA_ENABLED` | `true` | Master switch for all Ella features |
 | `ELLA_POSTGRES_AUTHORITY_ENABLED` | follows `ELLA_ENABLED` | Explicit account-deletion authority boundary. Set `false` only when Ella PostgreSQL persistence/schema is intentionally absent; enabled database failures remain fail-closed. |
+| `ELLA_CONTENT_WRITE_FENCE_LEASE_SECONDS` | `900` | Renewable Firestore writer lease; bounded to 900 seconds and removed on every request exit. |
+| `ELLA_CONTENT_WRITE_FENCE_ACQUIRE_SECONDS` | `15` | Bounded wait for the distributed content/owner fence. |
+| `ELLA_CONTENT_WRITE_FENCE_DRAIN_SECONDS` | `15` | Bounded deletion drain wait before returning truthful HTTP 202 for pending Firestore cleanup. |
 | `ELLA_N8N_BASE_URL` | `https://n8n.ella-ai-care.com` | n8n webhook base URL |
 | `ELLA_SUMMARY_ENABLED` | `true` | Use n8n for summary generation |
 | `ELLA_MEMORY_ENABLED` | `true` | Use n8n for memory extraction |

--- a/backend/ella/docs/CONTENT_WRITER_RECOVERY.md
+++ b/backend/ella/docs/CONTENT_WRITER_RECOVERY.md
@@ -9,13 +9,18 @@ process exit.
 
 The backend Docker image starts one Uvicorn process. Each writer registration
 is bound at process startup/first use to an internally generated immutable
-generation plus the kernel-observed system, hashed boot-bound host identity,
-boot ID, PID namespace, PID, and process start identity. Request data cannot choose
-these fields.
+generation plus the Linux-kernel-observed hashed boot-bound host identity,
+boot ID, PID namespace, PID, and process start identity. Request data cannot
+choose these fields. Production recovery is Linux-only. Darwin and every other
+system refuse before application, Google, configuration, or credential imports;
+the Darwin process adapter under `tests/support/` is test-only and the production
+CLI has no flag or environment escape hatch that can select it.
 
 The recovery trusted computing base is deliberately narrow:
 
-- local root is the only command authority;
+- effective UID 0, effective `CAP_SYS_ADMIN`, and a successful kernel
+  `NS_GET_PARENT` proof that the command is in the initial host PID namespace
+  are jointly required before any authority-bearing import or file read;
 - the kernel process table in the recorded host, boot, and PID namespace is
   authoritative for the process and all of its threads;
 - the durable Firestore transaction is authoritative for the final exact
@@ -25,19 +30,51 @@ Process exit is terminal for every thread in that process. The command accepts
 no terminal boolean, lease claim, owner JSON, PID, generation, host override,
 or remote proof. It is not registered as an HTTP route.
 
-The command must run in the same supervisor boundary that observed the worker.
-For Docker's single-Uvicorn image, run it on the same-boot host as root with the
-host `/proc` mounted: cross-namespace proof additionally requires effective
-`CAP_SYS_ADMIN` and a kernel `NS_GET_PARENT` check proving the command itself is
-in the initial host PID namespace. It then scans the host process table for the
-exact recorded PID namespace, namespace-local PID, and process start identity.
-Container-root, including a privileged nested PID namespace, cannot infer that
-another container is dead. A sidecar in a shared pod PID namespace can use the
-same-namespace path.
+The command must run in the same initial-host supervisor boundary that observed
+the worker. Normal container root, nested namespace root, a privileged nested
+PID namespace, and a sidecar are not command authorities. The production
+bootstrap refuses all of them before imports, config reads, credential reads,
+or output. After authorization it scans the host process table for the exact
+recorded PID namespace, namespace-local PID, and process start identity.
 Another worker, another host, another boot, an unknown namespace, a hidden
 process table, or an unavailable supervisor capability cannot prove absence
 and therefore cannot recover the record. Those cases intentionally remain
 `DRAINING`. Do not copy owner fields to make a replacement look local.
+
+## Fixed release and Firestore authority
+
+The recovery executable is installed separately from the application container
+at `/opt/omi-recovery/backend/scripts/content_writer_recovery.py` and must run
+with isolated Python (`-I`). The script, `/opt/omi-recovery/backend`, its Python
+executable, and every parent path must be root-owned and not group/world
+writable. The script itself may not be a symlink. Cwd, `PYTHONPATH`, user site,
+and interpreter environment settings are excluded before the release root is
+added to `sys.path`.
+
+The only configuration path is
+`/etc/omi/content-writer-recovery.json`. There is no CLI or environment option
+for another path. It has this non-secret shape:
+
+```json
+{
+  "schema_version": 1,
+  "project_id": "pinned-production-project",
+  "database_id": "(default)",
+  "credential_file": "/etc/omi/content-writer-recovery-service-account.json",
+  "deployment_receipt_file": "/etc/omi/content-writer-recovery-receipt.json"
+}
+```
+
+The config, credential, and deployment-receipt files must be regular,
+root-owned, mode `0600` (or more restrictive), reached through a root-owned
+non-writable parent chain, and opened with `O_NOFOLLOW`. The receipt pins the
+same project/database and the SHA-256 of the credential file. The service
+account's own project must match. Firestore receives explicit project,
+database, and credential objects; ambient `GCLOUD_PROJECT`,
+`GOOGLE_CLOUD_PROJECT`, `GOOGLE_APPLICATION_CREDENTIALS`, and
+`SERVICE_ACCOUNT_JSON` cannot select authority. `FIRESTORE_EMULATOR_HOST` is a
+hard refusal. This path never imports `database._client` and never materializes
+credential JSON in cwd or any derived path.
 
 ## Deterministic recovery sequence
 
@@ -46,12 +83,13 @@ and therefore cannot recover the record. Those cases intentionally remain
 2. From the recorded host/boot/PID namespace, verify the exact worker has
    reached the supervisor's terminal state. Do not restart or reuse its
    namespace before recovery.
-3. In a root-only shell, derive SHA-256 selectors for the exact UID and writer
-   token without writing plaintext to logs or receipts.
-4. Run from `backend/`:
+3. In the initial-host supervisor shell, derive SHA-256 selectors for the exact
+   UID and writer token without writing plaintext to logs or receipts.
+4. Run the fixed root-owned release (not the application checkout or container):
 
    ```text
-   sudo .venv/bin/python scripts/content_writer_recovery.py \
+   sudo /opt/omi-recovery/venv/bin/python3 -I \
+     /opt/omi-recovery/backend/scripts/content_writer_recovery.py \
      --subject-hash <64-lowercase-hex> \
      --token-hash <64-lowercase-hex>
    ```
@@ -72,9 +110,17 @@ owner-unknown, stale-token, record-replaced, corrupt, or unavailable results
 into a manual release.
 
 The recovery compare-and-set removes only the exact subject document's exact
-token when its complete owner identity still matches the terminal proof.
-Concurrent and duplicate commands converge through a durable recovery receipt;
-other tokens and other subjects remain untouched. A successful release has no
-safe manual rollback because recreating an operator-authored owner record would
-forge ownership. If the subsequent account-deletion retry fails, keep Firebase
-retained and retry the ordinary deletion flow; do not recreate the writer.
+token when its complete owner identity still matches the terminal proof. It
+stores one content-free latest receipt (`token_hash`, exact owner, timestamp),
+not recovery history. Its serialized size is therefore constant regardless of
+crash count. Any reviewed pre-release map shape is compacted to its latest
+validated receipt on the next transaction. Concurrent retries of that exact
+transaction converge; an absent,
+evicted, stale, colliding, or different-token receipt authorizes nothing.
+Ordinary ACTIVE cleanup deletes an empty fence even if a receipt exists, and
+tombstoning removes the receipt, so it cannot retain a fence document or block
+deletion. Other tokens and other subjects remain untouched. A successful
+release has no safe manual rollback because recreating an operator-authored
+owner record would forge ownership. If the subsequent account-deletion retry
+fails, keep Firebase retained and retry the ordinary deletion flow; do not
+recreate the writer.

--- a/backend/ella/docs/CONTENT_WRITER_RECOVERY.md
+++ b/backend/ella/docs/CONTENT_WRITER_RECOVERY.md
@@ -1,0 +1,80 @@
+# Durable content-writer recovery
+
+Account deletion remains `DRAINING` while any durable content writer is
+registered. Lease expiry is diagnostic only and never authorizes release. Use
+`scripts/content_writer_recovery.py` only for a writer orphaned by an actual
+process exit.
+
+## Trust boundary and deployment requirement
+
+The backend Docker image starts one Uvicorn process. Each writer registration
+is bound at process startup/first use to an internally generated immutable
+generation plus the kernel-observed system, hashed boot-bound host identity,
+boot ID, PID namespace, PID, and process start identity. Request data cannot choose
+these fields.
+
+The recovery trusted computing base is deliberately narrow:
+
+- local root is the only command authority;
+- the kernel process table in the recorded host, boot, and PID namespace is
+  authoritative for the process and all of its threads;
+- the durable Firestore transaction is authoritative for the final exact
+  subject-document, token, and owner-generation compare-and-set.
+
+Process exit is terminal for every thread in that process. The command accepts
+no terminal boolean, lease claim, owner JSON, PID, generation, host override,
+or remote proof. It is not registered as an HTTP route.
+
+The command must run in the same supervisor boundary that observed the worker.
+For Docker's single-Uvicorn image, run it on the same-boot host as root with the
+host `/proc` mounted: cross-namespace proof additionally requires effective
+`CAP_SYS_ADMIN` and a kernel `NS_GET_PARENT` check proving the command itself is
+in the initial host PID namespace. It then scans the host process table for the
+exact recorded PID namespace, namespace-local PID, and process start identity.
+Container-root, including a privileged nested PID namespace, cannot infer that
+another container is dead. A sidecar in a shared pod PID namespace can use the
+same-namespace path.
+Another worker, another host, another boot, an unknown namespace, a hidden
+process table, or an unavailable supervisor capability cannot prove absence
+and therefore cannot recover the record. Those cases intentionally remain
+`DRAINING`. Do not copy owner fields to make a replacement look local.
+
+## Deterministic recovery sequence
+
+1. Stop admission for the affected deployment generation. Keep Firebase
+   authentication and all user content retained.
+2. From the recorded host/boot/PID namespace, verify the exact worker has
+   reached the supervisor's terminal state. Do not restart or reuse its
+   namespace before recovery.
+3. In a root-only shell, derive SHA-256 selectors for the exact UID and writer
+   token without writing plaintext to logs or receipts.
+4. Run from `backend/`:
+
+   ```text
+   sudo .venv/bin/python scripts/content_writer_recovery.py \
+     --subject-hash <64-lowercase-hex> \
+     --token-hash <64-lowercase-hex>
+   ```
+
+5. Accept only exit code `0` with `result` equal to `recovered` or
+   `already_recovered`. The JSON receipt is content-free: it contains only
+   hashes, an owner fingerprint, the kernel proof kind, and the result.
+6. Retry the ordinary authenticated `DELETE /v1/users/delete-account` flow.
+   That retry advances the empty fence transactionally, performs exact purges,
+   and deletes Firebase authentication last.
+
+## Abort, retry, and rollback behavior
+
+Any nonzero exit is an abort. Leave the durable record unchanged, leave
+Firebase retained, and investigate the content-free reason. In particular,
+never convert `owner_live`, `pid_reused`, host/boot/namespace mismatch,
+owner-unknown, stale-token, record-replaced, corrupt, or unavailable results
+into a manual release.
+
+The recovery compare-and-set removes only the exact subject document's exact
+token when its complete owner identity still matches the terminal proof.
+Concurrent and duplicate commands converge through a durable recovery receipt;
+other tokens and other subjects remain untouched. A successful release has no
+safe manual rollback because recreating an operator-authored owner record would
+forge ownership. If the subsequent account-deletion retry fails, keep Firebase
+retained and retry the ordinary deletion flow; do not recreate the writer.

--- a/backend/ella/docs/HERMES_PRODUCT_FIT_CANARY.md
+++ b/backend/ella/docs/HERMES_PRODUCT_FIT_CANARY.md
@@ -141,6 +141,10 @@ python scripts/hermes_product_fit_canary.py cleanup \
 Cleanup refuses UID drift, a missing or non-protected receipt, or any receipt
 that does not attest all flags, selectors, and workflows are off. The bearer
 token stays in-process; output is a content-free receipt containing only the UID
-hash, removed-row count, and cleanup facts. Invitation revocation/classification cleanup and
-unclaimed pool cleanup remain in their existing reviewed operator CLIs when
-those artifacts still exist.
+hash, removed-row count, and cleanup facts. The account route revokes ordinary
+invitation authority and releases its pilot-capacity reservation in the same
+PostgreSQL transaction. A `202 deletion_pending` receipt is expected when a
+provisioned self-hosted Hermes profile, Honcho tenancy, or runtime registry
+entry still needs reviewed operator cleanup; it is a resumable typed state, not
+deletion completion. The operator must prove those exact quarantined artifacts
+absent before removing their disabled binding and retrying this command.

--- a/backend/ella/routers/ai_consent.py
+++ b/backend/ella/routers/ai_consent.py
@@ -40,12 +40,12 @@ def get_ai_consent_policy():
 
 
 @router.get("/v1/users/ai-consent")
-def get_ai_consent_status(uid: str = Depends(auth.get_current_user_uid)):
+def get_ai_consent_status(uid: str = Depends(auth.get_writable_user_uid)):
     return get_ai_consent_service().status(uid)
 
 
 @router.get("/v1/users/ai-consent/receipts/{receipt_id}")
-def get_ai_consent_receipt(receipt_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_ai_consent_receipt(receipt_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     receipt = get_ai_consent_service().receipt(uid, receipt_id)
     if receipt is None:
         raise HTTPException(status_code=404, detail={"code": "ai_consent_receipt_not_found"})
@@ -55,7 +55,7 @@ def get_ai_consent_receipt(receipt_id: str, uid: str = Depends(auth.get_current_
 @router.post("/v1/users/ai-consent")
 async def submit_ai_consent(
     request: AiConsentSubmissionRequest,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     try:
         return await submit_with_managed_cloud_authority(

--- a/backend/ella/routers/canonical_events.py
+++ b/backend/ella/routers/canonical_events.py
@@ -13,8 +13,9 @@ import json
 import hmac
 import logging
 import os
+from contextlib import AsyncExitStack, asynccontextmanager
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any, AsyncIterator, Optional
 
 import asyncpg
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -22,6 +23,7 @@ from pydantic import BaseModel, Field
 
 from database import content_write_fence
 from utils.ella.time_context import annotate_event_time, build_time_context
+from utils.other import endpoints as auth
 
 logger = logging.getLogger("ella.canonical_events")
 
@@ -112,24 +114,37 @@ def _completion_can_reinterpret(completion: SessionCompleteIn) -> bool:
     return (source_ref.get("scope_kind") or metadata.get("scope_kind")) == "memory" and can_reinterpret is True
 
 
-def _require_reinterpretation_completion_auth(
-    completion: SessionCompleteIn,
-    authorization: str,
-) -> None:
-    if not _reinterpretation_enabled() or not _completion_can_reinterpret(completion):
-        return
+def _authenticated_canonical_writer(authorization: str) -> Optional[str]:
+    """Return a Firebase subject, or ``None`` for the trusted ledger writer."""
     expected = os.getenv("ELLA_EVENT_LEDGER_TOKEN", "").strip()
-    if not expected:
-        raise HTTPException(
-            status_code=503,
-            detail={"code": "reinterpretation_completion_auth_not_configured"},
-        )
     scheme, _, token = authorization.partition(" ")
-    if scheme.lower() != "bearer" or not token or not hmac.compare_digest(token.encode(), expected.encode()):
+    if expected and scheme.lower() == "bearer" and token and hmac.compare_digest(token.encode(), expected.encode()):
+        return None
+    return auth.get_authenticated_user_uid(authorization)
+
+
+def _require_canonical_subject(principal_uid: Optional[str], requested_uid: Optional[str]) -> str:
+    if not requested_uid:
+        raise HTTPException(status_code=422, detail={"code": "canonical_event_uid_required"})
+    if principal_uid is not None and requested_uid != principal_uid:
+        raise HTTPException(status_code=403, detail={"code": "ownership_mismatch"})
+    return requested_uid
+
+
+@asynccontextmanager
+async def _canonical_write_fences(uids: set[str]) -> AsyncIterator[None]:
+    """Hold every exact-subject writer proof through the datastore commit."""
+    try:
+        async with AsyncExitStack() as stack:
+            for uid in sorted(uids):
+                await stack.enter_async_context(content_write_fence.request_content_write_fence(uid))
+            yield
+    except content_write_fence.ContentWriteFenceError as exc:
+        status_code = 403 if exc.code == "account_write_forbidden" else 503
         raise HTTPException(
-            status_code=401,
-            detail={"code": "invalid_reinterpretation_completion_token"},
-        )
+            status_code=status_code,
+            detail={"code": exc.code, "retryable": status_code == 503},
+        ) from exc
 
 
 def _reinterpretation_row(item: dict[str, Any]) -> dict[str, Any]:
@@ -695,7 +710,7 @@ def create_canonical_events_router(store: Optional[CanonicalEventStore] = None) 
     default_store = store or PostgresCanonicalEventStore()
 
     @router.post("/v1/ella/events")
-    async def write_events(batch: CanonicalEventsBatch):
+    async def write_events(batch: CanonicalEventsBatch, request: Request):
         """
         Idempotently write raw canonical events.
 
@@ -704,7 +719,10 @@ def create_canonical_events_router(store: Optional[CanonicalEventStore] = None) 
         existing raw text/metadata is never overwritten by summaries,
         corrections, retries, or downstream enrichment.
         """
-        return await default_store.write_batch(batch.events)
+        principal_uid = _authenticated_canonical_writer(request.headers.get("Authorization", ""))
+        event_uids = {_require_canonical_subject(principal_uid, event.uid) for event in batch.events}
+        async with _canonical_write_fences(event_uids):
+            return await default_store.write_batch(batch.events)
 
     @router.post("/v1/ella/sessions/{session_id}/complete")
     async def complete_session(
@@ -713,19 +731,10 @@ def create_canonical_events_router(store: Optional[CanonicalEventStore] = None) 
         request: Request,
     ):
         """Record source session completion without converting sessions into OMI objects."""
-        _require_reinterpretation_completion_auth(
-            completion,
-            request.headers.get("Authorization", ""),
-        )
-        try:
-            async with content_write_fence.request_content_write_fence(completion.uid):
-                return await default_store.complete_session(session_id, completion)
-        except content_write_fence.ContentWriteFenceError as exc:
-            status_code = 403 if exc.code == "account_write_forbidden" else 503
-            raise HTTPException(
-                status_code=status_code,
-                detail={"code": exc.code, "retryable": status_code == 503},
-            ) from exc
+        principal_uid = _authenticated_canonical_writer(request.headers.get("Authorization", ""))
+        uid = _require_canonical_subject(principal_uid, completion.uid)
+        async with _canonical_write_fences({uid}):
+            return await default_store.complete_session(session_id, completion)
 
     @router.get("/v1/ella/timeline")
     async def read_timeline(
@@ -760,4 +769,7 @@ def create_canonical_events_router(store: Optional[CanonicalEventStore] = None) 
 async def handle_events(request: Request, store: Optional[CanonicalEventStore] = None) -> dict[str, Any]:
     """Direct import helper for backend integration tests or legacy mounting."""
     payload = CanonicalEventsBatch(**(await request.json()))
-    return await (store or PostgresCanonicalEventStore()).write_batch(payload.events)
+    principal_uid = _authenticated_canonical_writer(request.headers.get("Authorization", ""))
+    event_uids = {_require_canonical_subject(principal_uid, event.uid) for event in payload.events}
+    async with _canonical_write_fences(event_uids):
+        return await (store or PostgresCanonicalEventStore()).write_batch(payload.events)

--- a/backend/ella/routers/canonical_events.py
+++ b/backend/ella/routers/canonical_events.py
@@ -19,6 +19,8 @@ from typing import Any, Optional
 import asyncpg
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
+
+from database import content_write_fence
 from utils.ella.time_context import annotate_event_time, build_time_context
 
 logger = logging.getLogger("ella.canonical_events")
@@ -715,7 +717,15 @@ def create_canonical_events_router(store: Optional[CanonicalEventStore] = None) 
             completion,
             request.headers.get("Authorization", ""),
         )
-        return await default_store.complete_session(session_id, completion)
+        try:
+            async with content_write_fence.request_content_write_fence(completion.uid):
+                return await default_store.complete_session(session_id, completion)
+        except content_write_fence.ContentWriteFenceError as exc:
+            status_code = 403 if exc.code == "account_write_forbidden" else 503
+            raise HTTPException(
+                status_code=status_code,
+                detail={"code": exc.code, "retryable": status_code == 503},
+            ) from exc
 
     @router.get("/v1/ella/timeline")
     async def read_timeline(

--- a/backend/ella/routers/chat.py
+++ b/backend/ella/routers/chat.py
@@ -1213,7 +1213,7 @@ async def ella_chat_history(
     uid: str = "",
     limit: int = 50,
     before: str = None,
-    authenticated_uid: str = Depends(auth.get_current_user_uid),
+    authenticated_uid: str = Depends(auth.get_writable_user_uid),
 ):
     """Return recent chat/context messages for a user from canonical timeline.
 

--- a/backend/ella/routers/chat.py
+++ b/backend/ella/routers/chat.py
@@ -681,7 +681,7 @@ async def _stream_level_4_openclaw(user_message: str, uid: str, client_info: dic
         _l4_trace.openclaw_latency_ms = _elapsed
         _l4_trace.total_latency_ms = _elapsed
         _l4_trace.response_status = 200
-        record_trace(_l4_trace)
+        await record_trace(_l4_trace)
 
         reply_preview = reply[:80] if reply else "(empty)"
         print(
@@ -1101,7 +1101,7 @@ async def ella_chat_stream(
         trace.resolved_agent = runtime.agent_id if runtime else HERMES_AGENT_ID
         trace.resolve_source = "isolated_runtime_binding" if runtime else "hermes_platform"
         trace.total_latency_ms = int((_time.time() - _trace_start) * 1000)
-        record_trace(trace)
+        await record_trace(trace)
         stream = (
             _stream_hermes_cloud_chat(
                 request.message,
@@ -1140,7 +1140,7 @@ async def ella_chat_stream(
         trace.resolved_agent = "N/A (ACK)"
         trace.resolve_source = "level_1_ack"
         trace.total_latency_ms = int((_time.time() - _trace_start) * 1000)
-        record_trace(trace)
+        await record_trace(trace)
         return StreamingResponse(
             _stream_level_1_ack(request.message),
             media_type="text/event-stream",
@@ -1150,7 +1150,7 @@ async def ella_chat_stream(
         trace.resolved_agent = "grok-direct"
         trace.resolve_source = "level_2_grok"
         trace.total_latency_ms = int((_time.time() - _trace_start) * 1000)
-        record_trace(trace)
+        await record_trace(trace)
         return StreamingResponse(
             _stream_level_2_grok(request.message),
             media_type="text/event-stream",
@@ -1160,7 +1160,7 @@ async def ella_chat_stream(
         trace.resolved_agent = "n8n-webhook"
         trace.resolve_source = "level_3_n8n"
         trace.total_latency_ms = int((_time.time() - _trace_start) * 1000)
-        record_trace(trace)
+        await record_trace(trace)
         return StreamingResponse(
             _stream_level_3_n8n(request.message, uid, request.conversation_id),
             media_type="text/event-stream",
@@ -1188,7 +1188,7 @@ async def ella_chat_stream(
     trace.resolved_agent = "grok-direct (level 0)"
     trace.resolve_source = "level_0_production"
     trace.total_latency_ms = int((_time.time() - _trace_start) * 1000)
-    record_trace(trace)
+    await record_trace(trace)
     return StreamingResponse(
         _stream_level_2_grok(request.message),
         media_type="text/event-stream",

--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -1371,7 +1371,7 @@ async def _submit_conversation_correction(
     conversation_id: str,
     request: ConversationCorrectionRequest,
     background_tasks: Optional[BackgroundTasks] = None,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ) -> ConversationCorrectionResponse:
     conversation = conversations_db.get_conversation(uid, conversation_id)
     if conversation is None:
@@ -1704,7 +1704,7 @@ async def _submit_conversation_correction(
 )
 def get_conversation_processing_retry_plan(
     conversation_id: str,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ) -> ConversationProcessingRetryPlan:
     plan = build_conversation_processing_retry_plan(uid, conversation_id)
     if plan is None:
@@ -1721,7 +1721,7 @@ def retry_failed_conversation_processing(
     conversation_id: str,
     request: RetryConversationProcessingRequest,
     background_tasks: BackgroundTasks,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ) -> RetryConversationProcessingResponse:
     """Atomically queue generic recovery followed by canonical Hermes enrichment."""
 
@@ -1807,7 +1807,7 @@ async def submit_conversation_correction_ella(
 def get_conversation_correction_receipt(
     conversation_id: str,
     correction_id: str,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ) -> ConversationCorrectionReceiptResponse:
     return _correction_receipt(
         uid=uid,
@@ -1823,7 +1823,7 @@ def get_conversation_correction_receipt(
 async def undo_conversation_correction(
     conversation_id: str,
     correction_id: str,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ) -> ConversationCorrectionReceiptResponse:
     conversation = conversations_db.get_conversation(uid, conversation_id)
     if conversation is None:

--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -823,7 +823,7 @@ async def _guardian_alert_history(uid: str, limit: int) -> dict[str, Any]:
 @alerts_router.get("/guardian-alerts")
 async def guardian_alerts(
     limit: int = Query(default=50, ge=1, le=200),
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ) -> dict[str, Any]:
     """Return newest-first Guardian alert history for the authenticated user."""
     return await _guardian_alert_history(uid, limit)

--- a/backend/ella/routers/invites.py
+++ b/backend/ella/routers/invites.py
@@ -98,7 +98,7 @@ async def _validated_payload(request: Request) -> InviteRedeemRequest:
 )
 async def redeem_invite(
     request: Request,
-    authenticated_uid: str = Depends(auth.get_current_user_uid),
+    authenticated_uid: str = Depends(auth.get_writable_user_uid),
     app_build: str = Header(default="", alias="X-Ella-App-Build"),
 ) -> dict:
     payload = await _validated_payload(request)

--- a/backend/ella/routers/memory_reinterpretation.py
+++ b/backend/ella/routers/memory_reinterpretation.py
@@ -64,7 +64,7 @@ def create_memory_reinterpretation_router(
     @router.get("/v1/ella/conversations/{conversation_id}/reinterpretations/latest")
     async def latest_reinterpretation(
         conversation_id: str,
-        uid: str = Depends(auth.get_current_user_uid),
+        uid: str = Depends(auth.get_writable_user_uid),
     ) -> dict[str, Any]:
         job = await _owned_job(uid=uid, conversation_id=conversation_id)
         return {"ok": True, "reinterpretation": public_job(job)}
@@ -73,7 +73,7 @@ def create_memory_reinterpretation_router(
     async def get_reinterpretation(
         conversation_id: str,
         job_id: str,
-        uid: str = Depends(auth.get_current_user_uid),
+        uid: str = Depends(auth.get_writable_user_uid),
     ) -> dict[str, Any]:
         job = await _owned_job(uid=uid, conversation_id=conversation_id, job_id=job_id)
         return {"ok": True, "reinterpretation": public_job(job)}

--- a/backend/ella/routers/onboarding.py
+++ b/backend/ella/routers/onboarding.py
@@ -123,7 +123,7 @@ async def ensure_onboarding(
     payload: OnboardingEnsureRequest,
     background_tasks: BackgroundTasks,
     response: Response,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ) -> dict[str, Any]:
     if not SCHEMA_VERSION_RE.fullmatch(payload.target_schema_version):
         raise HTTPException(status_code=400, detail={"code": "invalid_target_schema_version"})
@@ -227,7 +227,7 @@ async def ensure_onboarding(
 @router.get("/status")
 async def onboarding_status(
     target_schema_version: str = DEFAULT_TARGET_SCHEMA_VERSION,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ) -> dict[str, Any]:
     if not SCHEMA_VERSION_RE.fullmatch(target_schema_version):
         raise HTTPException(status_code=400, detail={"code": "invalid_target_schema_version"})

--- a/backend/ella/routers/resolve.py
+++ b/backend/ella/routers/resolve.py
@@ -193,7 +193,7 @@ async def resolve_endpoint(
     uid: Optional[str] = Query(None, description="Firebase UID (omiUid)"),
     email: Optional[str] = Query(None, description="User email"),
     phone: Optional[str] = Query(None, description="User phone (E.164)"),
-    authenticated_uid: str = Depends(auth.get_current_user_uid),
+    authenticated_uid: str = Depends(auth.get_writable_user_uid),
 ):
     """Resolve a user identifier to active agent routing info.
 
@@ -316,7 +316,7 @@ async def proxy_chat_history(
     agent_id: str,
     limit: int = 50,
     session_key: Optional[str] = None,
-    authenticated_uid: str = Depends(auth.get_current_user_uid),
+    authenticated_uid: str = Depends(auth.get_writable_user_uid),
 ):
     """Proxy chat history requests to the Provision API on Mac Mini.
 

--- a/backend/ella/routers/settings.py
+++ b/backend/ella/routers/settings.py
@@ -16,14 +16,14 @@ router = APIRouter(prefix="/v1/ella/settings", tags=["Ella Settings"])
 
 
 @router.get("")
-def get_settings(uid: str = Depends(auth.get_current_user_uid)) -> dict[str, Any]:
+def get_settings(uid: str = Depends(auth.get_writable_user_uid)) -> dict[str, Any]:
     """Return server-backed Ella app settings for the authenticated user."""
     voice = app_settings_db.get_voice_settings(uid)
     return build_settings_response(uid, voice)
 
 
 @router.patch("")
-def patch_settings(payload: dict[str, Any], uid: str = Depends(auth.get_current_user_uid)) -> dict[str, Any]:
+def patch_settings(payload: dict[str, Any], uid: str = Depends(auth.get_writable_user_uid)) -> dict[str, Any]:
     """Persist app settings from iOS. First slice stores effective voice mode."""
     voice = extract_voice_settings(payload)
     saved_voice = app_settings_db.save_voice_settings(uid, voice)
@@ -31,14 +31,14 @@ def patch_settings(payload: dict[str, Any], uid: str = Depends(auth.get_current_
 
 
 @router.get("/effective")
-def get_effective_settings(uid: str = Depends(auth.get_current_user_uid)) -> dict[str, Any]:
+def get_effective_settings(uid: str = Depends(auth.get_writable_user_uid)) -> dict[str, Any]:
     """Return settings plus backend-resolved routing fields for services like Guardian."""
     voice = app_settings_db.get_voice_settings(uid)
     return build_effective_voice_settings(uid, voice)
 
 
 @router.get("/effective/voice")
-def get_effective_voice_settings(uid: str = Depends(auth.get_current_user_uid)) -> dict[str, Any]:
+def get_effective_voice_settings(uid: str = Depends(auth.get_writable_user_uid)) -> dict[str, Any]:
     """Return only the effective voice resolver payload."""
     voice = app_settings_db.get_voice_settings(uid)
     return build_effective_voice_settings(uid, voice)["effective_voice_settings"]

--- a/backend/ella/routers/trace.py
+++ b/backend/ella/routers/trace.py
@@ -1,36 +1,38 @@
 """
-Ella Request Tracing — Persistent + In-Memory
+Ella Request Tracing — Durable, deletion-fenced telemetry
 
 Every routing decision is captured:
-- In-memory ring buffer (200 entries) for instant dashboard polling
 - Postgres `routing_traces` table for historical queries, analytics, retention
 
 Endpoints:
-  GET  /v1/ella/debug/traces        — recent traces (from memory or DB)
+  GET  /v1/ella/debug/traces        — recent traces (from DB)
   GET  /v1/ella/debug/trace/{uid}   — traces for a specific user
   GET  /v1/ella/debug/status        — routing config health
   POST /v1/ella/debug/client-trace  — iOS/client-reported trace (ingest)
   GET  /v1/ella/debug/stats         — aggregate stats (from DB)
 """
 
+import asyncio
 import json
 import logging
 import os
 import uuid
-from collections import deque
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import asyncpg
-from fastapi import APIRouter, Query, Request
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel, Field
+
+from database import content_write_fence
+from ella.config import ELLA_CONFIG
+from ella.routers.resolve import _get_pool as _get_resolve_pool
+from utils.other import endpoints as auth
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/ella/debug", tags=["ella-debug"])
-
-# In-memory ring buffer for fast recent queries
-_traces = deque(maxlen=200)
 
 # Database pool (lazy-initialized, shared via resolve.py's pool)
 _pool: Optional[asyncpg.Pool] = None
@@ -42,7 +44,6 @@ async def _get_pool() -> asyncpg.Pool:
     if _pool is None:
         # Try to reuse resolve.py's pool first
         try:
-            from ella.routers.resolve import _get_pool as _get_resolve_pool
             _pool = await _get_resolve_pool()
         except Exception:
             _pool = await asyncpg.create_pool(
@@ -59,28 +60,29 @@ async def _get_pool() -> asyncpg.Pool:
 
 class RouteTrace:
     """A single routing event through the system."""
+
     def __init__(self):
         self.trace_id = str(uuid.uuid4())[:8]
         self.timestamp = datetime.now(timezone.utc).isoformat()
         self.endpoint = ""
         self.method = ""
         self.client_ip = ""
-        self.client_type = ""       # "ios", "dashboard", "curl", "e2e-debugger"
-        self.client_version = ""    # "1.2.3"
+        self.client_type = ""  # "ios", "dashboard", "curl", "e2e-debugger"
+        self.client_version = ""  # "1.2.3"
         self.uid = ""
         self.debug_level = None
         self.resolved_agent = ""
         self.resolved_gateway = ""
         self.resolved_session_key = ""
-        self.resolve_source = ""    # "database", "fallback", "header_override"
+        self.resolve_source = ""  # "database", "fallback", "header_override"
         self.openclaw_status = None
         self.openclaw_latency_ms = 0
         self.response_status = None
         self.total_latency_ms = 0
         self.error = ""
         self.notes = []
-        self.client_route = ""      # route the client thinks it's using
-        self.client_headers = {}    # raw X-Ella-* headers from client
+        self.client_route = ""  # route the client thinks it's using
+        self.client_headers = {}  # raw X-Ella-* headers from client
 
     def to_dict(self):
         return {
@@ -109,8 +111,9 @@ class RouteTrace:
 
 
 async def _persist_trace(trace: RouteTrace):
-    """Write trace to postgres. Fire-and-forget — errors logged, not raised."""
+    """Write one trace while its transferred deletion fence remains live."""
     try:
+        content_write_fence.assert_detached_content_writer_current(trace.uid)
         pool = await _get_pool()
         await pool.execute(
             """
@@ -156,117 +159,89 @@ async def _persist_trace(trace: RouteTrace):
         logger.warning(f"[TRACE] Failed to persist trace {trace.trace_id}: {e}")
 
 
-def record_trace(trace: RouteTrace):
-    """Add a trace to the in-memory buffer, log it, and queue DB persist."""
-    _traces.appendleft(trace)
+async def record_trace(trace: RouteTrace) -> asyncio.Task:
+    """Transfer a writer registration before detached durable persistence."""
+    if not trace.uid:
+        raise content_write_fence.ContentWriteFenceError("account_content_fence_unavailable")
+    content_write_fence.assert_content_writer_admitted(trace.uid)
     logger.info(
-        f"[TRACE {trace.trace_id}] {trace.endpoint} uid={trace.uid} "
+        f"[TRACE {trace.trace_id}] {trace.endpoint} "
         f"-> agent={trace.resolved_agent} via={trace.resolve_source} "
         f"gateway={trace.resolved_gateway} "
         f"openclaw={trace.openclaw_status} "
         f"total={trace.total_latency_ms}ms"
     )
-    # Fire-and-forget DB persist via background task
-    import asyncio
-    try:
-        loop = asyncio.get_running_loop()
-        loop.create_task(_persist_trace(trace))
-    except RuntimeError:
-        # No running loop (shouldn't happen in FastAPI, but safety net)
-        pass
+    return await content_write_fence.start_content_writer_task(
+        trace.uid,
+        lambda: _persist_trace(trace),
+        name=f"routing-trace-{trace.trace_id}",
+    )
 
 
 # --------------- Client Trace Ingestion ---------------
 
+
 class ClientTracePayload(BaseModel):
-    """Trace data reported by iOS/web clients."""
-    uid: str
-    route: str = ""                # e.g. "/v1/ella/chat/stream"
-    resolvedAgent: str = ""
-    resolvedGateway: str = ""
-    sessionKey: str = ""
-    resolveSource: str = ""        # "cached", "api_resolve", "hardcoded"
-    clientType: str = ""           # "ios", "dashboard"
-    clientVersion: str = ""
-    debugLevel: int = -1
-    latencyMs: int = 0
-    status: int = 0
-    error: str = ""
-    notes: list = []
-    headers: dict = {}
+    """Bounded, content-free client telemetry; extra legacy fields are ignored."""
+
+    uid: str = Field(default="", max_length=128)
+    clientType: str = Field(default="", max_length=24)
+    debugLevel: int = Field(default=-1, ge=-1, le=4)
+    latencyMs: int = Field(default=0, ge=0, le=3_600_000)
+    status: int = Field(default=0, ge=0, le=599)
 
 
 @router.post("/client-trace")
-async def ingest_client_trace(payload: ClientTracePayload, request: Request):
-    """Ingest a trace reported by a client (iOS app, dashboard, etc).
+async def ingest_client_trace(
+    payload: ClientTracePayload,
+    authenticated_uid: str = Depends(auth.get_writable_user_uid),
+):
+    """Ingest bounded telemetry for the authenticated writable subject."""
+    if payload.uid and payload.uid != authenticated_uid:
+        raise HTTPException(status_code=403, detail={"code": "ownership_mismatch"})
 
-    Clients call this after completing a chat request to report their
-    view of the routing — which endpoint they hit, what agent they resolved,
-    timing from their perspective.
-    """
     trace = RouteTrace()
     trace.trace_id = f"c-{str(uuid.uuid4())[:6]}"  # "c-" prefix = client-reported
-    trace.endpoint = payload.route or "client-reported"
+    trace.endpoint = "client-reported"
     trace.method = "CLIENT"
-    trace.client_ip = request.client.host if request.client else ""
-    trace.client_type = payload.clientType
-    trace.client_version = payload.clientVersion
-    trace.uid = payload.uid
+    trace.client_type = payload.clientType if payload.clientType in {"ios", "dashboard", "web"} else "unknown"
+    trace.uid = authenticated_uid
     trace.debug_level = payload.debugLevel if payload.debugLevel >= 0 else None
-    trace.resolved_agent = payload.resolvedAgent
-    trace.resolved_gateway = payload.resolvedGateway
-    trace.resolved_session_key = payload.sessionKey
-    trace.resolve_source = payload.resolveSource
-    trace.openclaw_status = payload.status if payload.status > 0 else None
+    trace.response_status = payload.status if payload.status > 0 else None
     trace.total_latency_ms = payload.latencyMs
-    trace.error = payload.error
-    trace.notes = payload.notes or ["client-reported"]
-    trace.client_route = payload.route
-    trace.client_headers = payload.headers
+    trace.notes = ["client-telemetry"]
 
-    record_trace(trace)
+    await record_trace(trace)
 
     return {"ok": True, "traceId": trace.trace_id}
 
 
 # --------------- Query Endpoints ---------------
 
+
 @router.get("/traces")
 async def get_traces(
     limit: int = Query(50, ge=1, le=500),
     uid: Optional[str] = Query(None),
-    source: Optional[str] = Query(None, description="memory or db"),
-    hours: int = Query(0, ge=0, le=168, description="DB lookback hours (0=use memory)"),
+    source: Optional[str] = Query(None, description="legacy parameter; storage is always db"),
+    hours: int = Query(0, ge=0, le=168, description="DB lookback hours (0=24 hours)"),
     client_type: Optional[str] = Query(None),
     errors_only: bool = Query(False),
+    authenticated_uid: str = Depends(auth.get_current_user_uid),
 ):
-    """Get routing traces.
-
-    By default returns from in-memory buffer (fast, last 200).
-    Set source=db or hours>0 to query postgres for historical data.
-    """
-    if source == "db" or hours > 0:
-        return await _traces_from_db(limit, uid, hours or 24, client_type, errors_only)
-
-    # In-memory fast path
-    traces = list(_traces)
-    if uid:
-        traces = [t for t in traces if t.uid == uid]
-    if client_type:
-        traces = [t for t in traces if t.client_type == client_type]
-    if errors_only:
-        traces = [t for t in traces if t.error]
-    return {
-        "source": "memory",
-        "count": len(traces[:limit]),
-        "total": len(traces),
-        "traces": [t.to_dict() for t in traces[:limit]],
-    }
+    """Get durable routing traces for the authenticated subject only."""
+    del source
+    if uid and uid != authenticated_uid:
+        raise HTTPException(status_code=403, detail={"code": "ownership_mismatch"})
+    return await _traces_from_db(limit, authenticated_uid, hours or 24, client_type, errors_only)
 
 
 async def _traces_from_db(
-    limit: int, uid: Optional[str], hours: int,
-    client_type: Optional[str], errors_only: bool,
+    limit: int,
+    uid: Optional[str],
+    hours: int,
+    client_type: Optional[str],
+    errors_only: bool,
 ):
     """Query traces from postgres."""
     pool = await _get_pool()
@@ -340,23 +315,21 @@ async def get_user_traces(
     limit: int = Query(20, ge=1, le=100),
     source: Optional[str] = Query(None),
     hours: int = Query(0, ge=0, le=168),
+    authenticated_uid: str = Depends(auth.get_current_user_uid),
 ):
-    """Get routing traces for a specific user UID."""
-    if source == "db" or hours > 0:
-        return await _traces_from_db(limit, uid, hours or 24, None, False)
-
-    traces = [t for t in _traces if t.uid == uid]
-    return {
-        "uid": uid,
-        "source": "memory",
-        "count": len(traces[:limit]),
-        "traces": [t.to_dict() for t in traces[:limit]],
-    }
+    """Get durable routing traces for the exact authenticated subject."""
+    del source
+    if uid != authenticated_uid:
+        raise HTTPException(status_code=403, detail={"code": "ownership_mismatch"})
+    return await _traces_from_db(limit, authenticated_uid, hours or 24, None, False)
 
 
 @router.get("/stats")
-async def trace_stats(hours: int = Query(24, ge=1, le=168)):
-    """Aggregate trace statistics from the database."""
+async def trace_stats(
+    hours: int = Query(24, ge=1, le=168),
+    authenticated_uid: str = Depends(auth.get_current_user_uid),
+):
+    """Aggregate trace statistics for the authenticated subject."""
     pool = await _get_pool()
     row = await pool.fetchrow(
         """
@@ -369,8 +342,10 @@ async def trace_stats(hours: int = Query(24, ge=1, le=168)):
             COUNT(*) FILTER (WHERE method = 'CLIENT') AS client_reported
         FROM routing_traces
         WHERE created_at > NOW() - $1::interval
+          AND uid = $2
         """,
         timedelta(hours=hours),
+        authenticated_uid,
     )
     # Dynamic client type breakdown
     client_rows = await pool.fetch(
@@ -378,10 +353,12 @@ async def trace_stats(hours: int = Query(24, ge=1, le=168)):
         SELECT COALESCE(NULLIF(client_type, ''), 'unknown') AS ctype, COUNT(*) AS cnt
         FROM routing_traces
         WHERE created_at > NOW() - $1::interval
+          AND uid = $2
         GROUP BY ctype
         ORDER BY cnt DESC
         """,
         timedelta(hours=hours),
+        authenticated_uid,
     )
     # Dynamic resolve source breakdown
     source_rows = await pool.fetch(
@@ -389,10 +366,12 @@ async def trace_stats(hours: int = Query(24, ge=1, le=168)):
         SELECT COALESCE(NULLIF(resolve_source, ''), 'unknown') AS src, COUNT(*) AS cnt
         FROM routing_traces
         WHERE created_at > NOW() - $1::interval
+          AND uid = $2
         GROUP BY src
         ORDER BY cnt DESC
         """,
         timedelta(hours=hours),
+        authenticated_uid,
     )
     # Top agents
     agent_rows = await pool.fetch(
@@ -400,12 +379,14 @@ async def trace_stats(hours: int = Query(24, ge=1, le=168)):
         SELECT resolved_agent, COUNT(*) as cnt
         FROM routing_traces
         WHERE created_at > NOW() - $1::interval
+          AND uid = $2
           AND resolved_agent IS NOT NULL AND resolved_agent != ''
         GROUP BY resolved_agent
         ORDER BY cnt DESC
         LIMIT 10
         """,
         timedelta(hours=hours),
+        authenticated_uid,
     )
     return {
         "lookbackHours": hours,
@@ -422,17 +403,21 @@ async def trace_stats(hours: int = Query(24, ge=1, le=168)):
 
 
 @router.get("/status")
-async def debug_status():
-    """Current routing configuration and health."""
-    from ella.config import ELLA_CONFIG
-
+async def debug_status(authenticated_uid: str = Depends(auth.get_current_user_uid)):
+    """Current routing configuration and subject-scoped durable health."""
     # Quick DB count
     db_count = 0
     try:
         pool = await _get_pool()
         row = await pool.fetchrow(
-            "SELECT COUNT(*) AS cnt FROM routing_traces WHERE created_at > NOW() - $1::interval",
+            """
+            SELECT COUNT(*) AS cnt
+            FROM routing_traces
+            WHERE created_at > NOW() - $1::interval
+              AND uid = $2
+            """,
             timedelta(hours=24),
+            authenticated_uid,
         )
         db_count = row["cnt"] if row else 0
     except Exception:
@@ -442,22 +427,16 @@ async def debug_status():
         "debugLevel": ELLA_CONFIG.debug_level,
         "openclawUrl": os.getenv("OPENCLAW_URL", "NOT SET"),
         "openclawTokenSet": bool(os.getenv("OPENCLAW_GATEWAY_TOKEN")),
-        "traceBufferSize": len(_traces),
-        "traceBufferMax": 200,
+        "traceStorage": "database",
         "dbTraces24h": db_count,
-        "recentErrors": len([t for t in _traces if t.error]),
-        "uniqueUids": len(set(t.uid for t in _traces)),
-        "lastTrace": _traces[0].to_dict() if _traces else None,
     }
 
 
 # --------------- Debug Console (HTML) ---------------
 
-from fastapi.responses import HTMLResponse, FileResponse
-
 
 @router.get("/console", response_class=HTMLResponse)
-async def debug_console():
+async def debug_console(_authenticated_uid: str = Depends(auth.get_current_user_uid)):
     """Serve the Routing Debug Console HTML page."""
     console_path = "/var/www/ella-ai-care.com/debug-console.html"
     try:

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -1216,7 +1216,7 @@ async def create_voice_session(
 @entitlement_router.get("/v1/entitlement")
 @router.get("/entitlement")
 async def get_voice_entitlement(
-    authenticated_uid: str = Depends(auth.get_current_user_uid),
+    authenticated_uid: str = Depends(auth.get_writable_user_uid),
 ):
     """Return the stable frontend contract without exposing operator notes."""
     contract = await voice_canary_db.get_entitlement_contract(authenticated_uid)

--- a/backend/ella/services/account_deletion.py
+++ b/backend/ella/services/account_deletion.py
@@ -1,0 +1,84 @@
+"""Resumable orchestration for the authenticated account-deletion route."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from fastapi import HTTPException
+from starlette.concurrency import run_in_threadpool
+
+from database import account_deletion as account_deletion_db
+from ella.services.ai_consent import build_account_deletion_receipt
+
+
+@dataclass(frozen=True)
+class AccountDeletionResponse:
+    status_code: int
+    body: dict[str, Any]
+
+
+async def execute_account_deletion(
+    uid: str,
+    *,
+    delete_firestore: Callable[[str], Any],
+    delete_firebase: Callable[[str], Any],
+) -> AccountDeletionResponse:
+    """Advance every safe deletion stage once and return typed progress."""
+    try:
+        state = await account_deletion_db.quarantine_account_for_deletion(uid)
+    except account_deletion_db.AccountDeletionUnavailable as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": exc.code, "retryable": True},
+        ) from exc
+
+    remaining = set(state.external_cleanup_required)
+    try:
+        await run_in_threadpool(delete_firestore, uid)
+    except Exception:
+        remaining.add("firestore_data")
+
+    if not remaining:
+        try:
+            await account_deletion_db.finalize_account_deletion(uid)
+        except account_deletion_db.AccountDeletionUnavailable as exc:
+            if exc.code == "account_deletion_external_cleanup_incomplete":
+                remaining.update({"hermes_profile", "honcho_tenancy", "runtime_registry"})
+            else:
+                raise HTTPException(
+                    status_code=503,
+                    detail={"code": exc.code, "retryable": True},
+                ) from exc
+
+    if not remaining:
+        try:
+            await run_in_threadpool(delete_firebase, uid)
+        except Exception:
+            remaining.add("firebase_identity")
+
+    if remaining:
+        ordered_remaining = tuple(sorted(remaining))
+        return AccountDeletionResponse(
+            status_code=202,
+            body={
+                "status": "deletion_pending",
+                "code": "account_deletion_cleanup_pending",
+                "authority_quarantined": state.authority_quarantined,
+                "capacity_released": state.capacity_released,
+                "retryable": True,
+                "deletion_receipt": build_account_deletion_receipt(
+                    status="pending",
+                    remaining=ordered_remaining,
+                ),
+            },
+        )
+
+    return AccountDeletionResponse(
+        status_code=200,
+        body={
+            "status": "ok",
+            "message": "Account deleted successfully",
+            "deletion_receipt": build_account_deletion_receipt(),
+        },
+    )

--- a/backend/ella/services/account_deletion.py
+++ b/backend/ella/services/account_deletion.py
@@ -10,6 +10,7 @@ from fastapi import HTTPException
 from starlette.concurrency import run_in_threadpool
 
 from database import account_deletion as account_deletion_db
+from database import content_write_fence
 from ella.services.ai_consent import build_account_deletion_receipt
 
 
@@ -59,9 +60,37 @@ async def execute_account_deletion(
 
     remaining = set(state.external_cleanup_required)
     try:
+        writers_drained = await content_write_fence.tombstone_content_writes(uid)
+    except content_write_fence.ContentWriteFenceError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": exc.code, "retryable": True},
+        ) from exc
+    if not writers_drained:
+        remaining.add("firestore_data")
+        ordered_remaining = tuple(sorted(remaining))
+        return AccountDeletionResponse(
+            status_code=202,
+            body={
+                "status": "deletion_pending",
+                "code": "account_deletion_cleanup_pending",
+                "authority_quarantined": state.authority_quarantined,
+                "capacity_released": state.capacity_released,
+                "retryable": True,
+                "deletion_receipt": build_account_deletion_receipt(
+                    status="pending",
+                    remaining=ordered_remaining,
+                    external_cleanup_references=state.external_cleanup_references,
+                ),
+            },
+        )
+
+    try:
         await run_in_threadpool(delete_firestore, uid)
     except Exception:
         remaining.add("firestore_data")
+    else:
+        remaining.discard("firestore_data")
 
     if authority_enabled and not remaining:
         try:

--- a/backend/ella/services/account_deletion.py
+++ b/backend/ella/services/account_deletion.py
@@ -93,6 +93,13 @@ async def execute_account_deletion(
         remaining.discard("routing_traces")
 
     try:
+        await account_deletion_db.purge_memory_reinterpretation_work(uid)
+    except account_deletion_db.AccountDeletionUnavailable:
+        remaining.add("memory_reinterpretation")
+    else:
+        remaining.discard("memory_reinterpretation")
+
+    try:
         await run_in_threadpool(delete_firestore, uid)
     except Exception:
         remaining.add("firestore_data")

--- a/backend/ella/services/account_deletion.py
+++ b/backend/ella/services/account_deletion.py
@@ -86,6 +86,13 @@ async def execute_account_deletion(
         )
 
     try:
+        await account_deletion_db.purge_routing_traces(uid)
+    except account_deletion_db.AccountDeletionUnavailable:
+        remaining.add("routing_traces")
+    else:
+        remaining.discard("routing_traces")
+
+    try:
         await run_in_threadpool(delete_firestore, uid)
     except Exception:
         remaining.add("firestore_data")

--- a/backend/ella/services/account_deletion.py
+++ b/backend/ella/services/account_deletion.py
@@ -100,6 +100,13 @@ async def execute_account_deletion(
         remaining.discard("memory_reinterpretation")
 
     try:
+        await account_deletion_db.purge_canonical_event_ledger(uid)
+    except account_deletion_db.AccountDeletionUnavailable:
+        remaining.add("canonical_event_ledger")
+    else:
+        remaining.discard("canonical_event_ledger")
+
+    try:
         await run_in_threadpool(delete_firestore, uid)
     except Exception:
         remaining.add("firestore_data")

--- a/backend/ella/services/account_deletion.py
+++ b/backend/ella/services/account_deletion.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
 from typing import Any, Callable
 
 from fastapi import HTTPException
@@ -18,6 +19,18 @@ class AccountDeletionResponse:
     body: dict[str, Any]
 
 
+def ella_authority_persistence_enabled() -> bool:
+    """Return the explicit deletion-authority boundary without probing schema.
+
+    A missing/invalid enabled configuration remains enabled so database
+    failures cannot silently downgrade deletion to the legacy destructive path.
+    """
+    configured = os.getenv("ELLA_POSTGRES_AUTHORITY_ENABLED")
+    if configured is not None:
+        return configured.strip().lower() != "false"
+    return os.getenv("ELLA_ENABLED", "true").strip().lower() != "false"
+
+
 async def execute_account_deletion(
     uid: str,
     *,
@@ -25,13 +38,24 @@ async def execute_account_deletion(
     delete_firebase: Callable[[str], Any],
 ) -> AccountDeletionResponse:
     """Advance every safe deletion stage once and return typed progress."""
-    try:
-        state = await account_deletion_db.quarantine_account_for_deletion(uid)
-    except account_deletion_db.AccountDeletionUnavailable as exc:
-        raise HTTPException(
-            status_code=503,
-            detail={"code": exc.code, "retryable": True},
-        ) from exc
+    authority_enabled = ella_authority_persistence_enabled()
+    if authority_enabled:
+        try:
+            state = await account_deletion_db.quarantine_account_for_deletion(uid)
+        except account_deletion_db.AccountDeletionUnavailable as exc:
+            raise HTTPException(
+                status_code=503,
+                detail={"code": exc.code, "retryable": True},
+            ) from exc
+    else:
+        state = account_deletion_db.AccountDeletionState(
+            user_found=False,
+            capacity_released=False,
+            authority_quarantined=False,
+            external_cleanup_required=(),
+            external_cleanup_references=(),
+            counts={},
+        )
 
     remaining = set(state.external_cleanup_required)
     try:
@@ -39,7 +63,7 @@ async def execute_account_deletion(
     except Exception:
         remaining.add("firestore_data")
 
-    if not remaining:
+    if authority_enabled and not remaining:
         try:
             await account_deletion_db.finalize_account_deletion(uid)
         except account_deletion_db.AccountDeletionUnavailable as exc:
@@ -70,6 +94,7 @@ async def execute_account_deletion(
                 "deletion_receipt": build_account_deletion_receipt(
                     status="pending",
                     remaining=ordered_remaining,
+                    external_cleanup_references=state.external_cleanup_references,
                 ),
             },
         )

--- a/backend/ella/services/ai_consent.py
+++ b/backend/ella/services/ai_consent.py
@@ -217,6 +217,7 @@ def build_account_deletion_receipt(
         "firestore_data",
         "hermes_profile",
         "honcho_tenancy",
+        "routing_traces",
         "runtime_registry",
     }
     if any(item not in allowed_remaining for item in remaining):

--- a/backend/ella/services/ai_consent.py
+++ b/backend/ella/services/ai_consent.py
@@ -217,6 +217,7 @@ def build_account_deletion_receipt(
         "firestore_data",
         "hermes_profile",
         "honcho_tenancy",
+        "memory_reinterpretation",
         "routing_traces",
         "runtime_registry",
     }

--- a/backend/ella/services/ai_consent.py
+++ b/backend/ella/services/ai_consent.py
@@ -213,6 +213,7 @@ def build_account_deletion_receipt(
     if status not in {"completed", "pending"}:
         raise ValueError("account_deletion_receipt_status_invalid")
     allowed_remaining = {
+        "canonical_event_ledger",
         "firebase_identity",
         "firestore_data",
         "hermes_profile",

--- a/backend/ella/services/ai_consent.py
+++ b/backend/ella/services/ai_consent.py
@@ -204,15 +204,37 @@ ACCOUNT_DELETION_CONTRACT = {
 
 def build_account_deletion_receipt(
     *,
+    status: str = "completed",
+    remaining: tuple[str, ...] = (),
     now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
-) -> dict[str, str]:
-    """Return a non-identifying receipt for a completed synchronous deletion."""
-    return {
-        "request_id": f"aidel_{secrets.token_hex(16)}",
-        "status": "completed",
-        "scope": ACCOUNT_DELETION_CONTRACT["scope"],
-        "server_completed_at": now().astimezone(timezone.utc).isoformat(),
+) -> dict[str, Any]:
+    """Return a non-identifying receipt for deletion progress."""
+    if status not in {"completed", "pending"}:
+        raise ValueError("account_deletion_receipt_status_invalid")
+    allowed_remaining = {
+        "firebase_identity",
+        "firestore_data",
+        "hermes_profile",
+        "honcho_tenancy",
+        "runtime_registry",
     }
+    if any(item not in allowed_remaining for item in remaining):
+        raise ValueError("account_deletion_receipt_remaining_invalid")
+    timestamp = now().astimezone(timezone.utc).isoformat()
+    receipt: dict[str, Any] = {
+        "request_id": f"aidel_{secrets.token_hex(16)}",
+        "status": status,
+        "scope": ACCOUNT_DELETION_CONTRACT["scope"],
+    }
+    if status == "pending":
+        receipt["server_updated_at"] = timestamp
+        receipt["remaining"] = sorted(set(remaining))
+        receipt["operator_action_required"] = bool(
+            {"hermes_profile", "honcho_tenancy", "runtime_registry"} & set(remaining)
+        )
+    else:
+        receipt["server_completed_at"] = timestamp
+    return receipt
 
 
 class ConsentPolicyMismatch(ValueError):

--- a/backend/ella/services/ai_consent.py
+++ b/backend/ella/services/ai_consent.py
@@ -206,6 +206,7 @@ def build_account_deletion_receipt(
     *,
     status: str = "completed",
     remaining: tuple[str, ...] = (),
+    external_cleanup_references: tuple[str, ...] = (),
     now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
 ) -> dict[str, Any]:
     """Return a non-identifying receipt for deletion progress."""
@@ -220,6 +221,14 @@ def build_account_deletion_receipt(
     }
     if any(item not in allowed_remaining for item in remaining):
         raise ValueError("account_deletion_receipt_remaining_invalid")
+    if any(
+        not isinstance(value, str)
+        or len(value) != 25
+        or not value.startswith("ella-ext-")
+        or any(character not in "0123456789abcdef" for character in value[9:])
+        for value in external_cleanup_references
+    ):
+        raise ValueError("account_deletion_receipt_external_reference_invalid")
     timestamp = now().astimezone(timezone.utc).isoformat()
     receipt: dict[str, Any] = {
         "request_id": f"aidel_{secrets.token_hex(16)}",
@@ -232,6 +241,8 @@ def build_account_deletion_receipt(
         receipt["operator_action_required"] = bool(
             {"hermes_profile", "honcho_tenancy", "runtime_registry"} & set(remaining)
         )
+        if external_cleanup_references:
+            receipt["external_cleanup_references"] = sorted(set(external_cleanup_references))
     else:
         receipt["server_completed_at"] = timestamp
     return receipt
@@ -742,7 +753,7 @@ def assert_current_ai_consent(uid: str) -> str:
 
 
 def require_current_ai_consent(
-    authenticated_uid: str = Depends(auth.get_current_user_uid),
+    authenticated_uid: str = Depends(auth.get_writable_user_uid),
 ) -> str:
     return assert_current_ai_consent(authenticated_uid)
 

--- a/backend/ella/services/hermes_cloud_enrichment_outbox.py
+++ b/backend/ella/services/hermes_cloud_enrichment_outbox.py
@@ -234,6 +234,22 @@ class HermesCloudEnrichmentOutboxWorker:
 
 
 _worker_task: Optional[asyncio.Task] = None
+_worker_shutdown_task: Optional[asyncio.Task] = None
+
+
+async def _finish_worker_shutdown(worker_task: asyncio.Task) -> None:
+    global _worker_task, _worker_shutdown_task
+    try:
+        worker_task.cancel()
+        try:
+            await worker_task
+        except asyncio.CancelledError:
+            pass
+    finally:
+        if worker_task.done() and _worker_task is worker_task:
+            _worker_task = None
+        if _worker_shutdown_task is asyncio.current_task():
+            _worker_shutdown_task = None
 
 
 async def start_worker(
@@ -248,19 +264,33 @@ async def start_worker(
         ).split(",")
         if value.strip()
     }
-    if not selected or (_worker_task and not _worker_task.done()):
+    if not selected:
+        return
+    while _worker_shutdown_task is not None:
+        await asyncio.shield(_worker_shutdown_task)
+    if _worker_task and not _worker_task.done():
         return
     active_worker = worker or HermesCloudEnrichmentOutboxWorker(FirestoreHermesCloudEnrichmentOutbox())
     _worker_task = asyncio.create_task(active_worker.run_forever())
 
 
 async def stop_worker() -> None:
-    global _worker_task
-    if not _worker_task:
-        return
-    _worker_task.cancel()
+    global _worker_shutdown_task
+    shutdown_task = _worker_shutdown_task
+    if shutdown_task is None:
+        worker_task = _worker_task
+        if worker_task is None:
+            return
+        shutdown_task = asyncio.create_task(_finish_worker_shutdown(worker_task))
+        _worker_shutdown_task = shutdown_task
     try:
-        await _worker_task
+        await asyncio.shield(shutdown_task)
     except asyncio.CancelledError:
-        pass
-    _worker_task = None
+        # A caller timeout/cancellation must not cancel the shared join or
+        # clear the worker reference while its durable writer is still live.
+        raise
+    if shutdown_task.cancelled():
+        raise asyncio.CancelledError
+    exception = shutdown_task.exception()
+    if exception is not None:
+        raise exception

--- a/backend/ella/services/hermes_cloud_enrichment_outbox.py
+++ b/backend/ella/services/hermes_cloud_enrichment_outbox.py
@@ -175,7 +175,8 @@ class HermesCloudEnrichmentOutboxWorker:
             return False
         try:
             async with content_write_fence.detached_content_write_fence(uid) as writer:
-                job = await asyncio.to_thread(
+                job = await content_write_fence.run_admitted_threaded_mutation(
+                    uid,
                     self.repository.claim_next,
                     uid=uid,
                     writer_token=writer.token,
@@ -184,10 +185,11 @@ class HermesCloudEnrichmentOutboxWorker:
                 if not job:
                     return False
                 writer.assert_current()
-                result = await asyncio.to_thread(self.deliver, job)
+                result = await content_write_fence.run_admitted_threaded_mutation(uid, self.deliver, job)
                 writer.assert_current()
                 if result.ok:
-                    completed = await asyncio.to_thread(
+                    completed = await content_write_fence.run_admitted_threaded_mutation(
+                        uid,
                         self.repository.complete,
                         job_id=job["job_id"],
                         lease_token=job["lease_token"],
@@ -200,7 +202,8 @@ class HermesCloudEnrichmentOutboxWorker:
                     900,
                     self.retry_base_seconds * (2 ** min(int(job.get("attempt_count") or 1) - 1, 6)),
                 )
-                failed = await asyncio.to_thread(
+                failed = await content_write_fence.run_admitted_threaded_mutation(
+                    uid,
                     self.repository.fail,
                     job_id=job["job_id"],
                     lease_token=job["lease_token"],

--- a/backend/ella/services/hermes_cloud_enrichment_outbox.py
+++ b/backend/ella/services/hermes_cloud_enrichment_outbox.py
@@ -10,6 +10,7 @@ from urllib.parse import urlsplit
 
 import requests
 
+from database import content_write_fence
 from database.hermes_cloud_enrichment_outbox import (
     FirestoreHermesCloudEnrichmentOutbox,
 )
@@ -19,9 +20,13 @@ DEFAULT_URL = "http://127.0.0.1:8000" "/v1/ella/internal/hermes-cloud/enrichment
 
 
 class EnrichmentOutboxRepository(Protocol):
+    def peek_next_uid(self, *, scan_limit: int = 50) -> Optional[str]: ...
+
     def claim_next(
         self,
         *,
+        uid: str,
+        writer_token: str,
         lease_seconds: int,
         scan_limit: int = 50,
     ) -> Optional[dict[str, Any]]: ...
@@ -165,38 +170,49 @@ class HermesCloudEnrichmentOutboxWorker:
         self.poll_seconds = poll_seconds
 
     async def run_once(self) -> bool:
-        job = await asyncio.to_thread(
-            self.repository.claim_next,
-            lease_seconds=self.lease_seconds,
-        )
-        if not job:
+        uid = await asyncio.to_thread(self.repository.peek_next_uid)
+        if not uid:
             return False
-        result = await asyncio.to_thread(self.deliver, job)
-        if result.ok:
-            completed = await asyncio.to_thread(
-                self.repository.complete,
-                job_id=job["job_id"],
-                lease_token=job["lease_token"],
-                receipt=result.receipt or {"content_free": True},
-            )
-            if not completed:
-                raise RuntimeError("hermes_cloud_enrichment_lease_lost")
-            return True
-        retry_after = min(
-            900,
-            self.retry_base_seconds * (2 ** min(int(job.get("attempt_count") or 1) - 1, 6)),
-        )
-        failed = await asyncio.to_thread(
-            self.repository.fail,
-            job_id=job["job_id"],
-            lease_token=job["lease_token"],
-            error_code=result.error_code,
-            retryable=result.retryable,
-            retry_after_seconds=retry_after,
-        )
-        if not failed:
-            raise RuntimeError("hermes_cloud_enrichment_lease_lost")
-        return True
+        try:
+            async with content_write_fence.detached_content_write_fence(uid) as writer:
+                job = await asyncio.to_thread(
+                    self.repository.claim_next,
+                    uid=uid,
+                    writer_token=writer.token,
+                    lease_seconds=self.lease_seconds,
+                )
+                if not job:
+                    return False
+                writer.assert_current()
+                result = await asyncio.to_thread(self.deliver, job)
+                writer.assert_current()
+                if result.ok:
+                    completed = await asyncio.to_thread(
+                        self.repository.complete,
+                        job_id=job["job_id"],
+                        lease_token=job["lease_token"],
+                        receipt=result.receipt or {"content_free": True},
+                    )
+                    if not completed:
+                        raise RuntimeError("hermes_cloud_enrichment_lease_lost")
+                    return True
+                retry_after = min(
+                    900,
+                    self.retry_base_seconds * (2 ** min(int(job.get("attempt_count") or 1) - 1, 6)),
+                )
+                failed = await asyncio.to_thread(
+                    self.repository.fail,
+                    job_id=job["job_id"],
+                    lease_token=job["lease_token"],
+                    error_code=result.error_code,
+                    retryable=result.retryable,
+                    retry_after_seconds=retry_after,
+                )
+                if not failed:
+                    raise RuntimeError("hermes_cloud_enrichment_lease_lost")
+                return True
+        except content_write_fence.ContentWriteFenceError:
+            return False
 
     async def run_forever(self) -> None:
         while True:

--- a/backend/ella/services/memory_reinterpretation.py
+++ b/backend/ella/services/memory_reinterpretation.py
@@ -15,6 +15,7 @@ import httpx
 from pydantic import BaseModel, Field, field_validator
 
 import database.conversations as conversations_db
+from database import content_write_fence
 from database.memory_reinterpretations import canonical_transcript_hash
 from ella.services.hermes_session import canonical_omi_session_key
 from ella.services.summary_recovery import (
@@ -411,6 +412,7 @@ class MemoryReinterpretationWorker:
         self.lease_seconds = max(30, configured_lease)
 
     async def _require_current_lease(self, job: dict[str, Any]) -> None:
+        content_write_fence.assert_content_writer_admitted(job["uid"])
         try:
             current = await self.repository.renew_lease(
                 job,
@@ -425,18 +427,22 @@ class MemoryReinterpretationWorker:
             ) from exc
         if not current:
             raise ReinterpretationWorkerError("lease_lost", retryable=True)
+        content_write_fence.assert_content_writer_admitted(job["uid"])
 
     async def _heartbeat_lease(self, job: dict[str, Any]) -> None:
         interval = max(5.0, self.lease_seconds / 3)
         while True:
             await asyncio.sleep(interval)
             try:
+                content_write_fence.assert_content_writer_admitted(job["uid"])
                 renewed = await self.repository.renew_lease(
                     job,
                     lease_seconds=self.lease_seconds,
                 )
             except asyncio.CancelledError:
                 raise
+            except content_write_fence.ContentWriteFenceError:
+                return
             except Exception:
                 _WORKER_RUNTIME_METRICS["lease_renewal_failures_total"] += 1
                 logger.exception(
@@ -448,12 +454,24 @@ class MemoryReinterpretationWorker:
                 return
 
     async def run_once(self, worker_id: str) -> Optional[dict[str, Any]]:
-        job = await self.repository.claim_due(
-            worker_id,
-            lease_seconds=self.lease_seconds,
-        )
-        if job is None:
+        uid = await self.repository.next_due_uid()
+        if uid is None:
             return None
+        try:
+            async with content_write_fence.detached_content_write_fence(uid):
+                job = await self.repository.claim_due(
+                    worker_id,
+                    lease_seconds=self.lease_seconds,
+                    uid=uid,
+                )
+                if job is None:
+                    return None
+                content_write_fence.assert_content_writer_admitted(uid)
+                return await self._run_claimed(job)
+        except content_write_fence.ContentWriteFenceError:
+            return None
+
+    async def _run_claimed(self, job: dict[str, Any]) -> dict[str, Any]:
         started = time.monotonic()
         metrics: dict[str, Any] = {
             "attempt": job["attempt_count"],
@@ -495,6 +513,7 @@ class MemoryReinterpretationWorker:
                     if not finished:
                         raise ReinterpretationWorkerError("lease_lost", retryable=True)
                     return {"job_id": job["id"], "status": "conflict"}
+                content_write_fence.assert_content_writer_admitted(job["uid"])
                 plan = await self.hermes_client.propose(
                     job=job,
                     transcript=_ordered_transcript(rows),
@@ -603,6 +622,7 @@ class MemoryReinterpretationWorker:
                     "applied_indexes": sorted(applied_indexes),
                     "active_summary_version_id": expected_version_id,
                 }
+                content_write_fence.assert_content_writer_admitted(job["uid"])
                 if not await self.repository.record_progress(
                     job,
                     progress=progress,
@@ -631,7 +651,10 @@ class MemoryReinterpretationWorker:
             if not finished:
                 raise ReinterpretationWorkerError("lease_lost", retryable=True)
             return {"job_id": job["id"], "status": status}
+        except content_write_fence.ContentWriteFenceError:
+            raise
         except ReinterpretationWorkerError as exc:
+            content_write_fence.assert_content_writer_admitted(job["uid"])
             status = await self.repository.fail_or_retry(
                 job,
                 error_code=exc.code,
@@ -647,6 +670,7 @@ class MemoryReinterpretationWorker:
             )
             return {"job_id": job["id"], "status": status, "error_code": exc.code}
         except Exception as exc:
+            content_write_fence.assert_content_writer_admitted(job["uid"])
             status = await self.repository.fail_or_retry(
                 job,
                 error_code="worker_unhandled_error",

--- a/backend/ella/services/memory_reinterpretation.py
+++ b/backend/ella/services/memory_reinterpretation.py
@@ -703,6 +703,22 @@ class MemoryReinterpretationWorker:
 
 
 _worker_task: Optional[asyncio.Task] = None
+_worker_shutdown_task: Optional[asyncio.Task] = None
+
+
+async def _finish_worker_shutdown(worker_task: asyncio.Task) -> None:
+    global _worker_task, _worker_shutdown_task
+    try:
+        worker_task.cancel()
+        try:
+            await worker_task
+        except asyncio.CancelledError:
+            pass
+    finally:
+        if worker_task.done() and _worker_task is worker_task:
+            _worker_task = None
+        if _worker_shutdown_task is asyncio.current_task():
+            _worker_shutdown_task = None
 
 
 def worker_enabled() -> bool:
@@ -750,18 +766,32 @@ async def run_worker_loop(
 
 async def start_worker(worker: MemoryReinterpretationWorker) -> None:
     global _worker_task
-    if not worker_enabled() or (_worker_task and not _worker_task.done()):
+    if not worker_enabled():
+        return
+    while _worker_shutdown_task is not None:
+        await asyncio.shield(_worker_shutdown_task)
+    if _worker_task and not _worker_task.done():
         return
     _worker_task = asyncio.create_task(run_worker_loop(worker))
 
 
 async def stop_worker() -> None:
-    global _worker_task
-    if _worker_task is None:
-        return
-    _worker_task.cancel()
+    global _worker_shutdown_task
+    shutdown_task = _worker_shutdown_task
+    if shutdown_task is None:
+        worker_task = _worker_task
+        if worker_task is None:
+            return
+        shutdown_task = asyncio.create_task(_finish_worker_shutdown(worker_task))
+        _worker_shutdown_task = shutdown_task
     try:
-        await _worker_task
+        await asyncio.shield(shutdown_task)
     except asyncio.CancelledError:
-        pass
-    _worker_task = None
+        # A caller timeout/cancellation must not cancel the shared join or
+        # clear the worker reference while its durable writer is still live.
+        raise
+    if shutdown_task.cancelled():
+        raise asyncio.CancelledError
+    exception = shutdown_task.exception()
+    if exception is not None:
+        raise exception

--- a/backend/ella/services/memory_reinterpretation.py
+++ b/backend/ella/services/memory_reinterpretation.py
@@ -331,7 +331,8 @@ async def _create_pending_proposal(
         "scopes": ["proposals:write"],
         "allowed_tools": ["memory_reinterpretation_propose"],
     }
-    result = await asyncio.to_thread(
+    result = await content_write_fence.run_admitted_threaded_mutation(
+        job["uid"],
         proposal_ingest.create_proposal,
         session_claims=claims,
         tool_name="memory_reinterpretation_propose",
@@ -562,12 +563,15 @@ class MemoryReinterpretationWorker:
                     )
                     await self._require_current_lease(job)
                     try:
-                        applied = await self.correction_writer(
-                            job=job,
-                            proposal=proposal,
-                            correction_id=correction_id,
-                            proposal_index=index,
-                            expected_version_id=expected_version_id,
+                        applied = await content_write_fence.finish_admitted_content_mutation(
+                            job["uid"],
+                            self.correction_writer(
+                                job=job,
+                                proposal=proposal,
+                                correction_id=correction_id,
+                                proposal_index=index,
+                                expected_version_id=expected_version_id,
+                            ),
                         )
                     except ConcurrentConversationSummaryChangeError:
                         await self._require_current_lease(job)
@@ -605,11 +609,14 @@ class MemoryReinterpretationWorker:
                         index,
                     )
                     await self._require_current_lease(job)
-                    proposal_id = await self.pending_proposal_writer(
-                        job=job,
-                        proposal=proposal,
-                        proposal_id=fallback_id,
-                        proposal_index=index,
+                    proposal_id = await content_write_fence.finish_admitted_content_mutation(
+                        job["uid"],
+                        self.pending_proposal_writer(
+                            job=job,
+                            proposal=proposal,
+                            proposal_id=fallback_id,
+                            proposal_index=index,
+                        ),
                     )
                     if proposal_id not in proposal_ids:
                         proposal_ids.append(proposal_id)

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -11,6 +11,7 @@ import math
 import os
 import posixpath
 import re
+import uuid
 from dataclasses import dataclass
 from typing import Any, Optional
 from urllib.parse import urlparse
@@ -391,7 +392,12 @@ class HermesProvisionClient:
         target_schema_version: str,
         *,
         authority_snapshot: ProvisionAuthoritySnapshot | None = None,
+        idempotency_key: str,
     ) -> dict[str, Any]:
+        try:
+            request_idempotency_key = str(uuid.UUID(idempotency_key))
+        except (TypeError, ValueError, AttributeError) as exc:
+            raise ProvisioningError("provider_idempotency_key_invalid", retryable=False) from exc
         entry_snapshot = self.snapshot_authority(authority_snapshot)
         send_snapshot: ProvisionAuthoritySnapshot | None = None
         try:
@@ -413,9 +419,13 @@ class HermesProvisionClient:
                 }
                 authority = self.resolve_authority(payload_authority.snapshot())
                 send_snapshot = authority.snapshot()
+                headers = {
+                    "Authorization": f"Bearer {authority.token}",
+                    "Idempotency-Key": request_idempotency_key,
+                }
                 response = await client.post(
                     f"{authority.base_url}/provision",
-                    headers={"Authorization": f"Bearer {authority.token}"},
+                    headers=headers,
                     json=payload,
                 )
                 self.resolve_authority(send_snapshot)
@@ -813,10 +823,17 @@ class ProvisioningCoordinator:
             if not self_hosted_required and not legacy_required:
                 raise ProvisioningError("provisioning_disabled", retryable=False)
             if isinstance(self.client, HermesProvisionClient):
+                attempt = await self._repository_call(
+                    authority_snapshot,
+                    self.repository.begin_provider_attempt,
+                    uid=identity.uid,
+                    job_id=str(job["id"]),
+                )
                 result = await self.client.provision(
                     identity,
                     str(job["target_schema_version"]),
                     authority_snapshot=authority_snapshot,
+                    idempotency_key=str(attempt["idempotency_key"]),
                 )
                 self.client.resolve_authority(authority_snapshot)
             else:

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,10 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from database._client import db as firestore_db
+from database.content_write_fence import (
+    ContentWriteFenceMiddleware,
+    configure_firestore_db as configure_content_write_fence_firestore_db,
+)
 from modal import Image, App, asgi_app, Secret
 from routers import (
     workflow,
@@ -80,6 +84,7 @@ app.add_middleware(
 # Consent authority stays available even when ELLA_ENABLED=false so rollback
 # cannot leave protected generic OMI routes without grant/revoke endpoints.
 configure_ai_consent_firestore_db(firestore_db)
+configure_content_write_fence_firestore_db(firestore_db)
 app.include_router(ai_consent.router)
 app.include_router(transcribe.router)
 app.include_router(conversations.router)
@@ -131,6 +136,7 @@ methods_timeout = {
 }
 
 app.add_middleware(TimeoutMiddleware, methods_timeout=methods_timeout)
+app.add_middleware(ContentWriteFenceMiddleware)
 
 
 modal_app = App(

--- a/backend/migrations/017_add_provider_attempt_deletion_fence.sql
+++ b/backend/migrations/017_add_provider_attempt_deletion_fence.sql
@@ -1,0 +1,220 @@
+-- Durable, content-free proof that an external provisioning call may have
+-- created provider state. Apply after 015; migration 016 is reserved by
+-- ellaaicare/omi#360 and is intentionally not a prerequisite for this change.
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS ella_provider_attempts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL
+        REFERENCES users(id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    provisioning_job_id UUID NOT NULL
+        REFERENCES ella_provisioning_jobs(id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    provider TEXT NOT NULL CHECK (provider IN ('hermes')),
+    operation TEXT NOT NULL CHECK (operation IN ('provision')),
+    idempotency_key UUID NOT NULL,
+    correlation_ref TEXT COLLATE "C" NOT NULL
+        CHECK (correlation_ref ~ '^ella-ext-[0-9a-f]{16}$'),
+    proof_state TEXT NOT NULL DEFAULT 'unproven'
+        CHECK (proof_state IN ('unproven', 'deprovisioned', 'absence_proven')),
+    content_free BOOLEAN NOT NULL DEFAULT TRUE CHECK (content_free = TRUE),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    proved_at TIMESTAMPTZ,
+    CONSTRAINT ella_provider_attempts_proof_shape_check CHECK (
+        (proof_state = 'unproven' AND proved_at IS NULL)
+        OR (proof_state IN ('deprovisioned', 'absence_proven') AND proved_at IS NOT NULL)
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ella_provider_attempts_idempotency_key
+    ON ella_provider_attempts(idempotency_key);
+CREATE UNIQUE INDEX IF NOT EXISTS ella_provider_attempts_job_operation_key
+    ON ella_provider_attempts(provisioning_job_id, provider, operation);
+CREATE UNIQUE INDEX IF NOT EXISTS ella_provider_attempts_correlation_ref_key
+    ON ella_provider_attempts(correlation_ref);
+CREATE INDEX IF NOT EXISTS ella_provider_attempts_user_pending_idx
+    ON ella_provider_attempts(user_id, created_at)
+    WHERE proof_state = 'unproven';
+
+COMMENT ON TABLE ella_provider_attempts IS
+    'Content-free attempt markers written before provider calls; unproven rows block account-deletion completion.';
+COMMENT ON COLUMN ella_provider_attempts.idempotency_key IS
+    'Stable provider request key reused for every retry of one provisioning job operation.';
+COMMENT ON COLUMN ella_provider_attempts.correlation_ref IS
+    'Non-secret operator reference safe for typed deletion-pending receipts.';
+
+-- Defense in depth for every current/future authority writer. PENDING remains
+-- a narrowly supported bootstrap state; deletion tombstones are irreversible
+-- except for the idempotent DELETION_PENDING -> DELETED finalization.
+CREATE OR REPLACE FUNCTION ella_require_user_not_tombstoned_uuid()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+    owner_status TEXT;
+BEGIN
+    IF NEW.user_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+    SELECT status INTO owner_status FROM users WHERE id = NEW.user_id;
+    IF owner_status IS NULL OR owner_status IN ('DELETION_PENDING', 'DELETED') THEN
+        RAISE EXCEPTION 'authority_write_user_not_active' USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION ella_require_user_not_tombstoned_uid()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+    owner_status TEXT;
+BEGIN
+    SELECT status INTO owner_status FROM users WHERE omi_uid = NEW.uid;
+    IF owner_status IS NULL OR owner_status IN ('DELETION_PENDING', 'DELETED') THEN
+        RAISE EXCEPTION 'authority_write_user_not_active' USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION ella_require_target_owner_not_tombstoned()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+    account_status TEXT;
+    profile_status TEXT;
+BEGIN
+    SELECT status INTO account_status FROM users WHERE id = NEW.account_user_id;
+    SELECT status INTO profile_status FROM users WHERE id = NEW.profile_user_id;
+    IF account_status IS NULL OR profile_status IS NULL
+       OR account_status IN ('DELETION_PENDING', 'DELETED')
+       OR profile_status IN ('DELETION_PENDING', 'DELETED') THEN
+        RAISE EXCEPTION 'authority_write_user_not_active' USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION ella_require_scope_owner_not_tombstoned()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+    owner_status TEXT;
+BEGIN
+    SELECT u.status INTO owner_status
+    FROM ella_runtime_session_scopes scope
+    JOIN users u ON u.id = scope.user_id
+    WHERE scope.id = NEW.scope_id;
+    IF owner_status IS NULL OR owner_status IN ('DELETION_PENDING', 'DELETED') THEN
+        RAISE EXCEPTION 'authority_write_user_not_active' USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION ella_require_binding_owner_not_tombstoned()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+    owner_status TEXT;
+BEGIN
+    SELECT u.status INTO owner_status
+    FROM ella_runtime_bindings binding
+    JOIN users u ON u.id = binding.user_id
+    WHERE binding.id = NEW.binding_id;
+    IF owner_status IS NULL OR owner_status IN ('DELETION_PENDING', 'DELETED') THEN
+        RAISE EXCEPTION 'authority_write_user_not_active' USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION ella_require_photon_owner_not_tombstoned()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+    owner_status TEXT;
+BEGIN
+    SELECT u.status INTO owner_status
+    FROM ella_photon_channel_bindings photon
+    JOIN users u ON u.id = photon.user_id
+    WHERE photon.id = NEW.photon_binding_id;
+    IF owner_status IS NULL OR owner_status IN ('DELETION_PENDING', 'DELETED') THEN
+        RAISE EXCEPTION 'authority_write_user_not_active' USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION ella_fence_user_tombstone_transition()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    IF OLD.status = 'DELETED' AND NEW.status <> 'DELETED' THEN
+        RAISE EXCEPTION 'authority_write_user_not_active' USING ERRCODE = '55000';
+    END IF;
+    IF OLD.status = 'DELETION_PENDING'
+       AND NEW.status NOT IN ('DELETION_PENDING', 'DELETED') THEN
+        RAISE EXCEPTION 'authority_write_user_not_active' USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS ella_users_tombstone_write_fence ON users;
+CREATE TRIGGER ella_users_tombstone_write_fence
+BEFORE UPDATE ON users
+FOR EACH ROW EXECUTE FUNCTION ella_fence_user_tombstone_transition();
+
+DO $$
+DECLARE
+    table_name TEXT;
+BEGIN
+    FOREACH table_name IN ARRAY ARRAY[
+        'ella_managed_cloud_consent_authority',
+        'ella_invitation_redemptions',
+        'ella_provisioning_jobs',
+        'ella_runtime_bindings',
+        'ella_runtime_session_scopes',
+        'ella_photon_channel_bindings',
+        'agent_clusters'
+    ] LOOP
+        IF to_regclass(current_schema() || '.' || table_name) IS NOT NULL THEN
+            EXECUTE format('DROP TRIGGER IF EXISTS ella_tombstone_write_fence ON %I', table_name);
+            EXECUTE format(
+                'CREATE TRIGGER ella_tombstone_write_fence BEFORE INSERT OR UPDATE ON %I '
+                'FOR EACH ROW EXECUTE FUNCTION ella_require_user_not_tombstoned_uuid()',
+                table_name
+            );
+        END IF;
+    END LOOP;
+END
+$$;
+
+DROP TRIGGER IF EXISTS ella_tombstone_write_fence ON voice_entitlements;
+CREATE TRIGGER ella_tombstone_write_fence
+BEFORE INSERT OR UPDATE ON voice_entitlements
+FOR EACH ROW EXECUTE FUNCTION ella_require_user_not_tombstoned_uid();
+
+DROP TRIGGER IF EXISTS ella_tombstone_write_fence ON ella_runtime_targets;
+CREATE TRIGGER ella_tombstone_write_fence
+BEFORE INSERT OR UPDATE ON ella_runtime_targets
+FOR EACH ROW EXECUTE FUNCTION ella_require_target_owner_not_tombstoned();
+
+DROP TRIGGER IF EXISTS ella_tombstone_write_fence ON ella_runtime_interactions;
+CREATE TRIGGER ella_tombstone_write_fence
+BEFORE INSERT OR UPDATE ON ella_runtime_interactions
+FOR EACH ROW EXECUTE FUNCTION ella_require_scope_owner_not_tombstoned();
+
+DROP TRIGGER IF EXISTS ella_tombstone_write_fence ON ella_runtime_ingestion_receipts;
+CREATE TRIGGER ella_tombstone_write_fence
+BEFORE INSERT OR UPDATE ON ella_runtime_ingestion_receipts
+FOR EACH ROW EXECUTE FUNCTION ella_require_binding_owner_not_tombstoned();
+
+DROP TRIGGER IF EXISTS ella_tombstone_write_fence ON ella_photon_message_receipts;
+CREATE TRIGGER ella_tombstone_write_fence
+BEFORE INSERT OR UPDATE ON ella_photon_message_receipts
+FOR EACH ROW EXECUTE FUNCTION ella_require_photon_owner_not_tombstoned();
+
+DROP TRIGGER IF EXISTS ella_tombstone_write_fence ON ella_photon_quota_buckets;
+CREATE TRIGGER ella_tombstone_write_fence
+BEFORE INSERT OR UPDATE ON ella_photon_quota_buckets
+FOR EACH ROW EXECUTE FUNCTION ella_require_photon_owner_not_tombstoned();
+
+COMMIT;

--- a/backend/migrations/017_add_provider_attempt_deletion_fence.sql
+++ b/backend/migrations/017_add_provider_attempt_deletion_fence.sql
@@ -157,10 +157,74 @@ BEGIN
 END
 $$;
 
+-- Provider-attempt cleanup is the one post-tombstone authority mutation that
+-- must remain possible. Serialize on the owner row so direct SQL cannot insert
+-- an unproven attempt across the final external-count read, and admit only the
+-- exact forward proof transition once deletion has started.
+CREATE OR REPLACE FUNCTION ella_fence_provider_attempt_tombstone_write()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+    old_owner_status TEXT;
+    new_owner_status TEXT;
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        SELECT status INTO new_owner_status
+        FROM users
+        WHERE id = NEW.user_id
+        FOR SHARE;
+        IF new_owner_status IS NULL
+           OR new_owner_status IN ('DELETION_PENDING', 'DELETED') THEN
+            RAISE EXCEPTION 'authority_write_user_not_active' USING ERRCODE = '55000';
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    SELECT status INTO old_owner_status
+    FROM users
+    WHERE id = OLD.user_id
+    FOR SHARE;
+    IF NEW.user_id = OLD.user_id THEN
+        new_owner_status := old_owner_status;
+    ELSE
+        SELECT status INTO new_owner_status
+        FROM users
+        WHERE id = NEW.user_id
+        FOR SHARE;
+    END IF;
+
+    IF old_owner_status IS NULL OR new_owner_status IS NULL THEN
+        RAISE EXCEPTION 'authority_write_user_not_active' USING ERRCODE = '55000';
+    END IF;
+    IF old_owner_status NOT IN ('DELETION_PENDING', 'DELETED') THEN
+        IF new_owner_status IN ('DELETION_PENDING', 'DELETED') THEN
+            RAISE EXCEPTION 'authority_write_user_not_active' USING ERRCODE = '55000';
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    IF OLD.proof_state <> 'unproven'
+       OR NEW.proof_state NOT IN ('deprovisioned', 'absence_proven')
+       OR OLD.proved_at IS NOT NULL
+       OR NEW.proved_at IS NULL
+       OR NEW.updated_at < OLD.updated_at
+       OR (to_jsonb(NEW) - 'proof_state' - 'proved_at' - 'updated_at')
+          IS DISTINCT FROM
+          (to_jsonb(OLD) - 'proof_state' - 'proved_at' - 'updated_at') THEN
+        RAISE EXCEPTION 'authority_write_user_not_active' USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
+END
+$$;
+
 DROP TRIGGER IF EXISTS ella_users_tombstone_write_fence ON users;
 CREATE TRIGGER ella_users_tombstone_write_fence
 BEFORE UPDATE ON users
 FOR EACH ROW EXECUTE FUNCTION ella_fence_user_tombstone_transition();
+
+DROP TRIGGER IF EXISTS ella_provider_attempt_tombstone_write_fence ON ella_provider_attempts;
+CREATE TRIGGER ella_provider_attempt_tombstone_write_fence
+BEFORE INSERT OR UPDATE ON ella_provider_attempts
+FOR EACH ROW EXECUTE FUNCTION ella_fence_provider_attempt_tombstone_write();
 
 DO $$
 DECLARE

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -69,7 +69,7 @@ def _get_valid_action_item(uid: str, action_item_id: str) -> dict:
 
 
 @router.post("/v1/action-items", response_model=ActionItemResponse, tags=['action-items'])
-def create_action_item(request: CreateActionItemRequest, uid: str = Depends(auth.get_current_user_uid)):
+def create_action_item(request: CreateActionItemRequest, uid: str = Depends(auth.get_writable_user_uid)):
     """Create a new action item."""
     action_item_data = {
         'description': request.description,
@@ -111,7 +111,7 @@ def get_action_items(
     end_date: Optional[datetime] = Query(None, description="Filter by creation end date (inclusive)"),
     due_start_date: Optional[datetime] = Query(None, description="Filter by due start date (inclusive)"),
     due_end_date: Optional[datetime] = Query(None, description="Filter by due end date (inclusive)"),
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """Get action items for the current user."""
     action_items = action_items_db.get_action_items(
@@ -152,7 +152,7 @@ def get_action_items(
 
 
 @router.get("/v1/action-items/{action_item_id}", response_model=ActionItemResponse, tags=['action-items'])
-def get_action_item(action_item_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_action_item(action_item_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     """Get a specific action item by ID."""
     action_item = _get_valid_action_item(uid, action_item_id)
 
@@ -164,7 +164,7 @@ def get_action_item(action_item_id: str, uid: str = Depends(auth.get_current_use
 
 @router.patch("/v1/action-items/{action_item_id}", response_model=ActionItemResponse, tags=['action-items'])
 def update_action_item(
-    action_item_id: str, request: UpdateActionItemRequest, uid: str = Depends(auth.get_current_user_uid)
+    action_item_id: str, request: UpdateActionItemRequest, uid: str = Depends(auth.get_writable_user_uid)
 ):
     """Update an action item."""
     # Check if action item exists
@@ -221,7 +221,7 @@ def update_action_item(
 def toggle_action_item_completion(
     action_item_id: str,
     completed: bool = Query(description="Whether to mark as completed or not"),
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """Mark an action item as completed or uncompleted."""
     # Check if action item exists
@@ -240,7 +240,7 @@ def toggle_action_item_completion(
 
 
 @router.delete("/v1/action-items/{action_item_id}", status_code=204, tags=['action-items'])
-def delete_action_item(action_item_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def delete_action_item(action_item_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     """Delete an action item."""
     _get_valid_action_item(uid, action_item_id)
     success = action_items_db.delete_action_item(uid, action_item_id)
@@ -259,7 +259,7 @@ def delete_action_item(action_item_id: str, uid: str = Depends(auth.get_current_
 
 
 @router.get("/v1/conversations/{conversation_id}/action-items", tags=['action-items'])
-def get_conversation_action_items(conversation_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_conversation_action_items(conversation_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     """Get all action items for a specific conversation."""
     action_items = action_items_db.get_action_items_by_conversation(uid, conversation_id)
     response_items = [ActionItemResponse(**item) for item in action_items]
@@ -268,7 +268,7 @@ def get_conversation_action_items(conversation_id: str, uid: str = Depends(auth.
 
 
 @router.delete("/v1/conversations/{conversation_id}/action-items", status_code=204, tags=['action-items'])
-def delete_conversation_action_items(conversation_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def delete_conversation_action_items(conversation_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     """Delete all action items for a specific conversation."""
     deleted_count = action_items_db.delete_action_items_for_conversation(uid, conversation_id)
 
@@ -282,7 +282,7 @@ def delete_conversation_action_items(conversation_id: str, uid: str = Depends(au
 
 @router.post("/v1/action-items/batch", tags=['action-items'])
 def create_action_items_batch(
-    action_items: List[CreateActionItemRequest], uid: str = Depends(auth.get_current_user_uid)
+    action_items: List[CreateActionItemRequest], uid: str = Depends(auth.get_writable_user_uid)
 ):
     """Create multiple action items in a batch."""
     if not action_items:

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -1,11 +1,11 @@
 import asyncio
-import threading
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import Optional, List
 from datetime import datetime, timezone
 
 import database.action_items as action_items_db
+from database import content_write_fence
 from utils.other import endpoints as auth
 from utils.notifications import (
     send_action_item_data_message,
@@ -96,7 +96,11 @@ def create_action_item(request: CreateActionItemRequest, uid: str = Depends(auth
     def _run_auto_sync():
         asyncio.run(auto_sync_action_item(uid, {"id": action_item_id, **action_item_data}))
 
-    threading.Thread(target=_run_auto_sync, daemon=True).start()
+    content_write_fence.start_content_writer_thread(
+        uid,
+        _run_auto_sync,
+        name=f"action-item-sync-{action_item_id}",
+    )
 
     return ActionItemResponse(**action_item)
 

--- a/backend/routers/announcements.py
+++ b/backend/routers/announcements.py
@@ -160,7 +160,7 @@ class DismissAnnouncementRequest(BaseModel):
 async def dismiss_announcement_endpoint(
     announcement_id: str,
     data: DismissAnnouncementRequest,
-    uid: str = Depends(auth_endpoints.get_current_user_uid),
+    uid: str = Depends(auth_endpoints.get_writable_user_uid),
 ):
     """
     Mark an announcement as dismissed for the current user.

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -1,6 +1,5 @@
 import json
 import os
-import asyncio
 import time
 from datetime import datetime, timezone
 from typing import List, Optional
@@ -8,7 +7,7 @@ from urllib.parse import urlparse
 from pydantic import BaseModel as PydanticBaseModel, ValidationError
 import requests
 from ulid import ULID
-from fastapi import APIRouter, Depends, Form, UploadFile, File, HTTPException, Header, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, Form, UploadFile, File, HTTPException, Header, Query
 from fastapi.responses import HTMLResponse
 
 from utils.apps import fetch_app_chat_tools_from_manifest
@@ -1267,13 +1266,17 @@ async def get_twitter_initial_message(username: str, uid: str = Depends(auth.get
 
 
 @router.post('/v1/apps/migrate-owner', tags=['v1'])
-async def migrate_app_owner(old_id, uid: str = Depends(auth.get_writable_user_uid)):
+async def migrate_app_owner(
+    old_id,
+    background_tasks: BackgroundTasks,
+    uid: str = Depends(auth.get_writable_user_uid),
+):
     # Migrate app ownership in the database
     migrate_app_owner_id_db(uid, old_id)
 
     # Start async tasks to migrate memories and update persona connected accounts
-    asyncio.create_task(migrate_memories(old_id, uid))
-    asyncio.create_task(update_omi_persona_connected_accounts(uid))
+    background_tasks.add_task(migrate_memories, old_id, uid)
+    background_tasks.add_task(update_omi_persona_connected_accounts, uid)
 
     return {"status": "ok", "message": "Migration started"}
 

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -147,7 +147,7 @@ def _get_categories():
 
 
 @router.get('/v1/apps', tags=['v1'], response_model=List[AppBaseModel])
-def get_apps(uid: str = Depends(auth.get_current_user_uid), include_reviews: bool = True):
+def get_apps(uid: str = Depends(auth.get_writable_user_uid), include_reviews: bool = True):
     apps = get_available_apps(uid, include_reviews=include_reviews)
     return [normalize_app_numeric_fields(app.to_reduced_dict()) for app in apps]
 
@@ -285,7 +285,7 @@ def search_apps(
     installed_apps: bool | None = Query(default=None, description='Filter to show only installed/enabled apps'),
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=20, ge=1, le=100),
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """Search and filter apps with pagination.
 
@@ -385,7 +385,7 @@ def get_approved_apps(include_reviews: bool = False):
 
 
 @router.get('/v1/apps/popular', tags=['v1'], response_model=List[AppBaseModel])
-def get_popular_apps_endpoint(uid: str = Depends(auth.get_current_user_uid)):
+def get_popular_apps_endpoint(uid: str = Depends(auth.get_writable_user_uid)):
     apps = get_popular_apps()
     # Always exclude persona type apps
     filtered_apps = [app for app in apps if not app.is_a_persona()]
@@ -393,7 +393,7 @@ def get_popular_apps_endpoint(uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.post('/v1/apps', tags=['v1'])
-def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depends(auth.get_current_user_uid)):
+def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depends(auth.get_writable_user_uid)):
     data = json.loads(app_data)
     data['approved'] = False
     data['status'] = 'under-review'
@@ -485,7 +485,7 @@ def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depe
 
 @router.post('/v1/personas', tags=['v1'])
 async def create_persona(
-    persona_data: str = Form(...), file: UploadFile = File(...), uid=Depends(auth.get_current_user_uid)
+    persona_data: str = Form(...), file: UploadFile = File(...), uid=Depends(auth.get_writable_user_uid)
 ):
     data = json.loads(persona_data)
     data['approved'] = False
@@ -531,7 +531,7 @@ async def update_persona(
     persona_id: str,
     persona_data: str = Form(...),
     file: UploadFile = File(None),
-    uid=Depends(auth.get_current_user_uid),
+    uid=Depends(auth.get_writable_user_uid),
 ):
     data = json.loads(persona_data)
     persona = get_available_app_by_id(persona_id, uid)
@@ -577,7 +577,7 @@ async def update_persona(
 
 
 @router.get('/v1/personas', tags=['v1'])
-def get_persona_details(uid: str = Depends(auth.get_current_user_uid)):
+def get_persona_details(uid: str = Depends(auth.get_writable_user_uid)):
     app = get_persona_by_uid(uid)
     # print(app)
     app = App(**app) if app else None
@@ -593,7 +593,7 @@ def get_persona_details(uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.post('/v1/user/persona', tags=['v1'])
-async def get_or_create_user_persona(uid: str = Depends(auth.get_current_user_uid)):
+async def get_or_create_user_persona(uid: str = Depends(auth.get_writable_user_uid)):
     """Get or create a user persona.
 
     If the user already has a persona, return it.
@@ -648,13 +648,13 @@ async def get_or_create_user_persona(uid: str = Depends(auth.get_current_user_ui
 
 
 @router.get('/v1/apps/check-username', tags=['v1'])
-def check_username(username: str, uid: str = Depends(auth.get_current_user_uid)):
+def check_username(username: str, uid: str = Depends(auth.get_writable_user_uid)):
     is_taken = is_username_taken(username)
     return {'is_taken': is_taken}
 
 
 @router.get('/v1/personas/generate-username', tags=['v1'])
-def generate_username(handle: str, uid: str = Depends(auth.get_current_user_uid)):
+def generate_username(handle: str, uid: str = Depends(auth.get_writable_user_uid)):
     username = handle.replace(' ', '')
     username = increment_username(username)
     return {'username': username}
@@ -662,7 +662,7 @@ def generate_username(handle: str, uid: str = Depends(auth.get_current_user_uid)
 
 @router.patch('/v1/apps/{app_id}', tags=['v1'])
 def update_app(
-    app_id: str, app_data: str = Form(...), file: UploadFile = File(None), uid=Depends(auth.get_current_user_uid)
+    app_id: str, app_data: str = Form(...), file: UploadFile = File(None), uid=Depends(auth.get_writable_user_uid)
 ):
     data = json.loads(app_data)
     app = get_available_app_by_id(app_id, uid)
@@ -729,7 +729,7 @@ def update_app(
 
 
 @router.delete('/v1/apps/{app_id}', tags=['v1'])
-def delete_app(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def delete_app(app_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     app = get_available_app_by_id(app_id, uid)
     if not app:
         raise HTTPException(status_code=404, detail='App not found')
@@ -743,7 +743,7 @@ def delete_app(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.get('/v1/apps/{app_id}', tags=['v1'])
-def get_app_details(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_app_details(app_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     app = get_available_app_by_id_with_reviews(app_id, uid)
     app = App(**app) if app else None
     if not app:
@@ -791,7 +791,7 @@ def get_app_categories():
 
 
 @router.post('/v1/apps/review', tags=['v1'])
-def review_app(app_id: str, data: dict, uid: str = Depends(auth.get_current_user_uid)):
+def review_app(app_id: str, data: dict, uid: str = Depends(auth.get_writable_user_uid)):
     if 'score' not in data:
         raise HTTPException(status_code=422, detail='Score is required')
 
@@ -830,7 +830,7 @@ def review_app(app_id: str, data: dict, uid: str = Depends(auth.get_current_user
 
 
 @router.patch('/v1/apps/{app_id}/review', tags=['v1'])
-def update_app_review(app_id: str, data: dict, uid: str = Depends(auth.get_current_user_uid)):
+def update_app_review(app_id: str, data: dict, uid: str = Depends(auth.get_writable_user_uid)):
     if 'score' not in data:
         raise HTTPException(status_code=422, detail='Score is required')
 
@@ -872,7 +872,7 @@ def update_app_review(app_id: str, data: dict, uid: str = Depends(auth.get_curre
 
 
 @router.patch('/v1/apps/{app_id}/review/reply', tags=['v1'])
-def reply_to_review(app_id: str, data: dict, uid: str = Depends(auth.get_current_user_uid)):
+def reply_to_review(app_id: str, data: dict, uid: str = Depends(auth.get_writable_user_uid)):
     app = get_available_app_by_id(app_id, uid)
     app = App(**app) if app else None
     if not app:
@@ -916,7 +916,7 @@ def app_reviews(app_id: str):
 
 
 @router.patch('/v1/apps/{app_id}/change-visibility', tags=['v1'])
-def change_app_visibility(app_id: str, private: bool, uid: str = Depends(auth.get_current_user_uid)):
+def change_app_visibility(app_id: str, private: bool, uid: str = Depends(auth.get_writable_user_uid)):
     app = get_available_app_by_id(app_id, uid)
     app = App(**app) if app else None
     if not app:
@@ -1006,7 +1006,7 @@ def get_payment_plans_v1():
 
 
 @router.get('/v1/app/plans', tags=['v1'])
-def get_payment_plans(uid: str = Depends(auth.get_current_user_uid)):
+def get_payment_plans(uid: str = Depends(auth.get_writable_user_uid)):
     if not uid or len(uid) == 0 or not is_permit_payment_plan_get(uid):
         return []
     return [
@@ -1015,7 +1015,7 @@ def get_payment_plans(uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.post('/v1/app/generate-description', tags=['v1'])
-def generate_description_endpoint(data: dict, uid: str = Depends(auth.get_current_user_uid)):
+def generate_description_endpoint(data: dict, uid: str = Depends(auth.get_writable_user_uid)):
     if data['name'] == '':
         raise HTTPException(status_code=422, detail='App Name is required')
     if data['description'] == '':
@@ -1027,7 +1027,7 @@ def generate_description_endpoint(data: dict, uid: str = Depends(auth.get_curren
 
 
 @router.post('/v1/app/generate-description-emoji', tags=['v1'])
-def generate_description_and_emoji_endpoint(data: dict, uid: str = Depends(auth.get_current_user_uid)):
+def generate_description_and_emoji_endpoint(data: dict, uid: str = Depends(auth.get_writable_user_uid)):
     """
     Generate an app description and representative emoji.
     Used by the quick template creator feature.
@@ -1049,7 +1049,7 @@ def generate_description_and_emoji_endpoint(data: dict, uid: str = Depends(auth.
 
 
 @router.get('/v1/app/generate-prompts', tags=['v1'])
-async def generate_sample_prompts_endpoint(uid: str = Depends(auth.get_current_user_uid)):
+async def generate_sample_prompts_endpoint(uid: str = Depends(auth.get_writable_user_uid)):
     """
     Generate sample app prompts for the AI app generator.
     Uses a fast model to generate creative suggestions.
@@ -1117,7 +1117,7 @@ Be creative, fun, and varied. No generic ideas."""
 
 
 @router.post('/v1/app/generate', tags=['v1'])
-async def generate_app_endpoint(data: dict, uid: str = Depends(auth.get_current_user_uid)):
+async def generate_app_endpoint(data: dict, uid: str = Depends(auth.get_writable_user_uid)):
     """
     Generate an app configuration from a natural language prompt.
     This is an experimental feature that uses AI to create app configurations.
@@ -1155,7 +1155,7 @@ async def generate_app_endpoint(data: dict, uid: str = Depends(auth.get_current_
 
 
 @router.post('/v1/app/generate-icon', tags=['v1'])
-async def generate_app_icon_endpoint(data: dict, uid: str = Depends(auth.get_current_user_uid)):
+async def generate_app_icon_endpoint(data: dict, uid: str = Depends(auth.get_writable_user_uid)):
     """
     Generate an app icon using AI (DALL-E).
     Returns the icon as a base64 encoded PNG image.
@@ -1192,7 +1192,7 @@ async def generate_app_icon_endpoint(data: dict, uid: str = Depends(auth.get_cur
 
 
 @router.get('/v1/personas/twitter/profile', tags=['v1'])
-async def get_twitter_profile_data(handle: str, uid: str = Depends(auth.get_current_user_uid)):
+async def get_twitter_profile_data(handle: str, uid: str = Depends(auth.get_writable_user_uid)):
     if handle.startswith('@'):
         handle = handle[1:]
     profile = await get_twitter_profile(handle)
@@ -1226,7 +1226,7 @@ async def get_twitter_profile_data(handle: str, uid: str = Depends(auth.get_curr
 
 @router.get('/v1/personas/twitter/verify-ownership', tags=['v1'])
 async def verify_twitter_ownership_tweet(
-    username: str, handle: str, uid: str = Depends(auth.get_current_user_uid), persona_id: str | None = None
+    username: str, handle: str, uid: str = Depends(auth.get_writable_user_uid), persona_id: str | None = None
 ):
     # Get user info to check auth provider
     user = get_user_from_uid(uid)
@@ -1258,7 +1258,7 @@ async def verify_twitter_ownership_tweet(
 
 
 @router.get('/v1/personas/twitter/initial-message', tags=['v1'])
-async def get_twitter_initial_message(username: str, uid: str = Depends(auth.get_current_user_uid)):
+async def get_twitter_initial_message(username: str, uid: str = Depends(auth.get_writable_user_uid)):
     persona = get_persona_by_username_db(username)
     if persona:
         message = generate_persona_intro_message(persona['persona_prompt'], persona['name'])
@@ -1267,7 +1267,7 @@ async def get_twitter_initial_message(username: str, uid: str = Depends(auth.get
 
 
 @router.post('/v1/apps/migrate-owner', tags=['v1'])
-async def migrate_app_owner(old_id, uid: str = Depends(auth.get_current_user_uid)):
+async def migrate_app_owner(old_id, uid: str = Depends(auth.get_writable_user_uid)):
     # Migrate app ownership in the database
     migrate_app_owner_id_db(uid, old_id)
 
@@ -1329,7 +1329,7 @@ def _serialize_chat_tools_for_firestore(tools) -> list:
 
 
 @router.post('/v1/apps/mcp', tags=['v1'])
-async def add_mcp_server(data: McpServerRequest, uid: str = Depends(auth.get_current_user_uid)):
+async def add_mcp_server(data: McpServerRequest, uid: str = Depends(auth.get_writable_user_uid)):
     """Add a remote MCP server as a private app with chat tools.
 
     1. Extracts domain from URL and fetches logo via Brandfetch / logo.dev
@@ -1565,7 +1565,7 @@ async def mcp_oauth_callback(code: str, state: str):
 
 
 @router.post('/v1/apps/{app_id}/mcp/refresh', tags=['v1'])
-async def refresh_mcp_tools(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
+async def refresh_mcp_tools(app_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     """Re-discover tools from an MCP server and update the app."""
     app_data = get_app_by_id_db(app_id)
     if not app_data:
@@ -1630,7 +1630,7 @@ async def refresh_mcp_tools(app_id: str, uid: str = Depends(auth.get_current_use
 
 
 @router.post('/v1/apps/enable')
-def enable_app_endpoint(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def enable_app_endpoint(app_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     app = get_available_app_by_id(app_id, uid)
     app = App(**app) if app else None
     if not app:
@@ -1655,7 +1655,7 @@ def enable_app_endpoint(app_id: str, uid: str = Depends(auth.get_current_user_ui
 
 
 @router.post('/v1/apps/disable')
-def disable_app_endpoint(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def disable_app_endpoint(app_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     app = get_available_app_by_id(app_id, uid)
     app = App(**app) if app else None
     if not app:
@@ -1712,7 +1712,7 @@ def remove_app_access_tester(data: dict, secret_key: str = Header(...)):
 
 
 @router.get('/v1/apps/tester/check', tags=['v1'])
-def check_is_tester(uid: str = Depends(auth.get_current_user_uid)):
+def check_is_tester(uid: str = Depends(auth.get_writable_user_uid)):
     if is_tester(uid):
         return {'is_tester': True}
     return {'is_tester': False}
@@ -1771,7 +1771,7 @@ def reject_app(app_id: str, uid: str, secret_key: str = Header(...)):
 
 @router.delete('/v1/personas/{persona_id}', tags=['v1'])
 @router.post('/v1/app/thumbnails', tags=['v1'])
-async def upload_app_thumbnail_endpoint(file: UploadFile = File(...), uid: str = Depends(auth.get_current_user_uid)):
+async def upload_app_thumbnail_endpoint(file: UploadFile = File(...), uid: str = Depends(auth.get_writable_user_uid)):
     """Upload a thumbnail image for an app.
 
     Args:
@@ -1824,7 +1824,7 @@ def get_personas(persona_id: str, secret_key: str = Header(...)):
 
 
 @router.post('/v1/apps/{app_id}/keys', tags=['v1'])
-def create_api_key_for_app(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def create_api_key_for_app(app_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     app = get_available_app_by_id(app_id, uid)
     if not app:
         raise HTTPException(status_code=404, detail='App not found')
@@ -1842,7 +1842,7 @@ def create_api_key_for_app(app_id: str, uid: str = Depends(auth.get_current_user
 
 
 @router.get('/v1/apps/{app_id}/keys', tags=['v1'])
-def list_api_keys(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def list_api_keys(app_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     app = get_available_app_by_id(app_id, uid)
     if not app:
         raise HTTPException(status_code=404, detail='App not found')
@@ -1855,7 +1855,7 @@ def list_api_keys(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.delete('/v1/apps/{app_id}/keys/{key_id}', tags=['v1'])
-def delete_api_key(app_id: str, key_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def delete_api_key(app_id: str, key_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     app = get_available_app_by_id(app_id, uid)
     if not app:
         raise HTTPException(status_code=404, detail='App not found')

--- a/backend/routers/calendar_meetings.py
+++ b/backend/routers/calendar_meetings.py
@@ -36,7 +36,7 @@ class StoreMeetingResponse(BaseModel):
 @router.post('/v1/calendar/meetings', response_model=StoreMeetingResponse, tags=['calendar'])
 def store_calendar_meeting(
     request: StoreMeetingRequest,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """
     Store or update a calendar meeting in Firestore.
@@ -80,7 +80,7 @@ def store_calendar_meeting(
 @router.get('/v1/calendar/meetings/{meeting_id}', response_model=CalendarMeetingContext, tags=['calendar'])
 def get_calendar_meeting(
     meeting_id: str,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """Get a calendar meeting by its Firestore document ID"""
     meeting = calendar_db.get_meeting(uid, meeting_id)
@@ -93,7 +93,7 @@ def get_calendar_meeting(
 
 @router.get('/v1/calendar/meetings', response_model=List[CalendarMeetingContext], tags=['calendar'])
 def list_calendar_meetings(
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
     limit: int = 50,

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -73,7 +73,7 @@ def send_message(
     data: SendMessageRequest,
     plugin_id: Optional[str] = None,
     app_id: Optional[str] = None,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     compat_app_id = app_id or plugin_id
     print('send_message', data.text, compat_app_id, uid)
@@ -198,7 +198,7 @@ def send_message(
 
 
 @router.post('/v2/messages/{message_id}/report', tags=['chat'], response_model=dict)
-def report_message(message_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def report_message(message_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     message, msg_doc_id = chat_db.get_message(uid, message_id)
     if message is None:
         raise HTTPException(status_code=404, detail='Message not found')
@@ -212,7 +212,7 @@ def report_message(message_id: str, uid: str = Depends(auth.get_current_user_uid
 
 @router.delete('/v2/messages', tags=['chat'], response_model=Message)
 def clear_chat_messages(
-    app_id: Optional[str] = None, plugin_id: Optional[str] = None, uid: str = Depends(auth.get_current_user_uid)
+    app_id: Optional[str] = None, plugin_id: Optional[str] = None, uid: str = Depends(auth.get_writable_user_uid)
 ):
     compat_app_id = app_id or plugin_id
     if compat_app_id in ['null', '']:
@@ -290,7 +290,7 @@ def initial_message_util(uid: str, app_id: Optional[str] = None):
     dependencies=[Depends(require_current_ai_consent)],
 )
 def create_initial_message(
-    app_id: Optional[str] = None, plugin_id: Optional[str] = None, uid: str = Depends(auth.get_current_user_uid)
+    app_id: Optional[str] = None, plugin_id: Optional[str] = None, uid: str = Depends(auth.get_writable_user_uid)
 ):
     compat_app_id = app_id or plugin_id
     return initial_message_util(uid, compat_app_id)
@@ -298,7 +298,7 @@ def create_initial_message(
 
 @router.get('/v2/messages', response_model=List[Message], tags=['chat'])
 def get_messages(
-    plugin_id: Optional[str] = None, app_id: Optional[str] = None, uid: str = Depends(auth.get_current_user_uid)
+    plugin_id: Optional[str] = None, app_id: Optional[str] = None, uid: str = Depends(auth.get_writable_user_uid)
 ):
     compat_app_id = app_id or plugin_id
     if compat_app_id in ['null', '']:
@@ -328,7 +328,7 @@ def get_messages(
 async def create_voice_message_stream(
     files: List[UploadFile] = File(...),
     language: Optional[str] = Form(None),
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     # wav
     paths = retrieve_file_paths(files, uid)
@@ -353,7 +353,7 @@ async def create_voice_message_stream(
 async def transcribe_voice_message(
     files: List[UploadFile] = File(...),
     language: Optional[str] = Form(None),
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     # Check if files are empty
     if not files or len(files) == 0:
@@ -450,7 +450,7 @@ async def transcribe_voice_message(
     tags=['chat'],
     dependencies=[Depends(require_current_ai_consent)],
 )
-def upload_file_chat(files: List[UploadFile] = File(...), uid: str = Depends(auth.get_current_user_uid)):
+def upload_file_chat(files: List[UploadFile] = File(...), uid: str = Depends(auth.get_writable_user_uid)):
     thumbs_name = []
     files_chat = []
     for file in files:
@@ -508,7 +508,7 @@ def upload_file_chat(files: List[UploadFile] = File(...), uid: str = Depends(aut
     tags=['chat'],
     dependencies=[Depends(require_current_ai_consent)],
 )
-def upload_file_chat(files: List[UploadFile] = File(...), uid: str = Depends(auth.get_current_user_uid)):
+def upload_file_chat(files: List[UploadFile] = File(...), uid: str = Depends(auth.get_writable_user_uid)):
     thumbs_name = []
     files_chat = []
     for file in files:
@@ -557,7 +557,7 @@ def upload_file_chat(files: List[UploadFile] = File(...), uid: str = Depends(aut
 
 
 @router.post('/v1/messages/{message_id}/report', tags=['chat'], response_model=dict)
-def report_message(message_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def report_message(message_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     message, msg_doc_id = chat_db.get_message(uid, message_id)
     if message is None:
         raise HTTPException(status_code=404, detail='Message not found')
@@ -571,7 +571,7 @@ def report_message(message_id: str, uid: str = Depends(auth.get_current_user_uid
 
 @router.delete('/v1/messages', tags=['chat'], response_model=Message)
 def clear_chat_messages(
-    plugin_id: Optional[str] = None, app_id: Optional[str] = None, uid: str = Depends(auth.get_current_user_uid)
+    plugin_id: Optional[str] = None, app_id: Optional[str] = None, uid: str = Depends(auth.get_writable_user_uid)
 ):
     compat_app_id = app_id or plugin_id
     if compat_app_id in ['null', '']:
@@ -608,7 +608,7 @@ def clear_chat_messages(
     dependencies=[Depends(require_current_ai_consent)],
 )
 def create_initial_message(
-    plugin_id: Optional[str] = None, app_id: Optional[str] = None, uid: str = Depends(auth.get_current_user_uid)
+    plugin_id: Optional[str] = None, app_id: Optional[str] = None, uid: str = Depends(auth.get_writable_user_uid)
 ):
     compat_app_id = app_id or plugin_id
     return initial_message_util(uid, compat_app_id)

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -1,7 +1,6 @@
 import uuid
 import re
 import base64
-import threading
 from datetime import datetime, timezone
 from typing import List, Optional
 from pathlib import Path
@@ -12,6 +11,7 @@ from multipart.multipart import shutil
 
 import database.chat as chat_db
 import database.conversations as conversations_db
+from database import content_write_fence
 from database.apps import record_app_usage
 from models.app import App, UsageHistoryType
 from models.chat import (
@@ -80,6 +80,7 @@ def send_message(
 
     # Set Ella context for LLM proxy
     from utils.llm.clients import set_ella_context
+
     set_ella_context(uid=uid, task='chat')
 
     if compat_app_id in ['null', '']:
@@ -115,7 +116,12 @@ def send_message(
     chat_db.add_message(uid, message.dict())
 
     # Check for goal progress (background)
-    threading.Thread(target=extract_and_update_goal_progress, args=(uid, data.text)).start()
+    content_write_fence.start_content_writer_thread(
+        uid,
+        extract_and_update_goal_progress,
+        args=(uid, data.text),
+        name="chat-goal-progress",
+    )
 
     app = get_available_app_by_id(compat_app_id, uid)
     app = App(**app) if app else None

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -64,7 +64,7 @@ class ProcessConversationRequest(BaseModel):
     dependencies=[Depends(require_current_ai_consent)],
 )
 def process_in_progress_conversation(
-    request: ProcessConversationRequest = None, uid: str = Depends(auth.get_current_user_uid)
+    request: ProcessConversationRequest = None, uid: str = Depends(auth.get_writable_user_uid)
 ):
     conversation = retrieve_in_progress_conversation(uid)
     if not conversation:
@@ -102,7 +102,7 @@ def reprocess_conversation(
     conversation_id: str,
     language_code: Optional[str] = None,
     app_id: Optional[str] = None,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """
     Whenever a user wants to reprocess a conversation, or wants to force process a discarded one
@@ -136,7 +136,7 @@ def get_conversations(
     end_date: Optional[datetime] = Query(None, description="Filter by end date (inclusive)"),
     folder_id: Optional[str] = Query(None, description="Filter by folder ID"),
     starred: Optional[bool] = Query(None, description="Filter by starred status"),
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     print('get_conversations', uid, limit, offset, statuses, folder_id, starred)
     # force convos statuses to processing, completed on the empty filter
@@ -166,13 +166,13 @@ def get_conversations(
 
 
 @router.get("/v1/conversations/{conversation_id}", response_model=Conversation, tags=['conversations'])
-def get_conversation_by_id(conversation_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_conversation_by_id(conversation_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     print('get_conversation_by_id', uid, conversation_id)
     return _get_valid_conversation_by_id(uid, conversation_id)
 
 
 @router.patch("/v1/conversations/{conversation_id}/title", tags=['conversations'])
-def patch_conversation_title(conversation_id: str, title: str, uid: str = Depends(auth.get_current_user_uid)):
+def patch_conversation_title(conversation_id: str, title: str, uid: str = Depends(auth.get_writable_user_uid)):
     _get_valid_conversation_by_id(uid, conversation_id)
     conversations_db.update_conversation_title(uid, conversation_id, title)
     return {'status': 'Ok'}
@@ -181,7 +181,7 @@ def patch_conversation_title(conversation_id: str, title: str, uid: str = Depend
 @router.get(
     "/v1/conversations/{conversation_id}/photos", response_model=List[ConversationPhoto], tags=['conversations']
 )
-def get_conversation_photos(conversation_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_conversation_photos(conversation_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     _get_valid_conversation_by_id(uid, conversation_id)
     return conversations_db.get_conversation_photos(uid, conversation_id)
 
@@ -191,13 +191,13 @@ def get_conversation_photos(conversation_id: str, uid: str = Depends(auth.get_cu
     response_model=dict[str, List[TranscriptSegment]],
     tags=['conversations'],
 )
-def get_conversation_transcripts_by_models(conversation_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_conversation_transcripts_by_models(conversation_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     _get_valid_conversation_by_id(uid, conversation_id)
     return conversations_db.get_conversation_transcripts_by_model(uid, conversation_id)
 
 
 @router.delete("/v1/conversations/{conversation_id}", status_code=204, tags=['conversations'])
-def delete_conversation(conversation_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def delete_conversation(conversation_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     print('delete_conversation', conversation_id, uid)
     conversations_db.delete_conversation(uid, conversation_id)
     delete_vector(uid, conversation_id)
@@ -205,14 +205,14 @@ def delete_conversation(conversation_id: str, uid: str = Depends(auth.get_curren
 
 
 @router.get("/v1/conversations/{conversation_id}/recording", response_model=dict, tags=['conversations'])
-def conversation_has_audio_recording(conversation_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def conversation_has_audio_recording(conversation_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     _get_valid_conversation_by_id(uid, conversation_id)
     return {'has_recording': get_conversation_recording_if_exists(uid, conversation_id) is not None}
 
 
 @router.patch("/v1/conversations/{conversation_id}/events", response_model=dict, tags=['conversations'])
 def set_conversation_events_state(
-    conversation_id: str, data: SetConversationEventsStateRequest, uid: str = Depends(auth.get_current_user_uid)
+    conversation_id: str, data: SetConversationEventsStateRequest, uid: str = Depends(auth.get_writable_user_uid)
 ):
     conversation = _get_valid_conversation_by_id(uid, conversation_id)
     conversation = Conversation(**conversation)
@@ -228,7 +228,7 @@ def set_conversation_events_state(
 
 @router.patch("/v1/conversations/{conversation_id}/action-items", response_model=dict, tags=['conversations'])
 def set_action_item_status(
-    data: SetConversationActionItemsStateRequest, conversation_id: str, uid=Depends(auth.get_current_user_uid)
+    data: SetConversationActionItemsStateRequest, conversation_id: str, uid=Depends(auth.get_writable_user_uid)
 ):
     conversation = _get_valid_conversation_by_id(uid, conversation_id)
     conversation = Conversation(**conversation)
@@ -289,7 +289,7 @@ def set_action_item_status(
     "/v1/conversations/{conversation_id}/action-items/{action_item_idx}", response_model=dict, tags=['conversations']
 )
 def update_action_item_description(
-    conversation_id: str, data: UpdateActionItemDescriptionRequest, uid=Depends(auth.get_current_user_uid)
+    conversation_id: str, data: UpdateActionItemDescriptionRequest, uid=Depends(auth.get_writable_user_uid)
 ):
     conversation = _get_valid_conversation_by_id(uid, conversation_id)
     conversation = Conversation(**conversation)
@@ -321,7 +321,7 @@ def update_action_item_description(
 
 
 @router.delete("/v1/conversations/{conversation_id}/action-items", response_model=dict, tags=['conversations'])
-def delete_action_item(data: DeleteActionItemRequest, conversation_id: str, uid=Depends(auth.get_current_user_uid)):
+def delete_action_item(data: DeleteActionItemRequest, conversation_id: str, uid=Depends(auth.get_writable_user_uid)):
     conversation = _get_valid_conversation_by_id(uid, conversation_id)
     conversation = Conversation(**conversation)
     action_items = conversation.structured.action_items
@@ -352,7 +352,7 @@ def set_assignee_conversation_segment(
     assign_type: str,
     value: Optional[str] = None,
     use_for_speech_training: bool = True,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """
     Another complex endpoint.
@@ -427,7 +427,7 @@ def set_assignee_conversation_segment(
     assign_type: str,
     value: Optional[str] = None,
     use_for_speech_training: bool = True,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """
     Another complex endpoint.
@@ -513,7 +513,7 @@ def assign_segments_bulk(
     conversation_id: str,
     data: BulkAssignSegmentsRequest,
     background_tasks: BackgroundTasks,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     conversation = _get_valid_conversation_by_id(uid, conversation_id)
     conversation = Conversation(**conversation)
@@ -560,7 +560,7 @@ def assign_segments_bulk(
 
 @router.patch('/v1/conversations/{conversation_id}/visibility', tags=['conversations'])
 def set_conversation_visibility(
-    conversation_id: str, value: ConversationVisibility, uid: str = Depends(auth.get_current_user_uid)
+    conversation_id: str, value: ConversationVisibility, uid: str = Depends(auth.get_writable_user_uid)
 ):
     print('update_conversation_visibility', conversation_id, value, uid)
     _get_valid_conversation_by_id(uid, conversation_id)
@@ -576,7 +576,7 @@ def set_conversation_visibility(
 
 
 @router.patch('/v1/conversations/{conversation_id}/starred', tags=['conversations'])
-def set_conversation_starred(conversation_id: str, starred: bool, uid: str = Depends(auth.get_current_user_uid)):
+def set_conversation_starred(conversation_id: str, starred: bool, uid: str = Depends(auth.get_writable_user_uid)):
     print('update_conversation_starred', conversation_id, starred, uid)
     _get_valid_conversation_by_id(uid, conversation_id)
     conversations_db.set_conversation_starred(uid, conversation_id, starred)
@@ -626,7 +626,7 @@ def get_public_conversations(offset: int = 0, limit: int = 1000):
 
 
 @router.post("/v1/conversations/search", response_model=dict, tags=['conversations'])
-def search_conversations_endpoint(search_request: SearchRequest, uid: str = Depends(auth.get_current_user_uid)):
+def search_conversations_endpoint(search_request: SearchRequest, uid: str = Depends(auth.get_writable_user_uid)):
     # Convert ISO datetime strings to Unix timestamps if provided
     start_timestamp = None
     end_timestamp = None
@@ -649,7 +649,7 @@ def search_conversations_endpoint(search_request: SearchRequest, uid: str = Depe
 
 
 @router.get("/v1/conversations/{conversation_id}/suggested-apps", response_model=dict, tags=['conversations'])
-def get_conversation_suggested_apps(conversation_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_conversation_suggested_apps(conversation_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     from utils.apps import get_available_apps, get_available_app_by_id_with_reviews
     from models.app import App
 
@@ -688,7 +688,7 @@ def get_conversation_suggested_apps(conversation_id: str, uid: str = Depends(aut
     tags=['conversations'],
     dependencies=[Depends(require_current_ai_consent)],
 )
-def test_prompt(conversation_id: str, request: TestPromptRequest, uid: str = Depends(auth.get_current_user_uid)):
+def test_prompt(conversation_id: str, request: TestPromptRequest, uid: str = Depends(auth.get_writable_user_uid)):
     conversation_data = _get_valid_conversation_by_id(uid, conversation_id)
     conversation = Conversation(**conversation_data)
 
@@ -717,7 +717,7 @@ def test_prompt(conversation_id: str, request: TestPromptRequest, uid: str = Dep
 async def merge_conversations(
     request: MergeConversationsRequest,
     background_tasks: BackgroundTasks,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """
     Merge multiple conversations into a new conversation (async).

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -1,4 +1,3 @@
-import threading
 from datetime import datetime, timezone, timedelta
 from typing import List, Optional
 
@@ -10,6 +9,7 @@ import database.conversations as conversations_db
 import database.dev_api_key as dev_api_key_db
 import database.action_items as action_items_db
 import database.users as users_db
+from database import content_write_fence
 
 from models.memories import MemoryCategory, Memory, MemoryDB
 from models.conversation import (
@@ -200,7 +200,12 @@ def create_memory(
 
     # Update personas asynchronously if visibility is public
     if memory.visibility == 'public':
-        threading.Thread(target=update_personas_async, args=(uid,)).start()
+        content_write_fence.start_content_writer_thread(
+            uid,
+            update_personas_async,
+            args=(uid,),
+            name="developer-persona-refresh",
+        )
 
     return MemoryResponse(
         id=memory_db.id,
@@ -262,7 +267,12 @@ def create_memories_batch(
 
     # Update personas if any memory is public
     if has_public:
-        threading.Thread(target=update_personas_async, args=(uid,)).start()
+        content_write_fence.start_content_writer_thread(
+            uid,
+            update_personas_async,
+            args=(uid,),
+            name="developer-persona-refresh",
+        )
 
     # Prepare response
     created_memories = [

--- a/backend/routers/folders.py
+++ b/backend/routers/folders.py
@@ -18,7 +18,7 @@ router = APIRouter()
 
 
 @router.get('/v1/folders', response_model=List[Folder], tags=['folders'])
-def get_folders(uid: str = Depends(auth.get_current_user_uid)):
+def get_folders(uid: str = Depends(auth.get_writable_user_uid)):
     """
     Get all folders for the current user.
     Initializes system folders if this is the first access.
@@ -30,7 +30,7 @@ def get_folders(uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.post('/v1/folders', response_model=Folder, tags=['folders'])
-def create_folder(request: CreateFolderRequest, uid: str = Depends(auth.get_current_user_uid)):
+def create_folder(request: CreateFolderRequest, uid: str = Depends(auth.get_writable_user_uid)):
     """Create a new custom folder."""
     # Check folder limit (50 custom folders)
     existing = folders_db.get_folders(uid)
@@ -49,7 +49,7 @@ def create_folder(request: CreateFolderRequest, uid: str = Depends(auth.get_curr
 
 
 @router.get('/v1/folders/{folder_id}', response_model=Folder, tags=['folders'])
-def get_folder(folder_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_folder(folder_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     """Get a specific folder by ID."""
     folder = folders_db.get_folder(uid, folder_id)
     if not folder:
@@ -58,7 +58,7 @@ def get_folder(folder_id: str, uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.patch('/v1/folders/{folder_id}', response_model=Folder, tags=['folders'])
-def update_folder(folder_id: str, request: UpdateFolderRequest, uid: str = Depends(auth.get_current_user_uid)):
+def update_folder(folder_id: str, request: UpdateFolderRequest, uid: str = Depends(auth.get_writable_user_uid)):
     """Update folder metadata (name, description, color, icon, order)."""
     folder = folders_db.get_folder(uid, folder_id)
     if not folder:
@@ -75,7 +75,7 @@ def update_folder(folder_id: str, request: UpdateFolderRequest, uid: str = Depen
 def delete_folder(
     folder_id: str,
     move_to_folder_id: Optional[str] = Query(None, description="Target folder for conversations (defaults to 'Other')"),
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """Delete a folder and move its conversations to another folder."""
     folder = folders_db.get_folder(uid, folder_id)
@@ -89,7 +89,7 @@ def delete_folder(
 
 
 @router.post('/v1/folders/reorder', tags=['folders'])
-def reorder_folders(request: ReorderFoldersRequest, uid: str = Depends(auth.get_current_user_uid)):
+def reorder_folders(request: ReorderFoldersRequest, uid: str = Depends(auth.get_writable_user_uid)):
     """Reorder folders by providing an ordered list of folder IDs."""
     folders_db.reorder_folders(uid, request.folder_ids)
     return {"status": "ok"}
@@ -101,7 +101,7 @@ def get_folder_conversations(
     limit: int = Query(100, ge=1, le=1000),
     offset: int = Query(0, ge=0),
     include_discarded: bool = Query(False),
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """Get all conversations in a folder with pagination."""
     folder = folders_db.get_folder(uid, folder_id)
@@ -116,7 +116,7 @@ def get_folder_conversations(
 
 @router.patch('/v1/conversations/{conversation_id}/folder', tags=['folders'])
 def move_conversation_to_folder(
-    conversation_id: str, request: MoveConversationRequest, uid: str = Depends(auth.get_current_user_uid)
+    conversation_id: str, request: MoveConversationRequest, uid: str = Depends(auth.get_writable_user_uid)
 ):
     """Move a conversation to a different folder."""
     conversation = conversations_db.get_conversation(uid, conversation_id)
@@ -134,7 +134,7 @@ def move_conversation_to_folder(
 
 @router.post('/v1/folders/{folder_id}/conversations/bulk-move', tags=['folders'])
 def bulk_move_conversations(
-    folder_id: str, request: BulkMoveConversationsRequest, uid: str = Depends(auth.get_current_user_uid)
+    folder_id: str, request: BulkMoveConversationsRequest, uid: str = Depends(auth.get_writable_user_uid)
 ):
     """Move multiple conversations to a folder."""
     folder = folders_db.get_folder(uid, folder_id)

--- a/backend/routers/goals.py
+++ b/backend/routers/goals.py
@@ -86,7 +86,7 @@ class AdviceResponse(BaseModel):
 
 
 @router.get('/v1/goals', tags=['goals'])
-async def get_current_goal(uid: str = Depends(auth.get_current_user_uid)) -> Optional[dict]:
+async def get_current_goal(uid: str = Depends(auth.get_writable_user_uid)) -> Optional[dict]:
     """Get the current active goal for the user (backward compatibility)."""
     goal = goals_db.get_user_goal(uid)
     if goal:
@@ -99,7 +99,7 @@ async def get_current_goal(uid: str = Depends(auth.get_current_user_uid)) -> Opt
 
 
 @router.get('/v1/goals/all', tags=['goals'])
-async def get_all_goals(uid: str = Depends(auth.get_current_user_uid)) -> List[dict]:
+async def get_all_goals(uid: str = Depends(auth.get_writable_user_uid)) -> List[dict]:
     """Get all active goals for the user (up to 3)."""
     goals = goals_db.get_user_goals(uid, limit=3)
 
@@ -114,7 +114,7 @@ async def get_all_goals(uid: str = Depends(auth.get_current_user_uid)) -> List[d
 
 
 @router.post('/v1/goals', tags=['goals'])
-async def create_goal(goal: GoalCreate, uid: str = Depends(auth.get_current_user_uid)) -> dict:
+async def create_goal(goal: GoalCreate, uid: str = Depends(auth.get_writable_user_uid)) -> dict:
     """Create a new goal. This will deactivate any existing active goal."""
     goal_data = {
         'id': f"goal_{uuid.uuid4().hex[:12]}",
@@ -139,7 +139,7 @@ async def create_goal(goal: GoalCreate, uid: str = Depends(auth.get_current_user
 
 
 @router.patch('/v1/goals/{goal_id}', tags=['goals'])
-async def update_goal(goal_id: str, updates: GoalUpdate, uid: str = Depends(auth.get_current_user_uid)) -> dict:
+async def update_goal(goal_id: str, updates: GoalUpdate, uid: str = Depends(auth.get_writable_user_uid)) -> dict:
     """Update an existing goal."""
     update_data = updates.model_dump(exclude_unset=True)
 
@@ -164,7 +164,7 @@ async def update_goal(goal_id: str, updates: GoalUpdate, uid: str = Depends(auth
 async def update_goal_progress(
     goal_id: str,
     current_value: float = Query(..., description="New progress value"),
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ) -> dict:
     """Update the progress value of a goal."""
     updated_goal = goals_db.update_goal_progress(uid, goal_id, current_value)
@@ -183,7 +183,7 @@ async def update_goal_progress(
 
 @router.get('/v1/goals/{goal_id}/history', tags=['goals'])
 async def get_goal_history(
-    goal_id: str, days: int = Query(default=30, le=365), uid: str = Depends(auth.get_current_user_uid)
+    goal_id: str, days: int = Query(default=30, le=365), uid: str = Depends(auth.get_writable_user_uid)
 ) -> List[dict]:
     """Get progress history for a goal."""
     history = goals_db.get_goal_history(uid, goal_id, days)
@@ -197,7 +197,7 @@ async def get_goal_history(
 
 
 @router.delete('/v1/goals/{goal_id}', tags=['goals'])
-async def delete_goal(goal_id: str, uid: str = Depends(auth.get_current_user_uid)) -> dict:
+async def delete_goal(goal_id: str, uid: str = Depends(auth.get_writable_user_uid)) -> dict:
     """Delete a goal."""
     success = goals_db.delete_goal(uid, goal_id)
 
@@ -208,13 +208,13 @@ async def delete_goal(goal_id: str, uid: str = Depends(auth.get_current_user_uid
 
 
 @router.get('/v1/goals/suggest', tags=['goals'])
-async def suggest_goal(uid: str = Depends(auth.get_current_user_uid)) -> dict:
+async def suggest_goal(uid: str = Depends(auth.get_writable_user_uid)) -> dict:
     """Generate an AI-suggested goal based on user's memories and conversations."""
     return suggest_goal_llm(uid)
 
 
 @router.get('/v1/goals/{goal_id}/advice', tags=['goals'])
-async def get_goal_advice(goal_id: str, uid: str = Depends(auth.get_current_user_uid)) -> dict:
+async def get_goal_advice(goal_id: str, uid: str = Depends(auth.get_writable_user_uid)) -> dict:
     """Get AI-generated actionable advice for achieving a goal."""
     try:
         advice = get_goal_advice_llm(uid, goal_id)
@@ -224,7 +224,7 @@ async def get_goal_advice(goal_id: str, uid: str = Depends(auth.get_current_user
 
 
 @router.get('/v1/goals/advice', tags=['goals'])
-async def get_current_goal_advice(uid: str = Depends(auth.get_current_user_uid)) -> dict:
+async def get_current_goal_advice(uid: str = Depends(auth.get_writable_user_uid)) -> dict:
     """Get AI-generated advice for the current active goal."""
     goal = goals_db.get_user_goal(uid)
     if not goal:
@@ -241,7 +241,7 @@ class ProgressExtractRequest(BaseModel):
 
 @router.post('/v1/goals/extract-progress', tags=['goals'])
 async def extract_and_update_progress(
-    request: ProgressExtractRequest, uid: str = Depends(auth.get_current_user_uid)
+    request: ProgressExtractRequest, uid: str = Depends(auth.get_writable_user_uid)
 ) -> dict:
     """
     Extract goal progress from conversation/chat text and update if found.

--- a/backend/routers/imports.py
+++ b/backend/routers/imports.py
@@ -29,7 +29,7 @@ TEMP_DIR = '_temp'
 async def import_limitless_data(
     file: UploadFile = File(...),
     language: str = 'en',
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """
     Start a Limitless data import from a ZIP file export.
@@ -82,7 +82,7 @@ async def import_limitless_data(
     tags=['import'],
 )
 async def get_import_jobs(
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
     limit: int = 50,
 ):
     """
@@ -114,7 +114,7 @@ async def get_import_jobs(
 )
 async def get_import_job_status(
     job_id: str,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """
     Get the status of a specific import job.
@@ -150,7 +150,7 @@ async def get_import_job_status(
     tags=['import'],
 )
 async def delete_limitless_conversations(
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """
     Delete all conversations imported from Limitless.

--- a/backend/routers/imports.py
+++ b/backend/routers/imports.py
@@ -3,7 +3,6 @@ Import endpoints for importing data from external sources.
 """
 
 import os
-import threading
 import uuid
 from typing import List, Optional
 
@@ -11,6 +10,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 
 import database.import_jobs as import_jobs_db
 import database.conversations as conversations_db
+from database import content_write_fence
 from models.import_job import ImportJob, ImportJobResponse, ImportJobStatus, ImportSourceType
 from utils.other import endpoints as auth
 from utils.imports.limitless import create_import_job, process_limitless_import
@@ -66,9 +66,26 @@ async def import_limitless_data(
         )
         raise HTTPException(status_code=500, detail=f"Failed to save uploaded file: {str(e)}")
 
-    # Start background processing
-    thread = threading.Thread(target=process_limitless_import, args=(job.id, uid, zip_path, language), daemon=True)
-    thread.start()
+    # Transfer a durable writer registration before the request fence exits.
+    try:
+        content_write_fence.start_content_writer_thread(
+            uid,
+            process_limitless_import,
+            args=(job.id, uid, zip_path, language),
+            name=f"limitless-import-{job.id}",
+        )
+    except content_write_fence.ContentWriteFenceError as exc:
+        import_jobs_db.update_import_job(
+            job.id,
+            {
+                'status': ImportJobStatus.failed.value,
+                'error': exc.code,
+            },
+        )
+        raise HTTPException(
+            status_code=503,
+            detail={"code": exc.code, "retryable": True},
+        ) from exc
 
     return ImportJobResponse(
         job_id=job.id,

--- a/backend/routers/integration.py
+++ b/backend/routers/integration.py
@@ -24,6 +24,7 @@ from utils.conversations.location import get_google_maps_location
 from utils.conversations.memories import process_external_integration_memory
 from utils.conversations.search import search_conversations
 from utils.app_integrations import send_app_notification
+from utils.other.endpoints import admit_authenticated_content_writer
 
 # Rate limit settings - more conservative limits to prevent notification fatigue
 RATE_LIMIT_PERIOD = 3600  # 1 hour in seconds
@@ -97,6 +98,8 @@ async def create_conversation_via_integration(
     # Check if the app has the capability external_integration > action > create_conversation
     if not apps_utils.app_can_create_conversation(app):
         raise HTTPException(status_code=403, detail="App does not have the capability to create conversations")
+
+    await admit_authenticated_content_writer(uid)
 
     # Time
     started_at = (
@@ -172,6 +175,8 @@ async def create_memories_via_integration(
     # Check if the app has the capability external_integration > action > create_memories / create_facts
     if not apps_utils.app_can_create_memories(app):
         raise HTTPException(status_code=403, detail="App does not have the capability to create memories")
+
+    await admit_authenticated_content_writer(uid)
 
     # Validate that text is provided or explicit facts are provided
     if (not fact_data.text or len(fact_data.text.strip()) == 0) and (

--- a/backend/routers/integrations.py
+++ b/backend/routers/integrations.py
@@ -196,7 +196,7 @@ class IntegrationResponse(BaseModel):
 
 
 @router.get("/v1/integrations/{app_key}", response_model=IntegrationResponse, tags=['integrations'])
-def get_integration(app_key: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_integration(app_key: str, uid: str = Depends(auth.get_writable_user_uid)):
     """Get integration connection status for the current user."""
     integration = users_db.get_integration(uid, app_key)
 
@@ -207,7 +207,7 @@ def get_integration(app_key: str, uid: str = Depends(auth.get_current_user_uid))
 
 
 @router.put("/v1/integrations/{app_key}", tags=['integrations'])
-def save_integration(app_key: str, data: IntegrationData, uid: str = Depends(auth.get_current_user_uid)):
+def save_integration(app_key: str, data: IntegrationData, uid: str = Depends(auth.get_writable_user_uid)):
     """Save or update an integration connection."""
     # Convert Pydantic model to dict, excluding None values
     integration_data = data.model_dump(exclude_none=True)
@@ -218,7 +218,7 @@ def save_integration(app_key: str, data: IntegrationData, uid: str = Depends(aut
 
 
 @router.delete("/v1/integrations/{app_key}", status_code=204, tags=['integrations'])
-def delete_integration(app_key: str, uid: str = Depends(auth.get_current_user_uid)):
+def delete_integration(app_key: str, uid: str = Depends(auth.get_writable_user_uid)):
     """Delete an integration connection."""
     success = users_db.delete_integration(uid, app_key)
 
@@ -229,7 +229,7 @@ def delete_integration(app_key: str, uid: str = Depends(auth.get_current_user_ui
 
 
 @router.put("/v1/integrations/apple-health/sync", tags=['integrations'])
-def sync_apple_health_data(data: AppleHealthSyncData, uid: str = Depends(auth.get_current_user_uid)):
+def sync_apple_health_data(data: AppleHealthSyncData, uid: str = Depends(auth.get_writable_user_uid)):
     """
     Sync Apple Health data from the iOS device.
 
@@ -312,7 +312,7 @@ class OAuthUrlResponse(BaseModel):
 
 
 @router.get("/v1/integrations/{app_key}/oauth-url", response_model=OAuthUrlResponse, tags=['integrations'])
-def get_oauth_url(app_key: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_oauth_url(app_key: str, uid: str = Depends(auth.get_writable_user_uid)):
     """
     Get OAuth authorization URL for an integration.
     Frontend opens this URL in browser to start OAuth flow.

--- a/backend/routers/knowledge_graph.py
+++ b/backend/routers/knowledge_graph.py
@@ -40,7 +40,7 @@ class RebuildResponse(BaseModel):
 
 
 @router.get('/v1/knowledge-graph', tags=['knowledge_graph'], response_model=KnowledgeGraphResponse)
-def get_knowledge_graph(uid: str = Depends(auth.get_current_user_uid)):
+def get_knowledge_graph(uid: str = Depends(auth.get_writable_user_uid)):
     graph = kg_db.get_knowledge_graph(uid)
     return KnowledgeGraphResponse(
         nodes=graph.get('nodes', []),
@@ -55,7 +55,7 @@ def _rebuild_graph_task(uid: str, user_name: str):
 @router.post('/v1/knowledge-graph/rebuild', tags=['knowledge_graph'], response_model=RebuildResponse)
 def rebuild_graph(
     background_tasks: BackgroundTasks,
-    uid: str = Depends(auth.get_current_user_uid)
+    uid: str = Depends(auth.get_writable_user_uid)
 ):
     user = users_db.get_user_profile(uid)
     user_name = user.get('name', 'User') if isinstance(user, dict) else 'User'
@@ -74,6 +74,6 @@ def rebuild_graph(
 
 
 @router.delete('/v1/knowledge-graph', tags=['knowledge_graph'])
-def delete_knowledge_graph(uid: str = Depends(auth.get_current_user_uid)):
+def delete_knowledge_graph(uid: str = Depends(auth.get_writable_user_uid)):
     kg_db.delete_knowledge_graph(uid)
     return {"status": "deleted"}

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import threading
 from typing import List, Optional
 
 from fastapi import APIRouter, HTTPException, Depends
@@ -8,6 +7,7 @@ from pydantic import BaseModel
 import database.memories as memories_db
 import database.conversations as conversations_db
 import database.users as users_db
+from database import content_write_fence
 
 # from database.redis_db import get_filter_category_items
 # from database.vector_db import query_vectors_by_metadata
@@ -48,7 +48,12 @@ def create_memory(memory: Memory, uid: str = Depends(get_uid_from_mcp_api_key)):
     memory.category = identify_category_for_memory(memory.content)
     memory_db = MemoryDB.from_memory(memory, uid, None, True)
     memories_db.create_memory(uid, memory_db.model_dump())
-    threading.Thread(target=update_personas_async, args=(uid,)).start()
+    content_write_fence.start_content_writer_thread(
+        uid,
+        update_personas_async,
+        args=(uid,),
+        name="mcp-persona-refresh",
+    )
     return memory_db
 
 

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -25,8 +25,16 @@ from ella.services.summary_sanitizer import SummarySanitizationError, sanitize_s
 from models.memories import MemoryDB, Memory, MemoryCategory
 from models.conversation import CategoryEnum
 from utils.llm.memories import identify_category_for_memory
+from utils.other.endpoints import admit_authenticated_content_writer
 
 router = APIRouter()
+
+_CONTENT_MUTATION_TOOLS = {
+    "create_memory",
+    "delete_memory",
+    "edit_memory",
+    "update_conversation_summary",
+}
 
 # Store active sessions
 active_sessions: dict = {}
@@ -525,6 +533,12 @@ async def mcp_streamable_http(
 
     # Handle batch requests (array of messages)
     messages = body if isinstance(body, list) else [body]
+
+    if any(
+        message.get("method") == "tools/call" and (message.get("params") or {}).get("name") in _CONTENT_MUTATION_TOOLS
+        for message in messages
+    ):
+        await admit_authenticated_content_writer(user_id)
 
     # Check if all messages are notifications/responses (no id)
     all_notifications = all(msg.get("id") is None for msg in messages)

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -28,7 +28,7 @@ def _validate_memory(uid: str, memory_id: str) -> dict:
 
 
 @router.post('/v3/memories', tags=['memories'], response_model=MemoryDB)
-def create_memory(memory: Memory, uid: str = Depends(auth.get_current_user_uid)):
+def create_memory(memory: Memory, uid: str = Depends(auth.get_writable_user_uid)):
     memory.category = MemoryCategory.manual
     memory_db = MemoryDB.from_memory(memory, uid, None, True)
     memories_db.create_memory(uid, memory_db.dict())
@@ -41,7 +41,7 @@ def create_memory(memory: Memory, uid: str = Depends(auth.get_current_user_uid))
 
 
 @router.get('/v3/memories', tags=['memories'], response_model=List[MemoryDB])
-def get_memories(limit: int = 100, offset: int = 0, uid: str = Depends(auth.get_current_user_uid)):
+def get_memories(limit: int = 100, offset: int = 0, uid: str = Depends(auth.get_writable_user_uid)):
     # Use high limits for the first page
     # Warn: should remove
     if offset == 0:
@@ -65,7 +65,7 @@ def get_memories(limit: int = 100, offset: int = 0, uid: str = Depends(auth.get_
 
 
 @router.delete('/v3/memories/{memory_id}', tags=['memories'])
-def delete_memory(memory_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def delete_memory(memory_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     _validate_memory(uid, memory_id)
     memories_db.delete_memory(uid, memory_id)
     delete_memory_vector(uid, memory_id)
@@ -73,20 +73,20 @@ def delete_memory(memory_id: str, uid: str = Depends(auth.get_current_user_uid))
 
 
 @router.delete('/v3/memories', tags=['memories'])
-def delete_memories(uid: str = Depends(auth.get_current_user_uid)):
+def delete_memories(uid: str = Depends(auth.get_writable_user_uid)):
     memories_db.delete_all_memories(uid)
     return {'status': 'ok'}
 
 
 @router.post('/v3/memories/{memory_id}/review', tags=['memories'])
-def review_memory(memory_id: str, value: bool, uid: str = Depends(auth.get_current_user_uid)):
+def review_memory(memory_id: str, value: bool, uid: str = Depends(auth.get_writable_user_uid)):
     _validate_memory(uid, memory_id)
     memories_db.review_memory(uid, memory_id, value)
     return {'status': 'ok'}
 
 
 @router.patch('/v3/memories/{memory_id}', tags=['memories'])
-def edit_memory(memory_id: str, value: str, uid: str = Depends(auth.get_current_user_uid)):
+def edit_memory(memory_id: str, value: str, uid: str = Depends(auth.get_writable_user_uid)):
     _validate_memory(uid, memory_id)
     # first_word = value.split(' ')[0]
     # user_name = get_user_name(uid, use_default=False)
@@ -98,7 +98,7 @@ def edit_memory(memory_id: str, value: str, uid: str = Depends(auth.get_current_
 
 
 @router.patch('/v3/memories/{memory_id}/visibility', tags=['memories'])
-def update_memory_visibility(memory_id: str, value: str, uid: str = Depends(auth.get_current_user_uid)):
+def update_memory_visibility(memory_id: str, value: str, uid: str = Depends(auth.get_writable_user_uid)):
     _validate_memory(uid, memory_id)
     if value not in ['public', 'private']:
         raise HTTPException(status_code=400, detail='Invalid visibility value')

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -1,11 +1,11 @@
 import logging
-import threading
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import ValidationError
 
 import database.memories as memories_db
+from database import content_write_fence
 from database.vector_db import upsert_memory_vector, delete_memory_vector
 from models.memories import MemoryDB, Memory, MemoryCategory
 from utils.apps import update_personas_async
@@ -36,7 +36,12 @@ def create_memory(memory: Memory, uid: str = Depends(auth.get_writable_user_uid)
     upsert_memory_vector(uid, memory_db.id, memory_db.content, memory_db.category.value)
 
     if memory.visibility == 'public':
-        threading.Thread(target=update_personas_async, args=(uid,)).start()
+        content_write_fence.start_content_writer_thread(
+            uid,
+            update_personas_async,
+            args=(uid,),
+            name="memory-persona-refresh",
+        )
     return memory_db
 
 
@@ -103,5 +108,10 @@ def update_memory_visibility(memory_id: str, value: str, uid: str = Depends(auth
     if value not in ['public', 'private']:
         raise HTTPException(status_code=400, detail='Invalid visibility value')
     memories_db.change_memory_visibility(uid, memory_id, value)
-    threading.Thread(target=update_personas_async, args=(uid,)).start()
+    content_write_fence.start_content_writer_thread(
+        uid,
+        update_personas_async,
+        args=(uid,),
+        name="memory-persona-refresh",
+    )
     return {'status': 'ok'}

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -59,7 +59,7 @@ def check_rate_limit(app_id: str, user_id: str) -> Tuple[bool, int, int, int]:
 @router.post('/v1/users/fcm-token')
 def save_token(
     data: SaveFcmTokenRequest,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
     x_app_platform: str = Header(None, alias='X-App-Platform'),
     x_device_id_hash: str = Header(None, alias='X-Device-Id-Hash'),
 ):

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -156,7 +156,7 @@ def _try_reactivate_subscription(uid: str, target_price_id: str) -> dict | None:
 
 
 @router.get('/v1/payments/available-plans', response_model=AvailablePlansResponse)
-def get_available_plans_endpoint(uid: str = Depends(auth.get_current_user_uid)):
+def get_available_plans_endpoint(uid: str = Depends(auth.get_writable_user_uid)):
     """Get available subscription plans with their price IDs and billing intervals."""
     try:
 
@@ -242,7 +242,7 @@ def get_available_plans_endpoint(uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.post('/v1/payments/checkout-session')
-def create_checkout_session_endpoint(request: CreateCheckoutRequest, uid: str = Depends(auth.get_current_user_uid)):
+def create_checkout_session_endpoint(request: CreateCheckoutRequest, uid: str = Depends(auth.get_writable_user_uid)):
     # Check if user can make a new payment
     can_pay, reason = subscription_utils.can_user_make_payment(uid, request.price_id)
     if not can_pay:
@@ -262,7 +262,7 @@ def create_checkout_session_endpoint(request: CreateCheckoutRequest, uid: str = 
 
 
 @router.post('/v1/payments/upgrade-subscription')
-def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str = Depends(auth.get_current_user_uid)):
+def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str = Depends(auth.get_writable_user_uid)):
     """Schedule an upgrade/downgrade to take effect at the end of the current billing period."""
     current_subscription = users_db.get_user_subscription(uid)
 
@@ -346,7 +346,7 @@ def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str 
 
 
 @router.delete('/v1/payments/subscription')
-def cancel_subscription_endpoint(uid: str = Depends(auth.get_current_user_uid)):
+def cancel_subscription_endpoint(uid: str = Depends(auth.get_writable_user_uid)):
     subscription = users_db.get_user_subscription(uid)
     if not subscription.stripe_subscription_id:
         raise HTTPException(status_code=400, detail="No active Stripe subscription found.")
@@ -587,7 +587,7 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
 
 @router.post("/v1/stripe/connect-accounts")
 async def create_connect_account_endpoint(
-    country: str | None = Query(default=None), uid: str = Depends(auth.get_current_user_uid)
+    country: str | None = Query(default=None), uid: str = Depends(auth.get_writable_user_uid)
 ):
     """
     Create a Stripe Connect account and return the account creation response
@@ -614,7 +614,7 @@ def get_supported_countries():
 
 
 @router.get("/v1/stripe/onboarded", tags=['v1', 'stripe'])
-async def check_onboarding_status(uid: str = Depends(auth.get_current_user_uid)):
+async def check_onboarding_status(uid: str = Depends(auth.get_writable_user_uid)):
     """
     Check the onboarding status of a Connect account
     """
@@ -629,7 +629,7 @@ async def check_onboarding_status(uid: str = Depends(auth.get_current_user_uid))
 
 @router.post("/v1/stripe/refresh/{account_id}")
 async def refresh_account_link_endpoint(
-    request: Request, account_id: str, uid: str = Depends(auth.get_current_user_uid)
+    request: Request, account_id: str, uid: str = Depends(auth.get_writable_user_uid)
 ):
     """
     Generate a fresh account link if the previous one expired
@@ -710,7 +710,7 @@ async def stripe_return(account_id: str):
 
 
 @router.post("/v1/paypal/payment-details")
-def save_paypal_payment_details(data: dict, uid: str = Depends(auth.get_current_user_uid)):
+def save_paypal_payment_details(data: dict, uid: str = Depends(auth.get_writable_user_uid)):
     """
     Save PayPal payment details (email and paypal.me link)
     """
@@ -731,7 +731,7 @@ def save_paypal_payment_details(data: dict, uid: str = Depends(auth.get_current_
 
 
 @router.get("/v1/paypal/payment-details")
-def get_paypal_payment_details_endpoint(uid: str = Depends(auth.get_current_user_uid)):
+def get_paypal_payment_details_endpoint(uid: str = Depends(auth.get_writable_user_uid)):
     """
     Get the PayPal payment details for the user
     """
@@ -774,7 +774,7 @@ async def stripe_cancel():
 
 
 @router.post('/v1/payments/customer-portal')
-def create_customer_portal_endpoint(uid: str = Depends(auth.get_current_user_uid)):
+def create_customer_portal_endpoint(uid: str = Depends(auth.get_writable_user_uid)):
     """Create a Stripe Customer Portal session for managing payment methods and subscriptions."""
 
     customer_id = users_db.get_stripe_customer_id(uid)
@@ -817,7 +817,7 @@ async def portal_return():
 
 
 @router.get("/v1/payment-methods/status")
-def get_payment_method_status(uid: str = Depends(auth.get_current_user_uid)):
+def get_payment_method_status(uid: str = Depends(auth.get_writable_user_uid)):
     """Get the statuses of the payment methods for the user"""
     default_payment_method = get_default_payment_method(uid)
 
@@ -834,7 +834,7 @@ def get_payment_method_status(uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.post("/v1/payment-methods/default")
-def set_default_payment_method_endpoint(data: dict, uid: str = Depends(auth.get_current_user_uid)):
+def set_default_payment_method_endpoint(data: dict, uid: str = Depends(auth.get_writable_user_uid)):
     """Set the default payment method for the user"""
     method = data.get('method')
     if method not in ['stripe', 'paypal']:
@@ -844,7 +844,7 @@ def set_default_payment_method_endpoint(data: dict, uid: str = Depends(auth.get_
 
 
 @router.get("/v1/apps/{app_id}/subscription")
-def get_app_subscription(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_app_subscription(app_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     """Get user's subscription for a specific app"""
     try:
 
@@ -877,7 +877,7 @@ def get_app_subscription(app_id: str, uid: str = Depends(auth.get_current_user_u
 
 
 @router.delete("/v1/apps/{app_id}/subscription")
-def cancel_app_subscription(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def cancel_app_subscription(app_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     """Cancel user's subscription for a specific app"""
     try:
 

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -10,6 +10,7 @@ from fastapi.websockets import WebSocketDisconnect, WebSocket
 from starlette.websockets import WebSocketState
 
 import database.conversations as conversations_db
+from database import content_write_fence
 from database import users as users_db
 from database.redis_db import get_cached_user_geolocation
 from models.conversation import Conversation, ConversationStatus, Geolocation
@@ -105,6 +106,27 @@ async def _process_conversation_task(uid: str, conversation_id: str, language: s
     except Exception as e:
         print(f"Error in _process_conversation_task: {e}", uid, conversation_id)
         response = {"conversation_id": conversation_id, "error": str(e)}
+        data = bytearray()
+        data.extend(struct.pack("I", 201))
+        data.extend(bytes(json.dumps(response), "utf-8"))
+        try:
+            await websocket.send_bytes(data)
+        except Exception:
+            pass
+
+
+async def _process_conversation_task_with_fence(
+    uid: str,
+    conversation_id: str,
+    language: str,
+    websocket: WebSocket,
+):
+    """Own a durable registration for the complete detached processing graph."""
+    try:
+        async with content_write_fence.detached_content_write_fence(uid):
+            await _process_conversation_task(uid, conversation_id, language, websocket)
+    except content_write_fence.ContentWriteFenceError as exc:
+        response = {"conversation_id": conversation_id, "error": exc.code}
         data = bytearray()
         data.extend(struct.pack("I", 201))
         data.extend(bytes(json.dumps(response), "utf-8"))
@@ -327,11 +349,15 @@ async def _websocket_util_trigger(
                     memory_id = res.get('memory_id')
 
                     # DEBUG: Log received transcript segments
-                    print(f"[TRANSCRIPT-DEBUG] Received {len(segments) if segments else 0} segments for uid={uid} memory_id={memory_id}")
+                    print(
+                        f"[TRANSCRIPT-DEBUG] Received {len(segments) if segments else 0} segments for uid={uid} memory_id={memory_id}"
+                    )
                     if segments and len(segments) > 0:
                         # Log first segment content (truncated)
                         first_seg = segments[0]
-                        text_preview = first_seg.get("text", "")[:100] if isinstance(first_seg, dict) else str(first_seg)[:100]
+                        text_preview = (
+                            first_seg.get("text", "")[:100] if isinstance(first_seg, dict) else str(first_seg)[:100]
+                        )
                         print(f"[TRANSCRIPT-DEBUG] First segment preview: {text_preview}")
 
                     # Update conversation_id from transcript if provided
@@ -351,7 +377,9 @@ async def _websocket_util_trigger(
                     language = res.get('language', 'en')
                     if conversation_id:
                         print(f"Pusher received process_conversation request: {conversation_id}", uid)
-                        safe_create_task(_process_conversation_task(uid, conversation_id, language, websocket))
+                        safe_create_task(
+                            _process_conversation_task_with_fence(uid, conversation_id, language, websocket)
+                        )
                     continue
 
                 # Speaker sample extraction request - queue for background processing
@@ -412,11 +440,13 @@ async def _websocket_util_trigger(
                     ):
                         if len(audio_bytes_queue) >= AUDIO_BYTES_QUEUE_WARN_SIZE:
                             print(f"Warning: audio_bytes_queue size {len(audio_bytes_queue)}", uid)
-                        audio_bytes_queue.append({
-                            'type': 'app',
-                            'sample_rate': sample_rate,
-                            'data': trigger_audiobuffer.copy(),
-                        })
+                        audio_bytes_queue.append(
+                            {
+                                'type': 'app',
+                                'sample_rate': sample_rate,
+                                'data': trigger_audiobuffer.copy(),
+                            }
+                        )
                         audio_bytes_event.set()  # Wake consumer immediately
                         trigger_audiobuffer = bytearray()
                     if (
@@ -425,11 +455,13 @@ async def _websocket_util_trigger(
                     ):
                         if len(audio_bytes_queue) >= AUDIO_BYTES_QUEUE_WARN_SIZE:
                             print(f"Warning: audio_bytes_queue size {len(audio_bytes_queue)}", uid)
-                        audio_bytes_queue.append({
-                            'type': 'webhook',
-                            'sample_rate': sample_rate,
-                            'data': audiobuffer.copy(),
-                        })
+                        audio_bytes_queue.append(
+                            {
+                                'type': 'webhook',
+                                'sample_rate': sample_rate,
+                                'data': audiobuffer.copy(),
+                            }
+                        )
                         audio_bytes_event.set()  # Wake consumer immediately
                         audiobuffer = bytearray()
                     continue

--- a/backend/routers/speech_profile.py
+++ b/backend/routers/speech_profile.py
@@ -31,12 +31,12 @@ router = APIRouter()
 
 
 @router.get('/v3/speech-profile', tags=['v3'])
-def has_speech_profile(uid: str = Depends(auth.get_current_user_uid)):
+def has_speech_profile(uid: str = Depends(auth.get_writable_user_uid)):
     return {'has_profile': get_user_has_speech_profile(uid, max_age_days=90)}
 
 
 @router.get('/v4/speech-profile', tags=['v3'])
-def get_speech_profile(uid: str = Depends(auth.get_current_user_uid)):
+def get_speech_profile(uid: str = Depends(auth.get_writable_user_uid)):
     return {'url': get_profile_audio_if_exists(uid, download=False)}
 
 
@@ -49,7 +49,7 @@ def get_speech_profile(uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.post('/v3/upload-audio', tags=['v3'])
-def upload_profile(file: UploadFile, uid: str = Depends(auth.get_current_user_uid)):
+def upload_profile(file: UploadFile, uid: str = Depends(auth.get_writable_user_uid)):
     os.makedirs(f'_temp/{uid}', exist_ok=True)
     file_path = f"_temp/{uid}/{file.filename}"
     with open(file_path, 'wb') as f:
@@ -81,7 +81,7 @@ def upload_profile(file: UploadFile, uid: str = Depends(auth.get_current_user_ui
 
 @router.delete('/v3/speech-profile/expand', tags=['v3'])
 def delete_extra_speech_profile_sample(
-    memory_id: str, segment_idx: int, person_id: Optional[str] = None, uid: str = Depends(auth.get_current_user_uid)
+    memory_id: str, segment_idx: int, person_id: Optional[str] = None, uid: str = Depends(auth.get_writable_user_uid)
 ):
     print('delete_extra_speech_profile_sample', memory_id, segment_idx, person_id, uid)
     file_name = f'{memory_id}_segment_{segment_idx}.wav'
@@ -97,7 +97,7 @@ def delete_extra_speech_profile_sample(
 
 
 @router.get('/v3/speech-profile/expand', tags=['v3'])
-def get_extra_speech_profile_samples(person_id: Optional[str] = None, uid: str = Depends(auth.get_current_user_uid)):
+def get_extra_speech_profile_samples(person_id: Optional[str] = None, uid: str = Depends(auth.get_writable_user_uid)):
     if person_id:
         return get_user_person_speech_samples(uid, person_id)
     return get_additional_profile_recordings(uid)

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -14,6 +14,7 @@ from fastapi.responses import StreamingResponse
 from opuslib import Decoder
 from pydub import AudioSegment
 
+from database import content_write_fence
 from database import conversations as conversations_db
 from database import users as users_db
 from database.conversations import get_closest_conversation_to_timestamps, update_conversation_segments
@@ -158,8 +159,11 @@ def precache_conversation_audio_endpoint(
                     print(f"Error in parallel precache: {e}")
         print(f"Completed pre-cache for conversation {conversation_id}")
 
-    thread = threading.Thread(target=_precache_all_parallel, daemon=True)
-    thread.start()
+    content_write_fence.start_content_writer_thread(
+        uid,
+        _precache_all_parallel,
+        name=f"audio-precache-{conversation_id}",
+    )
 
     return {"status": "started", "audio_file_count": len(audio_files)}
 
@@ -254,8 +258,11 @@ def get_audio_signed_urls_endpoint(
                     except Exception as e:
                         print(f"Error in parallel cache: {e}")
 
-        thread = threading.Thread(target=_cache_uncached_parallel, daemon=True)
-        thread.start()
+        content_write_fence.start_content_writer_thread(
+            uid,
+            _cache_uncached_parallel,
+            name=f"audio-cache-{conversation_id}",
+        )
 
     return {"audio_files": result}
 

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -131,7 +131,7 @@ def _precache_audio_file(uid: str, conversation_id: str, audio_file: dict, fill_
 @router.post("/v1/sync/audio/{conversation_id}/precache", tags=['v1'])
 def precache_conversation_audio_endpoint(
     conversation_id: str,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """
     Warm the audio cache for a conversation.
@@ -167,7 +167,7 @@ def precache_conversation_audio_endpoint(
 @router.get("/v1/sync/audio/{conversation_id}/urls", tags=['v1'])
 def get_audio_signed_urls_endpoint(
     conversation_id: str,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """
     Get signed URLs for all audio files in a conversation.
@@ -271,7 +271,7 @@ def download_audio_file_endpoint(
     audio_file_id: str,
     request: Request,
     format: str = Query(default="wav", regex="^(wav|pcm)$"),
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """
     Download audio file from private cloud sync in the specified format.

--- a/backend/routers/task_integrations.py
+++ b/backend/routers/task_integrations.py
@@ -182,7 +182,7 @@ class DefaultTaskIntegrationResponse(BaseModel):
 
 
 @router.get("/v1/task-integrations", response_model=TaskIntegrationsResponse, tags=['task-integrations'])
-def get_task_integrations(uid: str = Depends(auth.get_current_user_uid)):
+def get_task_integrations(uid: str = Depends(auth.get_writable_user_uid)):
     """Get all task integration connections for the current user."""
     integrations = users_db.get_task_integrations(uid)
     default_app = users_db.get_default_task_integration(uid)
@@ -191,21 +191,21 @@ def get_task_integrations(uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.get("/v1/task-integrations/default", response_model=DefaultTaskIntegrationResponse, tags=['task-integrations'])
-def get_default_task_integration(uid: str = Depends(auth.get_current_user_uid)):
+def get_default_task_integration(uid: str = Depends(auth.get_writable_user_uid)):
     """Get the user's default task integration app."""
     default_app = users_db.get_default_task_integration(uid)
     return DefaultTaskIntegrationResponse(default_app=default_app)
 
 
 @router.put("/v1/task-integrations/default", response_model=DefaultTaskIntegrationResponse, tags=['task-integrations'])
-def set_default_task_integration(request: DefaultTaskIntegrationRequest, uid: str = Depends(auth.get_current_user_uid)):
+def set_default_task_integration(request: DefaultTaskIntegrationRequest, uid: str = Depends(auth.get_writable_user_uid)):
     """Set the user's default task integration app."""
     users_db.set_default_task_integration(uid, request.app_key)
     return DefaultTaskIntegrationResponse(default_app=request.app_key)
 
 
 @router.put("/v1/task-integrations/{app_key}", tags=['task-integrations'])
-def save_task_integration(app_key: str, data: TaskIntegrationData, uid: str = Depends(auth.get_current_user_uid)):
+def save_task_integration(app_key: str, data: TaskIntegrationData, uid: str = Depends(auth.get_writable_user_uid)):
     """Save or update a task integration connection."""
     # Convert Pydantic model to dict, excluding None values
     integration_data = data.model_dump(exclude_none=True)
@@ -216,7 +216,7 @@ def save_task_integration(app_key: str, data: TaskIntegrationData, uid: str = De
 
 
 @router.delete("/v1/task-integrations/{app_key}", status_code=204, tags=['task-integrations'])
-def delete_task_integration(app_key: str, uid: str = Depends(auth.get_current_user_uid)):
+def delete_task_integration(app_key: str, uid: str = Depends(auth.get_writable_user_uid)):
     """Delete a task integration connection."""
     success = users_db.delete_task_integration(uid, app_key)
 
@@ -243,7 +243,7 @@ class OAuthUrlResponse(BaseModel):
 
 
 @router.get("/v1/task-integrations/{app_key}/oauth-url", response_model=OAuthUrlResponse, tags=['task-integrations'])
-def get_oauth_url(app_key: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_oauth_url(app_key: str, uid: str = Depends(auth.get_writable_user_uid)):
     """
     Get OAuth authorization URL for a task integration.
     Frontend opens this URL in browser to start OAuth flow.
@@ -659,7 +659,7 @@ class CreateTaskResponse(BaseModel):
 
 @router.post("/v1/task-integrations/{app_key}/tasks", response_model=CreateTaskResponse, tags=['task-integrations'])
 async def create_task_via_integration(
-    app_key: str, request: CreateTaskRequest, uid: str = Depends(auth.get_current_user_uid)
+    app_key: str, request: CreateTaskRequest, uid: str = Depends(auth.get_writable_user_uid)
 ):
     """Create a task in the specified integration using stored credentials."""
 
@@ -709,7 +709,7 @@ async def create_task_via_integration(
 
 
 @router.get("/v1/task-integrations/asana/workspaces", tags=['task-integrations'])
-async def get_asana_workspaces(uid: str = Depends(auth.get_current_user_uid)):
+async def get_asana_workspaces(uid: str = Depends(auth.get_writable_user_uid)):
     """Get user's Asana workspaces"""
     data = users_db.get_task_integration(uid, 'asana')
 
@@ -749,7 +749,7 @@ async def get_asana_workspaces(uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.get("/v1/task-integrations/asana/projects/{workspace_gid}", tags=['task-integrations'])
-async def get_asana_projects(workspace_gid: str, uid: str = Depends(auth.get_current_user_uid)):
+async def get_asana_projects(workspace_gid: str, uid: str = Depends(auth.get_writable_user_uid)):
     """Get projects in an Asana workspace"""
     data = users_db.get_task_integration(uid, 'asana')
 
@@ -789,7 +789,7 @@ async def get_asana_projects(workspace_gid: str, uid: str = Depends(auth.get_cur
 
 
 @router.get("/v1/task-integrations/clickup/teams", tags=['task-integrations'])
-async def get_clickup_teams(uid: str = Depends(auth.get_current_user_uid)):
+async def get_clickup_teams(uid: str = Depends(auth.get_writable_user_uid)):
     """Get user's ClickUp teams"""
     data = users_db.get_task_integration(uid, 'clickup')
 
@@ -829,7 +829,7 @@ async def get_clickup_teams(uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.get("/v1/task-integrations/clickup/spaces/{team_id}", tags=['task-integrations'])
-async def get_clickup_spaces(team_id: str, uid: str = Depends(auth.get_current_user_uid)):
+async def get_clickup_spaces(team_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     """Get spaces in a ClickUp team"""
     data = users_db.get_task_integration(uid, 'clickup')
 
@@ -869,7 +869,7 @@ async def get_clickup_spaces(team_id: str, uid: str = Depends(auth.get_current_u
 
 
 @router.get("/v1/task-integrations/clickup/lists/{space_id}", tags=['task-integrations'])
-async def get_clickup_lists(space_id: str, uid: str = Depends(auth.get_current_user_uid)):
+async def get_clickup_lists(space_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     """Get lists in a ClickUp space"""
     data = users_db.get_task_integration(uid, 'clickup')
 

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -76,7 +76,6 @@ from utils.ella.scanner_keyterms import combine_deepgram_keyterms, get_scanner_k
 from utils.notifications import send_credit_limit_notification, send_silent_user_notification
 from utils.other import endpoints as auth
 from utils.other.storage import get_profile_audio_if_exists, get_user_has_speech_profile
-from utils.other.task import safe_create_task
 from utils.pusher import connect_to_trigger_pusher
 from utils.speaker_identification import detect_speaker_from_text
 from utils.stt.streaming import (
@@ -2030,7 +2029,11 @@ async def _stream_handler(
         if all(chunk is not None for chunk in image_chunks_cache[temp_id]):
             b64_image_data = "".join(image_chunks_cache[temp_id])
             del image_chunks_cache[temp_id]
-            safe_create_task(process_photo(uid, b64_image_data, temp_id, send_event_func, photo_buffer))
+            await content_write_fence.start_content_writer_task(
+                uid,
+                lambda: process_photo(uid, b64_image_data, temp_id, send_event_func, photo_buffer),
+                name="transcribe-photo-processing",
+            )
 
     # Initialize decoders based on codec
     opus_decoder = None

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -17,7 +17,7 @@ import opuslib  # type: ignore
 
 import lc3  # lc3py
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.websockets import WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
 from websockets.exceptions import ConnectionClosed
@@ -33,7 +33,7 @@ import database.conversations as conversations_db
 import database.calendar_meetings as calendar_db
 import database.users as user_db
 from database.users import get_user_conversation_lifecycle_preferences, get_user_transcription_preferences
-from database import redis_db
+from database import content_write_fence, redis_db
 from database.redis_db import (
     get_cached_user_geolocation,
     try_acquire_listen_lock,
@@ -2627,7 +2627,6 @@ async def web_listen_handler(
     # Authenticate via first message
     try:
         uid = auth.get_current_user_uid_from_ws_message(first_message)
-        await auth.assert_authenticated_user_writable(uid)
     except ValueError as e:
         await websocket.close(code=1008, reason=str(e))
         return
@@ -2642,57 +2641,63 @@ async def web_listen_handler(
         return
 
     try:
-        assert_current_ai_consent(uid)
-    except HTTPException as exc:
-        detail = exc.detail if isinstance(exc.detail, dict) else {}
-        await websocket.send_json(
-            {
-                "type": "auth_response",
-                "success": False,
-                "error": detail.get("code", "ai_consent_required"),
-            }
-        )
-        await websocket.close(code=1008, reason="AI consent required")
+        async with content_write_fence.request_content_write_fence(uid):
+            try:
+                assert_current_ai_consent(uid)
+            except HTTPException as exc:
+                detail = exc.detail if isinstance(exc.detail, dict) else {}
+                await websocket.send_json(
+                    {
+                        "type": "auth_response",
+                        "success": False,
+                        "error": detail.get("code", "ai_consent_required"),
+                    }
+                )
+                await websocket.close(code=1008, reason="AI consent required")
+                return
+
+            runtime_gate = await listen_runtime_gate(uid, user_db.is_exists_user)
+            if runtime_gate.get("required") and not runtime_gate.get("success"):
+                logging.getLogger(__name__).warning(
+                    "Isolated Ella web listen setup incomplete for uid=%s code=%s",
+                    uid,
+                    runtime_gate.get("error"),
+                )
+                await websocket.send_json(
+                    {
+                        "type": "auth_response",
+                        "success": False,
+                        "error": "ella_setup_incomplete",
+                    }
+                )
+                await websocket.close(code=1013, reason="Ella setup incomplete")
+                return
+
+            # Send success response
+            await websocket.send_json({"type": "auth_response", "success": True})
+            print("web_listen_handler authenticated", uid)
+
+            # Proceed with streaming (websocket already accepted, uid already validated)
+            custom_stt_mode = CustomSttMode.enabled if custom_stt == 'enabled' else CustomSttMode.disabled
+            onboarding_mode = onboarding == 'enabled'
+
+            await _stream_handler(
+                websocket,
+                uid,
+                language,
+                sample_rate,
+                codec,
+                channels,
+                include_speech_profile,
+                None,
+                conversation_timeout=conversation_timeout,
+                source=source,
+                custom_stt_mode=custom_stt_mode,
+                onboarding_mode=onboarding_mode,
+                socket_accepted_at=socket_accepted_at,
+            )
+    except content_write_fence.ContentWriteFenceError as exc:
+        await websocket.send_json({"type": "auth_response", "success": False, "error": exc.code})
+        await websocket.close(code=1008, reason="Account content unavailable")
         return
-
-    runtime_gate = await listen_runtime_gate(uid, user_db.is_exists_user)
-    if runtime_gate.get("required") and not runtime_gate.get("success"):
-        logging.getLogger(__name__).warning(
-            "Isolated Ella web listen setup incomplete for uid=%s code=%s",
-            uid,
-            runtime_gate.get("error"),
-        )
-        await websocket.send_json(
-            {
-                "type": "auth_response",
-                "success": False,
-                "error": "ella_setup_incomplete",
-            }
-        )
-        await websocket.close(code=1013, reason="Ella setup incomplete")
-        return
-
-    # Send success response
-    await websocket.send_json({"type": "auth_response", "success": True})
-    print("web_listen_handler authenticated", uid)
-
-    # Proceed with streaming (websocket already accepted, uid already validated)
-    custom_stt_mode = CustomSttMode.enabled if custom_stt == 'enabled' else CustomSttMode.disabled
-    onboarding_mode = onboarding == 'enabled'
-
-    await _stream_handler(
-        websocket,
-        uid,
-        language,
-        sample_rate,
-        codec,
-        channels,
-        include_speech_profile,
-        None,
-        conversation_timeout=conversation_timeout,
-        source=source,
-        custom_stt_mode=custom_stt_mode,
-        onboarding_mode=onboarding_mode,
-        socket_accepted_at=socket_accepted_at,
-    )
     print("web_listen_handler ended", uid)

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -2627,6 +2627,7 @@ async def web_listen_handler(
     # Authenticate via first message
     try:
         uid = auth.get_current_user_uid_from_ws_message(first_message)
+        await auth.assert_authenticated_user_writable(uid)
     except ValueError as e:
         await websocket.close(code=1008, reason=str(e))
         return

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -5,7 +5,7 @@ import hashlib
 import os
 
 import pytz
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from pydantic import BaseModel
 
 from database import (
@@ -56,7 +56,7 @@ from utils.llm.followup import followup_question_prompt
 from utils.notifications import send_notification, send_training_data_submitted_notification
 from utils.llm.external_integrations import generate_comprehensive_daily_summary
 from models.notification_message import NotificationMessage
-from ella.services.ai_consent import build_account_deletion_receipt
+from ella.services.account_deletion import execute_account_deletion
 from utils.other import endpoints as auth
 from utils.other.storage import (
     delete_all_conversation_recordings,
@@ -93,19 +93,17 @@ def get_user_profile_endpoint(uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.delete('/v1/users/delete-account', tags=['v1'])
-def delete_account(uid: str = Depends(auth.get_current_user_uid)):
-    try:
-        delete_user_data(uid)
-        # delete user from firebase auth
-        auth.delete_account(uid)
-        return {
-            'status': 'ok',
-            'message': 'Account deleted successfully',
-            'deletion_receipt': build_account_deletion_receipt(),
-        }
-    except Exception as e:
-        print('delete_account', str(e))
-        raise HTTPException(status_code=500, detail=str(e))
+async def delete_account(
+    response: Response,
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    result = await execute_account_deletion(
+        uid,
+        delete_firestore=delete_user_data,
+        delete_firebase=auth.delete_account,
+    )
+    response.status_code = result.status_code
+    return result.body
 
 
 @router.patch('/v1/users/geolocation', tags=['v1'])

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -84,7 +84,7 @@ class BatchMigrationRequest(BaseModel):
 
 
 @router.get('/v1/users/profile', tags=['v1'])
-def get_user_profile_endpoint(uid: str = Depends(auth.get_current_user_uid)):
+def get_user_profile_endpoint(uid: str = Depends(auth.get_writable_user_uid)):
     """Gets the full user profile, including data protection and migration status."""
     profile = get_user_profile(uid)
     if not profile:
@@ -95,7 +95,7 @@ def get_user_profile_endpoint(uid: str = Depends(auth.get_current_user_uid)):
 @router.delete('/v1/users/delete-account', tags=['v1'])
 async def delete_account(
     response: Response,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_authenticated_user_uid),
 ):
     result = await execute_account_deletion(
         uid,
@@ -107,7 +107,7 @@ async def delete_account(
 
 
 @router.patch('/v1/users/geolocation', tags=['v1'])
-def set_user_geolocation(geolocation: Geolocation, uid: str = Depends(auth.get_current_user_uid)):
+def set_user_geolocation(geolocation: Geolocation, uid: str = Depends(auth.get_writable_user_uid)):
     last_location_data = get_cached_user_geolocation(uid)
     if last_location_data:
         try:
@@ -139,7 +139,7 @@ def set_user_geolocation(geolocation: Geolocation, uid: str = Depends(auth.get_c
 
 
 @router.post('/v1/users/developer/webhook/{wtype}', tags=['v1'])
-def set_user_webhook_endpoint(wtype: WebhookType, data: dict, uid: str = Depends(auth.get_current_user_uid)):
+def set_user_webhook_endpoint(wtype: WebhookType, data: dict, uid: str = Depends(auth.get_writable_user_uid)):
     url = data['url']
     if url == '' or url == ',':
         disable_user_webhook_db(uid, wtype)
@@ -148,24 +148,24 @@ def set_user_webhook_endpoint(wtype: WebhookType, data: dict, uid: str = Depends
 
 
 @router.get('/v1/users/developer/webhook/{wtype}', tags=['v1'])
-def get_user_webhook_endpoint(wtype: WebhookType, uid: str = Depends(auth.get_current_user_uid)):
+def get_user_webhook_endpoint(wtype: WebhookType, uid: str = Depends(auth.get_writable_user_uid)):
     return {'url': get_user_webhook_db(uid, wtype)}
 
 
 @router.post('/v1/users/developer/webhook/{wtype}/disable', tags=['v1'])
-def disable_user_webhook_endpoint(wtype: WebhookType, uid: str = Depends(auth.get_current_user_uid)):
+def disable_user_webhook_endpoint(wtype: WebhookType, uid: str = Depends(auth.get_writable_user_uid)):
     disable_user_webhook_db(uid, wtype)
     return {'status': 'ok'}
 
 
 @router.post('/v1/users/developer/webhook/{wtype}/enable', tags=['v1'])
-def enable_user_webhook_endpoint(wtype: WebhookType, uid: str = Depends(auth.get_current_user_uid)):
+def enable_user_webhook_endpoint(wtype: WebhookType, uid: str = Depends(auth.get_writable_user_uid)):
     enable_user_webhook_db(uid, wtype)
     return {'status': 'ok'}
 
 
 @router.get('/v1/users/developer/webhooks/status', tags=['v1'])
-def get_user_webhooks_status(uid: str = Depends(auth.get_current_user_uid)):
+def get_user_webhooks_status(uid: str = Depends(auth.get_writable_user_uid)):
     # This only happens the first time because the user_webhook_status_db function will return None for existing users
     audio_bytes = user_webhook_status_db(uid, WebhookType.audio_bytes)
     if audio_bytes is None:
@@ -193,18 +193,18 @@ def get_user_webhooks_status(uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.post('/v1/users/store-recording-permission', tags=['v1'])
-def store_recording_permission(value: bool, uid: str = Depends(auth.get_current_user_uid)):
+def store_recording_permission(value: bool, uid: str = Depends(auth.get_writable_user_uid)):
     set_user_store_recording_permission(uid, value)
     return {'status': 'ok'}
 
 
 @router.get('/v1/users/store-recording-permission', tags=['v1'])
-def get_store_recording_permission(uid: str = Depends(auth.get_current_user_uid)):
+def get_store_recording_permission(uid: str = Depends(auth.get_writable_user_uid)):
     return {'store_recording_permission': get_user_store_recording_permission(uid)}
 
 
 @router.delete('/v1/users/store-recording-permission', tags=['v1'])
-def delete_permission_and_recordings(uid: str = Depends(auth.get_current_user_uid)):
+def delete_permission_and_recordings(uid: str = Depends(auth.get_writable_user_uid)):
     set_user_store_recording_permission(uid, False)
     delete_all_conversation_recordings(uid)
     return {'status': 'ok'}
@@ -216,7 +216,7 @@ def delete_permission_and_recordings(uid: str = Depends(auth.get_current_user_ui
 
 
 @router.get('/v1/users/onboarding', tags=['v1'])
-def get_onboarding_state(uid: str = Depends(auth.get_current_user_uid)):
+def get_onboarding_state(uid: str = Depends(auth.get_writable_user_uid)):
     """Get the user's onboarding state (completed status, acquisition source, etc.)."""
     state = get_user_onboarding_state(uid)
     return {
@@ -226,7 +226,7 @@ def get_onboarding_state(uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.patch('/v1/users/onboarding', tags=['v1'])
-def update_onboarding_state(data: dict, uid: str = Depends(auth.get_current_user_uid)):
+def update_onboarding_state(data: dict, uid: str = Depends(auth.get_writable_user_uid)):
     """Update the user's onboarding state."""
     current_state = get_user_onboarding_state(uid)
     if 'completed' in data:
@@ -243,13 +243,13 @@ def update_onboarding_state(data: dict, uid: str = Depends(auth.get_current_user
 
 
 @router.post('/v1/users/private-cloud-sync', tags=['v1'])
-def set_private_cloud_sync(value: bool, uid: str = Depends(auth.get_current_user_uid)):
+def set_private_cloud_sync(value: bool, uid: str = Depends(auth.get_writable_user_uid)):
     set_user_private_cloud_sync_enabled(uid, value)
     return {'status': 'ok'}
 
 
 @router.get('/v1/users/private-cloud-sync', tags=['v1'])
-def get_private_cloud_sync(uid: str = Depends(auth.get_current_user_uid)):
+def get_private_cloud_sync(uid: str = Depends(auth.get_writable_user_uid)):
     return {'private_cloud_sync_enabled': get_user_private_cloud_sync_enabled(uid)}
 
 
@@ -260,7 +260,7 @@ def get_private_cloud_sync(uid: str = Depends(auth.get_current_user_uid)):
 
 # TODO: consider adding person photo.
 @router.post('/v1/users/people', tags=['v1'], response_model=Person)
-def get_or_create_person(data: CreatePerson, uid: str = Depends(auth.get_current_user_uid)):
+def get_or_create_person(data: CreatePerson, uid: str = Depends(auth.get_writable_user_uid)):
     """Create a new person or return existing one with same name (idempotent by name).
 
     This enables backward compatibility: old apps can call this API and get the
@@ -284,7 +284,7 @@ def get_or_create_person(data: CreatePerson, uid: str = Depends(auth.get_current
 
 @router.get('/v1/users/people/{person_id}', tags=['v1'], response_model=Person)
 def get_single_person(
-    person_id: str, include_speech_samples: bool = False, uid: str = Depends(auth.get_current_user_uid)
+    person_id: str, include_speech_samples: bool = False, uid: str = Depends(auth.get_writable_user_uid)
 ):
     person = get_person(uid, person_id)
     if not person:
@@ -297,7 +297,7 @@ def get_single_person(
 
 
 @router.get('/v1/users/people', tags=['v1'], response_model=List[Person])
-def get_all_people(include_speech_samples: bool = True, uid: str = Depends(auth.get_current_user_uid)):
+def get_all_people(include_speech_samples: bool = True, uid: str = Depends(auth.get_writable_user_uid)):
     print('get_all_people', include_speech_samples)
     people = get_people(uid)
     if include_speech_samples:
@@ -312,14 +312,14 @@ def get_all_people(include_speech_samples: bool = True, uid: str = Depends(auth.
 def update_person_name(
     person_id: str,
     value: str,  # = Field(min_length=2, max_length=40),
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     update_person(uid, person_id, value)
     return {'status': 'ok'}
 
 
 @router.delete('/v1/users/people/{person_id}', tags=['v1'], status_code=204)
-def delete_person_endpoint(person_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def delete_person_endpoint(person_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     delete_person(uid, person_id)
     delete_user_person_speech_samples(uid, person_id)
     return {'status': 'ok'}
@@ -329,7 +329,7 @@ def delete_person_endpoint(person_id: str, uid: str = Depends(auth.get_current_u
 def delete_person_speech_sample_endpoint(
     person_id: str,
     sample_index: int,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """Delete a specific speech sample for a person by index."""
     person = get_person(uid, person_id)
@@ -362,7 +362,7 @@ def delete_person_speech_sample_endpoint(
 
 
 @router.delete('/v1/joan/{memory_id}/followup-question', tags=['v1'], status_code=204)
-def delete_person_endpoint(memory_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def delete_person_endpoint(memory_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     if memory_id == '0':
         memory = get_in_progress_conversation(uid)
         if not memory:
@@ -382,7 +382,7 @@ def delete_person_endpoint(memory_id: str, uid: str = Depends(auth.get_current_u
 def set_memory_summary_rating(
     memory_id: str,
     value: int,  # 0, 1, -1 (shown)
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     set_conversation_summary_rating_score(uid, memory_id, value)
     return {'status': 'ok'}
@@ -391,7 +391,7 @@ def set_memory_summary_rating(
 @router.get('/v1/users/analytics/memory_summary', tags=['v1'])
 def get_memory_summary_rating(
     memory_id: str,
-    _: str = Depends(auth.get_current_user_uid),
+    _: str = Depends(auth.get_writable_user_uid),
 ):
     rating = get_conversation_summary_rating_score(memory_id)
     # TODO: later ask reason, a set of options, if user says good, whats the best, if bad, whats the worst
@@ -405,7 +405,7 @@ def set_chat_message_analytics(
     message_id: str,
     value: int,
     reason: str = None,  # Reason for thumbs down (e.g. 'too_verbose', 'incorrect_or_hallucination')
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """
     Submit feedback rating for a chat message.
@@ -466,7 +466,7 @@ def set_chat_message_analytics(
 
 
 @router.get('/v1/users/language', tags=['v1'])
-def get_user_language(uid: str = Depends(auth.get_current_user_uid)):
+def get_user_language(uid: str = Depends(auth.get_writable_user_uid)):
     """Get the user's preferred language."""
     language = get_user_language_preference(uid)
     if not language:
@@ -475,7 +475,7 @@ def get_user_language(uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.patch('/v1/users/language', tags=['v1'])
-def set_user_language(data: dict, uid: str = Depends(auth.get_current_user_uid)):
+def set_user_language(data: dict, uid: str = Depends(auth.get_writable_user_uid)):
     """Set the user's preferred language (e.g., 'en', 'vi', etc.)."""
     language = data.get('language')
     if not language:
@@ -500,7 +500,7 @@ class TranscriptionPreferencesUpdate(BaseModel):
 
 
 @router.get('/v1/users/transcription-preferences', tags=['v1'], response_model=TranscriptionPreferencesResponse)
-def get_transcription_preferences_endpoint(uid: str = Depends(auth.get_current_user_uid)):
+def get_transcription_preferences_endpoint(uid: str = Depends(auth.get_writable_user_uid)):
     """Get user's transcription preferences (single language mode, vocabulary)."""
     prefs = get_user_transcription_preferences(uid)
     return prefs
@@ -508,7 +508,7 @@ def get_transcription_preferences_endpoint(uid: str = Depends(auth.get_current_u
 
 @router.patch('/v1/users/transcription-preferences', tags=['v1'])
 def update_transcription_preferences_endpoint(
-    data: TranscriptionPreferencesUpdate, uid: str = Depends(auth.get_current_user_uid)
+    data: TranscriptionPreferencesUpdate, uid: str = Depends(auth.get_writable_user_uid)
 ):
     """
     Update user's transcription preferences.
@@ -540,7 +540,7 @@ class ConversationLifecyclePreferencesUpdate(BaseModel):
     tags=['v1'],
     response_model=ConversationLifecyclePreferencesResponse,
 )
-def get_conversation_lifecycle_preferences_endpoint(uid: str = Depends(auth.get_current_user_uid)):
+def get_conversation_lifecycle_preferences_endpoint(uid: str = Depends(auth.get_writable_user_uid)):
     """Get user's conversation lifecycle preferences. Null values use server defaults."""
     return get_user_conversation_lifecycle_preferences(uid)
 
@@ -548,7 +548,7 @@ def get_conversation_lifecycle_preferences_endpoint(uid: str = Depends(auth.get_
 @router.patch('/v1/users/conversation-lifecycle-preferences', tags=['v1'])
 def update_conversation_lifecycle_preferences_endpoint(
     data: ConversationLifecyclePreferencesUpdate,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """Update user-specific conversation lifecycle preferences."""
     provided_fields = set(getattr(data, 'model_fields_set', getattr(data, '__fields_set__', set())))
@@ -577,7 +577,7 @@ def update_conversation_lifecycle_preferences_endpoint(
 
 @router.post('/v1/users/migration/requests', tags=['v1'])
 def handle_migration_requests(
-    request: Union[MigrationRequest, MigrationTargetRequest], uid: str = Depends(auth.get_current_user_uid)
+    request: Union[MigrationRequest, MigrationTargetRequest], uid: str = Depends(auth.get_writable_user_uid)
 ):
     """
     Handles data migration requests.
@@ -618,7 +618,7 @@ def handle_migration_requests(
 
 
 @router.get('/v1/users/migration/requests', tags=['v1'])
-def get_migration_requests(target_level: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_migration_requests(target_level: str, uid: str = Depends(auth.get_writable_user_uid)):
     """Checks which documents need to be migrated to the target level."""
     if target_level != 'enhanced':
         raise HTTPException(status_code=400, detail="Invalid target_level. Only migration to 'enhanced' is supported.")
@@ -632,7 +632,7 @@ def get_migration_requests(target_level: str, uid: str = Depends(auth.get_curren
 
 @router.post('/v1/users/migration/batch-requests', tags=['v1'])
 def handle_batch_migration_requests(
-    batch_request: BatchMigrationRequest, uid: str = Depends(auth.get_current_user_uid)
+    batch_request: BatchMigrationRequest, uid: str = Depends(auth.get_writable_user_uid)
 ):
     """Migrates a batch of data objects to the target protection level."""
     errors = []
@@ -667,7 +667,7 @@ def handle_batch_migration_requests(
 
 
 @router.post('/v1/users/migration/requests/data-protection-level/finalize', tags=['v1'])
-def finalize_migration_request(request: MigrationTargetRequest, uid: str = Depends(auth.get_current_user_uid)):
+def finalize_migration_request(request: MigrationTargetRequest, uid: str = Depends(auth.get_writable_user_uid)):
     """Finalizes the migration by setting the user's global protection level."""
     if request.target_level != 'enhanced':
         raise HTTPException(status_code=400, detail="Invalid target_level. Only migration to 'enhanced' is supported.")
@@ -680,7 +680,7 @@ def finalize_migration_request(request: MigrationTargetRequest, uid: str = Depen
 @router.put('/v1/users/preferences/app', tags=['v1'])
 def set_preferred_app_for_user(
     app_id: str = Query(..., description="The ID of the app to set as preferred"),
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
 ):
     """Sets the user's preferred app for future processing."""
 
@@ -705,7 +705,7 @@ def set_preferred_app_for_user(
 
 
 @router.get('/v1/users/training-data-opt-in', tags=['v1'])
-def get_training_data_opt_in_status(uid: str = Depends(auth.get_current_user_uid)):
+def get_training_data_opt_in_status(uid: str = Depends(auth.get_writable_user_uid)):
     """Get the user's training data opt-in status."""
     opt_in_data = get_user_training_data_opt_in(uid)
     if not opt_in_data:
@@ -714,7 +714,7 @@ def get_training_data_opt_in_status(uid: str = Depends(auth.get_current_user_uid
 
 
 @router.post('/v1/users/training-data-opt-in', tags=['v1'])
-def set_training_data_opt_in_status(uid: str = Depends(auth.get_current_user_uid)):
+def set_training_data_opt_in_status(uid: str = Depends(auth.get_writable_user_uid)):
     """Opt-in for training data program. User's request will be reviewed."""
     set_user_training_data_opt_in(uid, 'pending_review')
 
@@ -735,7 +735,7 @@ def set_training_data_opt_in_status(uid: str = Depends(auth.get_current_user_uid
 
 @router.get('/v1/users/me/usage', tags=['v1'], response_model=UserUsageResponse)
 def get_user_usage_stats_endpoint(
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.get_writable_user_uid),
     period: UsagePeriod = UsagePeriod.TODAY,
 ):
     """Gets daily and monthly usage stats for the authenticated user."""
@@ -744,7 +744,7 @@ def get_user_usage_stats_endpoint(
 
 
 @router.get('/v1/users/me/subscription', tags=['v1'], response_model=UserSubscriptionResponse)
-def get_user_subscription_endpoint(uid: str = Depends(auth.get_current_user_uid)):
+def get_user_subscription_endpoint(uid: str = Depends(auth.get_writable_user_uid)):
     """Gets the user's subscription plan and usage."""
     marketplace_reviewers = os.getenv('MARKETPLACE_APP_REVIEWERS', '').split(',')
     if uid in marketplace_reviewers:
@@ -899,7 +899,7 @@ class DailySummarySettingsUpdate(BaseModel):
 
 
 @router.get('/v1/users/daily-summary-settings', tags=['v1'], response_model=DailySummarySettingsResponse)
-def get_daily_summary_settings(uid: str = Depends(auth.get_current_user_uid)):
+def get_daily_summary_settings(uid: str = Depends(auth.get_writable_user_uid)):
     """
     Get user's daily summary notification settings.
 
@@ -918,7 +918,7 @@ def get_daily_summary_settings(uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.patch('/v1/users/daily-summary-settings', tags=['v1'])
-def update_daily_summary_settings(data: DailySummarySettingsUpdate, uid: str = Depends(auth.get_current_user_uid)):
+def update_daily_summary_settings(data: DailySummarySettingsUpdate, uid: str = Depends(auth.get_writable_user_uid)):
     """
     Update user's daily summary notification settings.
 
@@ -950,7 +950,7 @@ class TestDailySummaryRequest(BaseModel):
 
 
 @router.post('/v1/users/daily-summary-settings/test', tags=['v1'])
-def test_daily_summary(request: TestDailySummaryRequest = None, uid: str = Depends(auth.get_current_user_uid)):
+def test_daily_summary(request: TestDailySummaryRequest = None, uid: str = Depends(auth.get_writable_user_uid)):
     """
     Test endpoint to manually trigger daily summary for the authenticated user.
     This bypasses the time check and sends a summary immediately.
@@ -1063,7 +1063,7 @@ def test_daily_summary(request: TestDailySummaryRequest = None, uid: str = Depen
 
 @router.get('/v1/users/daily-summaries', tags=['v1'])
 def get_daily_summaries(
-    limit: int = Query(30, ge=1, le=100), offset: int = Query(0, ge=0), uid: str = Depends(auth.get_current_user_uid)
+    limit: int = Query(30, ge=1, le=100), offset: int = Query(0, ge=0), uid: str = Depends(auth.get_writable_user_uid)
 ):
     """
     Get list of daily summaries for the authenticated user.
@@ -1074,7 +1074,7 @@ def get_daily_summaries(
 
 
 @router.get('/v1/users/daily-summaries/{summary_id}', tags=['v1'])
-def get_daily_summary(summary_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_daily_summary(summary_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     """
     Get a single daily summary by ID.
     """
@@ -1085,7 +1085,7 @@ def get_daily_summary(summary_id: str, uid: str = Depends(auth.get_current_user_
 
 
 @router.delete('/v1/users/daily-summaries/{summary_id}', tags=['v1'])
-def delete_daily_summary(summary_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def delete_daily_summary(summary_id: str, uid: str = Depends(auth.get_writable_user_uid)):
     """
     Delete a daily summary by ID.
     """
@@ -1112,7 +1112,7 @@ class MentorNotificationSettingsUpdate(BaseModel):
 
 
 @router.get('/v1/users/mentor-notification-settings', tags=['v1'], response_model=MentorNotificationSettingsResponse)
-def get_mentor_notification_settings(uid: str = Depends(auth.get_current_user_uid)):
+def get_mentor_notification_settings(uid: str = Depends(auth.get_writable_user_uid)):
     """
     Get user's mentor notification frequency preference.
 
@@ -1129,7 +1129,7 @@ def get_mentor_notification_settings(uid: str = Depends(auth.get_current_user_ui
 
 @router.patch('/v1/users/mentor-notification-settings', tags=['v1'])
 def update_mentor_notification_settings(
-    data: MentorNotificationSettingsUpdate, uid: str = Depends(auth.get_current_user_uid)
+    data: MentorNotificationSettingsUpdate, uid: str = Depends(auth.get_writable_user_uid)
 ):
     """
     Update user's mentor notification frequency preference.

--- a/backend/routers/workflow.py
+++ b/backend/routers/workflow.py
@@ -10,6 +10,7 @@ import models.integrations as integration_models
 import models.conversation as conversation_models
 from routers.conversations import process_conversation, trigger_external_integrations
 from utils.conversations.location import get_google_maps_location
+from utils.other.endpoints import admit_authenticated_content_writer
 
 router = APIRouter()
 
@@ -19,7 +20,7 @@ router = APIRouter()
     response_model=integration_models.EmptyResponse,
     tags=['integration', 'workflow', 'memories'],
 )
-def create_memory(
+async def create_memory(
     request: Request,
     uid: str,
     api_key: Annotated[str | None, Header()],
@@ -27,6 +28,8 @@ def create_memory(
 ):
     if api_key != os.getenv('WORKFLOW_API_KEY'):
         raise HTTPException(status_code=401, detail="Invalid workflow API Key")
+
+    await admit_authenticated_content_writer(uid)
 
     # Time
     started_at = create_memory.started_at if create_memory.started_at is not None else datetime.now(timezone.utc)

--- a/backend/routers/wrapped.py
+++ b/backend/routers/wrapped.py
@@ -4,7 +4,6 @@ Wrapped 2025 API endpoints.
 Provides generation and retrieval of yearly recap data.
 """
 
-import threading
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -12,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 import database.wrapped as wrapped_db
+from database import content_write_fence
 from database.wrapped import WrappedStatus
 from utils.other import endpoints as auth
 
@@ -105,8 +105,12 @@ def generate_wrapped(year: int, uid: str = Depends(auth.get_writable_user_uid)):
         if wrapped_db.is_wrapped_stuck(wrapped):
             # Restart stuck job
             wrapped_db.reset_wrapped_for_regeneration(uid, year)
-            thread = threading.Thread(target=_run_wrapped_generation, args=(uid, year))
-            thread.start()
+            content_write_fence.start_content_writer_thread(
+                uid,
+                _run_wrapped_generation,
+                args=(uid, year),
+                name=f"wrapped-{year}",
+            )
             return GenerateWrappedResponse(
                 status=WrappedStatus.PROCESSING,
                 message="Restarting stuck generation...",
@@ -124,8 +128,12 @@ def generate_wrapped(year: int, uid: str = Depends(auth.get_writable_user_uid)):
         wrapped_db.create_wrapped(uid, year)
 
     # Start generation in background
-    thread = threading.Thread(target=_run_wrapped_generation, args=(uid, year))
-    thread.start()
+    content_write_fence.start_content_writer_thread(
+        uid,
+        _run_wrapped_generation,
+        args=(uid, year),
+        name=f"wrapped-{year}",
+    )
 
     return GenerateWrappedResponse(
         status=WrappedStatus.PROCESSING,

--- a/backend/routers/wrapped.py
+++ b/backend/routers/wrapped.py
@@ -45,7 +45,7 @@ def _run_wrapped_generation(uid: str, year: int):
 
 
 @router.get('/v1/wrapped/{year}', response_model=WrappedStatusResponse, tags=['wrapped'])
-def get_wrapped_status(year: int, uid: str = Depends(auth.get_current_user_uid)):
+def get_wrapped_status(year: int, uid: str = Depends(auth.get_writable_user_uid)):
     """
     Get the status and result of wrapped generation for a given year.
 
@@ -77,7 +77,7 @@ def get_wrapped_status(year: int, uid: str = Depends(auth.get_current_user_uid))
 
 
 @router.post('/v1/wrapped/{year}/generate', response_model=GenerateWrappedResponse, tags=['wrapped'])
-def generate_wrapped(year: int, uid: str = Depends(auth.get_current_user_uid)):
+def generate_wrapped(year: int, uid: str = Depends(auth.get_writable_user_uid)):
     """
     Start wrapped generation for a given year.
 

--- a/backend/scripts/content_writer_recovery.py
+++ b/backend/scripts/content_writer_recovery.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Recover one orphaned content writer using local kernel terminal proof."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from database._client import db as production_firestore_db
+from database import content_write_recovery
+
+ROOT_UID = 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        epilog=(
+            "Run only in the recorded worker's host, boot, and PID namespace. "
+            "A refusal is an abort: retain DRAINING and retry only after the boundary is authoritative."
+        ),
+    )
+    parser.add_argument(
+        "--subject-hash",
+        required=True,
+        help="SHA-256 of the exact Firebase UID; plaintext UIDs are not accepted",
+    )
+    parser.add_argument(
+        "--token-hash",
+        required=True,
+        help="SHA-256 of the exact durable writer token; plaintext tokens are not accepted",
+    )
+    return parser
+
+
+def _print_receipt(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    firestore_db: Any = production_firestore_db,
+) -> int:
+    args = _parser().parse_args(argv)
+    refusal = {
+        "action": "content_writer_recovery",
+        "content_free": True,
+        "result": "refused",
+    }
+    if os.geteuid() != ROOT_UID:
+        _print_receipt({**refusal, "reason": "account_writer_recovery_root_required"})
+        return 77
+    try:
+        receipt = content_write_recovery.recover_orphaned_writer(
+            firestore_db,
+            subject_hash=args.subject_hash,
+            token_hash=args.token_hash,
+        )
+    except content_write_recovery.ContentWriterRecoveryError as exc:
+        _print_receipt({**refusal, "reason": exc.code})
+        return 2
+    _print_receipt(receipt.to_dict())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/content_writer_recovery.py
+++ b/backend/scripts/content_writer_recovery.py
@@ -1,29 +1,142 @@
-#!/usr/bin/env python3
-"""Recover one orphaned content writer using local kernel terminal proof."""
+#!/opt/omi-recovery/venv/bin/python3 -I
+"""Recover one orphaned writer from the pinned host-supervisor boundary."""
 
-from __future__ import annotations
+# This file is intentionally a production-only bootstrap. Keep the first stage
+# limited to frozen/builtin modules: an untrusted cwd or PYTHONPATH must never
+# run application or credential code before the kernel authority check.
+import os
+import sys
+
+ROOT_UID = 0
+LINUX_CAP_SYS_ADMIN = 21
+LINUX_NS_GET_PARENT = 0xB702
+RECOVERY_RELEASE_ROOT = "/opt/omi-recovery/backend"
+RECOVERY_SCRIPT_PATH = RECOVERY_RELEASE_ROOT + "/scripts/content_writer_recovery.py"
+
+
+def _abort_before_import(code: int) -> None:
+    os._exit(code)
+
+
+if sys.platform != "linux":
+    _abort_before_import(78)
+if not (sys.flags.isolated and sys.flags.safe_path and sys.flags.no_user_site and sys.flags.ignore_environment):
+    _abort_before_import(77)
+if os.geteuid() != ROOT_UID:
+    _abort_before_import(77)
+
+# Isolation is now active, so these standard-library imports cannot be
+# substituted through cwd, PYTHONPATH, or user site-packages.
+import errno
+import fcntl
+import stat
+from pathlib import Path
+
+
+def _read_kernel_file(path: str, *, maximum: int) -> bytes:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        payload = os.read(descriptor, maximum + 1)
+    finally:
+        os.close(descriptor)
+    if len(payload) > maximum:
+        _abort_before_import(77)
+    return payload
+
+
+def _require_initial_host_supervisor() -> None:
+    try:
+        status = _read_kernel_file("/proc/self/status", maximum=128 * 1024).decode("ascii")
+        cap_eff = next(line.split(":", 1)[1].strip() for line in status.splitlines() if line.startswith("CapEff:"))
+        capabilities = int(cap_eff, 16)
+    except (OSError, UnicodeError, StopIteration, ValueError):
+        _abort_before_import(77)
+    if not capabilities & (1 << LINUX_CAP_SYS_ADMIN):
+        _abort_before_import(77)
+    try:
+        namespace_fd = os.open(
+            "/proc/self/ns/pid",
+            os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+    except OSError:
+        _abort_before_import(77)
+    try:
+        try:
+            parent_fd = fcntl.ioctl(namespace_fd, LINUX_NS_GET_PARENT)
+        except OSError as exc:
+            if exc.errno == errno.EINVAL:
+                return
+            _abort_before_import(77)
+        else:
+            os.close(parent_fd)
+            _abort_before_import(77)
+    finally:
+        os.close(namespace_fd)
+
+
+_require_initial_host_supervisor()
+
+
+def _require_root_owned_chain(path: Path, *, regular: bool, reject_symlink: bool) -> Path:
+    if not path.is_absolute():
+        _abort_before_import(77)
+    current = path
+    while True:
+        try:
+            metadata = current.lstat()
+        except OSError:
+            _abort_before_import(77)
+        if metadata.st_uid != ROOT_UID or metadata.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            _abort_before_import(77)
+        if current == path:
+            if reject_symlink and stat.S_ISLNK(metadata.st_mode):
+                _abort_before_import(77)
+            if regular and not (stat.S_ISREG(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode)):
+                _abort_before_import(77)
+            if not regular and not stat.S_ISDIR(metadata.st_mode):
+                _abort_before_import(77)
+        elif not stat.S_ISDIR(metadata.st_mode):
+            _abort_before_import(77)
+        if current == current.parent:
+            break
+        current = current.parent
+    resolved = path.resolve(strict=True)
+    if resolved != path:
+        return _require_root_owned_chain(resolved, regular=regular, reject_symlink=True)
+    return resolved
+
+
+script_path = Path(__file__).absolute()
+if str(script_path) != RECOVERY_SCRIPT_PATH:
+    _abort_before_import(77)
+_require_root_owned_chain(script_path, regular=True, reject_symlink=True)
+release_root = _require_root_owned_chain(Path(RECOVERY_RELEASE_ROOT), regular=False, reject_symlink=True)
+_require_root_owned_chain(Path(sys.executable), regular=True, reject_symlink=False)
+if os.environ.get("FIRESTORE_EMULATOR_HOST") is not None:
+    os.write(
+        1,
+        b'{"action":"content_writer_recovery","content_free":true,"reason":"account_writer_recovery_emulator_forbidden","result":"refused"}\n',
+    )
+    sys.exit(2)
+
+# Application and Google modules become reachable only after isolation, the
+# initial-host supervisor capability, and the root-owned release are proven.
+sys.path.insert(0, str(release_root))
 
 import argparse
 import json
-import os
-from pathlib import Path
-import sys
 from typing import Any, Sequence
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
-from database._client import db as production_firestore_db
-from database import content_write_recovery
-
-ROOT_UID = 0
+from database import content_write_recovery, content_write_recovery_authority
 
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=__doc__,
         epilog=(
-            "Run only in the recorded worker's host, boot, and PID namespace. "
-            "A refusal is an abort: retain DRAINING and retry only after the boundary is authoritative."
+            "Run only from the installed initial-host supervisor release. "
+            "A refusal retains DRAINING and authorizes no manual release."
         ),
     )
     parser.add_argument(
@@ -43,27 +156,30 @@ def _print_receipt(payload: dict[str, Any]) -> None:
     print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
 
 
-def main(
-    argv: Sequence[str] | None = None,
-    *,
-    firestore_db: Any = production_firestore_db,
-) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     refusal = {
         "action": "content_writer_recovery",
         "content_free": True,
         "result": "refused",
     }
-    if os.geteuid() != ROOT_UID:
-        _print_receipt({**refusal, "reason": "account_writer_recovery_root_required"})
-        return 77
     try:
+        (
+            firestore_db,
+            authority,
+            transactional,
+        ) = content_write_recovery_authority.load_production_recovery_firestore_client()
+        del authority
         receipt = content_write_recovery.recover_orphaned_writer(
             firestore_db,
             subject_hash=args.subject_hash,
             token_hash=args.token_hash,
+            transactional=transactional,
         )
-    except content_write_recovery.ContentWriterRecoveryError as exc:
+    except (
+        content_write_recovery.ContentWriterRecoveryError,
+        content_write_recovery_authority.RecoveryAuthorityError,
+    ) as exc:
         _print_receipt({**refusal, "reason": exc.code})
         return 2
     _print_receipt(receipt.to_dict())

--- a/backend/scripts/ella_memory_e2e_smoke.py
+++ b/backend/scripts/ella_memory_e2e_smoke.py
@@ -217,6 +217,8 @@ class MemorySmoke:
     def seed_multichannel_events(self) -> None:
         if not self.args.seed_multichannel:
             return
+        if not self.args.ledger_token:
+            raise SmokeFailure("Canonical event ledger token is required for multichannel seeding")
         phrase = self.args.phrase
         batch = []
         for channel in ("ios_chat", "imessage", "ios_voice"):
@@ -234,7 +236,12 @@ class MemorySmoke:
                     "metadata": {"test": "ella_memory_e2e_smoke", "synthetic": True, "phrase": phrase},
                 }
             )
-        response, elapsed = _json_request("POST", self.backend_url + "/v1/ella/events", {"events": batch})
+        response, elapsed = _json_request(
+            "POST",
+            self.backend_url + "/v1/ella/events",
+            {"events": batch},
+            headers={"Authorization": f"Bearer {self.args.ledger_token}"},
+        )
         self.metrics["write_multichannel_events_ms"] = elapsed
         self.artifacts["multichannel_write"] = response
         if response.get("ok") is not True:
@@ -288,6 +295,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--canonical-identity", default="plato")
     parser.add_argument("--mcp-token", default=_env("ELLA_PLATO_MCP_TOKEN", "").split(",")[0])
     parser.add_argument("--observer-token", default=_env("ELLA_OBSERVER_ADMIN_TOKEN", _env("ELLA_ADMIN_TOKEN", "")))
+    parser.add_argument("--ledger-token", default=_env("ELLA_EVENT_LEDGER_TOKEN", ""))
     parser.add_argument("--phrase", default=_default_phrase())
     parser.add_argument("--seed-multichannel", action="store_true")
     parser.add_argument("--enforce-latency", action="store_true")

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -16,4 +16,5 @@ pytest tests/unit/test_voice_message_language.py -v
 pytest tests/unit/test_speaker_assignment.py -v
 pytest tests/unit/test_voice_canary.py -v
 pytest tests/unit/test_voice_proxy_auth.py -v
+pytest tests/unit/test_content_write_fence.py -v
 pytest tests/postgres/test_voice_canary_postgres.py -v

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -17,4 +17,5 @@ pytest tests/unit/test_speaker_assignment.py -v
 pytest tests/unit/test_voice_canary.py -v
 pytest tests/unit/test_voice_proxy_auth.py -v
 pytest tests/unit/test_content_write_fence.py -v
+pytest tests/unit/test_trace_deletion_finality.py -v
 pytest tests/postgres/test_voice_canary_postgres.py -v

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,44 @@
+"""Repository-wide unit-test adapters that cannot be selected by production."""
+
+from __future__ import annotations
+
+import platform
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _nonlinux_content_writer_adapter(monkeypatch):
+    if platform.system() == "Linux":
+        yield
+        return
+
+    from database import content_write_recovery, content_writer_owner
+    from tests.support import content_writer_owner_nonlinux
+
+    previous_owner = content_writer_owner._process_owner
+    monkeypatch.setattr(
+        content_writer_owner,
+        "current_process_boundary",
+        content_writer_owner_nonlinux.current_process_boundary,
+    )
+    monkeypatch.setattr(
+        content_writer_owner,
+        "process_snapshot",
+        content_writer_owner_nonlinux.process_snapshot,
+    )
+
+    def no_production_supervisor_adapter(_pid_namespace, _namespace_pid):
+        raise content_writer_owner.ProcessOwnerError("account_writer_supervisor_authority_required")
+
+    monkeypatch.setattr(
+        content_writer_owner,
+        "linux_supervisor_process_snapshot",
+        no_production_supervisor_adapter,
+    )
+    monkeypatch.setattr(content_write_recovery.platform, "system", lambda: "Linux")
+    content_writer_owner._process_owner = None
+    try:
+        yield
+    finally:
+        content_writer_owner._process_owner = previous_owner

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -8,7 +8,7 @@ from typing import Any, Awaitable, Callable
 import asyncpg
 import pytest
 
-from database import authority_advisory_lock, managed_cloud_consent, voice_canary
+from database import authority_advisory_lock, content_write_fence, managed_cloud_consent, voice_canary
 from database.ella_provisioning import EllaProvisioningRepository
 from database.runtime_targets import RuntimeTargetLineage
 
@@ -987,6 +987,93 @@ def test_each_production_writer_waits_before_mutation_and_commits_after_release(
     async def scenario(pool):
         case = await _prepare_writer_case(pool, name)
         await _assert_serialized_writer(pool, case)
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_content_request_holds_owner_lock_across_real_commit_and_releases_on_cancellation():
+    async def scenario(pool):
+        uid = "synthetic-content-request-fence"
+        async with pool.acquire() as seed:
+            user_id = await seed.fetchval(
+                """
+                INSERT INTO users (omi_uid, email, profile_class, status)
+                VALUES ($1, $2, 'synthetic', 'ACTIVE')
+                RETURNING id
+                """,
+                uid,
+                f"{uid}@example.invalid",
+            )
+        owner = authority_advisory_lock.AuthorityOwner.from_values(user_id, user_id)
+        writer_entered = asyncio.Event()
+        release_writer = asyncio.Event()
+
+        async def writer():
+            async with content_write_fence._postgres_owner_fence(uid):
+                writer_entered.set()
+                await release_writer.wait()
+
+        writer_task = asyncio.create_task(writer())
+        await asyncio.wait_for(writer_entered.wait(), timeout=5)
+
+        async with pool.acquire() as deletion_connection:
+            deletion_transaction = deletion_connection.transaction()
+            await deletion_transaction.start()
+            deletion_lock = asyncio.create_task(
+                authority_advisory_lock.acquire_authority_lock(deletion_connection, owner=owner)
+            )
+            await _wait_for_advisory_waiter(pool, owner)
+            assert not deletion_lock.done()
+            release_writer.set()
+            await asyncio.wait_for(writer_task, timeout=5)
+            await asyncio.wait_for(deletion_lock, timeout=5)
+            await deletion_connection.execute(
+                "UPDATE users SET status = 'DELETION_PENDING' WHERE id = $1",
+                user_id,
+            )
+            await deletion_transaction.commit()
+
+        with pytest.raises(content_write_fence.ContentWriteFenceError) as forbidden:
+            async with content_write_fence._postgres_owner_fence(uid):
+                pass
+        assert forbidden.value.code == "account_write_forbidden"
+
+        cancellation_uid = f"{uid}-cancellation"
+        async with pool.acquire() as seed_cancellation:
+            cancellation_user_id = await seed_cancellation.fetchval(
+                """
+                INSERT INTO users (omi_uid, email, profile_class, status)
+                VALUES ($1, $2, 'synthetic', 'ACTIVE')
+                RETURNING id
+                """,
+                cancellation_uid,
+                f"{cancellation_uid}@example.invalid",
+            )
+        cancellation_owner = authority_advisory_lock.AuthorityOwner.from_values(
+            cancellation_user_id,
+            cancellation_user_id,
+        )
+        cancellation_entered = asyncio.Event()
+
+        async def cancelled_writer():
+            async with content_write_fence._postgres_owner_fence(cancellation_uid):
+                cancellation_entered.set()
+                await asyncio.Event().wait()
+
+        cancelled_task = asyncio.create_task(cancelled_writer())
+        await asyncio.wait_for(cancellation_entered.wait(), timeout=5)
+        cancelled_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled_task
+
+        async with pool.acquire() as cleanup_probe:
+            cleanup_transaction = cleanup_probe.transaction()
+            await cleanup_transaction.start()
+            await asyncio.wait_for(
+                authority_advisory_lock.acquire_authority_lock(cleanup_probe, owner=cancellation_owner),
+                timeout=5,
+            )
+            await cleanup_transaction.rollback()
 
     asyncio.run(_run_with_database(scenario))
 

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -114,6 +114,7 @@ async def _run_with_database(scenario):
                 "013_create_managed_cloud_consent_authority.sql",
                 "014_add_synthetic_invitation_operator_audit.sql",
                 "015_add_invitation_allowed_email_hash.sql",
+                "017_add_provider_attempt_deletion_fence.sql",
             ):
                 await conn.execute((MIGRATIONS / name).read_text(encoding="utf-8"))
         await scenario(pool)
@@ -657,21 +658,23 @@ async def _prepare_writer_case(
                     """
                     INSERT INTO users (
                         email, name, status, profile_class
-                    ) VALUES ($1, 'Synthetic Before', 'PENDING', 'synthetic')
+                    ) VALUES ($1, 'Synthetic Before', 'ACTIVE', 'synthetic')
                     RETURNING id
                     """,
                     email,
                 )
             else:
+                initial_status = "ACTIVE" if name == "identity_update" else "PENDING"
                 user_id = await conn.fetchval(
                     """
                     INSERT INTO users (
                         omi_uid, email, name, status, profile_class
-                    ) VALUES ($1, $2, 'Synthetic Before', 'PENDING', 'synthetic')
+                    ) VALUES ($1, $2, 'Synthetic Before', $3, 'synthetic')
                     RETURNING id
                     """,
                     uid,
                     email,
+                    initial_status,
                 )
         owner = authority_advisory_lock.AuthorityOwner.from_values(user_id, user_id)
         if name == "identity_bind":

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -991,89 +991,68 @@ def test_each_production_writer_waits_before_mutation_and_commits_after_release(
     asyncio.run(_run_with_database(scenario))
 
 
-def test_content_request_holds_owner_lock_across_real_commit_and_releases_on_cancellation():
+def test_content_admission_releases_pool_before_same_owner_nested_writers_at_full_capacity():
     async def scenario(pool):
-        uid = "synthetic-content-request-fence"
+        capacity = 6
+        users = []
         async with pool.acquire() as seed:
-            user_id = await seed.fetchval(
-                """
-                INSERT INTO users (omi_uid, email, profile_class, status)
-                VALUES ($1, $2, 'synthetic', 'ACTIVE')
-                RETURNING id
-                """,
-                uid,
-                f"{uid}@example.invalid",
-            )
-        owner = authority_advisory_lock.AuthorityOwner.from_values(user_id, user_id)
-        writer_entered = asyncio.Event()
-        release_writer = asyncio.Event()
+            for index in range(capacity):
+                uid = f"synthetic-content-reentry-{index}"
+                user_id = await seed.fetchval(
+                    """
+                    INSERT INTO users (omi_uid, email, profile_class, status)
+                    VALUES ($1, $2, 'synthetic', 'ACTIVE')
+                    RETURNING id
+                    """,
+                    uid,
+                    f"{uid}@example.invalid",
+                )
+                users.append((uid, user_id))
 
-        async def writer():
-            async with content_write_fence._postgres_owner_fence(uid):
-                writer_entered.set()
-                await release_writer.wait()
+        nested_count = 0
+        nested_lock = asyncio.Lock()
+        all_nested = asyncio.Event()
 
-        writer_task = asyncio.create_task(writer())
-        await asyncio.wait_for(writer_entered.wait(), timeout=5)
+        async def mounted_request(uid, user_id):
+            nonlocal nested_count
+            await content_write_fence._assert_postgres_owner_active(uid)
+            owner = authority_advisory_lock.AuthorityOwner.from_values(user_id, user_id)
+            async with pool.acquire() as nested_connection:
+                async with nested_connection.transaction():
+                    proof = await authority_advisory_lock.acquire_authority_lock(
+                        nested_connection,
+                        owner=owner,
+                    )
+                    assert (
+                        await authority_advisory_lock.verify_self_owner_after_lock(
+                            nested_connection,
+                            uid=uid,
+                            owner=owner,
+                            proof=proof,
+                        )
+                        == user_id
+                    )
+                    async with nested_lock:
+                        nested_count += 1
+                        if nested_count == capacity:
+                            all_nested.set()
+                    await asyncio.wait_for(all_nested.wait(), timeout=5)
 
-        async with pool.acquire() as deletion_connection:
-            deletion_transaction = deletion_connection.transaction()
-            await deletion_transaction.start()
-            deletion_lock = asyncio.create_task(
-                authority_advisory_lock.acquire_authority_lock(deletion_connection, owner=owner)
-            )
-            await _wait_for_advisory_waiter(pool, owner)
-            assert not deletion_lock.done()
-            release_writer.set()
-            await asyncio.wait_for(writer_task, timeout=5)
-            await asyncio.wait_for(deletion_lock, timeout=5)
-            await deletion_connection.execute(
-                "UPDATE users SET status = 'DELETION_PENDING' WHERE id = $1",
-                user_id,
-            )
-            await deletion_transaction.commit()
-
-        with pytest.raises(content_write_fence.ContentWriteFenceError) as forbidden:
-            async with content_write_fence._postgres_owner_fence(uid):
-                pass
-        assert forbidden.value.code == "account_write_forbidden"
-
-        cancellation_uid = f"{uid}-cancellation"
-        async with pool.acquire() as seed_cancellation:
-            cancellation_user_id = await seed_cancellation.fetchval(
-                """
-                INSERT INTO users (omi_uid, email, profile_class, status)
-                VALUES ($1, $2, 'synthetic', 'ACTIVE')
-                RETURNING id
-                """,
-                cancellation_uid,
-                f"{cancellation_uid}@example.invalid",
-            )
-        cancellation_owner = authority_advisory_lock.AuthorityOwner.from_values(
-            cancellation_user_id,
-            cancellation_user_id,
+        await asyncio.wait_for(
+            asyncio.gather(*(mounted_request(uid, user_id) for uid, user_id in users)),
+            timeout=10,
         )
-        cancellation_entered = asyncio.Event()
+        assert nested_count == capacity
 
-        async def cancelled_writer():
-            async with content_write_fence._postgres_owner_fence(cancellation_uid):
-                cancellation_entered.set()
-                await asyncio.Event().wait()
-
-        cancelled_task = asyncio.create_task(cancelled_writer())
-        await asyncio.wait_for(cancellation_entered.wait(), timeout=5)
-        cancelled_task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await cancelled_task
-
-        async with pool.acquire() as cleanup_probe:
-            cleanup_transaction = cleanup_probe.transaction()
-            await cleanup_transaction.start()
-            await asyncio.wait_for(
-                authority_advisory_lock.acquire_authority_lock(cleanup_probe, owner=cancellation_owner),
-                timeout=5,
+        blocked_uid, blocked_user_id = users[0]
+        async with pool.acquire() as tombstone:
+            await tombstone.execute(
+                "UPDATE users SET status = 'DELETION_PENDING' WHERE id = $1",
+                blocked_user_id,
             )
-            await cleanup_transaction.rollback()
+        with pytest.raises(content_write_fence.ContentWriteFenceError) as forbidden:
+            await content_write_fence._assert_postgres_owner_active(blocked_uid)
+        assert forbidden.value.code == "account_write_forbidden"
 
     asyncio.run(_run_with_database(scenario))
 

--- a/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
+++ b/backend/tests/postgres/test_hermes_cloud_pool_postgres.py
@@ -144,6 +144,7 @@ async def _run_with_database(scenario):
                 "013_create_managed_cloud_consent_authority.sql",
                 "014_add_synthetic_invitation_operator_audit.sql",
                 "015_add_invitation_allowed_email_hash.sql",
+                "017_add_provider_attempt_deletion_fence.sql",
             ):
                 await conn.execute((MIGRATIONS / name).read_text(encoding="utf-8"))
             assert await conn.fetchval(

--- a/backend/tests/postgres/test_invitation_redemption_postgres.py
+++ b/backend/tests/postgres/test_invitation_redemption_postgres.py
@@ -230,6 +230,7 @@ async def _run_with_database(
         async with pool.acquire() as conn:
             await conn.execute(BASE_PROVISIONING_SCHEMA)
             for name in (
+                "007_create_memory_reinterpretation_outbox.sql",
                 "008_create_voice_canary_controls.sql",
                 "009_create_hermes_cloud_runtime_pool.sql",
                 "010_add_cloud_profile_class.sql",
@@ -4121,6 +4122,66 @@ def test_account_deletion_routing_trace_purge_is_exact_repeatable_and_retains_ot
                 "notes": '["retained"]',
             }
         ]
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_account_deletion_memory_reinterpretation_purge_removes_attempts_and_retains_other_users():
+    async def scenario(pool: asyncpg.Pool) -> None:
+        async with pool.acquire() as connection:
+            await connection.executemany(
+                """
+                INSERT INTO memory_reinterpretation_jobs (
+                    id, uid, logical_session_id, conversation_id,
+                    starting_summary_version_id, source_identity,
+                    canonical_refs, transcript_hash, status, not_before
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, '[]'::jsonb, $7, 'running', NOW())
+                """,
+                [
+                    (
+                        "owned-memory-job",
+                        "memory-delete-user",
+                        "session-owned",
+                        "conversation-owned",
+                        "v1",
+                        "source-owned",
+                        "hash-owned",
+                    ),
+                    (
+                        "retained-memory-job",
+                        "memory-retained-user",
+                        "session-retained",
+                        "conversation-retained",
+                        "v1",
+                        "source-retained",
+                        "hash-retained",
+                    ),
+                ],
+            )
+            await connection.executemany(
+                """
+                INSERT INTO memory_reinterpretation_attempts (
+                    job_id, transcript_revision, attempt_number,
+                    lease_token, worker_id, status
+                )
+                VALUES ($1, 1, 1, $2, $3, 'running')
+                """,
+                [
+                    ("owned-memory-job", "owned-lease", "owned-worker"),
+                    ("retained-memory-job", "retained-lease", "retained-worker"),
+                ],
+            )
+
+        assert await account_deletion.purge_memory_reinterpretation_work("memory-delete-user") == 2
+        assert await account_deletion.purge_memory_reinterpretation_work("memory-delete-user") == 0
+        async with pool.acquire() as connection:
+            jobs = await connection.fetch("SELECT id, uid FROM memory_reinterpretation_jobs ORDER BY id")
+            attempts = await connection.fetch(
+                "SELECT job_id, lease_token FROM memory_reinterpretation_attempts ORDER BY job_id"
+            )
+        assert [dict(row) for row in jobs] == [{"id": "retained-memory-job", "uid": "memory-retained-user"}]
+        assert [dict(row) for row in attempts] == [{"job_id": "retained-memory-job", "lease_token": "retained-lease"}]
 
     asyncio.run(_run_with_database(scenario))
 

--- a/backend/tests/postgres/test_invitation_redemption_postgres.py
+++ b/backend/tests/postgres/test_invitation_redemption_postgres.py
@@ -122,6 +122,23 @@ CREATE TABLE users (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE canonical_events (
+    id BIGSERIAL PRIMARY KEY,
+    uid TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    text TEXT NOT NULL,
+    metadata JSONB NOT NULL,
+    raw_event JSONB NOT NULL
+);
+
+CREATE TABLE canonical_event_sessions (
+    id BIGSERIAL PRIMARY KEY,
+    uid TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    metadata JSONB NOT NULL,
+    raw_completion JSONB NOT NULL
+);
+
 CREATE TABLE ella_provisioning_jobs (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -4182,6 +4199,99 @@ def test_account_deletion_memory_reinterpretation_purge_removes_attempts_and_ret
             )
         assert [dict(row) for row in jobs] == [{"id": "retained-memory-job", "uid": "memory-retained-user"}]
         assert [dict(row) for row in attempts] == [{"job_id": "retained-memory-job", "lease_token": "retained-lease"}]
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_canonical_ledger_positive_control_exact_purge_rollback_and_retry():
+    async def scenario(pool: asyncpg.Pool) -> None:
+        target_uid = "canonical-delete-user"
+        retained_uid = "canonical-retained-user"
+        async with pool.acquire() as connection:
+            await connection.executemany(
+                """
+                INSERT INTO canonical_events (uid, event_id, text, metadata, raw_event)
+                VALUES ($1, $2, $3, $4::jsonb, $5::jsonb)
+                """,
+                [
+                    (target_uid, "owned-1", "private transcript one", '{"source":"owned"}', '{"uid":"owned"}'),
+                    (target_uid, "owned-2", "private transcript two", '{"source":"owned"}', '{"uid":"owned"}'),
+                    (retained_uid, "retained", "retained transcript", '{"source":"other"}', '{"uid":"other"}'),
+                ],
+            )
+            await connection.executemany(
+                """
+                INSERT INTO canonical_event_sessions (uid, session_id, metadata, raw_completion)
+                VALUES ($1, $2, $3::jsonb, $4::jsonb)
+                """,
+                [
+                    (target_uid, "owned-session", '{"source":"owned"}', '{"uid":"owned"}'),
+                    (retained_uid, "retained-session", '{"source":"other"}', '{"uid":"other"}'),
+                ],
+            )
+
+        # Positive control: the previously available deletion purges do not
+        # touch either canonical table.
+        assert await account_deletion.purge_routing_traces(target_uid) == 0
+        assert await account_deletion.purge_memory_reinterpretation_work(target_uid) == 0
+        async with pool.acquire() as connection:
+            assert await connection.fetchval("SELECT COUNT(*) FROM canonical_events WHERE uid = $1", target_uid) == 2
+            assert (
+                await connection.fetchval("SELECT COUNT(*) FROM canonical_event_sessions WHERE uid = $1", target_uid)
+                == 1
+            )
+            await connection.execute(
+                """
+                CREATE FUNCTION suppress_canonical_session_delete()
+                RETURNS trigger LANGUAGE plpgsql AS $$
+                BEGIN
+                    RETURN NULL;
+                END
+                $$;
+                CREATE TRIGGER suppress_canonical_session_delete
+                BEFORE DELETE ON canonical_event_sessions
+                FOR EACH ROW EXECUTE FUNCTION suppress_canonical_session_delete()
+                """
+            )
+
+        with pytest.raises(account_deletion.AccountDeletionUnavailable) as ambiguous:
+            await account_deletion.purge_canonical_event_ledger(target_uid)
+        assert ambiguous.value.code == "account_deletion_canonical_event_ledger_unavailable"
+        async with pool.acquire() as connection:
+            # The affected-count ambiguity rolls back the event delete too.
+            assert await connection.fetchval("SELECT COUNT(*) FROM canonical_events WHERE uid = $1", target_uid) == 2
+            assert (
+                await connection.fetchval("SELECT COUNT(*) FROM canonical_event_sessions WHERE uid = $1", target_uid)
+                == 1
+            )
+            await connection.execute("DROP TRIGGER suppress_canonical_session_delete ON canonical_event_sessions")
+
+        assert await account_deletion.purge_canonical_event_ledger(target_uid) == 3
+        assert await account_deletion.purge_canonical_event_ledger(target_uid) == 0
+        async with pool.acquire() as connection:
+            retained = await connection.fetchrow(
+                """
+                SELECT
+                    (SELECT COUNT(*) FROM canonical_events WHERE uid = $1) AS events,
+                    (SELECT COUNT(*) FROM canonical_event_sessions WHERE uid = $1) AS sessions
+                """,
+                retained_uid,
+            )
+            assert tuple(retained.values()) == (1, 1)
+            await connection.execute("DROP TABLE canonical_event_sessions")
+            await connection.execute(
+                """
+                INSERT INTO canonical_events (uid, event_id, text, metadata, raw_event)
+                VALUES ($1, 'missing-table', 'private transcript', '{}'::jsonb, '{}'::jsonb)
+                """,
+                target_uid,
+            )
+
+        with pytest.raises(account_deletion.AccountDeletionUnavailable) as missing:
+            await account_deletion.purge_canonical_event_ledger(target_uid)
+        assert missing.value.code == "account_deletion_canonical_event_ledger_unavailable"
+        async with pool.acquire() as connection:
+            assert await connection.fetchval("SELECT COUNT(*) FROM canonical_events WHERE uid = $1", target_uid) == 1
 
     asyncio.run(_run_with_database(scenario))
 

--- a/backend/tests/postgres/test_invitation_redemption_postgres.py
+++ b/backend/tests/postgres/test_invitation_redemption_postgres.py
@@ -4082,6 +4082,49 @@ def test_account_deletion_atomically_quarantines_authority_releases_capacity_and
     asyncio.run(_run_with_database(scenario))
 
 
+def test_account_deletion_routing_trace_purge_is_exact_repeatable_and_retains_other_users():
+    async def scenario(pool: asyncpg.Pool) -> None:
+        async with pool.acquire() as connection:
+            await connection.execute(
+                """
+                CREATE TABLE routing_traces (
+                    trace_id TEXT PRIMARY KEY,
+                    uid TEXT,
+                    notes JSONB NOT NULL DEFAULT '[]'::jsonb,
+                    client_headers JSONB NOT NULL DEFAULT '{}'::jsonb,
+                    resolved_session_key TEXT,
+                    error TEXT
+                )
+                """
+            )
+            await connection.executemany(
+                """
+                INSERT INTO routing_traces (
+                    trace_id, uid, notes, client_headers, resolved_session_key, error
+                ) VALUES ($1, $2, $3::jsonb, $4::jsonb, $5, $6)
+                """,
+                [
+                    ("owned-1", "routing-delete-user", '["sensitive-1"]', '{"Secret":"one"}', "session-1", "error-1"),
+                    ("owned-2", "routing-delete-user", '["sensitive-2"]', '{"Secret":"two"}', "session-2", "error-2"),
+                    ("retained", "routing-retained-user", '["retained"]', '{}', None, None),
+                ],
+            )
+
+        assert await account_deletion.purge_routing_traces("routing-delete-user") == 2
+        assert await account_deletion.purge_routing_traces("routing-delete-user") == 0
+        async with pool.acquire() as connection:
+            rows = await connection.fetch("SELECT trace_id, uid, notes FROM routing_traces ORDER BY trace_id")
+        assert [dict(row) for row in rows] == [
+            {
+                "trace_id": "retained",
+                "uid": "routing-retained-user",
+                "notes": '["retained"]',
+            }
+        ]
+
+    asyncio.run(_run_with_database(scenario))
+
+
 def test_account_deletion_mid_transaction_failure_rolls_back_every_authority_and_capacity_write():
     async def scenario(pool: asyncpg.Pool) -> None:
         invitation_id, uid = await _prepare_deletion_account(

--- a/backend/tests/postgres/test_invitation_redemption_postgres.py
+++ b/backend/tests/postgres/test_invitation_redemption_postgres.py
@@ -26,7 +26,7 @@ from database.runtime_targets import RuntimeTargetLineage, SELF_HOSTED_RUNTIME_M
 from ella.services import ai_consent
 from ella.services import account_deletion as account_deletion_service
 from ella.services import consent_authority, invitation_authority
-from ella.services.provisioning import ProvisioningCoordinator, VerifiedIdentity
+from ella.services.provisioning import HermesProvisionClient, ProvisioningCoordinator, VerifiedIdentity
 from ella.services.runtime_errors import ProvisioningError
 from ella.services.runtime_resolver import (
     resolve_isolated_runtime,
@@ -225,6 +225,7 @@ async def _run_with_database(
                 "013_create_managed_cloud_consent_authority.sql",
                 "014_add_synthetic_invitation_operator_audit.sql",
                 "015_add_invitation_allowed_email_hash.sql",
+                "017_add_provider_attempt_deletion_fence.sql",
             ):
                 await conn.execute((MIGRATIONS / name).read_text(encoding="utf-8"))
             assert await conn.fetchval(
@@ -4190,5 +4191,414 @@ def test_account_deletion_service_handles_partial_provision_and_repeat_without_o
             ("firestore", uid),
             ("firebase", uid),
         ]
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_lost_provider_ack_persists_unproven_attempt_blocks_firebase_and_retry_converges(monkeypatch):
+    class LostAcknowledgementClient(HermesProvisionClient):
+        provider_created = False
+
+        @staticmethod
+        def resolve_authority(_expected_snapshot=None):
+            return None
+
+        @classmethod
+        def snapshot_authority(cls, _expected_snapshot=None):
+            return None
+
+        async def provision(self, _identity, _target_schema_version, **kwargs):
+            assert kwargs["idempotency_key"]
+            self.provider_created = True
+            raise ProvisioningError("provision_service_timeout", retryable=True)
+
+    async def scenario(pool: asyncpg.Pool) -> None:
+        uid = "account-delete-lost-provider-ack"
+        email = "account-delete-lost-provider-ack@example.test"
+        await _prepare_deletion_account(
+            pool,
+            uid=uid,
+            email=email,
+            code="FGHJ-9ABC",
+            activate_runtime=False,
+        )
+        await managed_cloud_consent.synchronize_grant(grant=_self_hosted_grant(uid))
+        async with pool.acquire() as connection:
+            job = dict(
+                await connection.fetchrow(
+                    """
+                    INSERT INTO ella_provisioning_jobs (user_id, target_schema_version, state, stage)
+                    SELECT id, 'hermes-user-v1', 'provisioning', 'profile_ready'
+                    FROM users WHERE omi_uid = $1
+                    RETURNING *
+                    """,
+                    uid,
+                )
+            )
+
+        monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "true")
+        monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "false")
+        client = LostAcknowledgementClient()
+        coordinator = ProvisioningCoordinator(EllaProvisioningRepository(pool), client=client)
+        await coordinator.process_claimed_job(
+            job=job,
+            identity=VerifiedIdentity(uid=uid, email=email, name="Synthetic", timezone="UTC"),
+        )
+        assert client.provider_created is True
+
+        async with pool.acquire() as connection:
+            marker = dict(
+                await connection.fetchrow(
+                    """
+                    SELECT proof_state, content_free, idempotency_key, correlation_ref
+                    FROM ella_provider_attempts
+                    WHERE provisioning_job_id = $1
+                    """,
+                    job["id"],
+                )
+            )
+            assert (
+                await connection.fetchval(
+                    "SELECT COUNT(*) FROM ella_runtime_bindings WHERE user_id = (SELECT id FROM users WHERE omi_uid = $1)",
+                    uid,
+                )
+                == 0
+            )
+        assert marker["proof_state"] == "unproven"
+        assert marker["content_free"] is True
+        assert str(marker["idempotency_key"])
+        assert str(marker["correlation_ref"]).startswith("ella-ext-")
+
+        destructive_calls = []
+        for _attempt in range(2):
+            response = await account_deletion_service.execute_account_deletion(
+                uid,
+                delete_firestore=lambda exact_uid: destructive_calls.append(("firestore", exact_uid)),
+                delete_firebase=lambda exact_uid: destructive_calls.append(("firebase", exact_uid)),
+            )
+            assert response.status_code == 202
+            assert response.body["status"] == "deletion_pending"
+            assert response.body["deletion_receipt"]["external_cleanup_references"] == [marker["correlation_ref"]]
+            assert "firebase" not in {kind for kind, _uid in destructive_calls}
+
+        async with pool.acquire() as connection:
+            await connection.execute(
+                """
+                UPDATE ella_provider_attempts
+                SET proof_state = 'absence_proven',
+                    proved_at = CURRENT_TIMESTAMP,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE provisioning_job_id = $1
+                """,
+                job["id"],
+            )
+        completed = await account_deletion_service.execute_account_deletion(
+            uid,
+            delete_firestore=lambda exact_uid: destructive_calls.append(("firestore", exact_uid)),
+            delete_firebase=lambda exact_uid: destructive_calls.append(("firebase", exact_uid)),
+        )
+        assert completed.status_code == 200
+        assert destructive_calls[-1] == ("firebase", uid)
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_deletion_tombstone_serializes_inflight_provider_writer_and_quarantines_photon_immediately():
+    async def scenario(pool: asyncpg.Pool) -> None:
+        uid = "account-delete-writer-fence"
+        email = "account-delete-writer-fence@example.test"
+        await _prepare_deletion_account(
+            pool,
+            uid=uid,
+            email=email,
+            code="GHJK-ABCD",
+            activate_runtime=True,
+        )
+        repository = EllaProvisioningRepository(pool)
+        async with pool.acquire() as connection:
+            user_id = await connection.fetchval("SELECT id FROM users WHERE omi_uid = $1", uid)
+            await connection.execute(
+                """
+                UPDATE ella_runtime_bindings
+                SET active = false, status = 'disabled', updated_at = CURRENT_TIMESTAMP
+                WHERE user_id = $1 AND active = true
+                """,
+                user_id,
+            )
+            photon_runtime_binding_id = await connection.fetchval(
+                """
+                INSERT INTO ella_runtime_bindings (
+                    user_id, account_user_id, profile_user_id, role, provider,
+                    profile_name, agent_id, runtime_instance_id, api_base_url_ref,
+                    api_key_ref, honcho_workspace, observed_peer, observer_peer,
+                    template_version, prompt_pack_version, prompt_artifact_receipt,
+                    model_policy_version, voice_policy_version, expected_model,
+                    health_state, status, active, runtime_target_mode,
+                    target_endpoint_ref, target_credential_ref
+                ) VALUES (
+                    $1, $1, $1, 'user', 'hermes_cloud', $2, 'hermes-cloud', $3,
+                    'env:ELLA_TEST_ENDPOINT', 'env:ELLA_TEST_KEY', $4, $5, $6,
+                    'template-v1', 'prompt-v1', $7::jsonb, 'model-v1', 'voice-v1',
+                    'gpt-5.6-terra', 'healthy', 'active', true,
+                    'hermes-cloud-photon', 'env:ELLA_TEST_ENDPOINT', 'env:ELLA_TEST_KEY'
+                ) RETURNING id
+                """,
+                user_id,
+                f"photon-{uid}",
+                f"runtime-{uid}",
+                f"photon-workspace-{uid}",
+                f"photon-observed-{uid}",
+                f"photon-observer-{uid}",
+                json.dumps(_prompt_receipt()),
+            )
+            photon_binding_id = await connection.fetchval(
+                """
+                INSERT INTO ella_photon_channel_bindings (
+                    runtime_binding_id, user_id, status, line_identity_key,
+                    contact_identity_key, policy_commit_sha, command_tier_version,
+                    daily_message_limit, daily_initiation_limit
+                ) VALUES ($1, $2, 'enabled', $3, $4, $5, 'tier-v1', 10, 2)
+                RETURNING id
+                """,
+                photon_runtime_binding_id,
+                user_id,
+                "1" * 64,
+                "2" * 64,
+                "a" * 40,
+            )
+            job_id = await connection.fetchval(
+                """
+                INSERT INTO ella_provisioning_jobs (user_id, target_schema_version)
+                VALUES ($1, 'queued-after-delete-v1') RETURNING id
+                """,
+                user_id,
+            )
+            claim_token = uuid.uuid4()
+            await connection.execute(
+                """
+                UPDATE ella_runtime_bindings
+                SET claim_job_id = $2, claim_token = $3
+                WHERE id = $1
+                """,
+                photon_runtime_binding_id,
+                job_id,
+                claim_token,
+            )
+            await connection.execute(
+                """
+                CREATE FUNCTION delay_account_deletion_tombstone() RETURNS trigger AS $$
+                BEGIN
+                    IF NEW.status = 'DELETION_PENDING' THEN PERFORM pg_sleep(0.5); END IF;
+                    RETURN NEW;
+                END
+                $$ LANGUAGE plpgsql
+                """
+            )
+            await connection.execute(
+                """
+                CREATE TRIGGER delay_account_deletion_tombstone
+                BEFORE UPDATE ON users
+                FOR EACH ROW EXECUTE FUNCTION delay_account_deletion_tombstone()
+                """
+            )
+
+        positive = await repository.resolve_photon_channel_binding(
+            line_identity_key="1" * 64,
+            contact_identity_key="2" * 64,
+        )
+        assert positive and positive["omi_uid"] == uid
+
+        deletion = asyncio.create_task(account_deletion.quarantine_account_for_deletion(uid))
+        await asyncio.sleep(0.05)
+        queued_stage = asyncio.create_task(
+            repository.stage_runtime_binding(uid=uid, binding=_local_runtime_binding(uid))
+        )
+        owner = authority_advisory_lock.AuthorityOwner.from_values(user_id, user_id)
+        await _wait_for_operator_authority_waiter(pool, owner)
+        await deletion
+        with pytest.raises(authority_advisory_lock.AuthorityLockError) as blocked_stage:
+            await queued_stage
+        assert blocked_stage.value.code == "authority_write_user_not_active"
+
+        for _attempt in range(2):
+            assert (
+                await repository.resolve_photon_channel_binding(
+                    line_identity_key="1" * 64,
+                    contact_identity_key="2" * 64,
+                )
+                is None
+            )
+
+        with pytest.raises(managed_cloud_consent.ManagedCloudAuthorityUnavailable):
+            await managed_cloud_consent.synchronize_grant(grant=_self_hosted_grant(uid))
+        with pytest.raises(authority_advisory_lock.AuthorityLockError):
+            await repository.activate_user(uid)
+        with pytest.raises(authority_advisory_lock.AuthorityLockError):
+            await repository.update_job(
+                job_id=str(job_id),
+                state="ready",
+                stage="active",
+                retryable=False,
+            )
+        with pytest.raises(authority_advisory_lock.AuthorityLockError):
+            await repository.acquire_job(
+                uid=uid,
+                target_schema_version="post-delete-job-v1",
+                client_request_id=None,
+                request_payload_hash="0" * 64,
+            )
+        with pytest.raises(authority_advisory_lock.AuthorityLockError):
+            await repository.claim_job(str(job_id))
+        with pytest.raises(authority_advisory_lock.AuthorityLockError):
+            await repository.begin_provider_attempt(uid=uid, job_id=str(job_id))
+        with pytest.raises(authority_advisory_lock.AuthorityLockError):
+            await repository.record_cloud_side_effect(
+                uid=uid,
+                job_id=str(job_id),
+                claim_token=str(claim_token),
+                effect={"kind": "synthetic"},
+            )
+        with pytest.raises(authority_advisory_lock.AuthorityLockError):
+            await repository.record_cloud_rollback(
+                job_id=str(job_id),
+                state="blocked",
+                rollback_receipt={"content_free": True},
+                error_code="synthetic",
+                retryable=False,
+            )
+        with pytest.raises(authority_advisory_lock.AuthorityLockError):
+            await repository.record_photon_sidecar_preflight(
+                photon_binding_id=str(photon_binding_id),
+                connection_key="synthetic-connection",
+                oauth_expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+                receipt={"content_free": True},
+            )
+        with pytest.raises(authority_advisory_lock.AuthorityLockError):
+            await repository.ensure_user_identity(
+                uid=uid,
+                email=str(await pool.fetchval("SELECT email FROM users WHERE omi_uid = $1", uid)),
+                name="Resurrected",
+                timezone_name="UTC",
+            )
+        with pytest.raises(authority_advisory_lock.AuthorityLockError):
+            await voice_canary.upsert_entitlement(
+                uid=uid,
+                plan="resurrected",
+                daily_limit_s=1,
+                monthly_limit_s=1,
+                max_session_s=1,
+                max_concurrent=1,
+                soft_limit_ratio=0.8,
+                provider_allowlist=["hermes"],
+                mode_allowlist=["hermes-chat"],
+                fallback_policy={"enabled": False, "order": []},
+                operator_note="synthetic",
+            )
+
+        async with pool.acquire() as connection:
+            with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+                await connection.execute(
+                    """
+                    INSERT INTO ella_runtime_session_scopes (
+                        binding_id, user_id, role, channel, session_key
+                    ) VALUES ($1, $2, 'user', 'chat', $3)
+                    """,
+                    photon_runtime_binding_id,
+                    user_id,
+                    f"post-delete-{uid}",
+                )
+            with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+                await connection.execute(
+                    """
+                    INSERT INTO ella_runtime_ingestion_receipts (
+                        binding_id, canonical_event_id, source_identity, provenance
+                    ) VALUES ($1, 'post-delete-event', 'post-delete-source', 'synthetic')
+                    """,
+                    photon_runtime_binding_id,
+                )
+            with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+                await connection.execute(
+                    """
+                    INSERT INTO ella_photon_message_receipts (
+                        photon_binding_id, inbound_provider_message_key,
+                        inbound_payload_sha256, consent_grant_epoch
+                    ) VALUES ($1, $2, $3, $4)
+                    """,
+                    photon_binding_id,
+                    "3" * 64,
+                    "4" * 64,
+                    "post-delete-grant-epoch",
+                )
+
+        class FirestoreDocument:
+            exists = False
+            writes = []
+
+            def get(self):
+                return self
+
+            def set(self, payload, *, merge):
+                self.writes.append((payload, merge))
+
+        class Firestore:
+            document_ref = FirestoreDocument()
+
+            def collection(self, _name):
+                return self
+
+            def document(self, _uid):
+                return self.document_ref
+
+        fenced_firestore_repository = EllaProvisioningRepository(pool, firestore_db=Firestore())
+        with pytest.raises(authority_advisory_lock.AuthorityLockError):
+            await fenced_firestore_repository.ensure_omi_user_document(
+                uid=uid,
+                email=email,
+                name="Resurrected",
+                timezone_name="UTC",
+            )
+        assert FirestoreDocument.writes == []
+
+        async with pool.acquire() as connection:
+            state = dict(
+                await connection.fetchrow(
+                    """
+                        SELECT u.status, u.identities, entitlement.status AS entitlement_status,
+                               consent.decision AS consent_decision,
+                               photon.status AS photon_status, binding.active,
+                               job.state AS job_state,
+                               (SELECT array_agg(target_status ORDER BY target_status)
+                                FROM (
+                                    SELECT DISTINCT target.status AS target_status
+                                    FROM ella_runtime_targets target
+                                    WHERE target.account_user_id = u.id
+                                       OR target.profile_user_id = u.id
+                                ) statuses) AS target_statuses,
+                               (SELECT COUNT(*)
+                                FROM ella_runtime_bindings all_bindings
+                                WHERE all_bindings.user_id = u.id) AS binding_count
+                        FROM users u
+                        JOIN voice_entitlements entitlement ON entitlement.uid = u.omi_uid
+                        JOIN ella_managed_cloud_consent_authority consent ON consent.user_id = u.id
+                    JOIN ella_photon_channel_bindings photon ON photon.user_id = u.id
+                    JOIN ella_runtime_bindings binding ON binding.id = photon.runtime_binding_id
+                    JOIN ella_provisioning_jobs job ON job.id = $2
+                    WHERE u.id = $1
+                    """,
+                    user_id,
+                    job_id,
+                )
+            )
+        assert state == {
+            "status": "DELETION_PENDING",
+            "identities": "{}",
+            "entitlement_status": "revoked",
+            "consent_decision": "revoked",
+            "photon_status": "quarantined",
+            "active": False,
+            "job_state": "blocked",
+            "target_statuses": ["revoked"],
+            "binding_count": 2,
+        }
 
     asyncio.run(_run_with_database(scenario))

--- a/backend/tests/postgres/test_invitation_redemption_postgres.py
+++ b/backend/tests/postgres/test_invitation_redemption_postgres.py
@@ -11,6 +11,7 @@ import asyncpg
 import pytest
 
 from database import (
+    account_deletion,
     authority_advisory_lock,
     invitation_operator,
     invitations,
@@ -23,6 +24,7 @@ from database.ella_provisioning import (
 )
 from database.runtime_targets import RuntimeTargetLineage, SELF_HOSTED_RUNTIME_MODEL
 from ella.services import ai_consent
+from ella.services import account_deletion as account_deletion_service
 from ella.services import consent_authority, invitation_authority
 from ella.services.provisioning import ProvisioningCoordinator, VerifiedIdentity
 from ella.services.runtime_errors import ProvisioningError
@@ -102,6 +104,8 @@ CREATE TABLE users (
     identities JSONB NOT NULL DEFAULT '{}'::jsonb,
     settings JSONB NOT NULL DEFAULT '{}'::jsonb,
     tags TEXT[] NOT NULL DEFAULT ARRAY[]::text[],
+    conditions TEXT[] NOT NULL DEFAULT ARRAY[]::text[],
+    medications TEXT[] NOT NULL DEFAULT ARRAY[]::text[],
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -153,6 +157,13 @@ CREATE TABLE ella_runtime_bindings (
 
 CREATE UNIQUE INDEX ella_runtime_bindings_user_role_provider_key
     ON ella_runtime_bindings(user_id, role, provider);
+
+CREATE TABLE agent_clusters (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    agents JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL DEFAULT 'ACTIVE'
+);
 """
 
 
@@ -3884,5 +3895,300 @@ def test_kill_switch_after_invite_blocks_claim_and_preserves_pool(monkeypatch):
             "claim_job_id": None,
             "claim_token": None,
         }
+
+    asyncio.run(_run_with_database(scenario))
+
+
+async def _prepare_deletion_account(
+    pool: asyncpg.Pool,
+    *,
+    uid: str,
+    email: str,
+    code: str,
+    activate_runtime: bool,
+) -> tuple[str, str]:
+    issued = await pilot_invite_admin._issue_invitation(
+        code=code,
+        code_file_existed=False,
+        code_file_ref_hmac="7" * 64,
+        kind="ordinary",
+        allowed_email_hash=pilot_invite_admin._email_hash(CONFIG, email),
+        expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+        environment="account-deletion-postgres-test",
+        config=CONFIG,
+    )
+    await _redeem_self_hosted(uid, email, code)
+    if activate_runtime:
+        await managed_cloud_consent.synchronize_grant(grant=_self_hosted_grant(uid))
+        repository = EllaProvisioningRepository(pool)
+        await repository.stage_runtime_binding(
+            uid=uid,
+            binding=_local_runtime_binding(uid),
+        )
+        await repository.activate_runtime_binding(
+            uid=uid,
+            provider="hermes",
+            require_invitation_target=True,
+            authority_lineage=_self_hosted_lineage(),
+            model=SELF_HOSTED_RUNTIME_MODEL,
+        )
+        async with pool.acquire() as connection:
+            user_id = await connection.fetchval(
+                "SELECT id FROM users WHERE omi_uid = $1",
+                uid,
+            )
+            await connection.execute(
+                """
+                INSERT INTO agent_clusters (user_id, agents, status)
+                VALUES ($1, '{"agentId":"content-free"}'::jsonb, 'ACTIVE')
+                """,
+                user_id,
+            )
+    return str(issued["receipt_id"]), uid
+
+
+def test_account_deletion_atomically_quarantines_authority_releases_capacity_and_retries():
+    async def scenario(pool: asyncpg.Pool) -> None:
+        invitation_id, uid = await _prepare_deletion_account(
+            pool,
+            uid="account-delete-complete",
+            email="account-delete-complete@example.test",
+            code="CDEF-6789",
+            activate_runtime=True,
+        )
+
+        first = await account_deletion.quarantine_account_for_deletion(uid)
+        second = await account_deletion.quarantine_account_for_deletion(uid)
+
+        assert first.capacity_released is True
+        assert first.authority_quarantined is True
+        assert first.external_cleanup_required == (
+            "hermes_profile",
+            "honcho_tenancy",
+            "runtime_registry",
+        )
+        assert second.capacity_released is True
+        assert second.counts["invitations"] == 0
+        assert second.counts["capacity_reservations"] == 0
+        with pytest.raises(account_deletion.AccountDeletionUnavailable) as pending:
+            await account_deletion.finalize_account_deletion(uid)
+        assert pending.value.code == "account_deletion_external_cleanup_incomplete"
+
+        async with pool.acquire() as connection:
+            row = await connection.fetchrow(
+                """
+                SELECT invitation.state AS invitation_state,
+                       reservation.state AS capacity_state,
+                       entitlement.status AS entitlement_status,
+                       app_user.status AS user_status,
+                       app_user.email,
+                       binding.status AS binding_status,
+                       binding.active,
+                       cluster.status AS cluster_status,
+                       cluster.agents
+                FROM ella_invitations invitation
+                JOIN ella_invitation_capacity_reservations reservation
+                  ON reservation.id = invitation.capacity_reservation_id
+                JOIN ella_invitation_redemptions redemption
+                  ON redemption.invitation_id = invitation.id
+                JOIN users app_user ON app_user.id = redemption.user_id
+                JOIN voice_entitlements entitlement
+                  ON entitlement.uid = app_user.omi_uid
+                JOIN ella_runtime_bindings binding
+                  ON binding.user_id = app_user.id AND binding.provider = 'hermes'
+                JOIN agent_clusters cluster ON cluster.user_id = app_user.id
+                WHERE invitation.id = $1::uuid
+                """,
+                invitation_id,
+            )
+            target_states = await connection.fetch(
+                """
+                SELECT status
+                FROM ella_runtime_targets
+                WHERE invitation_target_id IN (
+                    SELECT invitation_target_id
+                    FROM ella_invitation_redemptions
+                    WHERE invitation_id = $1::uuid
+                )
+                """,
+                invitation_id,
+            )
+        row_data = dict(row)
+        deleted_email = row_data.pop("email")
+        assert row_data == {
+            "invitation_state": "revoked",
+            "capacity_state": "released",
+            "entitlement_status": "revoked",
+            "user_status": "DELETION_PENDING",
+            "binding_status": "disabled",
+            "active": False,
+            "cluster_status": "INACTIVE",
+            "agents": "{}",
+        }
+        assert deleted_email.startswith("deleted+")
+        assert deleted_email.endswith("@invalid.ella")
+        assert deleted_email != "account-delete-complete@example.test"
+        assert {target["status"] for target in target_states} == {"revoked"}
+
+        # A trusted operator can remove only the already-quarantined external
+        # binding after independently proving the profile/tenancy are absent.
+        async with pool.acquire() as connection:
+            async with connection.transaction():
+                await connection.execute(
+                    """
+                    DELETE FROM ella_runtime_targets
+                    WHERE account_user_id = (
+                        SELECT id FROM users WHERE omi_uid = $1
+                    )
+                    """,
+                    uid,
+                )
+                await connection.execute(
+                    """
+                    DELETE FROM ella_runtime_bindings
+                    WHERE user_id = (
+                        SELECT id FROM users WHERE omi_uid = $1
+                    ) AND provider = 'hermes'
+                    """,
+                    uid,
+                )
+        after_external_cleanup = await account_deletion.quarantine_account_for_deletion(uid)
+        assert after_external_cleanup.external_cleanup_required == ()
+        assert await account_deletion.finalize_account_deletion(uid) is True
+        assert await account_deletion.finalize_account_deletion(uid) is False
+        async with pool.acquire() as connection:
+            assert (
+                await connection.fetchval(
+                    "SELECT status FROM users WHERE omi_uid = $1",
+                    uid,
+                )
+                == "DELETED"
+            )
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_account_deletion_mid_transaction_failure_rolls_back_every_authority_and_capacity_write():
+    async def scenario(pool: asyncpg.Pool) -> None:
+        invitation_id, uid = await _prepare_deletion_account(
+            pool,
+            uid="account-delete-rollback",
+            email="account-delete-rollback@example.test",
+            code="DEFG-789A",
+            activate_runtime=True,
+        )
+        async with pool.acquire() as connection:
+            await connection.execute(
+                """
+                CREATE FUNCTION fail_account_deletion_user_update()
+                RETURNS trigger LANGUAGE plpgsql AS $$
+                BEGIN
+                    IF NEW.status = 'DELETION_PENDING' THEN
+                        RAISE EXCEPTION 'synthetic account deletion failure';
+                    END IF;
+                    RETURN NEW;
+                END
+                $$
+                """
+            )
+            await connection.execute(
+                """
+                CREATE TRIGGER fail_account_deletion_user_update
+                BEFORE UPDATE ON users
+                FOR EACH ROW EXECUTE FUNCTION fail_account_deletion_user_update()
+                """
+            )
+
+        with pytest.raises(account_deletion.AccountDeletionUnavailable) as failed:
+            await account_deletion.quarantine_account_for_deletion(uid)
+        assert failed.value.code == "account_deletion_authority_unavailable"
+
+        async with pool.acquire() as connection:
+            state = await connection.fetchrow(
+                """
+                SELECT invitation.state AS invitation_state,
+                       reservation.state AS capacity_state,
+                       entitlement.status AS entitlement_status,
+                       app_user.status AS user_status,
+                       binding.status AS binding_status,
+                       binding.active
+                FROM ella_invitations invitation
+                JOIN ella_invitation_capacity_reservations reservation
+                  ON reservation.id = invitation.capacity_reservation_id
+                JOIN ella_invitation_redemptions redemption
+                  ON redemption.invitation_id = invitation.id
+                JOIN users app_user ON app_user.id = redemption.user_id
+                JOIN voice_entitlements entitlement
+                  ON entitlement.uid = app_user.omi_uid
+                JOIN ella_runtime_bindings binding
+                  ON binding.user_id = app_user.id AND binding.provider = 'hermes'
+                WHERE invitation.id = $1::uuid
+                """,
+                invitation_id,
+            )
+        assert dict(state) == {
+            "invitation_state": "redeemed",
+            "capacity_state": "consumed",
+            "entitlement_status": "active",
+            "user_status": "ACTIVE",
+            "binding_status": "active",
+            "active": True,
+        }
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_account_deletion_service_handles_partial_provision_and_repeat_without_operator():
+    async def scenario(pool: asyncpg.Pool) -> None:
+        _invitation_id, uid = await _prepare_deletion_account(
+            pool,
+            uid="account-delete-partial",
+            email="account-delete-partial@example.test",
+            code="EFGH-89AB",
+            activate_runtime=False,
+        )
+        side_effects = []
+        for _attempt in range(2):
+            result = await account_deletion_service.execute_account_deletion(
+                uid,
+                delete_firestore=lambda exact_uid: side_effects.append(("firestore", exact_uid)),
+                delete_firebase=lambda exact_uid: side_effects.append(("firebase", exact_uid)),
+            )
+            assert result.status_code == 200
+            assert result.body["status"] == "ok"
+            assert result.body["deletion_receipt"]["status"] == "completed"
+
+        async with pool.acquire() as connection:
+            state = await connection.fetchrow(
+                """
+                SELECT app_user.status AS user_status,
+                       invitation.state AS invitation_state,
+                       reservation.state AS capacity_state,
+                       entitlement.status AS entitlement_status
+                FROM users app_user
+                JOIN ella_invitation_redemptions redemption
+                  ON redemption.user_id = app_user.id
+                JOIN ella_invitations invitation
+                  ON invitation.id = redemption.invitation_id
+                JOIN ella_invitation_capacity_reservations reservation
+                  ON reservation.id = invitation.capacity_reservation_id
+                JOIN voice_entitlements entitlement
+                  ON entitlement.uid = app_user.omi_uid
+                WHERE app_user.omi_uid = $1
+                """,
+                uid,
+            )
+        assert dict(state) == {
+            "user_status": "DELETED",
+            "invitation_state": "revoked",
+            "capacity_state": "released",
+            "entitlement_status": "revoked",
+        }
+        assert side_effects == [
+            ("firestore", uid),
+            ("firebase", uid),
+            ("firestore", uid),
+            ("firebase", uid),
+        ]
 
     asyncio.run(_run_with_database(scenario))

--- a/backend/tests/postgres/test_invitation_redemption_postgres.py
+++ b/backend/tests/postgres/test_invitation_redemption_postgres.py
@@ -4530,6 +4530,299 @@ def test_lost_provider_ack_persists_unproven_attempt_blocks_firebase_and_retry_c
     asyncio.run(_run_with_database(scenario))
 
 
+def test_provider_attempt_tombstone_trigger_allows_only_monotonic_terminal_proof():
+    async def scenario(pool: asyncpg.Pool) -> None:
+        async with pool.acquire() as connection:
+            await _ensure_users(
+                connection,
+                ("provider-trigger-active", "provider-trigger-pending", "provider-trigger-deleted", "other-owner"),
+            )
+
+            async def seed_attempt(uid: str, suffix: str) -> tuple[uuid.UUID, uuid.UUID, uuid.UUID]:
+                user_id = await connection.fetchval("SELECT id FROM users WHERE omi_uid = $1", uid)
+                job_id = await connection.fetchval(
+                    """
+                    INSERT INTO ella_provisioning_jobs (user_id, target_schema_version)
+                    VALUES ($1, $2) RETURNING id
+                    """,
+                    user_id,
+                    f"provider-trigger-{suffix}",
+                )
+                attempt_id = await connection.fetchval(
+                    """
+                    INSERT INTO ella_provider_attempts (
+                        user_id, provisioning_job_id, provider, operation,
+                        idempotency_key, correlation_ref
+                    ) VALUES ($1, $2, 'hermes', 'provision', $3, $4)
+                    RETURNING id
+                    """,
+                    user_id,
+                    job_id,
+                    uuid.uuid4(),
+                    f"ella-ext-{uuid.uuid4().hex[:16]}",
+                )
+                return user_id, job_id, attempt_id
+
+            active_user_id, _active_job_id, active_attempt_id = await seed_attempt(
+                "provider-trigger-active",
+                "active",
+            )
+            await connection.execute(
+                "UPDATE ella_provider_attempts SET updated_at = CURRENT_TIMESTAMP WHERE id = $1",
+                active_attempt_id,
+            )
+            assert (
+                await connection.fetchval(
+                    "SELECT proof_state FROM ella_provider_attempts WHERE id = $1",
+                    active_attempt_id,
+                )
+                == "unproven"
+            )
+
+            pending_user_id, pending_job_id, pending_attempt_id = await seed_attempt(
+                "provider-trigger-pending",
+                "pending",
+            )
+            _pending_user_id_2, _pending_job_id_2, pending_cleanup_id = await seed_attempt(
+                "provider-trigger-pending",
+                "pending-cleanup",
+            )
+            deleted_user_id, deleted_job_id, deleted_attempt_id = await seed_attempt(
+                "provider-trigger-deleted",
+                "deleted",
+            )
+            other_owner_id = await connection.fetchval("SELECT id FROM users WHERE omi_uid = 'other-owner'")
+            await connection.execute(
+                "UPDATE users SET status = 'DELETION_PENDING' WHERE id = $1",
+                pending_user_id,
+            )
+            await connection.execute(
+                "UPDATE users SET status = 'DELETED' WHERE id = $1",
+                deleted_user_id,
+            )
+
+            trigger_name = await connection.fetchval(
+                """
+                SELECT tgname
+                FROM pg_trigger
+                WHERE tgrelid = 'ella_provider_attempts'::regclass
+                  AND NOT tgisinternal
+                """
+            )
+            assert trigger_name == "ella_provider_attempt_tombstone_write_fence"
+
+            for user_id, job_id in (
+                (pending_user_id, pending_job_id),
+                (deleted_user_id, deleted_job_id),
+            ):
+                with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+                    await connection.execute(
+                        """
+                        INSERT INTO ella_provider_attempts (
+                            user_id, provisioning_job_id, provider, operation,
+                            idempotency_key, correlation_ref
+                        ) VALUES ($1, $2, 'hermes', 'provision', $3, $4)
+                        """,
+                        user_id,
+                        job_id,
+                        uuid.uuid4(),
+                        f"ella-ext-{uuid.uuid4().hex[:16]}",
+                    )
+
+            with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+                await connection.execute(
+                    "UPDATE ella_provider_attempts SET updated_at = updated_at WHERE id = $1",
+                    pending_attempt_id,
+                )
+            with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+                await connection.execute(
+                    "UPDATE ella_provider_attempts SET user_id = $2 WHERE id = $1",
+                    pending_attempt_id,
+                    other_owner_id,
+                )
+            with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+                await connection.execute(
+                    "UPDATE ella_provider_attempts SET idempotency_key = $2 WHERE id = $1",
+                    pending_attempt_id,
+                    uuid.uuid4(),
+                )
+            with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+                await connection.execute(
+                    "UPDATE ella_provider_attempts SET correlation_ref = $2 WHERE id = $1",
+                    pending_attempt_id,
+                    f"ella-ext-{uuid.uuid4().hex[:16]}",
+                )
+            with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+                await connection.execute(
+                    "UPDATE ella_provider_attempts SET id = $2 WHERE id = $1",
+                    pending_attempt_id,
+                    uuid.uuid4(),
+                )
+            with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+                await connection.execute(
+                    "UPDATE ella_provider_attempts SET provisioning_job_id = $2 WHERE id = $1",
+                    pending_attempt_id,
+                    _pending_job_id_2,
+                )
+            with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+                await connection.execute(
+                    "UPDATE ella_provider_attempts SET provider = 'other' WHERE id = $1",
+                    pending_attempt_id,
+                )
+            with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+                await connection.execute(
+                    "UPDATE ella_provider_attempts SET operation = 'other' WHERE id = $1",
+                    pending_attempt_id,
+                )
+            with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+                await connection.execute(
+                    "UPDATE ella_provider_attempts SET content_free = false WHERE id = $1",
+                    pending_attempt_id,
+                )
+
+            await connection.execute(
+                """
+                UPDATE ella_provider_attempts
+                SET proof_state = 'absence_proven',
+                    proved_at = CURRENT_TIMESTAMP,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = $1
+                """,
+                pending_cleanup_id,
+            )
+            await connection.execute(
+                """
+                UPDATE ella_provider_attempts
+                SET proof_state = 'deprovisioned',
+                    proved_at = CURRENT_TIMESTAMP,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = $1
+                """,
+                deleted_attempt_id,
+            )
+            assert (
+                await connection.fetchval(
+                    "SELECT COUNT(*) FROM ella_provider_attempts WHERE proof_state = 'unproven' AND user_id = $1",
+                    deleted_user_id,
+                )
+                == 0
+            )
+
+            for attempt_id in (pending_cleanup_id, deleted_attempt_id):
+                with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+                    await connection.execute(
+                        """
+                        UPDATE ella_provider_attempts
+                        SET proof_state = 'unproven', proved_at = NULL,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE id = $1
+                        """,
+                        attempt_id,
+                    )
+                with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+                    await connection.execute(
+                        """
+                        UPDATE ella_provider_attempts
+                        SET proof_state = CASE
+                                WHEN proof_state = 'deprovisioned' THEN 'absence_proven'
+                                ELSE 'deprovisioned'
+                            END,
+                            proved_at = CURRENT_TIMESTAMP,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE id = $1
+                        """,
+                        attempt_id,
+                    )
+
+            assert active_user_id != pending_user_id != deleted_user_id
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_provider_attempt_direct_writer_cannot_cross_finalization_count_read():
+    async def scenario(pool: asyncpg.Pool) -> None:
+        uid = "provider-attempt-finalize-race"
+        async with pool.acquire() as connection:
+            await _ensure_users(connection, (uid,))
+            user_id = await connection.fetchval("SELECT id FROM users WHERE omi_uid = $1", uid)
+            job_id = await connection.fetchval(
+                """
+                INSERT INTO ella_provisioning_jobs (user_id, target_schema_version)
+                VALUES ($1, 'provider-attempt-finalize-race') RETURNING id
+                """,
+                user_id,
+            )
+            await connection.execute(
+                "UPDATE users SET status = 'DELETION_PENDING' WHERE id = $1",
+                user_id,
+            )
+            await connection.execute("CREATE SEQUENCE provider_attempt_finalize_probe")
+            await connection.execute(
+                """
+                CREATE FUNCTION delay_provider_attempt_finalization() RETURNS trigger AS $$
+                BEGIN
+                    IF NEW.status = 'DELETED' AND OLD.status = 'DELETION_PENDING' THEN
+                        PERFORM nextval('provider_attempt_finalize_probe');
+                        PERFORM pg_sleep(0.5);
+                    END IF;
+                    RETURN NEW;
+                END
+                $$ LANGUAGE plpgsql
+                """
+            )
+            await connection.execute(
+                """
+                CREATE TRIGGER delay_provider_attempt_finalization
+                BEFORE UPDATE ON users
+                FOR EACH ROW EXECUTE FUNCTION delay_provider_attempt_finalization()
+                """
+            )
+
+        async def direct_insert() -> None:
+            async with pool.acquire() as connection:
+                await connection.execute(
+                    """
+                    INSERT INTO ella_provider_attempts (
+                        user_id, provisioning_job_id, provider, operation,
+                        idempotency_key, correlation_ref
+                    ) VALUES ($1, $2, 'hermes', 'provision', $3, $4)
+                    """,
+                    user_id,
+                    job_id,
+                    uuid.uuid4(),
+                    f"ella-ext-{uuid.uuid4().hex[:16]}",
+                )
+
+        finalization = asyncio.create_task(account_deletion.finalize_account_deletion(uid))
+        for _attempt in range(200):
+            async with pool.acquire() as connection:
+                count_read_completed = await connection.fetchval(
+                    "SELECT is_called FROM provider_attempt_finalize_probe"
+                )
+            if count_read_completed:
+                break
+            await asyncio.sleep(0.01)
+        assert count_read_completed is True
+        racing_insert = asyncio.create_task(direct_insert())
+        assert await finalization is True
+        with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+            await racing_insert
+
+        with pytest.raises(asyncpg.PostgresError, match="authority_write_user_not_active"):
+            await direct_insert()
+        async with pool.acquire() as connection:
+            assert await connection.fetchval("SELECT status FROM users WHERE id = $1", user_id) == "DELETED"
+            assert (
+                await connection.fetchval(
+                    "SELECT COUNT(*) FROM ella_provider_attempts WHERE user_id = $1",
+                    user_id,
+                )
+                == 0
+            )
+
+    asyncio.run(_run_with_database(scenario))
+
+
 def test_deletion_tombstone_serializes_inflight_provider_writer_and_quarantines_photon_immediately():
     async def scenario(pool: asyncpg.Pool) -> None:
         uid = "account-delete-writer-fence"

--- a/backend/tests/postgres/test_invitation_redemption_postgres.py
+++ b/backend/tests/postgres/test_invitation_redemption_postgres.py
@@ -93,6 +93,19 @@ pytestmark = pytest.mark.skipif(
     reason="ELLA_TEST_POSTGRES_DSN is required for invitation PostgreSQL tests",
 )
 
+
+@pytest.fixture(autouse=True)
+def _successful_content_writer_drain(monkeypatch):
+    async def tombstone(_uid):
+        return True
+
+    monkeypatch.setattr(
+        account_deletion_service.content_write_fence,
+        "tombstone_content_writes",
+        tombstone,
+    )
+
+
 BASE_PROVISIONING_SCHEMA = """
 CREATE TABLE users (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/backend/tests/postgres/test_runtime_migration_atomicity_postgres.py
+++ b/backend/tests/postgres/test_runtime_migration_atomicity_postgres.py
@@ -130,6 +130,10 @@ async def _assert_failure_rolls_back(filename: str, leaked_relations: tuple[str,
             "015_add_invitation_allowed_email_hash.sql",
             ("ella_runtime_targets_invitation_target_key",),
         ),
+        (
+            "017_add_provider_attempt_deletion_fence.sql",
+            ("ella_provider_attempts",),
+        ),
     ],
 )
 def test_migration_prerequisite_failure_is_atomic(filename, leaked_relations):

--- a/backend/tests/support/__init__.py
+++ b/backend/tests/support/__init__.py
@@ -1,0 +1,3 @@
+"""Test-only support modules; production code never imports this package."""
+
+"""Test-only adapters for recovery controls on non-production hosts."""

--- a/backend/tests/support/content_writer_owner_nonlinux.py
+++ b/backend/tests/support/content_writer_owner_nonlinux.py
@@ -1,0 +1,55 @@
+"""Non-production process adapter for running unit tests on Darwin."""
+
+from __future__ import annotations
+
+import hashlib
+import socket
+import subprocess
+
+from database import content_writer_owner
+
+_PS = "/bin/ps"
+_SYSCTL = "/usr/sbin/sysctl"
+
+
+def current_process_boundary() -> content_writer_owner.ProcessBoundary:
+    boot = subprocess.run(
+        [_SYSCTL, "-n", "kern.boottime"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=2,
+    ).stdout.strip()
+    host = socket.gethostname().strip()
+    return content_writer_owner.ProcessBoundary(
+        system="Linux",
+        host_id=hashlib.sha256(f"darwin-test-only:{host}".encode("utf-8")).hexdigest(),
+        boot_id=f"darwin-test-only:{boot}",
+        pid_namespace="darwin-test-only-process-table",
+    )
+
+
+def _ps_value(pid: int, field: str) -> str | None:
+    completed = subprocess.run(
+        [_PS, "-o", f"{field}=", "-p", str(pid)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=2,
+    )
+    if completed.returncode != 0:
+        return None
+    value = completed.stdout.strip()
+    return value or None
+
+
+def process_snapshot(system: str, pid: int) -> content_writer_owner.ProcessSnapshot | None:
+    assert system == "Linux"
+    first_start = _ps_value(pid, "lstart")
+    if first_start is None:
+        return None
+    state = _ps_value(pid, "state")
+    second_start = _ps_value(pid, "lstart")
+    if state is None or second_start is None or first_start != second_start:
+        raise content_writer_owner.ProcessOwnerError("account_writer_process_state_unknown")
+    return content_writer_owner.ProcessSnapshot(start_id=f"darwin-test-only:{first_start}", state=state[:1])

--- a/backend/tests/unit/test_account_deletion.py
+++ b/backend/tests/unit/test_account_deletion.py
@@ -1,7 +1,9 @@
 import asyncio
 import ast
 from pathlib import Path
+from types import SimpleNamespace
 
+from fastapi import Depends, Response
 from database import account_deletion as account_deletion_db
 from database.firestore_account_deletion import delete_firestore_user_data
 from ella.services import account_deletion as account_deletion_service
@@ -80,8 +82,28 @@ def _state(*, external=()):
         capacity_released=True,
         authority_quarantined=True,
         external_cleanup_required=tuple(external),
+        external_cleanup_references=(),
         counts={},
     )
+
+
+def _load_production_delete_route():
+    path = Path(__file__).resolve().parents[2] / "routers" / "users.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    route = next(node for node in tree.body if isinstance(node, ast.AsyncFunctionDef) and node.name == "delete_account")
+    route.decorator_list = []
+    namespace = {
+        "Depends": Depends,
+        "Response": Response,
+        "auth": SimpleNamespace(
+            get_authenticated_user_uid=lambda: "unused",
+            delete_account=lambda _uid: None,
+        ),
+        "delete_user_data": lambda _uid: None,
+        "execute_account_deletion": account_deletion_service.execute_account_deletion,
+    }
+    exec(compile(ast.fix_missing_locations(ast.Module(body=[route], type_ignores=[])), str(path), "exec"), namespace)
+    return namespace["delete_account"], namespace
 
 
 def test_authenticated_route_delegates_to_the_resumable_deletion_service():
@@ -256,3 +278,98 @@ def test_firebase_delete_lost_ack_converges_only_after_authoritative_absence(mon
     )
 
     assert auth_endpoints.delete_account("synthetic-user") == {"status": "already_deleted"}
+
+
+def test_production_route_uses_legacy_resumable_deletion_when_ella_authority_is_explicitly_disabled(monkeypatch):
+    calls = []
+    monkeypatch.setenv("ELLA_ENABLED", "false")
+    monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "false")
+
+    async def forbidden_quarantine(_uid):
+        raise AssertionError("disabled Ella persistence must not be probed")
+
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "quarantine_account_for_deletion",
+        forbidden_quarantine,
+    )
+    route, namespace = _load_production_delete_route()
+    namespace["delete_user_data"] = lambda uid: calls.append(("firestore", uid))
+    namespace["auth"].delete_account = lambda uid: calls.append(("firebase", uid))
+    response = Response()
+    body = asyncio.run(route(response=response, uid="authenticated-user"))
+
+    assert response.status_code == 200
+    assert body["status"] == "ok"
+    assert calls == [("firestore", "authenticated-user"), ("firebase", "authenticated-user")]
+
+
+def test_production_route_fails_closed_before_destructive_work_when_enabled_authority_is_unavailable(monkeypatch):
+    calls = []
+    monkeypatch.setenv("ELLA_ENABLED", "true")
+    monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "true")
+
+    async def unavailable(_uid):
+        raise account_deletion_db.AccountDeletionUnavailable("account_deletion_authority_unavailable")
+
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "quarantine_account_for_deletion",
+        unavailable,
+    )
+    route, namespace = _load_production_delete_route()
+    namespace["delete_user_data"] = lambda uid: calls.append(("firestore", uid))
+    namespace["auth"].delete_account = lambda uid: calls.append(("firebase", uid))
+    try:
+        asyncio.run(
+            route(
+                response=Response(),
+                uid="authenticated-user",
+            )
+        )
+    except Exception as exc:
+        assert exc.status_code == 503
+        assert exc.detail == {
+            "code": "account_deletion_authority_unavailable",
+            "retryable": True,
+        }
+    else:
+        raise AssertionError("enabled unavailable authority must fail closed")
+    assert calls == []
+
+
+def test_retained_firebase_subject_is_fenced_from_authenticated_content_writes(monkeypatch):
+    class Pool:
+        async def fetchval(self, _query, uid):
+            assert uid == "retained-firebase-subject"
+            return "DELETION_PENDING"
+
+    async def pool():
+        return Pool()
+
+    monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "true")
+    monkeypatch.setattr(auth_endpoints.voice_canary, "get_pool", pool)
+
+    try:
+        asyncio.run(auth_endpoints.assert_authenticated_user_writable("retained-firebase-subject"))
+    except Exception as exc:
+        assert exc.status_code == 403
+        assert exc.detail == {
+            "code": "account_write_forbidden",
+            "retryable": False,
+        }
+    else:
+        raise AssertionError("tombstoned Firebase subject must not regain content write authority")
+
+
+def test_explicit_legacy_mode_does_not_probe_optional_ella_authority_for_content_writes(monkeypatch):
+    async def forbidden_pool():
+        raise AssertionError("explicitly disabled Ella authority must not be probed")
+
+    monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "false")
+    monkeypatch.setattr(auth_endpoints.voice_canary, "get_pool", forbidden_pool)
+
+    assert (
+        asyncio.run(auth_endpoints.assert_authenticated_user_writable("legacy-firebase-subject"))
+        == "legacy-firebase-subject"
+    )

--- a/backend/tests/unit/test_account_deletion.py
+++ b/backend/tests/unit/test_account_deletion.py
@@ -18,10 +18,18 @@ def _successful_content_fence(monkeypatch):
     async def tombstone(_uid):
         return True
 
+    async def purge_routing_traces(_uid):
+        return 0
+
     monkeypatch.setattr(
         account_deletion_service.content_write_fence,
         "tombstone_content_writes",
         tombstone,
+    )
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "purge_routing_traces",
+        purge_routing_traces,
     )
 
 
@@ -323,6 +331,35 @@ def test_deletion_service_converts_firestore_and_firebase_failures_to_resumable_
     )
     assert retry.status_code == 200
     assert retry_calls == ["firestore", "firebase"]
+
+
+def test_deletion_service_never_reports_success_when_routing_trace_purge_is_unavailable(monkeypatch):
+    calls = []
+
+    async def quarantine(_uid):
+        return _state()
+
+    async def unavailable(_uid):
+        raise account_deletion_db.AccountDeletionUnavailable("account_deletion_routing_traces_unavailable")
+
+    async def forbidden_finalize(_uid):
+        raise AssertionError("trace absence must precede finalization")
+
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "quarantine_account_for_deletion", quarantine)
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "purge_routing_traces", unavailable)
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "finalize_account_deletion", forbidden_finalize)
+
+    result = asyncio.run(
+        account_deletion_service.execute_account_deletion(
+            "synthetic-user",
+            delete_firestore=lambda uid: calls.append(("firestore", uid)),
+            delete_firebase=lambda uid: calls.append(("firebase", uid)),
+        )
+    )
+
+    assert result.status_code == 202
+    assert result.body["deletion_receipt"]["remaining"] == ["routing_traces"]
+    assert calls == [("firestore", "synthetic-user")]
 
 
 def test_firebase_delete_lost_ack_converges_only_after_authoritative_absence(monkeypatch):

--- a/backend/tests/unit/test_account_deletion.py
+++ b/backend/tests/unit/test_account_deletion.py
@@ -24,6 +24,9 @@ def _successful_content_fence(monkeypatch):
     async def purge_memory_reinterpretation_work(_uid):
         return 0
 
+    async def purge_canonical_event_ledger(_uid):
+        return 0
+
     monkeypatch.setattr(
         account_deletion_service.content_write_fence,
         "tombstone_content_writes",
@@ -38,6 +41,11 @@ def _successful_content_fence(monkeypatch):
         account_deletion_service.account_deletion_db,
         "purge_memory_reinterpretation_work",
         purge_memory_reinterpretation_work,
+    )
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "purge_canonical_event_ledger",
+        purge_canonical_event_ledger,
     )
 
 
@@ -412,6 +420,51 @@ def test_deletion_service_retains_firebase_when_memory_work_purge_is_unavailable
     assert result.status_code == 202
     assert result.body["deletion_receipt"]["remaining"] == ["memory_reinterpretation"]
     assert calls == [("firestore", "synthetic-user")]
+
+
+def test_canonical_ledger_purge_is_resumable_and_precedes_firebase_last(monkeypatch):
+    calls = []
+
+    async def quarantine(_uid):
+        return _state()
+
+    async def unavailable(_uid):
+        calls.append("canonical-purge-failed")
+        raise account_deletion_db.AccountDeletionUnavailable("account_deletion_canonical_event_ledger_unavailable")
+
+    async def purged(_uid):
+        calls.append("canonical-purged")
+        return 2
+
+    async def finalize(_uid):
+        calls.append("finalized")
+        return True
+
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "quarantine_account_for_deletion", quarantine)
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "purge_canonical_event_ledger", unavailable)
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "finalize_account_deletion", finalize)
+
+    pending = asyncio.run(
+        account_deletion_service.execute_account_deletion(
+            "synthetic-user",
+            delete_firestore=lambda _uid: calls.append("firestore"),
+            delete_firebase=lambda _uid: calls.append("firebase"),
+        )
+    )
+    assert pending.status_code == 202
+    assert pending.body["deletion_receipt"]["remaining"] == ["canonical_event_ledger"]
+    assert calls == ["canonical-purge-failed", "firestore"]
+
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "purge_canonical_event_ledger", purged)
+    completed = asyncio.run(
+        account_deletion_service.execute_account_deletion(
+            "synthetic-user",
+            delete_firestore=lambda _uid: calls.append("firestore-retry"),
+            delete_firebase=lambda _uid: calls.append("firebase"),
+        )
+    )
+    assert completed.status_code == 200
+    assert calls[-4:] == ["canonical-purged", "firestore-retry", "finalized", "firebase"]
 
 
 def test_firebase_delete_lost_ack_converges_only_after_authoritative_absence(monkeypatch):

--- a/backend/tests/unit/test_account_deletion.py
+++ b/backend/tests/unit/test_account_deletion.py
@@ -1,14 +1,28 @@
 import asyncio
 import ast
+from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
 
 from fastapi import Depends, Response
+import pytest
 from database import account_deletion as account_deletion_db
 from database.firestore_account_deletion import delete_firestore_user_data
 from ella.services import account_deletion as account_deletion_service
 from firebase_admin.auth import UserNotFoundError
 from utils.other import endpoints as auth_endpoints
+
+
+@pytest.fixture(autouse=True)
+def _successful_content_fence(monkeypatch):
+    async def tombstone(_uid):
+        return True
+
+    monkeypatch.setattr(
+        account_deletion_service.content_write_fence,
+        "tombstone_content_writes",
+        tombstone,
+    )
 
 
 class _Snapshot:
@@ -264,6 +278,26 @@ def test_deletion_service_converts_firestore_and_firebase_failures_to_resumable_
     assert firebase_pending.status_code == 202
     assert firebase_pending.body["deletion_receipt"]["remaining"] == ["firebase_identity"]
 
+    retry_calls = []
+
+    async def quarantine_with_firestore_retry(_uid):
+        return _state(external=("firestore_data",))
+
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "quarantine_account_for_deletion",
+        quarantine_with_firestore_retry,
+    )
+    retry = asyncio.run(
+        account_deletion_service.execute_account_deletion(
+            "synthetic-user",
+            delete_firestore=lambda _uid: retry_calls.append("firestore"),
+            delete_firebase=lambda _uid: retry_calls.append("firebase"),
+        )
+    )
+    assert retry.status_code == 200
+    assert retry_calls == ["firestore", "firebase"]
+
 
 def test_firebase_delete_lost_ack_converges_only_after_authoritative_absence(monkeypatch):
     monkeypatch.setattr(
@@ -339,16 +373,18 @@ def test_production_route_fails_closed_before_destructive_work_when_enabled_auth
 
 
 def test_retained_firebase_subject_is_fenced_from_authenticated_content_writes(monkeypatch):
-    class Pool:
-        async def fetchval(self, _query, uid):
-            assert uid == "retained-firebase-subject"
-            return "DELETION_PENDING"
-
-    async def pool():
-        return Pool()
+    @asynccontextmanager
+    async def tombstoned_fence(uid):
+        assert uid == "retained-firebase-subject"
+        raise account_deletion_service.content_write_fence.ContentWriteFenceError("account_write_forbidden")
+        yield  # pragma: no cover
 
     monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "true")
-    monkeypatch.setattr(auth_endpoints.voice_canary, "get_pool", pool)
+    monkeypatch.setattr(
+        auth_endpoints.content_write_fence,
+        "content_write_fence",
+        tombstoned_fence,
+    )
 
     try:
         asyncio.run(auth_endpoints.assert_authenticated_user_writable("retained-firebase-subject"))
@@ -405,8 +441,18 @@ def test_explicit_legacy_mode_does_not_probe_optional_ella_authority_for_content
     async def forbidden_pool():
         raise AssertionError("explicitly disabled Ella authority must not be probed")
 
+    @asynccontextmanager
+    async def allowed_fence(uid):
+        assert uid == "legacy-firebase-subject"
+        yield uid
+
     monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "false")
-    monkeypatch.setattr(auth_endpoints.voice_canary, "get_pool", forbidden_pool)
+    monkeypatch.setattr(
+        account_deletion_service.content_write_fence.voice_canary,
+        "get_pool",
+        forbidden_pool,
+    )
+    monkeypatch.setattr(auth_endpoints.content_write_fence, "content_write_fence", allowed_fence)
 
     assert (
         asyncio.run(auth_endpoints.assert_authenticated_user_writable("legacy-firebase-subject"))

--- a/backend/tests/unit/test_account_deletion.py
+++ b/backend/tests/unit/test_account_deletion.py
@@ -31,11 +31,12 @@ class _Snapshot:
 
 
 class _Document:
-    def __init__(self, name, *, exists=True, children=None):
+    def __init__(self, name, *, exists=True, children=None, data=None):
         self.name = name
         self.exists = exists
         self.deleted = False
         self._children = list(children or ())
+        self.data = dict(data or {})
 
     def get(self):
         return type("DocumentState", (), {"exists": self.exists and not self.deleted})()
@@ -53,6 +54,11 @@ class _Collection:
 
     def limit(self, _batch_size):
         return self
+
+    def where(self, *, filter):
+        return _Collection(
+            [document for document in self.documents if document.data.get(filter.field_path) == filter.value]
+        )
 
     def stream(self):
         return [_Snapshot(document) for document in self.documents if not document.deleted]
@@ -75,13 +81,17 @@ class _Batch:
 
 
 class _Firestore:
-    def __init__(self, user_document):
+    def __init__(self, user_document, *, import_jobs=None):
         self.user_document = user_document
+        self.import_jobs = _Collection(import_jobs)
         self.fail_next_commit = False
 
     def collection(self, name):
-        assert name == "users"
-        return self
+        if name == "users":
+            return self
+        if name == "import_jobs":
+            return self.import_jobs
+        raise AssertionError(name)
 
     def document(self, _uid):
         return self.user_document
@@ -160,6 +170,22 @@ def test_firestore_delete_is_idempotent_and_resumes_after_partial_failure():
     }
     assert replay["status"] == "ok"
     assert replay["documents_deleted"] == 0
+
+
+def test_firestore_delete_removes_only_owned_top_level_import_jobs_and_retries():
+    owned_job = _Document("owned-job", data={"uid": "synthetic-user"})
+    other_job = _Document("other-job", data={"uid": "other-user"})
+    root_document = _Document("user")
+    firestore = _Firestore(root_document, import_jobs=[owned_job, other_job])
+
+    result = delete_firestore_user_data(firestore, "synthetic-user")
+    replay = delete_firestore_user_data(firestore, "synthetic-user")
+
+    assert result["documents_deleted"] == 2
+    assert replay["documents_deleted"] == 0
+    assert owned_job.deleted is True
+    assert other_job.deleted is False
+    assert root_document.deleted is True
 
 
 def test_deletion_service_returns_typed_pending_and_preserves_auth_retry(monkeypatch):

--- a/backend/tests/unit/test_account_deletion.py
+++ b/backend/tests/unit/test_account_deletion.py
@@ -21,6 +21,9 @@ def _successful_content_fence(monkeypatch):
     async def purge_routing_traces(_uid):
         return 0
 
+    async def purge_memory_reinterpretation_work(_uid):
+        return 0
+
     monkeypatch.setattr(
         account_deletion_service.content_write_fence,
         "tombstone_content_writes",
@@ -30,6 +33,11 @@ def _successful_content_fence(monkeypatch):
         account_deletion_service.account_deletion_db,
         "purge_routing_traces",
         purge_routing_traces,
+    )
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "purge_memory_reinterpretation_work",
+        purge_memory_reinterpretation_work,
     )
 
 
@@ -89,9 +97,10 @@ class _Batch:
 
 
 class _Firestore:
-    def __init__(self, user_document, *, import_jobs=None):
+    def __init__(self, user_document, *, import_jobs=None, enrichment_jobs=None):
         self.user_document = user_document
         self.import_jobs = _Collection(import_jobs)
+        self.enrichment_jobs = _Collection(enrichment_jobs)
         self.fail_next_commit = False
 
     def collection(self, name):
@@ -99,6 +108,8 @@ class _Firestore:
             return self
         if name == "import_jobs":
             return self.import_jobs
+        if name == "ella_hermes_cloud_enrichment_outbox":
+            return self.enrichment_jobs
         raise AssertionError(name)
 
     def document(self, _uid):
@@ -180,19 +191,27 @@ def test_firestore_delete_is_idempotent_and_resumes_after_partial_failure():
     assert replay["documents_deleted"] == 0
 
 
-def test_firestore_delete_removes_only_owned_top_level_import_jobs_and_retries():
+def test_firestore_delete_removes_only_owned_top_level_jobs_and_retries():
     owned_job = _Document("owned-job", data={"uid": "synthetic-user"})
     other_job = _Document("other-job", data={"uid": "other-user"})
+    owned_enrichment = _Document("owned-enrichment", data={"uid": "synthetic-user"})
+    other_enrichment = _Document("other-enrichment", data={"uid": "other-user"})
     root_document = _Document("user")
-    firestore = _Firestore(root_document, import_jobs=[owned_job, other_job])
+    firestore = _Firestore(
+        root_document,
+        import_jobs=[owned_job, other_job],
+        enrichment_jobs=[owned_enrichment, other_enrichment],
+    )
 
     result = delete_firestore_user_data(firestore, "synthetic-user")
     replay = delete_firestore_user_data(firestore, "synthetic-user")
 
-    assert result["documents_deleted"] == 2
+    assert result["documents_deleted"] == 3
     assert replay["documents_deleted"] == 0
     assert owned_job.deleted is True
     assert other_job.deleted is False
+    assert owned_enrichment.deleted is True
+    assert other_enrichment.deleted is False
     assert root_document.deleted is True
 
 
@@ -359,6 +378,39 @@ def test_deletion_service_never_reports_success_when_routing_trace_purge_is_unav
 
     assert result.status_code == 202
     assert result.body["deletion_receipt"]["remaining"] == ["routing_traces"]
+    assert calls == [("firestore", "synthetic-user")]
+
+
+def test_deletion_service_retains_firebase_when_memory_work_purge_is_unavailable(monkeypatch):
+    calls = []
+
+    async def quarantine(_uid):
+        return _state()
+
+    async def unavailable(_uid):
+        raise account_deletion_db.AccountDeletionUnavailable("account_deletion_memory_reinterpretation_unavailable")
+
+    async def forbidden_finalize(_uid):
+        raise AssertionError("memory-work absence must precede finalization")
+
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "quarantine_account_for_deletion", quarantine)
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "purge_memory_reinterpretation_work",
+        unavailable,
+    )
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "finalize_account_deletion", forbidden_finalize)
+
+    result = asyncio.run(
+        account_deletion_service.execute_account_deletion(
+            "synthetic-user",
+            delete_firestore=lambda uid: calls.append(("firestore", uid)),
+            delete_firebase=lambda uid: calls.append(("firebase", uid)),
+        )
+    )
+
+    assert result.status_code == 202
+    assert result.body["deletion_receipt"]["remaining"] == ["memory_reinterpretation"]
     assert calls == [("firestore", "synthetic-user")]
 
 

--- a/backend/tests/unit/test_account_deletion.py
+++ b/backend/tests/unit/test_account_deletion.py
@@ -1,0 +1,258 @@
+import asyncio
+import ast
+from pathlib import Path
+
+from database import account_deletion as account_deletion_db
+from database.firestore_account_deletion import delete_firestore_user_data
+from ella.services import account_deletion as account_deletion_service
+from firebase_admin.auth import UserNotFoundError
+from utils.other import endpoints as auth_endpoints
+
+
+class _Snapshot:
+    def __init__(self, reference):
+        self.reference = reference
+
+
+class _Document:
+    def __init__(self, name, *, exists=True, children=None):
+        self.name = name
+        self.exists = exists
+        self.deleted = False
+        self._children = list(children or ())
+
+    def get(self):
+        return type("DocumentState", (), {"exists": self.exists and not self.deleted})()
+
+    def collections(self):
+        return list(self._children)
+
+    def delete(self):
+        self.deleted = True
+
+
+class _Collection:
+    def __init__(self, documents=None):
+        self.documents = list(documents or ())
+
+    def limit(self, _batch_size):
+        return self
+
+    def stream(self):
+        return [_Snapshot(document) for document in self.documents if not document.deleted]
+
+
+class _Batch:
+    def __init__(self, database):
+        self.database = database
+        self.references = []
+
+    def delete(self, reference):
+        self.references.append(reference)
+
+    def commit(self):
+        if self.database.fail_next_commit:
+            self.database.fail_next_commit = False
+            raise RuntimeError("synthetic_firestore_failure")
+        for reference in self.references:
+            reference.delete()
+
+
+class _Firestore:
+    def __init__(self, user_document):
+        self.user_document = user_document
+        self.fail_next_commit = False
+
+    def collection(self, name):
+        assert name == "users"
+        return self
+
+    def document(self, _uid):
+        return self.user_document
+
+    def batch(self):
+        return _Batch(self)
+
+
+def _state(*, external=()):
+    return account_deletion_db.AccountDeletionState(
+        user_found=True,
+        capacity_released=True,
+        authority_quarantined=True,
+        external_cleanup_required=tuple(external),
+        counts={},
+    )
+
+
+def test_authenticated_route_delegates_to_the_resumable_deletion_service():
+    path = Path(__file__).resolve().parents[2] / "routers" / "users.py"
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    route = next(node for node in tree.body if isinstance(node, ast.AsyncFunctionDef) and node.name == "delete_account")
+    route_source = ast.get_source_segment(source, route) or ""
+
+    assert "@router.delete('/v1/users/delete-account'" in source
+    assert "await execute_account_deletion(" in route_source
+    assert "delete_firestore=delete_user_data" in route_source
+    assert "delete_firebase=auth.delete_account" in route_source
+    assert "except Exception" not in route_source
+
+
+def test_firestore_delete_is_idempotent_and_resumes_after_partial_failure():
+    nested_document = _Document("nested")
+    child_document = _Document("child", children=[_Collection([nested_document])])
+    root_document = _Document(
+        "user",
+        children=[_Collection([]), _Collection([child_document])],
+    )
+    firestore = _Firestore(root_document)
+    firestore.fail_next_commit = True
+    try:
+        delete_firestore_user_data(firestore, "synthetic-user")
+    except RuntimeError as exc:
+        assert str(exc) == "synthetic_firestore_failure"
+    else:  # pragma: no cover - the fake must exercise the failure boundary
+        raise AssertionError("expected the synthetic batch failure")
+
+    result = delete_firestore_user_data(firestore, "synthetic-user")
+    replay = delete_firestore_user_data(firestore, "synthetic-user")
+
+    assert result == {
+        "status": "ok",
+        "message": "Account data deleted successfully",
+        "documents_deleted": 3,
+    }
+    assert replay["status"] == "ok"
+    assert replay["documents_deleted"] == 0
+
+
+def test_deletion_service_returns_typed_pending_and_preserves_auth_retry(monkeypatch):
+    calls = []
+
+    async def quarantine(_uid):
+        calls.append("quarantine")
+        return _state(external=("hermes_profile", "honcho_tenancy", "runtime_registry"))
+
+    async def forbidden_finalize(_uid):
+        raise AssertionError("external cleanup must precede finalization")
+
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "quarantine_account_for_deletion",
+        quarantine,
+    )
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "finalize_account_deletion",
+        forbidden_finalize,
+    )
+    result = asyncio.run(
+        account_deletion_service.execute_account_deletion(
+            "synthetic-user",
+            delete_firestore=lambda _uid: calls.append("firestore"),
+            delete_firebase=lambda _uid: calls.append("firebase"),
+        )
+    )
+
+    assert result.status_code == 202
+    assert result.body["status"] == "deletion_pending"
+    assert result.body["authority_quarantined"] is True
+    assert result.body["capacity_released"] is True
+    assert result.body["deletion_receipt"]["operator_action_required"] is True
+    assert calls == ["quarantine", "firestore"]
+
+
+def test_deletion_service_completes_missing_external_profile_and_is_repeatable(monkeypatch):
+    calls = []
+
+    async def quarantine(_uid):
+        calls.append("quarantine")
+        return _state()
+
+    async def finalize(_uid):
+        calls.append("finalize")
+        return True
+
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "quarantine_account_for_deletion",
+        quarantine,
+    )
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "finalize_account_deletion",
+        finalize,
+    )
+    for _attempt in range(2):
+        result = asyncio.run(
+            account_deletion_service.execute_account_deletion(
+                "synthetic-user",
+                delete_firestore=lambda _uid: calls.append("firestore"),
+                delete_firebase=lambda _uid: calls.append("firebase"),
+            )
+        )
+        assert result.body["status"] == "ok"
+
+    assert calls == [
+        "quarantine",
+        "firestore",
+        "finalize",
+        "firebase",
+        "quarantine",
+        "firestore",
+        "finalize",
+        "firebase",
+    ]
+
+
+def test_deletion_service_converts_firestore_and_firebase_failures_to_resumable_state(monkeypatch):
+    async def quarantine(_uid):
+        return _state()
+
+    async def finalize(_uid):
+        return True
+
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "quarantine_account_for_deletion",
+        quarantine,
+    )
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "finalize_account_deletion",
+        finalize,
+    )
+    firestore_pending = asyncio.run(
+        account_deletion_service.execute_account_deletion(
+            "synthetic-user",
+            delete_firestore=lambda _uid: (_ for _ in ()).throw(RuntimeError("content must not escape")),
+            delete_firebase=lambda _uid: None,
+        )
+    )
+    assert firestore_pending.status_code == 202
+    assert firestore_pending.body["deletion_receipt"]["remaining"] == ["firestore_data"]
+
+    firebase_pending = asyncio.run(
+        account_deletion_service.execute_account_deletion(
+            "synthetic-user",
+            delete_firestore=lambda _uid: None,
+            delete_firebase=lambda _uid: (_ for _ in ()).throw(RuntimeError("content must not escape")),
+        )
+    )
+    assert firebase_pending.status_code == 202
+    assert firebase_pending.body["deletion_receipt"]["remaining"] == ["firebase_identity"]
+
+
+def test_firebase_delete_lost_ack_converges_only_after_authoritative_absence(monkeypatch):
+    monkeypatch.setattr(
+        auth_endpoints.auth,
+        "delete_user",
+        lambda _uid: (_ for _ in ()).throw(RuntimeError("synthetic_lost_ack")),
+    )
+    monkeypatch.setattr(
+        auth_endpoints.auth,
+        "get_user",
+        lambda _uid: (_ for _ in ()).throw(UserNotFoundError("not found")),
+    )
+
+    assert auth_endpoints.delete_account("synthetic-user") == {"status": "already_deleted"}

--- a/backend/tests/unit/test_account_deletion.py
+++ b/backend/tests/unit/test_account_deletion.py
@@ -361,6 +361,45 @@ def test_retained_firebase_subject_is_fenced_from_authenticated_content_writes(m
     else:
         raise AssertionError("tombstoned Firebase subject must not regain content write authority")
 
+    monkeypatch.setenv("FIRESTORE_EMULATOR_HOST", "localhost:9999")
+    monkeypatch.setenv("GCLOUD_PROJECT", "omi-ci")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "omi-ci")
+
+    from fastapi import FastAPI, HTTPException
+    from fastapi.testclient import TestClient
+    from routers import announcements
+
+    calls = []
+
+    async def tombstoned_subject():
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "account_write_forbidden", "retryable": False},
+        )
+
+    monkeypatch.setattr(
+        announcements,
+        "get_announcement_by_id",
+        lambda _announcement_id: calls.append("lookup"),
+    )
+    monkeypatch.setattr(
+        announcements,
+        "dismiss_announcement",
+        lambda *_args, **_kwargs: calls.append("firestore"),
+    )
+    app = FastAPI()
+    app.include_router(announcements.router)
+    app.dependency_overrides[auth_endpoints.get_writable_user_uid] = tombstoned_subject
+
+    response = TestClient(app).post(
+        "/v1/announcements/synthetic-announcement/dismiss",
+        json={"cta_clicked": False},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "account_write_forbidden"
+    assert calls == []
+
 
 def test_explicit_legacy_mode_does_not_probe_optional_ella_authority_for_content_writes(monkeypatch):
     async def forbidden_pool():

--- a/backend/tests/unit/test_account_deletion.py
+++ b/backend/tests/unit/test_account_deletion.py
@@ -7,7 +7,8 @@ from types import SimpleNamespace
 from fastapi import Depends, Response
 import pytest
 from database import account_deletion as account_deletion_db
-from database.firestore_account_deletion import delete_firestore_user_data
+from database import firestore_account_deletion
+from database.firestore_account_deletion import FirestoreAccountDeletionIncomplete, delete_firestore_user_data
 from ella.services import account_deletion as account_deletion_service
 from firebase_admin.auth import UserNotFoundError
 from utils.other import endpoints as auth_endpoints
@@ -53,6 +54,13 @@ class _Snapshot:
     def __init__(self, reference):
         self.reference = reference
 
+    @property
+    def id(self):
+        return self.reference.name
+
+    def to_dict(self):
+        return dict(self.reference.data)
+
 
 class _Document:
     def __init__(self, name, *, exists=True, children=None, data=None):
@@ -63,7 +71,17 @@ class _Document:
         self.data = dict(data or {})
 
     def get(self):
-        return type("DocumentState", (), {"exists": self.exists and not self.deleted})()
+        return type(
+            "DocumentState",
+            (),
+            {
+                "exists": self.exists and not self.deleted,
+                "to_dict": lambda _self: dict(self.data),
+            },
+        )()
+
+    def to_dict(self):
+        return dict(self.data)
 
     def collections(self):
         return list(self._children)
@@ -72,20 +90,39 @@ class _Document:
         self.deleted = True
 
 
-class _Collection:
-    def __init__(self, documents=None):
+class _Query:
+    def __init__(self, documents=None, *, limit=None):
         self.documents = list(documents or ())
+        self._limit = limit
 
-    def limit(self, _batch_size):
-        return self
+    def limit(self, batch_size):
+        return _Query(self.documents, limit=batch_size)
 
     def where(self, *, filter):
-        return _Collection(
-            [document for document in self.documents if document.data.get(filter.field_path) == filter.value]
+        return _Query(
+            [document for document in self.documents if document.data.get(filter.field_path) == filter.value],
+            limit=self._limit,
         )
 
     def stream(self):
-        return [_Snapshot(document) for document in self.documents if not document.deleted]
+        documents = [document for document in self.documents if document.exists and not document.deleted]
+        if self._limit is not None:
+            documents = documents[: self._limit]
+        return [_Snapshot(document) for document in documents]
+
+
+class _Collection(_Query):
+    def __init__(self, name, documents=None):
+        super().__init__(documents)
+        self.id = name
+
+    def document(self, document_id):
+        for document in self.documents:
+            if document.name == document_id:
+                return document
+        document = _Document(document_id, exists=False)
+        self.documents.append(document)
+        return document
 
 
 class _Batch:
@@ -100,31 +137,56 @@ class _Batch:
         if self.database.fail_next_commit:
             self.database.fail_next_commit = False
             raise RuntimeError("synthetic_firestore_failure")
+        self.database.committed_batch_sizes.append(len(self.references))
         for reference in self.references:
             reference.delete()
 
 
 class _Firestore:
-    def __init__(self, user_document, *, import_jobs=None, enrichment_jobs=None):
-        self.user_document = user_document
-        self.import_jobs = _Collection(import_jobs)
-        self.enrichment_jobs = _Collection(enrichment_jobs)
+    def __init__(self, user_document, *, collections=None, collection_groups=None):
+        self._collections = {name: _Collection(name, documents) for name, documents in (collections or {}).items()}
+        self._collections["users"] = _Collection("users", [user_document])
+        self._collection_groups = {
+            name: _Collection(name, documents) for name, documents in (collection_groups or {}).items()
+        }
         self.fail_next_commit = False
+        self.committed_batch_sizes = []
 
     def collection(self, name):
-        if name == "users":
-            return self
-        if name == "import_jobs":
-            return self.import_jobs
-        if name == "ella_hermes_cloud_enrichment_outbox":
-            return self.enrichment_jobs
-        raise AssertionError(name)
+        if name not in self._collections:
+            self._collections[name] = _Collection(name)
+        return self._collections[name]
 
-    def document(self, _uid):
-        return self.user_document
+    def collection_group(self, name):
+        if name not in self._collection_groups:
+            self._collection_groups[name] = _Collection(name)
+        return self._collection_groups[name]
+
+    def collections(self):
+        return list(self._collections.values())
 
     def batch(self):
         return _Batch(self)
+
+
+class _CacheAuthority:
+    def __init__(self, *, developer=(), mcp=(), retain=False):
+        self.developer = set(developer)
+        self.mcp = set(mcp)
+        self.retain = retain
+        self.calls = []
+
+    def invalidate_cached_dev_api_key(self, hashed_key):
+        self.calls.append(("developer", hashed_key))
+        if not self.retain:
+            self.developer.discard(hashed_key)
+        return hashed_key not in self.developer
+
+    def invalidate_cached_mcp_api_key(self, hashed_key):
+        self.calls.append(("mcp", hashed_key))
+        if not self.retain:
+            self.mcp.discard(hashed_key)
+        return hashed_key not in self.mcp
 
 
 def _state(*, external=()):
@@ -173,10 +235,10 @@ def test_authenticated_route_delegates_to_the_resumable_deletion_service():
 
 def test_firestore_delete_is_idempotent_and_resumes_after_partial_failure():
     nested_document = _Document("nested")
-    child_document = _Document("child", children=[_Collection([nested_document])])
+    child_document = _Document("child", children=[_Collection("nested-items", [nested_document])])
     root_document = _Document(
-        "user",
-        children=[_Collection([]), _Collection([child_document])],
+        "synthetic-user",
+        children=[_Collection("empty"), _Collection("children", [child_document])],
     )
     firestore = _Firestore(root_document)
     firestore.fail_next_commit = True
@@ -199,28 +261,182 @@ def test_firestore_delete_is_idempotent_and_resumes_after_partial_failure():
     assert replay["documents_deleted"] == 0
 
 
-def test_firestore_delete_removes_only_owned_top_level_jobs_and_retries():
-    owned_job = _Document("owned-job", data={"uid": "synthetic-user"})
-    other_job = _Document("other-job", data={"uid": "other-user"})
-    owned_enrichment = _Document("owned-enrichment", data={"uid": "synthetic-user"})
-    other_enrichment = _Document("other-enrichment", data={"uid": "other-user"})
-    root_document = _Document("user")
+def test_firestore_inventory_snapshot_covers_every_repository_owned_root():
+    assert tuple(
+        (owned.name, owned.owner_field, owned.api_key_cache)
+        for owned in firestore_account_deletion.OWNED_TOP_LEVEL_COLLECTIONS
+    ) == (
+        ("analytics", "uid", None),
+        ("dev_api_keys", "user_id", "developer"),
+        ("mcp_api_keys", "user_id", "mcp"),
+        ("tasks", "user_uid", None),
+        ("import_jobs", "uid", None),
+        ("ella_hermes_cloud_enrichment_outbox", "uid", None),
+        ("plugins_data", "uid", None),
+        ("mcp_identity_grants", "profile_uid", None),
+    )
+    assert tuple((owned.name, owned.owner_field) for owned in firestore_account_deletion.OWNED_COLLECTION_GROUPS) == (
+        ("reviews", "uid"),
+        ("usage_history", "uid"),
+    )
+    assert firestore_account_deletion.DIRECT_UID_DOCUMENT_COLLECTIONS == ("testers",)
+
+
+def test_production_firestore_cleanup_removes_seeded_inventory_and_retains_other_uid():
+    uid = "synthetic-user"
+    other_uid = "other-user"
+    ownership = {
+        "analytics": ("uid", None),
+        "dev_api_keys": ("user_id", "dev-owned-hash"),
+        "mcp_api_keys": ("user_id", "mcp-owned-hash"),
+        "tasks": ("user_uid", None),
+        "import_jobs": ("uid", None),
+        "ella_hermes_cloud_enrichment_outbox": ("uid", None),
+        "plugins_data": ("uid", None),
+        "mcp_identity_grants": ("profile_uid", None),
+    }
+    documents = {}
+    owned_documents = []
+    other_documents = []
+    for collection_name, (owner_field, hashed_key) in ownership.items():
+        owned_data = {owner_field: uid}
+        other_data = {owner_field: other_uid}
+        if hashed_key:
+            owned_data["hashed_key"] = hashed_key
+            other_data["hashed_key"] = f"other-{hashed_key}"
+        owned = _Document(f"owned-{collection_name}", data=owned_data)
+        other = _Document(f"other-{collection_name}", data=other_data)
+        documents[collection_name] = [owned, other]
+        owned_documents.append(owned)
+        other_documents.append(other)
+
+    tester_owned = _Document(uid, data={"uid": uid})
+    tester_other = _Document(other_uid, data={"uid": other_uid})
+    documents["testers"] = [tester_owned, tester_other]
+    owned_review = _Document("owned-review", data={"uid": uid})
+    other_review = _Document("other-review", data={"uid": other_uid})
+    owned_usage = _Document("owned-usage", data={"uid": uid})
+    other_usage = _Document("other-usage", data={"uid": other_uid})
+    nested = _Document("nested")
+    child = _Document("child", children=[_Collection("nested", [nested])])
+    root_document = _Document(uid, children=[_Collection("children", [child])])
+    cache = _CacheAuthority(
+        developer=("dev-owned-hash", "other-dev-owned-hash"),
+        mcp=("mcp-owned-hash", "other-mcp-owned-hash"),
+    )
     firestore = _Firestore(
         root_document,
-        import_jobs=[owned_job, other_job],
-        enrichment_jobs=[owned_enrichment, other_enrichment],
+        collections=documents,
+        collection_groups={
+            "reviews": [owned_review, other_review],
+            "usage_history": [owned_usage, other_usage],
+        },
     )
 
-    result = delete_firestore_user_data(firestore, "synthetic-user")
-    replay = delete_firestore_user_data(firestore, "synthetic-user")
+    result = delete_firestore_user_data(firestore, uid, batch_size=2, cache_authority=cache)
+    replay = delete_firestore_user_data(firestore, uid, batch_size=2, cache_authority=cache)
 
-    assert result["documents_deleted"] == 3
+    assert result["documents_deleted"] == 14
     assert replay["documents_deleted"] == 0
-    assert owned_job.deleted is True
-    assert other_job.deleted is False
-    assert owned_enrichment.deleted is True
-    assert other_enrichment.deleted is False
+    assert all(document.deleted for document in owned_documents)
+    assert all(not document.deleted for document in other_documents)
+    assert tester_owned.deleted is True
+    assert tester_other.deleted is False
+    assert owned_review.deleted is True
+    assert other_review.deleted is False
+    assert owned_usage.deleted is True
+    assert other_usage.deleted is False
+    assert child.deleted is True
+    assert nested.deleted is True
     assert root_document.deleted is True
+    assert cache.developer == {"other-dev-owned-hash"}
+    assert cache.mcp == {"other-mcp-owned-hash"}
+    assert cache.calls == [
+        ("developer", "dev-owned-hash"),
+        ("developer", "dev-owned-hash"),
+        ("mcp", "mcp-owned-hash"),
+        ("mcp", "mcp-owned-hash"),
+    ]
+
+
+def test_firestore_owned_collection_purge_is_bounded_across_multiple_batches():
+    uid = "synthetic-user"
+    tasks = [_Document(f"task-{index}", data={"user_uid": uid}) for index in range(5)]
+    firestore = _Firestore(_Document(uid), collections={"tasks": tasks})
+
+    result = delete_firestore_user_data(
+        firestore,
+        uid,
+        batch_size=2,
+        cache_authority=_CacheAuthority(),
+    )
+
+    assert result["documents_deleted"] == 6
+    assert firestore.committed_batch_sizes == [2, 2, 1]
+    assert all(task.deleted for task in tasks)
+
+
+@pytest.mark.parametrize("omitted_collection", ["analytics", "tasks"])
+def test_firestore_gate_fails_closed_when_known_inventory_entry_is_omitted(monkeypatch, omitted_collection):
+    uid = "synthetic-user"
+    owner_field = "uid" if omitted_collection == "analytics" else "user_uid"
+    retained = _Document("retained", data={owner_field: uid})
+    root_document = _Document(uid)
+    monkeypatch.setattr(
+        firestore_account_deletion,
+        "OWNED_TOP_LEVEL_COLLECTIONS",
+        tuple(
+            owned
+            for owned in firestore_account_deletion.OWNED_TOP_LEVEL_COLLECTIONS
+            if owned.name != omitted_collection
+        ),
+    )
+    firestore = _Firestore(root_document, collections={omitted_collection: [retained]})
+
+    with pytest.raises(
+        FirestoreAccountDeletionIncomplete,
+        match="account_deletion_firestore_inventory_incomplete",
+    ):
+        delete_firestore_user_data(firestore, uid, cache_authority=_CacheAuthority())
+
+    assert retained.deleted is False
+
+
+def test_firestore_gate_positive_control_detects_new_uid_linked_top_level_collection():
+    uid = "synthetic-user"
+    retained = _Document("retained", data={"uid": uid})
+    other = _Document("other", data={"uid": "other-user"})
+    firestore = _Firestore(
+        _Document(uid),
+        collections={"new_uid_linked_collection": [retained, other]},
+    )
+
+    with pytest.raises(
+        FirestoreAccountDeletionIncomplete,
+        match="account_deletion_firestore_inventory_incomplete",
+    ):
+        delete_firestore_user_data(firestore, uid, cache_authority=_CacheAuthority())
+
+    assert retained.deleted is False
+    assert other.deleted is False
+
+
+def test_firestore_api_key_cache_failure_preserves_resumable_key_record():
+    uid = "synthetic-user"
+    key = _Document("owned-key", data={"user_id": uid, "hashed_key": "owned-hash"})
+    firestore = _Firestore(_Document(uid), collections={"dev_api_keys": [key]})
+
+    with pytest.raises(
+        FirestoreAccountDeletionIncomplete,
+        match="account_deletion_api_key_cache_retained",
+    ):
+        delete_firestore_user_data(
+            firestore,
+            uid,
+            cache_authority=_CacheAuthority(developer=("owned-hash",), retain=True),
+        )
+
+    assert key.deleted is False
 
 
 def test_deletion_service_returns_typed_pending_and_preserves_auth_retry(monkeypatch):

--- a/backend/tests/unit/test_authority_writer_guard.py
+++ b/backend/tests/unit/test_authority_writer_guard.py
@@ -22,6 +22,8 @@ USER_MUTATION_RE = re.compile(
 )
 
 EXPECTED_WRITERS = {
+    ("database/account_deletion.py", "finalize_account_deletion"),
+    ("database/account_deletion.py", "quarantine_account_for_deletion"),
     ("database/ella_provisioning.py", "activate_runtime_binding"),
     ("database/ella_provisioning.py", "activate_user"),
     ("database/ella_provisioning.py", "claim_cloud_pool_binding"),
@@ -64,6 +66,8 @@ PROOF_GATED_HELPERS = {
     ("database/managed_cloud_consent.py", "lock_or_bootstrap_grant_on_connection"),
 }
 EXPECTED_GLOBAL_USER_WRITERS = {
+    ("database/account_deletion.py", "finalize_account_deletion"),
+    ("database/account_deletion.py", "quarantine_account_for_deletion"),
     ("database/ella_provisioning.py", "activate_runtime_binding"),
     ("database/ella_provisioning.py", "activate_user"),
     ("database/ella_provisioning.py", "ensure_user_identity"),
@@ -76,6 +80,14 @@ NON_AUTHORITY_USER_WRITERS = {
     ("ella/utils/auto_provision.py", "auto_provision_user"),
 }
 REAL_POSTGRES_WRITER_COVERAGE = {
+    ("database/account_deletion.py", "finalize_account_deletion"): (
+        "tests/postgres/test_invitation_redemption_postgres.py",
+        "test_account_deletion_atomically_quarantines_authority_releases_capacity_and_retries",
+    ),
+    ("database/account_deletion.py", "quarantine_account_for_deletion"): (
+        "tests/postgres/test_invitation_redemption_postgres.py",
+        "test_account_deletion_mid_transaction_failure_rolls_back_every_authority_and_capacity_write",
+    ),
     ("database/ella_provisioning.py", "activate_runtime_binding"): (
         "tests/postgres/test_authority_advisory_lock_postgres.py",
         '"runtime_activate"',

--- a/backend/tests/unit/test_authority_writer_guard.py
+++ b/backend/tests/unit/test_authority_writer_guard.py
@@ -8,12 +8,16 @@ PROTECTED_TABLES = {
     "voice_entitlements",
     "ella_runtime_targets",
     "ella_runtime_bindings",
+    "ella_provisioning_jobs",
+    "ella_photon_channel_bindings",
+    "ella_provider_attempts",
     "users",
 }
 MUTATION_RE = re.compile(
     r"\b(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+"
     r"(ella_managed_cloud_consent_authority|voice_entitlements|"
-    r"ella_runtime_targets|ella_runtime_bindings|users)\b",
+    r"ella_runtime_targets|ella_runtime_bindings|ella_provisioning_jobs|"
+    r"ella_photon_channel_bindings|ella_provider_attempts|users)\b",
     re.IGNORECASE,
 )
 USER_MUTATION_RE = re.compile(
@@ -26,6 +30,9 @@ EXPECTED_WRITERS = {
     ("database/account_deletion.py", "quarantine_account_for_deletion"),
     ("database/ella_provisioning.py", "activate_runtime_binding"),
     ("database/ella_provisioning.py", "activate_user"),
+    ("database/ella_provisioning.py", "acquire_job"),
+    ("database/ella_provisioning.py", "begin_provider_attempt"),
+    ("database/ella_provisioning.py", "claim_job"),
     ("database/ella_provisioning.py", "claim_cloud_pool_binding"),
     ("database/ella_provisioning.py", "cleanup_cloud_pool_binding"),
     ("database/ella_provisioning.py", "ensure_user_identity"),
@@ -33,8 +40,12 @@ EXPECTED_WRITERS = {
     ("database/ella_provisioning.py", "invalidate_self_hosted_authority_on_connection"),
     ("database/ella_provisioning.py", "promote_cloud_binding"),
     ("database/ella_provisioning.py", "quarantine_cloud_pool_claim"),
+    ("database/ella_provisioning.py", "record_cloud_rollback"),
+    ("database/ella_provisioning.py", "record_cloud_side_effect"),
+    ("database/ella_provisioning.py", "record_photon_sidecar_preflight"),
     ("database/ella_provisioning.py", "register_cloud_pool_binding"),
     ("database/ella_provisioning.py", "stage_runtime_binding"),
+    ("database/ella_provisioning.py", "update_job"),
     ("database/invitation_operator.py", "_cleanup_locked"),
     ("database/invitations.py", "_bind_verified_identity_on_connection"),
     ("database/invitations.py", "_redeem_locked_invitation"),
@@ -96,6 +107,18 @@ REAL_POSTGRES_WRITER_COVERAGE = {
         "tests/postgres/test_authority_advisory_lock_postgres.py",
         '"user_activate"',
     ),
+    ("database/ella_provisioning.py", "acquire_job"): (
+        "tests/postgres/test_invitation_redemption_postgres.py",
+        "test_deletion_tombstone_serializes_inflight_provider_writer_and_quarantines_photon_immediately",
+    ),
+    ("database/ella_provisioning.py", "begin_provider_attempt"): (
+        "tests/postgres/test_invitation_redemption_postgres.py",
+        "test_lost_provider_ack_persists_unproven_attempt_blocks_firebase_and_retry_converges",
+    ),
+    ("database/ella_provisioning.py", "claim_job"): (
+        "tests/postgres/test_invitation_redemption_postgres.py",
+        "test_deletion_tombstone_serializes_inflight_provider_writer_and_quarantines_photon_immediately",
+    ),
     ("database/ella_provisioning.py", "claim_cloud_pool_binding"): (
         "tests/postgres/test_authority_advisory_lock_postgres.py",
         '"cloud_claim"',
@@ -120,9 +143,25 @@ REAL_POSTGRES_WRITER_COVERAGE = {
         "tests/postgres/test_authority_advisory_lock_postgres.py",
         '"cloud_quarantine"',
     ),
+    ("database/ella_provisioning.py", "record_cloud_rollback"): (
+        "tests/postgres/test_invitation_redemption_postgres.py",
+        "test_deletion_tombstone_serializes_inflight_provider_writer_and_quarantines_photon_immediately",
+    ),
+    ("database/ella_provisioning.py", "record_cloud_side_effect"): (
+        "tests/postgres/test_invitation_redemption_postgres.py",
+        "test_deletion_tombstone_serializes_inflight_provider_writer_and_quarantines_photon_immediately",
+    ),
+    ("database/ella_provisioning.py", "record_photon_sidecar_preflight"): (
+        "tests/postgres/test_invitation_redemption_postgres.py",
+        "test_deletion_tombstone_serializes_inflight_provider_writer_and_quarantines_photon_immediately",
+    ),
     ("database/ella_provisioning.py", "stage_runtime_binding"): (
         "tests/postgres/test_authority_advisory_lock_postgres.py",
         '"runtime_stage"',
+    ),
+    ("database/ella_provisioning.py", "update_job"): (
+        "tests/postgres/test_invitation_redemption_postgres.py",
+        "test_deletion_tombstone_serializes_inflight_provider_writer_and_quarantines_photon_immediately",
     ),
     ("database/invitations.py", "_redeem_locked_invitation"): (
         "tests/postgres/test_invitation_redemption_postgres.py",

--- a/backend/tests/unit/test_content_write_fence.py
+++ b/backend/tests/unit/test_content_write_fence.py
@@ -190,6 +190,40 @@ def test_threaded_mutation_stale_token_is_joined_before_failure(monkeypatch, fen
     asyncio.run(scenario())
 
 
+def test_threaded_mutation_survives_repeated_cancellation_until_thread_terminal(monkeypatch, fence_environment):
+    entered = threading.Event()
+    release = threading.Event()
+    terminal = threading.Event()
+
+    async def assert_postgres_active(_uid):
+        return None
+
+    def mutate():
+        entered.set()
+        assert release.wait(3)
+        terminal.set()
+
+    monkeypatch.setattr(content_write_fence, "_assert_postgres_owner_active", assert_postgres_active)
+
+    async def scenario():
+        async with content_write_fence.detached_content_write_fence(UID) as writer:
+            operation = asyncio.create_task(content_write_fence.run_admitted_threaded_mutation(UID, mutate))
+            assert await asyncio.to_thread(entered.wait, 2)
+            for _ in range(6):
+                operation.cancel()
+                await asyncio.sleep(0)
+                assert not operation.done()
+                assert writer.token in _fence_state(fence_environment)["writers"]
+
+            release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await operation
+            assert terminal.is_set()
+
+    asyncio.run(scenario())
+    assert _fence_state(fence_environment) is None
+
+
 def _load_production_delete_route():
     path = Path(__file__).resolve().parents[2] / "routers" / "users.py"
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
@@ -334,12 +368,12 @@ def test_backend_mutation_and_raw_launch_inventory_covers_startup_services_and_u
         snapshot,
         digest,
         counts={
-            "launches": 188,
+            "launches": 190,
             "mutations": 229,
             "protected_mutations": 136,
             "raw_uid_mutations": 0,
         },
-        expected_digest="fa3f77dfd53a40a08ae365824de91d14b111fc258ac70898989c83c4522ccd53",
+        expected_digest="65caf3f77c7821fde6808fad43839e16f83023394b87b5ef49bcd37b41bd8963",
     )
     assert any(
         item.startswith("ella/services/hermes_cloud_enrichment_outbox.py:start_worker:create_task:")
@@ -361,7 +395,7 @@ def test_backend_inventory_positive_controls_reject_startup_raw_task_and_unfence
     backend = Path(__file__).resolve().parents[2]
     baseline, baseline_digest = _deterministic_backend_inventory(backend)
     expected_counts = {
-        "launches": 188,
+        "launches": 190,
         "mutations": 229,
         "protected_mutations": 136,
         "raw_uid_mutations": 0,

--- a/backend/tests/unit/test_content_write_fence.py
+++ b/backend/tests/unit/test_content_write_fence.py
@@ -1,0 +1,498 @@
+import asyncio
+import ast
+from contextlib import asynccontextmanager
+from copy import deepcopy
+import os
+from pathlib import Path
+from types import SimpleNamespace
+import threading
+import time
+
+from fastapi import Depends, FastAPI, Response
+from fastapi.responses import StreamingResponse
+from fastapi.testclient import TestClient
+import pytest
+
+os.environ.setdefault("FIRESTORE_EMULATOR_HOST", "localhost:9999")
+os.environ.setdefault("GCLOUD_PROJECT", "omi-ci")
+os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "omi-ci")
+
+from database import account_deletion as account_deletion_db
+from database import content_write_fence
+from ella.services import account_deletion as account_deletion_service
+from routers import announcements
+from utils.other import endpoints as auth_endpoints
+
+UID = "distributed-fence-user"
+
+
+class _Snapshot:
+    def __init__(self, data):
+        self._data = deepcopy(data)
+        self.exists = data is not None
+
+    def to_dict(self):
+        return deepcopy(self._data)
+
+
+class _Document:
+    def __init__(self, database, key):
+        self.database = database
+        self.key = key
+
+    def get(self, transaction=None):
+        del transaction
+        return _Snapshot(self.database.documents.get(self.key))
+
+
+class _Collection:
+    def __init__(self, database, name):
+        self.database = database
+        self.name = name
+
+    def document(self, document_id):
+        return _Document(self.database, (self.name, document_id))
+
+
+class _Transaction:
+    def __init__(self, database):
+        self.database = database
+
+    def set(self, reference, data):
+        self.database.documents[reference.key] = deepcopy(data)
+
+    def delete(self, reference):
+        self.database.documents.pop(reference.key, None)
+
+
+class _Firestore:
+    def __init__(self):
+        self.documents = {}
+        self.lock = threading.RLock()
+
+    def collection(self, name):
+        return _Collection(self, name)
+
+    def transaction(self):
+        return _Transaction(self)
+
+
+def _transactional(function):
+    def run(transaction, *args, **kwargs):
+        with transaction.database.lock:
+            return function(transaction, *args, **kwargs)
+
+    return run
+
+
+def _state():
+    return account_deletion_db.AccountDeletionState(
+        user_found=True,
+        capacity_released=True,
+        authority_quarantined=True,
+        external_cleanup_required=(),
+        external_cleanup_references=(),
+        counts={},
+    )
+
+
+@pytest.fixture
+def fence_environment(monkeypatch):
+    previous_database = content_write_fence._firestore_db
+    database = _Firestore()
+    content_write_fence.configure_firestore_db(database)
+    monkeypatch.setattr(content_write_fence.firestore, "transactional", _transactional)
+    monkeypatch.setenv("ELLA_CONTENT_WRITE_FENCE_LEASE_SECONDS", "3")
+    monkeypatch.setenv("ELLA_CONTENT_WRITE_FENCE_DRAIN_SECONDS", "3")
+    yield database
+    content_write_fence.configure_firestore_db(previous_database)
+
+
+def _fence_state(database):
+    reference = content_write_fence._fence_reference(database, UID)
+    return deepcopy(database.documents.get(reference.key))
+
+
+def _load_production_delete_route():
+    path = Path(__file__).resolve().parents[2] / "routers" / "users.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    route = next(node for node in tree.body if isinstance(node, ast.AsyncFunctionDef) and node.name == "delete_account")
+    route.decorator_list = []
+    namespace = {
+        "Depends": Depends,
+        "Response": Response,
+        "auth": SimpleNamespace(
+            get_authenticated_user_uid=lambda: UID,
+            delete_account=lambda _uid: None,
+        ),
+        "delete_user_data": lambda _uid: None,
+        "execute_account_deletion": account_deletion_service.execute_account_deletion,
+    }
+    exec(compile(ast.fix_missing_locations(ast.Module(body=[route], type_ignores=[])), str(path), "exec"), namespace)
+    return namespace["delete_account"], namespace
+
+
+def _production_app(delete_route):
+    app = FastAPI()
+    app.include_router(announcements.router)
+    app.add_api_route("/v1/users/delete-account", delete_route, methods=["DELETE"])
+    app.dependency_overrides[auth_endpoints.get_current_user_uid] = lambda: UID
+    app.add_middleware(content_write_fence.ContentWriteFenceMiddleware)
+    return app
+
+
+@pytest.mark.parametrize("authority_enabled", [True, False])
+def test_adversarial_production_route_writer_is_drained_before_deletion_reports_complete(
+    monkeypatch,
+    fence_environment,
+    authority_enabled,
+):
+    """Reproduce Iris's barrier on mounted writer and deletion entrypoints."""
+    monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "true" if authority_enabled else "false")
+    postgres_owner_lock = threading.Lock()
+    mutation_reached = threading.Event()
+    release_mutation = threading.Event()
+    content = set()
+    order = []
+
+    @asynccontextmanager
+    async def postgres_fence(uid):
+        assert uid == UID
+        acquired = await asyncio.to_thread(postgres_owner_lock.acquire, True, 2)
+        assert acquired
+        try:
+            yield
+        finally:
+            postgres_owner_lock.release()
+
+    monkeypatch.setattr(content_write_fence, "_postgres_owner_fence", postgres_fence)
+
+    async def quarantine(uid):
+        assert uid == UID
+        acquired = await asyncio.to_thread(postgres_owner_lock.acquire, True, 2)
+        assert acquired
+        try:
+            order.append("postgres_tombstone")
+            return _state()
+        finally:
+            postgres_owner_lock.release()
+
+    async def finalize(uid):
+        assert uid == UID
+        assert not content
+        order.append("final_absence_proof")
+        return True
+
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "quarantine_account_for_deletion", quarantine)
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "finalize_account_deletion", finalize)
+    monkeypatch.setattr(announcements, "get_announcement_by_id", lambda _announcement_id: object())
+
+    def dismiss(uid, announcement_id, cta_clicked):
+        assert (uid, announcement_id, cta_clicked) == (UID, "notice", False)
+        mutation_reached.set()
+        assert release_mutation.wait(5)
+        content.add("dismissal")
+        order.append("writer_commit")
+        return True
+
+    def delete_firestore(uid):
+        assert uid == UID
+        order.append("firestore_sweep")
+        content.clear()
+
+    def delete_firebase(uid):
+        assert uid == UID
+        assert not content
+        expected_prior = "final_absence_proof" if authority_enabled else "firestore_sweep"
+        assert order[-1] == expected_prior
+        order.append("firebase_delete")
+
+    monkeypatch.setattr(announcements, "dismiss_announcement", dismiss)
+    delete_route, delete_namespace = _load_production_delete_route()
+    delete_namespace["delete_user_data"] = delete_firestore
+    delete_namespace["auth"].delete_account = delete_firebase
+
+    app = _production_app(delete_route)
+    with TestClient(app) as writer_client, TestClient(app) as deletion_client:
+        responses = {}
+
+        def writer_request():
+            responses["writer"] = writer_client.post(
+                "/v1/announcements/notice/dismiss",
+                json={"cta_clicked": False},
+            )
+
+        def deletion_request():
+            responses["deletion"] = deletion_client.delete("/v1/users/delete-account")
+
+        writer = threading.Thread(target=writer_request)
+        deletion = threading.Thread(target=deletion_request)
+        writer.start()
+        assert mutation_reached.wait(2)
+        writer_state = _fence_state(fence_environment)
+        assert writer_state["state"] == content_write_fence.ACTIVE
+        assert len(writer_state["writers"]) == 1
+
+        deletion.start()
+        if not authority_enabled:
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                state = _fence_state(fence_environment)
+                if state and state["state"] == content_write_fence.DRAINING:
+                    break
+                time.sleep(0.01)
+            else:
+                raise AssertionError("legacy deletion did not durably drain the admitted writer")
+        assert "firestore_sweep" not in order
+
+        release_mutation.set()
+        writer.join(3)
+        deletion.join(3)
+
+        assert responses["writer"].status_code == 200
+        assert responses["deletion"].status_code == 200, (
+            responses["deletion"].json(),
+            order,
+            _fence_state(fence_environment),
+        )
+        assert order.index("writer_commit") < order.index("firestore_sweep")
+        if authority_enabled:
+            assert order.index("firestore_sweep") < order.index("final_absence_proof")
+            assert order.index("final_absence_proof") < order.index("firebase_delete")
+        else:
+            assert order.index("firestore_sweep") < order.index("firebase_delete")
+        assert not content
+        assert _fence_state(fence_environment)["state"] == content_write_fence.TOMBSTONED
+
+        fresh = writer_client.post(
+            "/v1/announcements/notice/dismiss",
+            json={"cta_clicked": False},
+        )
+        assert fresh.status_code == 403
+        assert fresh.json()["detail"]["code"] == "account_write_forbidden"
+        assert not content
+
+
+def test_active_writer_positive_control_commits_without_deletion(monkeypatch, fence_environment):
+    monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "false")
+    monkeypatch.setattr(announcements, "get_announcement_by_id", lambda _announcement_id: object())
+    mutations = []
+    monkeypatch.setattr(
+        announcements,
+        "dismiss_announcement",
+        lambda uid, *_args: mutations.append(uid) or True,
+    )
+
+    delete_route, _delete_namespace = _load_production_delete_route()
+    with TestClient(_production_app(delete_route)) as client:
+        response = client.post("/v1/announcements/notice/dismiss", json={"cta_clicked": False})
+
+    assert response.status_code == 200
+    assert mutations == [UID]
+    assert _fence_state(fence_environment) is None
+
+
+def test_request_fence_covers_streamed_commit_after_route_returns(monkeypatch, fence_environment):
+    monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "false")
+    stream_entered = threading.Event()
+    release_stream = threading.Event()
+    content = set()
+
+    app = FastAPI()
+
+    @app.post("/stream")
+    async def stream(uid: str = Depends(auth_endpoints.get_writable_user_uid)):
+        async def body():
+            stream_entered.set()
+            await asyncio.to_thread(release_stream.wait, 2)
+            content.add(uid)
+            yield b"done"
+
+        return StreamingResponse(body())
+
+    app.dependency_overrides[auth_endpoints.get_current_user_uid] = lambda: UID
+    app.add_middleware(content_write_fence.ContentWriteFenceMiddleware)
+
+    with TestClient(app) as writer_client:
+        response = {}
+        writer = threading.Thread(target=lambda: response.setdefault("value", writer_client.post("/stream")))
+        writer.start()
+        assert stream_entered.wait(2)
+
+        deletion = {}
+        deletion_thread = threading.Thread(
+            target=lambda: deletion.setdefault(
+                "value",
+                asyncio.run(content_write_fence.tombstone_content_writes(UID)),
+            )
+        )
+        deletion_thread.start()
+        time.sleep(0.1)
+        assert deletion_thread.is_alive()
+        assert not content
+
+        release_stream.set()
+        writer.join(3)
+        deletion_thread.join(3)
+
+    assert response["value"].status_code == 200
+    assert deletion == {"value": True}
+    assert content == {UID}
+    assert _fence_state(fence_environment)["state"] == content_write_fence.TOMBSTONED
+
+
+def test_two_independent_workers_are_durably_drained(monkeypatch, fence_environment):
+    monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "false")
+    entered = [threading.Event(), threading.Event()]
+    release = threading.Event()
+
+    def worker(index):
+        async def run():
+            async with content_write_fence.content_write_fence(UID):
+                entered[index].set()
+                await asyncio.to_thread(release.wait, 2)
+
+        asyncio.run(run())
+
+    workers = [threading.Thread(target=worker, args=(index,)) for index in range(2)]
+    for worker_thread in workers:
+        worker_thread.start()
+    assert all(event.wait(2) for event in entered)
+    assert len(_fence_state(fence_environment)["writers"]) == 2
+
+    result = {}
+
+    def delete():
+        result["tombstoned"] = asyncio.run(content_write_fence.tombstone_content_writes(UID))
+
+    deletion = threading.Thread(target=delete)
+    deletion.start()
+    time.sleep(0.1)
+    assert deletion.is_alive()
+    assert _fence_state(fence_environment)["state"] == content_write_fence.DRAINING
+    release.set()
+    for worker_thread in workers:
+        worker_thread.join(3)
+    deletion.join(3)
+
+    assert result == {"tombstoned": True}
+    assert _fence_state(fence_environment)["state"] == content_write_fence.TOMBSTONED
+
+
+@pytest.mark.parametrize("exit_kind", ["error", "cancellation"])
+def test_error_and_cancellation_release_writer_lease(monkeypatch, fence_environment, exit_kind):
+    monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "false")
+
+    async def run():
+        entered = asyncio.Event()
+
+        async def write():
+            async with content_write_fence.content_write_fence(UID):
+                entered.set()
+                if exit_kind == "error":
+                    raise RuntimeError("synthetic_writer_error")
+                await asyncio.Event().wait()
+
+        task = asyncio.create_task(write())
+        await entered.wait()
+        if exit_kind == "cancellation":
+            task.cancel()
+        with pytest.raises((RuntimeError, asyncio.CancelledError)):
+            await task
+
+    asyncio.run(run())
+    assert _fence_state(fence_environment) is None
+
+
+def test_authority_disabled_never_opens_postgres(monkeypatch, fence_environment):
+    monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "false")
+
+    async def forbidden_pool():
+        raise AssertionError("legacy content fencing must not open Ella PostgreSQL")
+
+    monkeypatch.setattr(content_write_fence.voice_canary, "get_pool", forbidden_pool)
+
+    async def run():
+        async with content_write_fence.content_write_fence(UID):
+            return "committed"
+
+    assert asyncio.run(run()) == "committed"
+
+
+def test_mounted_authenticated_writer_inventory_uses_scope_holding_dependencies():
+    backend = Path(__file__).resolve().parents[2]
+    endpoints_source = (backend / "utils" / "other" / "endpoints.py").read_text(encoding="utf-8")
+    endpoints_tree = ast.parse(endpoints_source)
+    writable_dependency = next(
+        node
+        for node in endpoints_tree.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "get_writable_user_uid"
+    )
+    assert any(isinstance(node, (ast.Yield, ast.YieldFrom)) for node in ast.walk(writable_dependency))
+    assert "content_write_fence.request_content_write_fence(uid)" in (
+        ast.get_source_segment(endpoints_source, writable_dependency) or ""
+    )
+
+    dependency_source = (backend / "dependencies.py").read_text(encoding="utf-8")
+    dependency_tree = ast.parse(dependency_source)
+    api_writer_dependencies = {
+        "get_current_user_id",
+        "get_uid_from_mcp_api_key",
+        "get_uid_with_conversations_write",
+        "get_uid_with_memories_write",
+        "get_uid_with_action_items_write",
+    }
+    functions = {
+        node.name: node for node in dependency_tree.body if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+    }
+    assert api_writer_dependencies <= set(functions)
+    for name in api_writer_dependencies:
+        assert any(isinstance(node, (ast.Yield, ast.YieldFrom)) for node in ast.walk(functions[name])), name
+
+    raw_mutation_dependencies = []
+    protected_mutations = []
+    for directory in (backend / "routers", backend / "ella" / "routers"):
+        for path in sorted(directory.glob("*.py")):
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                    continue
+                methods = {
+                    decorator.func.attr
+                    for decorator in node.decorator_list
+                    if isinstance(decorator, ast.Call)
+                    and isinstance(decorator.func, ast.Attribute)
+                    and decorator.func.attr in {"post", "put", "patch", "delete", "websocket"}
+                }
+                if not methods:
+                    continue
+                function_source = ast.get_source_segment(source, node) or ""
+                key = f"{path.relative_to(backend)}:{node.name}"
+                if (
+                    "Depends(auth.get_writable_user_uid)" in function_source
+                    or "Depends(auth_endpoints.get_writable_user_uid)" in function_source
+                    or "Depends(require_current_ai_consent)" in function_source
+                ):
+                    protected_mutations.append(key)
+                if (
+                    "Depends(auth.get_current_user_uid)" in function_source
+                    or "Depends(auth_endpoints.get_current_user_uid)" in function_source
+                ):
+                    raw_mutation_dependencies.append(key)
+
+    assert len(protected_mutations) >= 100
+    assert raw_mutation_dependencies == []
+    assert "routers/announcements.py:dismiss_announcement_endpoint" in protected_mutations
+    assert "routers/transcribe.py:listen_handler" in protected_mutations
+    transcribe_source = (backend / "routers" / "transcribe.py").read_text(encoding="utf-8")
+    assert "async with content_write_fence.request_content_write_fence(uid):" in transcribe_source
+    main_source = (backend / "main.py").read_text(encoding="utf-8")
+    assert "app.add_middleware(ContentWriteFenceMiddleware)" in main_source
+    apps_source = (backend / "routers" / "apps.py").read_text(encoding="utf-8")
+    assert "asyncio.create_task(migrate_memories" not in apps_source
+    assert "background_tasks.add_task(migrate_memories" in apps_source
+    for relative_path in ("routers/integration.py", "routers/workflow.py", "routers/mcp_sse.py"):
+        source = (backend / relative_path).read_text(encoding="utf-8")
+        assert "await admit_authenticated_content_writer(" in source, relative_path
+    assert "await auth.assert_authenticated_user_writable(uid)" not in transcribe_source

--- a/backend/tests/unit/test_content_write_fence.py
+++ b/backend/tests/unit/test_content_write_fence.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 from copy import deepcopy
 import hashlib
 import io
+import json
 import os
 from pathlib import Path
 import sys
@@ -127,10 +128,18 @@ def fence_environment(monkeypatch):
     async def purge_routing_traces(_uid):
         return 0
 
+    async def purge_memory_reinterpretation_work(_uid):
+        return 0
+
     monkeypatch.setattr(
         account_deletion_service.account_deletion_db,
         "purge_routing_traces",
         purge_routing_traces,
+    )
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "purge_memory_reinterpretation_work",
+        purge_memory_reinterpretation_work,
     )
     yield database
     content_write_fence.configure_firestore_db(previous_database)
@@ -175,6 +184,174 @@ def _load_voice_entitlement_route():
     }
     exec(compile(ast.fix_missing_locations(ast.Module(body=[route], type_ignores=[])), str(path), "exec"), namespace)
     return namespace["get_voice_entitlement"], namespace
+
+
+def _deterministic_backend_inventory(backend: Path, overrides=None):
+    overrides = overrides or {}
+    paths = {backend / "main.py", backend / "ella" / "__init__.py"}
+    for directory in (
+        backend / "routers",
+        backend / "ella" / "routers",
+        backend / "ella" / "services",
+        backend / "ella" / "utils",
+        backend / "utils",
+        backend / "database",
+    ):
+        paths.update(directory.rglob("*.py"))
+
+    launches = []
+    mutations = []
+    protected_mutations = []
+    raw_uid_mutations = []
+
+    class InventoryVisitor(ast.NodeVisitor):
+        def __init__(self, path, source):
+            self.path = path
+            self.source = source
+            self.functions = []
+
+        def _visit_function(self, node):
+            self.functions.append(node.name)
+            methods = {
+                decorator.func.attr
+                for decorator in node.decorator_list
+                if isinstance(decorator, ast.Call)
+                and isinstance(decorator.func, ast.Attribute)
+                and decorator.func.attr in {"post", "put", "patch", "delete", "websocket"}
+            }
+            if methods:
+                key = f"{self.path.relative_to(backend)}:{node.name}"
+                function_source = ast.get_source_segment(self.source, node) or ""
+                mutations.append(key)
+                if (
+                    "Depends(auth.get_writable_user_uid)" in function_source
+                    or "Depends(auth_endpoints.get_writable_user_uid)" in function_source
+                    or "Depends(require_current_ai_consent)" in function_source
+                    or "request_content_write_fence(" in function_source
+                ):
+                    protected_mutations.append(key)
+                if (
+                    "Depends(auth.get_current_user_uid)" in function_source
+                    or "Depends(auth_endpoints.get_current_user_uid)" in function_source
+                ):
+                    raw_uid_mutations.append(key)
+            self.generic_visit(node)
+            self.functions.pop()
+
+        visit_FunctionDef = _visit_function
+        visit_AsyncFunctionDef = _visit_function
+
+        def visit_Call(self, node):
+            name = ""
+            if isinstance(node.func, ast.Name):
+                name = node.func.id
+            elif isinstance(node.func, ast.Attribute):
+                name = node.func.attr
+            if name in {"create_task", "run_in_executor", "Thread", "start_new_thread"}:
+                function = self.functions[-1] if self.functions else "<module>"
+                launches.append(f"{self.path.relative_to(backend)}:{function}:{name}:{ast.unparse(node)}")
+            self.generic_visit(node)
+
+    for path in sorted(paths):
+        source = overrides.get(path, path.read_text(encoding="utf-8"))
+        InventoryVisitor(path, source).visit(ast.parse(source, filename=str(path)))
+
+    snapshot = {
+        "launches": sorted(launches),
+        "mutations": sorted(set(mutations)),
+        "protected_mutations": sorted(set(protected_mutations)),
+        "raw_uid_mutations": sorted(set(raw_uid_mutations)),
+    }
+    serialized = json.dumps(snapshot, sort_keys=True, separators=(",", ":"))
+    return snapshot, hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _assert_deterministic_backend_inventory(snapshot, digest, *, counts, expected_digest):
+    assert {key: len(value) for key, value in snapshot.items()} == counts
+    assert digest == expected_digest
+
+
+def test_backend_mutation_and_raw_launch_inventory_covers_startup_services_and_utilities():
+    backend = Path(__file__).resolve().parents[2]
+    snapshot, digest = _deterministic_backend_inventory(backend)
+
+    _assert_deterministic_backend_inventory(
+        snapshot,
+        digest,
+        counts={
+            "launches": 71,
+            "mutations": 229,
+            "protected_mutations": 135,
+            "raw_uid_mutations": 0,
+        },
+        expected_digest="3d0639b02127ec612d03244f05ca29faaed2fdefbf333cc8e9f3f5b432ea0e05",
+    )
+    assert any(
+        item.startswith("ella/services/hermes_cloud_enrichment_outbox.py:start_worker:create_task:")
+        for item in snapshot["launches"]
+    )
+    assert any(
+        item.startswith("ella/services/memory_reinterpretation.py:start_worker:create_task:")
+        for item in snapshot["launches"]
+    )
+
+
+def test_backend_inventory_positive_controls_reject_startup_raw_task_and_unfenced_uid_writer():
+    backend = Path(__file__).resolve().parents[2]
+    baseline, baseline_digest = _deterministic_backend_inventory(backend)
+    expected_counts = {
+        "launches": 71,
+        "mutations": 229,
+        "protected_mutations": 135,
+        "raw_uid_mutations": 0,
+    }
+
+    service_path = backend / "ella" / "services" / "hermes_cloud_enrichment_outbox.py"
+    service_source = service_path.read_text(encoding="utf-8")
+    injected_service = service_source.replace(
+        "    _worker_task = asyncio.create_task(active_worker.run_forever())",
+        "    _worker_task = asyncio.create_task(active_worker.run_forever())\n"
+        "    asyncio.create_task(active_worker.run_once())",
+        1,
+    )
+    startup_snapshot, startup_digest = _deterministic_backend_inventory(
+        backend,
+        {service_path: injected_service},
+    )
+    assert len(startup_snapshot["launches"]) == len(baseline["launches"]) + 1
+    assert any("active_worker.run_once()" in item for item in startup_snapshot["launches"])
+    with pytest.raises(AssertionError):
+        _assert_deterministic_backend_inventory(
+            startup_snapshot,
+            startup_digest,
+            counts=expected_counts,
+            expected_digest=baseline_digest,
+        )
+
+    route_path = backend / "ella" / "routers" / "settings.py"
+    injected_route = (
+        route_path.read_text(encoding="utf-8")
+        + """
+
+@router.post('/positive-control-unfenced-writer')
+async def positive_control_unfenced_writer(
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    await mutate_uid_content(uid)
+"""
+    )
+    writer_snapshot, writer_digest = _deterministic_backend_inventory(
+        backend,
+        {route_path: injected_route},
+    )
+    assert "ella/routers/settings.py:positive_control_unfenced_writer" in writer_snapshot["raw_uid_mutations"]
+    with pytest.raises(AssertionError):
+        _assert_deterministic_backend_inventory(
+            writer_snapshot,
+            writer_digest,
+            counts=expected_counts,
+            expected_digest=baseline_digest,
+        )
 
 
 def _production_app(delete_route):
@@ -808,6 +985,7 @@ def test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact
                     "Depends(auth.get_writable_user_uid)" in function_source
                     or "Depends(auth_endpoints.get_writable_user_uid)" in function_source
                     or "Depends(require_current_ai_consent)" in function_source
+                    or "request_content_write_fence(" in function_source
                 ):
                     protected_mutations.append(key)
                 if (
@@ -818,10 +996,11 @@ def test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact
 
     exact_protected = sorted(set(protected_mutations))
     exact_inventory_hash = hashlib.sha256("\n".join(exact_protected).encode("utf-8")).hexdigest()
-    assert len(exact_protected) == 133
-    assert exact_inventory_hash == "34e4792e5e7e04cf26e50e3af31d6abf4936e8f49637adcb151b457ca0bd3a36"
+    assert len(exact_protected) == 135
+    assert exact_inventory_hash == "d7f12be323f1e987a1dc047ca96cc97da8e3e7798820e319edc6d6de47efe429"
     assert raw_mutation_dependencies == []
     assert "ella/routers/trace.py:ingest_client_trace" in protected_mutations
+    assert "ella/routers/canonical_events.py:complete_session" in protected_mutations
 
     exact_mutations = sorted(set(mutation_routes))
     exact_mutation_hash = hashlib.sha256("\n".join(exact_mutations).encode("utf-8")).hexdigest()
@@ -831,8 +1010,8 @@ def test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact
     unauthenticated_inventory_hash = hashlib.sha256(
         "\n".join(mutations_without_writable_authority).encode("utf-8")
     ).hexdigest()
-    assert len(mutations_without_writable_authority) == 96
-    assert unauthenticated_inventory_hash == "a002a673c6ea5c5f04a7a558ccfce9f466feafde568899bc8b3ebe8be6cabd8d"
+    assert len(mutations_without_writable_authority) == 94
+    assert unauthenticated_inventory_hash == "084701269e75c53763662a82dbbd23218456fe524df327378e8d6a6219c02037"
     assert "ella/routers/trace.py:ingest_client_trace" not in mutations_without_writable_authority
     assert "routers/announcements.py:dismiss_announcement_endpoint" in protected_mutations
     assert "routers/transcribe.py:listen_handler" in protected_mutations

--- a/backend/tests/unit/test_content_write_fence.py
+++ b/backend/tests/unit/test_content_write_fence.py
@@ -131,6 +131,9 @@ def fence_environment(monkeypatch):
     async def purge_memory_reinterpretation_work(_uid):
         return 0
 
+    async def purge_canonical_event_ledger(_uid):
+        return 0
+
     monkeypatch.setattr(
         account_deletion_service.account_deletion_db,
         "purge_routing_traces",
@@ -141,6 +144,11 @@ def fence_environment(monkeypatch):
         "purge_memory_reinterpretation_work",
         purge_memory_reinterpretation_work,
     )
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "purge_canonical_event_ledger",
+        purge_canonical_event_ledger,
+    )
     yield database
     content_write_fence.configure_firestore_db(previous_database)
 
@@ -148,6 +156,38 @@ def fence_environment(monkeypatch):
 def _fence_state(database):
     reference = content_write_fence._fence_reference(database, UID)
     return deepcopy(database.documents.get(reference.key))
+
+
+def test_threaded_mutation_stale_token_is_joined_before_failure(monkeypatch, fence_environment):
+    entered = threading.Event()
+    release = threading.Event()
+    terminal = threading.Event()
+
+    async def assert_postgres_active(_uid):
+        return None
+
+    def mutate():
+        entered.set()
+        assert release.wait(3)
+        terminal.set()
+        return "mutated"
+
+    monkeypatch.setattr(content_write_fence, "_assert_postgres_owner_active", assert_postgres_active)
+
+    async def scenario():
+        async with content_write_fence.detached_content_write_fence(UID) as writer:
+            operation = asyncio.create_task(content_write_fence.run_admitted_threaded_mutation(UID, mutate))
+            assert await asyncio.to_thread(entered.wait, 2)
+            state = _fence_state(fence_environment)
+            state["writers"].pop(writer.token)
+            reference = content_write_fence._fence_reference(fence_environment, UID)
+            fence_environment.documents[reference.key] = state
+            release.set()
+            with pytest.raises(content_write_fence.ContentWriteFenceError, match="account_write_forbidden"):
+                await operation
+            assert terminal.is_set()
+
+    asyncio.run(scenario())
 
 
 def _load_production_delete_route():
@@ -228,6 +268,7 @@ def _deterministic_backend_inventory(backend: Path, overrides=None):
                     or "Depends(auth_endpoints.get_writable_user_uid)" in function_source
                     or "Depends(require_current_ai_consent)" in function_source
                     or "request_content_write_fence(" in function_source
+                    or "_canonical_write_fences(" in function_source
                 ):
                     protected_mutations.append(key)
                 if (
@@ -247,7 +288,21 @@ def _deterministic_backend_inventory(backend: Path, overrides=None):
                 name = node.func.id
             elif isinstance(node.func, ast.Attribute):
                 name = node.func.attr
-            if name in {"create_task", "run_in_executor", "Thread", "start_new_thread"}:
+            if name in {
+                "Thread",
+                "TaskGroup",
+                "add_task",
+                "create_task",
+                "finish_admitted_content_mutation",
+                "run_admitted_threaded_mutation",
+                "run_in_executor",
+                "safe_create_task",
+                "start_content_writer_task",
+                "start_content_writer_thread",
+                "start_new_thread",
+                "submit",
+                "to_thread",
+            }:
                 function = self.functions[-1] if self.functions else "<module>"
                 launches.append(f"{self.path.relative_to(backend)}:{function}:{name}:{ast.unparse(node)}")
             self.generic_visit(node)
@@ -279,12 +334,12 @@ def test_backend_mutation_and_raw_launch_inventory_covers_startup_services_and_u
         snapshot,
         digest,
         counts={
-            "launches": 71,
+            "launches": 188,
             "mutations": 229,
-            "protected_mutations": 135,
+            "protected_mutations": 136,
             "raw_uid_mutations": 0,
         },
-        expected_digest="3d0639b02127ec612d03244f05ca29faaed2fdefbf333cc8e9f3f5b432ea0e05",
+        expected_digest="fa3f77dfd53a40a08ae365824de91d14b111fc258ac70898989c83c4522ccd53",
     )
     assert any(
         item.startswith("ella/services/hermes_cloud_enrichment_outbox.py:start_worker:create_task:")
@@ -294,15 +349,21 @@ def test_backend_mutation_and_raw_launch_inventory_covers_startup_services_and_u
         item.startswith("ella/services/memory_reinterpretation.py:start_worker:create_task:")
         for item in snapshot["launches"]
     )
+    assert any(":submit:" in item for item in snapshot["launches"])
+    assert any(":add_task:" in item for item in snapshot["launches"])
+    assert any(":to_thread:" in item for item in snapshot["launches"])
+    assert any(":run_in_executor:" in item for item in snapshot["launches"])
+    assert any(":start_content_writer_thread:" in item for item in snapshot["launches"])
+    assert any("utils/ella/scanner_keyterms.py:_schedule_refresh:create_task:" in item for item in snapshot["launches"])
 
 
 def test_backend_inventory_positive_controls_reject_startup_raw_task_and_unfenced_uid_writer():
     backend = Path(__file__).resolve().parents[2]
     baseline, baseline_digest = _deterministic_backend_inventory(backend)
     expected_counts = {
-        "launches": 71,
+        "launches": 188,
         "mutations": 229,
-        "protected_mutations": 135,
+        "protected_mutations": 136,
         "raw_uid_mutations": 0,
     }
 
@@ -311,19 +372,48 @@ def test_backend_inventory_positive_controls_reject_startup_raw_task_and_unfence
     injected_service = service_source.replace(
         "    _worker_task = asyncio.create_task(active_worker.run_forever())",
         "    _worker_task = asyncio.create_task(active_worker.run_forever())\n"
-        "    asyncio.create_task(active_worker.run_once())",
+        "    asyncio.create_task(active_worker.run_once())\n"
+        "    executor.submit(active_worker.run_once)",
         1,
     )
     startup_snapshot, startup_digest = _deterministic_backend_inventory(
         backend,
         {service_path: injected_service},
     )
-    assert len(startup_snapshot["launches"]) == len(baseline["launches"]) + 1
+    assert len(startup_snapshot["launches"]) == len(baseline["launches"]) + 2
     assert any("active_worker.run_once()" in item for item in startup_snapshot["launches"])
+    assert any("executor.submit(active_worker.run_once)" in item for item in startup_snapshot["launches"])
     with pytest.raises(AssertionError):
         _assert_deterministic_backend_inventory(
             startup_snapshot,
             startup_digest,
+            counts=expected_counts,
+            expected_digest=baseline_digest,
+        )
+
+    background_path = backend / "ella" / "routers" / "onboarding.py"
+    injected_background = (
+        background_path.read_text(encoding="utf-8")
+        + """
+
+@router.post('/positive-control-background-writer')
+async def positive_control_background_writer(
+    background_tasks: BackgroundTasks,
+    uid: str = Depends(auth.get_writable_user_uid),
+):
+    background_tasks.add_task(mutate_uid_content, uid)
+"""
+    )
+    background_snapshot, background_digest = _deterministic_backend_inventory(
+        backend,
+        {background_path: injected_background},
+    )
+    assert len(background_snapshot["launches"]) == len(baseline["launches"]) + 1
+    assert any("background_tasks.add_task(mutate_uid_content, uid)" in item for item in background_snapshot["launches"])
+    with pytest.raises(AssertionError):
+        _assert_deterministic_backend_inventory(
+            background_snapshot,
+            background_digest,
             counts=expected_counts,
             expected_digest=baseline_digest,
         )
@@ -986,6 +1076,7 @@ def test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact
                     or "Depends(auth_endpoints.get_writable_user_uid)" in function_source
                     or "Depends(require_current_ai_consent)" in function_source
                     or "request_content_write_fence(" in function_source
+                    or "_canonical_write_fences(" in function_source
                 ):
                     protected_mutations.append(key)
                 if (
@@ -996,10 +1087,11 @@ def test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact
 
     exact_protected = sorted(set(protected_mutations))
     exact_inventory_hash = hashlib.sha256("\n".join(exact_protected).encode("utf-8")).hexdigest()
-    assert len(exact_protected) == 135
-    assert exact_inventory_hash == "d7f12be323f1e987a1dc047ca96cc97da8e3e7798820e319edc6d6de47efe429"
+    assert len(exact_protected) == 136
+    assert exact_inventory_hash == "164bcf6a4bb4a643a6c61ca519e55a2debbf15cae25cc8270c3e7427b7217748"
     assert raw_mutation_dependencies == []
     assert "ella/routers/trace.py:ingest_client_trace" in protected_mutations
+    assert "ella/routers/canonical_events.py:write_events" in protected_mutations
     assert "ella/routers/canonical_events.py:complete_session" in protected_mutations
 
     exact_mutations = sorted(set(mutation_routes))
@@ -1010,8 +1102,8 @@ def test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact
     unauthenticated_inventory_hash = hashlib.sha256(
         "\n".join(mutations_without_writable_authority).encode("utf-8")
     ).hexdigest()
-    assert len(mutations_without_writable_authority) == 94
-    assert unauthenticated_inventory_hash == "084701269e75c53763662a82dbbd23218456fe524df327378e8d6a6219c02037"
+    assert len(mutations_without_writable_authority) == 93
+    assert unauthenticated_inventory_hash == "073c713813921f26ce6cdcecfb04e359fce313b20f8d9f97e13cc649294a5434"
     assert "ella/routers/trace.py:ingest_client_trace" not in mutations_without_writable_authority
     assert "routers/announcements.py:dismiss_announcement_endpoint" in protected_mutations
     assert "routers/transcribe.py:listen_handler" in protected_mutations

--- a/backend/tests/unit/test_content_write_fence.py
+++ b/backend/tests/unit/test_content_write_fence.py
@@ -2,26 +2,45 @@ import asyncio
 import ast
 from contextlib import asynccontextmanager
 from copy import deepcopy
+import hashlib
+import io
 import os
 from pathlib import Path
+import sys
 from types import SimpleNamespace
 import threading
 import time
+import uuid
+from zipfile import ZipFile
 
 from fastapi import Depends, FastAPI, Response
 from fastapi.responses import StreamingResponse
 from fastapi.testclient import TestClient
+import httpx
 import pytest
 
 os.environ.setdefault("FIRESTORE_EMULATOR_HOST", "localhost:9999")
+os.environ.setdefault("STORAGE_EMULATOR_HOST", "http://localhost:4443")
 os.environ.setdefault("GCLOUD_PROJECT", "omi-ci")
 os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "omi-ci")
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ci_content_fence_test_key_32b")
 
 from database import account_deletion as account_deletion_db
 from database import content_write_fence
+from ella.routers import ai_consent
 from ella.services import account_deletion as account_deletion_service
-from routers import announcements
 from utils.other import endpoints as auth_endpoints
+
+_previous_notifications = sys.modules.get("utils.notifications")
+sys.modules["utils.notifications"] = SimpleNamespace(send_notification=lambda **_kwargs: None)
+try:
+    from routers import announcements, imports as imports_router
+    from utils.imports import limitless
+finally:
+    if _previous_notifications is None:
+        sys.modules.pop("utils.notifications", None)
+    else:
+        sys.modules["utils.notifications"] = _previous_notifications
 
 UID = "distributed-fence-user"
 
@@ -132,6 +151,23 @@ def _load_production_delete_route():
     return namespace["delete_account"], namespace
 
 
+def _load_voice_entitlement_route():
+    path = Path(__file__).resolve().parents[2] / "ella" / "routers" / "voice.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    route = next(
+        node for node in tree.body if isinstance(node, ast.AsyncFunctionDef) and node.name == "get_voice_entitlement"
+    )
+    route.decorator_list = []
+    namespace = {
+        "Depends": Depends,
+        "auth": auth_endpoints,
+        "voice_canary_db": SimpleNamespace(get_entitlement_contract=None),
+        "uuid": uuid,
+    }
+    exec(compile(ast.fix_missing_locations(ast.Module(body=[route], type_ignores=[])), str(path), "exec"), namespace)
+    return namespace["get_voice_entitlement"], namespace
+
+
 def _production_app(delete_route):
     app = FastAPI()
     app.include_router(announcements.router)
@@ -149,33 +185,20 @@ def test_adversarial_production_route_writer_is_drained_before_deletion_reports_
 ):
     """Reproduce Iris's barrier on mounted writer and deletion entrypoints."""
     monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "true" if authority_enabled else "false")
-    postgres_owner_lock = threading.Lock()
     mutation_reached = threading.Event()
     release_mutation = threading.Event()
     content = set()
     order = []
 
-    @asynccontextmanager
-    async def postgres_fence(uid):
+    async def assert_postgres_active(uid):
         assert uid == UID
-        acquired = await asyncio.to_thread(postgres_owner_lock.acquire, True, 2)
-        assert acquired
-        try:
-            yield
-        finally:
-            postgres_owner_lock.release()
 
-    monkeypatch.setattr(content_write_fence, "_postgres_owner_fence", postgres_fence)
+    monkeypatch.setattr(content_write_fence, "_assert_postgres_owner_active", assert_postgres_active)
 
     async def quarantine(uid):
         assert uid == UID
-        acquired = await asyncio.to_thread(postgres_owner_lock.acquire, True, 2)
-        assert acquired
-        try:
-            order.append("postgres_tombstone")
-            return _state()
-        finally:
-            postgres_owner_lock.release()
+        order.append("postgres_tombstone")
+        return _state()
 
     async def finalize(uid):
         assert uid == UID
@@ -257,6 +280,7 @@ def test_adversarial_production_route_writer_is_drained_before_deletion_reports_
         )
         assert order.index("writer_commit") < order.index("firestore_sweep")
         if authority_enabled:
+            assert order.index("postgres_tombstone") < order.index("firestore_sweep")
             assert order.index("firestore_sweep") < order.index("final_absence_proof")
             assert order.index("final_absence_proof") < order.index("firebase_delete")
         else:
@@ -379,6 +403,76 @@ def test_two_independent_workers_are_durably_drained(monkeypatch, fence_environm
     assert _fence_state(fence_environment)["state"] == content_write_fence.TOMBSTONED
 
 
+def test_detached_writer_transfers_child_registration_before_parent_release(monkeypatch, fence_environment):
+    monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "false")
+    child_entered = threading.Event()
+    release_child = threading.Event()
+    order = []
+
+    def child_commit():
+        child_entered.set()
+        assert release_child.wait(3)
+        content_write_fence.assert_detached_content_writer_current(UID)
+        order.append("child_commit")
+
+    async def parent():
+        async with content_write_fence.detached_content_write_fence(UID):
+            content_write_fence.start_content_writer_thread(UID, child_commit, name="nested-content-writer")
+            assert child_entered.wait(2)
+
+    asyncio.run(parent())
+    assert len(_fence_state(fence_environment)["writers"]) == 1
+
+    def delete():
+        assert asyncio.run(content_write_fence.tombstone_content_writes(UID)) is True
+        order.append("tombstoned")
+
+    deletion = threading.Thread(target=delete)
+    deletion.start()
+    time.sleep(0.1)
+    assert deletion.is_alive()
+
+    release_child.set()
+    deletion.join(3)
+    assert order == ["child_commit", "tombstoned"]
+    assert _fence_state(fence_environment)["state"] == content_write_fence.TOMBSTONED
+
+
+def test_expired_registration_never_proves_a_live_writer_absent(monkeypatch, fence_environment):
+    """Exercise the exact blocked-event-loop ordering from Iris's review."""
+    monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "false")
+    monkeypatch.setenv("ELLA_CONTENT_WRITE_FENCE_LEASE_SECONDS", "1")
+    monkeypatch.setenv("ELLA_CONTENT_WRITE_FENCE_DRAIN_SECONDS", "3")
+    entered = threading.Event()
+    order = []
+
+    def writer():
+        async def run():
+            async with content_write_fence.content_write_fence(UID):
+                entered.set()
+                time.sleep(1.5)
+                order.append("writer_commit")
+
+        asyncio.run(run())
+
+    writer_thread = threading.Thread(target=writer)
+    writer_thread.start()
+    assert entered.wait(2)
+    time.sleep(1.1)
+
+    def delete():
+        assert asyncio.run(content_write_fence.tombstone_content_writes(UID)) is True
+        order.append("tombstoned")
+
+    deletion_thread = threading.Thread(target=delete)
+    deletion_thread.start()
+    writer_thread.join(3)
+    deletion_thread.join(3)
+
+    assert order == ["writer_commit", "tombstoned"]
+    assert _fence_state(fence_environment)["state"] == content_write_fence.TOMBSTONED
+
+
 @pytest.mark.parametrize("exit_kind", ["error", "cancellation"])
 def test_error_and_cancellation_release_writer_lease(monkeypatch, fence_environment, exit_kind):
     monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "false")
@@ -419,7 +513,237 @@ def test_authority_disabled_never_opens_postgres(monkeypatch, fence_environment)
     assert asyncio.run(run()) == "committed"
 
 
-def test_mounted_authenticated_writer_inventory_uses_scope_holding_dependencies():
+class _PoolTransaction:
+    async def start(self):
+        return None
+
+    async def rollback(self):
+        return None
+
+
+class _PoolConnection:
+    def transaction(self):
+        return _PoolTransaction()
+
+    async def fetchval(self, _query, *_args):
+        return content_write_fence.ACTIVE
+
+
+class _BoundedPool:
+    def __init__(self, capacity):
+        self.semaphore = asyncio.Semaphore(capacity)
+        self.active = 0
+        self.maximum_active = 0
+
+    def acquire(self):
+        pool = self
+
+        @asynccontextmanager
+        async def manager():
+            await pool.semaphore.acquire()
+            pool.active += 1
+            pool.maximum_active = max(pool.maximum_active, pool.active)
+            try:
+                yield _PoolConnection()
+            finally:
+                pool.active -= 1
+                pool.semaphore.release()
+
+        return manager()
+
+
+@pytest.mark.parametrize("route_kind", ["consent", "entitlement"])
+def test_mounted_nested_database_routes_release_admission_connection_before_handler(
+    monkeypatch,
+    fence_environment,
+    route_kind,
+):
+    """Pool-size-N requests must all reach their real nested DB boundary."""
+    capacity = 2
+
+    async def scenario():
+        pool = _BoundedPool(capacity)
+        nested_count = 0
+        all_nested = asyncio.Event()
+        nested_lock = asyncio.Lock()
+
+        async def get_pool():
+            return pool
+
+        async def resolve_owner(_connection, *, uid):
+            assert uid == UID
+            return SimpleNamespace(account_user_id="account", profile_user_id="profile")
+
+        async def acquire_lock(_connection, *, owner):
+            assert owner.account_user_id == "account"
+            return object()
+
+        async def verify_owner(_connection, *, uid, owner, proof):
+            assert (uid, owner.profile_user_id, proof is not None) == (UID, "profile", True)
+            return "database-user"
+
+        async def nested_database_call(result):
+            nonlocal nested_count
+            async with pool.acquire():
+                async with nested_lock:
+                    nested_count += 1
+                    if nested_count == capacity:
+                        all_nested.set()
+                await asyncio.wait_for(all_nested.wait(), timeout=1)
+                return result
+
+        monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "true")
+        monkeypatch.setattr(content_write_fence.voice_canary, "get_pool", get_pool)
+        monkeypatch.setattr(
+            content_write_fence.authority_advisory_lock,
+            "resolve_self_owner_unlocked",
+            resolve_owner,
+        )
+        monkeypatch.setattr(
+            content_write_fence.authority_advisory_lock,
+            "acquire_authority_lock",
+            acquire_lock,
+        )
+        monkeypatch.setattr(
+            content_write_fence.authority_advisory_lock,
+            "verify_self_owner_after_lock",
+            verify_owner,
+        )
+
+        app = FastAPI()
+        if route_kind == "consent":
+
+            async def submit_authority(**_kwargs):
+                return await nested_database_call({"status": "ok"})
+
+            monkeypatch.setattr(ai_consent, "submit_with_managed_cloud_authority", submit_authority)
+            monkeypatch.setattr(ai_consent, "get_ai_consent_service", lambda: object())
+            app.include_router(ai_consent.router)
+            method = "POST"
+            path = "/v1/users/ai-consent"
+            body = {
+                "decision": "granted",
+                "policy_version": "ai-data-processors-v8",
+                "processor_set_hash": "sha256:" + ("1" * 64),
+                "request_id": "synthetic-request",
+                "app_version": "1.0",
+                "build_number": "1",
+                "locale": "en-US",
+                "scope_version": "scope-v1",
+                "scope_hash": "sha256:" + ("2" * 64),
+            }
+        else:
+
+            async def entitlement_contract(uid):
+                assert uid == UID
+                return await nested_database_call({"entitled": True})
+
+            entitlement_route, entitlement_namespace = _load_voice_entitlement_route()
+            entitlement_namespace["voice_canary_db"].get_entitlement_contract = entitlement_contract
+            app.add_api_route("/v1/entitlement", entitlement_route, methods=["GET"])
+            method = "GET"
+            path = "/v1/entitlement"
+            body = None
+
+        app.dependency_overrides[auth_endpoints.get_current_user_uid] = lambda: UID
+        app.add_middleware(content_write_fence.ContentWriteFenceMiddleware)
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            responses = await asyncio.wait_for(
+                asyncio.gather(*(client.request(method, path, json=body) for _index in range(capacity))),
+                timeout=2,
+            )
+
+        assert [response.status_code for response in responses] == [200, 200]
+        assert nested_count == capacity
+        assert pool.maximum_active == capacity
+        assert pool.active == 0
+
+    asyncio.run(scenario())
+
+
+def test_mounted_limitless_worker_transfers_fence_until_actual_upsert_finishes(
+    monkeypatch,
+    fence_environment,
+    tmp_path,
+):
+    monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "false")
+    monkeypatch.setattr(imports_router, "TEMP_DIR", str(tmp_path))
+    upsert_entered = threading.Event()
+    release_upsert = threading.Event()
+    worker_finished = threading.Event()
+    conversations = set()
+    job_updates = []
+
+    job = SimpleNamespace(id="limitless-job", status=SimpleNamespace(value="pending"))
+    monkeypatch.setattr(imports_router, "create_import_job", lambda uid, _source: job)
+    monkeypatch.setattr(
+        imports_router.import_jobs_db,
+        "update_import_job",
+        lambda job_id, update: job_updates.append((job_id, deepcopy(update))),
+    )
+
+    def upsert(uid, conversation):
+        assert uid == UID
+        upsert_entered.set()
+        assert release_upsert.wait(5)
+        conversations.add(conversation["id"])
+
+    monkeypatch.setattr(limitless.conversations_db, "upsert_conversation", upsert, raising=False)
+    monkeypatch.setattr(limitless, "send_notification", lambda **_kwargs: worker_finished.set())
+
+    archive = io.BytesIO()
+    with ZipFile(archive, "w") as bundle:
+        bundle.writestr(
+            "lifelogs/2026-08-02_12h00m00s_Synthetic.md",
+            "# Synthetic\n\n## Summary\n\n> [1](#startMs=1000&endMs=2000): Test content",
+        )
+
+    app = FastAPI()
+    app.include_router(imports_router.router)
+    app.dependency_overrides[auth_endpoints.get_current_user_uid] = lambda: UID
+    app.add_middleware(content_write_fence.ContentWriteFenceMiddleware)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/import/limitless",
+            files={"file": ("synthetic.zip", archive.getvalue(), "application/zip")},
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "pending"
+        assert upsert_entered.wait(2)
+        assert len(_fence_state(fence_environment)["writers"]) == 1
+
+        deletion_result = {}
+
+        def delete():
+            async def run():
+                assert await content_write_fence.tombstone_content_writes(UID) is True
+                conversations.clear()
+                deletion_result["complete"] = True
+
+            asyncio.run(run())
+
+        deletion = threading.Thread(target=delete)
+        deletion.start()
+        time.sleep(0.1)
+        assert deletion.is_alive()
+        assert not deletion_result
+
+        release_upsert.set()
+        assert worker_finished.wait(3)
+        deletion.join(3)
+
+    assert deletion_result == {"complete": True}
+    assert not conversations
+    assert any(update.get("status") == "completed" for _job_id, update in job_updates)
+    assert _fence_state(fence_environment)["state"] == content_write_fence.TOMBSTONED
+
+
+def test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact():
     backend = Path(__file__).resolve().parents[2]
     endpoints_source = (backend / "utils" / "other" / "endpoints.py").read_text(encoding="utf-8")
     endpoints_tree = ast.parse(endpoints_source)
@@ -481,7 +805,10 @@ def test_mounted_authenticated_writer_inventory_uses_scope_holding_dependencies(
                 ):
                     raw_mutation_dependencies.append(key)
 
-    assert len(protected_mutations) >= 100
+    exact_protected = sorted(set(protected_mutations))
+    exact_inventory_hash = hashlib.sha256("\n".join(exact_protected).encode("utf-8")).hexdigest()
+    assert len(exact_protected) == 132
+    assert exact_inventory_hash == "43b8dc6f802264329ddca1d2d893fd1d8bcc78f3f677c505a8c5720e5d1ca3cc"
     assert raw_mutation_dependencies == []
     assert "routers/announcements.py:dismiss_announcement_endpoint" in protected_mutations
     assert "routers/transcribe.py:listen_handler" in protected_mutations
@@ -496,3 +823,78 @@ def test_mounted_authenticated_writer_inventory_uses_scope_holding_dependencies(
         source = (backend / relative_path).read_text(encoding="utf-8")
         assert "await admit_authenticated_content_writer(" in source, relative_path
     assert "await auth.assert_authenticated_user_writable(uid)" not in transcribe_source
+
+    expected_transferred_threads = {
+        "routers/action_items.py:create_action_item",
+        "routers/chat.py:send_message",
+        "routers/developer.py:create_memories_batch",
+        "routers/developer.py:create_memory",
+        "routers/imports.py:import_limitless_data",
+        "routers/mcp.py:create_memory",
+        "routers/memories.py:create_memory",
+        "routers/memories.py:update_memory_visibility",
+        "routers/sync.py:get_audio_signed_urls_endpoint",
+        "routers/sync.py:precache_conversation_audio_endpoint",
+        "routers/wrapped.py:generate_wrapped",
+    }
+    transferred_threads = set()
+    direct_thread_routes = set()
+    detached_task_routes = set()
+    for directory in (backend / "routers", backend / "ella" / "routers"):
+        for path in sorted(directory.glob("*.py")):
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                    continue
+                key = f"{path.relative_to(backend)}:{node.name}"
+                calls = {
+                    child.func.attr if isinstance(child.func, ast.Attribute) else child.func.id
+                    for child in ast.walk(node)
+                    if isinstance(child, ast.Call) and isinstance(child.func, (ast.Attribute, ast.Name))
+                }
+                if "safe_create_task" in calls:
+                    detached_task_routes.add(key)
+                methods = {
+                    decorator.func.attr
+                    for decorator in node.decorator_list
+                    if isinstance(decorator, ast.Call)
+                    and isinstance(decorator.func, ast.Attribute)
+                    and decorator.func.attr in {"get", "post", "put", "patch", "delete", "websocket"}
+                }
+                if not methods:
+                    continue
+                if "start_content_writer_thread" in calls:
+                    transferred_threads.add(key)
+                if "Thread" in calls:
+                    direct_thread_routes.add(key)
+
+    assert transferred_threads == expected_transferred_threads
+    assert direct_thread_routes == {"routers/sync.py:sync_local_files"}
+    assert detached_task_routes == {
+        "routers/pusher.py:_websocket_util_trigger",
+        "routers/pusher.py:receive_tasks",
+    }
+    sync_source = (backend / "routers" / "sync.py").read_text(encoding="utf-8")
+    assert "[t.join() for t in threads" in sync_source
+    assert "await content_write_fence.start_content_writer_task(" in transcribe_source
+    assert "safe_create_task(process_photo" not in transcribe_source
+
+    pusher_source = (backend / "routers" / "pusher.py").read_text(encoding="utf-8")
+    assert "async with content_write_fence.detached_content_write_fence(uid):" in pusher_source
+    assert "_process_conversation_task_with_fence(" in pusher_source
+
+    processing_source = (backend / "utils" / "conversations" / "process_conversation.py").read_text(encoding="utf-8")
+    assert processing_source.count("content_write_fence.start_content_writer_thread(") == 6
+    for escaped_target in (
+        "threading.Thread(target=_extract_memories",
+        "threading.Thread(target=_extract_trends",
+        "threading.Thread(target=_save_action_items",
+        "threading.Thread(target=_update_goal_progress",
+        "threading.Thread(target=update_personas_async",
+    ):
+        assert escaped_target not in processing_source
+
+    storage_source = (backend / "utils" / "other" / "storage.py").read_text(encoding="utf-8")
+    assert storage_source.count("content_write_fence.start_content_writer_thread(") == 2
+    assert "threading.Thread(" not in storage_source

--- a/backend/tests/unit/test_content_write_fence.py
+++ b/backend/tests/unit/test_content_write_fence.py
@@ -123,6 +123,15 @@ def fence_environment(monkeypatch):
     monkeypatch.setattr(content_write_fence.firestore, "transactional", _transactional)
     monkeypatch.setenv("ELLA_CONTENT_WRITE_FENCE_LEASE_SECONDS", "3")
     monkeypatch.setenv("ELLA_CONTENT_WRITE_FENCE_DRAIN_SECONDS", "3")
+
+    async def purge_routing_traces(_uid):
+        return 0
+
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "purge_routing_traces",
+        purge_routing_traces,
+    )
     yield database
     content_write_fence.configure_firestore_db(previous_database)
 
@@ -775,6 +784,7 @@ def test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact
 
     raw_mutation_dependencies = []
     protected_mutations = []
+    mutation_routes = []
     for directory in (backend / "routers", backend / "ella" / "routers"):
         for path in sorted(directory.glob("*.py")):
             source = path.read_text(encoding="utf-8")
@@ -793,6 +803,7 @@ def test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact
                     continue
                 function_source = ast.get_source_segment(source, node) or ""
                 key = f"{path.relative_to(backend)}:{node.name}"
+                mutation_routes.append(key)
                 if (
                     "Depends(auth.get_writable_user_uid)" in function_source
                     or "Depends(auth_endpoints.get_writable_user_uid)" in function_source
@@ -807,9 +818,22 @@ def test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact
 
     exact_protected = sorted(set(protected_mutations))
     exact_inventory_hash = hashlib.sha256("\n".join(exact_protected).encode("utf-8")).hexdigest()
-    assert len(exact_protected) == 132
-    assert exact_inventory_hash == "43b8dc6f802264329ddca1d2d893fd1d8bcc78f3f677c505a8c5720e5d1ca3cc"
+    assert len(exact_protected) == 133
+    assert exact_inventory_hash == "34e4792e5e7e04cf26e50e3af31d6abf4936e8f49637adcb151b457ca0bd3a36"
     assert raw_mutation_dependencies == []
+    assert "ella/routers/trace.py:ingest_client_trace" in protected_mutations
+
+    exact_mutations = sorted(set(mutation_routes))
+    exact_mutation_hash = hashlib.sha256("\n".join(exact_mutations).encode("utf-8")).hexdigest()
+    assert len(exact_mutations) == 229
+    assert exact_mutation_hash == "aec1004c1c066d2c3fa31cb18ec978811f9c33a88df1cf16a2d3f406f489c2d5"
+    mutations_without_writable_authority = sorted(set(exact_mutations) - set(exact_protected))
+    unauthenticated_inventory_hash = hashlib.sha256(
+        "\n".join(mutations_without_writable_authority).encode("utf-8")
+    ).hexdigest()
+    assert len(mutations_without_writable_authority) == 96
+    assert unauthenticated_inventory_hash == "a002a673c6ea5c5f04a7a558ccfce9f466feafde568899bc8b3ebe8be6cabd8d"
+    assert "ella/routers/trace.py:ingest_client_trace" not in mutations_without_writable_authority
     assert "routers/announcements.py:dismiss_announcement_endpoint" in protected_mutations
     assert "routers/transcribe.py:listen_handler" in protected_mutations
     transcribe_source = (backend / "routers" / "transcribe.py").read_text(encoding="utf-8")
@@ -840,6 +864,7 @@ def test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact
     transferred_threads = set()
     direct_thread_routes = set()
     detached_task_routes = set()
+    raw_task_functions = set()
     for directory in (backend / "routers", backend / "ella" / "routers"):
         for path in sorted(directory.glob("*.py")):
             source = path.read_text(encoding="utf-8")
@@ -855,6 +880,8 @@ def test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact
                 }
                 if "safe_create_task" in calls:
                     detached_task_routes.add(key)
+                if "create_task" in calls:
+                    raw_task_functions.add(key)
                 methods = {
                     decorator.func.attr
                     for decorator in node.decorator_list
@@ -875,6 +902,19 @@ def test_mounted_authenticated_writer_inventory_and_detached_lifetimes_are_exact
         "routers/pusher.py:_websocket_util_trigger",
         "routers/pusher.py:receive_tasks",
     }
+    assert raw_task_functions == {
+        "ella/routers/chat.py:_stream_level_4_openclaw",
+        "ella/routers/voice.py:get_voice_context",
+        "ella/routers/voice.py:heartbeat_voice_canary_session",
+        "routers/pusher.py:_websocket_util_trigger",
+        "routers/transcribe.py:_create_speech_profile_loader_task",
+        "routers/transcribe.py:_send_message_event",
+        "routers/transcribe.py:_stream_handler",
+        "routers/transcribe.py:flush_stt_buffer",
+        "routers/transcribe.py:receive_data",
+        "routers/transcribe.py:speaker_identification_task",
+    }
+    assert "ella/routers/trace.py:record_trace" not in raw_task_functions
     sync_source = (backend / "routers" / "sync.py").read_text(encoding="utf-8")
     assert "[t.join() for t in threads" in sync_source
     assert "await content_write_fence.start_content_writer_task(" in transcribe_source

--- a/backend/tests/unit/test_conversation_processing_failures.py
+++ b/backend/tests/unit/test_conversation_processing_failures.py
@@ -384,7 +384,7 @@ def test_retry_claim_rejects_a_different_request_while_processing():
 def _conversation_api_client():
     app = FastAPI()
     app.include_router(conversations_router.router)
-    app.dependency_overrides[conversations_router.auth.get_current_user_uid] = lambda: "authenticated-user"
+    app.dependency_overrides[conversations_router.auth.get_writable_user_uid] = lambda: "authenticated-user"
     return app, TestClient(app)
 
 

--- a/backend/tests/unit/test_conversation_processing_failures.py
+++ b/backend/tests/unit/test_conversation_processing_failures.py
@@ -169,6 +169,11 @@ from utils.conversations.failure_state import (
 from routers import conversations as conversations_router
 
 
+@pytest.fixture(autouse=True)
+def _isolate_conversation_meeting_cache(monkeypatch):
+    monkeypatch.setattr(conversation_processor.redis_db, "get_conversation_meeting_id", lambda _conversation_id: None)
+
+
 def _long_conversation() -> Conversation:
     text = " ".join(["important"] * 3200)
     return Conversation(

--- a/backend/tests/unit/test_durable_worker_deletion_finality.py
+++ b/backend/tests/unit/test_durable_worker_deletion_finality.py
@@ -4,11 +4,12 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from copy import deepcopy
 from dataclasses import replace
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 import json
 import multiprocessing
 import os
 from pathlib import Path
+import subprocess
 import sys
 from types import SimpleNamespace
 import types
@@ -47,7 +48,12 @@ summary_stub.generate_stock_conversation_summary = lambda *args, **kwargs: None
 sys.modules.setdefault("utils.conversations.generic_summary", summary_stub)
 
 from database import account_deletion as account_deletion_db
-from database import content_write_fence, content_write_recovery, content_writer_owner
+from database import (
+    content_write_fence,
+    content_write_recovery,
+    content_write_recovery_authority,
+    content_writer_owner,
+)
 from database.memory_reinterpretations import InMemoryMemoryReinterpretationRepository
 from ella.routers import canonical_events
 from ella.routers.canonical_events import (
@@ -61,10 +67,11 @@ from ella.services import memory_reinterpretation as reinterpretation_service
 from ella.services import proposal_ingest
 from ella.services.hermes_cloud_enrichment_outbox import DeliveryResult, HermesCloudEnrichmentOutboxWorker
 from ella.services.memory_reinterpretation import ApplyResult, MemoryReinterpretationWorker, ReinterpretationPlan
-from scripts import content_writer_recovery as recovery_cli
 
 UID = "startup-worker-delete-user"
 OTHER_UID = "startup-worker-retained-user"
+PRODUCTION_CURRENT_PROCESS_BOUNDARY = content_writer_owner.current_process_boundary
+PRODUCTION_PROCESS_SNAPSHOT = content_writer_owner.process_snapshot
 
 
 class _Snapshot:
@@ -140,16 +147,6 @@ def _hold_process_writer(firestore, uid, token, ready, release):
     worker.join()
 
 
-def _run_unprivileged_recovery(subject_hash, token_hash):
-    if os.geteuid() == 0:
-        os.setuid(65534)
-    result = recovery_cli.main(
-        ["--subject-hash", subject_hash, "--token-hash", token_hash],
-        firestore_db=object(),
-    )
-    os._exit(result)
-
-
 def _shared_firestore(context):
     manager = context.Manager()
     return manager, _Firestore(documents=manager.dict(), lock=manager.RLock())
@@ -172,17 +169,24 @@ def _writer_record(firestore, uid, token):
     return state["writers"][token]
 
 
-def _invoke_recovery(monkeypatch, firestore, *, uid, token):
-    monkeypatch.setattr(recovery_cli.os, "geteuid", lambda: 0)
-    return recovery_cli.main(
-        [
-            "--subject-hash",
-            content_write_recovery.hash_selector(uid),
-            "--token-hash",
-            content_write_recovery.hash_selector(token),
-        ],
-        firestore_db=firestore,
-    )
+def _invoke_recovery(firestore, *, uid, token, transactional=_transactional):
+    refusal = {
+        "action": "content_writer_recovery",
+        "content_free": True,
+        "result": "refused",
+    }
+    try:
+        receipt = content_write_recovery.recover_orphaned_writer(
+            firestore,
+            subject_hash=content_write_recovery.hash_selector(uid),
+            token_hash=content_write_recovery.hash_selector(token),
+            transactional=transactional,
+        )
+    except content_write_recovery.ContentWriterRecoveryError as exc:
+        print(json.dumps({**refusal, "reason": exc.code}, sort_keys=True, separators=(",", ":")))
+        return 2
+    print(json.dumps(receipt.to_dict(), sort_keys=True, separators=(",", ":")))
+    return 0
 
 
 def _state():
@@ -844,7 +848,7 @@ def test_process_restart_uses_root_cli_and_real_kernel_terminal_proof_before_fir
             assert restarted_process.status_code == 202
             assert order == []
 
-            assert _invoke_recovery(monkeypatch, firestore, uid=UID, token=token) == 2
+            assert _invoke_recovery(firestore, uid=UID, token=token) == 2
             refused = json.loads(capsys.readouterr().out)
             assert refused == {
                 "action": "content_writer_recovery",
@@ -859,7 +863,7 @@ def test_process_restart_uses_root_cli_and_real_kernel_terminal_proof_before_fir
             process.terminate()
             process.join(5)
             assert not process.is_alive()
-            assert _invoke_recovery(monkeypatch, firestore, uid=UID, token=token) == 0
+            assert _invoke_recovery(firestore, uid=UID, token=token) == 0
             recovered = json.loads(capsys.readouterr().out)
             assert recovered["result"] == "recovered"
             assert recovered["proof_kind"] == "kernel_process_absent"
@@ -875,8 +879,8 @@ def test_process_restart_uses_root_cli_and_real_kernel_terminal_proof_before_fir
             content_write_fence._release_firestore_writer(firestore, UID, same_uid_token)
             converged = await client.delete("/v1/users/delete-account")
             assert converged.status_code == 200
-            assert _invoke_recovery(monkeypatch, firestore, uid=UID, token=token) == 0
-            assert json.loads(capsys.readouterr().out)["result"] == "already_recovered"
+            assert _invoke_recovery(firestore, uid=UID, token=token) == 2
+            assert json.loads(capsys.readouterr().out)["reason"] == "account_writer_recovery_stale_token"
 
     try:
         asyncio.run(scenario())
@@ -920,39 +924,79 @@ def test_recovery_surface_rejects_other_boundary_and_pid_reuse(
     state["writers"][token]["owner"] = replacement.to_storage()
     deletion_fence.documents[reference.key] = state
 
-    assert _invoke_recovery(monkeypatch, deletion_fence, uid=UID, token=token) == 2
+    assert _invoke_recovery(deletion_fence, uid=UID, token=token) == 2
     assert json.loads(capsys.readouterr().out)["reason"] == expected_reason
     assert token in content_write_fence._snapshot_data(reference.get())["writers"]
 
 
 def test_recovery_surface_rejects_stale_cross_uid_ownerless_and_actual_unprivileged_invocation(
-    monkeypatch,
     deletion_fence,
     capsys,
+    tmp_path,
 ):
     token = "selector-control-token"
     content_write_fence._acquire_firestore_writer(deletion_fence, UID, token, 3)
-    assert _invoke_recovery(monkeypatch, deletion_fence, uid=UID, token="stale-token") == 2
+    assert _invoke_recovery(deletion_fence, uid=UID, token="stale-token") == 2
     assert json.loads(capsys.readouterr().out)["reason"] == "account_writer_recovery_stale_token"
-    assert _invoke_recovery(monkeypatch, deletion_fence, uid=OTHER_UID, token=token) == 2
+    assert _invoke_recovery(deletion_fence, uid=OTHER_UID, token=token) == 2
     assert json.loads(capsys.readouterr().out)["reason"] == "account_writer_recovery_stale_token"
 
     reference = content_write_fence._fence_reference(deletion_fence, UID)
     state = content_write_fence._snapshot_data(reference.get())
     state["writers"][token] = state["writers"][token]["expires_at"]
     deletion_fence.documents[reference.key] = state
-    assert _invoke_recovery(monkeypatch, deletion_fence, uid=UID, token=token) == 2
+    assert _invoke_recovery(deletion_fence, uid=UID, token=token) == 2
     assert json.loads(capsys.readouterr().out)["reason"] == "account_writer_recovery_owner_unknown"
 
-    monkeypatch.setattr(recovery_cli.os, "geteuid", recovery_cli.os.getuid)
-    context = multiprocessing.get_context("fork")
-    process = context.Process(
-        target=_run_unprivileged_recovery,
-        args=(content_write_recovery.hash_selector(UID), content_write_recovery.hash_selector(token)),
+    hostile_path = tmp_path / "hostile"
+    hostile_database = hostile_path / "database"
+    hostile_database.mkdir(parents=True)
+    marker = tmp_path / "hostile-imported"
+    (hostile_database / "__init__.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('loaded')\n",
+        encoding="utf-8",
     )
-    process.start()
-    process.join(5)
-    assert process.exitcode == 77
+    hostile_google = hostile_path / "google"
+    hostile_google.mkdir()
+    (hostile_google / "__init__.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('loaded')\n",
+        encoding="utf-8",
+    )
+    credential_target = tmp_path / "credential-target"
+    (tmp_path / "google-credentials.json").symlink_to(credential_target)
+    environment = dict(os.environ)
+    environment.update(
+        {
+            "PYTHONPATH": str(hostile_path),
+            "SERVICE_ACCOUNT_JSON": '{"private_key":"fake-reviewer-control"}',
+            "FIRESTORE_EMULATOR_HOST": "127.0.0.1:65530",
+            "GCLOUD_PROJECT": "wrong-project",
+            "GOOGLE_CLOUD_PROJECT": "wrong-project",
+        }
+    )
+    script = Path(__file__).resolve().parents[2] / "scripts" / "content_writer_recovery.py"
+    for interpreter_flags in ([], ["-I"]):
+        completed = subprocess.run(
+            [
+                sys.executable,
+                *interpreter_flags,
+                str(script),
+                "--subject-hash",
+                content_write_recovery.hash_selector(UID),
+                "--token-hash",
+                content_write_recovery.hash_selector(token),
+            ],
+            cwd=tmp_path,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        assert completed.returncode == (77 if sys.platform == "linux" else 78)
+        assert completed.stdout == ""
+    assert not marker.exists()
+    assert not credential_target.exists()
 
 
 def test_recovery_surface_rejects_cross_generation_replacement_after_real_terminal_proof(
@@ -982,16 +1026,23 @@ def test_recovery_surface_rejects_cross_generation_replacement_after_real_termin
 
         return run
 
-    monkeypatch.setattr(content_write_recovery.firestore, "transactional", replace_before_compare_and_set)
     try:
-        assert _invoke_recovery(monkeypatch, firestore, uid=UID, token=token) == 2
+        assert (
+            _invoke_recovery(
+                firestore,
+                uid=UID,
+                token=token,
+                transactional=replace_before_compare_and_set,
+            )
+            == 2
+        )
         assert json.loads(capsys.readouterr().out)["reason"] == "account_writer_recovery_record_replaced"
         assert _writer_record(firestore, UID, token)["owner"]["generation"] == replaced_generation
     finally:
         manager.shutdown()
 
 
-def test_concurrent_recovery_surface_is_exact_and_idempotent(monkeypatch, deletion_fence):
+def test_concurrent_recovery_surface_is_exact_and_idempotent(deletion_fence):
     del deletion_fence
     context = multiprocessing.get_context("fork")
     manager, firestore = _shared_firestore(context)
@@ -1001,37 +1052,342 @@ def test_concurrent_recovery_surface_is_exact_and_idempotent(monkeypatch, deleti
     process.terminate()
     process.join(5)
     assert not process.is_alive()
-    monkeypatch.setattr(recovery_cli.os, "geteuid", lambda: 0)
-    receipts = []
-    receipt_lock = threading.Lock()
-
-    def collect(payload):
-        with receipt_lock:
-            receipts.append(payload)
-
-    monkeypatch.setattr(recovery_cli, "_print_receipt", collect)
 
     def recover():
-        return recovery_cli.main(
-            [
-                "--subject-hash",
-                content_write_recovery.hash_selector(UID),
-                "--token-hash",
-                content_write_recovery.hash_selector(token),
-            ],
-            firestore_db=firestore,
-        )
+        return content_write_recovery.recover_orphaned_writer(
+            firestore,
+            subject_hash=content_write_recovery.hash_selector(UID),
+            token_hash=content_write_recovery.hash_selector(token),
+            transactional=_transactional,
+        ).to_dict()
 
     try:
         with ThreadPoolExecutor(max_workers=2) as executor:
-            results = list(executor.map(lambda _index: recover(), range(2)))
-        assert results == [0, 0]
+            receipts = list(executor.map(lambda _index: recover(), range(2)))
         assert {receipt["result"] for receipt in receipts} == {"recovered", "already_recovered"}
         state = content_write_fence._snapshot_data(content_write_fence._fence_reference(firestore, UID).get())
         assert token not in state["writers"]
-        assert content_write_recovery.hash_selector(token) in state["writer_recoveries"]
+        assert state["writer_recovery"]["token_hash"] == content_write_recovery.hash_selector(token)
     finally:
         manager.shutdown()
+
+
+def test_concurrent_different_token_compaction_keeps_only_latest_retry_authority(monkeypatch, deletion_fence):
+    tokens = ("concurrent-compaction-a", "concurrent-compaction-b")
+    other_token = "concurrent-compaction-other-uid"
+    for token in tokens:
+        content_write_fence._acquire_firestore_writer(deletion_fence, UID, token, 3)
+    content_write_fence._acquire_firestore_writer(deletion_fence, OTHER_UID, other_token, 3)
+    monkeypatch.setattr(
+        content_write_recovery,
+        "prove_recorded_owner_terminal",
+        lambda owner: content_write_recovery.TerminalProcessProof(owner=owner, proof_kind="test-only-terminal"),
+    )
+
+    def recover(token):
+        return content_write_recovery.recover_orphaned_writer(
+            deletion_fence,
+            subject_hash=content_write_recovery.hash_selector(UID),
+            token_hash=content_write_recovery.hash_selector(token),
+            transactional=_transactional,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        receipts = list(executor.map(recover, tokens))
+    assert [receipt.result for receipt in receipts] == ["recovered", "recovered"]
+    state = content_write_fence._snapshot_data(content_write_fence._fence_reference(deletion_fence, UID).get())
+    assert state["writers"] == {}
+    latest_hash = state["writer_recovery"]["token_hash"]
+    latest_token = next(token for token in tokens if content_write_recovery.hash_selector(token) == latest_hash)
+    evicted_token = next(token for token in tokens if token != latest_token)
+    assert recover(latest_token).result == "already_recovered"
+    with pytest.raises(content_write_recovery.ContentWriterRecoveryError) as stale:
+        recover(evicted_token)
+    assert stale.value.code == "account_writer_recovery_stale_token"
+    other_state = content_write_fence._snapshot_data(
+        content_write_fence._fence_reference(deletion_fence, OTHER_UID).get()
+    )
+    assert set(other_state["writers"]) == {other_token}
+
+
+def test_recovery_receipt_is_strictly_bounded_across_five_thousand_cycles_and_deletion_converges(
+    monkeypatch,
+    deletion_fence,
+):
+    retained_token = "same-uid-retained-through-compaction"
+    other_token = "other-uid-retained-through-compaction"
+    content_write_fence._acquire_firestore_writer(deletion_fence, UID, retained_token, 3)
+    content_write_fence._acquire_firestore_writer(deletion_fence, OTHER_UID, other_token, 3)
+    owner = content_writer_owner.current_process_owner()
+    legacy_uid = "legacy-recovery-compaction-user"
+    legacy_token = "legacy-recovery-compaction-live-token"
+    legacy_reference = content_write_fence._fence_reference(deletion_fence, legacy_uid)
+    recovered_at = datetime.now(timezone.utc)
+    deletion_fence.documents[legacy_reference.key] = {
+        "state": content_write_fence.ACTIVE,
+        "writers": {},
+        "writer_recoveries": {
+            content_write_recovery.hash_selector(f"legacy-recovery-{index}"): {
+                "owner": owner.to_storage(),
+                "recovered_at": recovered_at,
+            }
+            for index in range(3001)
+        },
+    }
+    content_write_fence._acquire_firestore_writer(deletion_fence, legacy_uid, legacy_token, 3)
+    compacted_legacy = content_write_fence._snapshot_data(legacy_reference.get())
+    assert "writer_recoveries" not in compacted_legacy
+    assert set(compacted_legacy["writers"]) == {legacy_token}
+    assert len(json.dumps(compacted_legacy, default=str, separators=(",", ":")).encode("utf-8")) < 2048
+    content_write_fence._release_firestore_writer(deletion_fence, legacy_uid, legacy_token)
+    assert not legacy_reference.get().exists
+    monkeypatch.setattr(
+        content_write_recovery,
+        "prove_recorded_owner_terminal",
+        lambda recorded_owner: content_write_recovery.TerminalProcessProof(
+            owner=recorded_owner,
+            proof_kind="test-only-terminal",
+        ),
+    )
+    first_token = "bounded-recovery-0000"
+    last_token = None
+    for index in range(5001):
+        token = f"bounded-recovery-{index:04d}"
+        last_token = token
+        content_write_fence._acquire_firestore_writer(deletion_fence, UID, token, 3)
+        receipt = content_write_recovery.recover_orphaned_writer(
+            deletion_fence,
+            subject_hash=content_write_recovery.hash_selector(UID),
+            token_hash=content_write_recovery.hash_selector(token),
+            transactional=_transactional,
+        )
+        assert receipt.owner_fingerprint == owner.fingerprint()
+
+    reference = content_write_fence._fence_reference(deletion_fence, UID)
+    state = content_write_fence._snapshot_data(reference.get())
+    assert set(state["writers"]) == {retained_token}
+    assert state["writer_recovery"]["token_hash"] == content_write_recovery.hash_selector(last_token)
+    serialized = json.dumps(state, default=str, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    assert len(serialized) < 2048
+    assert _invoke_recovery(deletion_fence, uid=UID, token=first_token) == 2
+    assert retained_token in content_write_fence._snapshot_data(reference.get())["writers"]
+
+    assert content_write_fence._advance_firestore_tombstone(deletion_fence, UID) is False
+    content_write_fence._release_firestore_writer(deletion_fence, UID, retained_token)
+    assert content_write_fence._advance_firestore_tombstone(deletion_fence, UID) is True
+    tombstone = content_write_fence._snapshot_data(reference.get())
+    assert tombstone["state"] == content_write_fence.TOMBSTONED
+    assert "writer_recovery" not in tombstone
+    other_state = content_write_fence._snapshot_data(
+        content_write_fence._fence_reference(deletion_fence, OTHER_UID).get()
+    )
+    assert set(other_state["writers"]) == {other_token}
+
+
+def test_stale_receipt_or_hash_collision_never_releases_a_different_writer(monkeypatch, deletion_fence):
+    old_token = "old-recovered-token"
+    current_token = "different-current-token"
+    subject_hash = content_write_recovery.hash_selector(UID)
+    content_write_fence._acquire_firestore_writer(deletion_fence, UID, old_token, 3)
+    monkeypatch.setattr(
+        content_write_recovery,
+        "prove_recorded_owner_terminal",
+        lambda owner: content_write_recovery.TerminalProcessProof(owner=owner, proof_kind="test-only-terminal"),
+    )
+    content_write_recovery.recover_orphaned_writer(
+        deletion_fence,
+        subject_hash=subject_hash,
+        token_hash=content_write_recovery.hash_selector(old_token),
+        transactional=_transactional,
+    )
+    reference = content_write_fence._fence_reference(deletion_fence, UID)
+    state = content_write_fence._snapshot_data(reference.get())
+    owner = content_writer_owner.current_process_owner()
+    state["writers"][current_token] = content_write_fence.WriterRegistration(
+        expires_at=state["writer_recovery"]["recovered_at"] + timedelta(seconds=3),
+        owner=owner,
+    ).to_storage()
+    deletion_fence.documents[reference.key] = state
+    monkeypatch.setattr(content_write_recovery, "hash_selector", lambda _value: "a" * 64)
+    state = content_write_fence._snapshot_data(reference.get())
+    state["writer_recovery"]["token_hash"] = "a" * 64
+    deletion_fence.documents[reference.key] = state
+
+    with pytest.raises(content_write_recovery.ContentWriterRecoveryError) as raised:
+        content_write_recovery.recover_orphaned_writer(
+            deletion_fence,
+            subject_hash=subject_hash,
+            token_hash="a" * 64,
+            transactional=_transactional,
+        )
+    assert raised.value.code == "account_writer_recovery_selector_ambiguous"
+    assert current_token in content_write_fence._snapshot_data(reference.get())["writers"]
+
+
+def test_pinned_recovery_authority_ignores_hostile_ambient_project_and_credentials(monkeypatch):
+    pinned_project = "omi-production"
+    pinned_database = "(default)"
+    credential_path = Path("/protected/recovery-credential.json")
+    receipt_path = Path("/protected/recovery-receipt.json")
+    credential_payload = json.dumps(
+        {"type": "service_account", "project_id": pinned_project, "private_key": "test-only"}
+    ).encode("utf-8")
+    calls = {"credentials": 0, "clients": 0}
+
+    monkeypatch.delenv("FIRESTORE_EMULATOR_HOST", raising=False)
+    monkeypatch.setenv("GCLOUD_PROJECT", "hostile-project")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "hostile-project")
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/tmp/hostile.json")
+    monkeypatch.setenv("FIRESTORE_DATABASE", "hostile-database")
+    monkeypatch.setenv("SERVICE_ACCOUNT_JSON", '{"project_id":"hostile-project"}')
+    monkeypatch.setattr(
+        content_write_recovery_authority,
+        "_validated_config",
+        lambda _path: (pinned_project, pinned_database, credential_path, receipt_path),
+    )
+    monkeypatch.setattr(
+        content_write_recovery_authority,
+        "_read_protected_file",
+        lambda path, **_kwargs: credential_payload if path == credential_path else b"",
+    )
+    monkeypatch.setattr(content_write_recovery_authority, "_validated_receipt", lambda *_args, **_kwargs: None)
+
+    def credentials_factory(info):
+        calls["credentials"] += 1
+        assert info["project_id"] == pinned_project
+        return object()
+
+    class Client:
+        def __init__(self, *, project, database, credentials):
+            calls["clients"] += 1
+            assert credentials is not None
+            self.project = project
+            self.database = database
+
+    client, authority = content_write_recovery_authority._load_recovery_firestore_client(
+        Path("/fixed/config.json"),
+        credentials_factory=credentials_factory,
+        client_factory=Client,
+    )
+    assert (client.project, client.database) == (pinned_project, pinned_database)
+    assert (authority.project_id, authority.database_id) == (pinned_project, pinned_database)
+    assert calls == {"credentials": 1, "clients": 1}
+
+
+def test_recovery_authority_rejects_emulator_mismatch_and_symlink_before_credentials(
+    monkeypatch,
+    tmp_path,
+):
+    calls = {"config": 0, "credentials": 0, "clients": 0}
+    monkeypatch.setenv("FIRESTORE_EMULATOR_HOST", "127.0.0.1:65530")
+
+    def config(_path):
+        calls["config"] += 1
+        raise AssertionError("emulator refusal must precede config")
+
+    monkeypatch.setattr(content_write_recovery_authority, "_validated_config", config)
+    with pytest.raises(content_write_recovery_authority.RecoveryAuthorityError) as emulator:
+        content_write_recovery_authority._load_recovery_firestore_client(
+            Path("/fixed/config.json"),
+            credentials_factory=lambda _info: calls.__setitem__("credentials", calls["credentials"] + 1),
+            client_factory=lambda **_kwargs: calls.__setitem__("clients", calls["clients"] + 1),
+        )
+    assert emulator.value.code == "account_writer_recovery_emulator_forbidden"
+    assert calls == {"config": 0, "credentials": 0, "clients": 0}
+
+    monkeypatch.delenv("FIRESTORE_EMULATOR_HOST")
+    target = tmp_path / "target.json"
+    target.write_text("{}", encoding="utf-8")
+    symlink = tmp_path / "config.json"
+    symlink.symlink_to(target)
+    monkeypatch.setattr(content_write_recovery_authority, "_protected_parent_chain", lambda _path: None)
+    with pytest.raises(content_write_recovery_authority.RecoveryAuthorityError):
+        content_write_recovery_authority._read_protected_file(
+            symlink,
+            maximum=1024,
+            code="account_writer_recovery_config_unavailable",
+        )
+    assert calls == {"config": 0, "credentials": 0, "clients": 0}
+
+
+def test_recovery_authority_wrong_receipt_or_credential_project_loads_no_credentials(monkeypatch):
+    project = "omi-production"
+    credential_path = Path("/protected/recovery-credential.json")
+    receipt_path = Path("/protected/recovery-receipt.json")
+    calls = {"credentials": 0, "clients": 0}
+    monkeypatch.delenv("FIRESTORE_EMULATOR_HOST", raising=False)
+    monkeypatch.setattr(
+        content_write_recovery_authority,
+        "_validated_config",
+        lambda _path: (project, "(default)", credential_path, receipt_path),
+    )
+    monkeypatch.setattr(
+        content_write_recovery_authority,
+        "_read_protected_file",
+        lambda _path, **_kwargs: json.dumps(
+            {"type": "service_account", "project_id": "wrong-project", "private_key": "test-only"}
+        ).encode("utf-8"),
+    )
+
+    def wrong_receipt(*_args, **_kwargs):
+        raise content_write_recovery_authority.RecoveryAuthorityError(
+            "account_writer_recovery_deployment_receipt_mismatch"
+        )
+
+    def credentials_factory(_info):
+        calls["credentials"] += 1
+
+    def client_factory(**_kwargs):
+        calls["clients"] += 1
+
+    monkeypatch.setattr(content_write_recovery_authority, "_validated_receipt", wrong_receipt)
+    with pytest.raises(content_write_recovery_authority.RecoveryAuthorityError) as receipt_mismatch:
+        content_write_recovery_authority._load_recovery_firestore_client(
+            Path("/fixed/config.json"),
+            credentials_factory=credentials_factory,
+            client_factory=client_factory,
+        )
+    assert receipt_mismatch.value.code == "account_writer_recovery_deployment_receipt_mismatch"
+    assert calls == {"credentials": 0, "clients": 0}
+
+    monkeypatch.setattr(content_write_recovery_authority, "_validated_receipt", lambda *_args, **_kwargs: None)
+    with pytest.raises(content_write_recovery_authority.RecoveryAuthorityError) as mismatch:
+        content_write_recovery_authority._load_recovery_firestore_client(
+            Path("/fixed/config.json"),
+            credentials_factory=credentials_factory,
+            client_factory=client_factory,
+        )
+    assert mismatch.value.code == "account_writer_recovery_credentials_mismatch"
+    assert calls == {"credentials": 0, "clients": 0}
+
+
+def test_production_recovery_modules_refuse_darwin_before_firestore_calls(monkeypatch):
+    calls = {"firestore": 0}
+
+    class Firestore:
+        def collection(self, _name):
+            calls["firestore"] += 1
+            raise AssertionError("non-Linux refusal must precede Firestore")
+
+    assert content_writer_owner.SUPPORTED_RECOVERY_SYSTEMS == {"Linux"}
+    monkeypatch.setattr(content_write_recovery.platform, "system", lambda: "Darwin")
+    with pytest.raises(content_write_recovery.ContentWriterRecoveryError) as recovery:
+        content_write_recovery.recover_orphaned_writer(
+            Firestore(),
+            subject_hash="a" * 64,
+            token_hash="b" * 64,
+            transactional=_transactional,
+        )
+    assert recovery.value.code == "account_writer_recovery_system_unsupported"
+    assert calls == {"firestore": 0}
+
+    monkeypatch.setattr(content_writer_owner.platform, "system", lambda: "Darwin")
+    with pytest.raises(content_writer_owner.ProcessOwnerError) as boundary:
+        PRODUCTION_CURRENT_PROCESS_BOUNDARY()
+    assert boundary.value.code == "account_writer_os_boundary_unsupported"
+    with pytest.raises(content_writer_owner.ProcessOwnerError) as snapshot:
+        PRODUCTION_PROCESS_SNAPSHOT("Darwin", 1)
+    assert snapshot.value.code == "account_writer_os_boundary_unsupported"
 
 
 @pytest.mark.parametrize("terminal", ["success", "error", "timeout"])

--- a/backend/tests/unit/test_durable_worker_deletion_finality.py
+++ b/backend/tests/unit/test_durable_worker_deletion_finality.py
@@ -55,7 +55,7 @@ from ella.services import hermes_cloud_enrichment_outbox as enrichment_service
 from ella.services import memory_reinterpretation as reinterpretation_service
 from ella.services import proposal_ingest
 from ella.services.hermes_cloud_enrichment_outbox import DeliveryResult, HermesCloudEnrichmentOutboxWorker
-from ella.services.memory_reinterpretation import MemoryReinterpretationWorker, ReinterpretationPlan
+from ella.services.memory_reinterpretation import ApplyResult, MemoryReinterpretationWorker, ReinterpretationPlan
 
 UID = "startup-worker-delete-user"
 OTHER_UID = "startup-worker-retained-user"
@@ -628,6 +628,153 @@ def test_startup_memory_worker_is_drained_purged_and_tombstone_denied(
     assert hermes.calls == calls_before
 
 
+def test_positive_control_legacy_two_stops_release_enrichment_writer_before_thread_terminal(
+    monkeypatch,
+    deletion_fence,
+):
+    """Preserve Iris's exact old ordering as a mounted positive control."""
+    del deletion_fence
+    repository = _EnrichmentOutbox()
+    delivery_entered = threading.Event()
+    release_delivery = threading.Event()
+    thread_terminal = threading.Event()
+    order = []
+
+    def deliver(_job):
+        order.append("thread-entered")
+        delivery_entered.set()
+        assert release_delivery.wait(5)
+        order.append("thread-terminal")
+        thread_terminal.set()
+        return DeliveryResult(True, receipt={"content_free": True})
+
+    async def legacy_finish_admitted_content_mutation(uid, awaitable):
+        content_write_fence.assert_content_writer_admitted(uid)
+        task = asyncio.create_task(awaitable)
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            try:
+                await task
+            except Exception:
+                pass
+            raise
+
+    async def legacy_stop_worker():
+        worker_task = enrichment_service._worker_task
+        if worker_task is None:
+            return
+        worker_task.cancel()
+        try:
+            await worker_task
+        except asyncio.CancelledError:
+            pass
+        enrichment_service._worker_task = None
+
+    monkeypatch.setattr(
+        content_write_fence,
+        "finish_admitted_content_mutation",
+        legacy_finish_admitted_content_mutation,
+    )
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS", UID)
+    monkeypatch.setattr(enrichment_service, "_worker_task", None)
+    monkeypatch.setattr(enrichment_service, "_worker_shutdown_task", None)
+    worker = HermesCloudEnrichmentOutboxWorker(repository, deliver=deliver, poll_seconds=0.01)
+
+    async def purge_memory(_uid):
+        return 0
+
+    app = _deletion_app(
+        monkeypatch,
+        authority_enabled=True,
+        delete_firestore=lambda uid: (order.append("purge"), repository.purge(uid)),
+        delete_firebase=lambda _uid: order.append("firebase"),
+        purge_memory=purge_memory,
+    )
+
+    async def scenario():
+        await enrichment_service.start_worker(worker)
+        assert await asyncio.to_thread(delivery_entered.wait, 3)
+        first_stop = asyncio.create_task(legacy_stop_worker())
+        await asyncio.sleep(0)
+        second_stop = asyncio.create_task(legacy_stop_worker())
+        await asyncio.wait_for(asyncio.gather(first_stop, second_stop), 3)
+        assert not thread_terminal.is_set()
+
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+            deleted = await client.delete("/v1/users/delete-account")
+            assert deleted.status_code == 200
+
+        release_delivery.set()
+        assert await asyncio.to_thread(thread_terminal.wait, 3)
+
+    asyncio.run(scenario())
+    assert order == ["thread-entered", "purge", "firebase", "thread-terminal"]
+
+
+async def _cancel_two_coalesced_stops(service):
+    first_stop = asyncio.create_task(service.stop_worker())
+    while service._worker_shutdown_task is None:
+        await asyncio.sleep(0)
+    shared_shutdown = service._worker_shutdown_task
+    second_stop = asyncio.create_task(service.stop_worker())
+    await asyncio.sleep(0)
+    assert service._worker_shutdown_task is shared_shutdown
+
+    first_stop.cancel()
+    first_stop.cancel()
+    first_stop.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first_stop
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(second_stop, 0.05)
+
+    assert service._worker_shutdown_task is shared_shutdown
+    assert not shared_shutdown.done()
+    return shared_shutdown
+
+
+def test_process_restart_retains_orphan_token_until_exact_terminal_proof_recovery(monkeypatch, deletion_fence):
+    token = "terminated-process-writer-token"
+    content_write_fence._acquire_firestore_writer(deletion_fence, UID, token, 1)
+    order = []
+
+    async def purge_memory(_uid):
+        return 0
+
+    app = _deletion_app(
+        monkeypatch,
+        authority_enabled=True,
+        delete_firestore=lambda _uid: order.append("purge"),
+        delete_firebase=lambda _uid: order.append("firebase"),
+        purge_memory=purge_memory,
+    )
+
+    async def scenario():
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+            first_process = await client.delete("/v1/users/delete-account")
+            assert first_process.status_code == 202
+            state = content_write_fence._snapshot_data(content_write_fence._fence_reference(deletion_fence, UID).get())
+            assert state["state"] == content_write_fence.DRAINING
+            assert token in state["writers"]
+
+            # A new process sees the same durable blocker. Neither restart nor
+            # lease expiry is absence proof, so the retry remains resumable.
+            restarted_process = await client.delete("/v1/users/delete-account")
+            assert restarted_process.status_code == 202
+            assert order == []
+
+            old_process_terminal = True  # supplied by the process supervisor
+            assert old_process_terminal
+            content_write_fence._release_firestore_writer(deletion_fence, UID, token)
+
+            converged = await client.delete("/v1/users/delete-account")
+            assert converged.status_code == 200
+
+    asyncio.run(scenario())
+    assert order == ["purge", "firebase"]
+
+
 @pytest.mark.parametrize("terminal", ["success", "error", "timeout"])
 def test_stop_worker_joins_actual_enrichment_thread_before_deletion(monkeypatch, deletion_fence, terminal):
     del deletion_fence
@@ -661,6 +808,7 @@ def test_stop_worker_joins_actual_enrichment_thread_before_deletion(monkeypatch,
     )
     monkeypatch.setenv("ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS", UID)
     monkeypatch.setattr(enrichment_service, "_worker_task", None)
+    monkeypatch.setattr(enrichment_service, "_worker_shutdown_task", None)
 
     async def start():
         await enrichment_service.start_worker(worker)
@@ -676,18 +824,21 @@ def test_stop_worker_joins_actual_enrichment_thread_before_deletion(monkeypatch,
         assert enrichment_service._worker_task is first_task
         assert await asyncio.to_thread(delivery_entered.wait, 3)
 
-        shutdown = asyncio.create_task(app.router.shutdown())
-        await asyncio.sleep(0.05)
-        assert not shutdown.done()
+        shared_shutdown = await _cancel_two_coalesced_stops(enrichment_service)
+        assert enrichment_service._worker_task is first_task
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
             pending = await client.delete("/v1/users/delete-account")
             assert pending.status_code == 202
             assert "firebase-delete" not in order
             assert repository.jobs["target"]["status"] == "running"
+            assert enrichment_service._worker_shutdown_task is shared_shutdown
 
             release_delivery.set()
-            await asyncio.wait_for(shutdown, 3)
+            await asyncio.wait_for(enrichment_service.stop_worker(), 3)
+            assert shared_shutdown.done()
             assert enrichment_service._worker_task is None
+            assert enrichment_service._worker_shutdown_task is None
+            await enrichment_service.stop_worker()
             completed = await client.delete("/v1/users/delete-account")
             assert completed.status_code == 200
 
@@ -698,17 +849,34 @@ def test_stop_worker_joins_actual_enrichment_thread_before_deletion(monkeypatch,
     assert order.index("enrichment-purge") < order.index("firebase-delete")
 
 
-def test_stop_worker_joins_actual_memory_proposal_thread_before_deletion(monkeypatch, deletion_fence):
+@pytest.mark.parametrize("mutation_kind", ["proposal", "correction"])
+def test_stop_worker_joins_actual_memory_thread_before_deletion(monkeypatch, deletion_fence, mutation_kind):
     del deletion_fence
     repository = InMemoryMemoryReinterpretationRepository(debounce_seconds=0)
     target = asyncio.run(_seed_reinterpretation(repository, UID))
     retained = asyncio.run(_seed_reinterpretation(repository, OTHER_UID, completed=True))
-    proposal_entered = threading.Event()
-    release_proposal = threading.Event()
+    mutation_entered = threading.Event()
+    release_mutation = threading.Event()
     order = []
 
-    class AmbiguousHermes:
+    class HeldPlanHermes:
         async def propose(self, **_kwargs):
+            if mutation_kind == "correction":
+                return ReinterpretationPlan(
+                    outcome="proposals",
+                    proposals=[
+                        {
+                            "kind": "factual_correction",
+                            "certainty": "confirmed",
+                            "correction_text": "The remembered detail is corrected.",
+                            "evidence_event_ids": [f"event-{UID}"],
+                            "evidence_quote": "The remembered detail is corrected.",
+                            "corrected_summary": {
+                                "overview": "[Ella] The remembered detail is corrected.",
+                            },
+                        }
+                    ],
+                )
             return ReinterpretationPlan(
                 outcome="proposals",
                 proposals=[
@@ -729,18 +897,33 @@ def test_stop_worker_joins_actual_memory_proposal_thread_before_deletion(monkeyp
         }
 
     def create_proposal(**_kwargs):
-        order.append("proposal-entered")
-        proposal_entered.set()
-        assert release_proposal.wait(5)
-        order.append("proposal-returned")
+        order.append("proposal-thread-entered")
+        mutation_entered.set()
+        assert release_mutation.wait(5)
+        order.append("proposal-thread-terminal")
         return {"proposal": {"proposal_id": "proposal-after-cancel"}}
 
+    def apply_correction():
+        order.append("correction-thread-entered")
+        mutation_entered.set()
+        assert release_mutation.wait(5)
+        order.append("correction-thread-terminal")
+        return ApplyResult(
+            correction_id="correction-after-cancel",
+            active_summary_version_id=f"corrected-version-{UID}",
+        )
+
+    async def correction_writer(**_kwargs):
+        return await content_write_fence.run_admitted_threaded_mutation(UID, apply_correction)
+
     monkeypatch.setattr(proposal_ingest, "create_proposal", create_proposal)
+    worker_kwargs = {"correction_writer": correction_writer} if mutation_kind == "correction" else {}
     worker = MemoryReinterpretationWorker(
         repository,
-        hermes_client=AmbiguousHermes(),
+        hermes_client=HeldPlanHermes(),
         conversation_loader=conversation_loader,
         lease_seconds=30,
+        **worker_kwargs,
     )
 
     async def purge_memory(uid):
@@ -761,6 +944,7 @@ def test_stop_worker_joins_actual_memory_proposal_thread_before_deletion(monkeyp
     monkeypatch.setenv("ELLA_MEMORY_REINTERPRETATION_WORKER_ENABLED", "true")
     monkeypatch.setenv("ELLA_MEMORY_REINTERPRETATION_IDLE_SECONDS", "0.01")
     monkeypatch.setattr(reinterpretation_service, "_worker_task", None)
+    monkeypatch.setattr(reinterpretation_service, "_worker_shutdown_task", None)
 
     async def start():
         await reinterpretation_service.start_worker(worker)
@@ -774,25 +958,28 @@ def test_stop_worker_joins_actual_memory_proposal_thread_before_deletion(monkeyp
         assert first_task is not None
         await reinterpretation_service.start_worker(worker)
         assert reinterpretation_service._worker_task is first_task
-        assert await asyncio.to_thread(proposal_entered.wait, 3)
+        assert await asyncio.to_thread(mutation_entered.wait, 3)
 
-        shutdown = asyncio.create_task(app.router.shutdown())
-        await asyncio.sleep(0.05)
-        assert not shutdown.done()
+        shared_shutdown = await _cancel_two_coalesced_stops(reinterpretation_service)
+        assert reinterpretation_service._worker_task is first_task
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
             pending = await client.delete("/v1/users/delete-account")
             assert pending.status_code == 202
             assert "firebase-delete" not in order
             assert repository.jobs[target["id"]]["status"] == "running"
+            assert reinterpretation_service._worker_shutdown_task is shared_shutdown
 
-            release_proposal.set()
-            await asyncio.wait_for(shutdown, 3)
+            release_mutation.set()
+            await asyncio.wait_for(reinterpretation_service.stop_worker(), 3)
+            assert shared_shutdown.done()
             assert reinterpretation_service._worker_task is None
+            assert reinterpretation_service._worker_shutdown_task is None
+            await reinterpretation_service.stop_worker()
             completed = await client.delete("/v1/users/delete-account")
             assert completed.status_code == 200
 
     asyncio.run(scenario())
     assert target["id"] not in repository.jobs
     assert repository.jobs[retained["id"]]["uid"] == OTHER_UID
-    assert order.index("proposal-returned") < order.index("memory-purge")
+    assert order.index(f"{mutation_kind}-thread-terminal") < order.index("memory-purge")
     assert order.index("memory-purge") < order.index("firebase-delete")

--- a/backend/tests/unit/test_durable_worker_deletion_finality.py
+++ b/backend/tests/unit/test_durable_worker_deletion_finality.py
@@ -1,0 +1,464 @@
+import ast
+import asyncio
+from contextlib import asynccontextmanager
+from copy import deepcopy
+from datetime import timedelta
+import os
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+import types
+import threading
+
+from fastapi import Depends, FastAPI, Response
+from fastapi.testclient import TestClient
+import pytest
+
+os.environ.setdefault("FIRESTORE_EMULATOR_HOST", "localhost:9999")
+os.environ.setdefault("GCLOUD_PROJECT", "omi-ci")
+os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "omi-ci")
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ci_durable_worker_finality_key")
+
+if "stripe" not in sys.modules:
+    stripe_stub = types.ModuleType("stripe")
+    stripe_stub.api_key = None
+    sys.modules["stripe"] = stripe_stub
+if "redis" not in sys.modules:
+    redis_stub = types.ModuleType("redis")
+    redis_stub.Redis = lambda *args, **kwargs: None
+    sys.modules["redis"] = redis_stub
+storage_stub = types.ModuleType("utils.other.storage")
+storage_stub.list_audio_chunks = lambda *args, **kwargs: []
+sys.modules.setdefault("utils.other.storage", storage_stub)
+sys.modules.setdefault("websockets", types.ModuleType("websockets"))
+vector_stub = types.ModuleType("utils.conversations.vector")
+vector_stub.refresh_structured_summary_vector = lambda *args, **kwargs: None
+sys.modules.setdefault("utils.conversations.vector", vector_stub)
+summary_stub = types.ModuleType("utils.conversations.generic_summary")
+summary_stub.generate_stock_conversation_summary = lambda *args, **kwargs: None
+sys.modules.setdefault("utils.conversations.generic_summary", summary_stub)
+
+from database import account_deletion as account_deletion_db
+from database import content_write_fence
+from database.memory_reinterpretations import InMemoryMemoryReinterpretationRepository
+from ella.services import account_deletion as account_deletion_service
+from ella.services import hermes_cloud_enrichment_outbox as enrichment_service
+from ella.services import memory_reinterpretation as reinterpretation_service
+from ella.services.hermes_cloud_enrichment_outbox import DeliveryResult, HermesCloudEnrichmentOutboxWorker
+from ella.services.memory_reinterpretation import MemoryReinterpretationWorker, ReinterpretationPlan
+
+UID = "startup-worker-delete-user"
+OTHER_UID = "startup-worker-retained-user"
+
+
+class _Snapshot:
+    def __init__(self, data):
+        self._data = deepcopy(data)
+        self.exists = data is not None
+
+    def to_dict(self):
+        return deepcopy(self._data)
+
+
+class _Document:
+    def __init__(self, database, key):
+        self.database = database
+        self.key = key
+
+    def get(self, transaction=None):
+        del transaction
+        return _Snapshot(self.database.documents.get(self.key))
+
+
+class _Collection:
+    def __init__(self, database, name):
+        self.database = database
+        self.name = name
+
+    def document(self, document_id):
+        return _Document(self.database, (self.name, document_id))
+
+
+class _Transaction:
+    def __init__(self, database):
+        self.database = database
+
+    def set(self, reference, data):
+        self.database.documents[reference.key] = deepcopy(data)
+
+    def delete(self, reference):
+        self.database.documents.pop(reference.key, None)
+
+
+class _Firestore:
+    def __init__(self):
+        self.documents = {}
+        self.lock = threading.RLock()
+
+    def collection(self, name):
+        return _Collection(self, name)
+
+    def transaction(self):
+        return _Transaction(self)
+
+
+def _transactional(function):
+    def run(transaction, *args, **kwargs):
+        with transaction.database.lock:
+            return function(transaction, *args, **kwargs)
+
+    return run
+
+
+def _state():
+    return account_deletion_db.AccountDeletionState(
+        user_found=True,
+        capacity_released=True,
+        authority_quarantined=True,
+        external_cleanup_required=(),
+        external_cleanup_references=(),
+        counts={},
+    )
+
+
+def _load_production_delete_route():
+    path = Path(__file__).resolve().parents[2] / "routers" / "users.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    route = next(node for node in tree.body if isinstance(node, ast.AsyncFunctionDef) and node.name == "delete_account")
+    route.decorator_list = []
+    namespace = {
+        "Depends": Depends,
+        "Response": Response,
+        "auth": SimpleNamespace(
+            get_authenticated_user_uid=lambda: UID,
+            delete_account=lambda _uid: None,
+        ),
+        "delete_user_data": lambda _uid: None,
+        "execute_account_deletion": account_deletion_service.execute_account_deletion,
+    }
+    exec(compile(ast.fix_missing_locations(ast.Module(body=[route], type_ignores=[])), str(path), "exec"), namespace)
+    return namespace["delete_account"], namespace
+
+
+@pytest.fixture
+def deletion_fence(monkeypatch):
+    previous_database = content_write_fence._firestore_db
+    firestore = _Firestore()
+    content_write_fence.configure_firestore_db(firestore)
+    monkeypatch.setattr(content_write_fence.firestore, "transactional", _transactional)
+    monkeypatch.setenv("ELLA_CONTENT_WRITE_FENCE_DRAIN_SECONDS", "0.15")
+    monkeypatch.setenv("ELLA_CONTENT_WRITE_FENCE_LEASE_SECONDS", "3")
+
+    async def assert_postgres_active(_uid):
+        return None
+
+    async def purge_routing_traces(_uid):
+        return 0
+
+    monkeypatch.setattr(content_write_fence, "_assert_postgres_owner_active", assert_postgres_active)
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "purge_routing_traces", purge_routing_traces)
+    yield firestore
+    content_write_fence.configure_firestore_db(previous_database)
+
+
+def _deletion_app(
+    monkeypatch,
+    *,
+    authority_enabled,
+    delete_firestore,
+    delete_firebase,
+    purge_memory,
+):
+    monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "true" if authority_enabled else "false")
+
+    async def quarantine(_uid):
+        assert authority_enabled
+        return _state()
+
+    async def finalize(_uid):
+        assert authority_enabled
+        return True
+
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "quarantine_account_for_deletion", quarantine)
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "finalize_account_deletion", finalize)
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db, "purge_memory_reinterpretation_work", purge_memory
+    )
+    route, namespace = _load_production_delete_route()
+    namespace["delete_user_data"] = delete_firestore
+    namespace["auth"].delete_account = delete_firebase
+    app = FastAPI()
+    app.add_api_route("/v1/users/delete-account", route, methods=["DELETE"])
+    app.add_middleware(content_write_fence.ContentWriteFenceMiddleware)
+    return app
+
+
+class _EnrichmentOutbox:
+    def __init__(self):
+        self.lock = threading.RLock()
+        self.jobs = {
+            "target": {"job_id": "target", "uid": UID, "status": "pending", "attempt_count": 0},
+            "retained": {"job_id": "retained", "uid": OTHER_UID, "status": "completed", "attempt_count": 1},
+        }
+        self.commits = []
+
+    def peek_next_uid(self, *, scan_limit=50):
+        del scan_limit
+        with self.lock:
+            return next(
+                (job["uid"] for job in self.jobs.values() if job["status"] in {"pending", "retryable"}),
+                None,
+            )
+
+    def claim_next(self, *, uid, writer_token, lease_seconds, scan_limit=50):
+        del writer_token, lease_seconds, scan_limit
+        with self.lock:
+            job = next(
+                (
+                    item
+                    for item in self.jobs.values()
+                    if item["uid"] == uid and item["status"] in {"pending", "retryable"}
+                ),
+                None,
+            )
+            if job is None:
+                return None
+            job.update(status="running", lease_token="lease", attempt_count=job["attempt_count"] + 1)
+            return deepcopy(job)
+
+    def complete(self, *, job_id, lease_token, receipt):
+        del receipt
+        with self.lock:
+            job = self.jobs.get(job_id)
+            if job is None or job.get("lease_token") != lease_token:
+                return False
+            job["status"] = "completed"
+            self.commits.append(("complete", job["uid"]))
+            return True
+
+    def fail(self, **_kwargs):
+        raise AssertionError("the successful adversarial delivery must not fail")
+
+    def purge(self, uid):
+        with self.lock:
+            removed = [job_id for job_id, job in self.jobs.items() if job["uid"] == uid]
+            for job_id in removed:
+                del self.jobs[job_id]
+            return len(removed)
+
+
+@pytest.mark.parametrize("authority_enabled", [True, False])
+def test_startup_enrichment_worker_is_drained_purged_and_tombstone_denied(
+    monkeypatch,
+    deletion_fence,
+    authority_enabled,
+):
+    del deletion_fence
+    repository = _EnrichmentOutbox()
+    delivery_entered = threading.Event()
+    release_delivery = threading.Event()
+    worker_committed = threading.Event()
+    order = []
+
+    def deliver(job):
+        assert job["uid"] == UID
+        order.append("delivery_boundary")
+        delivery_entered.set()
+        assert release_delivery.wait(5)
+        order.append("delivery_returned")
+        return DeliveryResult(True, receipt={"content_free": True})
+
+    class Worker(HermesCloudEnrichmentOutboxWorker):
+        async def run_once(self):
+            worked = await super().run_once()
+            if repository.commits:
+                worker_committed.set()
+            return worked
+
+    worker = Worker(repository, deliver=deliver, poll_seconds=0.01)
+
+    def delete_firestore(uid):
+        order.append("enrichment_purge")
+        repository.purge(uid)
+
+    def delete_firebase(uid):
+        order.append(("firebase", uid))
+
+    async def purge_memory(_uid):
+        return 0
+
+    app = _deletion_app(
+        monkeypatch,
+        authority_enabled=authority_enabled,
+        delete_firestore=delete_firestore,
+        delete_firebase=delete_firebase,
+        purge_memory=purge_memory,
+    )
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS", UID)
+    monkeypatch.setattr(enrichment_service, "_worker_task", None)
+
+    async def start():
+        await enrichment_service.start_worker(worker)
+
+    app.router.add_event_handler("startup", start)
+    app.router.add_event_handler("shutdown", enrichment_service.stop_worker)
+    with TestClient(app) as client:
+        assert delivery_entered.wait(3)
+        pending = client.delete("/v1/users/delete-account")
+        assert pending.status_code == 202
+        assert ("firebase", UID) not in order
+        assert repository.jobs["target"]["status"] == "running"
+
+        release_delivery.set()
+        assert worker_committed.wait(3)
+        completed = client.delete("/v1/users/delete-account")
+        assert completed.status_code == 200
+
+    assert "target" not in repository.jobs
+    assert repository.jobs["retained"]["uid"] == OTHER_UID
+    assert order.index("delivery_returned") < order.index("enrichment_purge")
+    assert order.index("enrichment_purge") < order.index(("firebase", UID))
+
+    repository.jobs["post-tombstone"] = {
+        "job_id": "post-tombstone",
+        "uid": UID,
+        "status": "pending",
+        "attempt_count": 0,
+    }
+    deliveries_before = order.count("delivery_boundary")
+    assert asyncio.run(worker.run_once()) is False
+    assert repository.jobs["post-tombstone"]["status"] == "pending"
+    assert order.count("delivery_boundary") == deliveries_before
+
+
+async def _seed_reinterpretation(repository, uid, *, completed=False):
+    session_id = f"session-{uid}"
+    conversation_id = f"conversation-{uid}"
+    version_id = f"version-{uid}"
+    row = {
+        "uid": uid,
+        "session_id": session_id,
+        "event_id": f"event-{uid}",
+        "source_identity": f"source-{uid}",
+        "connection_id": "connection",
+        "turn_index": 0,
+        "role": "user",
+        "text": "The remembered detail is corrected.",
+        "started_at": "2026-08-03T00:00:00Z",
+        "scope_kind": "memory",
+        "conversation_id": conversation_id,
+        "active_summary_version_id": version_id,
+    }
+    completion = {
+        "uid": uid,
+        "session_id": session_id,
+        "source_identity": f"completion-{uid}",
+        "source_ref": {
+            "scope_kind": "memory",
+            "can_reinterpret": True,
+            "conversation_id": conversation_id,
+            "active_summary_version_id": version_id,
+        },
+    }
+    job = await repository.enqueue(completion, [row])
+    repository.now += timedelta(seconds=1)
+    if completed:
+        repository.jobs[job["id"]]["status"] = "no_change"
+    return job
+
+
+@pytest.mark.parametrize("authority_enabled", [True, False])
+def test_startup_memory_worker_is_drained_purged_and_tombstone_denied(
+    monkeypatch,
+    deletion_fence,
+    authority_enabled,
+):
+    del deletion_fence
+    repository = InMemoryMemoryReinterpretationRepository(debounce_seconds=0)
+    target = asyncio.run(_seed_reinterpretation(repository, UID))
+    retained = asyncio.run(_seed_reinterpretation(repository, OTHER_UID, completed=True))
+    delivery_entered = threading.Event()
+    release_delivery = threading.Event()
+    worker_committed = threading.Event()
+    order = []
+
+    class HeldHermes:
+        calls = 0
+
+        async def propose(self, **_kwargs):
+            self.calls += 1
+            order.append("memory_delivery_boundary")
+            delivery_entered.set()
+            assert await asyncio.to_thread(release_delivery.wait, 5)
+            order.append("memory_delivery_returned")
+            return ReinterpretationPlan(outcome="no_change", proposals=[])
+
+    async def conversation_loader(uid, conversation_id):
+        return {
+            "id": conversation_id,
+            "active_summary_version_id": f"version-{uid}",
+            "structured": {"overview": "[Ella] A remembered detail."},
+        }
+
+    class Worker(MemoryReinterpretationWorker):
+        async def run_once(self, worker_id):
+            result = await super().run_once(worker_id)
+            if result and result.get("status") == "no_change":
+                worker_committed.set()
+            return result
+
+    hermes = HeldHermes()
+    worker = Worker(repository, hermes_client=hermes, conversation_loader=conversation_loader, lease_seconds=30)
+
+    async def purge_memory(uid):
+        order.append("memory_purge")
+        removed = [job_id for job_id, job in repository.jobs.items() if job["uid"] == uid]
+        for job_id in removed:
+            del repository.jobs[job_id]
+        repository.attempts = [attempt for attempt in repository.attempts if attempt["job_id"] not in removed]
+        return len(removed)
+
+    def delete_firestore(uid):
+        order.append(("firestore", uid))
+
+    def delete_firebase(uid):
+        order.append(("firebase", uid))
+
+    app = _deletion_app(
+        monkeypatch,
+        authority_enabled=authority_enabled,
+        delete_firestore=delete_firestore,
+        delete_firebase=delete_firebase,
+        purge_memory=purge_memory,
+    )
+    monkeypatch.setenv("ELLA_MEMORY_REINTERPRETATION_WORKER_ENABLED", "true")
+    monkeypatch.setenv("ELLA_MEMORY_REINTERPRETATION_IDLE_SECONDS", "0.01")
+    monkeypatch.setattr(reinterpretation_service, "_worker_task", None)
+
+    async def start():
+        await reinterpretation_service.start_worker(worker)
+
+    app.router.add_event_handler("startup", start)
+    app.router.add_event_handler("shutdown", reinterpretation_service.stop_worker)
+    with TestClient(app) as client:
+        assert delivery_entered.wait(3)
+        pending = client.delete("/v1/users/delete-account")
+        assert pending.status_code == 202
+        assert ("firebase", UID) not in order
+        assert repository.jobs[target["id"]]["status"] == "running"
+
+        release_delivery.set()
+        assert worker_committed.wait(3)
+        completed = client.delete("/v1/users/delete-account")
+        assert completed.status_code == 200
+
+    assert target["id"] not in repository.jobs
+    assert repository.jobs[retained["id"]]["uid"] == OTHER_UID
+    assert order.index("memory_delivery_returned") < order.index("memory_purge")
+    assert order.index("memory_purge") < order.index(("firebase", UID))
+
+    post_tombstone = asyncio.run(_seed_reinterpretation(repository, UID))
+    calls_before = hermes.calls
+    assert asyncio.run(worker.run_once("post-tombstone-worker")) is None
+    assert repository.jobs[post_tombstone["id"]]["status"] == "pending"
+    assert hermes.calls == calls_before

--- a/backend/tests/unit/test_durable_worker_deletion_finality.py
+++ b/backend/tests/unit/test_durable_worker_deletion_finality.py
@@ -1,14 +1,19 @@
 import ast
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from copy import deepcopy
+from dataclasses import replace
 from datetime import timedelta
+import json
+import multiprocessing
 import os
 from pathlib import Path
 import sys
 from types import SimpleNamespace
 import types
 import threading
+import uuid
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Response
 from fastapi.testclient import TestClient
@@ -42,7 +47,7 @@ summary_stub.generate_stock_conversation_summary = lambda *args, **kwargs: None
 sys.modules.setdefault("utils.conversations.generic_summary", summary_stub)
 
 from database import account_deletion as account_deletion_db
-from database import content_write_fence
+from database import content_write_fence, content_write_recovery, content_writer_owner
 from database.memory_reinterpretations import InMemoryMemoryReinterpretationRepository
 from ella.routers import canonical_events
 from ella.routers.canonical_events import (
@@ -56,6 +61,7 @@ from ella.services import memory_reinterpretation as reinterpretation_service
 from ella.services import proposal_ingest
 from ella.services.hermes_cloud_enrichment_outbox import DeliveryResult, HermesCloudEnrichmentOutboxWorker
 from ella.services.memory_reinterpretation import ApplyResult, MemoryReinterpretationWorker, ReinterpretationPlan
+from scripts import content_writer_recovery as recovery_cli
 
 UID = "startup-worker-delete-user"
 OTHER_UID = "startup-worker-retained-user"
@@ -101,9 +107,9 @@ class _Transaction:
 
 
 class _Firestore:
-    def __init__(self):
-        self.documents = {}
-        self.lock = threading.RLock()
+    def __init__(self, *, documents=None, lock=None):
+        self.documents = {} if documents is None else documents
+        self.lock = threading.RLock() if lock is None else lock
 
     def collection(self, name):
         return _Collection(self, name)
@@ -118,6 +124,65 @@ def _transactional(function):
             return function(transaction, *args, **kwargs)
 
     return run
+
+
+def _hold_process_writer(firestore, uid, token, ready, release):
+    content_write_fence.firestore.transactional = _transactional
+    content_write_fence.configure_firestore_db(firestore)
+    content_write_fence._acquire_firestore_writer(firestore, uid, token, 3)
+
+    def hold_work():
+        ready.set()
+        release.wait(30)
+
+    worker = threading.Thread(target=hold_work, name="real-orphan-writer-thread")
+    worker.start()
+    worker.join()
+
+
+def _run_unprivileged_recovery(subject_hash, token_hash):
+    if os.geteuid() == 0:
+        os.setuid(65534)
+    result = recovery_cli.main(
+        ["--subject-hash", subject_hash, "--token-hash", token_hash],
+        firestore_db=object(),
+    )
+    os._exit(result)
+
+
+def _shared_firestore(context):
+    manager = context.Manager()
+    return manager, _Firestore(documents=manager.dict(), lock=manager.RLock())
+
+
+def _start_real_writer(context, firestore, *, uid, token):
+    ready = context.Event()
+    release = context.Event()
+    process = context.Process(
+        target=_hold_process_writer,
+        args=(firestore, uid, token, ready, release),
+    )
+    process.start()
+    assert ready.wait(5)
+    return process, release
+
+
+def _writer_record(firestore, uid, token):
+    state = content_write_fence._snapshot_data(content_write_fence._fence_reference(firestore, uid).get())
+    return state["writers"][token]
+
+
+def _invoke_recovery(monkeypatch, firestore, *, uid, token):
+    monkeypatch.setattr(recovery_cli.os, "geteuid", lambda: 0)
+    return recovery_cli.main(
+        [
+            "--subject-hash",
+            content_write_recovery.hash_selector(uid),
+            "--token-hash",
+            content_write_recovery.hash_selector(token),
+        ],
+        firestore_db=firestore,
+    )
 
 
 def _state():
@@ -734,9 +799,26 @@ async def _cancel_two_coalesced_stops(service):
     return shared_shutdown
 
 
-def test_process_restart_retains_orphan_token_until_exact_terminal_proof_recovery(monkeypatch, deletion_fence):
-    token = "terminated-process-writer-token"
-    content_write_fence._acquire_firestore_writer(deletion_fence, UID, token, 1)
+def test_process_restart_uses_root_cli_and_real_kernel_terminal_proof_before_firebase_last(
+    monkeypatch,
+    deletion_fence,
+    capsys,
+):
+    del deletion_fence
+    context = multiprocessing.get_context("fork")
+    manager, firestore = _shared_firestore(context)
+    token = "real-child-process-writer-token"
+    same_uid_token = "retained-same-uid-writer-token"
+    other_token = "retained-other-uid-writer-token"
+    process, release = _start_real_writer(context, firestore, uid=UID, token=token)
+    del release
+    content_write_fence.configure_firestore_db(firestore)
+    content_write_fence._acquire_firestore_writer(firestore, UID, same_uid_token, 3)
+    content_write_fence._acquire_firestore_writer(firestore, OTHER_UID, other_token, 3)
+    child_record = _writer_record(firestore, UID, token)
+    owner = content_writer_owner.ProcessOwner.from_storage(child_record["owner"])
+    assert owner.pid == process.pid
+    assert owner.generation != content_writer_owner.current_process_owner().generation
     order = []
 
     async def purge_memory(_uid):
@@ -754,25 +836,202 @@ def test_process_restart_retains_orphan_token_until_exact_terminal_proof_recover
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
             first_process = await client.delete("/v1/users/delete-account")
             assert first_process.status_code == 202
-            state = content_write_fence._snapshot_data(content_write_fence._fence_reference(deletion_fence, UID).get())
+            state = content_write_fence._snapshot_data(content_write_fence._fence_reference(firestore, UID).get())
             assert state["state"] == content_write_fence.DRAINING
             assert token in state["writers"]
 
-            # A new process sees the same durable blocker. Neither restart nor
-            # lease expiry is absence proof, so the retry remains resumable.
             restarted_process = await client.delete("/v1/users/delete-account")
             assert restarted_process.status_code == 202
             assert order == []
 
-            old_process_terminal = True  # supplied by the process supervisor
-            assert old_process_terminal
-            content_write_fence._release_firestore_writer(deletion_fence, UID, token)
+            assert _invoke_recovery(monkeypatch, firestore, uid=UID, token=token) == 2
+            refused = json.loads(capsys.readouterr().out)
+            assert refused == {
+                "action": "content_writer_recovery",
+                "content_free": True,
+                "reason": "account_writer_recovery_owner_live",
+                "result": "refused",
+            }
+            still_pending = await client.delete("/v1/users/delete-account")
+            assert still_pending.status_code == 202
+            assert order == []
 
+            process.terminate()
+            process.join(5)
+            assert not process.is_alive()
+            assert _invoke_recovery(monkeypatch, firestore, uid=UID, token=token) == 0
+            recovered = json.loads(capsys.readouterr().out)
+            assert recovered["result"] == "recovered"
+            assert recovered["proof_kind"] == "kernel_process_absent"
+            assert recovered["content_free"] is True
+            assert UID not in json.dumps(recovered)
+            assert token not in json.dumps(recovered)
+            recovered_state = content_write_fence._snapshot_data(
+                content_write_fence._fence_reference(firestore, UID).get()
+            )
+            assert token not in recovered_state["writers"]
+            assert same_uid_token in recovered_state["writers"]
+
+            content_write_fence._release_firestore_writer(firestore, UID, same_uid_token)
             converged = await client.delete("/v1/users/delete-account")
             assert converged.status_code == 200
+            assert _invoke_recovery(monkeypatch, firestore, uid=UID, token=token) == 0
+            assert json.loads(capsys.readouterr().out)["result"] == "already_recovered"
 
-    asyncio.run(scenario())
-    assert order == ["purge", "firebase"]
+    try:
+        asyncio.run(scenario())
+        assert order == ["purge", "firebase"]
+        retained = content_write_fence._snapshot_data(content_write_fence._fence_reference(firestore, OTHER_UID).get())
+        assert other_token in retained["writers"]
+    finally:
+        if process.is_alive():
+            process.terminate()
+            process.join(5)
+        manager.shutdown()
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_reason"),
+    [
+        ("host", "account_writer_recovery_host_mismatch"),
+        ("boot", "account_writer_recovery_boot_mismatch"),
+        ("namespace", "account_writer_recovery_pid_namespace_mismatch"),
+        ("start", "account_writer_recovery_pid_reused"),
+    ],
+)
+def test_recovery_surface_rejects_other_boundary_and_pid_reuse(
+    monkeypatch,
+    deletion_fence,
+    capsys,
+    mutation,
+    expected_reason,
+):
+    token = f"boundary-{mutation}-token"
+    content_write_fence._acquire_firestore_writer(deletion_fence, UID, token, 3)
+    reference = content_write_fence._fence_reference(deletion_fence, UID)
+    state = content_write_fence._snapshot_data(reference.get())
+    owner = content_writer_owner.ProcessOwner.from_storage(state["writers"][token]["owner"])
+    replacement = {
+        "host": replace(owner, host_id="f" * 64),
+        "boot": replace(owner, boot_id=f"other-{owner.boot_id}"),
+        "namespace": replace(owner, pid_namespace=f"other-{owner.pid_namespace}"),
+        "start": replace(owner, start_id=f"other-{owner.start_id}"),
+    }[mutation]
+    state["writers"][token]["owner"] = replacement.to_storage()
+    deletion_fence.documents[reference.key] = state
+
+    assert _invoke_recovery(monkeypatch, deletion_fence, uid=UID, token=token) == 2
+    assert json.loads(capsys.readouterr().out)["reason"] == expected_reason
+    assert token in content_write_fence._snapshot_data(reference.get())["writers"]
+
+
+def test_recovery_surface_rejects_stale_cross_uid_ownerless_and_actual_unprivileged_invocation(
+    monkeypatch,
+    deletion_fence,
+    capsys,
+):
+    token = "selector-control-token"
+    content_write_fence._acquire_firestore_writer(deletion_fence, UID, token, 3)
+    assert _invoke_recovery(monkeypatch, deletion_fence, uid=UID, token="stale-token") == 2
+    assert json.loads(capsys.readouterr().out)["reason"] == "account_writer_recovery_stale_token"
+    assert _invoke_recovery(monkeypatch, deletion_fence, uid=OTHER_UID, token=token) == 2
+    assert json.loads(capsys.readouterr().out)["reason"] == "account_writer_recovery_stale_token"
+
+    reference = content_write_fence._fence_reference(deletion_fence, UID)
+    state = content_write_fence._snapshot_data(reference.get())
+    state["writers"][token] = state["writers"][token]["expires_at"]
+    deletion_fence.documents[reference.key] = state
+    assert _invoke_recovery(monkeypatch, deletion_fence, uid=UID, token=token) == 2
+    assert json.loads(capsys.readouterr().out)["reason"] == "account_writer_recovery_owner_unknown"
+
+    monkeypatch.setattr(recovery_cli.os, "geteuid", recovery_cli.os.getuid)
+    context = multiprocessing.get_context("fork")
+    process = context.Process(
+        target=_run_unprivileged_recovery,
+        args=(content_write_recovery.hash_selector(UID), content_write_recovery.hash_selector(token)),
+    )
+    process.start()
+    process.join(5)
+    assert process.exitcode == 77
+
+
+def test_recovery_surface_rejects_cross_generation_replacement_after_real_terminal_proof(
+    monkeypatch,
+    deletion_fence,
+    capsys,
+):
+    del deletion_fence
+    context = multiprocessing.get_context("fork")
+    manager, firestore = _shared_firestore(context)
+    token = "cross-generation-cas-token"
+    process, release = _start_real_writer(context, firestore, uid=UID, token=token)
+    del release
+    process.terminate()
+    process.join(5)
+    assert not process.is_alive()
+    reference = content_write_fence._fence_reference(firestore, UID)
+    replaced_generation = uuid.uuid4().hex
+
+    def replace_before_compare_and_set(function):
+        def run(transaction, *args, **kwargs):
+            with transaction.database.lock:
+                state = content_write_fence._snapshot_data(reference.get())
+                state["writers"][token]["owner"]["generation"] = replaced_generation
+                transaction.database.documents[reference.key] = state
+                return function(transaction, *args, **kwargs)
+
+        return run
+
+    monkeypatch.setattr(content_write_recovery.firestore, "transactional", replace_before_compare_and_set)
+    try:
+        assert _invoke_recovery(monkeypatch, firestore, uid=UID, token=token) == 2
+        assert json.loads(capsys.readouterr().out)["reason"] == "account_writer_recovery_record_replaced"
+        assert _writer_record(firestore, UID, token)["owner"]["generation"] == replaced_generation
+    finally:
+        manager.shutdown()
+
+
+def test_concurrent_recovery_surface_is_exact_and_idempotent(monkeypatch, deletion_fence):
+    del deletion_fence
+    context = multiprocessing.get_context("fork")
+    manager, firestore = _shared_firestore(context)
+    token = "concurrent-recovery-token"
+    process, release = _start_real_writer(context, firestore, uid=UID, token=token)
+    del release
+    process.terminate()
+    process.join(5)
+    assert not process.is_alive()
+    monkeypatch.setattr(recovery_cli.os, "geteuid", lambda: 0)
+    receipts = []
+    receipt_lock = threading.Lock()
+
+    def collect(payload):
+        with receipt_lock:
+            receipts.append(payload)
+
+    monkeypatch.setattr(recovery_cli, "_print_receipt", collect)
+
+    def recover():
+        return recovery_cli.main(
+            [
+                "--subject-hash",
+                content_write_recovery.hash_selector(UID),
+                "--token-hash",
+                content_write_recovery.hash_selector(token),
+            ],
+            firestore_db=firestore,
+        )
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(lambda _index: recover(), range(2)))
+        assert results == [0, 0]
+        assert {receipt["result"] for receipt in receipts} == {"recovered", "already_recovered"}
+        state = content_write_fence._snapshot_data(content_write_fence._fence_reference(firestore, UID).get())
+        assert token not in state["writers"]
+        assert content_write_recovery.hash_selector(token) in state["writer_recoveries"]
+    finally:
+        manager.shutdown()
 
 
 @pytest.mark.parametrize("terminal", ["success", "error", "timeout"])

--- a/backend/tests/unit/test_durable_worker_deletion_finality.py
+++ b/backend/tests/unit/test_durable_worker_deletion_finality.py
@@ -10,9 +10,11 @@ from types import SimpleNamespace
 import types
 import threading
 
-from fastapi import Depends, FastAPI, Response
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Response
 from fastapi.testclient import TestClient
+import httpx
 import pytest
+import requests
 
 os.environ.setdefault("FIRESTORE_EMULATOR_HOST", "localhost:9999")
 os.environ.setdefault("GCLOUD_PROJECT", "omi-ci")
@@ -33,6 +35,7 @@ sys.modules.setdefault("utils.other.storage", storage_stub)
 sys.modules.setdefault("websockets", types.ModuleType("websockets"))
 vector_stub = types.ModuleType("utils.conversations.vector")
 vector_stub.refresh_structured_summary_vector = lambda *args, **kwargs: None
+vector_stub.save_structured_vector = lambda *args, **kwargs: None
 sys.modules.setdefault("utils.conversations.vector", vector_stub)
 summary_stub = types.ModuleType("utils.conversations.generic_summary")
 summary_stub.generate_stock_conversation_summary = lambda *args, **kwargs: None
@@ -41,9 +44,16 @@ sys.modules.setdefault("utils.conversations.generic_summary", summary_stub)
 from database import account_deletion as account_deletion_db
 from database import content_write_fence
 from database.memory_reinterpretations import InMemoryMemoryReinterpretationRepository
+from ella.routers import canonical_events
+from ella.routers.canonical_events import (
+    CanonicalEventsBatch,
+    InMemoryCanonicalEventStore,
+    create_canonical_events_router,
+)
 from ella.services import account_deletion as account_deletion_service
 from ella.services import hermes_cloud_enrichment_outbox as enrichment_service
 from ella.services import memory_reinterpretation as reinterpretation_service
+from ella.services import proposal_ingest
 from ella.services.hermes_cloud_enrichment_outbox import DeliveryResult, HermesCloudEnrichmentOutboxWorker
 from ella.services.memory_reinterpretation import MemoryReinterpretationWorker, ReinterpretationPlan
 
@@ -168,6 +178,7 @@ def _deletion_app(
     delete_firestore,
     delete_firebase,
     purge_memory,
+    purge_canonical=None,
 ):
     monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "true" if authority_enabled else "false")
 
@@ -183,6 +194,16 @@ def _deletion_app(
     monkeypatch.setattr(account_deletion_service.account_deletion_db, "finalize_account_deletion", finalize)
     monkeypatch.setattr(
         account_deletion_service.account_deletion_db, "purge_memory_reinterpretation_work", purge_memory
+    )
+    if purge_canonical is None:
+
+        async def purge_canonical(_uid):
+            return 0
+
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "purge_canonical_event_ledger",
+        purge_canonical,
     )
     route, namespace = _load_production_delete_route()
     namespace["delete_user_data"] = delete_firestore
@@ -245,6 +266,149 @@ class _EnrichmentOutbox:
             for job_id in removed:
                 del self.jobs[job_id]
             return len(removed)
+
+
+class _HeldCanonicalStore(InMemoryCanonicalEventStore):
+    def __init__(self):
+        super().__init__()
+        self.hold_uid = None
+        self.write_entered = threading.Event()
+        self.release_write = threading.Event()
+
+    async def write_batch(self, events):
+        if self.hold_uid and any(event.uid == self.hold_uid for event in events):
+            self.write_entered.set()
+            assert await asyncio.to_thread(self.release_write.wait, 5)
+        return await super().write_batch(events)
+
+    def purge(self, uid):
+        event_keys = [key for key, event in self._events.items() if event.get("uid") == uid]
+        session_keys = [key for key, session in self._sessions.items() if session.get("uid") == uid]
+        for key in event_keys:
+            del self._events[key]
+        for key in session_keys:
+            del self._sessions[key]
+        return len(event_keys) + len(session_keys)
+
+
+def _canonical_event(uid, event_id):
+    return {
+        "uid": uid,
+        "canonical_identity": uid,
+        "event_id": event_id,
+        "channel": "ios_voice",
+        "provider": "mounted-adversarial-test",
+        "role": "user",
+        "text": "Synthetic private transcript",
+        "started_at": "2026-08-03T00:00:00Z",
+        "source_ref": {"source_identity": f"source:{event_id}"},
+        "metadata": {"synthetic": True},
+    }
+
+
+def test_positive_control_legacy_mounted_canonical_route_writes_after_tombstone(deletion_fence):
+    del deletion_fence
+    assert asyncio.run(content_write_fence.tombstone_content_writes(UID)) is True
+    store = InMemoryCanonicalEventStore()
+    router = APIRouter()
+
+    @router.post("/v1/ella/events")
+    async def legacy_write(batch: CanonicalEventsBatch):
+        return await store.write_batch(batch.events)
+
+    app = FastAPI()
+    app.include_router(router)
+    app.add_middleware(content_write_fence.ContentWriteFenceMiddleware)
+    response = TestClient(app).post(
+        "/v1/ella/events",
+        json={"events": [_canonical_event(UID, "legacy-post-tombstone")]},
+    )
+
+    assert response.status_code == 200
+    assert any(event["uid"] == UID for event in store._events.values())
+
+
+def test_mounted_canonical_auth_drain_exact_purge_firebase_last_and_retry(monkeypatch, deletion_fence):
+    del deletion_fence
+    store = _HeldCanonicalStore()
+    asyncio.run(
+        store.write_batch(
+            [canonical_events.CanonicalEventIn(**_canonical_event(OTHER_UID, "retained-canonical-event"))]
+        )
+    )
+    store.hold_uid = UID
+    order = []
+
+    def authenticate(authorization):
+        if authorization != "Bearer exact-user-token":
+            raise HTTPException(status_code=401, detail="Invalid authorization token")
+        return UID
+
+    monkeypatch.setattr(canonical_events.auth, "get_authenticated_user_uid", authenticate)
+
+    async def purge_memory(_uid):
+        return 0
+
+    async def purge_canonical(uid):
+        order.append("canonical-purge")
+        return store.purge(uid)
+
+    app = _deletion_app(
+        monkeypatch,
+        authority_enabled=True,
+        delete_firestore=lambda _uid: order.append("firestore-purge"),
+        delete_firebase=lambda _uid: order.append("firebase-delete"),
+        purge_memory=purge_memory,
+        purge_canonical=purge_canonical,
+    )
+    app.include_router(create_canonical_events_router(store))
+
+    with TestClient(app) as client:
+        unauthenticated = client.post(
+            "/v1/ella/events",
+            json={"events": [_canonical_event(UID, "unauthenticated")]},
+        )
+        mismatch = client.post(
+            "/v1/ella/events",
+            headers={"Authorization": "Bearer exact-user-token"},
+            json={"events": [_canonical_event(OTHER_UID, "cross-subject")]},
+        )
+        assert unauthenticated.status_code == 401
+        assert mismatch.status_code == 403
+
+        write_result = {}
+
+        def write():
+            write_result["response"] = client.post(
+                "/v1/ella/events",
+                headers={"Authorization": "Bearer exact-user-token"},
+                json={"events": [_canonical_event(UID, "held-canonical-event")]},
+            )
+
+        writer = threading.Thread(target=write)
+        writer.start()
+        assert store.write_entered.wait(3)
+        pending = client.delete("/v1/users/delete-account")
+        assert pending.status_code == 202
+        assert "firebase-delete" not in order
+
+        store.release_write.set()
+        writer.join(3)
+        assert not writer.is_alive()
+        assert write_result["response"].status_code == 200
+
+        completed = client.delete("/v1/users/delete-account")
+        assert completed.status_code == 200
+        denied = client.post(
+            "/v1/ella/events",
+            headers={"Authorization": "Bearer exact-user-token"},
+            json={"events": [_canonical_event(UID, "fresh-post-tombstone")]},
+        )
+        assert denied.status_code == 403
+
+    assert not any(event["uid"] == UID for event in store._events.values())
+    assert any(event["uid"] == OTHER_UID for event in store._events.values())
+    assert order == ["canonical-purge", "firestore-purge", "firebase-delete"]
 
 
 @pytest.mark.parametrize("authority_enabled", [True, False])
@@ -462,3 +626,173 @@ def test_startup_memory_worker_is_drained_purged_and_tombstone_denied(
     assert asyncio.run(worker.run_once("post-tombstone-worker")) is None
     assert repository.jobs[post_tombstone["id"]]["status"] == "pending"
     assert hermes.calls == calls_before
+
+
+@pytest.mark.parametrize("terminal", ["success", "error", "timeout"])
+def test_stop_worker_joins_actual_enrichment_thread_before_deletion(monkeypatch, deletion_fence, terminal):
+    del deletion_fence
+    repository = _EnrichmentOutbox()
+    delivery_entered = threading.Event()
+    release_delivery = threading.Event()
+    order = []
+
+    def deliver(_job):
+        order.append("delivery-entered")
+        delivery_entered.set()
+        assert release_delivery.wait(5)
+        order.append(f"delivery-{terminal}")
+        if terminal == "error":
+            raise RuntimeError("synthetic-delivery-error")
+        if terminal == "timeout":
+            raise requests.Timeout("synthetic-delivery-timeout")
+        return DeliveryResult(True, receipt={"content_free": True})
+
+    worker = HermesCloudEnrichmentOutboxWorker(repository, deliver=deliver, poll_seconds=0.01)
+
+    async def purge_memory(_uid):
+        return 0
+
+    app = _deletion_app(
+        monkeypatch,
+        authority_enabled=True,
+        delete_firestore=lambda uid: (order.append("enrichment-purge"), repository.purge(uid)),
+        delete_firebase=lambda _uid: order.append("firebase-delete"),
+        purge_memory=purge_memory,
+    )
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_ENRICHMENT_ENABLED_UIDS", UID)
+    monkeypatch.setattr(enrichment_service, "_worker_task", None)
+
+    async def start():
+        await enrichment_service.start_worker(worker)
+
+    app.router.add_event_handler("startup", start)
+    app.router.add_event_handler("shutdown", enrichment_service.stop_worker)
+
+    async def scenario():
+        await app.router.startup()
+        first_task = enrichment_service._worker_task
+        assert first_task is not None
+        await enrichment_service.start_worker(worker)
+        assert enrichment_service._worker_task is first_task
+        assert await asyncio.to_thread(delivery_entered.wait, 3)
+
+        shutdown = asyncio.create_task(app.router.shutdown())
+        await asyncio.sleep(0.05)
+        assert not shutdown.done()
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+            pending = await client.delete("/v1/users/delete-account")
+            assert pending.status_code == 202
+            assert "firebase-delete" not in order
+            assert repository.jobs["target"]["status"] == "running"
+
+            release_delivery.set()
+            await asyncio.wait_for(shutdown, 3)
+            assert enrichment_service._worker_task is None
+            completed = await client.delete("/v1/users/delete-account")
+            assert completed.status_code == 200
+
+    asyncio.run(scenario())
+    assert "target" not in repository.jobs
+    assert repository.jobs["retained"]["uid"] == OTHER_UID
+    assert order.index(f"delivery-{terminal}") < order.index("enrichment-purge")
+    assert order.index("enrichment-purge") < order.index("firebase-delete")
+
+
+def test_stop_worker_joins_actual_memory_proposal_thread_before_deletion(monkeypatch, deletion_fence):
+    del deletion_fence
+    repository = InMemoryMemoryReinterpretationRepository(debounce_seconds=0)
+    target = asyncio.run(_seed_reinterpretation(repository, UID))
+    retained = asyncio.run(_seed_reinterpretation(repository, OTHER_UID, completed=True))
+    proposal_entered = threading.Event()
+    release_proposal = threading.Event()
+    order = []
+
+    class AmbiguousHermes:
+        async def propose(self, **_kwargs):
+            return ReinterpretationPlan(
+                outcome="proposals",
+                proposals=[
+                    {
+                        "kind": "ambiguous_reinterpretation",
+                        "certainty": "ambiguous",
+                        "correction_text": "The remembered location may have changed.",
+                        "evidence_event_ids": [f"event-{UID}"],
+                    }
+                ],
+            )
+
+    async def conversation_loader(uid, conversation_id):
+        return {
+            "id": conversation_id,
+            "active_summary_version_id": f"version-{uid}",
+            "structured": {"overview": "[Ella] A remembered detail."},
+        }
+
+    def create_proposal(**_kwargs):
+        order.append("proposal-entered")
+        proposal_entered.set()
+        assert release_proposal.wait(5)
+        order.append("proposal-returned")
+        return {"proposal": {"proposal_id": "proposal-after-cancel"}}
+
+    monkeypatch.setattr(proposal_ingest, "create_proposal", create_proposal)
+    worker = MemoryReinterpretationWorker(
+        repository,
+        hermes_client=AmbiguousHermes(),
+        conversation_loader=conversation_loader,
+        lease_seconds=30,
+    )
+
+    async def purge_memory(uid):
+        order.append("memory-purge")
+        removed = [job_id for job_id, job in repository.jobs.items() if job["uid"] == uid]
+        for job_id in removed:
+            del repository.jobs[job_id]
+        repository.attempts = [attempt for attempt in repository.attempts if attempt["job_id"] not in removed]
+        return len(removed)
+
+    app = _deletion_app(
+        monkeypatch,
+        authority_enabled=True,
+        delete_firestore=lambda _uid: order.append("firestore-purge"),
+        delete_firebase=lambda _uid: order.append("firebase-delete"),
+        purge_memory=purge_memory,
+    )
+    monkeypatch.setenv("ELLA_MEMORY_REINTERPRETATION_WORKER_ENABLED", "true")
+    monkeypatch.setenv("ELLA_MEMORY_REINTERPRETATION_IDLE_SECONDS", "0.01")
+    monkeypatch.setattr(reinterpretation_service, "_worker_task", None)
+
+    async def start():
+        await reinterpretation_service.start_worker(worker)
+
+    app.router.add_event_handler("startup", start)
+    app.router.add_event_handler("shutdown", reinterpretation_service.stop_worker)
+
+    async def scenario():
+        await app.router.startup()
+        first_task = reinterpretation_service._worker_task
+        assert first_task is not None
+        await reinterpretation_service.start_worker(worker)
+        assert reinterpretation_service._worker_task is first_task
+        assert await asyncio.to_thread(proposal_entered.wait, 3)
+
+        shutdown = asyncio.create_task(app.router.shutdown())
+        await asyncio.sleep(0.05)
+        assert not shutdown.done()
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+            pending = await client.delete("/v1/users/delete-account")
+            assert pending.status_code == 202
+            assert "firebase-delete" not in order
+            assert repository.jobs[target["id"]]["status"] == "running"
+
+            release_proposal.set()
+            await asyncio.wait_for(shutdown, 3)
+            assert reinterpretation_service._worker_task is None
+            completed = await client.delete("/v1/users/delete-account")
+            assert completed.status_code == 200
+
+    asyncio.run(scenario())
+    assert target["id"] not in repository.jobs
+    assert repository.jobs[retained["id"]]["uid"] == OTHER_UID
+    assert order.index("proposal-returned") < order.index("memory-purge")
+    assert order.index("memory-purge") < order.index("firebase-delete")

--- a/backend/tests/unit/test_ella_ai_consent.py
+++ b/backend/tests/unit/test_ella_ai_consent.py
@@ -1003,7 +1003,7 @@ def test_policy_is_public_but_status_and_receipts_require_firebase_auth(monkeypa
     assert client.get("/v1/users/ai-consent").status_code == 401
     assert client.get("/v1/users/ai-consent/receipts/aicr_unknown").status_code == 401
 
-    app.dependency_overrides[consent.auth.get_current_user_uid] = lambda: "user-a"
+    app.dependency_overrides[consent.auth.get_writable_user_uid] = lambda: "user-a"
     status_response = client.get("/v1/users/ai-consent")
     assert status_response.status_code == 200
     assert status_response.json()["subject_uid"] == "user-a"
@@ -1014,7 +1014,7 @@ def test_authenticated_api_records_exact_v7_profile_bound_receipt(monkeypatch):
     monkeypatch.setattr(ai_consent, "get_ai_consent_service", lambda: service)
     app = FastAPI()
     app.include_router(ai_consent.router)
-    app.dependency_overrides[consent.auth.get_current_user_uid] = lambda: "user-a"
+    app.dependency_overrides[consent.auth.get_writable_user_uid] = lambda: "user-a"
     client = TestClient(app)
 
     response = client.post(

--- a/backend/tests/unit/test_ella_app_settings.py
+++ b/backend/tests/unit/test_ella_app_settings.py
@@ -83,7 +83,7 @@ def _load_router(monkeypatch, stored_voice=None):
 
     app = FastAPI()
     app.include_router(module.router)
-    app.dependency_overrides[auth.get_current_user_uid] = lambda: "uid-1"
+    app.dependency_overrides[auth.get_writable_user_uid] = lambda: "uid-1"
     return TestClient(app), state
 
 

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -101,7 +101,7 @@ def _retry_conversation(status="processing", request_id="84eb13fa-31d9-40ba-a742
 def _retry_api_client():
     app = FastAPI()
     app.include_router(corrections.router)
-    app.dependency_overrides[corrections.auth.get_current_user_uid] = lambda: "authenticated-user"
+    app.dependency_overrides[corrections.auth.get_writable_user_uid] = lambda: "authenticated-user"
     return app, TestClient(app)
 
 

--- a/backend/tests/unit/test_ella_guardian_delivery.py
+++ b/backend/tests/unit/test_ella_guardian_delivery.py
@@ -9,7 +9,8 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
-sys.modules.setdefault("asyncpg", types.SimpleNamespace(Pool=object, create_pool=None))
+_MINIMAL_ASYNCPG_STUB = types.SimpleNamespace(Pool=object, create_pool=None)
+sys.modules.setdefault("asyncpg", _MINIMAL_ASYNCPG_STUB)
 sys.modules.setdefault("python_multipart", types.SimpleNamespace(__version__="0.0.20"))
 
 _BACKEND = Path(__file__).resolve().parents[2]
@@ -88,6 +89,12 @@ _ROUTER_SPEC = importlib.util.spec_from_file_location("ella_guardian_under_test"
 guardian = importlib.util.module_from_spec(_ROUTER_SPEC)
 assert _ROUTER_SPEC and _ROUTER_SPEC.loader
 _ROUTER_SPEC.loader.exec_module(guardian)
+
+
+def test_guardian_import_accepts_minimal_asyncpg_stub():
+    if sys.modules["asyncpg"] is _MINIMAL_ASYNCPG_STUB:
+        assert not hasattr(_MINIMAL_ASYNCPG_STUB, "Connection")
+    assert callable(guardian.auth.voice_canary.get_pool)
 
 
 class _FakePool:

--- a/backend/tests/unit/test_ella_guardian_delivery.py
+++ b/backend/tests/unit/test_ella_guardian_delivery.py
@@ -546,7 +546,7 @@ def test_guardian_alerts_endpoint_excludes_ack_only_rows_but_keeps_real_wake_wor
 
     app = FastAPI()
     app.include_router(guardian.alerts_router)
-    app.dependency_overrides[guardian.auth.get_current_user_uid] = lambda: "auth-uid"
+    app.dependency_overrides[guardian.auth.get_writable_user_uid] = lambda: "auth-uid"
 
     response = TestClient(app).get("/v1/ella/guardian-alerts?limit=50")
 
@@ -579,7 +579,7 @@ def test_guardian_alerts_endpoint_uses_authenticated_uid_not_query_uid(monkeypat
 
     app = FastAPI()
     app.include_router(guardian.alerts_router)
-    app.dependency_overrides[guardian.auth.get_current_user_uid] = lambda: "auth-uid"
+    app.dependency_overrides[guardian.auth.get_writable_user_uid] = lambda: "auth-uid"
     client = TestClient(app)
 
     response = client.get("/v1/ella/guardian-alerts?limit=50&uid=other-user")

--- a/backend/tests/unit/test_ella_provision_authority_split.py
+++ b/backend/tests/unit/test_ella_provision_authority_split.py
@@ -29,6 +29,7 @@ LEGACY_URL = "http://100.76.138.56:8200"
 HERMES_URL = APPROVED_HERMES_PROVISION_URL
 LEGACY_TOKEN = "legacy-test-token-distinct"
 HERMES_TOKEN = "hermes-test-token-distinct"
+PROVIDER_IDEMPOTENCY_KEY = "22222222-2222-2222-2222-222222222222"
 BINDING_ENV = "ELLA_TEST_HERMES_PROVISION_AUTHORITY_BINDING"
 
 REJECTION_CASES = (
@@ -243,7 +244,13 @@ def test_real_provision_client_and_coordinator_reject_before_http_or_repository_
     coordinator = ProvisioningCoordinator(ForbiddenRepository())
 
     with pytest.raises(ProvisioningError):
-        asyncio.run(client.provision(_identity(), "hermes-user-v1"))
+        asyncio.run(
+            client.provision(
+                _identity(),
+                "hermes-user-v1",
+                idempotency_key=PROVIDER_IDEMPOTENCY_KEY,
+            )
+        )
     with pytest.raises(ProvisioningError):
         asyncio.run(
             coordinator.ensure_job(
@@ -295,11 +302,20 @@ def test_real_provision_client_posts_only_to_accepted_exact_authority(monkeypatc
 
     monkeypatch.setattr(provisioning.httpx, "AsyncClient", AsyncClient)
 
-    result = asyncio.run(HermesProvisionClient().provision(_identity(), "hermes-user-v1"))
+    result = asyncio.run(
+        HermesProvisionClient().provision(
+            _identity(),
+            "hermes-user-v1",
+            idempotency_key=PROVIDER_IDEMPOTENCY_KEY,
+        )
+    )
 
     assert result == {"mode": "hermes_only", "provisionMode": "hermes_only"}
     assert captured["url"] == f"{APPROVED_HERMES_PROVISION_URL}/provision"
-    assert captured["headers"] == {"Authorization": f"Bearer {HERMES_TOKEN}"}
+    assert captured["headers"] == {
+        "Authorization": f"Bearer {HERMES_TOKEN}",
+        "Idempotency-Key": PROVIDER_IDEMPOTENCY_KEY,
+    }
 
 
 @pytest.mark.parametrize("case", REJECTION_CASES)
@@ -753,6 +769,10 @@ class _RecordingRepository:
         self.job.update(state="provisioning", stage="profile_ready")
         return dict(self.job)
 
+    async def begin_provider_attempt(self, **_kwargs):
+        self._record("begin_provider_attempt")
+        return {"idempotency_key": "22222222-2222-2222-2222-222222222222"}
+
     async def stage_runtime_binding(self, *, uid, binding):
         self._record("stage_runtime_binding")
         self.staged = {**binding, "omi_uid": uid, "revision": 1}
@@ -811,7 +831,13 @@ def test_real_provision_client_revalidates_after_client_entry_before_send(monkey
     monkeypatch.setattr(provisioning.httpx, "AsyncClient", AsyncClient)
 
     with pytest.raises(ProvisioningError):
-        asyncio.run(HermesProvisionClient().provision(_identity(), "hermes-user-v1"))
+        asyncio.run(
+            HermesProvisionClient().provision(
+                _identity(),
+                "hermes-user-v1",
+                idempotency_key=PROVIDER_IDEMPOTENCY_KEY,
+            )
+        )
 
     assert sends == []
 
@@ -861,6 +887,7 @@ def test_real_claimed_worker_stops_after_inflight_http_authority_drift(monkeypat
     assert repository.calls == [
         "assert_self_hosted_invite_schema_ready",
         "has_invitation_owned_self_hosted_runtime",
+        "begin_provider_attempt",
     ]
 
 
@@ -1516,7 +1543,13 @@ def test_http_transports_disable_redirects_proxies_and_environment_drift(monkeyp
     monkeypatch.setattr(provisioning.httpx, "AsyncClient", AsyncClient)
 
     with pytest.raises(ProvisioningError, match="provision_request_rejected"):
-        asyncio.run(HermesProvisionClient().provision(_identity(), "hermes-user-v1"))
+        asyncio.run(
+            HermesProvisionClient().provision(
+                _identity(),
+                "hermes-user-v1",
+                idempotency_key=PROVIDER_IDEMPOTENCY_KEY,
+            )
+        )
 
     assert captured["follow_redirects"] is False
     assert captured["trust_env"] is False

--- a/backend/tests/unit/test_ella_provisioning_repository.py
+++ b/backend/tests/unit/test_ella_provisioning_repository.py
@@ -115,6 +115,12 @@ class _LookupPool:
         self.calls.append((query, args))
         return "INSERT 0 1"
 
+    async def fetchval(self, query, *args):
+        self.calls.append((query, args))
+        if "SELECT status FROM users" in query:
+            return "ACTIVE"
+        raise AssertionError(query)
+
     def acquire(self):
         return _AsyncContext(self)
 
@@ -257,6 +263,12 @@ class _CloudClaimConnection:
                 "claim_token": args[3],
                 "status": "claiming",
             }
+        raise AssertionError(query)
+
+    async def fetchval(self, query, *_args):
+        self.queries.append(query)
+        if "SELECT status FROM users" in query:
+            return "ACTIVE"
         raise AssertionError(query)
 
 
@@ -428,6 +440,11 @@ class _ExpiredFinalizeConnection:
                 "omi_uid": args[0],
             }
         raise AssertionError("expired claim must not publish")
+
+    async def fetchval(self, query, *_args):
+        if "SELECT status FROM users" in query:
+            return "ACTIVE"
+        raise AssertionError(query)
 
 
 def test_cloud_pool_finalize_rechecks_lease_before_publish(monkeypatch):

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -11,6 +11,7 @@ from database.runtime_targets import (
 from database.ella_provisioning import (
     EllaProvisioningRepository,
     ProvisioningSchemaNotReadyError,
+    ensure_omi_user_document_contents,
 )
 from ella.services.ai_consent import (
     CURRENT_POLICY_VERSION,
@@ -290,15 +291,12 @@ def test_provision_timeout_is_bounded_for_cold_runtime_starts(monkeypatch, confi
 
 def test_omi_identity_defaults_do_not_grant_cloud_or_recording_permission():
     document = _FakeDocument(exists=True, data={"onboarding": {"completed": True}})
-    repository = EllaProvisioningRepository(pool=None, firestore_db=_FakeFirestore(document))
-
-    changed = asyncio.run(
-        repository.ensure_omi_user_document(
-            uid="user-a",
-            email="a@example.com",
-            name="A",
-            timezone_name="America/Los_Angeles",
-        )
+    changed = ensure_omi_user_document_contents(
+        _FakeFirestore(document),
+        uid="user-a",
+        email="a@example.com",
+        name="A",
+        timezone_name="America/Los_Angeles",
     )
 
     assert changed is True
@@ -310,16 +308,13 @@ def test_omi_identity_defaults_do_not_grant_cloud_or_recording_permission():
 
 def test_legacy_omi_identity_repair_preserves_cloud_sync_default():
     document = _FakeDocument(exists=True, data={"onboarding": {"completed": True}})
-    repository = EllaProvisioningRepository(pool=None, firestore_db=_FakeFirestore(document))
-
-    changed = asyncio.run(
-        repository.ensure_omi_user_document(
-            uid="legacy-user",
-            email="legacy@example.com",
-            name="Legacy",
-            timezone_name="America/Los_Angeles",
-            private_cloud_sync_default=True,
-        )
+    changed = ensure_omi_user_document_contents(
+        _FakeFirestore(document),
+        uid="legacy-user",
+        email="legacy@example.com",
+        name="Legacy",
+        timezone_name="America/Los_Angeles",
+        private_cloud_sync_default=True,
     )
 
     assert changed is True
@@ -334,6 +329,7 @@ def test_repository_schema_preflight_reports_missing_objects():
         {
             "jobs_table": True,
             "bindings_table": False,
+            "provider_attempts_table": False,
             "missing_indexes": ["ella_runtime_bindings_one_active_role_key"],
         }
     )
@@ -344,6 +340,7 @@ def test_repository_schema_preflight_reports_missing_objects():
 
     assert error.value.missing == (
         "table:ella_runtime_bindings",
+        "table:ella_provider_attempts",
         "index:ella_runtime_bindings_one_active_role_key",
     )
     assert len(pool.calls) == 1

--- a/backend/tests/unit/test_hermes_cloud_enrichment_outbox.py
+++ b/backend/tests/unit/test_hermes_cloud_enrichment_outbox.py
@@ -353,7 +353,12 @@ def test_firestore_repository_rejects_post_tombstone_claim_complete_fail_and_ret
 
     fence_reference.data = {
         "state": content_write_fence.ACTIVE,
-        "writers": {"current-writer": now},
+        "writers": {
+            "current-writer": {
+                "expires_at": now,
+                "owner": content_write_fence._current_process_owner().to_storage(),
+            }
+        },
     }
     admitted = Reference({**_job(), "status": "pending"})
     admitted_transaction = Transaction()

--- a/backend/tests/unit/test_hermes_cloud_enrichment_outbox.py
+++ b/backend/tests/unit/test_hermes_cloud_enrichment_outbox.py
@@ -1,9 +1,17 @@
 import asyncio
+from contextlib import asynccontextmanager
 from copy import deepcopy
+from datetime import datetime, timezone
+import os
 
 import pytest
 import requests
 
+os.environ.setdefault("FIRESTORE_EMULATOR_HOST", "localhost:9999")
+os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "omi-ci")
+
+from database import content_write_fence
+from database import hermes_cloud_enrichment_outbox as outbox_db
 from ella.services.hermes_cloud_enrichment_outbox import (
     DeliveryResult,
     HermesCloudEnrichmentOutboxWorker,
@@ -30,7 +38,15 @@ class FakeOutbox:
         self.failures = []
         self.lease_number = 0
 
-    def claim_next(self, *, lease_seconds, scan_limit=50):
+    def peek_next_uid(self, *, scan_limit=50):
+        del scan_limit
+        if self.job["status"] not in {"pending", "retryable", "running"}:
+            return None
+        return self.job["uid"]
+
+    def claim_next(self, *, uid, writer_token, lease_seconds, scan_limit=50):
+        assert uid == self.job["uid"]
+        assert writer_token
         if self.job["status"] not in {"pending", "retryable", "running"}:
             return None
         if self.job["status"] == "running" and not self.job.get("lease_expired"):
@@ -55,6 +71,22 @@ class FakeOutbox:
         self.job["status"] = "retryable" if kwargs["retryable"] else "blocked"
         self.failures.append(kwargs)
         return True
+
+
+@pytest.fixture(autouse=True)
+def _admitted_worker(monkeypatch):
+    class Writer:
+        token = "test-writer-token"
+
+        @staticmethod
+        def assert_current():
+            return None
+
+    @asynccontextmanager
+    async def admitted(_uid):
+        yield Writer()
+
+    monkeypatch.setattr(content_write_fence, "detached_content_write_fence", admitted)
 
 
 @pytest.mark.parametrize(
@@ -165,7 +197,11 @@ def test_401_blocks_until_operator_repairs_loopback_token(monkeypatch):
 
 def test_expired_lease_reclaims_after_process_interruption():
     repository = FakeOutbox()
-    first_claim = repository.claim_next(lease_seconds=240)
+    first_claim = repository.claim_next(
+        uid=_job()["uid"],
+        writer_token="direct-test-writer",
+        lease_seconds=240,
+    )
     assert first_claim["lease_token"] == "lease-1"
 
     repository.job["lease_expired"] = True
@@ -197,3 +233,187 @@ def test_successful_replay_is_idempotent():
     assert asyncio.run(worker.run_once()) is True
     assert asyncio.run(worker.run_once()) is False
     assert deliveries == [_job()["job_id"]]
+
+
+def test_stale_claim_fails_closed_at_external_delivery_boundary(monkeypatch):
+    repository = FakeOutbox()
+    deliveries = []
+
+    class StaleWriter:
+        token = "stale-writer-token"
+
+        @staticmethod
+        def assert_current():
+            raise content_write_fence.ContentWriteFenceError("account_write_forbidden")
+
+    @asynccontextmanager
+    async def stale(_uid):
+        yield StaleWriter()
+
+    monkeypatch.setattr(content_write_fence, "detached_content_write_fence", stale)
+    worker = HermesCloudEnrichmentOutboxWorker(
+        repository,
+        deliver=lambda job: deliveries.append(job) or DeliveryResult(True),
+    )
+
+    assert asyncio.run(worker.run_once()) is False
+    assert repository.job["status"] == "running"
+    assert deliveries == []
+    assert repository.completed == []
+    assert repository.failures == []
+
+
+def test_firestore_repository_rejects_post_tombstone_claim_complete_fail_and_retry():
+    class Snapshot:
+        def __init__(self, data):
+            self.data = data
+            self.exists = data is not None
+
+        def to_dict(self):
+            return deepcopy(self.data)
+
+    class Reference:
+        def __init__(self, data):
+            self.data = data
+
+        def get(self, transaction=None):
+            del transaction
+            return Snapshot(self.data)
+
+    class Transaction:
+        def __init__(self):
+            self.updates = []
+
+        def update(self, reference, values):
+            self.updates.append(values)
+            reference.data.update(values)
+
+    fence_reference = Reference({"state": content_write_fence.TOMBSTONED, "writers": {}})
+
+    class Collection:
+        def document(self, _document_id):
+            return fence_reference
+
+    class Database:
+        def collection(self, name):
+            assert name == content_write_fence.FENCE_COLLECTION
+            return Collection()
+
+    now = datetime.now(timezone.utc)
+    database = Database()
+
+    pending = Reference({**_job(), "status": "pending"})
+    claim_transaction = Transaction()
+    assert (
+        outbox_db._claim_transaction.to_wrap(
+            claim_transaction,
+            database,
+            pending,
+            writer_token="missing-writer",
+            now=now,
+            lease_seconds=240,
+        )
+        is None
+    )
+    assert claim_transaction.updates == []
+    assert pending.data["status"] == "pending"
+
+    running = Reference({**_job(), "status": "running", "lease_token": "stale-lease"})
+    complete_transaction = Transaction()
+    assert (
+        outbox_db._complete_transaction.to_wrap(
+            complete_transaction,
+            database,
+            running,
+            lease_token="stale-lease",
+            receipt={"content_free": True},
+            now=now,
+        )
+        is False
+    )
+    assert complete_transaction.updates == []
+
+    for retryable in (True, False):
+        fail_transaction = Transaction()
+        assert (
+            outbox_db._fail_transaction.to_wrap(
+                fail_transaction,
+                database,
+                running,
+                lease_token="stale-lease",
+                error_code="stale_worker",
+                retryable=retryable,
+                next_attempt_at=now if retryable else None,
+                now=now,
+            )
+            is False
+        )
+        assert fail_transaction.updates == []
+
+    fence_reference.data = {
+        "state": content_write_fence.ACTIVE,
+        "writers": {"current-writer": now},
+    }
+    admitted = Reference({**_job(), "status": "pending"})
+    admitted_transaction = Transaction()
+    claimed = outbox_db._claim_transaction.to_wrap(
+        admitted_transaction,
+        database,
+        admitted,
+        writer_token="current-writer",
+        now=now,
+        lease_seconds=240,
+    )
+    assert claimed["status"] == "running"
+    assert claimed["content_writer_token"] == "current-writer"
+
+    complete_transaction = Transaction()
+    assert outbox_db._complete_transaction.to_wrap(
+        complete_transaction,
+        database,
+        admitted,
+        lease_token=claimed["lease_token"],
+        receipt={"content_free": True},
+        now=now,
+    )
+    assert admitted.data["status"] == "completed"
+
+    retry_job = Reference(
+        {
+            **_job(),
+            "status": "running",
+            "lease_token": "current-lease",
+            "content_writer_token": "current-writer",
+        }
+    )
+    retry_transaction = Transaction()
+    assert outbox_db._fail_transaction.to_wrap(
+        retry_transaction,
+        database,
+        retry_job,
+        lease_token="current-lease",
+        error_code="retryable_failure",
+        retryable=True,
+        next_attempt_at=now,
+        now=now,
+    )
+    assert retry_job.data["status"] == "retryable"
+
+
+def test_firestore_repository_rejects_post_tombstone_enqueue(monkeypatch):
+    def forbidden(uid):
+        assert uid == _job()["uid"]
+        raise content_write_fence.ContentWriteFenceError("account_write_forbidden")
+
+    monkeypatch.setattr(content_write_fence, "assert_content_writer_admitted", forbidden)
+    repository = outbox_db.FirestoreHermesCloudEnrichmentOutbox(firestore_db=object())
+
+    with pytest.raises(content_write_fence.ContentWriteFenceError, match="account_write_forbidden"):
+        repository.enqueue(
+            job_id=_job()["job_id"],
+            uid=_job()["uid"],
+            conversation_id=_job()["conversation_id"],
+            client_interaction_id=_job()["client_interaction_id"],
+            transcript_sha256=_job()["transcript_sha256"],
+            policy_version="test-policy",
+        )

--- a/backend/tests/unit/test_hermes_cloud_enrichment_outbox.py
+++ b/backend/tests/unit/test_hermes_cloud_enrichment_outbox.py
@@ -87,6 +87,7 @@ def _admitted_worker(monkeypatch):
         yield Writer()
 
     monkeypatch.setattr(content_write_fence, "detached_content_write_fence", admitted)
+    monkeypatch.setattr(content_write_fence, "assert_content_writer_admitted", lambda _uid: None)
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/test_invitation_redemption.py
+++ b/backend/tests/unit/test_invitation_redemption.py
@@ -220,7 +220,7 @@ def test_routes_require_auth_and_use_only_authenticated_uid(monkeypatch):
         "get_user",
         lambda _uid: SimpleNamespace(email="verified@example.test", email_verified=True),
     )
-    app.dependency_overrides[auth.get_current_user_uid] = lambda: "firebase-subject"
+    app.dependency_overrides[auth.get_writable_user_uid] = lambda: "firebase-subject"
     response = client.post(
         "/v1/invite/redeem",
         json={"code": "ABCD-2345"},
@@ -236,7 +236,7 @@ def test_routes_require_auth_and_use_only_authenticated_uid(monkeypatch):
 def test_redeem_rejects_unverified_firebase_email_before_authority_or_database(monkeypatch):
     app = FastAPI()
     app.include_router(invites.router)
-    app.dependency_overrides[auth.get_current_user_uid] = lambda: "firebase-subject"
+    app.dependency_overrides[auth.get_writable_user_uid] = lambda: "firebase-subject"
     monkeypatch.setattr(
         invites.auth,
         "get_user",
@@ -287,7 +287,7 @@ def test_authenticated_malformed_body_returns_safe_invalid_envelope(
 ):
     app = FastAPI()
     app.include_router(invites.router)
-    app.dependency_overrides[auth.get_current_user_uid] = lambda: "firebase-subject"
+    app.dependency_overrides[auth.get_writable_user_uid] = lambda: "firebase-subject"
     redemption_called = False
 
     async def fake_redeem(**_kwargs):
@@ -336,7 +336,7 @@ def test_entitlement_read_requires_auth_and_is_uid_scoped(monkeypatch):
         return {"status": "none", "quota": {}}
 
     monkeypatch.setattr(voice.voice_canary_db, "get_entitlement_contract", fake_contract)
-    app.dependency_overrides[auth.get_current_user_uid] = lambda: "firebase-subject"
+    app.dependency_overrides[auth.get_writable_user_uid] = lambda: "firebase-subject"
     response = client.get("/v1/entitlement")
     assert response.status_code == 200
     assert captured["uid"] == "firebase-subject"
@@ -347,7 +347,7 @@ def test_entitlement_read_requires_auth_and_is_uid_scoped(monkeypatch):
 def test_typed_failure_shape_is_compatible_with_ios(monkeypatch):
     app = FastAPI()
     app.include_router(invites.router)
-    app.dependency_overrides[auth.get_current_user_uid] = lambda: "firebase-subject"
+    app.dependency_overrides[auth.get_writable_user_uid] = lambda: "firebase-subject"
 
     async def fake_redeem(**_kwargs):
         raise invitations.InviteRedemptionFailure(

--- a/backend/tests/unit/test_memory_reinterpretation_outbox.py
+++ b/backend/tests/unit/test_memory_reinterpretation_outbox.py
@@ -1224,7 +1224,7 @@ def test_authenticated_status_is_identifier_only_and_missing_nonowned_have_parit
     repository, job = asyncio.run(seed())
     app = FastAPI()
     app.include_router(reinterpretation_router.create_memory_reinterpretation_router(repository))
-    app.dependency_overrides[reinterpretation_router.auth.get_current_user_uid] = lambda: UID
+    app.dependency_overrides[reinterpretation_router.auth.get_writable_user_uid] = lambda: UID
     monkeypatch.setattr(
         reinterpretation_router.conversations_db,
         "get_conversation",
@@ -1241,7 +1241,7 @@ def test_authenticated_status_is_identifier_only_and_missing_nonowned_have_parit
     assert "proposal_plan" not in body
 
     missing = client.get("/v1/ella/conversations/missing/reinterpretations/latest")
-    app.dependency_overrides[reinterpretation_router.auth.get_current_user_uid] = lambda: UID.lower()
+    app.dependency_overrides[reinterpretation_router.auth.get_writable_user_uid] = lambda: UID.lower()
     nonowned = client.get(f"/v1/ella/conversations/{CONVERSATION_ID}/reinterpretations/latest")
     assert (missing.status_code, missing.json()) == (
         nonowned.status_code,
@@ -1496,7 +1496,7 @@ def test_worker_reinterpretation_receipt_and_authenticated_undo_restore_prior_su
 
     app = FastAPI()
     app.include_router(corrections.router)
-    app.dependency_overrides[corrections.auth.get_current_user_uid] = lambda: UID
+    app.dependency_overrides[corrections.auth.get_writable_user_uid] = lambda: UID
     client = TestClient(app)
 
     receipt = client.get(f"/v1/ella/conversations/{CONVERSATION_ID}/corrections/{correction_id}")

--- a/backend/tests/unit/test_memory_reinterpretation_outbox.py
+++ b/backend/tests/unit/test_memory_reinterpretation_outbox.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import asynccontextmanager
 import os
 import sys
 import types
@@ -38,6 +39,7 @@ from database.memory_reinterpretations import (
     InMemoryMemoryReinterpretationRepository,
     PostgresMemoryReinterpretationRepository,
 )
+from database import content_write_fence
 from ella.routers import corrections, memory_reinterpretation as reinterpretation_router
 from ella.routers.canonical_events import (
     CanonicalEventIn,
@@ -62,6 +64,17 @@ UID = "CaseSensitiveUserA"
 SESSION_ID = "signed-jti-1"
 CONVERSATION_ID = "memory-1"
 VERSION_ID = "summary-v1"
+
+
+@pytest.fixture(autouse=True)
+def _admitted_worker(monkeypatch):
+    @asynccontextmanager
+    async def admitted(uid):
+        yield SimpleNamespace(uid=uid)
+
+    monkeypatch.setattr(content_write_fence, "detached_content_write_fence", admitted)
+    monkeypatch.setattr(content_write_fence, "request_content_write_fence", admitted)
+    monkeypatch.setattr(content_write_fence, "assert_content_writer_admitted", lambda _uid: None)
 
 
 def _event(
@@ -542,6 +555,35 @@ def test_reinterpretation_completion_requires_configured_ledger_bearer(monkeypat
     assert accepted.json()["reinterpretation"]["job_id"]
 
 
+def test_reinterpretation_completion_rejects_post_tombstone_enqueue(monkeypatch):
+    repository = InMemoryMemoryReinterpretationRepository(debounce_seconds=45)
+    store = InMemoryCanonicalEventStore(repository)
+    asyncio.run(store.write_batch([_event("turn-tombstoned", "The glasses are in the blue backpack.")]))
+
+    @asynccontextmanager
+    async def tombstoned(uid):
+        assert uid == UID
+        raise content_write_fence.ContentWriteFenceError("account_write_forbidden")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(content_write_fence, "request_content_write_fence", tombstoned)
+    monkeypatch.setenv("ELLA_MEMORY_REINTERPRETATION_ENABLED", "true")
+    monkeypatch.setenv("ELLA_EVENT_LEDGER_TOKEN", "ledger-secret")
+    app = FastAPI()
+    app.include_router(create_canonical_events_router(store))
+    session_id, completion = _completion()
+
+    response = TestClient(app).post(
+        f"/v1/ella/sessions/{session_id}/complete",
+        headers={"Authorization": "Bearer ledger-secret"},
+        json=completion.model_dump(mode="json"),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == {"code": "account_write_forbidden", "retryable": False}
+    assert repository.jobs == {}
+
+
 def test_read_only_or_noise_completion_never_enqueues():
     async def run():
         for completion_values in (
@@ -852,6 +894,43 @@ def test_stale_starting_version_is_typed_conflict_before_hermes_call():
     asyncio.run(run())
 
 
+def test_stale_claim_fails_closed_before_hermes_delivery_or_durable_retry(monkeypatch):
+    async def run():
+        repository = InMemoryMemoryReinterpretationRepository(debounce_seconds=0)
+        await _seed_job(repository)
+        repository.now += timedelta(seconds=1)
+        hermes = _Hermes({"outcome": "no_change", "proposals": []})
+        checks = 0
+
+        @asynccontextmanager
+        async def admitted(uid):
+            assert uid == UID
+            yield SimpleNamespace(uid=uid)
+
+        def assert_current(uid):
+            nonlocal checks
+            assert uid == UID
+            checks += 1
+            if checks >= 2:
+                raise content_write_fence.ContentWriteFenceError("account_write_forbidden")
+
+        monkeypatch.setattr(content_write_fence, "detached_content_write_fence", admitted)
+        monkeypatch.setattr(content_write_fence, "assert_content_writer_admitted", assert_current)
+        worker = MemoryReinterpretationWorker(
+            repository,
+            hermes_client=hermes,
+            conversation_loader=_loader,
+        )
+
+        assert await worker.run_once("stale-worker") is None
+        job = next(iter(repository.jobs.values()))
+        assert job["status"] == "running"
+        assert hermes.calls == 0
+        assert repository.attempts[0]["status"] == "running"
+
+    asyncio.run(run())
+
+
 def test_retry_backoff_reaches_dead_letter_at_attempt_limit():
     class UnavailableHermes:
         async def propose(self, **kwargs):
@@ -1014,6 +1093,7 @@ def test_worker_heartbeat_renews_long_running_lease(monkeypatch):
         await worker._heartbeat_lease(
             {
                 "id": "job-1",
+                "uid": UID,
                 "transcript_revision": 4,
             }
         )

--- a/backend/tests/unit/test_trace_deletion_finality.py
+++ b/backend/tests/unit/test_trace_deletion_finality.py
@@ -233,6 +233,11 @@ def _fixed_app(monkeypatch, routing_pool, identity, order):
         order.append("purge")
         return routing_pool.purge(uid)
 
+    async def purge_memory_reinterpretation_work(uid):
+        assert uid == UID
+        order.append("purge_memory_reinterpretation")
+        return 0
+
     async def finalize(uid):
         assert uid == UID
         order.append("finalize")
@@ -245,6 +250,11 @@ def _fixed_app(monkeypatch, routing_pool, identity, order):
     monkeypatch.setattr(content_write_fence, "_assert_postgres_owner_active", assert_postgres_active)
     monkeypatch.setattr(account_deletion_service.account_deletion_db, "quarantine_account_for_deletion", quarantine)
     monkeypatch.setattr(account_deletion_service.account_deletion_db, "purge_routing_traces", purge)
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "purge_memory_reinterpretation_work",
+        purge_memory_reinterpretation_work,
+    )
     monkeypatch.setattr(account_deletion_service.account_deletion_db, "finalize_account_deletion", finalize)
 
     delete_route, namespace = _load_production_delete_route()

--- a/backend/tests/unit/test_trace_deletion_finality.py
+++ b/backend/tests/unit/test_trace_deletion_finality.py
@@ -1,0 +1,511 @@
+import asyncio
+import ast
+from copy import deepcopy
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from types import SimpleNamespace
+import threading
+import time
+
+from fastapi import APIRouter, Depends, FastAPI, Response
+from fastapi.testclient import TestClient
+import pytest
+
+from database import account_deletion as account_deletion_db
+from database import content_write_fence
+from ella.routers import trace as trace_router
+from ella.services import account_deletion as account_deletion_service
+from utils.other import endpoints as auth_endpoints
+
+UID = "trace-deletion-user"
+RETAINED_UID = "retained-trace-user"
+
+
+class _Snapshot:
+    def __init__(self, data):
+        self._data = deepcopy(data)
+        self.exists = data is not None
+
+    def to_dict(self):
+        return deepcopy(self._data)
+
+
+class _Document:
+    def __init__(self, database, key):
+        self.database = database
+        self.key = key
+
+    def get(self, transaction=None):
+        del transaction
+        return _Snapshot(self.database.documents.get(self.key))
+
+
+class _Collection:
+    def __init__(self, database, name):
+        self.database = database
+        self.name = name
+
+    def document(self, document_id):
+        return _Document(self.database, (self.name, document_id))
+
+
+class _Transaction:
+    def __init__(self, database):
+        self.database = database
+
+    def set(self, reference, data):
+        self.database.documents[reference.key] = deepcopy(data)
+
+    def delete(self, reference):
+        self.database.documents.pop(reference.key, None)
+
+
+class _Firestore:
+    def __init__(self):
+        self.documents = {}
+        self.lock = threading.RLock()
+
+    def collection(self, name):
+        return _Collection(self, name)
+
+    def transaction(self):
+        return _Transaction(self)
+
+
+def _transactional(function):
+    def run(transaction, *args, **kwargs):
+        with transaction.database.lock:
+            return function(transaction, *args, **kwargs)
+
+    return run
+
+
+def _state():
+    return account_deletion_db.AccountDeletionState(
+        user_found=True,
+        capacity_released=True,
+        authority_quarantined=True,
+        external_cleanup_required=(),
+        external_cleanup_references=(),
+        counts={},
+    )
+
+
+def _load_production_delete_route():
+    path = Path(__file__).resolve().parents[2] / "routers" / "users.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    route = next(node for node in tree.body if isinstance(node, ast.AsyncFunctionDef) and node.name == "delete_account")
+    route.decorator_list = []
+    namespace = {
+        "Depends": Depends,
+        "Response": Response,
+        "auth": SimpleNamespace(
+            get_authenticated_user_uid=lambda: UID,
+            delete_account=lambda _uid: None,
+        ),
+        "delete_user_data": lambda _uid: None,
+        "execute_account_deletion": account_deletion_service.execute_account_deletion,
+    }
+    exec(compile(ast.fix_missing_locations(ast.Module(body=[route], type_ignores=[])), str(path), "exec"), namespace)
+    return namespace["delete_account"], namespace
+
+
+class _RoutingPool:
+    def __init__(self, *, hold=True, max_size=20):
+        self.rows = []
+        self.committed = []
+        self.lock = threading.RLock()
+        self.release = threading.Event()
+        if not hold:
+            self.release.set()
+        self.entered = threading.Event()
+        self.entered_count = 0
+        self.slots = asyncio.Semaphore(max_size)
+
+    def seed(self, uid, note):
+        with self.lock:
+            self.rows.append(
+                self._row(
+                    (
+                        f"seed-{uid}",
+                        datetime.now(timezone.utc),
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        uid,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        0,
+                        None,
+                        0,
+                        None,
+                        f'["{note}"]',
+                        None,
+                        "{}",
+                    )
+                )
+            )
+
+    @staticmethod
+    def _row(args):
+        names = (
+            "trace_id",
+            "created_at",
+            "endpoint",
+            "method",
+            "client_ip",
+            "client_type",
+            "client_version",
+            "uid",
+            "debug_level",
+            "resolved_agent",
+            "resolved_gateway",
+            "resolved_session_key",
+            "resolve_source",
+            "openclaw_status",
+            "openclaw_latency_ms",
+            "response_status",
+            "total_latency_ms",
+            "error",
+            "notes",
+            "client_route",
+            "client_headers",
+        )
+        return dict(zip(names, args))
+
+    async def execute(self, query, *args):
+        assert "INSERT INTO routing_traces" in query
+        async with self.slots:
+            with self.lock:
+                self.entered_count += 1
+                self.entered.set()
+            deadline = asyncio.get_running_loop().time() + 30
+            while not self.release.is_set() and asyncio.get_running_loop().time() < deadline:
+                await asyncio.sleep(0.01)
+            assert self.release.is_set()
+            with self.lock:
+                row = self._row(args)
+                self.rows.append(row)
+                self.committed.append(dict(row))
+
+    async def fetch(self, _query, *params):
+        uid = params[1]
+        with self.lock:
+            return [dict(row) for row in self.rows if row["uid"] == uid]
+
+    def purge(self, uid):
+        with self.lock:
+            before = len(self.rows)
+            self.rows = [row for row in self.rows if row["uid"] != uid]
+            return before - len(self.rows)
+
+
+@pytest.fixture
+def trace_environment(monkeypatch):
+    previous_database = content_write_fence._firestore_db
+    firestore = _Firestore()
+    content_write_fence.configure_firestore_db(firestore)
+    monkeypatch.setattr(content_write_fence.firestore, "transactional", _transactional)
+    monkeypatch.setenv("ELLA_POSTGRES_AUTHORITY_ENABLED", "true")
+    monkeypatch.setenv("ELLA_CONTENT_WRITE_FENCE_DRAIN_SECONDS", "3")
+    yield firestore
+    content_write_fence.configure_firestore_db(previous_database)
+
+
+def _fixed_app(monkeypatch, routing_pool, identity, order):
+    async def get_pool():
+        return routing_pool
+
+    async def quarantine(uid):
+        assert uid == UID
+        order.append("quarantine")
+        return _state()
+
+    async def purge(uid):
+        assert uid == UID
+        order.append("purge")
+        return routing_pool.purge(uid)
+
+    async def finalize(uid):
+        assert uid == UID
+        order.append("finalize")
+        return True
+
+    async def assert_postgres_active(uid):
+        assert uid == identity["uid"]
+
+    monkeypatch.setattr(trace_router, "_get_pool", get_pool)
+    monkeypatch.setattr(content_write_fence, "_assert_postgres_owner_active", assert_postgres_active)
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "quarantine_account_for_deletion", quarantine)
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "purge_routing_traces", purge)
+    monkeypatch.setattr(account_deletion_service.account_deletion_db, "finalize_account_deletion", finalize)
+
+    delete_route, namespace = _load_production_delete_route()
+    namespace["delete_user_data"] = lambda uid: order.append(("firestore", uid))
+    namespace["auth"].delete_account = lambda uid: order.append(("firebase", uid))
+
+    app = FastAPI()
+    app.include_router(trace_router.router)
+    app.add_api_route("/v1/users/delete-account", delete_route, methods=["DELETE"])
+    app.dependency_overrides[auth_endpoints.get_current_user_uid] = lambda: identity["uid"]
+    app.add_middleware(content_write_fence.ContentWriteFenceMiddleware)
+    return app
+
+
+async def _start_asgi_request(app, method, path, payload=None):
+    body = json.dumps(payload).encode("utf-8") if payload is not None else b""
+    received = False
+    response = {"status": None, "body": bytearray()}
+    response_sent = asyncio.Event()
+
+    async def receive():
+        nonlocal received
+        if received:
+            await asyncio.sleep(3600)
+        received = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            response["status"] = message["status"]
+        elif message["type"] == "http.response.body":
+            response["body"].extend(message.get("body", b""))
+            if not message.get("more_body", False):
+                response_sent.set()
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+    }
+    application_task = asyncio.create_task(app(scope, receive, send))
+    await asyncio.wait_for(response_sent.wait(), timeout=3)
+    return response, application_task
+
+
+def _response_json(response):
+    return json.loads(bytes(response["body"]))
+
+
+def test_trace_probe_positive_control_reproduces_old_mounted_escape():
+    memory = []
+    persisted = []
+    persistence_entered = threading.Event()
+    release_persistence = threading.Event()
+    router = APIRouter(prefix="/v1/ella/debug")
+
+    async def persist(payload):
+        persistence_entered.set()
+        assert await asyncio.to_thread(release_persistence.wait, 3)
+        persisted.append(dict(payload))
+
+    @router.post("/client-trace")
+    async def ingest(payload: dict):
+        memory.append(dict(payload))
+        asyncio.get_running_loop().create_task(persist(payload))
+        return {"ok": True}
+
+    @router.get("/trace/{uid}")
+    async def read(uid: str):
+        return [row for row in memory if row.get("uid") == uid]
+
+    @router.delete("/account/{uid}")
+    async def delete(uid: str):
+        assert uid == UID
+        return {"status": "ok"}
+
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as client:
+        accepted = client.post("/v1/ella/debug/client-trace", json={"uid": UID, "notes": ["recoverable-note"]})
+        assert accepted.status_code == 200
+        assert persistence_entered.wait(2)
+        assert client.delete(f"/v1/ella/debug/account/{UID}").status_code == 200
+        assert client.get(f"/v1/ella/debug/trace/{UID}").json()[0]["notes"] == ["recoverable-note"]
+        release_persistence.set()
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline and len(persisted) < 1:
+            time.sleep(0.01)
+        assert persisted[0]["notes"] == ["recoverable-note"]
+        fresh = client.post("/v1/ella/debug/client-trace", json={"uid": UID, "notes": ["post-tombstone"]})
+        assert fresh.status_code == 200
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline and len(persisted) < 2:
+            time.sleep(0.01)
+        assert persisted[1]["notes"] == ["post-tombstone"]
+
+
+def test_mounted_trace_persistence_is_drained_purged_and_tombstoned(
+    monkeypatch,
+    trace_environment,
+):
+    routing_pool = _RoutingPool()
+    routing_pool.seed(RETAINED_UID, "retained-note")
+    identity = {"uid": UID}
+    order = []
+    app = _fixed_app(monkeypatch, routing_pool, identity, order)
+
+    async def scenario():
+        accepted, accepted_task = await _start_asgi_request(
+            app,
+            "POST",
+            "/v1/ella/debug/client-trace",
+            {
+                "uid": UID,
+                "clientType": "ios",
+                "latencyMs": 17,
+                "status": 200,
+                "notes": ["recoverable-sensitive-note"],
+                "headers": {"X-Ella-Secret": "recoverable-header"},
+                "sessionKey": "recoverable-session",
+                "error": "recoverable-error",
+            },
+        )
+        assert accepted["status"] == 200
+        await asyncio.wait_for(accepted_task, timeout=2)
+        assert routing_pool.entered.wait(2)
+        mismatch, mismatch_task = await _start_asgi_request(
+            app,
+            "POST",
+            "/v1/ella/debug/client-trace",
+            {"uid": RETAINED_UID},
+        )
+        assert mismatch["status"] == 403
+        await mismatch_task
+
+        deletion = asyncio.create_task(_start_asgi_request(app, "DELETE", "/v1/users/delete-account"))
+        await asyncio.sleep(0.15)
+        assert not deletion.done()
+        assert "purge" not in order
+
+        routing_pool.release.set()
+        deleted, deleted_task = await asyncio.wait_for(deletion, timeout=4)
+        assert deleted["status"] == 200
+        await deleted_task
+        assert order.index("quarantine") < order.index("purge")
+        assert order.index("purge") < order.index(("firestore", UID))
+        assert order.index(("firestore", UID)) < order.index("finalize")
+        assert order[-1] == ("firebase", UID)
+        committed = next(row for row in routing_pool.committed if row["uid"] == UID)
+        assert committed["notes"] == '["client-telemetry"]'
+        assert committed["client_headers"] == "{}"
+        assert committed["resolved_session_key"] is None
+        assert committed["error"] is None
+
+        deleted_read, deleted_read_task = await _start_asgi_request(
+            app,
+            "GET",
+            f"/v1/ella/debug/trace/{UID}",
+        )
+        await deleted_read_task
+        assert deleted_read["status"] == 200
+        assert _response_json(deleted_read)["source"] == "database"
+        assert _response_json(deleted_read)["traces"] == []
+        assert not hasattr(trace_router, "_traces")
+        assert all(row["uid"] != UID for row in routing_pool.rows)
+
+        fresh, fresh_task = await _start_asgi_request(
+            app,
+            "POST",
+            "/v1/ella/debug/client-trace",
+            {"uid": UID, "latencyMs": 1},
+        )
+        await fresh_task
+        assert fresh["status"] == 403
+        assert _response_json(fresh)["detail"]["code"] == "account_write_forbidden"
+
+        identity["uid"] = RETAINED_UID
+        retained_read, retained_read_task = await _start_asgi_request(
+            app,
+            "GET",
+            f"/v1/ella/debug/trace/{RETAINED_UID}",
+        )
+        await retained_read_task
+        assert retained_read["status"] == 200
+        assert _response_json(retained_read)["traces"][0]["notes"] == ["retained-note"]
+
+    asyncio.run(scenario())
+
+
+def test_trace_reads_require_exact_authenticated_subject(monkeypatch, trace_environment):
+    routing_pool = _RoutingPool(hold=False)
+
+    async def get_pool():
+        return routing_pool
+
+    monkeypatch.setattr(trace_router, "_get_pool", get_pool)
+    app = FastAPI()
+    app.include_router(trace_router.router)
+    app.add_middleware(content_write_fence.ContentWriteFenceMiddleware)
+
+    with TestClient(app) as client:
+        assert client.get(f"/v1/ella/debug/trace/{UID}").status_code == 401
+
+    app.dependency_overrides[auth_endpoints.get_current_user_uid] = lambda: UID
+    with TestClient(app) as client:
+        denied = client.get(f"/v1/ella/debug/trace/{RETAINED_UID}")
+        assert denied.status_code == 403
+        assert denied.json()["detail"]["code"] == "ownership_mismatch"
+
+
+def test_concurrent_trace_requests_release_request_lifetimes_before_bounded_pool_progress(
+    monkeypatch,
+    trace_environment,
+):
+    routing_pool = _RoutingPool(max_size=2)
+    identity = {"uid": UID}
+    app = _fixed_app(monkeypatch, routing_pool, identity, [])
+
+    async def scenario():
+        requests = await asyncio.gather(
+            *(
+                _start_asgi_request(
+                    app,
+                    "POST",
+                    "/v1/ella/debug/client-trace",
+                    {"uid": UID, "clientType": "ios", "latencyMs": index},
+                )
+                for index in range(6)
+            )
+        )
+        assert [response["status"] for response, _task in requests] == [200] * 6
+        await asyncio.gather(*(task for _response, task in requests))
+        assert routing_pool.entered.wait(2)
+        assert routing_pool.entered_count == 2
+        fence_key = content_write_fence._fence_reference(trace_environment, UID).key
+        state = trace_environment.documents[fence_key]
+        assert len(state["writers"]) == 6
+
+        routing_pool.release.set()
+        deadline = asyncio.get_running_loop().time() + 4
+        while asyncio.get_running_loop().time() < deadline:
+            with routing_pool.lock:
+                if len(routing_pool.rows) == 6:
+                    break
+            await asyncio.sleep(0.01)
+        assert len(routing_pool.rows) == 6
+        deadline = asyncio.get_running_loop().time() + 2
+        while asyncio.get_running_loop().time() < deadline:
+            state = trace_environment.documents.get(fence_key)
+            if state is None or not state["writers"]:
+                break
+            await asyncio.sleep(0.01)
+        assert state is None or state["writers"] == {}
+
+    asyncio.run(scenario())

--- a/backend/tests/unit/test_trace_deletion_finality.py
+++ b/backend/tests/unit/test_trace_deletion_finality.py
@@ -238,6 +238,11 @@ def _fixed_app(monkeypatch, routing_pool, identity, order):
         order.append("purge_memory_reinterpretation")
         return 0
 
+    async def purge_canonical_event_ledger(uid):
+        assert uid == UID
+        order.append("purge_canonical_event_ledger")
+        return 0
+
     async def finalize(uid):
         assert uid == UID
         order.append("finalize")
@@ -254,6 +259,11 @@ def _fixed_app(monkeypatch, routing_pool, identity, order):
         account_deletion_service.account_deletion_db,
         "purge_memory_reinterpretation_work",
         purge_memory_reinterpretation_work,
+    )
+    monkeypatch.setattr(
+        account_deletion_service.account_deletion_db,
+        "purge_canonical_event_ledger",
+        purge_canonical_event_ledger,
     )
     monkeypatch.setattr(account_deletion_service.account_deletion_db, "finalize_account_deletion", finalize)
 

--- a/backend/tests/unit/test_voice_canary.py
+++ b/backend/tests/unit/test_voice_canary.py
@@ -172,6 +172,28 @@ def test_entitlement_contract_defaults_are_canary_numbers():
     assert datetime.now(timezone.utc).tzinfo is not None
 
 
+def test_get_pool_uses_real_asyncpg_entrypoint(monkeypatch):
+    pool = object()
+    calls = []
+
+    async def create_pool(**kwargs):
+        calls.append(kwargs)
+        return pool
+
+    monkeypatch.setattr(voice_canary, "_pool", None)
+    monkeypatch.setattr(voice_canary.asyncpg, "create_pool", create_pool)
+    monkeypatch.setenv("ELLA_POSTGRES_DSN", "postgresql://voice-canary.test/authority")
+
+    assert asyncio.run(voice_canary.get_pool()) is pool
+    assert calls == [
+        {
+            "dsn": "postgresql://voice-canary.test/authority",
+            "min_size": 1,
+            "max_size": 10,
+        }
+    ]
+
+
 def test_operator_defaults_are_grok_only_and_have_no_fallback():
     assert voice_canary_admin.DEFAULT_PROVIDERS == ["grok-voice"]
     assert voice_canary_admin.DEFAULT_MODES == ["v4"]

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -10,7 +10,7 @@ from typing import Union, Tuple, List, Optional
 
 from fastapi import HTTPException
 
-from database import redis_db
+from database import content_write_fence, redis_db
 import database.memories as memories_db
 import database.conversations as conversations_db
 import database.notifications as notification_db
@@ -538,7 +538,11 @@ def _save_action_items(uid: str, conversation: Conversation):
         def _run_auto_sync():
             asyncio.run(auto_sync_action_items_batch(uid, created_items))
 
-        threading.Thread(target=_run_auto_sync, daemon=True).start()
+        content_write_fence.start_content_writer_thread(
+            uid,
+            _run_auto_sync,
+            name=f"conversation-action-sync-{conversation.id}",
+        )
 
 
 def _update_personas_async(uid: str):
@@ -650,21 +654,25 @@ def process_conversation(
         _trigger_apps(
             uid, conversation, is_reprocess=is_reprocess, app_id=app_id, language_code=language_code, people=people
         )
-        (
-            threading.Thread(
-                target=save_structured_vector,
-                args=(
-                    uid,
-                    conversation,
-                ),
-            ).start()
-            if not is_reprocess
-            else None
-        )
-        threading.Thread(target=_extract_memories, args=(uid, conversation)).start()
-        threading.Thread(target=_extract_trends, args=(uid, conversation)).start()
-        threading.Thread(target=_save_action_items, args=(uid, conversation)).start()
-        threading.Thread(target=_update_goal_progress, args=(uid, conversation)).start()
+        if not is_reprocess:
+            content_write_fence.start_content_writer_thread(
+                uid,
+                save_structured_vector,
+                args=(uid, conversation),
+                name=f"conversation-vector-{conversation.id}",
+            )
+        for name, target in (
+            ("memories", _extract_memories),
+            ("trends", _extract_trends),
+            ("action-items", _save_action_items),
+            ("goal-progress", _update_goal_progress),
+        ):
+            content_write_fence.start_content_writer_thread(
+                uid,
+                target,
+                args=(uid, conversation),
+                name=f"conversation-{name}-{conversation.id}",
+            )
 
     # Create audio files from chunks if private cloud sync was enabled
     if not is_reprocess and conversation.private_cloud_sync_enabled:
@@ -688,15 +696,19 @@ def process_conversation(
         folders_db.update_folder_conversation_count(uid, assigned_folder_id)
 
     if not is_reprocess:
-        threading.Thread(
-            target=conversation_created_webhook,
-            args=(
-                uid,
-                conversation,
-            ),
-        ).start()
+        content_write_fence.start_content_writer_thread(
+            uid,
+            conversation_created_webhook,
+            args=(uid, conversation),
+            name=f"conversation-webhook-{conversation.id}",
+        )
         # Update persona prompts with new conversation
-        threading.Thread(target=update_personas_async, args=(uid,)).start()
+        content_write_fence.start_content_writer_thread(
+            uid,
+            update_personas_async,
+            args=(uid,),
+            name=f"conversation-personas-{conversation.id}",
+        )
 
         # Disable important conversation for now
         # Send important conversation notification for long conversations (>30 minutes)
@@ -707,10 +719,12 @@ def process_conversation(
 
     # Ella post-process hook: notify n8n after conversation is fully saved
     if fire_postprocess_webhook:  # Fires for both initial processing and reprocessing
-        threading.Thread(
-            target=fire_postprocess_webhook,
+        content_write_fence.start_content_writer_thread(
+            uid,
+            fire_postprocess_webhook,
             args=(uid, conversation),
-        ).start()
+            name=f"conversation-postprocess-{conversation.id}",
+        )
 
     print('process_conversation completed conversation.id=', conversation.id)
     return conversation

--- a/backend/utils/ella/canonical_omi.py
+++ b/backend/utils/ella/canonical_omi.py
@@ -188,6 +188,9 @@ def write_omi_canonical_event(
     """Best-effort synchronous write to the local canonical ledger endpoint."""
     if not CANONICAL_OMI_WRITE_ENABLED:
         return {"ok": False, "skipped": True, "reason": "disabled"}
+    ledger_token = os.getenv("ELLA_EVENT_LEDGER_TOKEN", "").strip()
+    if not ledger_token:
+        raise RuntimeError("canonical_events_auth_not_configured")
 
     event = build_omi_canonical_event(
         uid,
@@ -200,7 +203,7 @@ def write_omi_canonical_event(
     response = requests.post(
         CANONICAL_EVENTS_URL,
         json={"events": [event]},
-        headers={"Content-Type": "application/json"},
+        headers={"Authorization": f"Bearer {ledger_token}", "Content-Type": "application/json"},
         timeout=timeout if timeout is not None else CANONICAL_OMI_TIMEOUT,
     )
     elapsed_ms = int((time.time() - started) * 1000)

--- a/backend/utils/imports/limitless.py
+++ b/backend/utils/imports/limitless.py
@@ -16,6 +16,7 @@ from zipfile import ZipFile
 
 import database.import_jobs as import_jobs_db
 import database.conversations as conversations_db
+from database import content_write_fence
 from models.conversation import (
     Conversation,
     ConversationSource,
@@ -200,6 +201,11 @@ def _create_overview_from_transcript(segments: List[TranscriptSegment], max_char
     return overview if overview else "Imported from Limitless"
 
 
+def _update_import_job(job_id: str, uid: str, updates: dict) -> None:
+    content_write_fence.assert_detached_content_writer_current(uid)
+    import_jobs_db.update_import_job(job_id, updates)
+
+
 def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code: str = 'en') -> None:
     """
     Background worker to process a Limitless ZIP export using LIGHT IMPORT mode.
@@ -220,8 +226,9 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
     """
     try:
         # Update status to processing
-        import_jobs_db.update_import_job(
+        _update_import_job(
             job_id,
+            uid,
             {
                 'status': ImportJobStatus.processing.value,
                 'started_at': datetime.now(timezone.utc).isoformat(),
@@ -247,7 +254,7 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                 print(f"[Limitless Import] First 5 lifelog files: {lifelog_files[:5]}")
 
             total_files = len(lifelog_files)
-            import_jobs_db.update_import_job(job_id, {'total_files': total_files})
+            _update_import_job(job_id, uid, {'total_files': total_files})
 
             if total_files == 0:
                 # Log more details about what we found
@@ -256,8 +263,9 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                 if md_files:
                     print(f"[Limitless Import] Sample .md files: {md_files[:10]}")
 
-                import_jobs_db.update_import_job(
+                _update_import_job(
                     job_id,
+                    uid,
                     {
                         'status': ImportJobStatus.failed.value,
                         'error': f'No lifelog files found in ZIP. Found {len(all_files)} total entries, {len(md_files)} .md files. Expected files in lifelogs/ folder.',
@@ -281,7 +289,7 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                     # Skip empty files
                     if not segments:
                         processed_files += 1
-                        import_jobs_db.update_import_job(job_id, {'processed_files': processed_files})
+                        _update_import_job(job_id, uid, {'processed_files': processed_files})
                         continue
 
                     # Calculate finished_at from last segment
@@ -329,6 +337,7 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                     )
 
                     # Save directly to database (skip all AI processing)
+                    content_write_fence.assert_detached_content_writer_current(uid)
                     conversations_db.upsert_conversation(uid, conversation.dict())
                     conversations_created += 1
 
@@ -341,8 +350,9 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
 
                 # Update progress every 10 files to reduce database writes
                 if processed_files % 10 == 0 or processed_files == total_files:
-                    import_jobs_db.update_import_job(
+                    _update_import_job(
                         job_id,
+                        uid,
                         {
                             'processed_files': processed_files,
                             'conversations_created': conversations_created,
@@ -361,8 +371,9 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                     # Partial success
                     error_msg = f"{len(errors)} files failed to process"
 
-            import_jobs_db.update_import_job(
+            _update_import_job(
                 job_id,
+                uid,
                 {
                     'status': final_status,
                     'completed_at': datetime.now(timezone.utc).isoformat(),
@@ -390,11 +401,14 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                     data={'type': 'import_failed', 'job_id': job_id},
                 )
 
+    except content_write_fence.ContentWriteFenceError as e:
+        print(f"Import job {job_id} stopped: {e.code}")
     except Exception as e:
         print(f"Import job {job_id} failed: {str(e)}")
         traceback.print_exc()
-        import_jobs_db.update_import_job(
+        _update_import_job(
             job_id,
+            uid,
             {
                 'status': ImportJobStatus.failed.value,
                 'error': str(e),

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -2,10 +2,12 @@ import json
 import os
 import time
 
-from fastapi import Header, HTTPException
+from fastapi import Depends, Header, HTTPException
 from fastapi import Request
 from firebase_admin import auth
 from firebase_admin.auth import InvalidIdTokenError, UserNotFoundError
+
+from database import voice_canary
 
 
 def get_user(uid: str):
@@ -46,8 +48,8 @@ def verify_token(token: str) -> str:
         raise InvalidIdTokenError(str(e))
 
 
-def get_current_user_uid(authorization: str = Header(None)):
-    """FastAPI dependency for HTTP endpoints with Authorization header."""
+def get_authenticated_user_uid(authorization: str = Header(None)) -> str:
+    """Verify the Firebase subject without consulting optional Ella storage."""
     if not authorization:
         raise HTTPException(status_code=401, detail="Authorization header not found")
     elif len(str(authorization).split(' ')) != 2:
@@ -61,6 +63,43 @@ def get_current_user_uid(authorization: str = Header(None)):
     except InvalidIdTokenError as e:
         print(f"Error verifying Firebase ID token: {e}", flush=True)
         raise HTTPException(status_code=401, detail="Invalid authorization token")
+
+
+def _ella_authority_persistence_enabled() -> bool:
+    configured = os.getenv("ELLA_POSTGRES_AUTHORITY_ENABLED")
+    if configured is not None:
+        return configured.strip().lower() != "false"
+    return os.getenv("ELLA_ENABLED", "true").strip().lower() != "false"
+
+
+async def assert_authenticated_user_writable(uid: str) -> str:
+    """Reject retained Firebase subjects once PostgreSQL is tombstoned."""
+    if not _ella_authority_persistence_enabled():
+        return uid
+    try:
+        pool = await voice_canary.get_pool()
+        status = await pool.fetchval("SELECT status FROM users WHERE omi_uid = $1", uid)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "account_authority_unavailable", "retryable": True},
+        ) from exc
+    if str(status or "") in {"DELETION_PENDING", "DELETED"}:
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "account_write_forbidden", "retryable": False},
+        )
+    return uid
+
+
+def get_current_user_uid(authorization: str = Header(None)) -> str:
+    """Backward-compatible raw Firebase authentication dependency."""
+    return get_authenticated_user_uid(authorization)
+
+
+async def get_writable_user_uid(uid: str = Depends(get_current_user_uid)) -> str:
+    """Fence normal authenticated content access against deletion tombstones."""
+    return await assert_authenticated_user_writable(uid)
 
 
 def get_current_user_uid_from_ws_message(message: dict) -> str:

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -1,13 +1,17 @@
 import json
 import os
 import time
+from typing import AsyncIterator
 
 from fastapi import Depends, Header, HTTPException
 from fastapi import Request
 from firebase_admin import auth
 from firebase_admin.auth import InvalidIdTokenError, UserNotFoundError
 
-from database import voice_canary
+from database import content_write_fence
+
+# Retained import surface used by focused Guardian collection and test overrides.
+voice_canary = content_write_fence.voice_canary
 
 
 def get_user(uid: str):
@@ -65,31 +69,37 @@ def get_authenticated_user_uid(authorization: str = Header(None)) -> str:
         raise HTTPException(status_code=401, detail="Invalid authorization token")
 
 
-def _ella_authority_persistence_enabled() -> bool:
-    configured = os.getenv("ELLA_POSTGRES_AUTHORITY_ENABLED")
-    if configured is not None:
-        return configured.strip().lower() != "false"
-    return os.getenv("ELLA_ENABLED", "true").strip().lower() != "false"
-
-
 async def assert_authenticated_user_writable(uid: str) -> str:
-    """Reject retained Firebase subjects once PostgreSQL is tombstoned."""
-    if not _ella_authority_persistence_enabled():
-        return uid
+    """Perform a compatibility preflight; committers must hold the dependency."""
     try:
-        pool = await voice_canary.get_pool()
-        status = await pool.fetchval("SELECT status FROM users WHERE omi_uid = $1", uid)
-    except Exception as exc:
+        async with content_write_fence.content_write_fence(uid):
+            return uid
+    except content_write_fence.ContentWriteFenceError as exc:
+        if exc.code == "account_write_forbidden":
+            raise HTTPException(
+                status_code=403,
+                detail={"code": "account_write_forbidden", "retryable": False},
+            ) from exc
         raise HTTPException(
             status_code=503,
-            detail={"code": "account_authority_unavailable", "retryable": True},
+            detail={"code": exc.code, "retryable": True},
         ) from exc
-    if str(status or "") in {"DELETION_PENDING", "DELETED"}:
+
+
+async def admit_authenticated_content_writer(uid: str) -> str:
+    """Admit a manually authenticated writer for the full ASGI request."""
+    try:
+        return await content_write_fence.admit_request_content_writer(uid)
+    except content_write_fence.ContentWriteFenceError as exc:
+        if exc.code == "account_write_forbidden":
+            raise HTTPException(
+                status_code=403,
+                detail={"code": "account_write_forbidden", "retryable": False},
+            ) from exc
         raise HTTPException(
-            status_code=403,
-            detail={"code": "account_write_forbidden", "retryable": False},
-        )
-    return uid
+            status_code=503,
+            detail={"code": exc.code, "retryable": True},
+        ) from exc
 
 
 def get_current_user_uid(authorization: str = Header(None)) -> str:
@@ -97,9 +107,21 @@ def get_current_user_uid(authorization: str = Header(None)) -> str:
     return get_authenticated_user_uid(authorization)
 
 
-async def get_writable_user_uid(uid: str = Depends(get_current_user_uid)) -> str:
-    """Fence normal authenticated content access against deletion tombstones."""
-    return await assert_authenticated_user_writable(uid)
+async def get_writable_user_uid(uid: str = Depends(get_current_user_uid)) -> AsyncIterator[str]:
+    """Hold the distributed deletion fence through the complete ASGI request."""
+    try:
+        async with content_write_fence.request_content_write_fence(uid):
+            yield uid
+    except content_write_fence.ContentWriteFenceError as exc:
+        if exc.code == "account_write_forbidden":
+            raise HTTPException(
+                status_code=403,
+                detail={"code": "account_write_forbidden", "retryable": False},
+            ) from exc
+        raise HTTPException(
+            status_code=503,
+            detail={"code": exc.code, "retryable": True},
+        ) from exc
 
 
 def get_current_user_uid_from_ws_message(message: dict) -> str:

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -5,7 +5,7 @@ import time
 from fastapi import Header, HTTPException
 from fastapi import Request
 from firebase_admin import auth
-from firebase_admin.auth import InvalidIdTokenError
+from firebase_admin.auth import InvalidIdTokenError, UserNotFoundError
 
 
 def get_user(uid: str):
@@ -157,5 +157,16 @@ def timeit(func):
 
 
 def delete_account(uid: str):
-    auth.delete_user(uid)
-    return {"message": "User deleted"}
+    try:
+        auth.delete_user(uid)
+        return {"status": "deleted"}
+    except UserNotFoundError:
+        return {"status": "already_deleted"}
+    except Exception:
+        # A lost delete acknowledgement is outcome-ambiguous. Confirm absence
+        # before treating it as success; otherwise preserve the retryable error.
+        try:
+            auth.get_user(uid)
+        except UserNotFoundError:
+            return {"status": "already_deleted"}
+        raise

--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -5,7 +5,6 @@ import os
 import wave
 from typing import List
 from concurrent.futures import ThreadPoolExecutor, as_completed
-import threading
 
 from google.cloud import storage
 from google.oauth2 import service_account
@@ -15,7 +14,7 @@ from google.cloud.exceptions import NotFound
 
 from database.redis_db import cache_signed_url, get_cached_signed_url
 from utils import encryption
-from database import users as users_db
+from database import content_write_fence, users as users_db
 
 if os.environ.get('SERVICE_ACCOUNT_JSON'):
     service_account_info = json.loads(os.environ["SERVICE_ACCOUNT_JSON"])
@@ -592,8 +591,11 @@ def get_or_create_merged_audio(
         except Exception as e:
             print(f"Error uploading audio cache: {e}")
 
-    cache_thread = threading.Thread(target=_upload_to_cache, daemon=True)
-    cache_thread.start()
+    content_write_fence.start_content_writer_thread(
+        uid,
+        _upload_to_cache,
+        name=f"merged-audio-cache-{conversation_id}-{audio_file_id}",
+    )
 
     return wav_data, False
 
@@ -687,8 +689,11 @@ def precache_conversation_audio(
         with ThreadPoolExecutor(max_workers=4) as executor:
             list(executor.map(_cache_single, audio_files))
 
-    thread = threading.Thread(target=_precache_all, daemon=True)
-    thread.start()
+    content_write_fence.start_content_writer_thread(
+        uid,
+        _precache_all,
+        name=f"conversation-audio-precache-{conversation_id}",
+    )
 
 
 # **********************************


### PR DESCRIPTION
## Summary
- replace the failing Firestore deletion loop with recursive, idempotent tree deletion
- atomically quarantine PostgreSQL consent/entitlement/target/binding/OMI identity authority and release ordinary pilot capacity under the shared owner advisory lock
- make the authenticated route safely resumable, including Firebase lost-ack handling and typed `202 deletion_pending` receipts for unsupported external cleanup
- close the authority-writer inventory and add exact-route, failure, retry, partial-provision, and disposable-PostgreSQL regressions

## Root cause
The deployed route reached `CollectionReference.parent.path` on the first empty Firestore subcollection. Firestore batches were committed independently, Firebase deletion followed afterward, and PostgreSQL invitation/runtime authority was never touched. A request could therefore return HTTP 500 after partial Firestore deletion while leaving a redeemed ordinary invitation and consumed pilot slot.

## Behavior
- PostgreSQL authority quarantine and capacity release are one transaction.
- Firestore cleanup is recursive and retry-safe.
- Firebase Auth is deleted last; missing users and lost delete acknowledgements converge idempotently.
- The current self-hosted `:8210` authority has no authenticated deprovision API or trusted completion receipt. Provisioned Hermes/Honcho/registry artifacts are disabled and reported as operator-required via a typed `202`, never falsely reported deleted.

## Validation
- 148 invitation/runtime tests, zero skips
- 170 repository backend tests
- disposable PostgreSQL rollback, partial-provision, repeat, and external-absence regressions
- Black 24.8, compile, YAML, `git diff --check`
- Gitleaks exact range: no leaks

Base: `2dbe91e4baeae7f190730af2061b2ccc5f16eb99`
Head: `95ad42785`

No deployment, migration, invitation issuance, flags, vendor, registry, profile, or retained Plato mutation.