### PR TITLE
Make Invite Redemption CI fail closed

### DIFF
--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -126,6 +126,7 @@ jobs:
           "httpx==0.28.0"
           "PyJWT==2.9.0"
           "pydantic==2.8.2"
+          "python-multipart==0.0.9"
           "pytest==8.3.2"
           "websockets==12.0"
 
@@ -154,6 +155,8 @@ jobs:
 
       - name: Run unit and PostgreSQL security tests
         run: |
+          set -euo pipefail
+
           collected="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \


### PR DESCRIPTION
## Scope

Stacked CI-only repair on PR #366 exact head `c8aedae72293e781f6271f4bc3edd1f1eb499c14`. This does not implement or alter the broader security plan.

- install the pinned `python-multipart==0.0.9` dependency required by the hosted test set
- enable `set -euo pipefail` so a failing pytest process cannot be hidden by `tee`
- preserve the existing 160-test discovery, required-ID, count, and zero-skip gates unchanged

## Verification

- deliberate nonexistent pytest node through the same `pytest | tee` shape: exit `4`, proving the pipeline fails closed
- exact Invite Redemption workflow test block: `160 passed`, zero failed/skipped
- `backend/test.sh`: 11 shards / 170 tests passed, including 10 PostgreSQL tests
- workflow YAML parsed successfully; `git diff --check` clean
- Gitleaks: no leaks in the successor commit

No merge, deploy, Caddy, production, environment, database, n8n, vendor, or credential mutation was performed. Tracks `ellaaicare/ella-ai#1185`.