### PR TITLE
Secure reviewed Ella routes and pause account deletion

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -13,6 +13,7 @@ on:
       - "backend/database/runtime_targets.py"
       - "backend/database/voice_canary.py"
       - "backend/routers/transcribe.py"
+      - "backend/routers/users.py"
       - "backend/ella/__init__.py"
       - "backend/ella/routers/auto_provision.py"
       - "backend/ella/routers/callbacks.py"
@@ -64,6 +65,7 @@ on:
       - "backend/scripts/hermes_cloud_shadow.py"
       - "backend/scripts/voice_canary_admin.py"
       - "backend/utils/ella/postprocess.py"
+      - "backend/utils/ella/exact_firebase_auth.py"
       - "backend/utils/ella/scanner_keyterms.py"
       - "backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md"
       - "backend/ella/docs/HERMES_CLOUD_RUNTIME_TARGETS_RUNBOOK.md"
@@ -91,6 +93,7 @@ on:
       - "backend/tests/unit/test_ella_callbacks_summary_update.py"
       - "backend/tests/unit/test_ella_conversation_corrections.py"
       - "backend/tests/unit/test_ella_guardian_delivery.py"
+      - "backend/tests/unit/test_ella_reviewed_route_integration.py"
       - "backend/tests/unit/test_ella_listen_runtime_gate.py"
       - "backend/tests/unit/test_ella_observer.py"
       - "backend/tests/unit/test_ella_plato_mcp.py"
@@ -114,6 +117,7 @@ on:
       - "backend/database/runtime_targets.py"
       - "backend/database/voice_canary.py"
       - "backend/routers/transcribe.py"
+      - "backend/routers/users.py"
       - "backend/ella/__init__.py"
       - "backend/ella/routers/auto_provision.py"
       - "backend/ella/routers/callbacks.py"
@@ -165,6 +169,7 @@ on:
       - "backend/scripts/hermes_cloud_shadow.py"
       - "backend/scripts/voice_canary_admin.py"
       - "backend/utils/ella/postprocess.py"
+      - "backend/utils/ella/exact_firebase_auth.py"
       - "backend/utils/ella/scanner_keyterms.py"
       - "backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md"
       - "backend/ella/docs/HERMES_CLOUD_RUNTIME_TARGETS_RUNBOOK.md"
@@ -192,6 +197,7 @@ on:
       - "backend/tests/unit/test_ella_callbacks_summary_update.py"
       - "backend/tests/unit/test_ella_conversation_corrections.py"
       - "backend/tests/unit/test_ella_guardian_delivery.py"
+      - "backend/tests/unit/test_ella_reviewed_route_integration.py"
       - "backend/tests/unit/test_ella_listen_runtime_gate.py"
       - "backend/tests/unit/test_ella_observer.py"
       - "backend/tests/unit/test_ella_plato_mcp.py"
@@ -268,6 +274,7 @@ jobs:
           database/runtime_targets.py
           database/voice_canary.py
           routers/transcribe.py
+          routers/users.py
           ella/routers/auto_provision.py
           ella/routers/callbacks.py
           ella/routers/ai_consent.py
@@ -277,6 +284,7 @@ jobs:
           ella/routers/onboarding.py
           ella/routers/observer.py
           ella/routers/plato_mcp.py
+          ella/routers/resolve.py
           ella/services/ai_consent.py
           ella/services/consent_authority.py
           ella/services/hermes_broker_client.py
@@ -308,7 +316,9 @@ jobs:
           scripts/hermes_cloud_shadow.py
           scripts/voice_canary_admin.py
           utils/ella/postprocess.py
+          utils/ella/exact_firebase_auth.py
           utils/ella/scanner_keyterms.py
+          tests/unit/test_ella_reviewed_route_integration.py
 
       - name: Validate formatting and OpenAPI contract
         run: >-
@@ -317,10 +327,11 @@ jobs:
           database/ella_provisioning.py database/invitations.py
           database/managed_cloud_consent.py
           database/runtime_targets.py database/voice_canary.py
+          routers/users.py
           ella/routers/auto_provision.py ella/routers/callbacks.py
           ella/routers/ai_consent.py ella/routers/chat.py
           ella/routers/guardian.py ella/routers/invites.py
-          ella/routers/onboarding.py ella/routers/plato_mcp.py
+          ella/routers/onboarding.py ella/routers/plato_mcp.py ella/routers/resolve.py
           ella/services/hermes_cloud_policy.py
           ella/services/hermes_broker_client.py
           ella/services/hermes_broker_prototype.py
@@ -333,7 +344,8 @@ jobs:
           ella/services/provisioning.py ella/services/runtime_resolver.py
           ella/services/summary_recovery.py
           ella/utils/auto_provision.py ella/utils/identity_sync.py
-          ella/utils/provision_authority.py utils/ella/scanner_keyterms.py
+          ella/utils/provision_authority.py utils/ella/exact_firebase_auth.py
+          utils/ella/scanner_keyterms.py
           scripts/voice_canary_admin.py
           scripts/hermes_product_fit_canary.py
           tests/unit/test_ella_callbacks_summary_update.py
@@ -342,6 +354,7 @@ jobs:
           tests/unit/test_ella_ai_consent.py
           tests/unit/test_ella_conversation_corrections.py
           tests/unit/test_ella_guardian_delivery.py
+          tests/unit/test_ella_reviewed_route_integration.py
           tests/unit/test_ella_listen_runtime_gate.py
           tests/unit/test_ella_observer.py tests/unit/test_invitation_redemption.py
           tests/unit/test_ella_plato_mcp.py
@@ -516,7 +529,7 @@ jobs:
               tests/unit/test_authority_writer_guard.py \
               tests/postgres/test_authority_advisory_lock_postgres.py |
               grep -c '::'
-          )" -eq 65
+          )" -eq 67
           pytest \
             tests/unit/test_authority_advisory_lock.py \
             tests/unit/test_authority_writer_guard.py \
@@ -526,8 +539,19 @@ jobs:
           pytest tests/unit/test_ella_callbacks_summary_update.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_conversation_corrections.py | grep -c '::')" -eq 64
           pytest tests/unit/test_ella_conversation_corrections.py -v
-          test "$(pytest --collect-only -q tests/unit/test_ella_guardian_delivery.py | grep -c '::')" -eq 18
+          test "$(pytest --collect-only -q tests/unit/test_ella_guardian_delivery.py | grep -c '::')" -eq 27
           pytest tests/unit/test_ella_guardian_delivery.py -v
+          reviewed_route_ids="$(pytest --collect-only -q tests/unit/test_ella_reviewed_route_integration.py | sed '/^$/d')"
+          required_reviewed_route_ids=(
+            "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_requires_exact_owner_before_lookup_and_returns_no_private_routing"
+            "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_missing_workspace_fails_closed_without_global_fallback"
+            "tests/unit/test_ella_reviewed_route_integration.py::test_account_deletion_declines_before_firestore_or_firebase_removal"
+          )
+          for required_id in "${required_reviewed_route_ids[@]}"; do
+            grep -Fqx "$required_id" <<<"$reviewed_route_ids"
+          done
+          test "$(grep -c '::' <<<"$reviewed_route_ids")" -eq 3
+          pytest tests/unit/test_ella_reviewed_route_integration.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_listen_runtime_gate.py | grep -c '::')" -eq 7
           pytest tests/unit/test_ella_listen_runtime_gate.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_observer.py | grep -c '::')" -eq 18

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -591,7 +591,7 @@ jobs:
             "tests/unit/test_ella_escalations_router_auth.py::test_load_context_allows_identities_phone_override"
             "tests/unit/test_ella_escalations_router_auth.py::test_policy_markdown_internal_key_reaches_same_auth_and_context"
             "tests/unit/test_ella_escalations_router_auth.py::test_evaluate_internal_key_reaches_load_context_for_explicit_uid"
-            "tests/unit/test_ella_escalations_router_auth.py::test_production_default_raw_empty_legacy_key_denies_all_authority_paths_before_context"
+            "tests/unit/test_ella_escalations_router_auth.py::test_production_default_empty_and_absent_credentials_deny_all_authority_paths_before_context"
           )
           for required_id in "${required_escalation_auth_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$escalation_auth_ids"

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -580,10 +580,22 @@ jobs:
           pytest tests/unit/test_ella_conversation_corrections.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_guardian_delivery.py | grep -c '::')" -eq 44
           pytest tests/unit/test_ella_guardian_delivery.py -v
-          test "$(pytest --collect-only -q tests/unit/test_ella_escalations_router_auth.py | grep -c '::')" -eq 8
-          pytest \
-            tests/unit/test_ella_escalations_router_auth.py::test_load_context_uses_canonical_phone_number_for_user_imessage \
-            -v
+          escalation_auth_ids="$(pytest --collect-only -q tests/unit/test_ella_escalations_router_auth.py | sed '/^$/d')"
+          required_escalation_auth_ids=(
+            "tests/unit/test_ella_escalations_router_auth.py::test_policy_view_internal_key_reaches_load_context_for_explicit_uid"
+            "tests/unit/test_ella_escalations_router_auth.py::test_policy_view_internal_key_requires_uid_before_load_context"
+            "tests/unit/test_ella_escalations_router_auth.py::test_policy_view_uid_uses_authenticated_uid_when_uid_omitted"
+            "tests/unit/test_ella_escalations_router_auth.py::test_policy_view_uid_rejects_cross_user_read"
+            "tests/unit/test_ella_escalations_router_auth.py::test_policy_view_denies_absent_empty_malformed_and_wrong_credentials_before_context"
+            "tests/unit/test_ella_escalations_router_auth.py::test_load_context_uses_canonical_phone_number_for_user_imessage"
+            "tests/unit/test_ella_escalations_router_auth.py::test_load_context_allows_identities_phone_override"
+            "tests/unit/test_ella_escalations_router_auth.py::test_policy_markdown_internal_key_reaches_same_auth_and_context"
+          )
+          for required_id in "${required_escalation_auth_ids[@]}"; do
+            grep -Fqx "$required_id" <<<"$escalation_auth_ids"
+          done
+          test "$(grep -c '::' <<<"$escalation_auth_ids")" -eq 8
+          pytest tests/unit/test_ella_escalations_router_auth.py -v
           reviewed_route_ids="$(pytest --collect-only -q tests/unit/test_ella_reviewed_route_integration.py | sed '/^$/d')"
           required_reviewed_route_ids=(
             "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_requires_exact_owner_before_lookup_and_returns_no_private_routing"

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -590,11 +590,13 @@ jobs:
             "tests/unit/test_ella_escalations_router_auth.py::test_load_context_uses_canonical_phone_number_for_user_imessage"
             "tests/unit/test_ella_escalations_router_auth.py::test_load_context_allows_identities_phone_override"
             "tests/unit/test_ella_escalations_router_auth.py::test_policy_markdown_internal_key_reaches_same_auth_and_context"
+            "tests/unit/test_ella_escalations_router_auth.py::test_evaluate_internal_key_reaches_load_context_for_explicit_uid"
+            "tests/unit/test_ella_escalations_router_auth.py::test_production_default_raw_empty_legacy_key_denies_all_authority_paths_before_context"
           )
           for required_id in "${required_escalation_auth_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$escalation_auth_ids"
           done
-          test "$(grep -c '::' <<<"$escalation_auth_ids")" -eq 8
+          test "$(grep -c '::' <<<"$escalation_auth_ids")" -eq 10
           pytest tests/unit/test_ella_escalations_router_auth.py -v
           reviewed_route_ids="$(pytest --collect-only -q tests/unit/test_ella_reviewed_route_integration.py | sed '/^$/d')"
           required_reviewed_route_ids=(

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -3,6 +3,13 @@ name: Hermes Cloud Runtime Tests
 on:
   pull_request:
     paths:
+      - "app/ios/Runner.xcodeproj/project.pbxproj"
+      - "app/ios/Runner/GuardianMode/GuardianAuthenticatedTransport.swift"
+      - "app/ios/Runner/GuardianMode/GuardianModeManager.swift"
+      - "app/ios/Runner/GuardianMode/GuardianModePollingService.swift"
+      - "app/ios/Tests/GuardianAuthenticatedTransportTests.swift"
+      - "app/lib/ella/services/ella_chat_service.dart"
+      - "app/test/ella/services/ella_chat_history_test.dart"
       - "backend/contracts/authority_advisory_lock_v1.json"
       - "backend/contracts/README.md"
       - "backend/database/authority_advisory_lock.py"
@@ -20,6 +27,7 @@ on:
       - "backend/ella/routers/canonical_events.py"
       - "backend/ella/routers/ai_consent.py"
       - "backend/ella/routers/chat.py"
+      - "backend/ella/routers/escalations.py"
       - "backend/ella/routers/guardian.py"
       - "backend/ella/routers/hermes_cloud_enrichment.py"
       - "backend/ella/routers/onboarding.py"
@@ -66,6 +74,7 @@ on:
       - "backend/scripts/voice_canary_admin.py"
       - "backend/utils/ella/postprocess.py"
       - "backend/utils/ella/exact_firebase_auth.py"
+      - "backend/utils/ella/scanner.py"
       - "backend/utils/ella/scanner_keyterms.py"
       - "backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md"
       - "backend/ella/docs/HERMES_CLOUD_RUNTIME_TARGETS_RUNBOOK.md"
@@ -103,10 +112,18 @@ on:
       - "backend/tests/unit/test_ella_onboarding_contract.py"
       - "backend/tests/unit/test_memory_reinterpretation_outbox.py"
       - "backend/tests/unit/test_scanner_keyterms.py"
+      - "backend/tests/unit/test_ella_scanner_batching.py"
       - ".github/workflows/hermes-cloud-runtime-tests.yml"
   push:
     branches: [main]
     paths:
+      - "app/ios/Runner.xcodeproj/project.pbxproj"
+      - "app/ios/Runner/GuardianMode/GuardianAuthenticatedTransport.swift"
+      - "app/ios/Runner/GuardianMode/GuardianModeManager.swift"
+      - "app/ios/Runner/GuardianMode/GuardianModePollingService.swift"
+      - "app/ios/Tests/GuardianAuthenticatedTransportTests.swift"
+      - "app/lib/ella/services/ella_chat_service.dart"
+      - "app/test/ella/services/ella_chat_history_test.dart"
       - "backend/contracts/authority_advisory_lock_v1.json"
       - "backend/contracts/README.md"
       - "backend/database/authority_advisory_lock.py"
@@ -124,6 +141,7 @@ on:
       - "backend/ella/routers/canonical_events.py"
       - "backend/ella/routers/ai_consent.py"
       - "backend/ella/routers/chat.py"
+      - "backend/ella/routers/escalations.py"
       - "backend/ella/routers/guardian.py"
       - "backend/ella/routers/hermes_cloud_enrichment.py"
       - "backend/ella/routers/onboarding.py"
@@ -170,6 +188,7 @@ on:
       - "backend/scripts/voice_canary_admin.py"
       - "backend/utils/ella/postprocess.py"
       - "backend/utils/ella/exact_firebase_auth.py"
+      - "backend/utils/ella/scanner.py"
       - "backend/utils/ella/scanner_keyterms.py"
       - "backend/ella/docs/HERMES_BROKER_PROTOTYPE_RUNBOOK.md"
       - "backend/ella/docs/HERMES_CLOUD_RUNTIME_TARGETS_RUNBOOK.md"
@@ -207,6 +226,7 @@ on:
       - "backend/tests/unit/test_ella_onboarding_contract.py"
       - "backend/tests/unit/test_memory_reinterpretation_outbox.py"
       - "backend/tests/unit/test_scanner_keyterms.py"
+      - "backend/tests/unit/test_ella_scanner_batching.py"
       - ".github/workflows/hermes-cloud-runtime-tests.yml"
 
 jobs:
@@ -278,6 +298,8 @@ jobs:
           ella/routers/auto_provision.py
           ella/routers/callbacks.py
           ella/routers/ai_consent.py
+          ella/routers/chat.py
+          ella/routers/escalations.py
           ella/routers/hermes_cloud_enrichment.py
           ella/routers/guardian.py
           ella/routers/invites.py
@@ -317,6 +339,7 @@ jobs:
           scripts/voice_canary_admin.py
           utils/ella/postprocess.py
           utils/ella/exact_firebase_auth.py
+          utils/ella/scanner.py
           utils/ella/scanner_keyterms.py
           tests/unit/test_ella_reviewed_route_integration.py
 
@@ -329,7 +352,7 @@ jobs:
           database/runtime_targets.py database/voice_canary.py
           routers/users.py
           ella/routers/auto_provision.py ella/routers/callbacks.py
-          ella/routers/ai_consent.py ella/routers/chat.py
+          ella/routers/ai_consent.py ella/routers/chat.py ella/routers/escalations.py
           ella/routers/guardian.py ella/routers/invites.py
           ella/routers/onboarding.py ella/routers/plato_mcp.py ella/routers/resolve.py
           ella/services/hermes_cloud_policy.py
@@ -345,7 +368,7 @@ jobs:
           ella/services/summary_recovery.py
           ella/utils/auto_provision.py ella/utils/identity_sync.py
           ella/utils/provision_authority.py utils/ella/exact_firebase_auth.py
-          utils/ella/scanner_keyterms.py
+          utils/ella/scanner.py utils/ella/scanner_keyterms.py
           scripts/voice_canary_admin.py
           scripts/hermes_product_fit_canary.py
           tests/unit/test_ella_callbacks_summary_update.py
@@ -355,6 +378,8 @@ jobs:
           tests/unit/test_ella_conversation_corrections.py
           tests/unit/test_ella_guardian_delivery.py
           tests/unit/test_ella_reviewed_route_integration.py
+          tests/unit/test_ella_runtime_route_isolation.py
+          tests/unit/test_ella_scanner_batching.py
           tests/unit/test_ella_listen_runtime_gate.py
           tests/unit/test_ella_observer.py tests/unit/test_invitation_redemption.py
           tests/unit/test_ella_plato_mcp.py
@@ -372,6 +397,7 @@ jobs:
           tests/unit/test_hermes_cloud_runtime.py
           tests/unit/test_hermes_cloud_staged_attestation.py
           tests/unit/test_memory_reinterpretation_outbox.py
+          tests/unit/test_ella_scanner_batching.py
           tests/unit/test_scanner_keyterms.py
           tests/postgres/test_hermes_cloud_pool_postgres.py
           tests/postgres/test_authority_advisory_lock_postgres.py
@@ -449,7 +475,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 490
+          test "$collected" -eq 491
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \
@@ -529,7 +555,7 @@ jobs:
               tests/unit/test_authority_writer_guard.py \
               tests/postgres/test_authority_advisory_lock_postgres.py |
               grep -c '::'
-          )" -eq 67
+          )" -eq 68
           pytest \
             tests/unit/test_authority_advisory_lock.py \
             tests/unit/test_authority_writer_guard.py \
@@ -539,18 +565,19 @@ jobs:
           pytest tests/unit/test_ella_callbacks_summary_update.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_conversation_corrections.py | grep -c '::')" -eq 64
           pytest tests/unit/test_ella_conversation_corrections.py -v
-          test "$(pytest --collect-only -q tests/unit/test_ella_guardian_delivery.py | grep -c '::')" -eq 27
+          test "$(pytest --collect-only -q tests/unit/test_ella_guardian_delivery.py | grep -c '::')" -eq 44
           pytest tests/unit/test_ella_guardian_delivery.py -v
           reviewed_route_ids="$(pytest --collect-only -q tests/unit/test_ella_reviewed_route_integration.py | sed '/^$/d')"
           required_reviewed_route_ids=(
             "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_requires_exact_owner_before_lookup_and_returns_no_private_routing"
-            "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_missing_workspace_fails_closed_without_global_fallback"
+            "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_retained_user_without_isolated_binding_fails_closed_without_global_fallback"
+            "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_reports_ready_invitation_self_hosted_binding_without_legacy_workspace"
             "tests/unit/test_ella_reviewed_route_integration.py::test_account_deletion_declines_before_firestore_or_firebase_removal"
           )
           for required_id in "${required_reviewed_route_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$reviewed_route_ids"
           done
-          test "$(grep -c '::' <<<"$reviewed_route_ids")" -eq 3
+          test "$(grep -c '::' <<<"$reviewed_route_ids")" -eq 4
           pytest tests/unit/test_ella_reviewed_route_integration.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_listen_runtime_gate.py | grep -c '::')" -eq 7
           pytest tests/unit/test_ella_listen_runtime_gate.py -v
@@ -562,3 +589,35 @@ jobs:
           pytest tests/unit/test_memory_reinterpretation_outbox.py -v
           test "$(pytest --collect-only -q tests/unit/test_scanner_keyterms.py | grep -c '::')" -eq 10
           pytest tests/unit/test_scanner_keyterms.py -v
+          test "$(pytest --collect-only -q tests/unit/test_ella_scanner_batching.py | grep -c '::')" -eq 8
+          pytest tests/unit/test_ella_scanner_batching.py -v
+
+  guardian-app-contracts:
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.41.1"
+          channel: stable
+          cache: true
+
+      - name: Run standard app tests and authenticated history contract
+        working-directory: app
+        run: |
+          ./test.sh
+          flutter test --no-pub test/ella/services/ella_chat_history_test.dart
+
+      - name: Compile and run Guardian authenticated transport contract
+        working-directory: app
+        run: |
+          swiftc \
+            -warnings-as-errors \
+            -D GUARDIAN_AUTH_TRANSPORT_TESTS \
+            ios/Runner/GuardianMode/GuardianAuthenticatedTransport.swift \
+            ios/Tests/GuardianAuthenticatedTransportTests.swift \
+            -o "$RUNNER_TEMP/guardian-authenticated-transport-tests"
+          "$RUNNER_TEMP/guardian-authenticated-transport-tests"

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -10,6 +10,7 @@ on:
       - "app/ios/Tests/GuardianAuthenticatedTransportTests.swift"
       - "app/lib/ella/services/ella_chat_service.dart"
       - "app/test/ella/services/ella_chat_history_test.dart"
+      - "backend/tests/fixtures/ella_chat_history_canonical_response_v1.json"
       - "backend/contracts/authority_advisory_lock_v1.json"
       - "backend/contracts/README.md"
       - "backend/database/authority_advisory_lock.py"
@@ -102,6 +103,8 @@ on:
       - "backend/tests/unit/test_ella_callbacks_summary_update.py"
       - "backend/tests/unit/test_ella_conversation_corrections.py"
       - "backend/tests/unit/test_ella_guardian_delivery.py"
+      - "backend/tests/unit/test_ella_canonical_context.py"
+      - "backend/tests/unit/test_ella_escalations_router_auth.py"
       - "backend/tests/unit/test_ella_reviewed_route_integration.py"
       - "backend/tests/unit/test_ella_listen_runtime_gate.py"
       - "backend/tests/unit/test_ella_observer.py"
@@ -124,6 +127,7 @@ on:
       - "app/ios/Tests/GuardianAuthenticatedTransportTests.swift"
       - "app/lib/ella/services/ella_chat_service.dart"
       - "app/test/ella/services/ella_chat_history_test.dart"
+      - "backend/tests/fixtures/ella_chat_history_canonical_response_v1.json"
       - "backend/contracts/authority_advisory_lock_v1.json"
       - "backend/contracts/README.md"
       - "backend/database/authority_advisory_lock.py"
@@ -216,6 +220,8 @@ on:
       - "backend/tests/unit/test_ella_callbacks_summary_update.py"
       - "backend/tests/unit/test_ella_conversation_corrections.py"
       - "backend/tests/unit/test_ella_guardian_delivery.py"
+      - "backend/tests/unit/test_ella_canonical_context.py"
+      - "backend/tests/unit/test_ella_escalations_router_auth.py"
       - "backend/tests/unit/test_ella_reviewed_route_integration.py"
       - "backend/tests/unit/test_ella_listen_runtime_gate.py"
       - "backend/tests/unit/test_ella_observer.py"
@@ -376,6 +382,8 @@ jobs:
           tests/unit/test_authority_writer_guard.py
           tests/unit/test_ella_ai_consent.py
           tests/unit/test_ella_conversation_corrections.py
+          tests/unit/test_ella_canonical_context.py
+          tests/unit/test_ella_escalations_router_auth.py
           tests/unit/test_ella_guardian_delivery.py
           tests/unit/test_ella_reviewed_route_integration.py
           tests/unit/test_ella_runtime_route_isolation.py
@@ -449,6 +457,7 @@ jobs:
             "tests/unit/test_hermes_product_fit_canary.py::test_fixture_cleanup_recovers_from_partial_cleanup_idempotently"
             "tests/unit/test_hermes_product_fit_canary.py::test_fixture_show_and_cleanup_accept_expected_post_enrichment_state_only"
             "tests/unit/test_ella_runtime_route_isolation.py::test_cloud_chat_failure_still_emits_one_terminal_marker"
+            "tests/unit/test_ella_runtime_route_isolation.py::test_legacy_history_unexpected_failure_logs_fixed_content_free_classification"
             "tests/unit/test_ella_runtime_route_isolation.py::test_self_hosted_voice_session_uses_exact_invitation_authority_without_legacy_registry"
             "tests/unit/test_ella_runtime_route_isolation.py::test_self_hosted_voice_session_activation_race_drift_fails_before_token_or_provider"
             "tests/unit/test_ella_runtime_route_isolation.py::test_self_hosted_voice_session_authority_denials_precede_provider_setup[invitation_runtime_fallback_enabled]"
@@ -475,7 +484,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 491
+          test "$collected" -eq 492
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \
@@ -557,7 +566,7 @@ jobs:
               sed '/^$/d'
           )"
           grep -Fqx \
-            "tests/postgres/test_authority_advisory_lock_postgres.py::test_guardian_alert_history_returns_only_exact_case_sensitive_firebase_subject" \
+            "tests/postgres/test_authority_advisory_lock_postgres.py::test_mounted_guardian_alert_history_isolates_case_distinct_firebase_subjects" \
             <<<"$authority_lock_ids"
           test "$(grep -c '::' <<<"$authority_lock_ids")" -eq 69
           pytest \
@@ -571,18 +580,24 @@ jobs:
           pytest tests/unit/test_ella_conversation_corrections.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_guardian_delivery.py | grep -c '::')" -eq 44
           pytest tests/unit/test_ella_guardian_delivery.py -v
+          test "$(pytest --collect-only -q tests/unit/test_ella_escalations_router_auth.py | grep -c '::')" -eq 8
+          pytest \
+            tests/unit/test_ella_escalations_router_auth.py::test_load_context_uses_canonical_phone_number_for_user_imessage \
+            -v
           reviewed_route_ids="$(pytest --collect-only -q tests/unit/test_ella_reviewed_route_integration.py | sed '/^$/d')"
           required_reviewed_route_ids=(
             "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_requires_exact_owner_before_lookup_and_returns_no_private_routing"
             "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_retained_user_without_isolated_binding_fails_closed_without_global_fallback"
             "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_reports_ready_invitation_self_hosted_binding_without_legacy_workspace"
-            "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_unexpected_runtime_failure_logs_only_fixed_content_free_code"
+            "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_unexpected_runtime_failure_logs_fixed_content_free_classification"
+            "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_expected_provisioning_failure_logs_fixed_content_free_classification"
+            "tests/unit/test_ella_reviewed_route_integration.py::test_legacy_history_proxy_unexpected_failure_logs_no_runtime_material"
             "tests/unit/test_ella_reviewed_route_integration.py::test_account_deletion_declines_before_firestore_or_firebase_removal"
           )
           for required_id in "${required_reviewed_route_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$reviewed_route_ids"
           done
-          test "$(grep -c '::' <<<"$reviewed_route_ids")" -eq 5
+          test "$(grep -c '::' <<<"$reviewed_route_ids")" -eq 7
           pytest tests/unit/test_ella_reviewed_route_integration.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_listen_runtime_gate.py | grep -c '::')" -eq 7
           pytest tests/unit/test_ella_listen_runtime_gate.py -v

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -549,13 +549,17 @@ jobs:
             tests/unit/test_ella_provision_authority_split.py \
             tests/unit/test_ella_plato_mcp.py \
             -v
-          test "$(
+          authority_lock_ids="$(
             pytest --collect-only -q \
               tests/unit/test_authority_advisory_lock.py \
               tests/unit/test_authority_writer_guard.py \
               tests/postgres/test_authority_advisory_lock_postgres.py |
-              grep -c '::'
-          )" -eq 68
+              sed '/^$/d'
+          )"
+          grep -Fqx \
+            "tests/postgres/test_authority_advisory_lock_postgres.py::test_guardian_alert_history_returns_only_exact_case_sensitive_firebase_subject" \
+            <<<"$authority_lock_ids"
+          test "$(grep -c '::' <<<"$authority_lock_ids")" -eq 69
           pytest \
             tests/unit/test_authority_advisory_lock.py \
             tests/unit/test_authority_writer_guard.py \
@@ -572,12 +576,13 @@ jobs:
             "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_requires_exact_owner_before_lookup_and_returns_no_private_routing"
             "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_retained_user_without_isolated_binding_fails_closed_without_global_fallback"
             "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_reports_ready_invitation_self_hosted_binding_without_legacy_workspace"
+            "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_unexpected_runtime_failure_logs_only_fixed_content_free_code"
             "tests/unit/test_ella_reviewed_route_integration.py::test_account_deletion_declines_before_firestore_or_firebase_removal"
           )
           for required_id in "${required_reviewed_route_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$reviewed_route_ids"
           done
-          test "$(grep -c '::' <<<"$reviewed_route_ids")" -eq 4
+          test "$(grep -c '::' <<<"$reviewed_route_ids")" -eq 5
           pytest tests/unit/test_ella_reviewed_route_integration.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_listen_runtime_gate.py | grep -c '::')" -eq 7
           pytest tests/unit/test_ella_listen_runtime_gate.py -v

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		5934842C2F4C228400888317 /* silence_100ms.wav in Resources */ = {isa = PBXBuildFile; fileRef = 5934842B2F4C228400888317 /* silence_100ms.wav */; };
 		GDPOLL1111111111111111 /* GuardianModePollingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = GDPOLL0000000000000001 /* GuardianModePollingService.swift */; };
 		GDDEBUF111111111111111 /* DebugEventBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = GDDEBUF000000000000001 /* DebugEventBuffer.swift */; };
+		GDAUTH1111111111111111 /* GuardianAuthenticatedTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = GDAUTH0000000000000001 /* GuardianAuthenticatedTransport.swift */; };
+		GDAUTH1111111111111112 /* GuardianAuthenticatedTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = GDAUTH0000000000000001 /* GuardianAuthenticatedTransport.swift */; };
 		GDMP301111111111111111 /* test_audio_0.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = GDMP300000000000000000 /* test_audio_0.mp3 */; };
 		GDMP301111111111111112 /* test_audio_1.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = GDMP300000000000000001 /* test_audio_1.mp3 */; };
 		GDMP301111111111111113 /* test_audio_2.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = GDMP300000000000000002 /* test_audio_2.mp3 */; };
@@ -115,6 +117,7 @@
 		8F5D6E82A28E418DA2C0BBD4 /* GuardianModeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuardianModeManager.swift; sourceTree = "<group>"; };
 		GDPOLL0000000000000001 /* GuardianModePollingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuardianModePollingService.swift; sourceTree = "<group>"; };
 		GDDEBUF000000000000001 /* DebugEventBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugEventBuffer.swift; sourceTree = "<group>"; };
+		GDAUTH0000000000000001 /* GuardianAuthenticatedTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuardianAuthenticatedTransport.swift; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -290,6 +293,7 @@
 				8F5D6E82A28E418DA2C0BBD4 /* GuardianModeManager.swift */,
 				GDPOLL0000000000000001 /* GuardianModePollingService.swift */,
 				GDDEBUF000000000000001 /* DebugEventBuffer.swift */,
+				GDAUTH0000000000000001 /* GuardianAuthenticatedTransport.swift */,
 				5934842B2F4C228400888317 /* silence_100ms.wav */,
 				GDMP300000000000000000 /* test_audio_0.mp3 */,
 				GDMP300000000000000001 /* test_audio_1.mp3 */,
@@ -553,6 +557,7 @@
 				5934841E2F4C0CF000888317 /* GuardianModeManager.swift in Sources */,
 				GDPOLL1111111111111111 /* GuardianModePollingService.swift in Sources */,
 				GDDEBUF111111111111111 /* DebugEventBuffer.swift in Sources */,
+				GDAUTH1111111111111111 /* GuardianAuthenticatedTransport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -575,6 +580,7 @@
 				A6120CC9725B450B9E342698 /* GuardianModeManager.swift in Sources */,
 				GDPOLL1111111111111111 /* GuardianModePollingService.swift in Sources */,
 				GDDEBUF111111111111111 /* DebugEventBuffer.swift in Sources */,
+				GDAUTH1111111111111112 /* GuardianAuthenticatedTransport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/app/ios/Runner/GuardianMode/GuardianAuthenticatedTransport.swift
+++ b/app/ios/Runner/GuardianMode/GuardianAuthenticatedTransport.swift
@@ -1,0 +1,139 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+#if canImport(FirebaseAuth) && !GUARDIAN_AUTH_TRANSPORT_TESTS
+import FirebaseAuth
+#endif
+
+struct GuardianBearerCredential: Equatable {
+    let uid: String
+    let token: String
+}
+
+enum GuardianAuthenticationError: Error {
+    case unavailable
+    case ownerChanged
+}
+
+/// Reads the current Firebase subject and token as one credential. The subject
+/// is checked again after the async token fetch so an account switch cannot
+/// release a token under the previous owner.
+final class GuardianFirebaseBearerProvider {
+    typealias Provider = (_ forcingRefresh: Bool) async throws -> GuardianBearerCredential
+
+    private let provider: Provider
+
+    init(provider: @escaping Provider) {
+        self.provider = provider
+    }
+
+    func credential(forcingRefresh: Bool) async throws -> GuardianBearerCredential {
+        let credential = try await provider(forcingRefresh)
+        guard !credential.uid.isEmpty, !credential.token.isEmpty else {
+            throw GuardianAuthenticationError.unavailable
+        }
+        return credential
+    }
+
+#if canImport(FirebaseAuth) && !GUARDIAN_AUTH_TRANSPORT_TESTS
+    static let shared = GuardianFirebaseBearerProvider { forcingRefresh in
+        guard let user = Auth.auth().currentUser else {
+            throw GuardianAuthenticationError.unavailable
+        }
+        let expectedUID = user.uid
+        let token = try await user.getIDToken(forcingRefresh: forcingRefresh)
+        guard Auth.auth().currentUser?.uid == expectedUID else {
+            throw GuardianAuthenticationError.ownerChanged
+        }
+        return GuardianBearerCredential(uid: expectedUID, token: token)
+    }
+#else
+    static let shared = GuardianFirebaseBearerProvider { _ in
+        throw GuardianAuthenticationError.unavailable
+    }
+#endif
+}
+
+/// Firebase-authorized native transport matching the Flutter networking
+/// contract: attach the current bearer, then force-refresh and retry once on
+/// an HTTP 401. A refreshed credential must retain the exact Firebase owner.
+final class GuardianAuthenticatedTransport {
+    typealias TokenProvider = (_ forcingRefresh: Bool) async throws -> GuardianBearerCredential
+    typealias Transport = (URLRequest) async throws -> (Data, URLResponse)
+
+    private let tokenProvider: TokenProvider
+    private let transport: Transport
+
+    private static let session: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 10.0
+        configuration.timeoutIntervalForResource = 10.0
+        configuration.waitsForConnectivity = true
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        return URLSession(configuration: configuration)
+    }()
+
+    init(
+        tokenProvider: @escaping TokenProvider,
+        transport: @escaping Transport
+    ) {
+        self.tokenProvider = tokenProvider
+        self.transport = transport
+    }
+
+    static let shared = GuardianAuthenticatedTransport(
+        tokenProvider: GuardianFirebaseBearerProvider.shared.credential,
+        transport: { request in
+            try await session.data(for: request)
+        }
+    )
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        let initial = try await tokenProvider(false)
+        let firstResult = try await transport(authorize(request, token: initial.token))
+        guard (firstResult.1 as? HTTPURLResponse)?.statusCode == 401 else {
+            return firstResult
+        }
+
+        let refreshed = try await tokenProvider(true)
+        guard refreshed.uid == initial.uid else {
+            throw GuardianAuthenticationError.ownerChanged
+        }
+        return try await transport(authorize(request, token: refreshed.token))
+    }
+
+    private func authorize(_ request: URLRequest, token: String) -> URLRequest {
+        var authorized = request
+        authorized.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        return authorized
+    }
+}
+
+enum GuardianNativeRequestFactory {
+    static func pollRequest(backendURL: String) -> URLRequest? {
+        guard let url = URL(string: "\(backendURL)/v1/ella/guardian/next-audio") else {
+            return nil
+        }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10.0
+        return request
+    }
+
+    static func playbackRequest(backendURL: String, body: [String: Any]) -> URLRequest? {
+        guard let url = URL(string: "\(backendURL)/v1/ella/guardian/playback-event") else {
+            return nil
+        }
+        var subjectFreeBody = body
+        subjectFreeBody.removeValue(forKey: "uid")
+        guard let data = try? JSONSerialization.data(withJSONObject: subjectFreeBody) else {
+            return nil
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 3.0
+        request.httpBody = data
+        return request
+    }
+}

--- a/app/ios/Runner/GuardianMode/GuardianModeManager.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModeManager.swift
@@ -250,18 +250,7 @@ class GuardianModeManager: NSObject {
         let portName = port.portName
         let deviceUID = port.uid
 
-        let uid = UserDefaults.standard.string(forKey: "flutter.uid")
-                   ?? UserDefaults.standard.string(forKey: "uid")
-                   ?? "unknown"
-        guard uid != "unknown" else { return }
-
         let backendURL = GuardianModePollingService.shared.backendURL
-        guard let url = URL(string: "\(backendURL)/v1/ella/guardian/playback-event") else { return }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 3.0
 
         var eventMetadata = metadata ?? [:]
         if let triggerType = triggerType {
@@ -269,7 +258,6 @@ class GuardianModeManager: NSObject {
         }
 
         var body: [String: Any] = [
-            "uid": uid,
             "event_type": eventType,
             "port_type": portType,
             "port_name": portName,
@@ -285,11 +273,11 @@ class GuardianModeManager: NSObject {
         if !eventMetadata.isEmpty {
             body["metadata"] = eventMetadata
         }
-        guard let data = try? JSONSerialization.data(withJSONObject: body) else { return }
-        request.httpBody = data
-
-        URLSession.shared.dataTask(with: request) { _, _, _ in }.resume()
-        NSLog("PLAYBACK_EVENT type=\(eventType) trace=\(traceId ?? "none") item=\(queueItemId ?? "none") port=\(portType) device=\(portName.isEmpty ? "unknown" : portName) uid=\(uid)")
+        guard let request = GuardianNativeRequestFactory.playbackRequest(backendURL: backendURL, body: body) else { return }
+        Task {
+            _ = try? await GuardianAuthenticatedTransport.shared.data(for: request)
+        }
+        NSLog("PLAYBACK_EVENT type=\(eventType) trace=\(traceId ?? "none") item=\(queueItemId ?? "none") port=\(portType) device=\(portName.isEmpty ? "unknown" : portName)")
     }
 
     // MARK: - Audio Injection with Pre-download + Retry

--- a/app/ios/Runner/GuardianMode/GuardianModePollingService.swift
+++ b/app/ios/Runner/GuardianMode/GuardianModePollingService.swift
@@ -11,13 +11,6 @@ class GuardianModePollingService {
 
     private var pollTimer: DispatchSourceTimer?
 
-    private let session: URLSession = {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 10.0
-        config.timeoutIntervalForResource = 10.0
-        return URLSession(configuration: config)
-    }()
-
     var pollInterval: TimeInterval = 3.0
     var backendURL: String = "https://api.ella-ai-care.com"
 
@@ -109,17 +102,13 @@ class GuardianModePollingService {
     }
 
     func pollForNewAudio() async throws -> PollResponse? {
-        // Flutter shared_preferences stores with "flutter." prefix on iOS
-        let uid = UserDefaults.standard.string(forKey: "flutter.uid") ?? UserDefaults.standard.string(forKey: "uid") ?? "unknown"
-        let endpoint = "\(backendURL)/v1/ella/guardian/next-audio?uid=\(uid)"
-
-        guard let url = URL(string: endpoint) else {
+        guard let request = GuardianNativeRequestFactory.pollRequest(backendURL: backendURL) else {
             throw NSError(domain: "GuardianPolling", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "Invalid backend URL"
             ])
         }
 
-        let (data, response) = try await session.data(from: url)
+        let (data, response) = try await GuardianAuthenticatedTransport.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw NSError(domain: "GuardianPolling", code: 2, userInfo: [

--- a/app/ios/Tests/GuardianAuthenticatedTransportTests.swift
+++ b/app/ios/Tests/GuardianAuthenticatedTransportTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+private enum TestFailure: Error {
+    case failed(String)
+}
+
+private func expect(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+    if !condition() {
+        throw TestFailure.failed(message)
+    }
+}
+
+private func response(status: Int, url: URL) throws -> HTTPURLResponse {
+    guard let value = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil) else {
+        throw TestFailure.failed("could not create HTTP response")
+    }
+    return value
+}
+
+private func testPollAddsBearerAndRetriesWithForcedRefresh() async throws {
+    var refreshCalls: [Bool] = []
+    var requests: [URLRequest] = []
+    let transport = GuardianAuthenticatedTransport(
+        tokenProvider: { forcingRefresh in
+            refreshCalls.append(forcingRefresh)
+            return GuardianBearerCredential(
+                uid: "firebase-owner",
+                token: forcingRefresh ? "fresh-token" : "stale-token"
+            )
+        },
+        transport: { request in
+            requests.append(request)
+            let status = requests.count == 1 ? 401 : 200
+            return (Data(#"{"url":null}"#.utf8), try response(status: status, url: request.url!))
+        }
+    )
+    let request = try require(GuardianNativeRequestFactory.pollRequest(backendURL: "https://api.example.test"))
+
+    _ = try await transport.data(for: request)
+
+    try expect(refreshCalls == [false, true], "401 did not force exactly one token refresh")
+    try expect(requests.count == 2, "401 did not retry exactly once")
+    try expect(requests[0].value(forHTTPHeaderField: "Authorization") == "Bearer stale-token", "initial bearer missing")
+    try expect(requests[1].value(forHTTPHeaderField: "Authorization") == "Bearer fresh-token", "refreshed bearer missing")
+    try expect(requests[0].url?.query == nil, "poll request trusted a caller-selected UID")
+}
+
+private func testPlaybackBodyCannotCarryCallerSelectedUID() async throws {
+    var recordedRequest: URLRequest?
+    let transport = GuardianAuthenticatedTransport(
+        tokenProvider: { _ in GuardianBearerCredential(uid: "firebase-owner", token: "firebase-token") },
+        transport: { request in
+            recordedRequest = request
+            return (Data(), try response(status: 200, url: request.url!))
+        }
+    )
+    let request = try require(
+        GuardianNativeRequestFactory.playbackRequest(
+            backendURL: "https://api.example.test",
+            body: ["uid": "caller-selected", "event_type": "started", "port_type": "Speaker"]
+        )
+    )
+
+    _ = try await transport.data(for: request)
+
+    let sent = try require(recordedRequest)
+    let body = try JSONSerialization.jsonObject(with: sent.httpBody ?? Data()) as? [String: Any]
+    try expect(body?["uid"] == nil, "playback request retained a caller-selected UID")
+    try expect(sent.value(forHTTPHeaderField: "Authorization") == "Bearer firebase-token", "playback bearer missing")
+}
+
+private func testRefreshOwnerDriftStopsBeforeRetry() async throws {
+    var requestCount = 0
+    let transport = GuardianAuthenticatedTransport(
+        tokenProvider: { forcingRefresh in
+            GuardianBearerCredential(uid: forcingRefresh ? "owner-b" : "owner-a", token: "token")
+        },
+        transport: { request in
+            requestCount += 1
+            return (Data(), try response(status: 401, url: request.url!))
+        }
+    )
+    let request = try require(GuardianNativeRequestFactory.pollRequest(backendURL: "https://api.example.test"))
+
+    do {
+        _ = try await transport.data(for: request)
+        throw TestFailure.failed("owner drift unexpectedly retried")
+    } catch GuardianAuthenticationError.ownerChanged {
+        try expect(requestCount == 1, "owner drift started a cross-account retry")
+    }
+}
+
+private func require<T>(_ value: T?, _ message: String = "required value missing") throws -> T {
+    guard let value else {
+        throw TestFailure.failed(message)
+    }
+    return value
+}
+
+@main
+private struct GuardianAuthenticatedTransportTestRunner {
+    static func main() async throws {
+        try await testPollAddsBearerAndRetriesWithForcedRefresh()
+        try await testPlaybackBodyCannotCarryCallerSelectedUID()
+        try await testRefreshOwnerDriftStopsBeforeRetry()
+        print("Guardian authenticated native transport tests passed: 3")
+    }
+}

--- a/app/lib/ella/services/ella_chat_service.dart
+++ b/app/lib/ella/services/ella_chat_service.dart
@@ -74,30 +74,14 @@ Future<List<ServerMessage>> fetchEllaChatHistory({
 
     final result = <ServerMessage>[];
     for (final m in rawMessages) {
-      final role = m['role'] as String? ?? '';
-      final content = m['content'] as String? ?? '';
-      final ts = m['timestamp'] as String?;
-      final id = m['id'] as String? ?? const Uuid().v4();
+      final message = Map<String, dynamic>.from(m as Map);
+      final content = message['text'] as String? ?? '';
       if (content.isEmpty) continue;
       if (content.startsWith('[SYSTEM:')) {
         continue; // Filter scanner notifications from chat UI
       }
-
-      result.add(
-        ServerMessage(
-          id,
-          ts != null ? DateTime.parse(ts).toLocal() : DateTime.now(),
-          content,
-          role == 'user' ? MessageSender.human : MessageSender.ai,
-          MessageType.text,
-          null,
-          false,
-          [],
-          [],
-          [],
-          askForNps: false,
-        ),
-      );
+      final parsed = ServerMessage.fromJson(message)..askForNps = false;
+      result.add(parsed);
     }
 
     // API returns newest first; reverse for chronological UI order

--- a/app/lib/ella/services/ella_chat_service.dart
+++ b/app/lib/ella/services/ella_chat_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:http/http.dart' as http;
 import 'package:uuid/uuid.dart';
 
 import 'package:omi/backend/http/api/messages.dart';
@@ -11,11 +12,6 @@ import 'package:omi/ella/demo/demo_fixtures.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
-
-/// Feature flag — direct gateway chat bypasses backend canonical writeback.
-/// Keep disabled so iOS chat routes through /v1/ella/chat/stream, hydrates from
-/// the shared canonical timeline, and writes ios_chat turns to /v1/ella/events.
-const bool _useDirectChat = false;
 
 /// Build Ella-specific debug headers for routing observability (Issue #216).
 /// Backend trace.py captures these to correlate client requests with server routing decisions.
@@ -30,179 +26,39 @@ Map<String, String> _ellaDebugHeaders({required String routeSource}) {
   };
 }
 
-/// Cached resolve result with expiry.
-class _ResolvedEndpoint {
-  final String agentId;
-  final String sessionKey;
-  final String gatewayUrl;
-  final String token;
-  final String historyUrl;
-  final DateTime expiresAt;
+typedef EllaApiCall = Future<http.Response?> Function({
+  required String url,
+  required Map<String, String> headers,
+  required String body,
+  required String method,
+  Duration? timeout,
+  int? retries,
+});
 
-  _ResolvedEndpoint({
-    required this.agentId,
-    required this.sessionKey,
-    required this.gatewayUrl,
-    required this.token,
-    this.historyUrl = '',
-    required this.expiresAt,
-  });
+typedef EllaDebugHeadersBuilder = Map<String, String> Function({required String routeSource});
+typedef EllaApiBaseUrlProvider = String? Function();
 
-  bool get isExpired => DateTime.now().isAfter(expiresAt);
+String? _ellaApiBaseUrl() => Env.apiBaseUrl;
 
-  Map<String, dynamic> toJson() => {
-        'agentId': agentId,
-        'sessionKey': sessionKey,
-        'gatewayUrl': gatewayUrl,
-        'token': token,
-        'historyUrl': historyUrl,
-        'expiresAt': expiresAt.toIso8601String(),
-      };
-
-  factory _ResolvedEndpoint.fromJson(Map<String, dynamic> json) => _ResolvedEndpoint(
-        agentId: json['agentId'] ?? '',
-        sessionKey: json['sessionKey'] ?? '',
-        gatewayUrl: json['gatewayUrl'] ?? '',
-        token: json['token'] ?? '',
-        historyUrl: json['historyUrl'] ?? '',
-        expiresAt: DateTime.tryParse(json['expiresAt'] ?? '') ?? DateTime(2000),
-      );
-}
-
-/// In-memory cache (fast path).
-_ResolvedEndpoint? _cachedEndpoint;
-
-/// Resolve the user's active Ella endpoint. Returns null on any failure.
-Future<_ResolvedEndpoint?> _resolveEndpoint() async {
-  final uid = SharedPreferencesUtil().uid;
-  if (uid.isEmpty) return null;
-
-  // 1. Check in-memory cache
-  if (_cachedEndpoint != null && !_cachedEndpoint!.isExpired) {
-    return _cachedEndpoint;
-  }
-
-  // 2. Check SharedPreferences cache
-  final cached = SharedPreferencesUtil().getString('ellaResolvedEndpoint');
-  if (cached.isNotEmpty) {
-    try {
-      final endpoint = _ResolvedEndpoint.fromJson(jsonDecode(cached));
-      if (!endpoint.isExpired) {
-        _cachedEndpoint = endpoint;
-        return endpoint;
-      }
-    } catch (_) {
-      // Corrupted cache, proceed to network call
-    }
-  }
-
-  // 3. Call resolve endpoint
-  try {
-    final response = await makeApiCall(
-      url: '${Env.apiBaseUrl}v1/ella/resolve?uid=$uid',
-      headers: _ellaDebugHeaders(routeSource: 'resolve'),
-      method: 'GET',
-      body: '',
-      timeout: const Duration(seconds: 5),
-    );
-
-    if (response == null || response.statusCode != 200) {
-      Logger.debug('[EllaChat] Resolve failed: ${response?.statusCode}');
-      return null;
-    }
-
-    // Log trace ID for routing observability (Issue #216)
-    final traceId = response.headers['x-ella-trace-id'];
-    if (traceId != null) {
-      Logger.debug('[EllaChat] Resolve trace: $traceId');
-    }
-
-    final data = jsonDecode(response.body) as Map<String, dynamic>;
-    final routing = data['routing'] as Map<String, dynamic>? ?? data;
-    final endpoint = _ResolvedEndpoint(
-      agentId: routing['agentId'] ?? '',
-      sessionKey: routing['sessionKey'] ?? '',
-      gatewayUrl: routing['gatewayUrl'] ?? '',
-      token: routing['token'] ?? '',
-      historyUrl: routing['historyUrl'] ?? '',
-      expiresAt: DateTime.now().add(const Duration(hours: 1)),
-    );
-
-    // Validate — must have gatewayUrl and token at minimum
-    if (endpoint.gatewayUrl.isEmpty || endpoint.token.isEmpty) {
-      Logger.debug('[EllaChat] Resolve returned incomplete data');
-      return null;
-    }
-
-    // Cache it
-    _cachedEndpoint = endpoint;
-    SharedPreferencesUtil().saveString(
-      'ellaResolvedEndpoint',
-      jsonEncode(endpoint.toJson()),
-    );
-
-    return endpoint;
-  } catch (e) {
-    Logger.debug('[EllaChat] Resolve error: $e');
-    return null;
-  }
-}
-
-/// Invalidate the resolve cache (call on gateway auth failures).
-void _invalidateResolveCache() {
-  _cachedEndpoint = null;
-  SharedPreferencesUtil().remove('ellaResolvedEndpoint');
-}
-
-/// Parse one line of OpenAI SSE into a ServerMessageChunk.
-/// Returns null for non-content lines (comments, empty, malformed).
-ServerMessageChunk? _parseOpenAiSseChunk(String line, String messageId) {
-  if (line.startsWith(':')) return null;
-  if (!line.startsWith('data: ')) return null;
-
-  final payload = line.substring(6).trim();
-  if (payload == '[DONE]') return null;
-
-  try {
-    final json = jsonDecode(payload) as Map<String, dynamic>;
-    final choices = json['choices'] as List<dynamic>?;
-    if (choices == null || choices.isEmpty) return null;
-
-    final delta = choices[0]['delta'] as Map<String, dynamic>?;
-    if (delta == null) return null;
-
-    final content = delta['content'] as String?;
-    if (content == null || content.isEmpty) return null;
-
-    return ServerMessageChunk(messageId, content, MessageChunkType.data);
-  } catch (e) {
-    Logger.debug('[EllaChat] Failed to parse OpenAI SSE chunk: $e');
-    return null;
-  }
-}
-
-/// Fetch chat history from the VPS proxy endpoint.
+/// Fetch chat history from the authenticated first-party backend endpoint.
 /// Returns messages in chronological order (oldest first), or empty list on failure.
-Future<List<ServerMessage>> fetchEllaChatHistory({int limit = 50}) async {
+Future<List<ServerMessage>> fetchEllaChatHistory({
+  int limit = 50,
+  EllaApiCall apiCall = makeApiCall,
+  EllaDebugHeadersBuilder debugHeadersBuilder = _ellaDebugHeaders,
+  EllaApiBaseUrlProvider apiBaseUrlProvider = _ellaApiBaseUrl,
+}) async {
   if (SharedPreferencesUtil().demoMode) {
     return DemoFixtures.chatMessages();
   }
 
-  final endpoint = await _resolveEndpoint();
-  if (endpoint == null || endpoint.historyUrl.isEmpty) {
-    Logger.debug(
-      '[EllaChat] Cannot fetch history: no resolved endpoint or historyUrl',
-    );
-    return [];
-  }
-
   try {
-    final uid = SharedPreferencesUtil().uid;
-    final url =
-        '${Env.apiBaseUrl}${endpoint.historyUrl.replaceFirst(RegExp(r'^/'), '')}?uid=${Uri.encodeComponent(uid)}&limit=$limit';
-    final response = await makeApiCall(
+    final url = Uri.parse(
+      '${apiBaseUrlProvider()}v1/ella/chat/history',
+    ).replace(queryParameters: {'limit': '$limit'}).toString();
+    final response = await apiCall(
       url: url,
-      headers: _ellaDebugHeaders(routeSource: 'chat-history'),
+      headers: debugHeadersBuilder(routeSource: 'chat-history'),
       method: 'GET',
       body: '',
       timeout: const Duration(seconds: 10),
@@ -265,103 +121,10 @@ Stream<ServerMessageChunk> sendEllaChatStream(String text) async* {
     return;
   }
 
-  // Feature flag — delegate to existing proxy path if disabled
-  if (!_useDirectChat) {
-    yield* sendEllaMessageStream(
-      text,
-      headers: _ellaDebugHeaders(routeSource: 'proxy-canonical'),
-      clientMessageId: const Uuid().v4(),
-      clientSentAt: DateTime.now().toUtc(),
-    );
-    return;
-  }
-
-  // Attempt to resolve the user's agent endpoint when direct mode is enabled.
-  final endpoint = await _resolveEndpoint();
-  if (endpoint == null) {
-    Logger.debug('[EllaChat] Resolve unavailable, using proxy fallback');
-    yield* sendEllaMessageStream(
-      text,
-      headers: _ellaDebugHeaders(routeSource: 'proxy-resolve-fail'),
-      clientMessageId: const Uuid().v4(),
-      clientSentAt: DateTime.now().toUtc(),
-    );
-    return;
-  }
-
-  // Legacy direct gateway path. Production keeps this disabled so canonical
-  // writeback remains centralized in the backend.
-  const messageId = '1000';
-  final accumulatedText = StringBuffer();
-
-  try {
-    await for (var line in makeStreamingApiCall(
-      url: '${endpoint.gatewayUrl}/v1/chat/completions',
-      headers: {
-        'Authorization': 'Bearer ${endpoint.token}',
-        'x-openclaw-scopes': 'operator.write',
-        if (endpoint.sessionKey.isNotEmpty) 'x-openclaw-session-key': endpoint.sessionKey,
-        ..._ellaDebugHeaders(routeSource: 'pattern-c'),
-      },
-      body: jsonEncode({
-        'model': 'openclaw:${endpoint.agentId}',
-        'messages': [
-          {'role': 'user', 'content': text},
-        ],
-        'stream': true,
-      }),
-    )) {
-      if (line.trim().isEmpty || line.startsWith(':')) continue;
-
-      // Check for stream terminator
-      if (line.trim() == 'data: [DONE]') break;
-
-      final chunk = _parseOpenAiSseChunk(line, messageId);
-      if (chunk != null) {
-        accumulatedText.write(chunk.text);
-        yield chunk;
-      }
-    }
-  } catch (e) {
-    Logger.error('[EllaChat] Direct stream error: $e');
-
-    // No text accumulated — invalidate cache and retry via proxy
-    if (accumulatedText.isEmpty) {
-      _invalidateResolveCache();
-      yield* sendEllaMessageStream(
-        text,
-        headers: _ellaDebugHeaders(routeSource: 'proxy-gateway-error'),
-        clientMessageId: const Uuid().v4(),
-        clientSentAt: DateTime.now().toUtc(),
-      );
-      return;
-    }
-    // Partial text accumulated — fall through to synthesize done chunk below
-  }
-
-  // Synthesize the done chunk from accumulated text
-  final fullText = accumulatedText.toString();
-  if (fullText.isNotEmpty) {
-    final serverMessage = ServerMessage(
-      const Uuid().v4(),
-      DateTime.now(),
-      fullText,
-      MessageSender.ai,
-      MessageType.text,
-      null,
-      false,
-      [],
-      [],
-      [],
-      askForNps: false,
-    );
-    yield ServerMessageChunk(
-      messageId,
-      jsonEncode(serverMessage.toJson()),
-      MessageChunkType.done,
-      message: serverMessage,
-    );
-  } else {
-    yield ServerMessageChunk.failedMessage();
-  }
+  yield* sendEllaMessageStream(
+    text,
+    headers: _ellaDebugHeaders(routeSource: 'proxy-canonical'),
+    clientMessageId: const Uuid().v4(),
+    clientSentAt: DateTime.now().toUtc(),
+  );
 }

--- a/app/lib/ella/services/ella_chat_service.dart
+++ b/app/lib/ella/services/ella_chat_service.dart
@@ -73,15 +73,19 @@ Future<List<ServerMessage>> fetchEllaChatHistory({
     final rawMessages = data['messages'] as List<dynamic>? ?? [];
 
     final result = <ServerMessage>[];
-    for (final m in rawMessages) {
-      final message = Map<String, dynamic>.from(m as Map);
-      final content = message['text'] as String? ?? '';
-      if (content.isEmpty) continue;
-      if (content.startsWith('[SYSTEM:')) {
-        continue; // Filter scanner notifications from chat UI
+    for (final rawMessage in rawMessages) {
+      if (rawMessage is! Map<String, dynamic>) continue;
+      try {
+        final message = ServerMessage.fromJson(rawMessage);
+        if (message.text.isEmpty || message.text.startsWith('[SYSTEM:')) {
+          continue; // Filter empty and scanner notification entries from chat UI.
+        }
+        message.askForNps = false;
+        result.add(message);
+      } catch (_) {
+        // A malformed history entry must not discard valid siblings.
+        continue;
       }
-      final parsed = ServerMessage.fromJson(message)..askForNps = false;
-      result.add(parsed);
     }
 
     // API returns newest first; reverse for chronological UI order

--- a/app/test/ella/services/ella_chat_history_test.dart
+++ b/app/test/ella/services/ella_chat_history_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -10,6 +11,8 @@ import 'package:omi/ella/services/ella_chat_service.dart';
 
 Map<String, String> _testDebugHeaders({required String routeSource}) => {'X-Ella-Route-Source': routeSource};
 String _testApiBaseUrl() => 'https://first-party.example/';
+String _productionHistoryResponse() =>
+    File('../backend/tests/fixtures/ella_chat_history_canonical_response_v1.json').readAsStringSync();
 
 void main() {
   setUp(() async {
@@ -17,39 +20,8 @@ void main() {
     await SharedPreferencesUtil.init();
   });
 
-  test('cold history fetch parses the canonical production response without resolver or UID input', () async {
+  test('production canonical history maps exact human and ai messages through the first-party endpoint', () async {
     final requestedUrls = <Uri>[];
-    final canonicalHistoryResponse = {
-      'messages': [
-        {
-          'id': 'm-newer',
-          'created_at': '2026-08-03T12:01:00Z',
-          'text': 'Ready when you are.',
-          'sender': 'ai',
-          'type': 'text',
-          'plugin_id': null,
-          'from_integration': false,
-          'memories': <Object>[],
-          'files': <Object>[],
-          'metadata': {'source': 'canonical_timeline'},
-        },
-        {
-          'id': 'm-older',
-          'created_at': '2026-08-03T12:00:00Z',
-          'text': 'Hello',
-          'sender': 'human',
-          'type': 'text',
-          'plugin_id': null,
-          'from_integration': false,
-          'memories': <Object>[],
-          'files': <Object>[],
-          'metadata': {'source': 'canonical_timeline'},
-        },
-      ],
-      'hasMore': false,
-      'source': 'canonical_timeline',
-      'fallback': false,
-    };
 
     final messages = await fetchEllaChatHistory(
       limit: 25,
@@ -60,7 +32,7 @@ void main() {
         expect(method, 'GET');
         expect(body, isEmpty);
         expect(headers['X-Ella-Route-Source'], 'chat-history');
-        return http.Response(jsonEncode(canonicalHistoryResponse), 200);
+        return http.Response(_productionHistoryResponse(), 200);
       },
     );
 
@@ -70,13 +42,15 @@ void main() {
     expect(requestedUrls.single.toString(), isNot(contains('/resolve')));
     expect(requestedUrls.single.toString(), isNot(contains('caller-selected-uid')));
     expect(messages, hasLength(2));
-    expect(messages.map((message) => message.id), ['m-older', 'm-newer']);
-    expect(messages.first.text, 'Hello');
-    expect(messages.first.sender, MessageSender.human);
-    expect(messages.first.askForNps, isFalse);
-    expect(messages.last.text, 'Ready when you are.');
-    expect(messages.last.sender, MessageSender.ai);
-    expect(messages.last.askForNps, isFalse);
+    expect(messages[0].id, 'canonical-user-turn');
+    expect(messages[0].text, 'Exact user history request.');
+    expect(messages[0].sender, MessageSender.human);
+    expect(messages[0].createdAt.toUtc(), DateTime.parse('2026-08-03T12:00:00Z'));
+    expect(messages[1].id, 'canonical-assistant-turn');
+    expect(messages[1].text, 'Exact assistant history response.');
+    expect(messages[1].sender, MessageSender.ai);
+    expect(messages[1].createdAt.toUtc(), DateTime.parse('2026-08-03T12:01:00Z'));
+    expect(messages.every((message) => !message.askForNps), isTrue);
   });
 
   test('history returns empty for authenticated empty history', () async {
@@ -94,18 +68,54 @@ void main() {
     expect(messages, isEmpty);
   });
 
-  test('history fails closed on authentication failure', () async {
-    var calls = 0;
+  test('malformed production entries fail safely without dropping valid siblings or accepting legacy aliases',
+      () async {
+    final payload = jsonDecode(_productionHistoryResponse()) as Map<String, dynamic>;
+    final canonicalMessages = payload['messages'] as List<dynamic>;
+    payload['messages'] = [
+      canonicalMessages[0],
+      'not-a-message',
+      {
+        'id': 'legacy-alias-message',
+        'role': 'user',
+        'content': 'Legacy aliases must not mask contract drift.',
+        'timestamp': '2026-08-03T12:00:30Z',
+      },
+      {
+        'id': 'malformed-production-message',
+        'created_at': 'not-a-timestamp',
+        'text': 'Malformed timestamp',
+        'sender': 'human',
+        'type': 'text',
+      },
+      canonicalMessages[1],
+    ];
+
     final messages = await fetchEllaChatHistory(
       debugHeadersBuilder: _testDebugHeaders,
       apiBaseUrlProvider: _testApiBaseUrl,
       apiCall: ({required url, required headers, required body, required method, timeout, retries}) async {
-        calls += 1;
-        return http.Response('{"detail":"invalid bearer"}', 401);
+        return http.Response(jsonEncode(payload), 200);
       },
     );
 
-    expect(calls, 1);
-    expect(messages, isEmpty);
+    expect(messages.map((message) => message.id), ['canonical-user-turn', 'canonical-assistant-turn']);
+  });
+
+  test('authentication and upstream failures remain empty rather than fabricating history', () async {
+    var calls = 0;
+    for (final status in [401, 502, 503]) {
+      final messages = await fetchEllaChatHistory(
+        debugHeadersBuilder: _testDebugHeaders,
+        apiBaseUrlProvider: _testApiBaseUrl,
+        apiCall: ({required url, required headers, required body, required method, timeout, retries}) async {
+          calls += 1;
+          return http.Response('{"detail":"unavailable"}', status);
+        },
+      );
+
+      expect(messages, isEmpty);
+    }
+    expect(calls, 3);
   });
 }

--- a/app/test/ella/services/ella_chat_history_test.dart
+++ b/app/test/ella/services/ella_chat_history_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ella_chat_service.dart';
+
+Map<String, String> _testDebugHeaders({required String routeSource}) => {'X-Ella-Route-Source': routeSource};
+String _testApiBaseUrl() => 'https://first-party.example/';
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({'uid': 'caller-selected-uid'});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('history uses the first-party authenticated endpoint without resolver or UID input', () async {
+    final requestedUrls = <Uri>[];
+
+    final messages = await fetchEllaChatHistory(
+      limit: 25,
+      debugHeadersBuilder: _testDebugHeaders,
+      apiBaseUrlProvider: _testApiBaseUrl,
+      apiCall: ({required url, required headers, required body, required method, timeout, retries}) async {
+        requestedUrls.add(Uri.parse(url));
+        expect(method, 'GET');
+        expect(body, isEmpty);
+        expect(headers['X-Ella-Route-Source'], 'chat-history');
+        return http.Response(
+          '{"messages":[{"id":"m1","role":"user","content":"Hello","timestamp":"2026-08-03T12:00:00Z"}]}',
+          200,
+        );
+      },
+    );
+
+    expect(requestedUrls, hasLength(1));
+    expect(requestedUrls.single.path, endsWith('/v1/ella/chat/history'));
+    expect(requestedUrls.single.queryParameters, {'limit': '25'});
+    expect(requestedUrls.single.toString(), isNot(contains('/resolve')));
+    expect(requestedUrls.single.toString(), isNot(contains('caller-selected-uid')));
+    expect(messages, hasLength(1));
+    expect(messages.single.text, 'Hello');
+  });
+
+  test('history returns empty for authenticated empty history', () async {
+    var calls = 0;
+    final messages = await fetchEllaChatHistory(
+      debugHeadersBuilder: _testDebugHeaders,
+      apiBaseUrlProvider: _testApiBaseUrl,
+      apiCall: ({required url, required headers, required body, required method, timeout, retries}) async {
+        calls += 1;
+        return http.Response('{"messages":[]}', 200);
+      },
+    );
+
+    expect(calls, 1);
+    expect(messages, isEmpty);
+  });
+
+  test('history fails closed on authentication failure', () async {
+    var calls = 0;
+    final messages = await fetchEllaChatHistory(
+      debugHeadersBuilder: _testDebugHeaders,
+      apiBaseUrlProvider: _testApiBaseUrl,
+      apiCall: ({required url, required headers, required body, required method, timeout, retries}) async {
+        calls += 1;
+        return http.Response('{"detail":"invalid bearer"}', 401);
+      },
+    );
+
+    expect(calls, 1);
+    expect(messages, isEmpty);
+  });
+}

--- a/app/test/ella/services/ella_chat_history_test.dart
+++ b/app/test/ella/services/ella_chat_history_test.dart
@@ -1,8 +1,11 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/message.dart';
 import 'package:omi/ella/services/ella_chat_service.dart';
 
 Map<String, String> _testDebugHeaders({required String routeSource}) => {'X-Ella-Route-Source': routeSource};
@@ -14,8 +17,39 @@ void main() {
     await SharedPreferencesUtil.init();
   });
 
-  test('history uses the first-party authenticated endpoint without resolver or UID input', () async {
+  test('cold history fetch parses the canonical production response without resolver or UID input', () async {
     final requestedUrls = <Uri>[];
+    final canonicalHistoryResponse = {
+      'messages': [
+        {
+          'id': 'm-newer',
+          'created_at': '2026-08-03T12:01:00Z',
+          'text': 'Ready when you are.',
+          'sender': 'ai',
+          'type': 'text',
+          'plugin_id': null,
+          'from_integration': false,
+          'memories': <Object>[],
+          'files': <Object>[],
+          'metadata': {'source': 'canonical_timeline'},
+        },
+        {
+          'id': 'm-older',
+          'created_at': '2026-08-03T12:00:00Z',
+          'text': 'Hello',
+          'sender': 'human',
+          'type': 'text',
+          'plugin_id': null,
+          'from_integration': false,
+          'memories': <Object>[],
+          'files': <Object>[],
+          'metadata': {'source': 'canonical_timeline'},
+        },
+      ],
+      'hasMore': false,
+      'source': 'canonical_timeline',
+      'fallback': false,
+    };
 
     final messages = await fetchEllaChatHistory(
       limit: 25,
@@ -26,10 +60,7 @@ void main() {
         expect(method, 'GET');
         expect(body, isEmpty);
         expect(headers['X-Ella-Route-Source'], 'chat-history');
-        return http.Response(
-          '{"messages":[{"id":"m1","role":"user","content":"Hello","timestamp":"2026-08-03T12:00:00Z"}]}',
-          200,
-        );
+        return http.Response(jsonEncode(canonicalHistoryResponse), 200);
       },
     );
 
@@ -38,8 +69,14 @@ void main() {
     expect(requestedUrls.single.queryParameters, {'limit': '25'});
     expect(requestedUrls.single.toString(), isNot(contains('/resolve')));
     expect(requestedUrls.single.toString(), isNot(contains('caller-selected-uid')));
-    expect(messages, hasLength(1));
-    expect(messages.single.text, 'Hello');
+    expect(messages, hasLength(2));
+    expect(messages.map((message) => message.id), ['m-older', 'm-newer']);
+    expect(messages.first.text, 'Hello');
+    expect(messages.first.sender, MessageSender.human);
+    expect(messages.first.askForNps, isFalse);
+    expect(messages.last.text, 'Ready when you are.');
+    expect(messages.last.sender, MessageSender.ai);
+    expect(messages.last.askForNps, isFalse);
   });
 
   test('history returns empty for authenticated empty history', () async {

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -3098,6 +3098,39 @@ class EllaProvisioningRepository:
         if result == "UPDATE 0":
             raise LookupError("user_not_found")
 
+    async def update_guardian_mode(self, uid: str, guardian_mode: Optional[str]) -> Optional[str]:
+        """Update one active user's Guardian preference under owner authority."""
+        async with self.pool.acquire() as connection:
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+                connection,
+                uid=uid,
+            )
+            async with connection.transaction():
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(
+                    connection,
+                    owner=owner,
+                )
+                await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=uid,
+                    owner=owner,
+                    proof=owner_lock,
+                )
+                row = await connection.fetchrow(
+                    """
+                    UPDATE users
+                    SET guardian_mode = $2, updated_at = CURRENT_TIMESTAMP
+                    WHERE omi_uid = $1
+                      AND status = 'ACTIVE'
+                    RETURNING guardian_mode
+                    """,
+                    uid,
+                    guardian_mode,
+                )
+        if row is None:
+            raise LookupError("active_user_not_found")
+        return row["guardian_mode"]
+
     async def has_active_retained_runtime(self, uid: str) -> bool:
         """Return whether an authenticated legacy user still has usable routing."""
         row = await self.pool.fetchrow(

--- a/backend/ella/docs/GUARDIAN_TRACE_CONTRACT.md
+++ b/backend/ella/docs/GUARDIAN_TRACE_CONTRACT.md
@@ -50,6 +50,10 @@ Issue #598 should use:
 
 `POST /v1/ella/guardian/trace/log`
 
+This service callback requires the scoped Guardian service key in
+`X-Guardian-Key`. The backend scanner uses the same scoped authority for its
+Guardian service writes.
+
 ```json
 {
   "trace_id": "conversation-uuid",
@@ -95,6 +99,9 @@ The backend persists these stages:
 
 `GET /v1/ella/guardian/next-audio` returns:
 
+The native app sends a current Firebase bearer. The backend derives the exact
+queue owner from that verified subject; no caller-selected UID is accepted.
+
 ```json
 {
   "url": "https://...",
@@ -118,7 +125,6 @@ Issue #599 should call:
 
 ```json
 {
-  "uid": "omi-user-id",
   "queue_item_id": "guardian_abc123",
   "trace_id": "conversation-uuid",
   "event_type": "started",
@@ -134,7 +140,6 @@ Issue #599 should call:
 
 Required fields:
 
-- `uid`
 - `event_type`: `started`, `completed`, or `failed`
 - `queue_item_id` or `trace_id`
 - `port_type`
@@ -142,9 +147,17 @@ Required fields:
 The backend persists stages named `ios_playback_started`,
 `ios_playback_completed`, and `ios_playback_failed`.
 
+The native app authenticates this receipt with a current Firebase bearer. The
+backend derives the owner from the exact token subject and rejects any optional
+body UID that does not exactly match it.
+
 For `failed`, include the failure reason in `metadata.error`.
 
 ## Trace Readback
 
 `GET /v1/ella/guardian/trace/{trace_id}` returns ordered stages plus aggregate
 latency. This is the readback endpoint for #589 canary proof.
+
+Native owner reads require a Firebase bearer and derive the exact owner from the
+token. Scoped internal reads require `X-Guardian-Key` plus an explicit UID; the
+query enforces both trace id and owner.

--- a/backend/ella/docs/hermes-cloud-runtime-targets.openapi.yaml
+++ b/backend/ella/docs/hermes-cloud-runtime-targets.openapi.yaml
@@ -47,7 +47,7 @@ paths:
   /v1/ella/resolve:
     get:
       tags: [Runtime Resolution]
-      summary: Resolve retained or Cloud runtime routing for the authenticated UID.
+      summary: Return redacted isolated-runtime readiness for the authenticated UID.
       parameters:
         - name: uid
           in: query
@@ -56,7 +56,7 @@ paths:
           description: Must match the Firebase bearer subject.
       responses:
         "200":
-          description: Redacted route. Cloud returns only first-party backend URLs.
+          description: Redacted availability, status, and provider only; no endpoint, token, session, or workspace fields.
         "403":
           description: UID does not match the bearer subject.
         "409":
@@ -374,7 +374,7 @@ paths:
   /v1/ella/guardian/next-audio:
     get:
       tags: [Observer and Guardian]
-      summary: Consolidate and consume Guardian audio through the exact Guardian target.
+      summary: Consume Guardian audio for the exact Firebase bearer subject.
       x-ella-runtime-target:
         mode: hermes-cloud-guardian
         fallback: none

--- a/backend/ella/routers/chat.py
+++ b/backend/ella/routers/chat.py
@@ -1334,7 +1334,10 @@ async def ella_chat_history(
         _elapsed = int((_time.time() - _start) * 1000)
         logger.error(f"[FLOW:HISTORY] uid={uid} timeout latency={_elapsed}ms")
         return {"messages": [], "hasMore": False, "source": "provision_openclaw_history_migration", "fallback": True}
-    except Exception as e:
+    except Exception:
         _elapsed = int((_time.time() - _start) * 1000)
-        logger.error(f"[FLOW:HISTORY] uid={uid} error={e} latency={_elapsed}ms")
+        logger.error(
+            "[FLOW:HISTORY] code=ella_legacy_history_unavailable classification=unexpected latency=%sms",
+            _elapsed,
+        )
         return {"messages": [], "hasMore": False, "source": "provision_openclaw_history_migration", "fallback": True}

--- a/backend/ella/routers/chat.py
+++ b/backend/ella/routers/chat.py
@@ -23,6 +23,7 @@ import logging
 import os
 import re
 import hashlib
+import time as _time
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 from zoneinfo import ZoneInfo
@@ -57,8 +58,8 @@ from utils.ella.canonical_context import (
     fetch_canonical_timeline,
     format_canonical_context,
 )
+from utils.ella.exact_firebase_auth import get_exact_firebase_uid, require_matching_firebase_uid
 from utils.ella.time_context import timezone_name
-from utils.other import endpoints as auth
 
 logger = logging.getLogger(__name__)
 
@@ -401,8 +402,6 @@ async def _stream_level_1_ack(user_message: str):
 
 async def _stream_level_2_grok(user_message: str):
     """Level 2: Direct Grok API call via xAI."""
-    import time as _time
-
     _start = _time.time()
 
     if not XAI_API_KEY:
@@ -467,8 +466,6 @@ async def _stream_level_2_grok(user_message: str):
 
 async def _stream_level_3_n8n(user_message: str, uid: str, conversation_id: str):
     """Level 3: Route through n8n webhook for full pipeline testing."""
-    import time as _time
-
     _start = _time.time()
 
     webhook_url = ELLA_CONFIG.n8n_chat_webhook
@@ -542,8 +539,6 @@ async def _stream_level_4_openclaw(user_message: str, uid: str, client_info: dic
     Sends SSE keep-alive comments (: keepalive) every 5s while waiting
     for OpenClaw to prevent proxy/client idle timeouts.
     """
-    import time as _time
-
     _start = _time.time()
 
     if not OPENCLAW_GATEWAY_TOKEN:
@@ -731,8 +726,6 @@ async def _stream_hermes_chat(
     runtime: IsolatedRuntime | None = None,
 ):
     """Stream iOS chat through Hermes while preserving OMI chat SSE format."""
-    import time as _time
-
     _start = _time.time()
     if runtime is None and await runtime_authority_enabled(uid):
         yield "data: Error: isolated runtime required\n\n"
@@ -1056,8 +1049,6 @@ async def ella_chat_stream(
 
     Set via env ELLA_DEBUG_LEVEL or header X-Ella-Debug-Level.
     """
-    import time as _time
-
     _trace_start = _time.time()
 
     if request.uid and request.uid != authenticated_uid:
@@ -1213,7 +1204,7 @@ async def ella_chat_history(
     uid: str = "",
     limit: int = 50,
     before: str = None,
-    authenticated_uid: str = Depends(auth.get_current_user_uid),
+    authenticated_uid: str = Depends(get_exact_firebase_uid),
 ):
     """Return recent chat/context messages for a user from canonical timeline.
 
@@ -1228,13 +1219,9 @@ async def ella_chat_history(
         limit: Max messages to return (default 50, max 200)
         before: ISO timestamp — only return messages before this time
     """
-    import time as _time
-
     _start = _time.time()
 
-    if uid and uid != authenticated_uid:
-        raise HTTPException(status_code=403, detail={"code": "ownership_mismatch"})
-    uid = authenticated_uid
+    uid = require_matching_firebase_uid(authenticated_uid, uid, feature="Chat history")
     runtime_bound = await runtime_authority_enabled(authenticated_uid)
     if runtime_bound:
         try:

--- a/backend/ella/routers/escalations.py
+++ b/backend/ella/routers/escalations.py
@@ -63,9 +63,13 @@ async def _get_pool() -> asyncpg.Pool:
     return _pool
 
 
-def _verify_key(x_guardian_key: Optional[str], x_escalation_key: Optional[str], key: Optional[str]) -> None:
+def _has_valid_service_key(x_guardian_key: Optional[str], x_escalation_key: Optional[str], key: Optional[str]) -> bool:
     provided = x_escalation_key or x_guardian_key or key
-    if provided != ESCALATION_WEBHOOK_KEY:
+    return bool(ESCALATION_WEBHOOK_KEY.strip()) and provided == ESCALATION_WEBHOOK_KEY
+
+
+def _verify_key(x_guardian_key: Optional[str], x_escalation_key: Optional[str], key: Optional[str]) -> None:
+    if not _has_valid_service_key(x_guardian_key, x_escalation_key, key):
         raise HTTPException(status_code=403, detail="Invalid escalation key")
 
 
@@ -77,8 +81,7 @@ def _resolve_policy_view_uid(
     key: Optional[str],
 ) -> str:
     """Resolve the policy-view UID for either app auth or internal callers."""
-    provided_key = x_escalation_key or x_guardian_key or key
-    if provided_key == ESCALATION_WEBHOOK_KEY:
+    if _has_valid_service_key(x_guardian_key, x_escalation_key, key):
         if not uid:
             raise HTTPException(status_code=400, detail="uid is required for internal policy lookup")
         return uid

--- a/backend/ella/routers/escalations.py
+++ b/backend/ella/routers/escalations.py
@@ -125,7 +125,7 @@ async def _load_context(uid: str) -> tuple[UserPolicyContext, list[CaregiverPoli
         """
         SELECT id, omi_uid, guardian_mode, email, phone_number, identities
         FROM users
-        WHERE LOWER(omi_uid) = LOWER($1)
+        WHERE omi_uid = $1
         """,
         uid,
     )

--- a/backend/ella/routers/escalations.py
+++ b/backend/ella/routers/escalations.py
@@ -7,6 +7,7 @@ returned plan and report delivery status to trace tables.
 
 import json
 import os
+import secrets
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -65,7 +66,14 @@ async def _get_pool() -> asyncpg.Pool:
 
 def _has_valid_service_key(x_guardian_key: Optional[str], x_escalation_key: Optional[str], key: Optional[str]) -> bool:
     provided = x_escalation_key or x_guardian_key or key
-    return bool(ESCALATION_WEBHOOK_KEY.strip()) and provided == ESCALATION_WEBHOOK_KEY
+    configured = ESCALATION_WEBHOOK_KEY
+    return bool(
+        configured
+        and configured.strip()
+        and provided
+        and provided.strip()
+        and secrets.compare_digest(provided, configured)
+    )
 
 
 def _verify_key(x_guardian_key: Optional[str], x_escalation_key: Optional[str], key: Optional[str]) -> None:

--- a/backend/ella/routers/escalations.py
+++ b/backend/ella/routers/escalations.py
@@ -29,7 +29,7 @@ router = APIRouter(prefix="/v1/ella/escalations", tags=["Ella Escalations"])
 
 ESCALATION_WEBHOOK_KEY = os.getenv(
     "ELLA_ESCALATION_WEBHOOK_KEY",
-    os.getenv("GUARDIAN_WEBHOOK_KEY", "4f13699d8462adf71e35d2098e6a791f"),
+    os.getenv("GUARDIAN_WEBHOOK_KEY", ""),
 )
 
 _pool: Optional[asyncpg.Pool] = None

--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -775,7 +775,7 @@ async def _guardian_alert_history(uid: str, limit: int) -> dict[str, Any]:
                     id
                 ) AS trace_id
             FROM guardian_queue
-            WHERE LOWER(uid) = LOWER($1)
+            WHERE uid = $1
               AND COALESCE(trigger_type, '') <> 'wake_word_ack'
               AND COALESCE(metadata->>'ack_only', '') <> 'true'
             ORDER BY created_at DESC
@@ -795,7 +795,7 @@ async def _guardian_alert_history(uid: str, limit: int) -> dict[str, Any]:
                     ORDER BY created_at DESC
                 ) AS events
             FROM guardian_pipeline_events
-            WHERE LOWER(uid) = LOWER($1)
+            WHERE uid = $1
               AND trace_id IN (SELECT trace_id FROM queue_rows)
             GROUP BY trace_id
         ),
@@ -815,7 +815,7 @@ async def _guardian_alert_history(uid: str, limit: int) -> dict[str, Any]:
                     ORDER BY updated_at DESC
                 ) AS deliveries
             FROM guardian_delivery_log
-            WHERE LOWER(uid) = LOWER($1)
+            WHERE uid = $1
               AND trace_id IN (SELECT trace_id FROM queue_rows)
             GROUP BY trace_id
         )

--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -32,6 +32,7 @@ from pydantic import BaseModel, Field
 
 from ella.routers.resolve import resolve_user_routing
 from database import app_settings as app_settings_db
+from database.ella_provisioning import EllaProvisioningRepository
 from ella.services.app_settings import TTS_PROVIDERS, build_effective_voice_settings
 from ella.services.ai_consent import assert_current_ai_consent
 from ella.services.hermes_cloud import HermesCloudClient
@@ -56,6 +57,7 @@ from utils.ella.canonical_context import (
     canonical_events_to_chat_turns,
     fetch_canonical_timeline,
 )
+from utils.ella.exact_firebase_auth import get_exact_firebase_uid, require_matching_firebase_uid
 from utils.ella.time_context import build_time_context, local_time_fields
 from utils.other import endpoints as auth
 
@@ -400,6 +402,13 @@ class PlaybackEventRequest(BaseModel):
     device_uid: str = ""  # unique device ID from AVAudioSessionPortDescription
     duration_ms: int = 0  # estimated audio duration in ms
     metadata: Optional[dict] = None
+
+
+class GuardianModeUpdateRequest(BaseModel):
+    """Authenticated, user-scoped Whispers mode update."""
+
+    override: Optional[str] = None
+    features: list[str] = Field(default_factory=list)
 
 
 class PlaybackDebugEventRequest(BaseModel):
@@ -1261,11 +1270,75 @@ Rules:
 # ---------------------------------------------------------------------------
 
 
+_GUARDIAN_OVERRIDE_MODES = {"cyborg", "chatbot", "demo"}
+_GUARDIAN_FEATURE_MODES = {"active_support", "emergency_only", "memory_support", "maximum_awareness"}
+
+
+def _guardian_mode_response(guardian_mode: Optional[str]) -> dict[str, Any]:
+    normalized = _normalize_mode(guardian_mode)
+    current_mode = normalized.upper()
+    return {
+        "success": True,
+        "currentMode": current_mode,
+        "override": current_mode if normalized in _GUARDIAN_OVERRIDE_MODES else None,
+        "features": [current_mode] if normalized in _GUARDIAN_FEATURE_MODES else [],
+        "showDemo": False,
+    }
+
+
+def _requested_guardian_mode(req: GuardianModeUpdateRequest) -> Optional[str]:
+    normalized_override = _normalize_mode(req.override) if req.override else MODE_OFF
+    normalized_features = {_normalize_mode(value) for value in req.features if str(value).strip()}
+
+    if req.override:
+        if normalized_override not in _GUARDIAN_OVERRIDE_MODES:
+            raise HTTPException(status_code=422, detail="Unsupported Guardian override")
+        if normalized_features:
+            raise HTTPException(status_code=422, detail="Guardian override and features cannot be combined")
+        return normalized_override.upper()
+
+    if not normalized_features or normalized_features == {MODE_OFF}:
+        return None
+    if len(normalized_features) != 1 or not normalized_features.issubset(_GUARDIAN_FEATURE_MODES):
+        raise HTTPException(status_code=422, detail="Choose exactly one supported Guardian feature")
+    return next(iter(normalized_features)).upper()
+
+
+@router.get("/mode")
+async def get_guardian_mode(authenticated_uid: str = Depends(get_exact_firebase_uid)) -> dict[str, Any]:
+    """Read Whispers mode for the exact Firebase bearer subject."""
+    pool = await _get_pool()
+    row = await pool.fetchrow(
+        "SELECT guardian_mode FROM users WHERE LOWER(omi_uid) = LOWER($1)",
+        authenticated_uid,
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Guardian user is not provisioned")
+    return _guardian_mode_response(row["guardian_mode"])
+
+
+@router.put("/mode")
+async def update_guardian_mode(
+    req: GuardianModeUpdateRequest,
+    authenticated_uid: str = Depends(get_exact_firebase_uid),
+) -> dict[str, Any]:
+    """Update Whispers mode for the exact Firebase bearer subject."""
+    guardian_mode = _requested_guardian_mode(req)
+    pool = await _get_pool()
+    try:
+        updated_mode = await EllaProvisioningRepository(pool).update_guardian_mode(
+            authenticated_uid,
+            guardian_mode,
+        )
+    except LookupError:
+        raise HTTPException(status_code=404, detail="Guardian user is not provisioned")
+    return _guardian_mode_response(updated_mode)
+
+
 @router.get("/next-audio")
-async def next_audio(uid: str):
+async def next_audio(uid: str, authenticated_uid: str = Depends(get_exact_firebase_uid)):
     """Pop next audio clip from queue. Consolidates if pile-up detected."""
-    if not uid or uid == "unknown":
-        return {"url": None}
+    uid = require_matching_firebase_uid(authenticated_uid, uid, feature="Guardian")
 
     _start = time.time()
     pool = await _get_pool()

--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -18,6 +18,7 @@ import hashlib
 import json
 import os
 import re
+import secrets
 import time
 import uuid
 from datetime import datetime
@@ -57,9 +58,13 @@ from utils.ella.canonical_context import (
     canonical_events_to_chat_turns,
     fetch_canonical_timeline,
 )
-from utils.ella.exact_firebase_auth import get_exact_firebase_uid, require_matching_firebase_uid
+from utils.ella.exact_firebase_auth import (
+    EllaRequestAuthority,
+    get_exact_firebase_uid,
+    get_firebase_or_service_authority,
+    require_matching_firebase_uid,
+)
 from utils.ella.time_context import build_time_context, local_time_fields
-from utils.other import endpoints as auth
 
 router = APIRouter(prefix="/v1/ella/guardian", tags=["Guardian Mode"])
 alerts_router = APIRouter(prefix="/v1/ella", tags=["Guardian Mode"])
@@ -70,7 +75,7 @@ alerts_router = APIRouter(prefix="/v1/ella", tags=["Guardian Mode"])
 
 AUDIO_BASE_DIR = "/var/www/ella-ai-care.com/audio"
 AUDIO_PUBLIC_URL = "https://ella-ai-care.com/audio"
-GUARDIAN_WEBHOOK_KEY = os.getenv("GUARDIAN_WEBHOOK_KEY", "4f13699d8462adf71e35d2098e6a791f")
+GUARDIAN_WEBHOOK_KEY = os.getenv("GUARDIAN_WEBHOOK_KEY", "")
 SMTP_FROM = os.getenv("ELLA_SMTP_FROM", "guardian@ella-ai-care.com")
 N8N_GUARDIAN_DELIVER_WEBHOOK = os.getenv(
     "N8N_GUARDIAN_DELIVER_WEBHOOK",
@@ -108,6 +113,24 @@ _pool: Optional[asyncpg.Pool] = None
 
 # uid -> last playback event (resets on restart — used only for echo risk)
 _playback_events: dict[str, dict] = {}
+
+
+get_guardian_authenticated_uid = get_exact_firebase_uid
+
+
+def get_guardian_user_or_service_authority(
+    authorization: Optional[str] = Header(None),
+    x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
+    key: Optional[str] = Header(None, alias="X-Key"),
+) -> EllaRequestAuthority:
+    """Authenticate either the exact Firebase owner or the Guardian service."""
+    return get_firebase_or_service_authority(
+        authorization=authorization,
+        provided_service_key=x_guardian_key or key,
+        configured_service_key=GUARDIAN_WEBHOOK_KEY,
+        service="guardian",
+    )
+
 
 # Echo risk by iOS AVAudioSession portType rawValue
 _ECHO_RISK = {
@@ -160,14 +183,7 @@ def _verify_key(
 ) -> None:
     """Verify webhook authentication key."""
     provided = x_guardian_key or key
-    if provided != GUARDIAN_WEBHOOK_KEY:
-        raise HTTPException(status_code=403, detail="Invalid guardian key")
-
-
-def _verify_optional_trace_key(x_guardian_key: Optional[str] = None, key: Optional[str] = None) -> None:
-    """Allow legacy scanner trace posts without a key, but reject bad keys when present."""
-    provided = x_guardian_key or key
-    if provided and provided != GUARDIAN_WEBHOOK_KEY:
+    if not GUARDIAN_WEBHOOK_KEY or not provided or not secrets.compare_digest(provided, GUARDIAN_WEBHOOK_KEY):
         raise HTTPException(status_code=403, detail="Invalid guardian key")
 
 
@@ -241,7 +257,7 @@ async def _load_delivery_context(uid: str) -> tuple[UserPolicyContext, list[Care
         """
         SELECT id, omi_uid, guardian_mode, email, phone_number, identities
         FROM users
-        WHERE LOWER(omi_uid) = LOWER($1)
+        WHERE omi_uid = $1
         """,
         uid,
     )
@@ -393,7 +409,7 @@ async def _mark_reserved_steps_dispatch_failed(trace_id: str, steps: list[dict],
 class PlaybackEventRequest(BaseModel):
     """JSON body for /playback-event endpoint."""
 
-    uid: str
+    uid: Optional[str] = None
     queue_item_id: Optional[str] = None
     trace_id: Optional[str] = None
     event_type: str = "started"  # started, completed, failed
@@ -419,7 +435,7 @@ class PlaybackDebugEventRequest(BaseModel):
     playback trace server-side without requiring manual copy/paste.
     """
 
-    uid: str
+    uid: Optional[str] = None
     event_name: str
     trace_id: Optional[str] = None
     queue_item_id: Optional[str] = None
@@ -732,7 +748,7 @@ async def _guardian_alert_history(uid: str, limit: int) -> dict[str, Any]:
         """
         SELECT timezone
         FROM users
-        WHERE LOWER(omi_uid) = LOWER($1)
+        WHERE omi_uid = $1
         """,
         uid,
     )
@@ -832,7 +848,7 @@ async def _guardian_alert_history(uid: str, limit: int) -> dict[str, Any]:
 @alerts_router.get("/guardian-alerts")
 async def guardian_alerts(
     limit: int = Query(default=50, ge=1, le=200),
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(get_exact_firebase_uid),
 ) -> dict[str, Any]:
     """Return newest-first Guardian alert history for the authenticated user."""
     return await _guardian_alert_history(uid, limit)
@@ -1309,7 +1325,7 @@ async def get_guardian_mode(authenticated_uid: str = Depends(get_exact_firebase_
     """Read Whispers mode for the exact Firebase bearer subject."""
     pool = await _get_pool()
     row = await pool.fetchrow(
-        "SELECT guardian_mode FROM users WHERE LOWER(omi_uid) = LOWER($1)",
+        "SELECT guardian_mode FROM users WHERE omi_uid = $1",
         authenticated_uid,
     )
     if row is None:
@@ -1336,7 +1352,7 @@ async def update_guardian_mode(
 
 
 @router.get("/next-audio")
-async def next_audio(uid: str, authenticated_uid: str = Depends(get_exact_firebase_uid)):
+async def next_audio(uid: Optional[str] = None, authenticated_uid: str = Depends(get_exact_firebase_uid)):
     """Pop next audio clip from queue. Consolidates if pile-up detected."""
     uid = require_matching_firebase_uid(authenticated_uid, uid, feature="Guardian")
 
@@ -1589,7 +1605,7 @@ async def enqueue(
 
     pool = await _get_pool()
     mode_row = await pool.fetchrow(
-        "SELECT guardian_mode FROM users WHERE LOWER(omi_uid) = LOWER($1)",
+        "SELECT guardian_mode FROM users WHERE omi_uid = $1",
         uid,
     )
     guardian_mode = mode_row["guardian_mode"] if mode_row else None
@@ -1922,8 +1938,12 @@ async def upload_audio_json(
 
 
 @router.get("/queue")
-async def view_queue(uid: str):
+async def view_queue(
+    uid: Optional[str] = None,
+    authority: EllaRequestAuthority = Depends(get_guardian_user_or_service_authority),
+):
     """View pending queue items for a user (non-consuming read)."""
+    uid = authority.require_uid(uid, feature="Guardian queue")
     pool = await _get_pool()
 
     rows = await pool.fetch(
@@ -2052,16 +2072,17 @@ GUARDIAN_ACTIVE_AUDIO_URL = f"{AUDIO_PUBLIC_URL}/system/guardian-active.mp3"
 
 
 @router.post("/activate")
-async def activate_guardian(request: Request):
+async def activate_guardian(
+    request: Request,
+    authenticated_uid: str = Depends(get_exact_firebase_uid),
+):
     """
     Called by iOS when user enables Guardian Mode.
     Enqueues a "Guardian active" confirmation audio message.
     Also called on first successful queue poll to confirm connectivity.
     """
     body = await request.json()
-    uid = body.get("uid")
-    if not uid:
-        raise HTTPException(status_code=400, detail="uid is required")
+    uid = require_matching_firebase_uid(authenticated_uid, body.get("uid"), feature="Guardian activation")
 
     print(f"[FLOW:GUARDIAN-ACTIVATE] uid={uid} starting activation", flush=True)
 
@@ -2110,18 +2131,24 @@ async def activate_guardian(request: Request):
 
 
 @router.get("/trace/{conversation_id}")
-async def get_pipeline_trace(conversation_id: str):
+async def get_pipeline_trace(
+    conversation_id: str,
+    uid: Optional[str] = Query(None),
+    authority: EllaRequestAuthority = Depends(get_guardian_user_or_service_authority),
+):
     """Get the full pipeline trace for a conversation."""
+    uid = authority.require_uid(uid, feature="Guardian trace")
     try:
         pool = await _get_pool()
         rows = await pool.fetch(
             """
             SELECT stage, status, latency_ms, metadata, created_at, uid
             FROM guardian_pipeline_events
-            WHERE trace_id = $1
+            WHERE trace_id = $1 AND uid = $2
             ORDER BY created_at ASC
             """,
             conversation_id,
+            uid,
         )
 
         if not rows:
@@ -2440,7 +2467,7 @@ async def log_pipeline_event(
     key: Optional[str] = Header(None, alias="X-Key"),
 ):
     """Log a pipeline event (called by n8n workflows)."""
-    _verify_optional_trace_key(x_guardian_key, key)
+    _verify_key(x_guardian_key, key)
     metadata = dict(req.metadata or {})
     if req.error_detail:
         metadata["error_detail"] = req.error_detail
@@ -2494,11 +2521,15 @@ async def log_pipeline_event(
 
 
 @router.post("/playback-event")
-async def record_playback_event(req: PlaybackEventRequest):
+async def record_playback_event(
+    req: PlaybackEventRequest,
+    authenticated_uid: str = Depends(get_exact_firebase_uid),
+):
     """iOS calls this when guardian audio starts playing.
     Records output route so the consolidator knows echo risk."""
+    uid = require_matching_firebase_uid(authenticated_uid, req.uid, feature="Guardian playback")
     echo_risk = _ECHO_RISK.get(req.port_type, "unknown")
-    _playback_events[req.uid] = {
+    _playback_events[uid] = {
         "queue_item_id": req.queue_item_id,
         "trace_id": req.trace_id,
         "event_type": req.event_type,
@@ -2516,7 +2547,7 @@ async def record_playback_event(req: PlaybackEventRequest):
         status = "error" if event_type == "failed" else "success"
         await _log_pipeline_event(
             trace_id=trace_id,
-            uid=req.uid,
+            uid=uid,
             stage=f"ios_playback_{event_type}",
             status=status,
             latency_ms=req.duration_ms if event_type in ("completed", "failed") else None,
@@ -2532,14 +2563,17 @@ async def record_playback_event(req: PlaybackEventRequest):
         )
 
     print(
-        f"[FLOW:PLAYBACK-EVENT] uid={req.uid} trace={trace_id} item={req.queue_item_id} event={req.event_type} port={req.port_type} risk={echo_risk} device={req.port_name!r}",
+        f"[FLOW:PLAYBACK-EVENT] uid={uid} trace={trace_id} item={req.queue_item_id} event={req.event_type} port={req.port_type} risk={echo_risk} device={req.port_name!r}",
         flush=True,
     )
     return {"ok": True, "trace_id": trace_id, "echo_risk": echo_risk}
 
 
 @router.post("/playback-debug")
-async def record_playback_debug_event(req: PlaybackDebugEventRequest):
+async def record_playback_debug_event(
+    req: PlaybackDebugEventRequest,
+    authenticated_uid: str = Depends(get_exact_firebase_uid),
+):
     """Broader iOS Guardian debug-event sink.
 
     Unlike /playback-event, this accepts non-route lifecycle markers such as
@@ -2547,6 +2581,7 @@ async def record_playback_debug_event(req: PlaybackDebugEventRequest):
     failures that happen before AVFoundation playback starts.
     """
 
+    uid = require_matching_firebase_uid(authenticated_uid, req.uid, feature="Guardian playback debug")
     metadata = dict(req.metadata or {})
     event_name = (req.event_name or "unknown").strip().lower().replace(" ", "_")
     stage = req.stage or f"ios_debug_{event_name}"
@@ -2556,7 +2591,7 @@ async def record_playback_debug_event(req: PlaybackDebugEventRequest):
     if trace_id:
         await _log_pipeline_event(
             trace_id=trace_id,
-            uid=req.uid,
+            uid=uid,
             stage=stage,
             status=req.status,
             latency_ms=req.latency_ms,
@@ -2572,7 +2607,7 @@ async def record_playback_debug_event(req: PlaybackDebugEventRequest):
         )
 
     print(
-        f"[FLOW:PLAYBACK-DEBUG] uid={req.uid} trace={trace_id} item={req.queue_item_id} "
+        f"[FLOW:PLAYBACK-DEBUG] uid={uid} trace={trace_id} item={req.queue_item_id} "
         f"event={event_name} status={req.status} port={req.port_type or 'n/a'}",
         flush=True,
     )

--- a/backend/ella/routers/resolve.py
+++ b/backend/ella/routers/resolve.py
@@ -215,7 +215,7 @@ async def resolve_endpoint(
         logger.info("Ella resolve runtime unavailable for uid=%s code=%s", uid, exc.code)
         runtime = None
     except Exception:
-        logger.exception("Ella resolve runtime authority failed closed for uid=%s", uid)
+        logger.error("Ella resolve runtime authority failed closed code=unexpected_runtime_authority_error")
         runtime = None
 
     return {

--- a/backend/ella/routers/resolve.py
+++ b/backend/ella/routers/resolve.py
@@ -1,21 +1,16 @@
 """
 Ella Resolve Router - User identity to active Ella agent resolution.
 
-Resolves any user identifier (Firebase UID, email, phone) to the correct
-Hermes or legacy OpenClaw agent routing info (agentId, sessionKey, gatewayUrl,
-token).
+Resolves the exact Firebase bearer subject to non-secret runtime availability.
 
 Endpoints:
 - GET  /v1/ella/resolve?uid={firebase_uid}
-- GET  /v1/ella/resolve?email={email}
-- GET  /v1/ella/resolve?phone={phone}
 
 Used by:
 - iOS Flutter app for history/config discovery. Production chat should use
   /v1/ella/chat/stream so the backend can hydrate from and write to the
   canonical timeline.
-- E2E Flow Debugger
-- Any client that needs to discover the active agent runtime
+- Authenticated clients that need a non-secret runtime readiness signal
 """
 
 import json
@@ -29,8 +24,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 
 from database.ella_provisioning import EllaProvisioningRepository
-from ella.services.provisioning import ProvisioningError
-from ella.services.runtime_resolver import resolve_isolated_runtime, runtime_bindings_enabled
+from ella.services.runtime_resolver import resolve_isolated_runtime
+from utils.ella.exact_firebase_auth import get_exact_firebase_uid, require_matching_firebase_uid
 from utils.other import endpoints as auth
 
 logger = logging.getLogger(__name__)
@@ -50,7 +45,6 @@ HERMES_AGENT_ID = os.getenv("HERMES_AGENT_ID", "hermes")
 HERMES_GATEWAY_URL = os.getenv("HERMES_GATEWAY_PUBLIC_URL", "https://api.ella-ai-care.com/hermes")
 HERMES_GATEWAY_TOKEN = os.getenv("HERMES_API_SERVER_KEY", os.getenv("API_SERVER_KEY", ""))
 HERMES_PROVISION_URL = os.getenv("HERMES_PROVISION_API_URL", "http://100.76.138.56:8210")
-HERMES_WORKSPACE = os.getenv("HERMES_WORKSPACE", "/Users/ellaai/.hermes/profiles/plato-eval/workspace")
 
 
 async def _get_pool() -> asyncpg.Pool:
@@ -131,10 +125,12 @@ async def resolve_user_routing(uid: str) -> Optional[dict]:
             "routing": routing,
         }
 
-    agents = json.loads(row["agents"]) if row["agents"] else None
+    agents_raw = row["agents"]
+    agents = json.loads(agents_raw) if isinstance(agents_raw, str) else agents_raw
 
     routing = None
-    if agents:
+    workspace = str(agents.get("workspace") or "").strip() if isinstance(agents, dict) else ""
+    if agents and workspace:
         gateway_url = agents.get("gatewayUrl", DEFAULT_GATEWAY_URL)
         routing = {
             "agentId": agents.get("userAgentId"),
@@ -152,7 +148,7 @@ async def resolve_user_routing(uid: str) -> Optional[dict]:
             "provisionToken": PROVISION_API_KEY,
             "provisionUrl": PROVISION_API_URL,
             "clusterStatus": row["cluster_status"],
-            "workspace": agents.get("workspace"),
+            "workspace": workspace,
             "historyUrl": f"/v1/ella/chat/history/{agents.get('userAgentId', '')}",
         }
         if CHAT_PLATFORM == "hermes":
@@ -167,7 +163,7 @@ async def resolve_user_routing(uid: str) -> Optional[dict]:
                     "token": HERMES_GATEWAY_TOKEN,
                     "provisionToken": PROVISION_API_KEY,
                     "provisionUrl": HERMES_PROVISION_URL,
-                    "workspace": HERMES_WORKSPACE,
+                    "workspace": workspace,
                     "historyUrl": "/v1/ella/chat/history",
                     "platform": "hermes",
                 }
@@ -191,123 +187,41 @@ async def resolve_user_routing(uid: str) -> Optional[dict]:
 @router.get("/resolve")
 async def resolve_endpoint(
     uid: Optional[str] = Query(None, description="Firebase UID (omiUid)"),
-    email: Optional[str] = Query(None, description="User email"),
-    phone: Optional[str] = Query(None, description="User phone (E.164)"),
-    authenticated_uid: str = Depends(auth.get_current_user_uid),
+    authenticated_uid: str = Depends(get_exact_firebase_uid),
 ):
-    """Resolve a user identifier to active agent routing info.
-
-    Accepts one of: uid, email, phone. Returns the user's agent cluster
-    routing information including agentId, sessionKey, gatewayUrl, and token.
-    """
-    if email or phone:
-        raise HTTPException(status_code=400, detail={"code": "unsupported_identity_lookup"})
-    uid = uid or authenticated_uid
-    if uid != authenticated_uid:
-        raise HTTPException(status_code=403, detail={"code": "ownership_mismatch"})
-
-    try:
-        resolved = await resolve_user_routing(authenticated_uid)
-    except ProvisioningError as exc:
-        raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
-    routed_platform = str(((resolved or {}).get("routing") or {}).get("platform") or "")
-    if runtime_bindings_enabled(authenticated_uid) or routed_platform == "hermes_cloud":
-        if not resolved:
-            raise HTTPException(status_code=404, detail={"code": "user_not_found"})
-        routing = resolved.get("routing") or {}
-        public_routing = {
-            "agentId": routing.get("agentId"),
-            "historyUrl": "/v1/ella/chat/history",
-            "platform": routing.get("platform") or "hermes",
-            "bindingRevision": routing.get("bindingRevision"),
-            "modelPolicyVersion": routing.get("modelPolicyVersion"),
-            "voicePolicyVersion": routing.get("voicePolicyVersion"),
-        }
-        if routing.get("runtimeBound") is not None:
-            public_routing["runtimeBound"] = routing.get("runtimeBound")
-        return {
-            "user": resolved["user"],
-            "routing": public_routing,
-        }
-
+    """Resolve only the exact Firebase bearer subject to a safe status view."""
+    uid = require_matching_firebase_uid(authenticated_uid, uid, feature="Ella resolve")
     pool = await _get_pool()
-
-    # Build query based on which identifier was provided
-    if uid:
-        row = await pool.fetchrow(
-            """
-            SELECT u.id, u.name, u.omi_uid, u.status, u.guardian_mode, u.timezone,
-                   u.conditions, u.medications,
-                   ac.agents, ac.status AS cluster_status
-            FROM users u
-            LEFT JOIN agent_clusters ac ON ac.user_id = u.id
-            WHERE u.omi_uid = $1
-            """,
-            uid,
-        )
-    else:
-        raise HTTPException(status_code=400, detail={"code": "uid_required"})
+    row = await pool.fetchrow(
+        """
+        SELECT u.omi_uid, u.status, ac.agents, ac.status AS cluster_status
+        FROM users u
+        LEFT JOIN agent_clusters ac ON ac.user_id = u.id
+        WHERE u.omi_uid = $1
+        """,
+        uid,
+    )
 
     if not row:
-        identifier = uid or email or phone
         raise HTTPException(
             status_code=404,
-            detail={"error": "user_not_found", "identifier": identifier},
+            detail={"error": "user_not_found"},
         )
 
-    agents = json.loads(row["agents"]) if row["agents"] else None
-
-    routing = None
-    if agents:
-        gateway_url = agents.get("gatewayUrl", DEFAULT_GATEWAY_URL)
-        routing = {
-            "agentId": agents.get("userAgentId"),
-            "caregiverAgentId": agents.get("caregiverAgentId"),
-            "scannerAgentId": agents.get("scannerAgentId"),
-            "summarizerAgentId": agents.get("summarizerAgentId"),
-            "sessionKey": (
-                f"agent:{agents.get('userAgentId')}:direct:ella:omi-{row['omi_uid'].lower()}"
-                if row["omi_uid"] and agents.get("userAgentId")
-                else None
-            ),
-            "gatewayUrl": PUBLIC_GATEWAY_URL,
-            "scannerGatewayUrl": agents.get("scannerGatewayUrl", gateway_url),
-            "token": agents.get("gatewayToken") or OPENCLAW_GATEWAY_TOKEN,
-            "provisionToken": PROVISION_API_KEY,
-            "provisionUrl": PROVISION_API_URL,
-            "clusterStatus": row["cluster_status"],
-            "workspace": agents.get("workspace"),
-            "historyUrl": f"/v1/ella/chat/history/{agents.get('userAgentId', '')}",
-        }
-        if CHAT_PLATFORM == "hermes":
-            routing.update(
-                {
-                    "agentId": HERMES_AGENT_ID,
-                    "sessionKey": f"ella:omi:{row['omi_uid'].lower()}:canonical",
-                    "gatewayUrl": HERMES_GATEWAY_URL.rstrip("/"),
-                    "scannerGatewayUrl": HERMES_GATEWAY_URL.rstrip("/"),
-                    "token": HERMES_GATEWAY_TOKEN,
-                    "provisionToken": PROVISION_API_KEY,
-                    "provisionUrl": HERMES_PROVISION_URL,
-                    "clusterStatus": row["cluster_status"],
-                    "workspace": HERMES_WORKSPACE,
-                    "historyUrl": "/v1/ella/chat/history",
-                    "platform": "hermes",
-                }
-            )
+    agents_raw = row["agents"]
+    agents = json.loads(agents_raw) if isinstance(agents_raw, str) else agents_raw
+    workspace = str(agents.get("workspace") or "").strip() if isinstance(agents, dict) else ""
 
     return {
         "user": {
-            "id": str(row["id"]),
-            "name": row["name"],
             "omiUid": row["omi_uid"],
             "status": row["status"],
-            "guardianMode": row["guardian_mode"],
-            "timezone": row["timezone"],
-            "conditions": row["conditions"],
-            "medications": row["medications"],
         },
-        "routing": routing,
+        "routing": {
+            "available": bool(agents and workspace),
+            "clusterStatus": row["cluster_status"],
+            "platform": "hermes" if CHAT_PLATFORM == "hermes" else "openclaw",
+        },
     }
 
 

--- a/backend/ella/routers/resolve.py
+++ b/backend/ella/routers/resolve.py
@@ -6,11 +6,8 @@ Resolves the exact Firebase bearer subject to non-secret runtime availability.
 Endpoints:
 - GET  /v1/ella/resolve?uid={firebase_uid}
 
-Used by:
-- iOS Flutter app for history/config discovery. Production chat should use
-  /v1/ella/chat/stream so the backend can hydrate from and write to the
-  canonical timeline.
-- Authenticated clients that need a non-secret runtime readiness signal
+Used by authenticated clients that need a non-secret runtime readiness signal.
+Chat history uses the first-party /v1/ella/chat/history endpoint directly.
 """
 
 import json
@@ -24,6 +21,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 
 from database.ella_provisioning import EllaProvisioningRepository
+from ella.services.runtime_errors import ProvisioningError
 from ella.services.runtime_resolver import resolve_isolated_runtime
 from utils.ella.exact_firebase_auth import get_exact_firebase_uid, require_matching_firebase_uid
 from utils.other import endpoints as auth
@@ -194,9 +192,8 @@ async def resolve_endpoint(
     pool = await _get_pool()
     row = await pool.fetchrow(
         """
-        SELECT u.omi_uid, u.status, ac.agents, ac.status AS cluster_status
+        SELECT u.omi_uid, u.status
         FROM users u
-        LEFT JOIN agent_clusters ac ON ac.user_id = u.id
         WHERE u.omi_uid = $1
         """,
         uid,
@@ -208,9 +205,18 @@ async def resolve_endpoint(
             detail={"error": "user_not_found"},
         )
 
-    agents_raw = row["agents"]
-    agents = json.loads(agents_raw) if isinstance(agents_raw, str) else agents_raw
-    workspace = str(agents.get("workspace") or "").strip() if isinstance(agents, dict) else ""
+    try:
+        runtime = await resolve_isolated_runtime(
+            uid,
+            EllaProvisioningRepository(pool),
+            target_mode="hermes-cloud-chat",
+        )
+    except ProvisioningError as exc:
+        logger.info("Ella resolve runtime unavailable for uid=%s code=%s", uid, exc.code)
+        runtime = None
+    except Exception:
+        logger.exception("Ella resolve runtime authority failed closed for uid=%s", uid)
+        runtime = None
 
     return {
         "user": {
@@ -218,9 +224,9 @@ async def resolve_endpoint(
             "status": row["status"],
         },
         "routing": {
-            "available": bool(agents and workspace),
-            "clusterStatus": row["cluster_status"],
-            "platform": "hermes" if CHAT_PLATFORM == "hermes" else "openclaw",
+            "available": runtime is not None,
+            "clusterStatus": runtime.status if runtime else None,
+            "platform": runtime.provider if runtime else None,
         },
     }
 

--- a/backend/ella/routers/resolve.py
+++ b/backend/ella/routers/resolve.py
@@ -211,11 +211,11 @@ async def resolve_endpoint(
             EllaProvisioningRepository(pool),
             target_mode="hermes-cloud-chat",
         )
-    except ProvisioningError as exc:
-        logger.info("Ella resolve runtime unavailable for uid=%s code=%s", uid, exc.code)
+    except ProvisioningError:
+        logger.info("code=ella_resolve_runtime_unavailable classification=provisioning")
         runtime = None
     except Exception:
-        logger.error("Ella resolve runtime authority failed closed code=unexpected_runtime_authority_error")
+        logger.error("code=ella_resolve_runtime_authority_error classification=unexpected")
         runtime = None
 
     return {
@@ -269,6 +269,6 @@ async def proxy_chat_history(
             if resp.status_code != 200:
                 return JSONResponse(status_code=resp.status_code, content={"error": "upstream_error"})
             return resp.json()
-    except Exception as e:
-        logger.error(f"Chat history proxy error: {e}")
+    except Exception:
+        logger.error("code=ella_legacy_history_proxy_unavailable classification=unexpected")
         return JSONResponse(status_code=502, content={"error": "provision_unreachable"})

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -56,7 +56,6 @@ from utils.llm.followup import followup_question_prompt
 from utils.notifications import send_notification, send_training_data_submitted_notification
 from utils.llm.external_integrations import generate_comprehensive_daily_summary
 from models.notification_message import NotificationMessage
-from ella.services.ai_consent import build_account_deletion_receipt
 from utils.other import endpoints as auth
 from utils.other.storage import (
     delete_all_conversation_recordings,
@@ -94,18 +93,13 @@ def get_user_profile_endpoint(uid: str = Depends(auth.get_current_user_uid)):
 
 @router.delete('/v1/users/delete-account', tags=['v1'])
 def delete_account(uid: str = Depends(auth.get_current_user_uid)):
-    try:
-        delete_user_data(uid)
-        # delete user from firebase auth
-        auth.delete_account(uid)
-        return {
-            'status': 'ok',
-            'message': 'Account deleted successfully',
-            'deletion_receipt': build_account_deletion_receipt(),
-        }
-    except Exception as e:
-        print('delete_account', str(e))
-        raise HTTPException(status_code=500, detail=str(e))
+    raise HTTPException(
+        status_code=503,
+        detail={
+            'code': 'account_deletion_temporarily_unavailable',
+            'message': 'Account deletion is temporarily unavailable.',
+        },
+    )
 
 
 @router.patch('/v1/users/geolocation', tags=['v1'])

--- a/backend/tests/fixtures/ella_chat_history_canonical_response_v1.json
+++ b/backend/tests/fixtures/ella_chat_history_canonical_response_v1.json
@@ -1,0 +1,43 @@
+{
+  "messages": [
+    {
+      "id": "canonical-assistant-turn",
+      "created_at": "2026-08-03T12:01:00+00:00",
+      "text": "Exact assistant history response.",
+      "sender": "ai",
+      "type": "text",
+      "plugin_id": null,
+      "from_integration": false,
+      "memories": [],
+      "files": [],
+      "metadata": {
+        "source": "canonical_timeline",
+        "channel": "ios_chat",
+        "provider": "omi-backend",
+        "source_identity": "omi:assistant-turn",
+        "title": "Assistant message"
+      }
+    },
+    {
+      "id": "canonical-user-turn",
+      "created_at": "2026-08-03T12:00:00+00:00",
+      "text": "Exact user history request.",
+      "sender": "human",
+      "type": "text",
+      "plugin_id": null,
+      "from_integration": false,
+      "memories": [],
+      "files": [],
+      "metadata": {
+        "source": "canonical_timeline",
+        "channel": "ios_chat",
+        "provider": "omi-backend",
+        "source_identity": "omi:user-turn",
+        "title": "User message"
+      }
+    }
+  ],
+  "hasMore": false,
+  "source": "canonical_timeline",
+  "fallback": false
+}

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -14,6 +14,7 @@ from database import authority_advisory_lock, managed_cloud_consent, voice_canar
 from database.ella_provisioning import EllaProvisioningRepository
 from database.runtime_targets import RuntimeTargetLineage
 from ella.routers import guardian
+from utils.ella import exact_firebase_auth
 
 TEST_DSN = os.getenv("ELLA_TEST_POSTGRES_DSN", "").strip()
 MIGRATIONS = Path(__file__).resolve().parents[2] / "migrations"
@@ -188,21 +189,22 @@ def test_guardian_mode_get_returns_only_exact_case_sensitive_firebase_subject():
     asyncio.run(_run_with_database(scenario))
 
 
-def test_guardian_alert_history_returns_only_exact_case_sensitive_firebase_subject():
+def test_mounted_guardian_alert_history_isolates_case_distinct_firebase_subjects(monkeypatch):
     async def scenario(pool):
         await pool.execute(
             """
             CREATE TABLE guardian_queue (
                 id TEXT PRIMARY KEY,
                 uid TEXT NOT NULL,
-                url TEXT,
-                priority TEXT,
+                url TEXT NOT NULL DEFAULT '',
+                priority TEXT NOT NULL,
                 message TEXT,
                 trigger_type TEXT,
                 metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
-                created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                 consumed_at TIMESTAMPTZ
             );
+
             CREATE TABLE guardian_pipeline_events (
                 id BIGSERIAL PRIMARY KEY,
                 trace_id TEXT NOT NULL,
@@ -211,8 +213,9 @@ def test_guardian_alert_history_returns_only_exact_case_sensitive_firebase_subje
                 status TEXT NOT NULL,
                 latency_ms INTEGER,
                 metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
-                created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
             );
+
             CREATE TABLE guardian_delivery_log (
                 id BIGSERIAL PRIMARY KEY,
                 trace_id TEXT NOT NULL,
@@ -222,57 +225,115 @@ def test_guardian_alert_history_returns_only_exact_case_sensitive_firebase_subje
                 caregiver_id TEXT,
                 status TEXT NOT NULL,
                 error_message TEXT,
-                created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
             );
+
             INSERT INTO users (omi_uid, timezone)
-            VALUES ('CaseUID', 'UTC'), ('caseuid', 'UTC');
-            INSERT INTO guardian_queue (id, uid, message, trigger_type, metadata)
-            VALUES
-                ('upper-private', 'CaseUID', 'Upper private alert', 'wake_word', '{"trace_id":"shared-trace"}'),
-                ('lower-private', 'caseuid', 'Lower private alert', 'wake_word', '{"trace_id":"shared-trace"}');
-            INSERT INTO guardian_pipeline_events (trace_id, uid, stage, status, metadata)
-            VALUES
-                ('shared-trace', 'CaseUID', 'upper-private-stage', 'success', '{}'::jsonb),
-                ('shared-trace', 'caseuid', 'lower-private-stage', 'success', '{}'::jsonb);
-            INSERT INTO guardian_delivery_log (trace_id, uid, channel, target, status)
-            VALUES
-                ('shared-trace', 'CaseUID', 'upper-private-channel', 'user', 'sent'),
-                ('shared-trace', 'caseuid', 'lower-private-channel', 'user', 'sent');
+            VALUES ('CaseUID', 'UTC'), ('caseuid', 'America/Los_Angeles');
+
+            INSERT INTO guardian_queue (
+                id, uid, priority, message, trigger_type, metadata, created_at
+            ) VALUES
+                (
+                    'upper-private', 'CaseUID', 'urgent', 'UPPER_QUEUE_PRIVATE', 'safety',
+                    '{"trace_id":"owner-local-trace","private":"UPPER_QUEUE_METADATA"}',
+                    '2026-08-03T12:01:00Z'
+                ),
+                (
+                    'lower-private', 'caseuid', 'normal', 'LOWER_QUEUE_PRIVATE', 'safety',
+                    '{"trace_id":"owner-local-trace","private":"LOWER_QUEUE_METADATA"}',
+                    '2026-08-03T12:00:00Z'
+                );
+
+            INSERT INTO guardian_pipeline_events (
+                trace_id, uid, stage, status, metadata, created_at
+            ) VALUES
+                (
+                    'owner-local-trace', 'CaseUID', 'upper-private-event', 'success',
+                    '{"private":"UPPER_EVENT_PRIVATE"}', '2026-08-03T12:01:10Z'
+                ),
+                (
+                    'owner-local-trace', 'caseuid', 'lower-private-event', 'success',
+                    '{"private":"LOWER_EVENT_PRIVATE"}', '2026-08-03T12:00:10Z'
+                );
+
+            INSERT INTO guardian_delivery_log (
+                trace_id, uid, channel, target, status, error_message, created_at, updated_at
+            ) VALUES
+                (
+                    'owner-local-trace', 'CaseUID', 'email', 'upper-private-target', 'sent',
+                    'UPPER_DELIVERY_PRIVATE', '2026-08-03T12:01:20Z', '2026-08-03T12:01:20Z'
+                ),
+                (
+                    'owner-local-trace', 'caseuid', 'imessage', 'lower-private-target', 'sent',
+                    'LOWER_DELIVERY_PRIVATE', '2026-08-03T12:00:20Z', '2026-08-03T12:00:20Z'
+                );
             """
         )
 
-        authenticated_uid = {"value": "CaseUID"}
-        app = FastAPI()
-        app.include_router(guardian.alerts_router)
-        app.dependency_overrides[guardian.get_guardian_authenticated_uid] = lambda: authenticated_uid["value"]
+        before = {
+            table: [tuple(row.values()) for row in await pool.fetch(f"SELECT * FROM {table} ORDER BY id")]
+            for table in ("guardian_queue", "guardian_pipeline_events", "guardian_delivery_log")
+        }
+
+        def verify_token(token):
+            if token == "valid-lower":
+                return {"uid": "caseuid"}
+            if token == "valid-upper":
+                return {"uid": "CaseUID"}
+            raise ValueError("invalid bearer")
+
+        monkeypatch.setattr(exact_firebase_auth.firebase_auth, "verify_id_token", verify_token)
         previous_pool = guardian._pool
         guardian._pool = pool
+        app = FastAPI()
+        app.include_router(guardian.alerts_router)
+        transport = httpx.ASGITransport(app=app)
         try:
-            async with httpx.AsyncClient(
-                transport=httpx.ASGITransport(app=app),
-                base_url="http://testserver",
-            ) as client:
-                upper = await client.get("/v1/ella/guardian-alerts")
-                authenticated_uid["value"] = "caseuid"
-                lower = await client.get("/v1/ella/guardian-alerts")
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                lower_response = await client.get(
+                    "/v1/ella/guardian-alerts?limit=50&uid=CaseUID",
+                    headers={"Authorization": "Bearer valid-lower"},
+                )
+                upper_response = await client.get(
+                    "/v1/ella/guardian-alerts?limit=50",
+                    headers={"Authorization": "Bearer valid-upper"},
+                )
         finally:
             guardian._pool = previous_pool
 
-        assert upper.status_code == 200
-        assert lower.status_code == 200
-        assert upper.json()["uid"] == "CaseUID"
-        assert lower.json()["uid"] == "caseuid"
-        assert [alert["queue_item_id"] for alert in upper.json()["alerts"]] == ["upper-private"]
-        assert [alert["queue_item_id"] for alert in lower.json()["alerts"]] == ["lower-private"]
-        assert [event["stage"] for event in upper.json()["alerts"][0]["events"]] == ["upper-private-stage"]
-        assert [event["stage"] for event in lower.json()["alerts"][0]["events"]] == ["lower-private-stage"]
-        assert [delivery["channel"] for delivery in upper.json()["alerts"][0]["deliveries"]] == [
-            "upper-private-channel"
-        ]
-        assert [delivery["channel"] for delivery in lower.json()["alerts"][0]["deliveries"]] == [
-            "lower-private-channel"
-        ]
+        assert lower_response.status_code == 200
+        lower = lower_response.json()
+        assert lower["uid"] == "caseuid"
+        assert [alert["queue_item_id"] for alert in lower["alerts"]] == ["lower-private"]
+        assert [event["stage"] for event in lower["alerts"][0]["events"]] == ["lower-private-event"]
+        assert [delivery["target"] for delivery in lower["alerts"][0]["deliveries"]] == ["lower-private-target"]
+        lower_serialized = str(lower)
+        assert "LOWER_QUEUE_PRIVATE" in lower_serialized
+        for upper_private in (
+            "upper-private",
+            "UPPER_QUEUE_PRIVATE",
+            "UPPER_QUEUE_METADATA",
+            "upper-private-event",
+            "UPPER_EVENT_PRIVATE",
+            "upper-private-target",
+            "UPPER_DELIVERY_PRIVATE",
+        ):
+            assert upper_private not in lower_serialized
+
+        assert upper_response.status_code == 200
+        upper = upper_response.json()
+        assert upper["uid"] == "CaseUID"
+        assert [alert["queue_item_id"] for alert in upper["alerts"]] == ["upper-private"]
+        assert [event["stage"] for event in upper["alerts"][0]["events"]] == ["upper-private-event"]
+        assert [delivery["target"] for delivery in upper["alerts"][0]["deliveries"]] == ["upper-private-target"]
+
+        after = {
+            table: [tuple(row.values()) for row in await pool.fetch(f"SELECT * FROM {table} ORDER BY id")]
+            for table in ("guardian_queue", "guardian_pipeline_events", "guardian_delivery_log")
+        }
+        assert after == before
 
     asyncio.run(_run_with_database(scenario))
 

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -37,6 +37,7 @@ CREATE TABLE users (
     identities JSONB NOT NULL DEFAULT '{}'::jsonb,
     settings JSONB NOT NULL DEFAULT '{}'::jsonb,
     tags TEXT[] NOT NULL DEFAULT ARRAY[]::text[],
+    guardian_mode TEXT,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -627,7 +628,7 @@ async def _prepare_writer_case(
             expected_after=0,
         )
 
-    if name in {"identity_create", "identity_update", "identity_bind", "user_activate"}:
+    if name in {"identity_create", "identity_update", "identity_bind", "user_activate", "guardian_mode"}:
         email = f"{uid}@example.invalid"
         if name == "identity_create":
             owner = authority_advisory_lock.provisional_identity_owner(uid)
@@ -673,6 +674,11 @@ async def _prepare_writer_case(
                     uid,
                     email,
                 )
+                if name == "guardian_mode":
+                    await conn.execute(
+                        "UPDATE users SET status = 'ACTIVE' WHERE id = $1",
+                        user_id,
+                    )
         owner = authority_advisory_lock.AuthorityOwner.from_values(user_id, user_id)
         if name == "identity_bind":
 
@@ -724,6 +730,22 @@ async def _prepare_writer_case(
                 snapshot=snapshot,
                 expected_before="Synthetic Before",
                 expected_after="Synthetic After",
+            )
+
+        if name == "guardian_mode":
+
+            async def guardian_mode_snapshot():
+                return await pool.fetchval(
+                    "SELECT guardian_mode FROM users WHERE id = $1",
+                    user_id,
+                )
+
+            return _WriterCase(
+                owner=owner,
+                writer=lambda: repository.update_guardian_mode(uid, "ACTIVE_SUPPORT"),
+                snapshot=guardian_mode_snapshot,
+                expected_before=None,
+                expected_after="ACTIVE_SUPPORT",
             )
 
         async def status_snapshot():
@@ -972,6 +994,7 @@ async def _prepare_writer_case(
         "identity_update",
         "identity_bind",
         "user_activate",
+        "guardian_mode",
         "runtime_stage",
         "runtime_activate",
         "cloud_claim",
@@ -1008,6 +1031,7 @@ def _authority_error_code(error: BaseException) -> str | None:
         "entitlement_status",
         "entitlement_delete",
         "user_activate",
+        "guardian_mode",
         "runtime_stage",
         "runtime_activate",
         "cloud_claim",

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable
 
 import asyncpg
+import httpx
 import pytest
+from fastapi import FastAPI
 
 from database import authority_advisory_lock, managed_cloud_consent, voice_canary
 from database.ella_provisioning import EllaProvisioningRepository
@@ -182,6 +184,95 @@ def test_guardian_mode_get_returns_only_exact_case_sensitive_firebase_subject():
 
         assert upper["currentMode"] == "EMERGENCY_ONLY"
         assert lower["currentMode"] == "ACTIVE_SUPPORT"
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_guardian_alert_history_returns_only_exact_case_sensitive_firebase_subject():
+    async def scenario(pool):
+        await pool.execute(
+            """
+            CREATE TABLE guardian_queue (
+                id TEXT PRIMARY KEY,
+                uid TEXT NOT NULL,
+                url TEXT,
+                priority TEXT,
+                message TEXT,
+                trigger_type TEXT,
+                metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                consumed_at TIMESTAMPTZ
+            );
+            CREATE TABLE guardian_pipeline_events (
+                id BIGSERIAL PRIMARY KEY,
+                trace_id TEXT NOT NULL,
+                uid TEXT NOT NULL,
+                stage TEXT NOT NULL,
+                status TEXT NOT NULL,
+                latency_ms INTEGER,
+                metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE guardian_delivery_log (
+                id BIGSERIAL PRIMARY KEY,
+                trace_id TEXT NOT NULL,
+                uid TEXT NOT NULL,
+                channel TEXT NOT NULL,
+                target TEXT NOT NULL,
+                caregiver_id TEXT,
+                status TEXT NOT NULL,
+                error_message TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            INSERT INTO users (omi_uid, timezone)
+            VALUES ('CaseUID', 'UTC'), ('caseuid', 'UTC');
+            INSERT INTO guardian_queue (id, uid, message, trigger_type, metadata)
+            VALUES
+                ('upper-private', 'CaseUID', 'Upper private alert', 'wake_word', '{"trace_id":"shared-trace"}'),
+                ('lower-private', 'caseuid', 'Lower private alert', 'wake_word', '{"trace_id":"shared-trace"}');
+            INSERT INTO guardian_pipeline_events (trace_id, uid, stage, status, metadata)
+            VALUES
+                ('shared-trace', 'CaseUID', 'upper-private-stage', 'success', '{}'::jsonb),
+                ('shared-trace', 'caseuid', 'lower-private-stage', 'success', '{}'::jsonb);
+            INSERT INTO guardian_delivery_log (trace_id, uid, channel, target, status)
+            VALUES
+                ('shared-trace', 'CaseUID', 'upper-private-channel', 'user', 'sent'),
+                ('shared-trace', 'caseuid', 'lower-private-channel', 'user', 'sent');
+            """
+        )
+
+        authenticated_uid = {"value": "CaseUID"}
+        app = FastAPI()
+        app.include_router(guardian.alerts_router)
+        app.dependency_overrides[guardian.get_guardian_authenticated_uid] = lambda: authenticated_uid["value"]
+        previous_pool = guardian._pool
+        guardian._pool = pool
+        try:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://testserver",
+            ) as client:
+                upper = await client.get("/v1/ella/guardian-alerts")
+                authenticated_uid["value"] = "caseuid"
+                lower = await client.get("/v1/ella/guardian-alerts")
+        finally:
+            guardian._pool = previous_pool
+
+        assert upper.status_code == 200
+        assert lower.status_code == 200
+        assert upper.json()["uid"] == "CaseUID"
+        assert lower.json()["uid"] == "caseuid"
+        assert [alert["queue_item_id"] for alert in upper.json()["alerts"]] == ["upper-private"]
+        assert [alert["queue_item_id"] for alert in lower.json()["alerts"]] == ["lower-private"]
+        assert [event["stage"] for event in upper.json()["alerts"][0]["events"]] == ["upper-private-stage"]
+        assert [event["stage"] for event in lower.json()["alerts"][0]["events"]] == ["lower-private-stage"]
+        assert [delivery["channel"] for delivery in upper.json()["alerts"][0]["deliveries"]] == [
+            "upper-private-channel"
+        ]
+        assert [delivery["channel"] for delivery in lower.json()["alerts"][0]["deliveries"]] == [
+            "lower-private-channel"
+        ]
 
     asyncio.run(_run_with_database(scenario))
 

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -11,6 +11,7 @@ import pytest
 from database import authority_advisory_lock, managed_cloud_consent, voice_canary
 from database.ella_provisioning import EllaProvisioningRepository
 from database.runtime_targets import RuntimeTargetLineage
+from ella.routers import guardian
 
 TEST_DSN = os.getenv("ELLA_TEST_POSTGRES_DSN", "").strip()
 MIGRATIONS = Path(__file__).resolve().parents[2] / "migrations"
@@ -161,6 +162,28 @@ async def _seed_grant(pool, uid):
             "sha256:" + ("3" * 64),
         )
     return authority_advisory_lock.AuthorityOwner.from_values(user_id, user_id)
+
+
+def test_guardian_mode_get_returns_only_exact_case_sensitive_firebase_subject():
+    async def scenario(pool):
+        await pool.execute(
+            """
+            INSERT INTO users (omi_uid, guardian_mode)
+            VALUES ('CaseUID', 'EMERGENCY_ONLY'), ('caseuid', 'ACTIVE_SUPPORT')
+            """
+        )
+        previous_pool = guardian._pool
+        guardian._pool = pool
+        try:
+            upper = await guardian.get_guardian_mode(authenticated_uid="CaseUID")
+            lower = await guardian.get_guardian_mode(authenticated_uid="caseuid")
+        finally:
+            guardian._pool = previous_pool
+
+        assert upper["currentMode"] == "EMERGENCY_ONLY"
+        assert lower["currentMode"] == "ACTIVE_SUPPORT"
+
+    asyncio.run(_run_with_database(scenario))
 
 
 def _prompt_receipt() -> dict[str, Any]:

--- a/backend/tests/unit/test_authority_writer_guard.py
+++ b/backend/tests/unit/test_authority_writer_guard.py
@@ -33,6 +33,7 @@ EXPECTED_WRITERS = {
     ("database/ella_provisioning.py", "quarantine_cloud_pool_claim"),
     ("database/ella_provisioning.py", "register_cloud_pool_binding"),
     ("database/ella_provisioning.py", "stage_runtime_binding"),
+    ("database/ella_provisioning.py", "update_guardian_mode"),
     ("database/invitation_operator.py", "_cleanup_locked"),
     ("database/invitations.py", "_bind_verified_identity_on_connection"),
     ("database/invitations.py", "_redeem_locked_invitation"),
@@ -68,6 +69,7 @@ EXPECTED_GLOBAL_USER_WRITERS = {
     ("database/ella_provisioning.py", "activate_user"),
     ("database/ella_provisioning.py", "ensure_user_identity"),
     ("database/ella_provisioning.py", "finalize_cloud_pool_claim"),
+    ("database/ella_provisioning.py", "update_guardian_mode"),
     ("database/invitations.py", "_bind_verified_identity_on_connection"),
     ("database/invitation_operator.py", "_cleanup_locked"),
     ("ella/utils/auto_provision.py", "auto_provision_user"),
@@ -95,6 +97,10 @@ REAL_POSTGRES_WRITER_COVERAGE = {
     ("database/ella_provisioning.py", "finalize_cloud_pool_claim"): (
         "tests/postgres/test_authority_advisory_lock_postgres.py",
         '"cloud_finalize"',
+    ),
+    ("database/ella_provisioning.py", "update_guardian_mode"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        '"guardian_mode"',
     ),
     ("database/ella_provisioning.py", "invalidate_self_hosted_authority_on_connection"): (
         "tests/postgres/test_invitation_redemption_postgres.py",

--- a/backend/tests/unit/test_ella_canonical_context.py
+++ b/backend/tests/unit/test_ella_canonical_context.py
@@ -1,6 +1,8 @@
 import asyncio
+import json
 import sys
 import types
+from pathlib import Path
 
 sys.modules.setdefault("python_multipart", types.SimpleNamespace(__version__="0.0.20"))
 
@@ -12,6 +14,43 @@ from utils.ella.canonical_context import (
     canonical_events_to_chat_turns,
     format_canonical_context,
 )
+
+_HISTORY_CONTRACT_FIXTURE = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "ella_chat_history_canonical_response_v1.json"
+)
+
+
+def _history_contract_fixture():
+    return json.loads(_HISTORY_CONTRACT_FIXTURE.read_text(encoding="utf-8"))
+
+
+def _history_contract_events():
+    return [
+        {
+            "uid": "uid-1",
+            "event_id": "canonical-user-turn",
+            "source_identity": "omi:user-turn",
+            "channel": "ios_chat",
+            "provider": "omi-backend",
+            "role": "user",
+            "text": "Exact user history request.",
+            "title": "User message",
+            "started_at": "2026-08-03T12:00:00+00:00",
+            "metadata": {},
+        },
+        {
+            "uid": "uid-1",
+            "event_id": "canonical-assistant-turn",
+            "source_identity": "omi:assistant-turn",
+            "channel": "ios_chat",
+            "provider": "omi-backend",
+            "role": "assistant",
+            "text": "Exact assistant history response.",
+            "title": "Assistant message",
+            "started_at": "2026-08-03T12:01:00+00:00",
+            "metadata": {},
+        },
+    ]
 
 
 def _cafe_event():
@@ -47,14 +86,10 @@ def test_default_context_channels_include_external_continuity_sources():
     assert "companion_note" in DEFAULT_CONTEXT_CHANNELS
 
 
-def test_canonical_events_to_server_messages_maps_ios_history_shape():
-    messages = canonical_events_to_server_messages([_cafe_event()])
+def test_canonical_events_to_server_messages_matches_first_party_history_contract_fixture():
+    messages = canonical_events_to_server_messages(_history_contract_events())
 
-    assert messages[0]["id"] == "omi:cafe-123:summary"
-    assert messages[0]["sender"] == "human"
-    assert messages[0]["metadata"]["source"] == "canonical_timeline"
-    assert messages[0]["metadata"]["channel"] == "omi"
-    assert "Cafe Coffee and Waffle Stop" in messages[0]["metadata"]["title"]
+    assert messages == _history_contract_fixture()["messages"]
 
 
 def test_chat_history_prefers_canonical_timeline(monkeypatch):
@@ -62,19 +97,22 @@ def test_chat_history_prefers_canonical_timeline(monkeypatch):
         assert uid == "uid-1"
         assert limit == 5
         assert before is None
-        return [_cafe_event()]
+        return _history_contract_events()
+
+    async def authority_disabled(uid):
+        assert uid == "uid-1"
+        return False
 
     async def fail_resolve(_uid):
         raise AssertionError("legacy routing fallback should not be used when canonical has events")
 
     monkeypatch.setattr(ella_chat, "_fetch_chat_canonical_events", fake_events)
+    monkeypatch.setattr(ella_chat, "runtime_authority_enabled", authority_disabled)
     monkeypatch.setattr(ella_chat, "resolve_user_routing", fail_resolve)
 
     result = asyncio.run(ella_chat.ella_chat_history("uid-1", limit=5, authenticated_uid="uid-1"))
 
-    assert result["source"] == "canonical_timeline"
-    assert result["fallback"] is False
-    assert result["messages"][0]["id"] == "omi:cafe-123:summary"
+    assert result == _history_contract_fixture()
 
 
 def test_guardian_recent_turns_prefers_canonical_timeline(monkeypatch):
@@ -101,8 +139,12 @@ def test_guardian_isolated_context_never_uses_openclaw_history(monkeypatch):
     async def fail_resolve(_uid):
         raise AssertionError("isolated Guardian context must not use OpenClaw history")
 
+    async def authority_enabled(uid):
+        assert uid == "uid-isolated"
+        return True
+
     monkeypatch.setattr(guardian, "fetch_canonical_timeline", no_events)
-    monkeypatch.setattr(guardian, "runtime_bindings_enabled", lambda uid=None: True)
+    monkeypatch.setattr(guardian, "runtime_authority_enabled", authority_enabled)
     monkeypatch.setattr(guardian, "resolve_user_routing", fail_resolve)
 
     assert asyncio.run(guardian._get_recent_chat_turns("uid-isolated", limit=3)) == []

--- a/backend/tests/unit/test_ella_escalations_router_auth.py
+++ b/backend/tests/unit/test_ella_escalations_router_auth.py
@@ -300,43 +300,46 @@ def test_evaluate_internal_key_reaches_load_context_for_explicit_uid(monkeypatch
     assert response["trace_id"] == "uid-1"
 
 
-def test_production_default_raw_empty_legacy_key_denies_all_authority_paths_before_context(monkeypatch):
+def test_production_default_empty_and_absent_credentials_deny_all_authority_paths_before_context(monkeypatch):
     monkeypatch.delenv("ELLA_ESCALATION_WEBHOOK_KEY", raising=False)
     monkeypatch.delenv("GUARDIAN_WEBHOOK_KEY", raising=False)
     production_escalations = _load_escalations_module("ella_escalations_production_default_under_test")
     assert production_escalations.ESCALATION_WEBHOOK_KEY == ""
+    loaded_uids = []
 
-    async def fail_load_context(_uid):
+    async def fail_load_context(uid):
+        loaded_uids.append(uid)
         raise AssertionError("_load_context must not run for an unconfigured service authority")
 
     monkeypatch.setattr(production_escalations, "_load_context", fail_load_context)
     app = FastAPI()
     app.include_router(production_escalations.router)
 
+    denial_cases = (
+        ("absent", {}, (None, None, None)),
+        ("raw-empty-legacy", {"X-Key": ""}, (None, None, "")),
+        ("whitespace-legacy", {"X-Key": " "}, (None, None, " ")),
+        ("raw-empty-guardian", {"X-Guardian-Key": ""}, ("", None, None)),
+        ("raw-empty-escalation", {"X-Escalation-Key": ""}, (None, "", None)),
+    )
     with TestClient(app) as client:
-        policy_response = client.get(
-            "/v1/ella/escalations/policy",
-            params={"uid": "uid-1"},
-            headers={"X-Key": ""},
-        )
-        markdown_response = client.get(
-            "/v1/ella/escalations/policy.md",
-            params={"uid": "uid-1"},
-            headers={"X-Key": ""},
-        )
-        evaluate_response = client.post(
-            "/v1/ella/escalations/evaluate",
-            headers={"X-Key": ""},
-            json={"uid": "uid-1"},
-        )
+        for case_name, headers, verifier_arguments in denial_cases:
+            for path in ("/v1/ella/escalations/policy", "/v1/ella/escalations/policy.md"):
+                response = client.get(path, params={"uid": "uid-1"}, headers=headers)
+                assert response.status_code == 401, (case_name, path, response.text)
 
-    assert policy_response.status_code == 401
-    assert markdown_response.status_code == 401
-    assert evaluate_response.status_code == 403
+            evaluate_response = client.post(
+                "/v1/ella/escalations/evaluate",
+                headers=headers,
+                json={"uid": "uid-1"},
+            )
+            assert evaluate_response.status_code == 403, (case_name, evaluate_response.text)
 
-    with pytest.raises(HTTPException) as exc:
-        production_escalations._verify_key(None, None, "")
-    assert exc.value.status_code == 403
+            with pytest.raises(HTTPException) as exc:
+                production_escalations._verify_key(*verifier_arguments)
+            assert exc.value.status_code == 403, case_name
+
+    assert loaded_uids == []
 
     monkeypatch.setattr(production_escalations, "ESCALATION_WEBHOOK_KEY", " \t")
     with pytest.raises(HTTPException) as exc:

--- a/backend/tests/unit/test_ella_escalations_router_auth.py
+++ b/backend/tests/unit/test_ella_escalations_router_auth.py
@@ -5,7 +5,8 @@ import types
 from pathlib import Path
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 sys.modules.setdefault("asyncpg", types.SimpleNamespace(Pool=object, Connection=object, create_pool=None))
 firebase_admin = types.ModuleType("firebase_admin")
@@ -21,17 +22,25 @@ sys.modules.setdefault("firebase_admin", firebase_admin)
 sys.modules.setdefault("firebase_admin.auth", firebase_auth)
 
 _ROUTER_PATH = Path(__file__).resolve().parents[2] / "ella" / "routers" / "escalations.py"
-_SPEC = importlib.util.spec_from_file_location("ella_escalations_under_test", _ROUTER_PATH)
-escalations = importlib.util.module_from_spec(_SPEC)
-assert _SPEC and _SPEC.loader
-_SPEC.loader.exec_module(escalations)
+
+
+def _load_escalations_module(module_name):
+    spec = importlib.util.spec_from_file_location(module_name, _ROUTER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+escalations = _load_escalations_module("ella_escalations_under_test")
 
 _TEST_ESCALATION_WEBHOOK_KEY = "test-only-escalation-authority-key"
 
 
-@pytest.fixture(autouse=True)
-def _configure_test_escalation_webhook_key(monkeypatch):
+@pytest.fixture
+def configured_escalation_key(monkeypatch):
     monkeypatch.setattr(escalations, "ESCALATION_WEBHOOK_KEY", _TEST_ESCALATION_WEBHOOK_KEY)
+    return _TEST_ESCALATION_WEBHOOK_KEY
 
 
 def _policy_context(uid):
@@ -55,7 +64,7 @@ def _policy_context(uid):
     )
 
 
-def test_policy_view_internal_key_reaches_load_context_for_explicit_uid(monkeypatch):
+def test_policy_view_internal_key_reaches_load_context_for_explicit_uid(monkeypatch, configured_escalation_key):
     loaded_uids = []
 
     async def fake_load_context(uid):
@@ -79,7 +88,7 @@ def test_policy_view_internal_key_reaches_load_context_for_explicit_uid(monkeypa
     assert response["uid"] == "uid-1"
 
 
-def test_policy_view_internal_key_requires_uid_before_load_context(monkeypatch):
+def test_policy_view_internal_key_requires_uid_before_load_context(monkeypatch, configured_escalation_key):
     async def fail_load_context(_uid):
         raise AssertionError("_load_context must not run without an explicit service-authority UID")
 
@@ -129,7 +138,9 @@ def test_policy_view_uid_rejects_cross_user_read(monkeypatch):
     assert exc.value.status_code == 403
 
 
-def test_policy_view_denies_absent_empty_malformed_and_wrong_credentials_before_context(monkeypatch):
+def test_policy_view_denies_absent_empty_malformed_and_wrong_credentials_before_context(
+    monkeypatch, configured_escalation_key
+):
     async def fail_load_context(_uid):
         raise AssertionError("_load_context must not run for denied authority")
 
@@ -234,7 +245,7 @@ def test_load_context_allows_identities_phone_override(monkeypatch):
     assert user.user_phone == "+15550000099"
 
 
-def test_policy_markdown_internal_key_reaches_same_auth_and_context(monkeypatch):
+def test_policy_markdown_internal_key_reaches_same_auth_and_context(monkeypatch, configured_escalation_key):
     loaded_uids = []
 
     async def fake_load_context(uid):
@@ -260,3 +271,74 @@ def test_policy_markdown_internal_key_reaches_same_auth_and_context(monkeypatch)
     assert "- guardian_mode: `memory_support`" in body
     assert "`direct_user_request`" in body
     assert "`critical_safety`" in body
+
+
+def test_evaluate_internal_key_reaches_load_context_for_explicit_uid(monkeypatch, configured_escalation_key):
+    loaded_uids = []
+
+    async def fake_load_context(uid):
+        loaded_uids.append(uid)
+        return _policy_context(uid)
+
+    async def fake_log_decision(_uid, _decision):
+        return None
+
+    monkeypatch.setattr(escalations, "_load_context", fake_load_context)
+    monkeypatch.setattr(escalations, "_log_decision", fake_log_decision)
+
+    response = asyncio.run(
+        escalations.evaluate_escalation(
+            escalations.EscalationEvaluateRequest(uid="uid-1"),
+            x_guardian_key=None,
+            x_escalation_key=_TEST_ESCALATION_WEBHOOK_KEY,
+            key=None,
+        )
+    )
+
+    assert loaded_uids == ["uid-1"]
+    assert response["ok"] is True
+    assert response["trace_id"] == "uid-1"
+
+
+def test_production_default_raw_empty_legacy_key_denies_all_authority_paths_before_context(monkeypatch):
+    monkeypatch.delenv("ELLA_ESCALATION_WEBHOOK_KEY", raising=False)
+    monkeypatch.delenv("GUARDIAN_WEBHOOK_KEY", raising=False)
+    production_escalations = _load_escalations_module("ella_escalations_production_default_under_test")
+    assert production_escalations.ESCALATION_WEBHOOK_KEY == ""
+
+    async def fail_load_context(_uid):
+        raise AssertionError("_load_context must not run for an unconfigured service authority")
+
+    monkeypatch.setattr(production_escalations, "_load_context", fail_load_context)
+    app = FastAPI()
+    app.include_router(production_escalations.router)
+
+    with TestClient(app) as client:
+        policy_response = client.get(
+            "/v1/ella/escalations/policy",
+            params={"uid": "uid-1"},
+            headers={"X-Key": ""},
+        )
+        markdown_response = client.get(
+            "/v1/ella/escalations/policy.md",
+            params={"uid": "uid-1"},
+            headers={"X-Key": ""},
+        )
+        evaluate_response = client.post(
+            "/v1/ella/escalations/evaluate",
+            headers={"X-Key": ""},
+            json={"uid": "uid-1"},
+        )
+
+    assert policy_response.status_code == 401
+    assert markdown_response.status_code == 401
+    assert evaluate_response.status_code == 403
+
+    with pytest.raises(HTTPException) as exc:
+        production_escalations._verify_key(None, None, "")
+    assert exc.value.status_code == 403
+
+    monkeypatch.setattr(production_escalations, "ESCALATION_WEBHOOK_KEY", " \t")
+    with pytest.raises(HTTPException) as exc:
+        production_escalations._verify_key(None, None, " \t")
+    assert exc.value.status_code == 403

--- a/backend/tests/unit/test_ella_escalations_router_auth.py
+++ b/backend/tests/unit/test_ella_escalations_router_auth.py
@@ -26,28 +26,74 @@ escalations = importlib.util.module_from_spec(_SPEC)
 assert _SPEC and _SPEC.loader
 _SPEC.loader.exec_module(escalations)
 
+_TEST_ESCALATION_WEBHOOK_KEY = "test-only-escalation-authority-key"
 
-def test_policy_view_uid_allows_internal_key_with_explicit_uid():
-    assert (
-        escalations._resolve_policy_view_uid(
-            "uid-1",
-            authorization=None,
-            x_guardian_key=escalations.ESCALATION_WEBHOOK_KEY,
-            x_escalation_key=None,
-            key=None,
-        )
-        == "uid-1"
+
+@pytest.fixture(autouse=True)
+def _configure_test_escalation_webhook_key(monkeypatch):
+    monkeypatch.setattr(escalations, "ESCALATION_WEBHOOK_KEY", _TEST_ESCALATION_WEBHOOK_KEY)
+
+
+def _policy_context(uid):
+    return (
+        escalations.UserPolicyContext(
+            uid=uid,
+            guardian_mode="memory_support",
+            user_email="user@example.test",
+            user_phone="+15550000001",
+        ),
+        [
+            escalations.CaregiverPolicyContext(
+                caregiver_id="caregiver-1",
+                status="ACTIVE",
+                is_emergency_contact=True,
+                name="Emily",
+                email="caregiver@example.test",
+                phone="+15550000002",
+            )
+        ],
     )
 
 
-def test_policy_view_uid_requires_uid_for_internal_key():
-    with pytest.raises(HTTPException) as exc:
-        escalations._resolve_policy_view_uid(
-            None,
+def test_policy_view_internal_key_reaches_load_context_for_explicit_uid(monkeypatch):
+    loaded_uids = []
+
+    async def fake_load_context(uid):
+        loaded_uids.append(uid)
+        return _policy_context(uid)
+
+    monkeypatch.setattr(escalations, "_load_context", fake_load_context)
+
+    response = asyncio.run(
+        escalations.get_escalation_policy(
+            uid="uid-1",
             authorization=None,
-            x_guardian_key=escalations.ESCALATION_WEBHOOK_KEY,
+            x_guardian_key=_TEST_ESCALATION_WEBHOOK_KEY,
             x_escalation_key=None,
             key=None,
+        )
+    )
+
+    assert loaded_uids == ["uid-1"]
+    assert response["ok"] is True
+    assert response["uid"] == "uid-1"
+
+
+def test_policy_view_internal_key_requires_uid_before_load_context(monkeypatch):
+    async def fail_load_context(_uid):
+        raise AssertionError("_load_context must not run without an explicit service-authority UID")
+
+    monkeypatch.setattr(escalations, "_load_context", fail_load_context)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            escalations.get_escalation_policy(
+                uid=None,
+                authorization=None,
+                x_guardian_key=_TEST_ESCALATION_WEBHOOK_KEY,
+                x_escalation_key=None,
+                key=None,
+            )
         )
 
     assert exc.value.status_code == 400
@@ -83,17 +129,44 @@ def test_policy_view_uid_rejects_cross_user_read(monkeypatch):
     assert exc.value.status_code == 403
 
 
-def test_policy_view_uid_requires_authorization_without_internal_key():
-    with pytest.raises(HTTPException) as exc:
-        escalations._resolve_policy_view_uid(
-            "uid-1",
-            authorization=None,
-            x_guardian_key=None,
-            x_escalation_key=None,
-            key=None,
-        )
+def test_policy_view_denies_absent_empty_malformed_and_wrong_credentials_before_context(monkeypatch):
+    async def fail_load_context(_uid):
+        raise AssertionError("_load_context must not run for denied authority")
 
-    assert exc.value.status_code == 401
+    verified_tokens = []
+
+    def reject_firebase_token(token):
+        verified_tokens.append(token)
+        raise InvalidIdTokenError
+
+    monkeypatch.setattr(escalations, "_load_context", fail_load_context)
+    monkeypatch.setattr(escalations.auth_endpoints, "verify_token", reject_firebase_token)
+
+    denial_cases = {
+        "absent": {},
+        "raw-empty-guardian-key": {"x_guardian_key": ""},
+        "raw-empty-escalation-key": {"x_escalation_key": ""},
+        "raw-empty-legacy-key": {"key": ""},
+        "malformed-service-key": {"x_escalation_key": f" {_TEST_ESCALATION_WEBHOOK_KEY} "},
+        "wrong-service-key": {"x_guardian_key": "wrong-test-only-key"},
+        "malformed-firebase-authorization": {"authorization": "not-a-bearer-token"},
+        "invalid-firebase-token": {"authorization": "Bearer invalid-test-token"},
+    }
+
+    for case_name, overrides in denial_cases.items():
+        arguments = {
+            "uid": "uid-1",
+            "authorization": None,
+            "x_guardian_key": None,
+            "x_escalation_key": None,
+            "key": None,
+            **overrides,
+        }
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(escalations.get_escalation_policy(**arguments))
+        assert exc.value.status_code == 401, case_name
+
+    assert verified_tokens == ["invalid-test-token"]
 
 
 class _FakePool:
@@ -161,26 +234,12 @@ def test_load_context_allows_identities_phone_override(monkeypatch):
     assert user.user_phone == "+15550000099"
 
 
-def test_policy_markdown_endpoint_uses_same_auth_and_context(monkeypatch):
+def test_policy_markdown_internal_key_reaches_same_auth_and_context(monkeypatch):
+    loaded_uids = []
+
     async def fake_load_context(uid):
-        return (
-            escalations.UserPolicyContext(
-                uid=uid,
-                guardian_mode="memory_support",
-                user_email="user@example.test",
-                user_phone="+15550000001",
-            ),
-            [
-                escalations.CaregiverPolicyContext(
-                    caregiver_id="caregiver-1",
-                    status="ACTIVE",
-                    is_emergency_contact=True,
-                    name="Emily",
-                    email="caregiver@example.test",
-                    phone="+15550000002",
-                )
-            ],
-        )
+        loaded_uids.append(uid)
+        return _policy_context(uid)
 
     monkeypatch.setattr(escalations, "_load_context", fake_load_context)
 
@@ -188,12 +247,13 @@ def test_policy_markdown_endpoint_uses_same_auth_and_context(monkeypatch):
         escalations.get_escalation_policy_markdown(
             uid="uid-1",
             authorization=None,
-            x_guardian_key=escalations.ESCALATION_WEBHOOK_KEY,
+            x_guardian_key=_TEST_ESCALATION_WEBHOOK_KEY,
             x_escalation_key=None,
             key=None,
         )
     )
 
+    assert loaded_uids == ["uid-1"]
     assert response.media_type == "text/markdown; charset=utf-8"
     body = response.body.decode("utf-8")
     assert "- uid: `uid-1`" in body

--- a/backend/tests/unit/test_ella_escalations_router_auth.py
+++ b/backend/tests/unit/test_ella_escalations_router_auth.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from fastapi import HTTPException
 
-sys.modules.setdefault("asyncpg", types.SimpleNamespace(Pool=object, create_pool=None))
+sys.modules.setdefault("asyncpg", types.SimpleNamespace(Pool=object, Connection=object, create_pool=None))
 firebase_admin = types.ModuleType("firebase_admin")
 firebase_auth = types.ModuleType("firebase_admin.auth")
 
@@ -99,8 +99,10 @@ def test_policy_view_uid_requires_authorization_without_internal_key():
 class _FakePool:
     def __init__(self, user_row):
         self.user_row = user_row
+        self.fetchrow_queries = []
 
-    async def fetchrow(self, *_args):
+    async def fetchrow(self, query, *args):
+        self.fetchrow_queries.append((query, args))
         return self.user_row
 
     async def fetch(self, *_args):
@@ -108,19 +110,20 @@ class _FakePool:
 
 
 def test_load_context_uses_canonical_phone_number_for_user_imessage(monkeypatch):
+    pool = _FakePool(
+        {
+            "id": "user-1",
+            "omi_uid": "canonical-uid",
+            "guardian_mode": "off",
+            "email": "user@example.test",
+            "phone_number": "+15550000001",
+            "identities": {},
+        }
+    )
     monkeypatch.setattr(
         escalations,
         "_pool",
-        _FakePool(
-            {
-                "id": "user-1",
-                "omi_uid": "canonical-uid",
-                "guardian_mode": "off",
-                "email": "user@example.test",
-                "phone_number": "+15550000001",
-                "identities": {},
-            }
-        ),
+        pool,
     )
 
     user, caregivers = asyncio.run(escalations._load_context("canonical-uid"))
@@ -132,6 +135,9 @@ def test_load_context_uses_canonical_phone_number_for_user_imessage(monkeypatch)
         "enabled": True,
         "reason": "Phone number on file",
     }
+    assert pool.fetchrow_queries[0][1] == ("canonical-uid",)
+    assert "WHERE omi_uid = $1" in pool.fetchrow_queries[0][0]
+    assert "lower(omi_uid)" not in pool.fetchrow_queries[0][0].lower()
 
 
 def test_load_context_allows_identities_phone_override(monkeypatch):

--- a/backend/tests/unit/test_ella_guardian_delivery.py
+++ b/backend/tests/unit/test_ella_guardian_delivery.py
@@ -14,6 +14,12 @@ from utils.ella import exact_firebase_auth
 sys.modules.setdefault("asyncpg", types.SimpleNamespace(Pool=object, Connection=object, create_pool=None))
 sys.modules.setdefault("python_multipart", types.SimpleNamespace(__version__="0.0.20"))
 
+
+@pytest.fixture(autouse=True)
+def _configured_guardian_service_key(monkeypatch):
+    monkeypatch.setattr(guardian, "GUARDIAN_WEBHOOK_KEY", "configured-guardian-service-key")
+
+
 _BACKEND = Path(__file__).resolve().parents[2]
 _POLICY_PATH = _BACKEND / "ella" / "services" / "escalation_policy.py"
 _POLICY_SPEC = importlib.util.spec_from_file_location("ella.services.escalation_policy", _POLICY_PATH)
@@ -409,14 +415,24 @@ def test_wake_word_row_matches_fallback_variants():
     assert guardian._is_wake_word_row({"trigger_type": "wake_word_fallback", "metadata": {}})
 
 
-def test_trace_log_allows_missing_key_but_rejects_bad_key(monkeypatch):
+def test_trace_log_requires_configured_key_and_rejects_bad_key(monkeypatch):
     pool = _FakePool()
     monkeypatch.setattr(guardian, "_pool", pool)
+
+    with pytest.raises(HTTPException) as missing:
+        asyncio.run(
+            guardian.log_pipeline_event(
+                guardian.TraceLogRequest(trace_id="trace-1", uid="uid-1", stage="scanner_classified"),
+                x_guardian_key=None,
+                key=None,
+            )
+        )
+    assert missing.value.status_code == 403
 
     ok = asyncio.run(
         guardian.log_pipeline_event(
             guardian.TraceLogRequest(trace_id="trace-1", uid="uid-1", stage="scanner_classified"),
-            x_guardian_key=None,
+            x_guardian_key=guardian.GUARDIAN_WEBHOOK_KEY,
             key=None,
         )
     )
@@ -548,7 +564,7 @@ def test_guardian_alerts_endpoint_excludes_ack_only_rows_but_keeps_real_wake_wor
 
     app = FastAPI()
     app.include_router(guardian.alerts_router)
-    app.dependency_overrides[guardian.auth.get_current_user_uid] = lambda: "auth-uid"
+    app.dependency_overrides[guardian.get_guardian_authenticated_uid] = lambda: "auth-uid"
 
     response = TestClient(app).get("/v1/ella/guardian-alerts?limit=50")
 
@@ -581,7 +597,7 @@ def test_guardian_alerts_endpoint_uses_authenticated_uid_not_query_uid(monkeypat
 
     app = FastAPI()
     app.include_router(guardian.alerts_router)
-    app.dependency_overrides[guardian.auth.get_current_user_uid] = lambda: "auth-uid"
+    app.dependency_overrides[guardian.get_guardian_authenticated_uid] = lambda: "auth-uid"
     client = TestClient(app)
 
     response = client.get("/v1/ella/guardian-alerts?limit=50&uid=other-user")
@@ -756,6 +772,9 @@ class _GuardianRoutePool:
     def __init__(self, mode=None):
         self.mode = mode
         self.fetchrow_calls = []
+        self.fetch_calls = []
+        self.fetchval_calls = []
+        self.execute_calls = []
         self.guardian_mode_updates = []
 
     async def fetchrow(self, query, *args):
@@ -773,6 +792,34 @@ class _GuardianRoutePool:
                 "created_at": datetime(2026, 8, 2, tzinfo=timezone.utc),
             }
         return {"guardian_mode": self.mode}
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append((query, args))
+        if "guardian_pipeline_events" in query and "trace_id = $1 AND uid = $2" in query:
+            now = datetime(2026, 8, 3, tzinfo=timezone.utc)
+            return [
+                {
+                    "stage": "scanner_classified",
+                    "status": "success",
+                    "latency_ms": 4,
+                    "metadata": {},
+                    "created_at": now,
+                    "uid": args[1],
+                }
+            ]
+        return []
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append((query, args))
+        return 0
+
+    async def execute(self, query, *args):
+        self.execute_calls.append((query, args))
+        return "OK"
+
+    @property
+    def call_count(self):
+        return len(self.fetchrow_calls) + len(self.fetch_calls) + len(self.fetchval_calls) + len(self.execute_calls)
 
 
 class _GuardianRepository:
@@ -815,6 +862,161 @@ def test_guardian_next_audio_uses_authenticated_owner_only(monkeypatch):
     assert accepted.json()["id"] == "queue-a"
     assert len(pool.fetchrow_calls) == 2
     assert all(args == ("uid-a",) for _, args in pool.fetchrow_calls)
+
+
+def test_guardian_native_owner_routes_derive_subject_without_caller_uid(monkeypatch):
+    pool = _GuardianRoutePool()
+    client = _guardian_route_client(monkeypatch, pool)
+    headers = {"Authorization": "Bearer valid-a"}
+
+    next_audio = client.get("/v1/ella/guardian/next-audio", headers=headers)
+    playback = client.post(
+        "/v1/ella/guardian/playback-event",
+        headers=headers,
+        json={"event_type": "started", "port_type": "Speaker", "trace_id": "trace-a"},
+    )
+    playback_debug = client.post(
+        "/v1/ella/guardian/playback-debug",
+        headers=headers,
+        json={"event_name": "received", "trace_id": "trace-a"},
+    )
+    queue = client.get("/v1/ella/guardian/queue", headers=headers)
+    activate = client.post("/v1/ella/guardian/activate", headers=headers, json={})
+    trace = client.get("/v1/ella/guardian/trace/trace-a", headers=headers)
+
+    assert [response.status_code for response in (next_audio, playback, playback_debug, queue, activate, trace)] == [
+        200,
+        200,
+        200,
+        200,
+        200,
+        200,
+    ]
+    assert guardian._playback_events["uid-a"]["trace_id"] == "trace-a"
+    assert queue.json()["uid"] == "uid-a"
+    assert activate.json()["uid"] == "uid-a"
+    assert trace.json()["uid"] == "uid-a"
+    assert any(args == ("trace-a", "uid-a") for _, args in pool.fetch_calls)
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "body"),
+    [
+        ("GET", "/v1/ella/guardian/queue?uid=uid-b", None),
+        ("POST", "/v1/ella/guardian/activate", {"uid": "uid-b"}),
+        ("GET", "/v1/ella/guardian/trace/trace-a?uid=uid-b", None),
+        ("POST", "/v1/ella/guardian/playback-event", {"uid": "uid-b", "port_type": "Speaker"}),
+        (
+            "POST",
+            "/v1/ella/guardian/playback-debug",
+            {"uid": "uid-b", "event_name": "received", "trace_id": "trace-a"},
+        ),
+    ],
+)
+def test_guardian_owner_routes_reject_missing_malformed_and_cross_user_before_state(
+    monkeypatch,
+    method,
+    path,
+    body,
+):
+    for headers, expected_status in (
+        ({}, 401),
+        ({"Authorization": "Basic valid-a"}, 401),
+        ({"Authorization": "Bearer expired"}, 401),
+        ({"Authorization": "Bearer valid-a"}, 403),
+    ):
+        pool = _GuardianRoutePool()
+        client = _guardian_route_client(monkeypatch, pool)
+
+        response = client.request(method, path, headers=headers, json=body)
+
+        assert response.status_code == expected_status
+        assert pool.call_count == 0
+
+
+def test_guardian_owner_or_service_reads_enforce_service_scope_and_owner(monkeypatch):
+    pool = _GuardianRoutePool()
+    client = _guardian_route_client(monkeypatch, pool)
+    service_headers = {"X-Guardian-Key": guardian.GUARDIAN_WEBHOOK_KEY}
+
+    queue = client.get("/v1/ella/guardian/queue?uid=uid-b", headers=service_headers)
+    trace = client.get("/v1/ella/guardian/trace/trace-a?uid=uid-b", headers=service_headers)
+
+    assert queue.status_code == 200
+    assert trace.status_code == 200
+    assert queue.json()["uid"] == "uid-b"
+    assert trace.json()["uid"] == "uid-b"
+    assert any(args == ("trace-a", "uid-b") for _, args in pool.fetch_calls)
+
+    calls_after_success = pool.call_count
+    for headers in (
+        {"X-Guardian-Key": "wrong-service"},
+        {"Authorization": "Bearer valid-a", "X-Guardian-Key": "wrong-service"},
+    ):
+        assert client.get("/v1/ella/guardian/queue?uid=uid-a", headers=headers).status_code == 403
+        assert client.get("/v1/ella/guardian/trace/trace-a?uid=uid-a", headers=headers).status_code == 403
+    assert pool.call_count == calls_after_success
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "body", "files", "data"),
+    [
+        ("POST", "/v1/ella/guardian/enqueue", {"uid": "uid-a", "url": "https://audio.example/a.mp3"}, None, None),
+        ("POST", "/v1/ella/guardian/synthesize", {"uid": "uid-a", "text": "Hello"}, None, None),
+        ("POST", "/v1/ella/guardian/upload", None, {"file": ("a.mp3", b"audio", "audio/mpeg")}, {"uid": "uid-a"}),
+        ("POST", "/v1/ella/guardian/upload-json", {"uid": "uid-a", "audio_base64": "YXVkaW8="}, None, None),
+        ("GET", "/v1/ella/guardian/debug-events?uid=uid-a", None, None, None),
+        ("POST", "/v1/ella/guardian/debug-trigger", {"uid": "uid-a"}, None, None),
+        ("POST", "/v1/ella/guardian/deliver", {"uid": "uid-a"}, None, None),
+        (
+            "POST",
+            "/v1/ella/guardian/email/send",
+            {"to": "owner@example.test", "subject": "Alert", "body": "Body", "uid": "uid-a"},
+            None,
+            None,
+        ),
+        ("POST", "/v1/ella/guardian/trace/log", {"trace_id": "trace-a", "uid": "uid-a", "stage": "scan"}, None, None),
+    ],
+)
+def test_guardian_service_routes_reject_missing_and_wrong_scope_before_state(
+    monkeypatch,
+    method,
+    path,
+    body,
+    files,
+    data,
+):
+    for headers in ({}, {"X-Guardian-Key": "wrong-service"}):
+        pool = _GuardianRoutePool()
+        client = _guardian_route_client(monkeypatch, pool)
+        request_kwargs = {"headers": headers}
+        if body is not None:
+            request_kwargs["json"] = body
+        if files is not None:
+            request_kwargs["files"] = files
+        if data is not None:
+            request_kwargs["data"] = data
+
+        response = client.request(method, path, **request_kwargs)
+
+        assert response.status_code == 403
+        assert pool.call_count == 0
+
+
+def test_guardian_trace_log_accepts_only_configured_trace_service_key(monkeypatch):
+    pool = _GuardianRoutePool()
+    client = _guardian_route_client(monkeypatch, pool)
+    payload = {"trace_id": "trace-a", "uid": "uid-a", "stage": "scanner_classified"}
+
+    accepted = client.post(
+        "/v1/ella/guardian/trace/log",
+        headers={"X-Guardian-Key": guardian.GUARDIAN_WEBHOOK_KEY},
+        json=payload,
+    )
+
+    assert accepted.status_code == 200
+    assert accepted.json()["logged"] is True
+    assert pool.execute_calls
 
 
 def test_guardian_mode_read_and_write_use_authenticated_owner_only(monkeypatch):

--- a/backend/tests/unit/test_ella_guardian_delivery.py
+++ b/backend/tests/unit/test_ella_guardian_delivery.py
@@ -9,7 +9,9 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
-sys.modules.setdefault("asyncpg", types.SimpleNamespace(Pool=object, create_pool=None))
+from utils.ella import exact_firebase_auth
+
+sys.modules.setdefault("asyncpg", types.SimpleNamespace(Pool=object, Connection=object, create_pool=None))
 sys.modules.setdefault("python_multipart", types.SimpleNamespace(__version__="0.0.20"))
 
 _BACKEND = Path(__file__).resolve().parents[2]
@@ -748,3 +750,127 @@ def test_guardian_cloud_target_revoked_at_provider_boundary_blocks_send(monkeypa
     assert error.value.code == "runtime_admission_revoked"
     assert CloudClient.provider_posts == 0
     assert _FakeAsyncClient.posts == []
+
+
+class _GuardianRoutePool:
+    def __init__(self, mode=None):
+        self.mode = mode
+        self.fetchrow_calls = []
+        self.guardian_mode_updates = []
+
+    async def fetchrow(self, query, *args):
+        self.fetchrow_calls.append((query, args))
+        if "COUNT(*) FILTER" in query:
+            return {"pending": 0}
+        if "UPDATE guardian_queue" in query:
+            return {
+                "id": "queue-a",
+                "url": "https://audio.example/a.mp3",
+                "priority": "normal",
+                "message": "",
+                "trigger_type": "guardian",
+                "metadata": {"trace_id": "trace-a"},
+                "created_at": datetime(2026, 8, 2, tzinfo=timezone.utc),
+            }
+        return {"guardian_mode": self.mode}
+
+
+class _GuardianRepository:
+    def __init__(self, pool):
+        self.pool = pool
+
+    async def update_guardian_mode(self, uid, guardian_mode):
+        self.pool.guardian_mode_updates.append((uid, guardian_mode))
+        self.pool.mode = guardian_mode
+        return guardian_mode
+
+
+def _guardian_route_client(monkeypatch, pool):
+    monkeypatch.setattr(guardian, "_pool", pool)
+    monkeypatch.setattr(guardian, "EllaProvisioningRepository", _GuardianRepository)
+
+    def verify_token(token):
+        if token == "valid-a":
+            return {"uid": "uid-a"}
+        if token == "valid-b":
+            return {"uid": "uid-b"}
+        raise ValueError("expired or invalid")
+
+    monkeypatch.setattr(exact_firebase_auth.firebase_auth, "verify_id_token", verify_token)
+    app = FastAPI()
+    app.include_router(guardian.router)
+    return TestClient(app)
+
+
+def test_guardian_next_audio_uses_authenticated_owner_only(monkeypatch):
+    pool = _GuardianRoutePool()
+    client = _guardian_route_client(monkeypatch, pool)
+
+    accepted = client.get(
+        "/v1/ella/guardian/next-audio?uid=uid-a",
+        headers={"Authorization": "Bearer valid-a"},
+    )
+
+    assert accepted.status_code == 200
+    assert accepted.json()["id"] == "queue-a"
+    assert len(pool.fetchrow_calls) == 2
+    assert all(args == ("uid-a",) for _, args in pool.fetchrow_calls)
+
+
+def test_guardian_mode_read_and_write_use_authenticated_owner_only(monkeypatch):
+    pool = _GuardianRoutePool()
+    client = _guardian_route_client(monkeypatch, pool)
+
+    read_response = client.get(
+        "/v1/ella/guardian/mode",
+        headers={"Authorization": "Bearer valid-a"},
+    )
+    write_response = client.put(
+        "/v1/ella/guardian/mode",
+        headers={"Authorization": "Bearer valid-a"},
+        json={"override": None, "features": ["ACTIVE_SUPPORT"]},
+    )
+
+    assert read_response.status_code == 200
+    assert read_response.json()["currentMode"] == "OFF"
+    assert write_response.status_code == 200
+    assert write_response.json()["currentMode"] == "ACTIVE_SUPPORT"
+    assert pool.fetchrow_calls[0][1] == ("uid-a",)
+    assert pool.guardian_mode_updates == [("uid-a", "ACTIVE_SUPPORT")]
+
+
+@pytest.mark.parametrize("authorization", [None, "Bearer expired", "Basic valid-a"])
+def test_guardian_mode_auth_denials_happen_before_database_work(monkeypatch, authorization):
+    pool = _GuardianRoutePool()
+    client = _guardian_route_client(monkeypatch, pool)
+    headers = {"Authorization": authorization} if authorization else {}
+
+    mode_read = client.get("/v1/ella/guardian/mode", headers=headers)
+    mode_write = client.put(
+        "/v1/ella/guardian/mode",
+        headers=headers,
+        json={"override": None, "features": ["ACTIVE_SUPPORT"]},
+    )
+
+    assert mode_read.status_code == 401
+    assert mode_write.status_code == 401
+    assert pool.fetchrow_calls == []
+
+
+@pytest.mark.parametrize(
+    ("headers", "expected_status"),
+    [
+        ({}, 401),
+        ({"Authorization": "Bearer expired"}, 401),
+        ({"Authorization": "Basic valid-a"}, 401),
+        ({"Authorization": "Bearer valid-b"}, 403),
+    ],
+)
+def test_guardian_next_audio_auth_denials_happen_before_database_work(monkeypatch, headers, expected_status):
+    pool = _GuardianRoutePool()
+    client = _guardian_route_client(monkeypatch, pool)
+
+    next_audio = client.get("/v1/ella/guardian/next-audio?uid=uid-a", headers=headers)
+
+    assert next_audio.status_code == expected_status
+    assert pool.fetchrow_calls == []

--- a/backend/tests/unit/test_ella_guardian_delivery.py
+++ b/backend/tests/unit/test_ella_guardian_delivery.py
@@ -508,6 +508,8 @@ def test_guardian_alert_history_normalizes_queue_event_delivery_rows(monkeypatch
     assert alert["test"] is True
     assert alert["created_time"]["timezone"] == "America/Los_Angeles"
     assert pool.fetch_args[0] == ("uid-1", 50)
+    assert pool.fetch_query.count("WHERE uid = $1") == 3
+    assert "lower(uid)" not in pool.fetch_query.lower()
     assert "COALESCE(trigger_type, '') <> 'wake_word_ack'" in pool.fetch_query
     assert "COALESCE(metadata->>'ack_only', '') <> 'true'" in pool.fetch_query
 

--- a/backend/tests/unit/test_ella_reviewed_route_integration.py
+++ b/backend/tests/unit/test_ella_reviewed_route_integration.py
@@ -1,7 +1,9 @@
 """Mounted contract tests for the reviewed Ella route integration."""
 
+import asyncio
 import ast
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
@@ -47,7 +49,11 @@ def _load_resolve_router():
     runtime_errors_module = types.ModuleType("ella.services.runtime_errors")
 
     class ProvisioningError(Exception):
-        pass
+        def __init__(self, code, *, retryable=False, detail=None):
+            super().__init__(code)
+            self.code = code
+            self.retryable = retryable
+            self.detail = detail or {}
 
     runtime_errors_module.ProvisioningError = ProvisioningError
     sys.modules.setdefault("ella", types.ModuleType("ella"))
@@ -72,6 +78,8 @@ def _resolve_client(monkeypatch, pool, *, runtime):
 
     async def resolve_runtime(uid, repository, target_mode):
         runtime_calls.append((uid, repository, target_mode))
+        if isinstance(runtime, BaseException):
+            raise runtime
         return runtime
 
     monkeypatch.setattr(resolve, "EllaProvisioningRepository", lambda active_pool: ("repository", active_pool))
@@ -157,33 +165,119 @@ def test_resolve_reports_ready_invitation_self_hosted_binding_without_legacy_wor
     assert runtime_calls == [("uid-a", ("repository", pool), "hermes-cloud-chat")]
 
 
-def test_resolve_unexpected_runtime_failure_logs_only_fixed_content_free_code(monkeypatch, caplog):
+class _HostileRuntimeError(RuntimeError):
+    def __init__(self):
+        super().__init__(
+            "endpoint=https://secret token=secret session=secret-session workspace=/secret/workspace provider_payload=SECRET"
+        )
+        self.endpoint = "https://secret"
+        self.token = "secret"
+        self.session = "secret-session"
+        self.workspace = "/secret/workspace"
+        self.provider_payload = {"private": "SECRET"}
+
+
+def _assert_runtime_material_absent(value):
+    serialized = str(value)
+    for forbidden in (
+        "https://secret",
+        "token=secret",
+        "secret-session",
+        "/secret/workspace",
+        "provider_payload",
+        "SECRET",
+    ):
+        assert forbidden not in serialized
+
+
+def test_resolve_unexpected_runtime_failure_logs_fixed_content_free_classification(monkeypatch, caplog):
     pool = _ResolvePool()
-    client, _runtime_calls = _resolve_client(monkeypatch, pool, runtime=None)
-    endpoint_marker = "https://private-runtime.example/internal"
-    token_marker = "runtime-token-marker"
+    client, runtime_calls = _resolve_client(monkeypatch, pool, runtime=_HostileRuntimeError())
 
-    async def fail_with_runtime_material(*_args, **_kwargs):
-        raise RuntimeError(f"endpoint={endpoint_marker} token={token_marker}")
-
-    monkeypatch.setattr(resolve, "resolve_isolated_runtime", fail_with_runtime_material)
-
-    with caplog.at_level("ERROR"):
+    with caplog.at_level("ERROR", logger=resolve.__name__):
         response = client.get(
-            "/v1/ella/resolve?uid=uid-a",
+            "/v1/ella/resolve",
             headers={"Authorization": "Bearer valid-a"},
         )
 
     assert response.status_code == 200
-    assert response.json()["routing"] == {
-        "available": False,
-        "clusterStatus": None,
-        "platform": None,
+    assert response.json() == {
+        "user": {"omiUid": "uid-a", "status": "active"},
+        "routing": {"available": False, "clusterStatus": None, "platform": None},
     }
-    assert "code=unexpected_runtime_authority_error" in caplog.text
-    assert endpoint_marker not in caplog.text
-    assert token_marker not in caplog.text
-    assert "RuntimeError" not in caplog.text
+    assert runtime_calls == [("uid-a", ("repository", pool), "hermes-cloud-chat")]
+    assert [record.getMessage() for record in caplog.records] == [
+        "code=ella_resolve_runtime_authority_error classification=unexpected"
+    ]
+    assert all(record.exc_info is None and record.stack_info is None for record in caplog.records)
+    _assert_runtime_material_absent(caplog.text)
+    _assert_runtime_material_absent(response.text)
+
+
+def test_resolve_expected_provisioning_failure_logs_fixed_content_free_classification(monkeypatch, caplog):
+    pool = _ResolvePool()
+    hostile_code = "runtime_missing endpoint=https://secret token=secret"
+    error = resolve.ProvisioningError(
+        hostile_code,
+        retryable=True,
+        detail={"session": "secret-session", "workspace": "/secret/workspace"},
+    )
+    client, _runtime_calls = _resolve_client(monkeypatch, pool, runtime=error)
+
+    with caplog.at_level("INFO", logger=resolve.__name__):
+        response = client.get(
+            "/v1/ella/resolve",
+            headers={"Authorization": "Bearer valid-a"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["routing"] == {"available": False, "clusterStatus": None, "platform": None}
+    assert [record.getMessage() for record in caplog.records] == [
+        "code=ella_resolve_runtime_unavailable classification=provisioning"
+    ]
+    assert all(record.exc_info is None and record.stack_info is None for record in caplog.records)
+    _assert_runtime_material_absent(caplog.text)
+    _assert_runtime_material_absent(response.text)
+
+
+def test_legacy_history_proxy_unexpected_failure_logs_no_runtime_material(monkeypatch, caplog):
+    async def no_runtime(*_args, **_kwargs):
+        return None
+
+    async def owned_routing(uid):
+        assert uid == "uid-a"
+        return {"routing": {"agentId": "agent-a"}}
+
+    class HostileAsyncClient:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def get(self, *_args, **_kwargs):
+            raise _HostileRuntimeError()
+
+    monkeypatch.setattr(resolve, "_pool", _ResolvePool())
+    monkeypatch.setattr(resolve, "EllaProvisioningRepository", lambda pool: ("repository", pool))
+    monkeypatch.setattr(resolve, "resolve_isolated_runtime", no_runtime)
+    monkeypatch.setattr(resolve, "resolve_user_routing", owned_routing)
+    monkeypatch.setattr(resolve.httpx, "AsyncClient", HostileAsyncClient)
+
+    with caplog.at_level("ERROR", logger=resolve.__name__):
+        response = asyncio.run(resolve.proxy_chat_history("agent-a", authenticated_uid="uid-a"))
+
+    assert response.status_code == 502
+    assert json.loads(response.body) == {"error": "provision_unreachable"}
+    assert [record.getMessage() for record in caplog.records] == [
+        "code=ella_legacy_history_proxy_unavailable classification=unexpected"
+    ]
+    assert all(record.exc_info is None and record.stack_info is None for record in caplog.records)
+    _assert_runtime_material_absent(caplog.text)
+    _assert_runtime_material_absent(response.body)
 
 
 def _load_delete_account_route():

--- a/backend/tests/unit/test_ella_reviewed_route_integration.py
+++ b/backend/tests/unit/test_ella_reviewed_route_integration.py
@@ -157,6 +157,35 @@ def test_resolve_reports_ready_invitation_self_hosted_binding_without_legacy_wor
     assert runtime_calls == [("uid-a", ("repository", pool), "hermes-cloud-chat")]
 
 
+def test_resolve_unexpected_runtime_failure_logs_only_fixed_content_free_code(monkeypatch, caplog):
+    pool = _ResolvePool()
+    client, _runtime_calls = _resolve_client(monkeypatch, pool, runtime=None)
+    endpoint_marker = "https://private-runtime.example/internal"
+    token_marker = "runtime-token-marker"
+
+    async def fail_with_runtime_material(*_args, **_kwargs):
+        raise RuntimeError(f"endpoint={endpoint_marker} token={token_marker}")
+
+    monkeypatch.setattr(resolve, "resolve_isolated_runtime", fail_with_runtime_material)
+
+    with caplog.at_level("ERROR"):
+        response = client.get(
+            "/v1/ella/resolve?uid=uid-a",
+            headers={"Authorization": "Bearer valid-a"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["routing"] == {
+        "available": False,
+        "clusterStatus": None,
+        "platform": None,
+    }
+    assert "code=unexpected_runtime_authority_error" in caplog.text
+    assert endpoint_marker not in caplog.text
+    assert token_marker not in caplog.text
+    assert "RuntimeError" not in caplog.text
+
+
 def _load_delete_account_route():
     source = (_BACKEND / "routers" / "users.py").read_text(encoding="utf-8")
     tree = ast.parse(source)

--- a/backend/tests/unit/test_ella_reviewed_route_integration.py
+++ b/backend/tests/unit/test_ella_reviewed_route_integration.py
@@ -5,6 +5,7 @@ import importlib.util
 import sys
 import types
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 from fastapi import Depends, FastAPI, HTTPException
@@ -16,8 +17,7 @@ _BACKEND = Path(__file__).resolve().parents[2]
 
 
 class _ResolvePool:
-    def __init__(self, *, workspace="/profiles/uid-a/workspace"):
-        self.workspace = workspace
+    def __init__(self):
         self.fetchrow_calls = []
 
     async def fetchrow(self, _query, *args):
@@ -25,12 +25,6 @@ class _ResolvePool:
         return {
             "omi_uid": "uid-a",
             "status": "active",
-            "agents": {
-                "userAgentId": "private-agent",
-                "gatewayToken": "private-routing-value",
-                "workspace": self.workspace,
-            },
-            "cluster_status": "ready",
         }
 
 
@@ -50,8 +44,15 @@ def _load_resolve_router():
         return None
 
     runtime_module.resolve_isolated_runtime = resolve_isolated_runtime
+    runtime_errors_module = types.ModuleType("ella.services.runtime_errors")
+
+    class ProvisioningError(Exception):
+        pass
+
+    runtime_errors_module.ProvisioningError = ProvisioningError
     sys.modules.setdefault("ella", types.ModuleType("ella"))
     sys.modules.setdefault("ella.services", types.ModuleType("ella.services"))
+    sys.modules.setdefault("ella.services.runtime_errors", runtime_errors_module)
     sys.modules.setdefault("ella.services.runtime_resolver", runtime_module)
 
     path = _BACKEND / "ella" / "routers" / "resolve.py"
@@ -65,8 +66,16 @@ def _load_resolve_router():
 resolve = _load_resolve_router()
 
 
-def _resolve_client(monkeypatch, pool):
+def _resolve_client(monkeypatch, pool, *, runtime):
     monkeypatch.setattr(resolve, "_pool", pool)
+    runtime_calls = []
+
+    async def resolve_runtime(uid, repository, target_mode):
+        runtime_calls.append((uid, repository, target_mode))
+        return runtime
+
+    monkeypatch.setattr(resolve, "EllaProvisioningRepository", lambda active_pool: ("repository", active_pool))
+    monkeypatch.setattr(resolve, "resolve_isolated_runtime", resolve_runtime)
 
     def verify_token(token):
         if token == "valid-a":
@@ -76,12 +85,13 @@ def _resolve_client(monkeypatch, pool):
     monkeypatch.setattr(exact_firebase_auth.firebase_auth, "verify_id_token", verify_token)
     app = FastAPI()
     app.include_router(resolve.router)
-    return TestClient(app)
+    return TestClient(app), runtime_calls
 
 
 def test_resolve_requires_exact_owner_before_lookup_and_returns_no_private_routing(monkeypatch):
     pool = _ResolvePool()
-    client = _resolve_client(monkeypatch, pool)
+    runtime = SimpleNamespace(provider="hermes_cloud", status="active")
+    client, runtime_calls = _resolve_client(monkeypatch, pool, runtime=runtime)
 
     assert client.get("/v1/ella/resolve?uid=uid-a").status_code == 401
     assert (
@@ -100,19 +110,20 @@ def test_resolve_requires_exact_owner_before_lookup_and_returns_no_private_routi
 
     assert response.status_code == 200
     assert pool.fetchrow_calls == [("uid-a",)]
+    assert runtime_calls == [("uid-a", ("repository", pool), "hermes-cloud-chat")]
     assert response.json() == {
         "user": {"omiUid": "uid-a", "status": "active"},
-        "routing": {"available": True, "clusterStatus": "ready", "platform": "openclaw"},
+        "routing": {"available": True, "clusterStatus": "active", "platform": "hermes_cloud"},
     }
     serialized = str(response.json()).lower()
     for forbidden in ("token", "session", "agentid", "workspace", "condition", "medication", "provision"):
         assert forbidden not in serialized
 
 
-def test_resolve_missing_workspace_fails_closed_without_global_fallback(monkeypatch):
-    pool = _ResolvePool(workspace="")
+def test_resolve_retained_user_without_isolated_binding_fails_closed_without_global_fallback(monkeypatch):
+    pool = _ResolvePool()
     monkeypatch.setattr(resolve, "CHAT_PLATFORM", "hermes")
-    client = _resolve_client(monkeypatch, pool)
+    client, runtime_calls = _resolve_client(monkeypatch, pool, runtime=None)
 
     response = client.get(
         "/v1/ella/resolve?uid=uid-a",
@@ -122,9 +133,28 @@ def test_resolve_missing_workspace_fails_closed_without_global_fallback(monkeypa
     assert response.status_code == 200
     assert response.json() == {
         "user": {"omiUid": "uid-a", "status": "active"},
-        "routing": {"available": False, "clusterStatus": "ready", "platform": "hermes"},
+        "routing": {"available": False, "clusterStatus": None, "platform": None},
     }
+    assert runtime_calls == [("uid-a", ("repository", pool), "hermes-cloud-chat")]
     assert "HERMES_WORKSPACE" not in (_BACKEND / "ella" / "routers" / "resolve.py").read_text(encoding="utf-8")
+
+
+def test_resolve_reports_ready_invitation_self_hosted_binding_without_legacy_workspace(monkeypatch):
+    pool = _ResolvePool()
+    runtime = SimpleNamespace(provider="hermes", status="active")
+    client, runtime_calls = _resolve_client(monkeypatch, pool, runtime=runtime)
+
+    response = client.get(
+        "/v1/ella/resolve",
+        headers={"Authorization": "Bearer valid-a"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "user": {"omiUid": "uid-a", "status": "active"},
+        "routing": {"available": True, "clusterStatus": "active", "platform": "hermes"},
+    }
+    assert runtime_calls == [("uid-a", ("repository", pool), "hermes-cloud-chat")]
 
 
 def _load_delete_account_route():

--- a/backend/tests/unit/test_ella_reviewed_route_integration.py
+++ b/backend/tests/unit/test_ella_reviewed_route_integration.py
@@ -1,0 +1,165 @@
+"""Mounted contract tests for the reviewed Ella route integration."""
+
+import ast
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock
+
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from utils.ella import exact_firebase_auth
+
+_BACKEND = Path(__file__).resolve().parents[2]
+
+
+class _ResolvePool:
+    def __init__(self, *, workspace="/profiles/uid-a/workspace"):
+        self.workspace = workspace
+        self.fetchrow_calls = []
+
+    async def fetchrow(self, _query, *args):
+        self.fetchrow_calls.append(args)
+        return {
+            "omi_uid": "uid-a",
+            "status": "active",
+            "agents": {
+                "userAgentId": "private-agent",
+                "gatewayToken": "private-routing-value",
+                "workspace": self.workspace,
+            },
+            "cluster_status": "ready",
+        }
+
+
+def _load_resolve_router():
+    asyncpg_module = types.ModuleType("asyncpg")
+    asyncpg_module.Pool = object
+    asyncpg_module.create_pool = None
+    sys.modules.setdefault("asyncpg", asyncpg_module)
+
+    provisioning_module = types.ModuleType("database.ella_provisioning")
+    provisioning_module.EllaProvisioningRepository = object
+    sys.modules.setdefault("database.ella_provisioning", provisioning_module)
+
+    runtime_module = types.ModuleType("ella.services.runtime_resolver")
+
+    async def resolve_isolated_runtime(*_args, **_kwargs):
+        return None
+
+    runtime_module.resolve_isolated_runtime = resolve_isolated_runtime
+    sys.modules.setdefault("ella", types.ModuleType("ella"))
+    sys.modules.setdefault("ella.services", types.ModuleType("ella.services"))
+    sys.modules.setdefault("ella.services.runtime_resolver", runtime_module)
+
+    path = _BACKEND / "ella" / "routers" / "resolve.py"
+    spec = importlib.util.spec_from_file_location("ella_reviewed_resolve_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+resolve = _load_resolve_router()
+
+
+def _resolve_client(monkeypatch, pool):
+    monkeypatch.setattr(resolve, "_pool", pool)
+
+    def verify_token(token):
+        if token == "valid-a":
+            return {"uid": "uid-a"}
+        raise ValueError("expired or invalid")
+
+    monkeypatch.setattr(exact_firebase_auth.firebase_auth, "verify_id_token", verify_token)
+    app = FastAPI()
+    app.include_router(resolve.router)
+    return TestClient(app)
+
+
+def test_resolve_requires_exact_owner_before_lookup_and_returns_no_private_routing(monkeypatch):
+    pool = _ResolvePool()
+    client = _resolve_client(monkeypatch, pool)
+
+    assert client.get("/v1/ella/resolve?uid=uid-a").status_code == 401
+    assert (
+        client.get(
+            "/v1/ella/resolve?uid=uid-b",
+            headers={"Authorization": "Bearer valid-a"},
+        ).status_code
+        == 403
+    )
+    assert pool.fetchrow_calls == []
+
+    response = client.get(
+        "/v1/ella/resolve?uid=uid-a",
+        headers={"Authorization": "Bearer valid-a"},
+    )
+
+    assert response.status_code == 200
+    assert pool.fetchrow_calls == [("uid-a",)]
+    assert response.json() == {
+        "user": {"omiUid": "uid-a", "status": "active"},
+        "routing": {"available": True, "clusterStatus": "ready", "platform": "openclaw"},
+    }
+    serialized = str(response.json()).lower()
+    for forbidden in ("token", "session", "agentid", "workspace", "condition", "medication", "provision"):
+        assert forbidden not in serialized
+
+
+def test_resolve_missing_workspace_fails_closed_without_global_fallback(monkeypatch):
+    pool = _ResolvePool(workspace="")
+    monkeypatch.setattr(resolve, "CHAT_PLATFORM", "hermes")
+    client = _resolve_client(monkeypatch, pool)
+
+    response = client.get(
+        "/v1/ella/resolve?uid=uid-a",
+        headers={"Authorization": "Bearer valid-a"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "user": {"omiUid": "uid-a", "status": "active"},
+        "routing": {"available": False, "clusterStatus": "ready", "platform": "hermes"},
+    }
+    assert "HERMES_WORKSPACE" not in (_BACKEND / "ella" / "routers" / "resolve.py").read_text(encoding="utf-8")
+
+
+def _load_delete_account_route():
+    source = (_BACKEND / "routers" / "users.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    function = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "delete_account")
+    function.decorator_list = []
+    authenticated_uid = lambda: "uid-a"
+    firestore_delete = Mock()
+    firebase_delete = Mock()
+    auth = types.SimpleNamespace(get_current_user_uid=authenticated_uid, delete_account=firebase_delete)
+    namespace = {
+        "Depends": Depends,
+        "HTTPException": HTTPException,
+        "auth": auth,
+        "delete_user_data": firestore_delete,
+    }
+    exec(compile(ast.Module(body=[function], type_ignores=[]), "backend/routers/users.py", "exec"), namespace)
+    return namespace["delete_account"], firestore_delete, firebase_delete
+
+
+def test_account_deletion_declines_before_firestore_or_firebase_removal():
+    route, firestore_delete, firebase_delete = _load_delete_account_route()
+    app = FastAPI()
+    app.add_api_route("/v1/users/delete-account", route, methods=["DELETE"])
+
+    with TestClient(app) as client:
+        response = client.delete("/v1/users/delete-account")
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": {
+            "code": "account_deletion_temporarily_unavailable",
+            "message": "Account deletion is temporarily unavailable.",
+        }
+    }
+    firestore_delete.assert_not_called()
+    firebase_delete.assert_not_called()

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import sys
 from dataclasses import replace
 from types import ModuleType
@@ -303,47 +304,42 @@ def test_isolated_history_fails_closed_without_binding(monkeypatch):
 
 
 def test_public_resolver_is_authenticated_and_redacts_internal_runtime(monkeypatch):
-    async def fake_resolve(uid):
-        assert uid == "user-a"
-        return {
-            "user": {"id": "1", "omiUid": uid, "name": "A"},
-            "routing": {
-                "agentId": "hermes",
-                "gatewayUrl": "http://100.76.138.56:8701",
-                "token": "secret",
-                "profileName": "omi-user-a",
-                "bindingRevision": 3,
-                "modelPolicyVersion": "frontier-v1",
-                "voicePolicyVersion": "ella-voice-v1",
-            },
-        }
+    class Pool:
+        async def fetchrow(self, _query, uid):
+            assert uid == "user-a"
+            return {
+                "omi_uid": uid,
+                "status": "active",
+                "agents": {
+                    "userAgentId": "hermes",
+                    "gatewayToken": "secret",
+                    "workspace": "/private/user-a",
+                },
+                "cluster_status": "ready",
+            }
 
-    monkeypatch.setattr(resolve, "runtime_bindings_enabled", lambda uid=None: True)
-    monkeypatch.setattr(resolve, "resolve_user_routing", fake_resolve)
+    monkeypatch.setattr(resolve, "_pool", Pool())
+    monkeypatch.setattr(resolve, "CHAT_PLATFORM", "hermes")
 
-    result = asyncio.run(resolve.resolve_endpoint(uid="user-a", email=None, phone=None, authenticated_uid="user-a"))
+    result = asyncio.run(resolve.resolve_endpoint(uid="user-a", authenticated_uid="user-a"))
 
-    assert result["routing"] == {
-        "agentId": "hermes",
-        "historyUrl": "/v1/ella/chat/history",
-        "platform": "hermes",
-        "bindingRevision": 3,
-        "modelPolicyVersion": "frontier-v1",
-        "voicePolicyVersion": "ella-voice-v1",
+    assert result == {
+        "user": {"omiUid": "user-a", "status": "active"},
+        "routing": {"available": True, "clusterStatus": "ready", "platform": "hermes"},
     }
     assert "secret" not in str(result)
     assert "gatewayUrl" not in result["routing"]
-    assert "profileName" not in result["routing"]
+    assert "workspace" not in result["routing"]
 
 
 def test_public_resolver_rejects_cross_user_and_email_lookup():
     with pytest.raises(HTTPException) as mismatch:
-        asyncio.run(resolve.resolve_endpoint(uid="user-b", email=None, phone=None, authenticated_uid="user-a"))
+        asyncio.run(resolve.resolve_endpoint(uid="user-b", authenticated_uid="user-a"))
     assert mismatch.value.status_code == 403
 
-    with pytest.raises(HTTPException) as unsupported:
-        asyncio.run(resolve.resolve_endpoint(uid=None, email="a@example.com", phone=None, authenticated_uid="user-a"))
-    assert unsupported.value.status_code == 400
+    parameters = inspect.signature(resolve.resolve_endpoint).parameters
+    assert "email" not in parameters
+    assert "phone" not in parameters
 
 
 def test_voice_session_rejects_cross_user_before_issuing_token():

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -6,7 +6,8 @@ from types import ModuleType
 from types import SimpleNamespace
 
 import pytest
-from fastapi import HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.testclient import TestClient
 
 sys.modules.setdefault("websockets", ModuleType("websockets"))
 conversations_module = ModuleType("database.conversations")
@@ -16,6 +17,7 @@ sys.modules.setdefault("database.conversations", conversations_module)
 from ella.routers import chat, resolve, voice
 from ella.services import runtime_resolver
 from ella.services.provisioning import ProvisioningError
+from utils.ella import exact_firebase_auth
 
 RUNTIME_AUTHORITY_DIGEST = "a" * 64
 
@@ -207,6 +209,94 @@ def test_chat_history_rejects_query_uid_that_differs_from_firebase_subject():
     assert error.value.status_code == 403
 
 
+def test_mounted_chat_history_authenticates_before_runtime_or_history_work(monkeypatch):
+    downstream_calls = []
+
+    def verify_token(token):
+        if token == "valid-a":
+            return {"uid": "user-a"}
+        raise ValueError("expired or invalid")
+
+    async def authority_enabled(uid):
+        downstream_calls.append(("authority", uid))
+        return True
+
+    async def runtime(uid, **_kwargs):
+        downstream_calls.append(("runtime", uid))
+        return SimpleNamespace(provider="hermes_cloud")
+
+    async def no_events(uid, *, limit, before=None):
+        downstream_calls.append(("history", uid, limit, before))
+        return []
+
+    monkeypatch.setattr(exact_firebase_auth.firebase_auth, "verify_id_token", verify_token)
+    monkeypatch.setattr(chat, "runtime_authority_enabled", authority_enabled)
+    monkeypatch.setattr(chat, "resolve_isolated_runtime", runtime)
+    monkeypatch.setattr(chat, "_fetch_chat_canonical_events", no_events)
+    app = FastAPI()
+    app.include_router(chat.router)
+    client = TestClient(app)
+
+    for headers in ({}, {"Authorization": "Basic valid-a"}, {"Authorization": "Bearer expired"}):
+        assert client.get("/v1/ella/chat/history", headers=headers).status_code == 401
+    assert (
+        client.get(
+            "/v1/ella/chat/history?uid=user-b",
+            headers={"Authorization": "Bearer valid-a"},
+        ).status_code
+        == 403
+    )
+    assert downstream_calls == []
+
+    response = client.get(
+        "/v1/ella/chat/history?limit=17",
+        headers={"Authorization": "Bearer valid-a"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "messages": [],
+        "hasMore": False,
+        "source": "canonical_timeline_empty",
+        "fallback": False,
+    }
+    assert downstream_calls == [
+        ("authority", "user-a"),
+        ("runtime", "user-a"),
+        ("history", "user-a", 17, None),
+    ]
+
+    async def valid_events(uid, *, limit, before=None):
+        downstream_calls.append(("valid-history", uid, limit, before))
+        return [
+            {
+                "uid": uid,
+                "event_id": "history-a",
+                "channel": "ios_chat",
+                "provider": "omi-backend",
+                "role": "assistant",
+                "text": "A valid first-party history turn.",
+                "started_at": "2026-08-03T12:00:00+00:00",
+                "metadata": {},
+            }
+        ]
+
+    monkeypatch.setattr(chat, "_fetch_chat_canonical_events", valid_events)
+    valid = client.get(
+        "/v1/ella/chat/history?limit=5",
+        headers={"Authorization": "Bearer valid-a"},
+    )
+
+    assert valid.status_code == 200
+    assert valid.json()["source"] == "canonical_timeline"
+    assert valid.json()["messages"][0]["text"] == "A valid first-party history turn."
+    assert downstream_calls[-3:] == [
+        ("authority", "user-a"),
+        ("runtime", "user-a"),
+        ("valid-history", "user-a", 5, None),
+    ]
+
+
 def test_isolated_history_never_uses_openclaw_fallback(monkeypatch):
     async def fake_runtime(uid, **kwargs):
         assert uid == "user-a"
@@ -320,13 +410,21 @@ def test_public_resolver_is_authenticated_and_redacts_internal_runtime(monkeypat
 
     monkeypatch.setattr(resolve, "_pool", Pool())
     monkeypatch.setattr(resolve, "CHAT_PLATFORM", "hermes")
+    runtime_calls = []
+
+    async def active_runtime(uid, repository, target_mode):
+        runtime_calls.append((uid, repository.pool, target_mode))
+        return SimpleNamespace(provider="hermes", status="active")
+
+    monkeypatch.setattr(resolve, "resolve_isolated_runtime", active_runtime)
 
     result = asyncio.run(resolve.resolve_endpoint(uid="user-a", authenticated_uid="user-a"))
 
     assert result == {
         "user": {"omiUid": "user-a", "status": "active"},
-        "routing": {"available": True, "clusterStatus": "ready", "platform": "hermes"},
+        "routing": {"available": True, "clusterStatus": "active", "platform": "hermes"},
     }
+    assert runtime_calls == [("user-a", resolve._pool, "hermes-cloud-chat")]
     assert "secret" not in str(result)
     assert "gatewayUrl" not in result["routing"]
     assert "workspace" not in result["routing"]

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -349,6 +349,76 @@ def test_cloud_history_never_uses_openclaw_fallback(monkeypatch):
     }
 
 
+def test_legacy_history_unexpected_failure_logs_fixed_content_free_classification(monkeypatch, caplog):
+    class HostileHistoryError(RuntimeError):
+        def __init__(self):
+            super().__init__(
+                "endpoint=https://secret token=secret session=secret-session workspace=/secret/workspace "
+                "provider_payload=SECRET"
+            )
+            self.endpoint = "https://secret"
+            self.token = "secret"
+            self.session = "secret-session"
+            self.workspace = "/secret/workspace"
+            self.provider_payload = {"private": "SECRET"}
+
+    class HostileAsyncClient:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def get(self, *_args, **_kwargs):
+            raise HostileHistoryError()
+
+    async def authority_disabled(uid):
+        assert uid == "user-a"
+        return False
+
+    async def no_events(uid, *, limit, before=None):
+        assert uid == "user-a"
+        return []
+
+    async def owned_legacy_routing(uid):
+        assert uid == "user-a"
+        return {"routing": {"agentId": "ella-user-a", "workspace": "/legacy/user-a"}}
+
+    monkeypatch.setattr(chat, "runtime_authority_enabled", authority_disabled)
+    monkeypatch.setattr(chat, "_fetch_chat_canonical_events", no_events)
+    monkeypatch.setattr(chat, "resolve_user_routing", owned_legacy_routing)
+    monkeypatch.setattr(chat.httpx, "AsyncClient", HostileAsyncClient)
+
+    with caplog.at_level("ERROR", logger=chat.__name__):
+        result = asyncio.run(chat.ella_chat_history("user-a", authenticated_uid="user-a"))
+
+    assert result == {
+        "messages": [],
+        "hasMore": False,
+        "source": "provision_openclaw_history_migration",
+        "fallback": True,
+    }
+    assert len(caplog.records) == 1
+    log_message = caplog.records[0].getMessage()
+    log_prefix = "[FLOW:HISTORY] code=ella_legacy_history_unavailable classification=unexpected latency="
+    assert log_message.startswith(log_prefix) and log_message.endswith("ms")
+    assert int(log_message.removeprefix(log_prefix).removesuffix("ms")) >= 0
+    assert all(record.exc_info is None and record.stack_info is None for record in caplog.records)
+    serialized = f"{caplog.text} {result}"
+    for forbidden in (
+        "https://secret",
+        "token=secret",
+        "secret-session",
+        "/secret/workspace",
+        "provider_payload",
+        "SECRET",
+    ):
+        assert forbidden not in serialized
+
+
 def test_isolated_history_fails_closed_without_binding(monkeypatch):
     async def missing_runtime(uid, **kwargs):
         raise ProvisioningError("hermes_not_provisioned", retryable=True)

--- a/backend/tests/unit/test_ella_scanner_batching.py
+++ b/backend/tests/unit/test_ella_scanner_batching.py
@@ -20,6 +20,33 @@ def teardown_function():
     scanner.reset_scanner_batch_state()
 
 
+def test_guardian_trace_service_caller_uses_scoped_key(monkeypatch):
+    posts = []
+
+    def fake_post(url, **kwargs):
+        posts.append((url, kwargs))
+        return _FakeResponse(200)
+
+    monkeypatch.setattr(scanner, "GUARDIAN_WEBHOOK_KEY", "configured-guardian-service-key")
+    monkeypatch.setattr(scanner.requests, "post", fake_post)
+
+    scanner._log_trace_event("trace-a", "uid-a", "scanner_dispatched", "success")
+
+    assert len(posts) == 1
+    assert posts[0][0] == scanner.GUARDIAN_TRACE_LOG_URL
+    assert posts[0][1]["headers"] == {"X-Guardian-Key": "configured-guardian-service-key"}
+
+
+def test_guardian_trace_service_caller_fails_closed_without_configured_key(monkeypatch):
+    posts = []
+    monkeypatch.setattr(scanner, "GUARDIAN_WEBHOOK_KEY", "")
+    monkeypatch.setattr(scanner.requests, "post", lambda *args, **kwargs: posts.append((args, kwargs)))
+
+    scanner._log_trace_event("trace-a", "uid-a", "scanner_dispatched", "success")
+
+    assert posts == []
+
+
 def test_wake_word_bypasses_ambient_batching(monkeypatch):
     posts = []
 

--- a/backend/utils/ella/exact_firebase_auth.py
+++ b/backend/utils/ella/exact_firebase_auth.py
@@ -1,0 +1,67 @@
+"""Strict Firebase and narrowly scoped service authentication for Ella routes."""
+
+import secrets
+from dataclasses import dataclass
+from typing import Optional
+
+from fastapi import Header, HTTPException
+from firebase_admin import auth as firebase_auth
+
+
+@dataclass(frozen=True)
+class EllaRequestAuthority:
+    """Authority established before any user-scoped downstream work begins."""
+
+    firebase_uid: Optional[str] = None
+    service: Optional[str] = None
+
+    @property
+    def is_service(self) -> bool:
+        return self.service is not None
+
+    def require_uid(self, claimed_uid: Optional[str], *, feature: str) -> str:
+        normalized_claim = (claimed_uid or "").strip()
+        if self.firebase_uid is not None:
+            return require_matching_firebase_uid(self.firebase_uid, normalized_claim, feature=feature)
+        if not normalized_claim:
+            raise HTTPException(status_code=400, detail=f"{feature} UID is required")
+        return normalized_claim
+
+
+def get_exact_firebase_uid(authorization: Optional[str] = Header(None)) -> str:
+    """Return the Firebase subject without admin-key or local-dev fallbacks."""
+    parts = authorization.split() if authorization else []
+    if len(parts) != 2 or parts[0].lower() != "bearer" or not parts[1]:
+        raise HTTPException(status_code=401, detail="Missing or invalid Firebase bearer")
+    try:
+        decoded = firebase_auth.verify_id_token(parts[1])
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid or expired Firebase bearer")
+    uid = str(decoded.get("uid") or "").strip() if isinstance(decoded, dict) else ""
+    if not uid:
+        raise HTTPException(status_code=401, detail="Invalid Firebase bearer subject")
+    return uid
+
+
+def require_matching_firebase_uid(authenticated_uid: str, claimed_uid: Optional[str], *, feature: str) -> str:
+    """Reject a caller-supplied subject that differs from the verified token."""
+    normalized_claim = (claimed_uid or "").strip()
+    if normalized_claim and normalized_claim != authenticated_uid:
+        raise HTTPException(status_code=403, detail=f"{feature} UID does not match authenticated user")
+    return authenticated_uid
+
+
+def get_firebase_or_service_authority(
+    *,
+    authorization: Optional[str],
+    provided_service_key: Optional[str],
+    configured_service_key: Optional[str],
+    service: str,
+) -> EllaRequestAuthority:
+    """Authenticate either an exact Firebase bearer or one named service."""
+    if provided_service_key is not None:
+        configured = configured_service_key or ""
+        if not configured or not provided_service_key or not secrets.compare_digest(provided_service_key, configured):
+            raise HTTPException(status_code=403, detail=f"Invalid {service} service credential")
+        return EllaRequestAuthority(service=service)
+    return EllaRequestAuthority(firebase_uid=get_exact_firebase_uid(authorization))

--- a/backend/utils/ella/scanner.py
+++ b/backend/utils/ella/scanner.py
@@ -27,7 +27,7 @@ ELLA_POSTGRES_USER = os.getenv("ELLA_POSTGRES_USER", "postgres")
 ELLA_POSTGRES_PASSWORD = os.getenv("ELLA_POSTGRES_PASSWORD", "postgres")
 ELLA_POSTGRES_DATABASE = os.getenv("ELLA_POSTGRES_DATABASE", "ella_ai")
 GUARDIAN_ENQUEUE_URL = os.getenv("ELLA_GUARDIAN_ENQUEUE_URL", "http://127.0.0.1:8000/v1/ella/guardian/enqueue")
-GUARDIAN_WEBHOOK_KEY = os.getenv("GUARDIAN_WEBHOOK_KEY", "4f13699d8462adf71e35d2098e6a791f")
+GUARDIAN_WEBHOOK_KEY = os.getenv("GUARDIAN_WEBHOOK_KEY", "")
 GUARDIAN_WAKE_ACK_AUDIO_URL = os.getenv(
     "ELLA_GUARDIAN_WAKE_ACK_AUDIO_URL",
     "https://ella-ai-care.com/audio/system/wake_ack_pulse.mp3",
@@ -620,6 +620,8 @@ def _log_trace_event(
     latency_ms: Optional[int] = None,
 ) -> None:
     """Best-effort trace write; scanner must never block transcription."""
+    if not GUARDIAN_WEBHOOK_KEY:
+        return
     try:
         requests.post(
             GUARDIAN_TRACE_LOG_URL,
@@ -631,6 +633,7 @@ def _log_trace_event(
                 "latency_ms": latency_ms,
                 "metadata": metadata or {},
             },
+            headers={"X-Guardian-Key": GUARDIAN_WEBHOOK_KEY},
             timeout=0.25,
         )
     except Exception:
@@ -692,6 +695,8 @@ def _enqueue_wake_ack(uid: str, conversation_id: str, trace_id: str, scanner_seg
     def _post() -> None:
         start = time.time()
         try:
+            if not GUARDIAN_WEBHOOK_KEY:
+                return
             if GUARDIAN_WAKE_ACK_DIRECT_DB:
                 result = _insert_wake_ack_direct(uid, trace_id, payload)
                 _log_trace_event(
@@ -777,7 +782,7 @@ def _insert_wake_ack_direct(uid: str, trace_id: str, payload: dict) -> dict:
         with conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT guardian_mode FROM users WHERE LOWER(omi_uid) = LOWER(%s)",
+                    "SELECT guardian_mode FROM users WHERE omi_uid = %s",
                     (uid,),
                 )
                 row = cur.fetchone()


### PR DESCRIPTION
## Scope

Ports only the reviewed backend route contracts from ellaaicare/omi#362 head `fa58df1ed74e25e4bd8f1f934e2d06a2957d66be` onto current `main` base `2dbe91e4baeae7f190730af2061b2ccc5f16eb99`:

- `GET /v1/ella/resolve`: exact Firebase bearer ownership, non-secret availability response, no email/phone lookup, and no global `plato-eval` workspace fallback.
- `GET` / `PUT /v1/ella/guardian/mode`: exact Firebase subject; the write uses the shared account/profile advisory-lock contract and re-proves ownership before updating an active user.
- `GET /v1/ella/guardian/next-audio`: exact Firebase subject and caller UID match before queue access.
- `DELETE /v1/users/delete-account`: typed `503 account_deletion_temporarily_unavailable` before any Firestore/Firebase mutation until ellaaicare/omi#364 lands.

No migrations are added or required. In particular, migration 017 remains owned by ellaaicare/omi#364 and is not included here.

Coordination: ellaaicare/ella-ai#1174.

## Validation

Exact head: `70b640e7f4d0bb5f0e007054a5f4e0b92cd3bed8`

- Hermes runtime primary gate: `490 passed`, zero skipped.
- Exact reviewed boundary collections: `701 passed`, zero skipped (`443 + 67 + 15 + 64 + 27 + 3 + 7 + 18 + 19 + 28 + 10`).
- Real PostgreSQL Guardian writer contention and owner-drift rollback included in the 67-test authority gate.
- Pinned Black 24.8 / compile / OpenAPI / YAML / `git diff --check`: pass.
- Gitleaks exact commit range: pass, no findings.

## Deliberately omitted

The broader iOS, chat, voice, scanner, service-auth, and other route changes carried by the source commits are not ported. This PR is limited to the three owner-test route behaviors and the temporary deletion guard; ellaaicare/omi#364 is unchanged.

No deploy, merge, migration, invitation issuance, or live-state mutation was performed.
