### PR TITLE
Secure Ella route authority and service subjects

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -529,6 +529,7 @@ jobs:
             "tests/unit/test_ella_auth_authority_contract.py::test_admin_key_suffix_cannot_mint_arbitrary_subject"
             "tests/unit/test_ella_auth_authority_contract.py::test_admin_branch_observation_is_bounded_and_content_free"
             "tests/unit/test_ella_auth_authority_contract.py::test_exact_firebase_boundary_never_accepts_admin_key"
+            "tests/unit/test_ella_auth_authority_contract.py::test_ella_lazy_exports_keep_imports_at_module_scope"
             "tests/unit/test_ella_auth_authority_contract.py::test_minimum_client_build_is_fail_closed_and_version_aware"
             "tests/unit/test_ella_auth_authority_contract.py::test_service_authority_is_constant_time_bound_to_one_subject"
             "tests/unit/test_ella_auth_authority_contract.py::test_ella_user_routes_do_not_inherit_legacy_admin_subject_auth"
@@ -553,7 +554,7 @@ jobs:
           for required_id in "${required_incident_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$incident_ids"
           done
-          test "$(grep -c '::' <<<"$incident_ids")" -eq 53
+          test "$(grep -c '::' <<<"$incident_ids")" -eq 54
           pytest \
             tests/unit/test_ella_incident_1182_route_isolation.py \
             tests/unit/test_ella_incident_1182_callback_auth.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -315,6 +315,7 @@ jobs:
         run: >-
           python -m py_compile
           database/authority_advisory_lock.py
+          database/ella_caregivers.py
           database/ella_provisioning.py
           database/honcho_attestation.py
           database/hermes_cloud_enrichment_outbox.py
@@ -327,6 +328,7 @@ jobs:
           ella/routers/auto_provision.py
           ella/routers/callbacks.py
           ella/routers/canonical_events.py
+          ella/routers/corrections.py
           ella/routers/debug_metadata.py
           ella/routers/ai_consent.py
           ella/routers/chat.py
@@ -334,10 +336,12 @@ jobs:
           ella/routers/hermes_cloud_enrichment.py
           ella/routers/guardian.py
           ella/routers/invites.py
+          ella/routers/memory_reinterpretation.py
           ella/routers/onboarding.py
           ella/routers/observer.py
           ella/routers/plato_mcp.py
           ella/routers/resolve.py
+          ella/routers/settings.py
           ella/routers/trace.py
           ella/routers/voice.py
           ella/services/ai_consent.py
@@ -367,11 +371,13 @@ jobs:
           ella/utils/provision_authority.py
           scripts/hermes_cloud_pool_admin.py
           scripts/ella_memory_e2e_smoke.py
+          scripts/ella_observer_cron.py
           scripts/hermes_cloud_enrichment_smoke.py
           scripts/hermes_product_fit_canary.py
           scripts/pilot_invite_admin.py
           scripts/hermes_cloud_shadow.py
           scripts/voice_canary_admin.py
+          utils/ella/__init__.py
           utils/ella/postprocess.py
           utils/ella/canonical_auth.py
           utils/ella/canonical_context.py
@@ -379,22 +385,26 @@ jobs:
           utils/ella/exact_firebase_auth.py
           utils/ella/scanner.py
           utils/ella/scanner_keyterms.py
+          utils/other/endpoints.py
           tests/unit/test_ella_reviewed_route_integration.py
 
       - name: Validate formatting and OpenAPI contract
         run: >-
           black --check --line-length 120 --skip-string-normalization
           database/authority_advisory_lock.py
+          database/ella_caregivers.py
           database/ella_provisioning.py database/honcho_attestation.py database/invitations.py
           database/managed_cloud_consent.py
           database/runtime_targets.py database/voice_canary.py
           routers/users.py
           ella/routers/auto_provision.py ella/routers/callbacks.py
           ella/routers/ai_consent.py ella/routers/canonical_events.py ella/routers/chat.py
+          ella/routers/corrections.py
           ella/routers/debug_metadata.py ella/routers/escalations.py
-          ella/routers/guardian.py ella/routers/invites.py
+          ella/routers/guardian.py ella/routers/hermes_cloud_enrichment.py ella/routers/invites.py
+          ella/routers/memory_reinterpretation.py ella/routers/observer.py ella/routers/photon.py
           ella/routers/onboarding.py ella/routers/plato_mcp.py ella/routers/resolve.py
-          ella/routers/trace.py
+          ella/routers/settings.py ella/routers/trace.py
           ella/services/hermes_cloud_policy.py
           ella/services/hermes_broker_client.py
           ella/services/hermes_broker_prototype.py
@@ -409,16 +419,21 @@ jobs:
           ella/services/summary_recovery.py
           ella/utils/auto_provision.py ella/utils/identity_sync.py
           ella/utils/provision_authority.py
-          utils/ella/canonical_auth.py utils/ella/canonical_context.py
+          utils/ella/__init__.py utils/ella/canonical_auth.py utils/ella/canonical_context.py
           utils/ella/canonical_omi.py utils/ella/exact_firebase_auth.py
           utils/ella/scanner.py utils/ella/scanner_keyterms.py
+          utils/other/endpoints.py
           scripts/voice_canary_admin.py
           scripts/ella_memory_e2e_smoke.py
+          scripts/ella_observer_cron.py
           scripts/hermes_product_fit_canary.py
           tests/unit/test_ella_callbacks_summary_update.py
           tests/unit/test_authority_advisory_lock.py
           tests/unit/test_authority_writer_guard.py
           tests/unit/test_ella_ai_consent.py
+          tests/unit/test_ella_all_router_authority_manifest.py
+          tests/unit/test_ella_app_settings.py
+          tests/unit/test_ella_auth_authority_contract.py
           tests/unit/test_ella_conversation_corrections.py
           tests/unit/test_ella_canonical_context.py
           tests/unit/test_ella_debug_metadata.py
@@ -439,6 +454,7 @@ jobs:
           tests/unit/test_ella_provisioning_service.py
           tests/unit/test_hermes_cloud_openapi.py
           tests/unit/test_hermes_cloud_enrichment.py
+          tests/unit/test_hermes_cloud_enrichment_router.py
           tests/unit/test_hermes_cloud_photon.py
           tests/unit/test_hermes_broker_prototype.py
           tests/unit/test_hermes_binding_envelope_contract.py
@@ -455,7 +471,7 @@ jobs:
           tests/postgres/test_runtime_migration_atomicity_postgres.py
           &&
           black --check --line-length 120 --skip-string-normalization
-          --line-ranges 900-925 --line-ranges 1555-1585
+          --line-ranges 900-925 --line-ranges 1210-1225 --line-ranges 1555-1585
           ella/routers/voice.py
           &&
           python -c "import yaml; from openapi_spec_validator import validate; validate(yaml.safe_load(open('ella/docs/hermes-cloud-runtime-targets.openapi.yaml', encoding='utf-8')))"
@@ -468,6 +484,8 @@ jobs:
               tests/unit/test_ella_incident_1182_route_isolation.py \
               tests/unit/test_ella_incident_1182_callback_auth.py \
               tests/unit/test_ella_incident_1182_voice_diagnostics_auth.py \
+              tests/unit/test_ella_auth_authority_contract.py \
+              tests/unit/test_ella_all_router_authority_manifest.py \
               tests/unit/test_ella_provisioning_service.py::test_retained_authority_inventory_mutation_sensitivity_across_all_roots_and_aliases \
               tests/unit/test_ella_provisioning_service.py::test_primary_fallback_authorities_preserve_outbound_selection_and_legacy_truthiness \
               tests/unit/test_ella_provisioning_service.py::test_authority_credential_presence_optional_none_and_redacted_separation_contract \
@@ -500,10 +518,23 @@ jobs:
             "tests/unit/test_ella_incident_1182_route_isolation.py::test_affected_background_boundaries_are_exact_and_trace_has_no_detached_task"
             "tests/unit/test_ella_incident_1182_callback_auth.py::test_emergency_contact_crud_rejects_unauthenticated_and_cross_owner_before_storage"
             "tests/unit/test_ella_incident_1182_callback_auth.py::test_emergency_contact_exact_owner_positive_control"
+            "tests/unit/test_ella_incident_1182_callback_auth.py::test_first_party_caregiver_routes_derive_owner_and_reject_caller_uid"
+            "tests/unit/test_ella_incident_1182_callback_auth.py::test_caregiver_routes_reject_unauth_admin_and_service_before_storage"
             "tests/unit/test_ella_incident_1182_callback_auth.py::test_internal_callback_service_fails_closed_and_positive_control_is_scoped"
+            "tests/unit/test_ella_incident_1182_callback_auth.py::test_callback_routes_reject_unbound_wrong_and_nonservice_authority_before_effects"
+            "tests/unit/test_ella_incident_1182_callback_auth.py::test_callback_routes_accept_only_matching_bound_subject"
             "tests/unit/test_ella_incident_1182_callback_auth.py::test_caregiver_token_generation_requires_two_distinct_configured_secrets"
             "tests/unit/test_ella_incident_1182_callback_auth.py::test_dashboard_signing_has_no_source_fallback"
             "tests/unit/test_ella_incident_1182_voice_diagnostics_auth.py::test_voice_diagnostics_require_exact_firebase_bearer"
+            "tests/unit/test_ella_auth_authority_contract.py::test_admin_key_suffix_cannot_mint_arbitrary_subject"
+            "tests/unit/test_ella_auth_authority_contract.py::test_admin_branch_observation_is_bounded_and_content_free"
+            "tests/unit/test_ella_auth_authority_contract.py::test_exact_firebase_boundary_never_accepts_admin_key"
+            "tests/unit/test_ella_auth_authority_contract.py::test_minimum_client_build_is_fail_closed_and_version_aware"
+            "tests/unit/test_ella_auth_authority_contract.py::test_service_authority_is_constant_time_bound_to_one_subject"
+            "tests/unit/test_ella_auth_authority_contract.py::test_ella_user_routes_do_not_inherit_legacy_admin_subject_auth"
+            "tests/unit/test_ella_auth_authority_contract.py::test_fifteen_fixed_capability_admin_guards_are_retained"
+            "tests/unit/test_ella_all_router_authority_manifest.py::test_all_ella_router_modules_and_routes_have_declared_authority_and_disposition"
+            "tests/unit/test_ella_all_router_authority_manifest.py::test_every_router_source_is_registered_without_disabling_conditional_routers"
             "tests/unit/test_ella_provisioning_service.py::test_retained_authority_inventory_mutation_sensitivity_across_all_roots_and_aliases"
             "tests/unit/test_ella_provisioning_service.py::test_primary_fallback_authorities_preserve_outbound_selection_and_legacy_truthiness"
             "tests/unit/test_ella_provisioning_service.py::test_authority_credential_presence_optional_none_and_redacted_separation_contract"
@@ -522,11 +553,13 @@ jobs:
           for required_id in "${required_incident_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$incident_ids"
           done
-          test "$(grep -c '::' <<<"$incident_ids")" -eq 35
+          test "$(grep -c '::' <<<"$incident_ids")" -eq 53
           pytest \
             tests/unit/test_ella_incident_1182_route_isolation.py \
             tests/unit/test_ella_incident_1182_callback_auth.py \
             tests/unit/test_ella_incident_1182_voice_diagnostics_auth.py \
+            tests/unit/test_ella_auth_authority_contract.py \
+            tests/unit/test_ella_all_router_authority_manifest.py \
             tests/unit/test_ella_provisioning_service.py::test_retained_authority_inventory_mutation_sensitivity_across_all_roots_and_aliases \
             tests/unit/test_ella_provisioning_service.py::test_primary_fallback_authorities_preserve_outbound_selection_and_legacy_truthiness \
             tests/unit/test_ella_provisioning_service.py::test_authority_credential_presence_optional_none_and_redacted_separation_contract \
@@ -635,7 +668,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 513
+          test "$collected" -eq 514
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \
@@ -734,7 +767,8 @@ jobs:
           escalation_auth_ids="$(pytest --collect-only -q tests/unit/test_ella_escalations_router_auth.py | sed '/^$/d')"
           required_escalation_auth_ids=(
             "tests/unit/test_ella_escalations_router_auth.py::test_policy_view_internal_key_reaches_load_context_for_explicit_uid"
-            "tests/unit/test_ella_escalations_router_auth.py::test_policy_view_internal_key_requires_uid_before_load_context"
+            "tests/unit/test_ella_escalations_router_auth.py::test_policy_view_internal_key_rejects_wrong_subject_before_context"
+            "tests/unit/test_ella_escalations_router_auth.py::test_policy_view_internal_key_requires_bound_subject_before_load_context"
             "tests/unit/test_ella_escalations_router_auth.py::test_policy_view_uid_uses_authenticated_uid_when_uid_omitted"
             "tests/unit/test_ella_escalations_router_auth.py::test_policy_view_uid_rejects_cross_user_read"
             "tests/unit/test_ella_escalations_router_auth.py::test_policy_view_denies_absent_empty_malformed_and_wrong_credentials_before_context"
@@ -747,7 +781,7 @@ jobs:
           for required_id in "${required_escalation_auth_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$escalation_auth_ids"
           done
-          test "$(grep -c '::' <<<"$escalation_auth_ids")" -eq 10
+          test "$(grep -c '::' <<<"$escalation_auth_ids")" -eq 11
           pytest tests/unit/test_ella_escalations_router_auth.py -v
           reviewed_route_ids="$(pytest --collect-only -q tests/unit/test_ella_reviewed_route_integration.py | sed '/^$/d')"
           required_reviewed_route_ids=(
@@ -766,7 +800,7 @@ jobs:
           pytest tests/unit/test_ella_reviewed_route_integration.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_listen_runtime_gate.py | grep -c '::')" -eq 7
           pytest tests/unit/test_ella_listen_runtime_gate.py -v
-          test "$(pytest --collect-only -q tests/unit/test_ella_observer.py | grep -c '::')" -eq 18
+          test "$(pytest --collect-only -q tests/unit/test_ella_observer.py | grep -c '::')" -eq 19
           pytest tests/unit/test_ella_observer.py -v
           test "$(pytest --collect-only -q tests/unit/test_invitation_redemption.py | grep -c '::')" -eq 19
           pytest tests/unit/test_invitation_redemption.py -v

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -16,6 +16,14 @@ SONIOX_API_KEY=
 DEEPGRAM_API_KEY=
 
 ADMIN_KEY=
+# Legacy ADMIN_KEY subject minting is disabled unless the requested subject is
+# explicitly listed here. Keep empty for ordinary user traffic.
+ELLA_ADMIN_SUBJECT_ALLOWLIST=
+# Any production marker disables LOCAL_DEVELOPMENT subject fallback.
+ELLA_PRODUCTION=false
+# Dormant until the reviewed successor build is released. Once set, exact
+# Firebase Ella requests below this numeric/dotted build return HTTP 426.
+ELLA_MIN_SUPPORTED_CLIENT_BUILD=
 OPENAI_API_KEY=
 
 # Generic OMI summary provider chain. OpenRouter remains inside the stock OMI
@@ -80,6 +88,8 @@ ELLA_HERMES_CLOUD_ENRICHMENT_URL=http://127.0.0.1:8000/v1/ella/internal/hermes-c
 ELLA_HERMES_CLOUD_ENRICHMENT_TIMEOUT=180
 ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN=
 ELLA_HERMES_CLOUD_ENRICHMENT_MAX_OUTPUT_ATTEMPTS=3
+ELLA_HERMES_CLOUD_PHOTON_SIDECAR_TOKEN=
+ELLA_HERMES_CLOUD_PHOTON_INTERNAL_OWNER_UID=
 
 # Ella isolated Hermes onboarding. Keep both flags false until the provisioning
 # schema is migrated and a synthetic two-user 8210 canary passes.
@@ -149,9 +159,18 @@ ELLA_POSTGRES_DB=ella_ai
 ELLA_EVENT_LEDGER_TOKEN=
 # Separate internal callback and caregiver-token authorities. Do not reuse
 # Firebase, Guardian, escalation, or provider credentials.
+# Every service request must also carry X-Ella-Subject-Uid matching its one
+# user-scoped body, query, or path subject.
 ELLA_CALLBACK_SERVICE_KEY=
 ELLA_CAREGIVER_SERVICE_KEY=
+GUARDIAN_WEBHOOK_KEY=
+ELLA_ESCALATION_WEBHOOK_KEY=
+ELLA_OBSERVER_ADMIN_TOKEN=
 ELLA_DASHBOARD_SECRET=
+# Existing Hermes authority name; do not introduce HERMES_GATEWAY_TOKEN as a
+# second environment variable. The model is an atomic Step 0 prerequisite.
+HERMES_API_SERVER_KEY=
+HERMES_MODEL=
 # Debug reads are exact-subject authenticated and default disabled.
 ELLA_DEBUG_ROUTES_ENABLED=false
 ELLA_DEBUG_METADATA_ENABLED=false

--- a/backend/database/ella_caregivers.py
+++ b/backend/database/ella_caregivers.py
@@ -63,3 +63,40 @@ def delete_caregiver(uid: str, caregiver_id: str) -> bool:
         return False
     ref.delete()
     return True
+
+
+def set_emergency_caregiver(uid: str, caregiver_id: str) -> Optional[str]:
+    """Select at most one caregiver as the user's emergency contact."""
+    caregivers = list(_caregivers_ref(uid).stream())
+    if caregiver_id and not any(document.id == caregiver_id for document in caregivers):
+        return None
+    batch = db.batch()
+    for document in caregivers:
+        batch.update(document.reference, {'is_emergency_contact': document.id == caregiver_id})
+    batch.commit()
+    return caregiver_id
+
+
+def get_emergency_caregiver_id(uid: str) -> Optional[str]:
+    for document in _caregivers_ref(uid).stream():
+        if document.to_dict().get('is_emergency_contact') is True:
+            return document.id
+    return None
+
+
+def refresh_caregiver_invite(uid: str, caregiver_id: str) -> Optional[dict]:
+    ref = _caregivers_ref(uid).document(caregiver_id)
+    document = ref.get()
+    if not document.exists:
+        return None
+    now = datetime.now(timezone.utc)
+    ref.update(
+        {
+            'invite_code': ''.join(secrets.choice(string.digits) for _ in range(6)),
+            'invite_expires_at': (now + timedelta(days=7)).isoformat(),
+            'invited_at': now.isoformat(),
+            'status': 'invited',
+            'updated_at': now.isoformat(),
+        }
+    )
+    return ref.get().to_dict()

--- a/backend/ella/docs/ella-auth-cutover-runbook.md
+++ b/backend/ella/docs/ella-auth-cutover-runbook.md
@@ -1,0 +1,135 @@
+# Ella Auth Cutover Runbook
+
+This runbook implements the backend portions of ella-ai issue 1185 plan v4 plus
+the v5 emergency-route correction. Source changes do not authorize a deploy or
+an edge change. Deployment requires a fresh accepting review of the exact head.
+
+## Authority And Edge Matrix
+
+The executable route inventory is
+`backend/tests/unit/test_ella_all_router_authority_manifest.py`. It declares
+every route in all current Ella router modules, including conditional Guardian
+and voice routes, observer, plato_mcp, and escalations.
+
+- Firebase exact owner: chat, onboarding, settings, resolve, invitations,
+  canonical owner events/timeline, emergency-contact and caregiver CRUD,
+  Guardian owner controls, and `POST /v1/ella/emergency`.
+- Exact bound service subject: callback notification/summary/conversation data,
+  dashboard-token minting, ledger service events/timeline, Guardian service
+  routes, escalation evaluation, observer, enrichment, Photon, and internal
+  TTS. A service credential without `X-Ella-Subject-Uid` is denied.
+- Dual exact authority: canonical events/timeline, escalation-policy reads,
+  Guardian queue/trace reads, and TTS only where the manifest says so.
+- `/hermes/*` remains permanently denied at the public edge.
+- `/v1/ella/debug/*` remains permanently edge-denied and internal-only.
+
+No step in this runbook changes Caddy. A separate authorized operation owns
+each deny or lift.
+
+## Containment Precondition
+
+Before any source deploy, obtain explicit owner authorization to edge-deny all
+currently reachable exposed families:
+
+- `/v1/ella/emergency`
+- `/v1/ella/daily-summary`
+- `/v1/ella/conversation/*/data`
+- `/v1/ella/observer/*`
+- singular `POST/PUT/DELETE /v1/ella/emergency-contact*`
+
+If authorization is absent, stop before deploy. Record the owner-accepted
+temporary exposure and an explicit expiration. Never claim to lift a route that
+was not first denied and read back as denied.
+
+## Step 0
+
+Stage these values and update their exact consumers atomically without printing
+values:
+
+- `ELLA_CALLBACK_SERVICE_KEY`
+- `ELLA_CAREGIVER_SERVICE_KEY`
+- `ELLA_INTERNAL_VOICE_TTS_TOKEN`
+- `HERMES_MODEL`
+
+Every n8n or Guardian service call must send its distinct credential and one
+`X-Ella-Subject-Uid` that matches the request body/query/path subject. Prove the
+credential is present and the header shape is correct before deploy. Preserve
+`HERMES_API_SERVER_KEY`; do not add a shadowing `HERMES_GATEWAY_TOKEN`
+environment value.
+
+Run the bounded ADMIN branch observation before allowlisting/removal. Its only
+permitted fields are invocation count and caller class. Then set an explicit
+`ELLA_ADMIN_SUBJECT_ALLOWLIST` or keep it empty and prove controlled ADMIN_KEY
+impersonation is denied. Any production marker must disable
+`LOCAL_DEVELOPMENT` subject fallback.
+
+`ELLA_PLATO_UID` is not Step 0. Set it only post-deploy and pre-binding, verify
+process readback without exposing the value, then create and read back the owner
+binding.
+
+## Backend-First Hard Cutover
+
+There is no unauthenticated dual-accept window.
+
+1. Deploy reviewed backend authority checks while affected public paths remain
+   denied.
+2. Atomically update n8n/Guardian consumers to the authenticated credential plus
+   exact-subject contract and run safe synthetic probes.
+3. Record the exact first released iOS build containing the accepted successor
+   client, then set `ELLA_MIN_SUPPORTED_CLIENT_BUILD` to that exact value.
+4. At the recorded cutover instant, deny the public caller-UID webhook. Older or
+   unattributed Firebase clients receive HTTP 426 `update_required`.
+5. Rollback may restore an authenticated service or keep clients unavailable or
+   update-required. It must never restore caller-selected unauthenticated UID
+   authority.
+
+## Staged Edge Procedure
+
+Before every separately authorized stage:
+
+1. Record the current Caddy SHA-256 and create a hash-verified backup.
+2. Validate configuration.
+3. Record exact matchers being removed and test the command that re-denies only
+   that stage.
+4. Capture a 30-minute pre-stage request and attributable-5xx baseline for the
+   affected routes and controls.
+5. Gracefully reload, read back exact paths, and run safe synthetic probes.
+
+Observe each stage for 30 minutes. Immediately re-deny and stop on any
+unauthorized success, cross-owner success, downstream work after a rejected
+request, Guardian functional failure, or voice regression. Also roll back on
+three attributable 5xx responses within five minutes, or greater than one
+percent attributable 5xx over at least 100 affected-route requests. With fewer
+than 100 requests, the complete 30-minute synthetic/functional matrix is
+mandatory. Backend rollback never removes an edge deny.
+
+Lift only in this order:
+
+1. conversation-data and dashboard-token reads/mints
+2. timeline and emergency-contact owner reads
+3. events, notification, observer, and emergency bounded writes
+4. TTS and daily-summary spend/scheduled work
+5. authenticated backend chat
+6. onboarding after the accepted successor client is released
+
+Direct Hermes and debug routes never lift under this issue.
+
+## Functional Receipts
+
+Guardian/TTS acceptance requires valid audio from a redacted, non-family
+synthetic request using the internal token plus bound subject. Missing, wrong,
+rotated/expired, and cross-owner authority must fail before provider work. Any
+failure immediately re-denies TTS. Health 200 is only an additional control.
+
+The same-window memory receipt must record all six outcomes:
+
+1. authenticated listen admission
+2. conversation processing
+3. same-user memory readback
+4. second-user memory and conversation denial
+5. containment proof for the same observation window
+6. controlled ADMIN_KEY impersonation denial
+
+Receipts contain statuses, booleans, counts, timestamps, random correlation
+identifiers, and exact reviewed/deployed heads only. Do not record credentials,
+headers, UIDs, user content, transcripts, medical data, or provider payloads.

--- a/backend/ella/routers/ai_consent.py
+++ b/backend/ella/routers/ai_consent.py
@@ -14,7 +14,7 @@ from ella.services.ai_consent import (
 )
 from ella.services.consent_authority import submit_with_managed_cloud_authority
 from database.managed_cloud_consent import ManagedCloudAuthorityUnavailable
-from utils.other import endpoints as auth
+from utils.ella.exact_firebase_auth import get_exact_firebase_uid
 
 router = APIRouter(tags=["AI Consent"])
 
@@ -40,12 +40,12 @@ def get_ai_consent_policy():
 
 
 @router.get("/v1/users/ai-consent")
-def get_ai_consent_status(uid: str = Depends(auth.get_current_user_uid)):
+def get_ai_consent_status(uid: str = Depends(get_exact_firebase_uid)):
     return get_ai_consent_service().status(uid)
 
 
 @router.get("/v1/users/ai-consent/receipts/{receipt_id}")
-def get_ai_consent_receipt(receipt_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_ai_consent_receipt(receipt_id: str, uid: str = Depends(get_exact_firebase_uid)):
     receipt = get_ai_consent_service().receipt(uid, receipt_id)
     if receipt is None:
         raise HTTPException(status_code=404, detail={"code": "ai_consent_receipt_not_found"})
@@ -55,7 +55,7 @@ def get_ai_consent_receipt(receipt_id: str, uid: str = Depends(auth.get_current_
 @router.post("/v1/users/ai-consent")
 async def submit_ai_consent(
     request: AiConsentSubmissionRequest,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(get_exact_firebase_uid),
 ):
     try:
         return await submit_with_managed_cloud_authority(

--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -1080,7 +1080,10 @@ async def update_caregiver_permissions(
     caregiver = update_caregiver(
         authenticated_uid,
         caregiver_id,
-        {"permissions": request.model_dump()},
+        {
+            "permissions.receive_daily_summary": request.receive_daily_summary,
+            "permissions.daily_summary_email": request.daily_summary_email,
+        },
     )
     if caregiver is None:
         raise HTTPException(status_code=404, detail="Caregiver not found")

--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -36,7 +36,7 @@ from typing import Any, Dict, List, Optional
 import asyncpg
 import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 import database.conversations as conversations_db
 import database.memories as memories_db
@@ -44,6 +44,15 @@ import database.users as users_db
 from database._client import db
 from database.honcho_attestation import authority_credential
 from models.conversation import CategoryEnum
+from database.ella_caregivers import (
+    create_caregiver,
+    delete_caregiver,
+    get_caregivers,
+    get_emergency_caregiver_id,
+    refresh_caregiver_invite,
+    set_emergency_caregiver,
+    update_caregiver,
+)
 from database.ella_contacts import create_contact, delete_contact, get_contact, get_contacts, update_contact
 from ella.config import ELLA_CONFIG
 from ella.services.ai_consent import assert_current_ai_consent
@@ -59,7 +68,13 @@ from ella.services.summary_writeback import (
 )
 from utils.notifications import send_notification
 from utils.ella.canonical_omi import write_omi_canonical_event
-from utils.ella.exact_firebase_auth import get_exact_firebase_uid, require_matching_firebase_uid
+from utils.ella.exact_firebase_auth import (
+    ELLA_SUBJECT_UID_HEADER,
+    EllaRequestAuthority,
+    get_exact_firebase_uid,
+    get_exact_service_authority,
+    require_matching_firebase_uid,
+)
 from utils.other.storage import storage_client
 
 logger = logging.getLogger(__name__)
@@ -79,25 +94,28 @@ CALLBACK_SERVICE_HEADER = "X-Ella-Callback-Service-Key"
 CAREGIVER_SERVICE_HEADER = "X-Ella-Caregiver-Service-Key"
 
 
-def _require_service_key(provided: Optional[str], *, env_name: str, service: str) -> str:
-    configured = os.getenv(env_name, "").strip()
-    if not configured:
-        raise HTTPException(status_code=503, detail={"code": f"{service}_service_auth_not_configured"})
-    if not provided or not secrets.compare_digest(provided, configured):
-        raise HTTPException(status_code=403, detail={"code": f"invalid_{service}_service_credential"})
-    return service
-
-
 def require_callback_service(
     service_key: Optional[str] = Header(default=None, alias=CALLBACK_SERVICE_HEADER),
-) -> str:
-    return _require_service_key(service_key, env_name="ELLA_CALLBACK_SERVICE_KEY", service="ella_callback")
+    subject_uid: Optional[str] = Header(default=None, alias=ELLA_SUBJECT_UID_HEADER),
+) -> EllaRequestAuthority:
+    return get_exact_service_authority(
+        provided_service_key=service_key,
+        configured_service_key=os.getenv("ELLA_CALLBACK_SERVICE_KEY", "").strip(),
+        service_subject_uid=subject_uid,
+        service="ella_callback",
+    )
 
 
 def require_caregiver_service(
     service_key: Optional[str] = Header(default=None, alias=CAREGIVER_SERVICE_HEADER),
-) -> str:
-    return _require_service_key(service_key, env_name="ELLA_CAREGIVER_SERVICE_KEY", service="ella_caregiver")
+    subject_uid: Optional[str] = Header(default=None, alias=ELLA_SUBJECT_UID_HEADER),
+) -> EllaRequestAuthority:
+    return get_exact_service_authority(
+        provided_service_key=service_key,
+        configured_service_key=os.getenv("ELLA_CAREGIVER_SERVICE_KEY", "").strip(),
+        service_subject_uid=subject_uid,
+        service="ella_caregiver",
+    )
 
 
 # ============================================================================
@@ -360,7 +378,7 @@ async def update_conversation_summary(
     conversation_id: str,
     update: ConversationSummaryUpdate,
     uid: str = None,
-    _service: str = Depends(require_callback_service),
+    service: EllaRequestAuthority = Depends(require_callback_service),
 ):
     """
     Update the structured summary of an OMI conversation.
@@ -369,6 +387,7 @@ async def update_conversation_summary(
     """
     if not uid:
         raise HTTPException(status_code=400, detail="uid query parameter required")
+    uid = service.require_uid(uid, feature="Conversation summary callback")
 
     try:
         return await write_conversation_summary(
@@ -412,7 +431,7 @@ async def list_enrichment_reconcile_candidates(
     uid: Optional[str] = None,
     lookback_minutes: int = 180,
     limit: int = 25,
-    _service: str = Depends(require_callback_service),
+    service: EllaRequestAuthority = Depends(require_callback_service),
 ):
     """
     Internal helper for n8n reconciliation.
@@ -421,6 +440,7 @@ async def list_enrichment_reconcile_candidates(
     """
     if not uid:
         raise HTTPException(status_code=400, detail="uid query parameter required")
+    uid = service.require_uid(uid, feature="Enrichment reconciliation")
     if lookback_minutes <= 0:
         raise HTTPException(status_code=400, detail="lookback_minutes must be positive")
     if limit <= 0 or limit > 200:
@@ -489,7 +509,7 @@ def _structured_field(structured, key: str):
 async def get_conversation_data(
     conversation_id: str,
     uid: Optional[str] = None,
-    _service: str = Depends(require_callback_service),
+    service: EllaRequestAuthority = Depends(require_callback_service),
 ):
     """
     Fetch conversation data used by the reprocessing pipeline when re-firing the
@@ -497,6 +517,7 @@ async def get_conversation_data(
     """
     if not uid:
         raise HTTPException(status_code=400, detail="uid query parameter required")
+    uid = service.require_uid(uid, feature="Conversation data callback")
 
     try:
         conversation = conversations_db.get_conversation(uid, conversation_id)
@@ -555,7 +576,7 @@ async def ella_health():
 @router.post("/notification", response_model=NotificationResponse)
 async def ella_notification(
     request: NotificationRequest,
-    _service: str = Depends(require_callback_service),
+    service: EllaRequestAuthority = Depends(require_callback_service),
 ):
     """
     Send push notification to user with optional TTS audio.
@@ -566,6 +587,7 @@ async def ella_notification(
     Flow:
         Letta agent tool call -> n8n webhook -> this endpoint -> TTS -> GCS -> FCM -> iOS
     """
+    request.uid = service.require_uid(request.uid, feature="Ella notification")
     assert_current_ai_consent(request.uid)
     logger.info(f"[Ella] Notification: uid={request.uid}, urgency={request.urgency}, audio={request.generate_audio}")
 
@@ -800,7 +822,7 @@ class DailySummaryResponse(BaseModel):
 @router.post("/daily-summary", response_model=DailySummaryResponse)
 async def ella_daily_summary(
     request: DailySummaryRequest,
-    _service: str = Depends(require_callback_service),
+    service: EllaRequestAuthority = Depends(require_callback_service),
 ):
     """
     Trigger daily summary generation for a user's caregivers.
@@ -814,6 +836,7 @@ async def ella_daily_summary(
         OR
         Caregiver dashboard "Send Summary Now" -> this endpoint -> n8n daily-summary webhook
     """
+    request.uid = service.require_uid(request.uid, feature="Ella daily summary")
     logger.info(f"[Ella] Daily summary requested: uid={request.uid}, date={request.date}")
 
     summary_date = request.date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
@@ -981,6 +1004,112 @@ async def delete_emergency_contact(
         raise HTTPException(status_code=404, detail="Contact not found")
 
     logger.info("[Ella] Contact deleted")
+
+
+# ============================================================================
+# Authenticated first-party caregiver API
+# ============================================================================
+
+
+class CaregiverInviteRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., min_length=1, max_length=200)
+    phone: Optional[str] = Field(default=None, max_length=20)
+    email: str = Field(..., min_length=3, max_length=254)
+    relationship: str = Field(default="other", max_length=100)
+    permissions: Dict[str, bool] = Field(default_factory=dict)
+
+
+class CaregiverPermissionsUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    receive_daily_summary: bool
+    daily_summary_email: bool
+
+
+class EmergencyCaregiverUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    caregiver_id: str = Field(default="", max_length=128)
+
+
+@router.get("/caregivers")
+async def list_caregivers(authenticated_uid: str = Depends(get_exact_firebase_uid)):
+    caregivers = get_caregivers(authenticated_uid)
+    return {"caregivers": caregivers}
+
+
+@router.post("/caregivers/invite", status_code=201)
+async def invite_caregiver(
+    request: CaregiverInviteRequest,
+    authenticated_uid: str = Depends(get_exact_firebase_uid),
+):
+    caregiver = create_caregiver(authenticated_uid, request.model_dump())
+    return {
+        "invite_id": caregiver["id"],
+        "caregiver_id": caregiver["id"],
+        "invite_code": caregiver["invite_code"],
+        "status": caregiver["status"],
+        "expires_at": caregiver["invite_expires_at"],
+    }
+
+
+@router.get("/caregivers/emergency-contact")
+async def get_emergency_caregiver(authenticated_uid: str = Depends(get_exact_firebase_uid)):
+    return {"caregiver_id": get_emergency_caregiver_id(authenticated_uid)}
+
+
+@router.put("/caregivers/emergency-contact")
+async def update_emergency_caregiver(
+    request: EmergencyCaregiverUpdate,
+    authenticated_uid: str = Depends(get_exact_firebase_uid),
+):
+    selected = set_emergency_caregiver(authenticated_uid, request.caregiver_id.strip())
+    if request.caregiver_id.strip() and selected is None:
+        raise HTTPException(status_code=404, detail="Caregiver not found")
+    return {"caregiver_id": selected}
+
+
+@router.put("/caregivers/{caregiver_id}/permissions")
+async def update_caregiver_permissions(
+    caregiver_id: str,
+    request: CaregiverPermissionsUpdate,
+    authenticated_uid: str = Depends(get_exact_firebase_uid),
+):
+    caregiver = update_caregiver(
+        authenticated_uid,
+        caregiver_id,
+        {"permissions": request.model_dump()},
+    )
+    if caregiver is None:
+        raise HTTPException(status_code=404, detail="Caregiver not found")
+    return caregiver
+
+
+@router.post("/caregivers/{caregiver_id}/resend-invite")
+async def resend_caregiver_invite(
+    caregiver_id: str,
+    authenticated_uid: str = Depends(get_exact_firebase_uid),
+):
+    caregiver = refresh_caregiver_invite(authenticated_uid, caregiver_id)
+    if caregiver is None:
+        raise HTTPException(status_code=404, detail="Caregiver not found")
+    return {
+        "caregiver_id": caregiver["id"],
+        "invite_code": caregiver["invite_code"],
+        "status": caregiver["status"],
+        "expires_at": caregiver["invite_expires_at"],
+    }
+
+
+@router.delete("/caregivers/{caregiver_id}", status_code=204)
+async def remove_caregiver(
+    caregiver_id: str,
+    authenticated_uid: str = Depends(get_exact_firebase_uid),
+):
+    if not delete_caregiver(authenticated_uid, caregiver_id):
+        raise HTTPException(status_code=404, detail="Caregiver not found")
 
 
 # ============================================================================
@@ -1160,7 +1289,7 @@ async def caregiver_dashboard_data(token: str, date: Optional[str] = None):
 async def generate_dashboard_token_endpoint(
     uid: str,
     caregiver_id: str,
-    _service: str = Depends(require_caregiver_service),
+    service: EllaRequestAuthority = Depends(require_caregiver_service),
 ):
     """
     Generate a dashboard token for a caregiver. Called by n8n workflows
@@ -1169,6 +1298,7 @@ async def generate_dashboard_token_endpoint(
     This is an internal endpoint — should be called from n8n on the same VPS,
     not exposed to end users.
     """
+    uid = service.require_uid(uid, feature="Caregiver dashboard token")
     token = generate_dashboard_token(caregiver_id=caregiver_id, user_id=uid, omi_uid=uid, hours_valid=24)
     dashboard_url = f"https://ella-ai-care.com/dashboard/?token={token}"
 

--- a/backend/ella/routers/canonical_events.py
+++ b/backend/ella/routers/canonical_events.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field
 from database.honcho_attestation import authority_credential
 from utils.ella.canonical_auth import CANONICAL_EVENT_SERVICE_HEADER
 from utils.ella.exact_firebase_auth import (
+    ELLA_SUBJECT_UID_HEADER,
     EllaRequestAuthority,
     get_exact_firebase_uid,
     get_firebase_or_service_authority,
@@ -134,6 +135,10 @@ def _require_reinterpretation_completion_auth(
 def _canonical_event_authority(
     authorization: Optional[str] = Header(default=None),
     service_key: Optional[str] = Header(default=None, alias=CANONICAL_EVENT_SERVICE_HEADER),
+    service_subject_uid: Optional[str] = Header(default=None, alias=ELLA_SUBJECT_UID_HEADER),
+    x_app_version: Optional[str] = Header(default=None, alias="X-App-Version"),
+    x_ella_app_build: Optional[str] = Header(default=None, alias="X-Ella-App-Build"),
+    x_ella_client_version: Optional[str] = Header(default=None, alias="X-Ella-Client-Version"),
 ) -> EllaRequestAuthority:
     """Authenticate an exact Firebase subject or the dedicated ledger service."""
     configured = os.getenv("ELLA_EVENT_LEDGER_TOKEN", "").strip()
@@ -148,8 +153,19 @@ def _canonical_event_authority(
             provided_service_key=provided_service_key,
             configured_service_key=configured,
             service="canonical-event-ledger",
+            service_subject_uid=service_subject_uid,
+            x_app_version=x_app_version,
+            x_ella_app_build=x_ella_app_build,
+            x_ella_client_version=x_ella_client_version,
         )
-    return EllaRequestAuthority(firebase_uid=get_exact_firebase_uid(authorization))
+    return EllaRequestAuthority(
+        firebase_uid=get_exact_firebase_uid(
+            authorization,
+            x_app_version,
+            x_ella_app_build,
+            x_ella_client_version,
+        )
+    )
 
 
 def _authorize_canonical_owner(

--- a/backend/ella/routers/corrections.py
+++ b/backend/ella/routers/corrections.py
@@ -38,7 +38,7 @@ from ella.services.summary_recovery import (
 from ella.services.summary_writeback import ConcurrentConversationSummaryChangeError
 from ella.services import proposal_ingest
 from models.conversation import Conversation, ConversationStatus
-from utils.other import endpoints as auth
+from utils.ella.exact_firebase_auth import get_exact_firebase_uid
 
 logger = logging.getLogger(__name__)
 
@@ -1371,7 +1371,7 @@ async def _submit_conversation_correction(
     conversation_id: str,
     request: ConversationCorrectionRequest,
     background_tasks: Optional[BackgroundTasks] = None,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(get_exact_firebase_uid),
 ) -> ConversationCorrectionResponse:
     conversation = conversations_db.get_conversation(uid, conversation_id)
     if conversation is None:
@@ -1704,7 +1704,7 @@ async def _submit_conversation_correction(
 )
 def get_conversation_processing_retry_plan(
     conversation_id: str,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(get_exact_firebase_uid),
 ) -> ConversationProcessingRetryPlan:
     plan = build_conversation_processing_retry_plan(uid, conversation_id)
     if plan is None:
@@ -1721,7 +1721,7 @@ def retry_failed_conversation_processing(
     conversation_id: str,
     request: RetryConversationProcessingRequest,
     background_tasks: BackgroundTasks,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(get_exact_firebase_uid),
 ) -> RetryConversationProcessingResponse:
     """Atomically queue generic recovery followed by canonical Hermes enrichment."""
 
@@ -1807,7 +1807,7 @@ async def submit_conversation_correction_ella(
 def get_conversation_correction_receipt(
     conversation_id: str,
     correction_id: str,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(get_exact_firebase_uid),
 ) -> ConversationCorrectionReceiptResponse:
     return _correction_receipt(
         uid=uid,
@@ -1823,7 +1823,7 @@ def get_conversation_correction_receipt(
 async def undo_conversation_correction(
     conversation_id: str,
     correction_id: str,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(get_exact_firebase_uid),
 ) -> ConversationCorrectionReceiptResponse:
     conversation = conversations_db.get_conversation(uid, conversation_id)
     if conversation is None:

--- a/backend/ella/routers/escalations.py
+++ b/backend/ella/routers/escalations.py
@@ -12,10 +12,8 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 import asyncpg
-from firebase_admin.auth import InvalidIdTokenError
 from fastapi import APIRouter, Header, HTTPException, Response
 from pydantic import BaseModel, Field
-from utils.other import endpoints as auth_endpoints
 
 from database.honcho_attestation import authority_credential
 from ella.services.escalation_policy import (
@@ -25,6 +23,12 @@ from ella.services.escalation_policy import (
     build_policy_markdown_view,
     build_plain_language_policy_view,
     evaluate_escalation_policy,
+)
+from utils.ella.exact_firebase_auth import (
+    ELLA_SUBJECT_UID_HEADER,
+    EllaRequestAuthority,
+    get_exact_firebase_uid,
+    get_exact_service_authority,
 )
 
 router = APIRouter(prefix="/v1/ella/escalations", tags=["Ella Escalations"])
@@ -83,37 +87,46 @@ def _verify_key(x_guardian_key: Optional[str], x_escalation_key: Optional[str], 
         raise HTTPException(status_code=403, detail="Invalid escalation key")
 
 
+def _service_authority(
+    x_guardian_key: Optional[str],
+    x_escalation_key: Optional[str],
+    key: Optional[str],
+    subject_uid: Optional[str],
+) -> EllaRequestAuthority:
+    return get_exact_service_authority(
+        provided_service_key=x_escalation_key or x_guardian_key or key,
+        configured_service_key=ESCALATION_WEBHOOK_KEY,
+        service_subject_uid=subject_uid,
+        service="ella_escalation",
+    )
+
+
 def _resolve_policy_view_uid(
     uid: Optional[str],
     authorization: Optional[str],
     x_guardian_key: Optional[str],
     x_escalation_key: Optional[str],
     key: Optional[str],
+    subject_uid: Optional[str],
+    x_app_version: Optional[str] = None,
+    x_ella_app_build: Optional[str] = None,
+    x_ella_client_version: Optional[str] = None,
 ) -> str:
     """Resolve the policy-view UID for either app auth or internal callers."""
     if _has_valid_service_key(x_guardian_key, x_escalation_key, key):
-        if not uid:
-            raise HTTPException(status_code=400, detail="uid is required for internal policy lookup")
-        return uid
-
-    if not authorization:
-        raise HTTPException(status_code=401, detail="Authorization header not found")
-
-    parts = str(authorization).split(" ")
-    if len(parts) != 2 or parts[0].lower() != "bearer" or not parts[1]:
-        raise HTTPException(status_code=401, detail="Invalid authorization token")
-
-    try:
-        authenticated_uid = auth_endpoints.verify_token(parts[1])
-    except InvalidIdTokenError:
-        raise HTTPException(status_code=401, detail="Invalid authorization token")
-    except Exception as e:
-        print(f"Error verifying Firebase ID token: {type(e).__name__}: {e}", flush=True)
-        raise HTTPException(status_code=401, detail="Invalid authorization token")
-
-    if uid and uid != authenticated_uid:
-        raise HTTPException(status_code=403, detail="Authenticated user cannot read another user's escalation policy")
-    return authenticated_uid
+        return _service_authority(
+            x_guardian_key,
+            x_escalation_key,
+            key,
+            subject_uid,
+        ).require_uid(uid, feature="Escalation policy")
+    authenticated_uid = get_exact_firebase_uid(
+        authorization,
+        x_app_version,
+        x_ella_app_build,
+        x_ella_client_version,
+    )
+    return EllaRequestAuthority(firebase_uid=authenticated_uid).require_uid(uid, feature="Escalation policy")
 
 
 def _dict_value(data: Any, *keys: str) -> dict[str, Any]:
@@ -227,9 +240,11 @@ async def evaluate_escalation(
     x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
     x_escalation_key: Optional[str] = Header(None, alias="X-Escalation-Key"),
     key: Optional[str] = Header(None, alias="X-Key"),
+    subject_uid: Optional[str] = Header(None, alias=ELLA_SUBJECT_UID_HEADER),
 ):
     """Evaluate a classified event and return a deterministic delivery plan."""
-    _verify_key(x_guardian_key, x_escalation_key, key)
+    authority = _service_authority(x_guardian_key, x_escalation_key, key, subject_uid)
+    req.uid = authority.require_uid(req.uid, feature="Escalation evaluation")
     user, caregivers = await _load_context(req.uid)
     event = EscalationEvent(
         uid=req.uid,
@@ -255,9 +270,23 @@ async def get_escalation_policy(
     x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
     x_escalation_key: Optional[str] = Header(None, alias="X-Escalation-Key"),
     key: Optional[str] = Header(None, alias="X-Key"),
+    subject_uid: Optional[str] = Header(None, alias=ELLA_SUBJECT_UID_HEADER),
+    x_app_version: Optional[str] = Header(default=None, alias="X-App-Version"),
+    x_ella_app_build: Optional[str] = Header(default=None, alias="X-Ella-App-Build"),
+    x_ella_client_version: Optional[str] = Header(default=None, alias="X-Ella-Client-Version"),
 ):
     """Return the read-only effective policy view for user/caregiver UI."""
-    resolved_uid = _resolve_policy_view_uid(uid, authorization, x_guardian_key, x_escalation_key, key)
+    resolved_uid = _resolve_policy_view_uid(
+        uid,
+        authorization,
+        x_guardian_key,
+        x_escalation_key,
+        key,
+        subject_uid,
+        x_app_version,
+        x_ella_app_build,
+        x_ella_client_version,
+    )
     user, caregivers = await _load_context(resolved_uid)
     policy = build_plain_language_policy_view(user, caregivers)
     return {
@@ -274,9 +303,23 @@ async def get_escalation_policy_markdown(
     x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
     x_escalation_key: Optional[str] = Header(None, alias="X-Escalation-Key"),
     key: Optional[str] = Header(None, alias="X-Key"),
+    subject_uid: Optional[str] = Header(None, alias=ELLA_SUBJECT_UID_HEADER),
+    x_app_version: Optional[str] = Header(default=None, alias="X-App-Version"),
+    x_ella_app_build: Optional[str] = Header(default=None, alias="X-Ella-App-Build"),
+    x_ella_client_version: Optional[str] = Header(default=None, alias="X-Ella-Client-Version"),
 ):
     """Return the effective policy as generated Markdown for agents/workspaces."""
-    resolved_uid = _resolve_policy_view_uid(uid, authorization, x_guardian_key, x_escalation_key, key)
+    resolved_uid = _resolve_policy_view_uid(
+        uid,
+        authorization,
+        x_guardian_key,
+        x_escalation_key,
+        key,
+        subject_uid,
+        x_app_version,
+        x_ella_app_build,
+        x_ella_client_version,
+    )
     user, caregivers = await _load_context(resolved_uid)
     markdown = build_policy_markdown_view(user, caregivers)
     return Response(content=markdown, media_type="text/markdown; charset=utf-8")

--- a/backend/ella/routers/guardian.py
+++ b/backend/ella/routers/guardian.py
@@ -60,8 +60,10 @@ from utils.ella.canonical_context import (
     fetch_canonical_timeline,
 )
 from utils.ella.exact_firebase_auth import (
+    ELLA_SUBJECT_UID_HEADER,
     EllaRequestAuthority,
     get_exact_firebase_uid,
+    get_exact_service_authority,
     get_firebase_or_service_authority,
     require_matching_firebase_uid,
 )
@@ -123,6 +125,10 @@ def get_guardian_user_or_service_authority(
     authorization: Optional[str] = Header(None),
     x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
     key: Optional[str] = Header(None, alias="X-Key"),
+    subject_uid: Optional[str] = Header(None, alias=ELLA_SUBJECT_UID_HEADER),
+    x_app_version: Optional[str] = Header(default=None, alias="X-App-Version"),
+    x_ella_app_build: Optional[str] = Header(default=None, alias="X-Ella-App-Build"),
+    x_ella_client_version: Optional[str] = Header(default=None, alias="X-Ella-Client-Version"),
 ) -> EllaRequestAuthority:
     """Authenticate either the exact Firebase owner or the Guardian service."""
     return get_firebase_or_service_authority(
@@ -130,6 +136,10 @@ def get_guardian_user_or_service_authority(
         provided_service_key=x_guardian_key or key,
         configured_service_key=GUARDIAN_WEBHOOK_KEY,
         service="guardian",
+        service_subject_uid=subject_uid,
+        x_app_version=x_app_version,
+        x_ella_app_build=x_ella_app_build,
+        x_ella_client_version=x_ella_client_version,
     )
 
 
@@ -181,11 +191,15 @@ async def _get_pool() -> asyncpg.Pool:
 def _verify_key(
     x_guardian_key: Optional[str] = None,
     key: Optional[str] = None,
-) -> None:
+    subject_uid: Optional[str] = None,
+) -> EllaRequestAuthority:
     """Verify webhook authentication key."""
-    provided = x_guardian_key or key
-    if not GUARDIAN_WEBHOOK_KEY or not provided or not secrets.compare_digest(provided, GUARDIAN_WEBHOOK_KEY):
-        raise HTTPException(status_code=403, detail="Invalid guardian key")
+    return get_exact_service_authority(
+        provided_service_key=x_guardian_key or key,
+        configured_service_key=GUARDIAN_WEBHOOK_KEY,
+        service_subject_uid=subject_uid,
+        service="guardian",
+    )
 
 
 def _dict_value(data: object, *keys: str) -> dict:
@@ -1592,14 +1606,13 @@ async def enqueue(
     req: EnqueueRequest,
     x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
     key: Optional[str] = Header(None, alias="X-Key"),
+    subject_uid: Optional[str] = Header(None, alias=ELLA_SUBJECT_UID_HEADER),
 ):
     """Enqueue an audio clip for a user."""
     _start = time.time()
-    _verify_key(x_guardian_key, key)
-
-    uid = req.uid or req.userID
-    if not uid:
-        raise HTTPException(status_code=400, detail="uid (or userID) is required")
+    authority = _verify_key(x_guardian_key, key, subject_uid)
+    uid = authority.require_uid(req.uid or req.userID, feature="Guardian enqueue")
+    req.uid = uid
 
     item_id = req.id or f"guardian_{uuid.uuid4().hex[:12]}"
     trace_id = _trace_id_from_metadata(req.metadata, item_id)
@@ -1769,9 +1782,11 @@ async def synthesize_audio(
     req: SynthesizeRequest,
     x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
     key: Optional[str] = None,
+    subject_uid: Optional[str] = Header(None, alias=ELLA_SUBJECT_UID_HEADER),
 ):
     """Resolve user voice settings and synthesize Guardian one-shot audio."""
-    _verify_key(x_guardian_key, key)
+    authority = _verify_key(x_guardian_key, key, subject_uid)
+    req.uid = authority.require_uid(req.uid, feature="Guardian synthesis")
     text = req.text.strip()
     if not text:
         raise HTTPException(status_code=400, detail="text required")
@@ -1887,10 +1902,12 @@ async def upload_audio(
     filename: Optional[str] = Form(None),
     x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
     key: Optional[str] = Header(None, alias="X-Key"),
+    subject_uid: Optional[str] = Header(None, alias=ELLA_SUBJECT_UID_HEADER),
 ):
     """Upload an audio file and return its public URL."""
     _start = time.time()
-    _verify_key(x_guardian_key, key)
+    authority = _verify_key(x_guardian_key, key, subject_uid)
+    uid = authority.require_uid(uid, feature="Guardian audio upload")
 
     content = await file.read()
     result = _store_audio_content(uid, content, filename)
@@ -1910,10 +1927,12 @@ async def upload_audio_json(
     req: UploadJsonRequest,
     x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
     key: Optional[str] = Header(None, alias="X-Key"),
+    subject_uid: Optional[str] = Header(None, alias=ELLA_SUBJECT_UID_HEADER),
 ):
     """Upload a base64-encoded audio file and return its public URL."""
     _start = time.time()
-    _verify_key(x_guardian_key, key)
+    authority = _verify_key(x_guardian_key, key, subject_uid)
+    req.uid = authority.require_uid(req.uid, feature="Guardian JSON audio upload")
 
     try:
         content = base64.b64decode(req.audio_base64, validate=True)
@@ -1989,9 +2008,11 @@ async def view_debug_events(
     limit: int = 50,
     x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
     key: Optional[str] = Header(None, alias="X-Key"),
+    subject_uid: Optional[str] = Header(None, alias=ELLA_SUBJECT_UID_HEADER),
 ):
     """Return recent Guardian pipeline/debug events for a user."""
-    _verify_key(x_guardian_key, key)
+    authority = _verify_key(x_guardian_key, key, subject_uid)
+    uid = authority.require_uid(uid, feature="Guardian debug events")
     pool = await _get_pool()
     safe_limit = max(1, min(limit, 200))
 
@@ -2037,9 +2058,11 @@ async def debug_trigger(
     req: DebugTriggerRequest,
     x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
     key: Optional[str] = Header(None, alias="X-Key"),
+    subject_uid: Optional[str] = Header(None, alias=ELLA_SUBJECT_UID_HEADER),
 ):
     """Insert a direct debug Guardian queue item for device validation."""
-    _verify_key(x_guardian_key, key)
+    authority = _verify_key(x_guardian_key, key, subject_uid)
+    req.uid = authority.require_uid(req.uid, feature="Guardian debug trigger")
 
     item_id = req.queue_item_id or f"guardian_{uuid.uuid4().hex[:12]}"
     trace_id = req.trace_id or item_id
@@ -2061,6 +2084,7 @@ async def debug_trigger(
         ),
         x_guardian_key=x_guardian_key,
         key=key,
+        subject_uid=req.uid,
     )
 
 
@@ -2224,14 +2248,13 @@ async def deliver(
     req: DeliverRequest,
     x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
     key: Optional[str] = Header(None, alias="X-Key"),
+    subject_uid: Optional[str] = Header(None, alias=ELLA_SUBJECT_UID_HEADER),
 ):
     """Evaluate escalation policy, reserve idempotency rows, then dispatch to n8n."""
     started_at = time.time()
-    _verify_key(x_guardian_key, key)
-
-    uid = req.uid.strip()
-    if not uid:
-        raise HTTPException(status_code=400, detail="uid is required")
+    authority = _verify_key(x_guardian_key, key, subject_uid)
+    uid = authority.require_uid(req.uid, feature="Guardian delivery")
+    req.uid = uid
 
     trace_id = req.trace_id or uid
     user, caregivers = await _load_delivery_context(uid)
@@ -2310,6 +2333,7 @@ async def deliver(
                 headers={
                     "Content-Type": "application/json",
                     "X-Guardian-Key": GUARDIAN_WEBHOOK_KEY,
+                    "X-Ella-Subject-Uid": uid,
                 },
             )
             dispatch_ok = response.status_code < 300
@@ -2365,9 +2389,11 @@ async def email_send(
     req: EmailSendRequest,
     x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
     key: Optional[str] = Header(None, alias="X-Key"),
+    subject_uid: Optional[str] = Header(None, alias=ELLA_SUBJECT_UID_HEADER),
 ):
     """Send a guardian alert email via configured SMTP relay."""
-    _verify_key(x_guardian_key, key)
+    authority = _verify_key(x_guardian_key, key, subject_uid)
+    req.uid = authority.require_uid(req.uid, feature="Guardian email")
     if not req.to:
         raise HTTPException(status_code=400, detail="email recipient is required")
 
@@ -2466,9 +2492,11 @@ async def log_pipeline_event(
     req: TraceLogRequest,
     x_guardian_key: Optional[str] = Header(None, alias="X-Guardian-Key"),
     key: Optional[str] = Header(None, alias="X-Key"),
+    subject_uid: Optional[str] = Header(None, alias=ELLA_SUBJECT_UID_HEADER),
 ):
     """Log a pipeline event (called by n8n workflows)."""
-    _verify_key(x_guardian_key, key)
+    authority = _verify_key(x_guardian_key, key, subject_uid)
+    req.uid = authority.require_uid(req.uid, feature="Guardian trace log")
     metadata = dict(req.metadata or {})
     if req.error_detail:
         metadata["error_detail"] = req.error_detail

--- a/backend/ella/routers/hermes_cloud_enrichment.py
+++ b/backend/ella/routers/hermes_cloud_enrichment.py
@@ -11,6 +11,11 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from ella.services.hermes_cloud_enrichment import HermesCloudEnrichmentService
 from ella.services.runtime_errors import ProvisioningError
+from utils.ella.exact_firebase_auth import (
+    ELLA_SUBJECT_UID_HEADER,
+    EllaRequestAuthority,
+    get_exact_service_authority,
+)
 
 
 class HermesCloudEnrichmentIn(BaseModel):
@@ -38,18 +43,24 @@ class HermesCloudEnrichmentIn(BaseModel):
     )
 
 
-def _require_service_token(presented: Optional[str]) -> None:
+def _require_service_token(presented: Optional[str], subject_uid: Optional[str]) -> EllaRequestAuthority:
     expected = os.getenv("ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN", "")
     if len(expected) < 32:
         raise HTTPException(
             status_code=503,
             detail={"code": "hermes_cloud_enrichment_auth_not_configured"},
         )
-    if not presented or not hmac.compare_digest(presented.encode(), expected.encode()):
+    if not presented or not hmac.compare_digest(presented, expected):
         raise HTTPException(
             status_code=401,
-            detail={"code": "invalid_hermes_cloud_enrichment_token"},
+            detail={"code": "invalid_hermes_cloud_enrichment_service_credential"},
         )
+    return get_exact_service_authority(
+        provided_service_key=presented,
+        configured_service_key=expected,
+        service_subject_uid=subject_uid,
+        service="hermes_cloud_enrichment",
+    )
 
 
 def _http_error(exc: ProvisioningError) -> HTTPException:
@@ -101,8 +112,10 @@ def create_hermes_cloud_enrichment_router(
             default=None,
             alias="X-Ella-Hermes-Cloud-Enrichment-Token",
         ),
+        subject_uid: Optional[str] = Header(default=None, alias=ELLA_SUBJECT_UID_HEADER),
     ) -> dict[str, Any]:
-        _require_service_token(x_service_token)
+        authority = _require_service_token(x_service_token, subject_uid)
+        payload.uid = authority.require_uid(payload.uid, feature="Hermes Cloud enrichment")
         try:
             result = await (await _service()).enrich(
                 uid=payload.uid,

--- a/backend/ella/routers/invites.py
+++ b/backend/ella/routers/invites.py
@@ -20,6 +20,7 @@ from ella.services.invitation_authority import (
     revalidate_invitation_pilot,
     revalidate_self_hosted_invitation,
 )
+from utils.ella.exact_firebase_auth import get_exact_firebase_uid
 from utils.other import endpoints as auth
 
 router = APIRouter(prefix="/v1/invite", tags=["ella-invites"])
@@ -98,7 +99,7 @@ async def _validated_payload(request: Request) -> InviteRedeemRequest:
 )
 async def redeem_invite(
     request: Request,
-    authenticated_uid: str = Depends(auth.get_current_user_uid),
+    authenticated_uid: str = Depends(get_exact_firebase_uid),
     app_build: str = Header(default="", alias="X-Ella-App-Build"),
 ) -> dict:
     payload = await _validated_payload(request)

--- a/backend/ella/routers/memory_reinterpretation.py
+++ b/backend/ella/routers/memory_reinterpretation.py
@@ -18,7 +18,7 @@ from ella.services.memory_reinterpretation import (
     MemoryReinterpretationWorker,
     worker_runtime_metrics,
 )
-from utils.other import endpoints as auth
+from utils.ella.exact_firebase_auth import get_exact_firebase_uid
 
 
 def _operator_token() -> str:
@@ -64,7 +64,7 @@ def create_memory_reinterpretation_router(
     @router.get("/v1/ella/conversations/{conversation_id}/reinterpretations/latest")
     async def latest_reinterpretation(
         conversation_id: str,
-        uid: str = Depends(auth.get_current_user_uid),
+        uid: str = Depends(get_exact_firebase_uid),
     ) -> dict[str, Any]:
         job = await _owned_job(uid=uid, conversation_id=conversation_id)
         return {"ok": True, "reinterpretation": public_job(job)}
@@ -73,7 +73,7 @@ def create_memory_reinterpretation_router(
     async def get_reinterpretation(
         conversation_id: str,
         job_id: str,
-        uid: str = Depends(auth.get_current_user_uid),
+        uid: str = Depends(get_exact_firebase_uid),
     ) -> dict[str, Any]:
         job = await _owned_job(uid=uid, conversation_id=conversation_id, job_id=job_id)
         return {"ok": True, "reinterpretation": public_job(job)}

--- a/backend/ella/routers/observer.py
+++ b/backend/ella/routers/observer.py
@@ -7,6 +7,7 @@ smoke tests. They are token-gated and default to dry-run behavior.
 from __future__ import annotations
 
 import os
+import secrets
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -18,6 +19,11 @@ from ella.services.observer_apply import apply_pending_observer_memory_proposals
 from ella.services.observer import observer_log_to_dict, run_observer
 from ella.services.observer_extractor import build_extraction_result, combined_extractor, normalize_extractor_mode
 from ella.services.observer_logs import ObserverRunLogStore, PostgresObserverRunLogStore
+from utils.ella.exact_firebase_auth import (
+    ELLA_SUBJECT_UID_HEADER,
+    EllaRequestAuthority,
+    get_exact_service_authority,
+)
 
 DEFAULT_OBSERVER_LIMIT = 100
 MAX_OBSERVER_LIMIT = 500
@@ -50,7 +56,7 @@ def _env(name: str, default: str = "") -> str:
 
 
 def _observer_token() -> str:
-    return _env("ELLA_OBSERVER_ADMIN_TOKEN", _env("ELLA_ADMIN_TOKEN", ""))
+    return _env("ELLA_OBSERVER_ADMIN_TOKEN")
 
 
 def _token_from_authorization(authorization: Optional[str]) -> str:
@@ -62,13 +68,18 @@ def _token_from_authorization(authorization: Optional[str]) -> str:
     return value
 
 
-def _authenticate(authorization: Optional[str], x_ella_observer_token: Optional[str]) -> None:
-    configured = _observer_token()
-    if not configured:
-        raise HTTPException(status_code=503, detail="Observer admin token is not configured")
+def _authenticate(
+    authorization: Optional[str],
+    x_ella_observer_token: Optional[str],
+    subject_uid: Optional[str],
+) -> EllaRequestAuthority:
     supplied = (x_ella_observer_token or "").strip() or _token_from_authorization(authorization)
-    if supplied != configured:
-        raise HTTPException(status_code=401, detail="Invalid observer admin token")
+    return get_exact_service_authority(
+        provided_service_key=supplied,
+        configured_service_key=_observer_token(),
+        service_subject_uid=subject_uid,
+        service="ella_observer",
+    )
 
 
 def _parse_datetime(value: datetime | str | None) -> Optional[datetime]:
@@ -106,10 +117,10 @@ def create_observer_router(
         request: ObserverRunRequest,
         authorization: Optional[str] = Header(default=None),
         x_ella_observer_token: Optional[str] = Header(default=None, alias="X-Ella-Observer-Token"),
+        subject_uid: Optional[str] = Header(default=None, alias=ELLA_SUBJECT_UID_HEADER),
     ):
-        _authenticate(authorization, x_ella_observer_token)
-        if not request.uid:
-            raise HTTPException(status_code=400, detail="uid is required")
+        authority = _authenticate(authorization, x_ella_observer_token, subject_uid)
+        request.uid = authority.require_uid(request.uid, feature="Observer run")
         source_events = await events.timeline(
             uid=request.uid,
             since=_parse_datetime(request.since),
@@ -145,10 +156,10 @@ def create_observer_router(
         request: ObserverApplyRequest,
         authorization: Optional[str] = Header(default=None),
         x_ella_observer_token: Optional[str] = Header(default=None, alias="X-Ella-Observer-Token"),
+        subject_uid: Optional[str] = Header(default=None, alias=ELLA_SUBJECT_UID_HEADER),
     ):
-        _authenticate(authorization, x_ella_observer_token)
-        if not request.uid:
-            raise HTTPException(status_code=400, detail="uid is required")
+        authority = _authenticate(authorization, x_ella_observer_token, subject_uid)
+        request.uid = authority.require_uid(request.uid, feature="Observer apply")
         return await apply_pending_observer_memory_proposals(
             profile_uid=request.uid,
             event_store=events,
@@ -161,12 +172,17 @@ def create_observer_router(
     @router.get("/runs/{run_id}")
     async def get_run(
         run_id: str,
+        uid: str,
         authorization: Optional[str] = Header(default=None),
         x_ella_observer_token: Optional[str] = Header(default=None, alias="X-Ella-Observer-Token"),
+        subject_uid: Optional[str] = Header(default=None, alias=ELLA_SUBJECT_UID_HEADER),
     ):
-        _authenticate(authorization, x_ella_observer_token)
+        authority = _authenticate(authorization, x_ella_observer_token, subject_uid)
+        uid = authority.require_uid(uid, feature="Observer run readback")
         log = await logs.get(run_id)
         if not log:
+            raise HTTPException(status_code=404, detail="Observer run not found")
+        if not secrets.compare_digest(str(log.get("profile_uid") or ""), uid):
             raise HTTPException(status_code=404, detail="Observer run not found")
         return {"ok": True, "observer_run": log}
 
@@ -174,11 +190,13 @@ def create_observer_router(
     async def health(
         authorization: Optional[str] = Header(default=None),
         x_ella_observer_token: Optional[str] = Header(default=None, alias="X-Ella-Observer-Token"),
+        subject_uid: Optional[str] = Header(default=None, alias=ELLA_SUBJECT_UID_HEADER),
     ):
-        _authenticate(authorization, x_ella_observer_token)
+        authority = _authenticate(authorization, x_ella_observer_token, subject_uid)
         return {
             "ok": True,
             "mode": "proposal_only",
+            "subject_bound": bool(authority.service_subject_uid),
             "default_dry_run": True,
             "default_extractor_mode": normalize_extractor_mode(""),
         }

--- a/backend/ella/routers/onboarding.py
+++ b/backend/ella/routers/onboarding.py
@@ -41,6 +41,7 @@ from ella.services.provisioning import (
     self_hosted_runtime_authority_required,
 )
 from ella.services.runtime_resolver import runtime_bindings_enabled
+from utils.ella.exact_firebase_auth import get_exact_firebase_uid
 from utils.other import endpoints as auth
 
 logger = logging.getLogger("ella.onboarding")
@@ -123,7 +124,7 @@ async def ensure_onboarding(
     payload: OnboardingEnsureRequest,
     background_tasks: BackgroundTasks,
     response: Response,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(get_exact_firebase_uid),
 ) -> dict[str, Any]:
     if not SCHEMA_VERSION_RE.fullmatch(payload.target_schema_version):
         raise HTTPException(status_code=400, detail={"code": "invalid_target_schema_version"})
@@ -227,7 +228,7 @@ async def ensure_onboarding(
 @router.get("/status")
 async def onboarding_status(
     target_schema_version: str = DEFAULT_TARGET_SCHEMA_VERSION,
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(get_exact_firebase_uid),
 ) -> dict[str, Any]:
     if not SCHEMA_VERSION_RE.fullmatch(target_schema_version):
         raise HTTPException(status_code=400, detail={"code": "invalid_target_schema_version"})

--- a/backend/ella/routers/photon.py
+++ b/backend/ella/routers/photon.py
@@ -19,6 +19,7 @@ from ella.services.hermes_cloud_photon import (
     PhotonSidecarPreflight,
 )
 from ella.services.runtime_errors import ProvisioningError
+from utils.ella.exact_firebase_auth import ELLA_SUBJECT_UID_HEADER, get_exact_service_authority
 
 
 class PhotonPreflightIn(BaseModel):
@@ -55,7 +56,7 @@ class PhotonDeliveryAckIn(BaseModel):
     acknowledged_at: datetime
 
 
-def _require_sidecar_token(presented: Optional[str]) -> None:
+def _require_sidecar_authority(presented: Optional[str], subject_uid: Optional[str]) -> str:
     expected = os.getenv("ELLA_HERMES_CLOUD_PHOTON_SIDECAR_TOKEN", "")
     if len(expected) < 32:
         raise HTTPException(
@@ -64,6 +65,16 @@ def _require_sidecar_token(presented: Optional[str]) -> None:
         )
     if not presented or not hmac.compare_digest(presented.encode(), expected.encode()):
         raise HTTPException(status_code=401, detail={"code": "invalid_photon_sidecar_token"})
+    owner_uid = os.getenv("ELLA_HERMES_CLOUD_PHOTON_INTERNAL_OWNER_UID", "").strip()
+    if not owner_uid:
+        raise HTTPException(status_code=503, detail={"code": "photon_owner_subject_not_configured"})
+    authority = get_exact_service_authority(
+        provided_service_key=presented,
+        configured_service_key=expected,
+        service_subject_uid=subject_uid,
+        service="photon_sidecar",
+    )
+    return authority.require_uid(owner_uid, feature="Photon sidecar")
 
 
 def _http_error(exc: ProvisioningError) -> HTTPException:
@@ -108,8 +119,9 @@ def create_photon_router(
             default=None,
             alias="X-Ella-Photon-Sidecar-Token",
         ),
+        subject_uid: Optional[str] = Header(default=None, alias=ELLA_SUBJECT_UID_HEADER),
     ) -> dict[str, Any]:
-        _require_sidecar_token(x_sidecar_token)
+        _require_sidecar_authority(x_sidecar_token, subject_uid)
         try:
             receipt = await (await _adapter()).preflight(
                 PhotonSidecarPreflight(
@@ -136,8 +148,9 @@ def create_photon_router(
             default=None,
             alias="X-Ella-Photon-Sidecar-Token",
         ),
+        subject_uid: Optional[str] = Header(default=None, alias=ELLA_SUBJECT_UID_HEADER),
     ) -> dict[str, Any]:
-        _require_sidecar_token(x_sidecar_token)
+        _require_sidecar_authority(x_sidecar_token, subject_uid)
         try:
             result = await (await _adapter()).handle_inbound(
                 PhotonInboundEnvelope(
@@ -170,8 +183,9 @@ def create_photon_router(
             default=None,
             alias="X-Ella-Photon-Sidecar-Token",
         ),
+        subject_uid: Optional[str] = Header(default=None, alias=ELLA_SUBJECT_UID_HEADER),
     ) -> dict[str, Any]:
-        _require_sidecar_token(x_sidecar_token)
+        _require_sidecar_authority(x_sidecar_token, subject_uid)
         try:
             result = await (await _adapter()).acknowledge_delivery(
                 PhotonDeliveryAck(

--- a/backend/ella/routers/plato_mcp.py
+++ b/backend/ella/routers/plato_mcp.py
@@ -571,7 +571,7 @@ async def _fetch_canonical_timeline(limit: int, channels: list[str], since: Opti
         params["since"] = since
     params["timezone"] = _plato_timezone()
     async with httpx.AsyncClient(timeout=20.0) as client:
-        response = await client.get(timeline_url, params=params, headers=canonical_event_service_headers())
+        response = await client.get(timeline_url, params=params, headers=canonical_event_service_headers(_plato_uid()))
     if response.status_code != 200:
         raise RuntimeError(f"timeline_http_{response.status_code}")
     payload = response.json()

--- a/backend/ella/routers/resolve.py
+++ b/backend/ella/routers/resolve.py
@@ -25,7 +25,6 @@ from database.honcho_attestation import authority_credential
 from ella.services.runtime_errors import ProvisioningError
 from ella.services.runtime_resolver import resolve_isolated_runtime, retained_owner_uid_configured
 from utils.ella.exact_firebase_auth import get_exact_firebase_uid, require_matching_firebase_uid
-from utils.other import endpoints as auth
 
 logger = logging.getLogger(__name__)
 
@@ -252,7 +251,7 @@ async def proxy_chat_history(
     agent_id: str,
     limit: int = 50,
     session_key: Optional[str] = None,
-    authenticated_uid: str = Depends(auth.get_current_user_uid),
+    authenticated_uid: str = Depends(get_exact_firebase_uid),
 ):
     """Proxy chat history requests to the Provision API on Mac Mini.
 

--- a/backend/ella/routers/settings.py
+++ b/backend/ella/routers/settings.py
@@ -10,20 +10,20 @@ from ella.services.app_settings import (
     build_settings_response,
     extract_voice_settings,
 )
-from utils.other import endpoints as auth
+from utils.ella.exact_firebase_auth import get_exact_firebase_uid
 
 router = APIRouter(prefix="/v1/ella/settings", tags=["Ella Settings"])
 
 
 @router.get("")
-def get_settings(uid: str = Depends(auth.get_current_user_uid)) -> dict[str, Any]:
+def get_settings(uid: str = Depends(get_exact_firebase_uid)) -> dict[str, Any]:
     """Return server-backed Ella app settings for the authenticated user."""
     voice = app_settings_db.get_voice_settings(uid)
     return build_settings_response(uid, voice)
 
 
 @router.patch("")
-def patch_settings(payload: dict[str, Any], uid: str = Depends(auth.get_current_user_uid)) -> dict[str, Any]:
+def patch_settings(payload: dict[str, Any], uid: str = Depends(get_exact_firebase_uid)) -> dict[str, Any]:
     """Persist app settings from iOS. First slice stores effective voice mode."""
     voice = extract_voice_settings(payload)
     saved_voice = app_settings_db.save_voice_settings(uid, voice)
@@ -31,14 +31,14 @@ def patch_settings(payload: dict[str, Any], uid: str = Depends(auth.get_current_
 
 
 @router.get("/effective")
-def get_effective_settings(uid: str = Depends(auth.get_current_user_uid)) -> dict[str, Any]:
+def get_effective_settings(uid: str = Depends(get_exact_firebase_uid)) -> dict[str, Any]:
     """Return settings plus backend-resolved routing fields for services like Guardian."""
     voice = app_settings_db.get_voice_settings(uid)
     return build_effective_voice_settings(uid, voice)
 
 
 @router.get("/effective/voice")
-def get_effective_voice_settings(uid: str = Depends(auth.get_current_user_uid)) -> dict[str, Any]:
+def get_effective_voice_settings(uid: str = Depends(get_exact_firebase_uid)) -> dict[str, Any]:
     """Return only the effective voice resolver payload."""
     voice = app_settings_db.get_voice_settings(uid)
     return build_effective_voice_settings(uid, voice)["effective_voice_settings"]

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -70,7 +70,6 @@ from ella.services.voice_honcho import (
 )
 from utils.ella.canonical_context import fetch_canonical_timeline
 from utils.ella.exact_firebase_auth import get_exact_firebase_uid
-from utils.other import endpoints as auth
 
 # JWT handling
 try:
@@ -1216,7 +1215,7 @@ async def create_voice_session(
 @entitlement_router.get("/v1/entitlement")
 @router.get("/entitlement")
 async def get_voice_entitlement(
-    authenticated_uid: str = Depends(auth.get_current_user_uid),
+    authenticated_uid: str = Depends(get_exact_firebase_uid),
 ):
     """Return the stable frontend contract without exposing operator notes."""
     contract = await voice_canary_db.get_entitlement_contract(authenticated_uid)

--- a/backend/ella/services/ai_consent.py
+++ b/backend/ella/services/ai_consent.py
@@ -15,7 +15,7 @@ from typing import Any, Callable, Literal, Optional, Protocol
 from fastapi import Depends, Header, HTTPException
 from google.cloud.firestore_v1 import transactional
 
-from utils.other import endpoints as auth
+from utils.ella.exact_firebase_auth import get_exact_firebase_uid
 
 ConsentDecision = Literal["granted", "declined", "revoked"]
 
@@ -720,7 +720,7 @@ def assert_current_ai_consent(uid: str) -> str:
 
 
 def require_current_ai_consent(
-    authenticated_uid: str = Depends(auth.get_current_user_uid),
+    authenticated_uid: str = Depends(get_exact_firebase_uid),
 ) -> str:
     return assert_current_ai_consent(authenticated_uid)
 
@@ -729,6 +729,9 @@ def require_current_ai_consent_or_internal_tts(
     authorization: Optional[str] = Header(default=None),
     x_internal_token: Optional[str] = Header(default=None, alias="X-Ella-Internal-Token"),
     x_subject_uid: Optional[str] = Header(default=None, alias="X-Ella-Subject-Uid"),
+    x_app_version: Optional[str] = Header(default=None, alias="X-App-Version"),
+    x_ella_app_build: Optional[str] = Header(default=None, alias="X-Ella-App-Build"),
+    x_ella_client_version: Optional[str] = Header(default=None, alias="X-Ella-Client-Version"),
 ) -> str:
     configured_internal_token = os.getenv("ELLA_INTERNAL_VOICE_TTS_TOKEN", "")
     if (
@@ -741,13 +744,15 @@ def require_current_ai_consent_or_internal_tts(
             raise HTTPException(status_code=400, detail={"code": "ai_consent_subject_required"})
         return assert_current_ai_consent(subject_uid)
     if authorization:
-        return assert_current_ai_consent(auth.get_current_user_uid(authorization))
-    if ai_consent_global_enforcement_enabled():
-        raise HTTPException(status_code=401, detail={"code": "authorization_required"})
-    # A legacy anonymous request has no trustworthy subject to compare with the
-    # UID canary. Canary clients must send Firebase auth; global enforcement
-    # removes this migration bridge for every caller.
-    return "migration-bypass"
+        return assert_current_ai_consent(
+            get_exact_firebase_uid(
+                authorization,
+                x_app_version,
+                x_ella_app_build,
+                x_ella_client_version,
+            )
+        )
+    raise HTTPException(status_code=401, detail={"code": "authorization_required"})
 
 
 def resolve_processor(provider_alias: str) -> Optional[dict[str, Any]]:

--- a/backend/ella/services/hermes_cloud_enrichment_outbox.py
+++ b/backend/ella/services/hermes_cloud_enrichment_outbox.py
@@ -109,6 +109,7 @@ def deliver_enrichment_job(job: dict[str, Any]) -> DeliveryResult:
             headers={
                 "Content-Type": "application/json",
                 "X-Ella-Hermes-Cloud-Enrichment-Token": token,
+                "X-Ella-Subject-Uid": str(job["uid"]),
             },
             timeout=timeout,
         )

--- a/backend/scripts/ella_memory_e2e_smoke.py
+++ b/backend/scripts/ella_memory_e2e_smoke.py
@@ -103,7 +103,7 @@ class MemorySmoke:
             "POST",
             self.backend_url + path,
             payload,
-            headers={"X-Ella-Observer-Token": self.args.observer_token},
+            headers={"X-Ella-Observer-Token": self.args.observer_token, "X-Ella-Subject-Uid": self.args.uid},
         )
         self.metrics[path.strip("/").replace("/", "_") + "_ms"] = elapsed
         return response
@@ -115,7 +115,7 @@ class MemorySmoke:
             raise SmokeFailure(f"backend health failed: {health}")
         observer, elapsed = _get_json(
             self.backend_url + "/v1/ella/observer/health",
-            headers={"X-Ella-Observer-Token": self.args.observer_token},
+            headers={"X-Ella-Observer-Token": self.args.observer_token, "X-Ella-Subject-Uid": self.args.uid},
         )
         self.metrics["observer_health_ms"] = elapsed
         if observer.get("ok") is not True:
@@ -241,7 +241,7 @@ class MemorySmoke:
             "POST",
             self.backend_url + "/v1/ella/events",
             {"events": batch},
-            {"X-Ella-Event-Ledger-Key": ledger_token},
+            {"X-Ella-Event-Ledger-Key": ledger_token, "X-Ella-Subject-Uid": self.args.uid},
         )
         self.metrics["write_multichannel_events_ms"] = elapsed
         self.artifacts["multichannel_write"] = response

--- a/backend/scripts/ella_observer_cron.py
+++ b/backend/scripts/ella_observer_cron.py
@@ -42,7 +42,7 @@ def main() -> int:
     parser.add_argument("--live", action="store_true", help="Create proposals instead of dry-running")
     args = parser.parse_args()
 
-    token = _env("ELLA_OBSERVER_ADMIN_TOKEN", _env("ELLA_ADMIN_TOKEN", ""))
+    token = _env("ELLA_OBSERVER_ADMIN_TOKEN")
     if not token:
         print("ELLA_OBSERVER_ADMIN_TOKEN is required", file=sys.stderr)
         return 2
@@ -66,7 +66,11 @@ def main() -> int:
     }
     url = args.backend_url.rstrip("/") + "/v1/ella/observer/run"
     with httpx.Client(timeout=60.0) as client:
-        response = client.post(url, headers={"X-Ella-Observer-Token": token}, json=payload)
+        response = client.post(
+            url,
+            headers={"X-Ella-Observer-Token": token, "X-Ella-Subject-Uid": args.uid},
+            json=payload,
+        )
     if response.status_code >= 400:
         print(f"Observer request failed: HTTP {response.status_code} {response.text[:500]}", file=sys.stderr)
         return 1

--- a/backend/scripts/hermes_product_fit_canary.py
+++ b/backend/scripts/hermes_product_fit_canary.py
@@ -1247,7 +1247,10 @@ class LiveCanaryAdapter:
             "client_interaction_id": client_interaction_id,
             "transcript_sha256": self.config.enrichment_transcript_sha256,
         }
-        headers = {"X-Ella-Hermes-Cloud-Enrichment-Token": token}
+        headers = {
+            "X-Ella-Hermes-Cloud-Enrichment-Token": token,
+            "X-Ella-Subject-Uid": self.config.uid,
+        }
         async with httpx.AsyncClient(timeout=120.0, follow_redirects=False, trust_env=False) as client:
             first = await _request_json(
                 client,

--- a/backend/tests/unit/test_ella_ai_consent.py
+++ b/backend/tests/unit/test_ella_ai_consent.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from ella.routers import ai_consent
 from ella.services import ai_consent as consent, consent_authority
 from database import managed_cloud_consent
+from utils.ella.exact_firebase_auth import get_exact_firebase_uid
 
 
 def _submission(
@@ -766,18 +767,20 @@ def test_tts_internal_service_token_cannot_bypass_subject_consent(monkeypatch):
     assert missing_consent.value.detail["code"] == "ai_consent_required"
 
 
-def test_tts_uid_canary_does_not_break_unattributed_legacy_callers(monkeypatch):
+def test_tts_uid_canary_rejects_unattributed_legacy_callers(monkeypatch):
     monkeypatch.setenv("ELLA_AI_CONSENT_ENFORCEMENT_UIDS", "user-a")
     monkeypatch.delenv("ELLA_AI_CONSENT_ENFORCEMENT_ENABLED", raising=False)
     monkeypatch.delenv("ELLA_INTERNAL_VOICE_TTS_TOKEN", raising=False)
 
-    result = consent.require_current_ai_consent_or_internal_tts(
-        authorization=None,
-        x_internal_token=None,
-        x_subject_uid=None,
-    )
+    with pytest.raises(HTTPException) as error:
+        consent.require_current_ai_consent_or_internal_tts(
+            authorization=None,
+            x_internal_token=None,
+            x_subject_uid=None,
+        )
 
-    assert result == "migration-bypass"
+    assert error.value.status_code == 401
+    assert error.value.detail == {"code": "authorization_required"}
 
 
 def test_tts_global_enforcement_rejects_unattributed_legacy_callers(monkeypatch):
@@ -799,7 +802,7 @@ def test_tts_global_enforcement_rejects_unattributed_legacy_callers(monkeypatch)
 def test_tts_authenticated_canary_subject_must_have_current_consent(monkeypatch):
     repository = consent.InMemoryConsentRepository()
     monkeypatch.setattr(consent, "_repository", repository)
-    monkeypatch.setattr(consent.auth, "get_current_user_uid", lambda _authorization: "user-a")
+    monkeypatch.setattr(consent, "get_exact_firebase_uid", lambda *_args: "user-a")
     monkeypatch.setenv("ELLA_AI_CONSENT_ENFORCEMENT_UIDS", "user-a")
 
     with pytest.raises(HTTPException) as error:
@@ -1003,7 +1006,7 @@ def test_policy_is_public_but_status_and_receipts_require_firebase_auth(monkeypa
     assert client.get("/v1/users/ai-consent").status_code == 401
     assert client.get("/v1/users/ai-consent/receipts/aicr_unknown").status_code == 401
 
-    app.dependency_overrides[consent.auth.get_current_user_uid] = lambda: "user-a"
+    app.dependency_overrides[get_exact_firebase_uid] = lambda: "user-a"
     status_response = client.get("/v1/users/ai-consent")
     assert status_response.status_code == 200
     assert status_response.json()["subject_uid"] == "user-a"
@@ -1014,7 +1017,7 @@ def test_authenticated_api_records_exact_v7_profile_bound_receipt(monkeypatch):
     monkeypatch.setattr(ai_consent, "get_ai_consent_service", lambda: service)
     app = FastAPI()
     app.include_router(ai_consent.router)
-    app.dependency_overrides[consent.auth.get_current_user_uid] = lambda: "user-a"
+    app.dependency_overrides[get_exact_firebase_uid] = lambda: "user-a"
     client = TestClient(app)
 
     response = client.post(

--- a/backend/tests/unit/test_ella_all_router_authority_manifest.py
+++ b/backend/tests/unit/test_ella_all_router_authority_manifest.py
@@ -1,0 +1,469 @@
+import ast
+from pathlib import Path
+
+BACKEND = Path(__file__).resolve().parents[2]
+ROUTERS = BACKEND / "ella" / "routers"
+HTTP_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE", "WEBSOCKET"}
+
+
+def _group(module, authority, disposition, *routes):
+    return module, authority, disposition, routes
+
+
+ROUTE_GROUPS = (
+    _group(
+        "ai_consent",
+        "public_metadata",
+        "public",
+        ("GET", "/v1/users/ai-consent/policy", "get_ai_consent_policy"),
+    ),
+    _group(
+        "ai_consent",
+        "firebase_exact_owner",
+        "public",
+        ("GET", "/v1/users/ai-consent", "get_ai_consent_status"),
+        ("GET", "/v1/users/ai-consent/receipts/{receipt_id}", "get_ai_consent_receipt"),
+        ("POST", "/v1/users/ai-consent", "submit_ai_consent"),
+    ),
+    _group(
+        "callbacks",
+        "callback_service_exact_subject",
+        "staged_public",
+        ("PATCH", "/v1/ella/conversation/{conversation_id}/summary", "update_conversation_summary"),
+        (
+            "GET",
+            "/v1/ella/conversations/enrichment/reconcile-candidates",
+            "list_enrichment_reconcile_candidates",
+        ),
+        ("GET", "/v1/ella/conversation/{conversation_id}/data", "get_conversation_data"),
+        ("POST", "/v1/ella/notification", "ella_notification"),
+        ("POST", "/v1/ella/daily-summary", "ella_daily_summary"),
+    ),
+    _group(
+        "callbacks",
+        "public_metadata",
+        "public",
+        ("GET", "/v1/ella/health", "ella_health"),
+    ),
+    _group(
+        "callbacks",
+        "firebase_exact_owner",
+        "staged_public",
+        ("POST", "/v1/ella/emergency", "ella_emergency"),
+        ("POST", "/v1/ella/emergency-contact", "create_emergency_contact"),
+        ("GET", "/v1/ella/emergency-contacts/{uid}", "list_emergency_contacts"),
+        ("PUT", "/v1/ella/emergency-contact/{contact_id}", "update_emergency_contact"),
+        ("DELETE", "/v1/ella/emergency-contact/{contact_id}", "delete_emergency_contact"),
+        ("GET", "/v1/ella/caregivers", "list_caregivers"),
+        ("POST", "/v1/ella/caregivers/invite", "invite_caregiver"),
+        ("GET", "/v1/ella/caregivers/emergency-contact", "get_emergency_caregiver"),
+        ("PUT", "/v1/ella/caregivers/emergency-contact", "update_emergency_caregiver"),
+        ("PUT", "/v1/ella/caregivers/{caregiver_id}/permissions", "update_caregiver_permissions"),
+        ("POST", "/v1/ella/caregivers/{caregiver_id}/resend-invite", "resend_caregiver_invite"),
+        ("DELETE", "/v1/ella/caregivers/{caregiver_id}", "remove_caregiver"),
+    ),
+    _group(
+        "callbacks",
+        "signed_dashboard_token",
+        "public",
+        ("GET", "/v1/ella/caregiver-dashboard-data", "caregiver_dashboard_data"),
+    ),
+    _group(
+        "callbacks",
+        "caregiver_service_exact_subject",
+        "staged_public",
+        ("POST", "/v1/ella/generate-dashboard-token", "generate_dashboard_token_endpoint"),
+    ),
+    _group(
+        "canonical_events",
+        "firebase_or_ledger_service_exact_subject",
+        "staged_public",
+        ("POST", "/v1/ella/events", "write_events"),
+        ("POST", "/v1/ella/sessions/{session_id}/complete", "complete_session"),
+        ("GET", "/v1/ella/timeline", "read_timeline"),
+    ),
+    _group(
+        "chat",
+        "firebase_exact_owner_with_consent",
+        "staged_public",
+        ("POST", "/v1/ella/chat/stream", "ella_chat_stream"),
+    ),
+    _group(
+        "chat",
+        "firebase_exact_owner",
+        "staged_public",
+        ("GET", "/v1/ella/chat/history", "ella_chat_history"),
+    ),
+    _group(
+        "corrections",
+        "firebase_exact_owner",
+        "public",
+        (
+            "GET",
+            "/v1/conversations/{conversation_id}/processing-retry-plan",
+            "get_conversation_processing_retry_plan",
+        ),
+        (
+            "POST",
+            "/v1/conversations/{conversation_id}/processing-retries",
+            "retry_failed_conversation_processing",
+        ),
+        (
+            "GET",
+            "/v1/ella/conversations/{conversation_id}/corrections/{correction_id}",
+            "get_conversation_correction_receipt",
+        ),
+        (
+            "POST",
+            "/v1/ella/conversations/{conversation_id}/corrections/{correction_id}/undo",
+            "undo_conversation_correction",
+        ),
+    ),
+    _group(
+        "corrections",
+        "firebase_exact_owner_with_consent",
+        "public",
+        (
+            "POST",
+            "/v1/ella/conversations/{conversation_id}/corrections",
+            "submit_conversation_correction_ella",
+        ),
+        ("POST", "/v1/conversations/{conversation_id}/corrections", "submit_conversation_correction"),
+    ),
+    _group(
+        "debug_metadata",
+        "firebase_exact_owner",
+        "permanent_edge_deny",
+        ("GET", "/v1/ella/debug/conversations/metadata", "list_conversation_metadata"),
+        (
+            "GET",
+            "/v1/ella/debug/conversations/{conversation_id}/metadata",
+            "read_conversation_metadata",
+        ),
+    ),
+    _group(
+        "trace",
+        "firebase_exact_owner",
+        "permanent_edge_deny",
+        ("POST", "/v1/ella/debug/client-trace", "ingest_client_trace"),
+        ("GET", "/v1/ella/debug/traces", "get_traces"),
+        ("GET", "/v1/ella/debug/trace/{uid}", "get_user_traces"),
+        ("GET", "/v1/ella/debug/stats", "trace_stats"),
+        ("GET", "/v1/ella/debug/status", "debug_status"),
+        ("GET", "/v1/ella/debug/console", "debug_console"),
+    ),
+    _group(
+        "escalations",
+        "escalation_service_exact_subject",
+        "internal_only",
+        ("POST", "/v1/ella/escalations/evaluate", "evaluate_escalation"),
+    ),
+    _group(
+        "escalations",
+        "firebase_or_escalation_service_exact_subject",
+        "public",
+        ("GET", "/v1/ella/escalations/policy", "get_escalation_policy"),
+        ("GET", "/v1/ella/escalations/policy.md", "get_escalation_policy_markdown"),
+    ),
+    _group(
+        "guardian",
+        "firebase_exact_owner",
+        "staged_public",
+        ("GET", "/v1/ella/guardian-alerts", "guardian_alerts"),
+        ("GET", "/v1/ella/guardian/mode", "get_guardian_mode"),
+        ("PUT", "/v1/ella/guardian/mode", "update_guardian_mode"),
+        ("GET", "/v1/ella/guardian/next-audio", "next_audio"),
+        ("POST", "/v1/ella/guardian/activate", "activate_guardian"),
+        ("POST", "/v1/ella/guardian/playback-event", "record_playback_event"),
+        ("POST", "/v1/ella/guardian/playback-debug", "record_playback_debug_event"),
+    ),
+    _group(
+        "guardian",
+        "guardian_service_exact_subject",
+        "internal_only",
+        ("POST", "/v1/ella/guardian/enqueue", "enqueue"),
+        ("POST", "/v1/ella/guardian/synthesize", "synthesize_audio"),
+        ("POST", "/v1/ella/guardian/upload", "upload_audio"),
+        ("POST", "/v1/ella/guardian/upload-json", "upload_audio_json"),
+        ("GET", "/v1/ella/guardian/debug-events", "view_debug_events"),
+        ("POST", "/v1/ella/guardian/debug-trigger", "debug_trigger"),
+        ("POST", "/v1/ella/guardian/deliver", "deliver"),
+        ("POST", "/v1/ella/guardian/email/send", "email_send"),
+        ("POST", "/v1/ella/guardian/trace/log", "log_pipeline_event"),
+    ),
+    _group(
+        "guardian",
+        "firebase_or_guardian_service_exact_subject",
+        "internal_only",
+        ("GET", "/v1/ella/guardian/queue", "view_queue"),
+        ("GET", "/v1/ella/guardian/trace/{conversation_id}", "get_pipeline_trace"),
+    ),
+    _group(
+        "hermes_cloud_enrichment",
+        "hermes_enrichment_service_exact_subject",
+        "internal_only",
+        ("POST", "/v1/ella/internal/hermes-cloud/enrichment/run", "run"),
+    ),
+    _group(
+        "invites",
+        "firebase_exact_owner",
+        "public",
+        ("POST", "/v1/invite/redeem", "redeem_invite"),
+    ),
+    _group(
+        "mcp_onboarding",
+        "mcp_session_exact_profile",
+        "public",
+        ("GET", "/v1/ella/mcp/onboarding", "get_mcp_onboarding"),
+        ("GET", "/v1/ella/mcp/start_here", "get_mcp_start_here"),
+        ("GET", "/v1/ella/mcp/surface-prompt", "get_mcp_surface_prompt"),
+    ),
+    _group(
+        "mcp_onboarding",
+        "firebase_exchange_exact_subject",
+        "oauth_public",
+        ("POST", "/v1/ella/mcp/onboarding/oauth", "post_mcp_oauth_onboarding"),
+    ),
+    _group(
+        "mcp_onboarding",
+        "oauth_protocol",
+        "oauth_public",
+        ("POST", "/v1/ella/mcp/register", "post_mcp_register"),
+        ("GET", "/v1/ella/mcp/authorize", "get_mcp_authorize"),
+        ("POST", "/v1/ella/mcp/token", "post_mcp_token"),
+    ),
+    _group(
+        "mcp_onboarding",
+        "public_metadata",
+        "public",
+        ("GET", "/v1/ella/mcp/surface-prompt/public", "get_public_mcp_surface_prompt"),
+        ("GET", "/v1/ella/mcp/info", "get_mcp_onboarding_info"),
+    ),
+    _group(
+        "mcp_well_known",
+        "public_metadata",
+        "public",
+        (
+            "GET",
+            "/.well-known/oauth-protected-resource/v1/ella/plato/mcp",
+            "get_oauth_protected_resource_subpath",
+        ),
+        ("GET", "/.well-known/oauth-protected-resource", "get_oauth_protected_resource"),
+        ("GET", "/.well-known/oauth-authorization-server", "get_oauth_authorization_server"),
+    ),
+    _group(
+        "memory_reinterpretation",
+        "firebase_exact_owner",
+        "public",
+        (
+            "GET",
+            "/v1/ella/conversations/{conversation_id}/reinterpretations/latest",
+            "latest_reinterpretation",
+        ),
+        (
+            "GET",
+            "/v1/ella/conversations/{conversation_id}/reinterpretations/{job_id}",
+            "get_reinterpretation",
+        ),
+    ),
+    _group(
+        "memory_reinterpretation",
+        "fixed_operator",
+        "internal_only",
+        (
+            "POST",
+            "/v1/ella/internal/memory-reinterpretations/run-once",
+            "run_once",
+        ),
+        ("GET", "/v1/ella/internal/memory-reinterpretations/metrics", "metrics"),
+    ),
+    _group(
+        "observer",
+        "observer_service_exact_subject",
+        "staged_public",
+        ("POST", "/v1/ella/observer/run", "run"),
+        ("POST", "/v1/ella/observer/apply-pending", "apply_pending"),
+        ("GET", "/v1/ella/observer/runs/{run_id}", "get_run"),
+        ("GET", "/v1/ella/observer/health", "health"),
+    ),
+    _group(
+        "onboarding",
+        "firebase_exact_owner_with_consent",
+        "lift_last",
+        ("POST", "/v1/ella/onboarding/ensure", "ensure_onboarding"),
+    ),
+    _group(
+        "onboarding",
+        "firebase_exact_owner",
+        "lift_last",
+        ("GET", "/v1/ella/onboarding/status", "onboarding_status"),
+    ),
+    _group(
+        "photon",
+        "photon_service_exact_subject",
+        "internal_only",
+        ("POST", "/v1/ella/internal/hermes-cloud/photon/preflight", "preflight"),
+        ("POST", "/v1/ella/internal/hermes-cloud/photon/inbound", "inbound"),
+        ("POST", "/v1/ella/internal/hermes-cloud/photon/delivery-ack", "delivery_ack"),
+    ),
+    _group(
+        "plato_mcp",
+        "plato_mcp_fixed_profile",
+        "public",
+        ("POST", "/v1/ella/plato/mcp", "plato_mcp_streamable_http"),
+        ("GET", "/v1/ella/plato/mcp", "plato_mcp_sse_keepalive"),
+        ("POST", "/v1/ella/plato/mcp/sse/message", "plato_mcp_sse_message"),
+        ("DELETE", "/v1/ella/plato/mcp", "plato_mcp_delete_session"),
+    ),
+    _group(
+        "plato_mcp",
+        "oauth_protocol",
+        "oauth_public",
+        ("GET", "/v1/ella/plato/mcp/authorize", "plato_mcp_authorize"),
+        ("POST", "/v1/ella/plato/mcp/token", "plato_mcp_token"),
+    ),
+    _group(
+        "plato_mcp",
+        "public_metadata",
+        "public",
+        ("GET", "/v1/ella/plato/mcp/info", "plato_mcp_info"),
+        ("POST", "/v1/ella/plato/mcp/info", "plato_mcp_info"),
+    ),
+    _group(
+        "resolve",
+        "firebase_exact_owner",
+        "public",
+        ("GET", "/v1/ella/resolve", "resolve_endpoint"),
+        ("GET", "/v1/ella/chat/history/{agent_id}", "proxy_chat_history"),
+    ),
+    _group(
+        "settings",
+        "firebase_exact_owner",
+        "public",
+        ("GET", "/v1/ella/settings", "get_settings"),
+        ("PATCH", "/v1/ella/settings", "patch_settings"),
+        ("GET", "/v1/ella/settings/effective", "get_effective_settings"),
+        ("GET", "/v1/ella/settings/effective/voice", "get_effective_voice_settings"),
+    ),
+    _group(
+        "voice",
+        "firebase_exact_owner",
+        "staged_public",
+        ("GET", "/v1/voice/providers", "get_voice_providers"),
+        ("GET", "/v1/entitlement", "get_voice_entitlement"),
+        ("GET", "/v1/voice/entitlement", "get_voice_entitlement"),
+        ("GET", "/v1/voice/health", "voice_health"),
+    ),
+    _group(
+        "voice",
+        "firebase_exact_owner_with_consent",
+        "staged_public",
+        ("POST", "/v1/voice/session", "create_voice_session"),
+    ),
+    _group(
+        "voice",
+        "voice_proxy_session_exact_subject",
+        "internal_only",
+        ("POST", "/v1/voice/canary/accept", "accept_voice_canary_session"),
+        ("POST", "/v1/voice/canary/heartbeat", "heartbeat_voice_canary_session"),
+        ("POST", "/v1/voice/canary/complete", "complete_voice_canary_session"),
+        ("POST", "/v1/voice/context", "get_voice_context"),
+        ("POST", "/v1/voice/tool", "execute_voice_tool"),
+        ("POST", "/v1/voice/search-omi", "search_omi_conversations"),
+        ("POST", "/v1/voice/search", "unified_search"),
+    ),
+    _group(
+        "voice",
+        "public_metadata",
+        "public",
+        ("GET", "/v1/voice/config", "get_voice_config"),
+    ),
+    _group(
+        "voice",
+        "firebase_or_internal_tts_exact_subject",
+        "staged_public",
+        ("POST", "/v1/voice/tts", "synthesize_speech"),
+    ),
+)
+
+
+def _declared_routes():
+    declared = {}
+    for module, authority, disposition, routes in ROUTE_GROUPS:
+        for method, path, endpoint in routes:
+            key = (module, method, path)
+            assert key not in declared, f"duplicate route declaration: {key}"
+            declared[key] = (endpoint, authority, disposition)
+    return declared
+
+
+def _source_routes(path):
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    prefixes = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        value = node.value
+        if not isinstance(value, ast.Call):
+            continue
+        function_name = value.func.id if isinstance(value.func, ast.Name) else getattr(value.func, "attr", "")
+        if function_name != "APIRouter":
+            continue
+        prefix = ""
+        for keyword in value.keywords:
+            if keyword.arg == "prefix" and isinstance(keyword.value, ast.Constant):
+                prefix = keyword.value.value
+        for target in targets:
+            if isinstance(target, ast.Name):
+                prefixes[target.id] = prefix
+
+    routes = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for decorator in node.decorator_list:
+            if not (
+                isinstance(decorator, ast.Call)
+                and isinstance(decorator.func, ast.Attribute)
+                and decorator.func.attr.upper() in HTTP_METHODS
+                and decorator.args
+                and isinstance(decorator.args[0], ast.Constant)
+                and isinstance(decorator.func.value, ast.Name)
+            ):
+                continue
+            method = decorator.func.attr.upper()
+            route_path = prefixes.get(decorator.func.value.id, "") + decorator.args[0].value
+            key = (path.stem, method, route_path)
+            assert key not in routes, f"duplicate source route: {key}"
+            routes[key] = node.name
+    return routes
+
+
+def test_all_ella_router_modules_and_routes_have_declared_authority_and_disposition():
+    module_paths = {path.stem: path for path in ROUTERS.glob("*.py") if path.name != "__init__.py"}
+    declared_modules = {module for module, *_rest in ROUTE_GROUPS} | {"auto_provision"}
+    assert set(module_paths) == declared_modules
+
+    actual = {}
+    for path in module_paths.values():
+        actual.update(_source_routes(path))
+
+    declared = _declared_routes()
+    assert set(actual) == set(declared)
+    for key, endpoint_name in actual.items():
+        declared_endpoint, authority, disposition = declared[key]
+        assert endpoint_name == declared_endpoint
+        assert authority
+        assert disposition
+
+
+def test_every_router_source_is_registered_without_disabling_conditional_routers():
+    ella_init = (BACKEND / "ella" / "__init__.py").read_text(encoding="utf-8")
+    main_source = (BACKEND / "main.py").read_text(encoding="utf-8")
+    modules_with_routes = {module for module, *_rest in ROUTE_GROUPS}
+    for module in modules_with_routes - {"ai_consent"}:
+        assert f"from ella.routers.{module} import" in ella_init, module
+    assert "app.include_router(ai_consent.router)" in main_source
+    assert 'if ELLA_GUARDIAN_ENABLED:' in ella_init
+    assert 'if ELLA_VOICE_V2_ENABLED:' in ella_init

--- a/backend/tests/unit/test_ella_app_settings.py
+++ b/backend/tests/unit/test_ella_app_settings.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 from google.cloud.firestore_v1 import SERVER_TIMESTAMP
 
 from ella.services import app_settings as service
-from utils.other import endpoints as auth
+from utils.ella.exact_firebase_auth import get_exact_firebase_uid
 
 
 def test_extract_voice_settings_normalizes_ios_payload():
@@ -83,7 +83,7 @@ def _load_router(monkeypatch, stored_voice=None):
 
     app = FastAPI()
     app.include_router(module.router)
-    app.dependency_overrides[auth.get_current_user_uid] = lambda: "uid-1"
+    app.dependency_overrides[get_exact_firebase_uid] = lambda: "uid-1"
     return TestClient(app), state
 
 

--- a/backend/tests/unit/test_ella_auth_authority_contract.py
+++ b/backend/tests/unit/test_ella_auth_authority_contract.py
@@ -1,0 +1,141 @@
+import logging
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from firebase_admin.auth import InvalidIdTokenError
+
+from utils.ella import exact_firebase_auth
+from utils.other import endpoints
+
+BACKEND = Path(__file__).resolve().parents[2]
+
+
+def _reject_firebase(_token):
+    raise InvalidIdTokenError("not firebase")
+
+
+def test_admin_key_suffix_cannot_mint_arbitrary_subject(monkeypatch):
+    monkeypatch.setenv("ADMIN_KEY", "unit-admin-key:")
+    monkeypatch.delenv("ELLA_ADMIN_SUBJECT_ALLOWLIST", raising=False)
+    monkeypatch.setattr(endpoints.auth, "verify_id_token", _reject_firebase)
+
+    with pytest.raises(InvalidIdTokenError):
+        endpoints.verify_token("unit-admin-key:attacker", caller_class="http")
+
+    monkeypatch.setenv("ELLA_ADMIN_SUBJECT_ALLOWLIST", "controlled-user")
+    assert endpoints.verify_token("unit-admin-key:controlled-user", caller_class="http") == "controlled-user"
+    with pytest.raises(InvalidIdTokenError):
+        endpoints.verify_token("unit-admin-key:controlled-user-extra", caller_class="http")
+
+
+def test_admin_branch_observation_is_bounded_and_content_free(monkeypatch, caplog):
+    monkeypatch.setenv("ADMIN_KEY", "unit-admin-key:")
+    monkeypatch.delenv("ELLA_ADMIN_SUBJECT_ALLOWLIST", raising=False)
+    monkeypatch.setattr(endpoints.auth, "verify_id_token", _reject_firebase)
+    endpoints._ADMIN_BRANCH_COUNTS.clear()
+
+    with caplog.at_level(logging.INFO, logger=endpoints.__name__):
+        with pytest.raises(InvalidIdTokenError):
+            endpoints.verify_token("unit-admin-key:sensitive-subject", caller_class="http")
+
+    record = caplog.records[-1]
+    assert record.caller_class == "http"
+    assert record.invocation_count == 1
+    assert record.invocation_count <= endpoints._ADMIN_BRANCH_COUNT_LIMIT
+    assert "sensitive-subject" not in record.getMessage()
+    assert set(record.__dict__) & {"token", "uid", "headers", "content"} == set()
+
+
+@pytest.mark.parametrize("marker", ["ELLA_PRODUCTION", "PRODUCTION", "ENVIRONMENT", "DD_ENV"])
+def test_production_marker_disables_local_development_subject_fallback(monkeypatch, marker):
+    monkeypatch.delenv("ADMIN_KEY", raising=False)
+    monkeypatch.setenv("LOCAL_DEVELOPMENT", "true")
+    monkeypatch.setenv(marker, "production")
+    monkeypatch.setattr(endpoints.auth, "verify_id_token", _reject_firebase)
+
+    with pytest.raises(InvalidIdTokenError):
+        endpoints.verify_token("not-firebase")
+
+
+def test_nonproduction_local_development_fallback_remains_available(monkeypatch):
+    monkeypatch.delenv("ADMIN_KEY", raising=False)
+    monkeypatch.setenv("LOCAL_DEVELOPMENT", "true")
+    for marker in ("ELLA_PRODUCTION", "PRODUCTION", "ENVIRONMENT", "DD_ENV"):
+        monkeypatch.delenv(marker, raising=False)
+    monkeypatch.setattr(endpoints.auth, "verify_id_token", _reject_firebase)
+
+    assert endpoints.verify_token("not-firebase") == "123"
+
+
+def test_exact_firebase_boundary_never_accepts_admin_key(monkeypatch):
+    monkeypatch.setenv("ADMIN_KEY", "unit-admin-key:")
+    monkeypatch.setenv("ELLA_ADMIN_SUBJECT_ALLOWLIST", "controlled-user")
+    monkeypatch.setattr(exact_firebase_auth.firebase_auth, "verify_id_token", _reject_firebase)
+
+    with pytest.raises(HTTPException) as error:
+        exact_firebase_auth.get_exact_firebase_uid("Bearer unit-admin-key:controlled-user")
+
+    assert error.value.status_code == 401
+
+
+def test_minimum_client_build_is_fail_closed_and_version_aware(monkeypatch):
+    monkeypatch.setattr(exact_firebase_auth.firebase_auth, "verify_id_token", lambda _token: {"uid": "user-a"})
+    monkeypatch.setenv("ELLA_MIN_SUPPORTED_CLIENT_BUILD", "805")
+
+    with pytest.raises(HTTPException) as missing:
+        exact_firebase_auth.get_exact_firebase_uid("Bearer firebase", None, None, None)
+    assert missing.value.status_code == 426
+
+    with pytest.raises(HTTPException) as old:
+        exact_firebase_auth.get_exact_firebase_uid("Bearer firebase", None, "804", None)
+    assert old.value.status_code == 426
+    assert exact_firebase_auth.get_exact_firebase_uid("Bearer firebase", None, "805", None) == "user-a"
+
+    monkeypatch.setenv("ELLA_MIN_SUPPORTED_CLIENT_BUILD", "1.0.525")
+    assert exact_firebase_auth.get_exact_firebase_uid("Bearer firebase", "1.0.525", None, None) == "user-a"
+    with pytest.raises(HTTPException) as old_version:
+        exact_firebase_auth.get_exact_firebase_uid("Bearer firebase", "1.0.524", None, None)
+    assert old_version.value.status_code == 426
+
+    monkeypatch.setenv("ELLA_MIN_SUPPORTED_CLIENT_BUILD", "not-a-version")
+    with pytest.raises(HTTPException) as invalid_configuration:
+        exact_firebase_auth.get_exact_firebase_uid("Bearer firebase", None, "805", None)
+    assert invalid_configuration.value.status_code == 503
+
+
+def test_service_authority_is_constant_time_bound_to_one_subject():
+    authority = exact_firebase_auth.get_exact_service_authority(
+        provided_service_key="service-secret",
+        configured_service_key="service-secret",
+        service_subject_uid="user-a",
+        service="test_service",
+    )
+    assert authority.require_uid("user-a", feature="test") == "user-a"
+    with pytest.raises(HTTPException) as cross_owner:
+        authority.require_uid("user-b", feature="test")
+    assert cross_owner.value.status_code == 403
+
+    with pytest.raises(HTTPException) as unbound:
+        exact_firebase_auth.get_exact_service_authority(
+            provided_service_key="service-secret",
+            configured_service_key="service-secret",
+            service_subject_uid=None,
+            service="test_service",
+        )
+    assert unbound.value.status_code == 403
+
+
+def test_ella_user_routes_do_not_inherit_legacy_admin_subject_auth():
+    sources = [
+        *(BACKEND / "ella" / "routers").glob("*.py"),
+        *(BACKEND / "ella" / "services").glob("*.py"),
+    ]
+    assert not any("auth.get_current_user_uid" in path.read_text(encoding="utf-8") for path in sources)
+
+
+def test_fifteen_fixed_capability_admin_guards_are_retained():
+    assert (BACKEND / "routers" / "apps.py").read_text(encoding="utf-8").count("os.getenv('ADMIN_KEY')") == 12
+    assert (BACKEND / "routers" / "notifications.py").read_text(encoding="utf-8").count("os.getenv('ADMIN_KEY')") == 1
+    assert (BACKEND / "routers" / "updates.py").read_text(encoding="utf-8").count("os.getenv('ADMIN_KEY')") == 1
+    assert (BACKEND / "routers" / "announcements.py").read_text(encoding="utf-8").count('os.getenv("ADMIN_KEY")') == 1

--- a/backend/tests/unit/test_ella_auth_authority_contract.py
+++ b/backend/tests/unit/test_ella_auth_authority_contract.py
@@ -1,3 +1,4 @@
+import ast
 import logging
 from pathlib import Path
 
@@ -79,6 +80,18 @@ def test_exact_firebase_boundary_never_accepts_admin_key(monkeypatch):
     assert error.value.status_code == 401
 
 
+def test_ella_lazy_exports_keep_imports_at_module_scope():
+    source = (BACKEND / "utils" / "ella" / "__init__.py").read_text()
+    tree = ast.parse(source)
+    lazy_loader = next(
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "__getattr__"
+    )
+
+    assert not any(isinstance(node, (ast.Import, ast.ImportFrom)) for node in ast.walk(lazy_loader))
+
+
 def test_minimum_client_build_is_fail_closed_and_version_aware(monkeypatch):
     monkeypatch.setattr(exact_firebase_auth.firebase_auth, "verify_id_token", lambda _token: {"uid": "user-a"})
     monkeypatch.setenv("ELLA_MIN_SUPPORTED_CLIENT_BUILD", "805")
@@ -91,11 +104,22 @@ def test_minimum_client_build_is_fail_closed_and_version_aware(monkeypatch):
         exact_firebase_auth.get_exact_firebase_uid("Bearer firebase", None, "804", None)
     assert old.value.status_code == 426
     assert exact_firebase_auth.get_exact_firebase_uid("Bearer firebase", None, "805", None) == "user-a"
+    with pytest.raises(HTTPException) as old_shared_header:
+        exact_firebase_auth.get_exact_firebase_uid("Bearer firebase", "1.0.525+804", None, None)
+    assert old_shared_header.value.status_code == 426
+    assert exact_firebase_auth.get_exact_firebase_uid("Bearer firebase", "1.0.525+805", None, None) == "user-a"
+    with pytest.raises(HTTPException) as missing_build_component:
+        exact_firebase_auth.get_exact_firebase_uid("Bearer firebase", "1.0.525", None, None)
+    assert missing_build_component.value.status_code == 426
 
     monkeypatch.setenv("ELLA_MIN_SUPPORTED_CLIENT_BUILD", "1.0.525")
     assert exact_firebase_auth.get_exact_firebase_uid("Bearer firebase", "1.0.525", None, None) == "user-a"
+    assert exact_firebase_auth.get_exact_firebase_uid("Bearer firebase", "1.0.525+805", None, None) == "user-a"
+    with pytest.raises(HTTPException) as build_only_for_semantic_gate:
+        exact_firebase_auth.get_exact_firebase_uid("Bearer firebase", None, "805", None)
+    assert build_only_for_semantic_gate.value.status_code == 426
     with pytest.raises(HTTPException) as old_version:
-        exact_firebase_auth.get_exact_firebase_uid("Bearer firebase", "1.0.524", None, None)
+        exact_firebase_auth.get_exact_firebase_uid("Bearer firebase", "1.0.524+999", None, None)
     assert old_version.value.status_code == 426
 
     monkeypatch.setenv("ELLA_MIN_SUPPORTED_CLIENT_BUILD", "not-a-version")

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -31,6 +31,10 @@ assert _callbacks_spec is not None and _callbacks_spec.loader is not None
 _callbacks_spec.loader.exec_module(callbacks)
 
 
+def _service_authority(uid: str):
+    return callbacks.EllaRequestAuthority(service="test_callback", service_subject_uid=uid)
+
+
 @pytest.fixture(autouse=True)
 def disable_canonical_omi_network(monkeypatch):
     monkeypatch.setattr(
@@ -60,6 +64,7 @@ def test_update_conversation_summary_clears_stale_app_results(monkeypatch):
                 category="personal",
             ),
             uid="user-123",
+            service=_service_authority("user-123"),
         )
     )
 
@@ -93,6 +98,7 @@ def test_update_conversation_summary_adds_missing_ella_prefix(monkeypatch):
                 overview="Updated overview with enough useful context to safely replace the prior summary.",
             ),
             uid="user-123",
+            service=_service_authority("user-123"),
         )
     )
 
@@ -119,6 +125,7 @@ def test_update_conversation_summary_removes_raw_scanner_audit_sentence(monkeypa
                 ),
             ),
             uid="user-123",
+            service=_service_authority("user-123"),
         )
     )
 
@@ -140,6 +147,7 @@ def test_update_conversation_summary_rejects_internal_debug_jargon(monkeypatch):
                     ),
                 ),
                 uid="user-123",
+                service=_service_authority("user-123"),
             )
         )
 
@@ -167,6 +175,7 @@ def test_update_conversation_summary_allows_user_facing_mcp_api_topic(monkeypatc
                 category="technology",
             ),
             uid="user-123",
+            service=_service_authority("user-123"),
         )
     )
 
@@ -182,6 +191,7 @@ def test_update_conversation_summary_rejects_invalid_category():
                 "conv-123",
                 callbacks.ConversationSummaryUpdate(category="definitely-not-a-real-category"),
                 uid="user-123",
+                service=_service_authority("user-123"),
             )
         )
 
@@ -209,7 +219,13 @@ def test_get_conversation_data_returns_transcript_payload(monkeypatch):
         },
     )
 
-    result = asyncio.run(callbacks.get_conversation_data("conv-123", uid="user-123"))
+    result = asyncio.run(
+        callbacks.get_conversation_data(
+            "conv-123",
+            uid="user-123",
+            service=_service_authority("user-123"),
+        )
+    )
 
     assert result["conversation_id"] == "conv-123"
     assert result["uid"] == "user-123"
@@ -235,7 +251,13 @@ def test_get_conversation_data_404s_when_missing(monkeypatch):
     monkeypatch.setattr(callbacks.conversations_db, "get_conversation", lambda uid, conversation_id: None)
 
     with pytest.raises(HTTPException) as excinfo:
-        asyncio.run(callbacks.get_conversation_data("missing-conv", uid="user-123"))
+        asyncio.run(
+            callbacks.get_conversation_data(
+                "missing-conv",
+                uid="user-123",
+                service=_service_authority("user-123"),
+            )
+        )
 
     assert excinfo.value.status_code == 404
     assert "Conversation not found" in excinfo.value.detail
@@ -296,6 +318,7 @@ def test_update_conversation_summary_records_version_and_marks_correction_applie
                 summary_source="observer",
             ),
             uid="user-123",
+            service=_service_authority("user-123"),
         )
     )
 
@@ -364,6 +387,7 @@ def test_update_conversation_summary_persists_internal_assessment_when_available
                 summary_kind="observer_enriched",
             ),
             uid="user-123",
+            service=_service_authority("user-123"),
         )
     )
 
@@ -503,6 +527,7 @@ def test_update_conversation_summary_writes_enriched_omi_to_canonical(monkeypatc
                 require_canonical=True,
             ),
             uid="user-123",
+            service=_service_authority("user-123"),
         )
     )
 
@@ -557,6 +582,7 @@ def test_update_conversation_summary_same_trace_is_idempotent(monkeypatch):
                 trace_id="summary-retry:conversation-1:request-1",
             ),
             uid="user-1",
+            service=_service_authority("user-1"),
         )
     )
 

--- a/backend/tests/unit/test_ella_conversation_corrections.py
+++ b/backend/tests/unit/test_ella_conversation_corrections.py
@@ -101,7 +101,7 @@ def _retry_conversation(status="processing", request_id="84eb13fa-31d9-40ba-a742
 def _retry_api_client():
     app = FastAPI()
     app.include_router(corrections.router)
-    app.dependency_overrides[corrections.auth.get_current_user_uid] = lambda: "authenticated-user"
+    app.dependency_overrides[corrections.get_exact_firebase_uid] = lambda: "authenticated-user"
     return app, TestClient(app)
 
 

--- a/backend/tests/unit/test_ella_escalations_router_auth.py
+++ b/backend/tests/unit/test_ella_escalations_router_auth.py
@@ -80,6 +80,7 @@ def test_policy_view_internal_key_reaches_load_context_for_explicit_uid(monkeypa
             x_guardian_key=_TEST_ESCALATION_WEBHOOK_KEY,
             x_escalation_key=None,
             key=None,
+            subject_uid="uid-1",
         )
     )
 
@@ -88,7 +89,28 @@ def test_policy_view_internal_key_reaches_load_context_for_explicit_uid(monkeypa
     assert response["uid"] == "uid-1"
 
 
-def test_policy_view_internal_key_requires_uid_before_load_context(monkeypatch, configured_escalation_key):
+def test_policy_view_internal_key_rejects_wrong_subject_before_context(monkeypatch, configured_escalation_key):
+    async def fail_load_context(_uid):
+        raise AssertionError("_load_context must not run for a mismatched service subject")
+
+    monkeypatch.setattr(escalations, "_load_context", fail_load_context)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            escalations.get_escalation_policy(
+                uid="uid-1",
+                authorization=None,
+                x_guardian_key=_TEST_ESCALATION_WEBHOOK_KEY,
+                x_escalation_key=None,
+                key=None,
+                subject_uid="uid-2",
+            )
+        )
+
+    assert exc.value.status_code == 403
+
+
+def test_policy_view_internal_key_requires_bound_subject_before_load_context(monkeypatch, configured_escalation_key):
     async def fail_load_context(_uid):
         raise AssertionError("_load_context must not run without an explicit service-authority UID")
 
@@ -102,14 +124,15 @@ def test_policy_view_internal_key_requires_uid_before_load_context(monkeypatch, 
                 x_guardian_key=_TEST_ESCALATION_WEBHOOK_KEY,
                 x_escalation_key=None,
                 key=None,
+                subject_uid=None,
             )
         )
 
-    assert exc.value.status_code == 400
+    assert exc.value.status_code == 403
 
 
 def test_policy_view_uid_uses_authenticated_uid_when_uid_omitted(monkeypatch):
-    monkeypatch.setattr(escalations.auth_endpoints, "verify_token", lambda token: "uid-1")
+    monkeypatch.setattr(escalations, "get_exact_firebase_uid", lambda *_args: "uid-1")
 
     assert (
         escalations._resolve_policy_view_uid(
@@ -118,13 +141,14 @@ def test_policy_view_uid_uses_authenticated_uid_when_uid_omitted(monkeypatch):
             x_guardian_key=None,
             x_escalation_key=None,
             key=None,
+            subject_uid=None,
         )
         == "uid-1"
     )
 
 
 def test_policy_view_uid_rejects_cross_user_read(monkeypatch):
-    monkeypatch.setattr(escalations.auth_endpoints, "verify_token", lambda token: "uid-1")
+    monkeypatch.setattr(escalations, "get_exact_firebase_uid", lambda *_args: "uid-1")
 
     with pytest.raises(HTTPException) as exc:
         escalations._resolve_policy_view_uid(
@@ -133,6 +157,7 @@ def test_policy_view_uid_rejects_cross_user_read(monkeypatch):
             x_guardian_key=None,
             x_escalation_key=None,
             key=None,
+            subject_uid=None,
         )
 
     assert exc.value.status_code == 403
@@ -146,12 +171,12 @@ def test_policy_view_denies_absent_empty_malformed_and_wrong_credentials_before_
 
     verified_tokens = []
 
-    def reject_firebase_token(token):
-        verified_tokens.append(token)
-        raise InvalidIdTokenError
+    def reject_firebase_token(authorization, *_version_headers):
+        verified_tokens.append(authorization)
+        raise HTTPException(status_code=401, detail="Invalid or expired Firebase bearer")
 
     monkeypatch.setattr(escalations, "_load_context", fail_load_context)
-    monkeypatch.setattr(escalations.auth_endpoints, "verify_token", reject_firebase_token)
+    monkeypatch.setattr(escalations, "get_exact_firebase_uid", reject_firebase_token)
 
     denial_cases = {
         "absent": {},
@@ -171,13 +196,23 @@ def test_policy_view_denies_absent_empty_malformed_and_wrong_credentials_before_
             "x_guardian_key": None,
             "x_escalation_key": None,
             "key": None,
+            "subject_uid": None,
             **overrides,
         }
         with pytest.raises(HTTPException) as exc:
             asyncio.run(escalations.get_escalation_policy(**arguments))
         assert exc.value.status_code == 401, case_name
 
-    assert verified_tokens == ["invalid-test-token"]
+    assert verified_tokens == [
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "not-a-bearer-token",
+        "Bearer invalid-test-token",
+    ]
 
 
 class _FakePool:
@@ -261,6 +296,7 @@ def test_policy_markdown_internal_key_reaches_same_auth_and_context(monkeypatch,
             x_guardian_key=_TEST_ESCALATION_WEBHOOK_KEY,
             x_escalation_key=None,
             key=None,
+            subject_uid="uid-1",
         )
     )
 
@@ -292,6 +328,7 @@ def test_evaluate_internal_key_reaches_load_context_for_explicit_uid(monkeypatch
             x_guardian_key=None,
             x_escalation_key=_TEST_ESCALATION_WEBHOOK_KEY,
             key=None,
+            subject_uid="uid-1",
         )
     )
 
@@ -333,7 +370,7 @@ def test_production_default_empty_and_absent_credentials_deny_all_authority_path
                 headers=headers,
                 json={"uid": "uid-1"},
             )
-            assert evaluate_response.status_code == 403, (case_name, evaluate_response.text)
+            assert evaluate_response.status_code == 503, (case_name, evaluate_response.text)
 
             with pytest.raises(HTTPException) as exc:
                 production_escalations._verify_key(*verifier_arguments)

--- a/backend/tests/unit/test_ella_guardian_delivery.py
+++ b/backend/tests/unit/test_ella_guardian_delivery.py
@@ -261,6 +261,7 @@ def test_deliver_dispatches_pending_backend_resolved_recipient(monkeypatch):
         guardian.deliver(
             guardian.DeliverRequest(uid="uid-1", trace_id="trace-1", severity="critical", summary="Needs help"),
             x_guardian_key=guardian.GUARDIAN_WEBHOOK_KEY,
+            subject_uid="uid-1",
         )
     )
 
@@ -268,6 +269,7 @@ def test_deliver_dispatches_pending_backend_resolved_recipient(monkeypatch):
     assert len(_FakeAsyncClient.posts) == 1
     _url, kwargs = _FakeAsyncClient.posts[0]
     assert kwargs["headers"]["X-Guardian-Key"] == guardian.GUARDIAN_WEBHOOK_KEY
+    assert kwargs["headers"]["X-Ella-Subject-Uid"] == "uid-1"
     step = kwargs["json"]["delivery_plan"][0]
     assert step["target"] == "user"
     assert step["recipient_phone"] == "+15550000001"
@@ -277,11 +279,13 @@ def test_synthesize_audio_resolves_server_voice_settings(monkeypatch):
     _FakeAsyncClient.posts = []
     monkeypatch.setattr(guardian.httpx, "AsyncClient", _FakeAsyncClient)
     monkeypatch.setattr(guardian.app_settings_db, "get_voice_settings", lambda uid: {"voice_mode": "grok-voice"})
+    monkeypatch.setattr(guardian, "ELLA_INTERNAL_VOICE_TTS_TOKEN", "test-internal-tts-token")
 
     response = asyncio.run(
         guardian.synthesize_audio(
             guardian.SynthesizeRequest(uid="uid-1", text="Hello", trace_id="trace-1"),
             x_guardian_key=guardian.GUARDIAN_WEBHOOK_KEY,
+            subject_uid="uid-1",
         )
     )
 
@@ -289,6 +293,8 @@ def test_synthesize_audio_resolves_server_voice_settings(monkeypatch):
     url, kwargs = _FakeAsyncClient.posts[0]
     assert url == guardian.ELLA_INTERNAL_VOICE_TTS_URL
     assert kwargs["headers"]["X-TTS-Provider"] == "xai-tts"
+    assert kwargs["headers"]["X-Ella-Internal-Token"] == guardian.ELLA_INTERNAL_VOICE_TTS_TOKEN
+    assert kwargs["headers"]["X-Ella-Subject-Uid"] == "uid-1"
     assert kwargs["json"]["text"] == "Hello"
     assert response.headers["x-guardian-tts-provider"] == "xai-tts"
     assert response.headers["x-guardian-voice-mode"] == "grok-voice"
@@ -304,6 +310,7 @@ def test_synthesize_audio_uses_matching_tts_provider(monkeypatch):
         guardian.synthesize_audio(
             guardian.SynthesizeRequest(uid="uid-1", text="Hello", trace_id="trace-1"),
             x_guardian_key=guardian.GUARDIAN_WEBHOOK_KEY,
+            subject_uid="uid-1",
         )
     )
 
@@ -347,6 +354,7 @@ def test_synthesize_audio_falls_back_to_next_candidate(monkeypatch):
         guardian.synthesize_audio(
             guardian.SynthesizeRequest(uid="uid-1", text="Hello", trace_id="trace-1"),
             x_guardian_key=guardian.GUARDIAN_WEBHOOK_KEY,
+            subject_uid="uid-1",
         )
     )
 
@@ -434,6 +442,7 @@ def test_trace_log_requires_configured_key_and_rejects_bad_key(monkeypatch):
             guardian.TraceLogRequest(trace_id="trace-1", uid="uid-1", stage="scanner_classified"),
             x_guardian_key=guardian.GUARDIAN_WEBHOOK_KEY,
             key=None,
+            subject_uid="uid-1",
         )
     )
     assert ok["logged"] is True
@@ -939,7 +948,10 @@ def test_guardian_owner_routes_reject_missing_malformed_and_cross_user_before_st
 def test_guardian_owner_or_service_reads_enforce_service_scope_and_owner(monkeypatch):
     pool = _GuardianRoutePool()
     client = _guardian_route_client(monkeypatch, pool)
-    service_headers = {"X-Guardian-Key": guardian.GUARDIAN_WEBHOOK_KEY}
+    service_headers = {
+        "X-Guardian-Key": guardian.GUARDIAN_WEBHOOK_KEY,
+        "X-Ella-Subject-Uid": "uid-b",
+    }
 
     queue = client.get("/v1/ella/guardian/queue?uid=uid-b", headers=service_headers)
     trace = client.get("/v1/ella/guardian/trace/trace-a?uid=uid-b", headers=service_headers)
@@ -952,8 +964,14 @@ def test_guardian_owner_or_service_reads_enforce_service_scope_and_owner(monkeyp
 
     calls_after_success = pool.call_count
     for headers in (
-        {"X-Guardian-Key": "wrong-service"},
-        {"Authorization": "Bearer valid-a", "X-Guardian-Key": "wrong-service"},
+        {"X-Guardian-Key": "wrong-service", "X-Ella-Subject-Uid": "uid-a"},
+        {"X-Guardian-Key": guardian.GUARDIAN_WEBHOOK_KEY},
+        {"X-Guardian-Key": guardian.GUARDIAN_WEBHOOK_KEY, "X-Ella-Subject-Uid": "uid-b"},
+        {
+            "Authorization": "Bearer valid-a",
+            "X-Guardian-Key": "wrong-service",
+            "X-Ella-Subject-Uid": "uid-a",
+        },
     ):
         assert client.get("/v1/ella/guardian/queue?uid=uid-a", headers=headers).status_code == 403
         assert client.get("/v1/ella/guardian/trace/trace-a?uid=uid-a", headers=headers).status_code == 403
@@ -988,7 +1006,12 @@ def test_guardian_service_routes_reject_missing_and_wrong_scope_before_state(
     files,
     data,
 ):
-    for headers in ({}, {"X-Guardian-Key": "wrong-service"}):
+    for headers in (
+        {},
+        {"X-Guardian-Key": "wrong-service", "X-Ella-Subject-Uid": "uid-a"},
+        {"X-Guardian-Key": guardian.GUARDIAN_WEBHOOK_KEY},
+        {"X-Guardian-Key": guardian.GUARDIAN_WEBHOOK_KEY, "X-Ella-Subject-Uid": "uid-b"},
+    ):
         pool = _GuardianRoutePool()
         client = _guardian_route_client(monkeypatch, pool)
         request_kwargs = {"headers": headers}
@@ -1001,7 +1024,7 @@ def test_guardian_service_routes_reject_missing_and_wrong_scope_before_state(
 
         response = client.request(method, path, **request_kwargs)
 
-        assert response.status_code == 403
+        assert response.status_code == 403, (headers, response.text)
         assert pool.call_count == 0
 
 
@@ -1012,7 +1035,10 @@ def test_guardian_trace_log_accepts_only_configured_trace_service_key(monkeypatc
 
     accepted = client.post(
         "/v1/ella/guardian/trace/log",
-        headers={"X-Guardian-Key": guardian.GUARDIAN_WEBHOOK_KEY},
+        headers={
+            "X-Guardian-Key": guardian.GUARDIAN_WEBHOOK_KEY,
+            "X-Ella-Subject-Uid": "uid-a",
+        },
         json=payload,
     )
 

--- a/backend/tests/unit/test_ella_incident_1182_callback_auth.py
+++ b/backend/tests/unit/test_ella_incident_1182_callback_auth.py
@@ -153,7 +153,15 @@ def test_first_party_caregiver_routes_derive_owner_and_reject_caller_uid(monkeyp
     monkeypatch.setattr(
         callbacks,
         "update_caregiver",
-        lambda uid, _caregiver_id, data: effects.append(("permissions", uid)) or {"id": "caregiver-a", **data},
+        lambda uid, _caregiver_id, data: effects.append(("permissions", uid, data))
+        or {
+            "id": "caregiver-a",
+            "permissions": {
+                "receive_emergency_alerts": False,
+                "receive_daily_summary": data["permissions.receive_daily_summary"],
+                "daily_summary_email": data["permissions.daily_summary_email"],
+            },
+        },
     )
     monkeypatch.setattr(
         callbacks,
@@ -202,12 +210,20 @@ def test_first_party_caregiver_routes_derive_owner_and_reject_caller_uid(monkeyp
     ]
 
     assert [response.status_code for response in responses] == [200, 201, 200, 200, 200, 200, 204]
+    assert responses[4].json()["permissions"]["receive_emergency_alerts"] is False
     assert effects == [
         ("list", "uid-a"),
         ("invite", "uid-a"),
         ("get-emergency", "uid-a"),
         ("set-emergency", "uid-a"),
-        ("permissions", "uid-a"),
+        (
+            "permissions",
+            "uid-a",
+            {
+                "permissions.receive_daily_summary": True,
+                "permissions.daily_summary_email": True,
+            },
+        ),
         ("resend", "uid-a"),
         ("delete", "uid-a"),
     ]

--- a/backend/tests/unit/test_ella_incident_1182_callback_auth.py
+++ b/backend/tests/unit/test_ella_incident_1182_callback_auth.py
@@ -19,6 +19,8 @@ from utils.ella import exact_firebase_auth
 def _verify_firebase(token):
     if token == "token-a":
         return {"uid": "uid-a"}
+    if token == "token-b":
+        return {"uid": "uid-b"}
     raise ValueError("invalid token")
 
 
@@ -118,6 +120,129 @@ def test_emergency_contact_exact_owner_positive_control(monkeypatch):
     assert emergency.json()["push_sent"] is True
 
 
+def test_first_party_caregiver_routes_derive_owner_and_reject_caller_uid(monkeypatch):
+    effects = []
+
+    monkeypatch.setattr(
+        callbacks,
+        "get_caregivers",
+        lambda uid: effects.append(("list", uid)) or [{"id": "caregiver-a", "name": "Caregiver"}],
+    )
+    monkeypatch.setattr(
+        callbacks,
+        "create_caregiver",
+        lambda uid, data: effects.append(("invite", uid))
+        or {
+            **data,
+            "id": "caregiver-a",
+            "invite_code": "123456",
+            "status": "invited",
+            "invite_expires_at": "2026-08-11T00:00:00+00:00",
+        },
+    )
+    monkeypatch.setattr(
+        callbacks,
+        "get_emergency_caregiver_id",
+        lambda uid: effects.append(("get-emergency", uid)) or "caregiver-a",
+    )
+    monkeypatch.setattr(
+        callbacks,
+        "set_emergency_caregiver",
+        lambda uid, caregiver_id: effects.append(("set-emergency", uid)) or caregiver_id,
+    )
+    monkeypatch.setattr(
+        callbacks,
+        "update_caregiver",
+        lambda uid, _caregiver_id, data: effects.append(("permissions", uid)) or {"id": "caregiver-a", **data},
+    )
+    monkeypatch.setattr(
+        callbacks,
+        "refresh_caregiver_invite",
+        lambda uid, _caregiver_id: effects.append(("resend", uid))
+        or {
+            "id": "caregiver-a",
+            "invite_code": "654321",
+            "status": "invited",
+            "invite_expires_at": "2026-08-11T00:00:00+00:00",
+        },
+    )
+    monkeypatch.setattr(
+        callbacks,
+        "delete_caregiver",
+        lambda uid, _caregiver_id: effects.append(("delete", uid)) or True,
+    )
+    client = _client(monkeypatch)
+    headers = {"Authorization": "Bearer token-a"}
+
+    responses = [
+        client.get("/v1/ella/caregivers", headers=headers),
+        client.post(
+            "/v1/ella/caregivers/invite",
+            headers=headers,
+            json={
+                "name": "Caregiver",
+                "email": "caregiver@example.test",
+                "relationship": "friend",
+                "permissions": {"receive_daily_summary": True, "daily_summary_email": True},
+            },
+        ),
+        client.get("/v1/ella/caregivers/emergency-contact", headers=headers),
+        client.put(
+            "/v1/ella/caregivers/emergency-contact",
+            headers=headers,
+            json={"caregiver_id": "caregiver-a"},
+        ),
+        client.put(
+            "/v1/ella/caregivers/caregiver-a/permissions",
+            headers=headers,
+            json={"receive_daily_summary": True, "daily_summary_email": True},
+        ),
+        client.post("/v1/ella/caregivers/caregiver-a/resend-invite", headers=headers),
+        client.delete("/v1/ella/caregivers/caregiver-a", headers=headers),
+    ]
+
+    assert [response.status_code for response in responses] == [200, 201, 200, 200, 200, 200, 204]
+    assert effects == [
+        ("list", "uid-a"),
+        ("invite", "uid-a"),
+        ("get-emergency", "uid-a"),
+        ("set-emergency", "uid-a"),
+        ("permissions", "uid-a"),
+        ("resend", "uid-a"),
+        ("delete", "uid-a"),
+    ]
+
+    effects.clear()
+    caller_uid = client.post(
+        "/v1/ella/caregivers/invite",
+        headers={"Authorization": "Bearer token-b"},
+        json={
+            "uid": "uid-a",
+            "name": "Caregiver",
+            "email": "caregiver@example.test",
+            "relationship": "friend",
+        },
+    )
+    assert caller_uid.status_code == 422
+    assert effects == []
+
+
+def test_caregiver_routes_reject_unauth_admin_and_service_before_storage(monkeypatch):
+    effects = []
+    monkeypatch.setattr(callbacks, "get_caregivers", lambda uid: effects.append(uid) or [])
+    monkeypatch.setenv("ADMIN_KEY", "unit-admin-key:")
+    monkeypatch.setenv("ELLA_ADMIN_SUBJECT_ALLOWLIST", "uid-a")
+    client = _client(monkeypatch)
+
+    for headers in (
+        {},
+        {"Authorization": "Bearer unit-admin-key:uid-a"},
+        {"X-Ella-Caregiver-Service-Key": "caregiver-service-test", "X-Ella-Subject-Uid": "uid-a"},
+    ):
+        assert client.get("/v1/ella/caregivers", headers=headers).status_code == 401
+    assert effects == []
+
+
 def test_internal_callback_service_fails_closed_and_positive_control_is_scoped(monkeypatch):
     effects = []
 
@@ -137,17 +262,135 @@ def test_internal_callback_service_fails_closed_and_positive_control_is_scoped(m
     monkeypatch.setenv("ELLA_CALLBACK_SERVICE_KEY", "callback-service-test")
     wrong = client.get(
         "/v1/ella/conversations/enrichment/reconcile-candidates?uid=uid-a",
-        headers={"X-Ella-Callback-Service-Key": "wrong"},
+        headers={"X-Ella-Callback-Service-Key": "wrong", "X-Ella-Subject-Uid": "uid-a"},
     )
     assert wrong.status_code == 403
     assert effects == []
 
-    accepted = client.get(
+    unbound = client.get(
         "/v1/ella/conversations/enrichment/reconcile-candidates?uid=uid-a",
         headers={"X-Ella-Callback-Service-Key": "callback-service-test"},
     )
+    assert unbound.status_code == 403
+    assert effects == []
+
+    cross_owner = client.get(
+        "/v1/ella/conversations/enrichment/reconcile-candidates?uid=uid-a",
+        headers={
+            "X-Ella-Callback-Service-Key": "callback-service-test",
+            "X-Ella-Subject-Uid": "uid-b",
+        },
+    )
+    assert cross_owner.status_code == 403
+    assert effects == []
+
+    accepted = client.get(
+        "/v1/ella/conversations/enrichment/reconcile-candidates?uid=uid-a",
+        headers={
+            "X-Ella-Callback-Service-Key": "callback-service-test",
+            "X-Ella-Subject-Uid": "uid-a",
+        },
+    )
     assert accepted.status_code == 200
     assert effects == ["db"]
+
+
+def test_callback_routes_reject_unbound_wrong_and_nonservice_authority_before_effects(monkeypatch):
+    effects = []
+    monkeypatch.setenv("ELLA_CALLBACK_SERVICE_KEY", "callback-service-test")
+    monkeypatch.setattr(callbacks, "assert_current_ai_consent", lambda uid: effects.append(("consent", uid)))
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: effects.append(("read", uid, conversation_id)) or {},
+    )
+    monkeypatch.setattr(callbacks, "send_notification", lambda **kwargs: effects.append(("push", kwargs["user_id"])))
+    client = _client(monkeypatch)
+
+    requests = (
+        ("get", "/v1/ella/conversation/conversation-a/data?uid=uid-a", {}),
+        (
+            "post",
+            "/v1/ella/notification",
+            {"json": {"uid": "uid-a", "message": "Test", "generate_audio": False}},
+        ),
+        ("post", "/v1/ella/daily-summary", {"json": {"uid": "uid-a"}}),
+    )
+    denied_headers = (
+        {},
+        {"Authorization": "Bearer token-a"},
+        {"X-Ella-Callback-Service-Key": "wrong", "X-Ella-Subject-Uid": "uid-a"},
+        {"X-Ella-Callback-Service-Key": "callback-service-test"},
+        {"X-Ella-Callback-Service-Key": "callback-service-test", "X-Ella-Subject-Uid": "uid-b"},
+    )
+    for method, path, kwargs in requests:
+        for headers in denied_headers:
+            assert getattr(client, method)(path, headers=headers, **kwargs).status_code == 403
+    assert effects == []
+
+
+def test_callback_routes_accept_only_matching_bound_subject(monkeypatch):
+    effects = []
+
+    class Response:
+        status_code = 200
+        text = "ok"
+
+    class Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def post(self, *_args, **_kwargs):
+            effects.append(("daily-summary", "uid-a"))
+            return Response()
+
+    monkeypatch.setenv("ELLA_CALLBACK_SERVICE_KEY", "callback-service-test")
+    monkeypatch.setattr(callbacks, "assert_current_ai_consent", lambda uid: effects.append(("consent", uid)))
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: effects.append(("read", uid, conversation_id)) or {},
+    )
+    monkeypatch.setattr(callbacks, "send_notification", lambda **kwargs: effects.append(("push", kwargs["user_id"])))
+    monkeypatch.setattr(callbacks.httpx, "AsyncClient", lambda **_kwargs: Client())
+    client = _client(monkeypatch)
+    headers = {
+        "X-Ella-Callback-Service-Key": "callback-service-test",
+        "X-Ella-Subject-Uid": "uid-a",
+    }
+
+    assert (
+        client.get(
+            "/v1/ella/conversation/conversation-a/data?uid=uid-a",
+            headers=headers,
+        ).status_code
+        == 200
+    )
+    assert (
+        client.post(
+            "/v1/ella/notification",
+            headers=headers,
+            json={"uid": "uid-a", "message": "Test", "generate_audio": False},
+        ).status_code
+        == 200
+    )
+    assert (
+        client.post(
+            "/v1/ella/daily-summary",
+            headers=headers,
+            json={"uid": "uid-a"},
+        ).status_code
+        == 200
+    )
+    assert effects == [
+        ("read", "uid-a", "conversation-a"),
+        ("consent", "uid-a"),
+        ("push", "uid-a"),
+        ("daily-summary", "uid-a"),
+    ]
 
 
 def test_caregiver_token_generation_requires_two_distinct_configured_secrets(monkeypatch):
@@ -160,13 +403,16 @@ def test_caregiver_token_generation_requires_two_distinct_configured_secrets(mon
     assert (
         client.post(
             "/v1/ella/generate-dashboard-token?uid=uid-a&caregiver_id=caregiver-a",
-            headers={"X-Ella-Caregiver-Service-Key": "wrong"},
+            headers={"X-Ella-Caregiver-Service-Key": "wrong", "X-Ella-Subject-Uid": "uid-a"},
         ).status_code
         == 403
     )
     accepted = client.post(
         "/v1/ella/generate-dashboard-token?uid=uid-a&caregiver_id=caregiver-a",
-        headers={"X-Ella-Caregiver-Service-Key": "caregiver-service-test"},
+        headers={
+            "X-Ella-Caregiver-Service-Key": "caregiver-service-test",
+            "X-Ella-Subject-Uid": "uid-a",
+        },
     )
     assert accepted.status_code == 200
     assert accepted.json()["expires_in_hours"] == 24

--- a/backend/tests/unit/test_ella_incident_1182_route_isolation.py
+++ b/backend/tests/unit/test_ella_incident_1182_route_isolation.py
@@ -149,14 +149,25 @@ def test_canonical_service_validates_every_identity_and_preserves_internal_sync(
     app = FastAPI()
     app.include_router(canonical_events.create_canonical_events_router(store))
     client = TestClient(app)
-    headers = {"X-Ella-Event-Ledger-Key": "ledger-service-test"}
+    headers = {
+        "X-Ella-Event-Ledger-Key": "ledger-service-test",
+        "X-Ella-Subject-Uid": "uid-a",
+    }
 
     accepted = client.post(
         "/v1/ella/events",
         headers=headers,
-        json={"events": [_event(), _event("uid-b", event_id="event-b")]},
+        json={"events": [_event()]},
     )
     assert accepted.status_code == 200
+    assert len(store.writes) == 1
+
+    mixed_owner = client.post(
+        "/v1/ella/events",
+        headers=headers,
+        json={"events": [_event(), _event("uid-b", event_id="event-b")]},
+    )
+    assert mixed_owner.status_code == 403
     assert len(store.writes) == 1
 
     malformed = _event(event_id="event-c")
@@ -165,13 +176,14 @@ def test_canonical_service_validates_every_identity_and_preserves_internal_sync(
     assert rejected.status_code == 403
     assert len(store.writes) == 1
 
-    timeline = client.get("/v1/ella/timeline?uid=uid-b", headers=headers)
+    uid_b_headers = {**headers, "X-Ella-Subject-Uid": "uid-b"}
+    timeline = client.get("/v1/ella/timeline?uid=uid-b", headers=uid_b_headers)
     assert timeline.status_code == 200
     assert store.timeline_calls[0][0] == "uid-b"
 
     completion = client.post(
         "/v1/ella/sessions/session-b/complete",
-        headers=headers,
+        headers=uid_b_headers,
         json={
             "uid": "uid-b",
             "canonical_identity": "uid-b",
@@ -757,6 +769,27 @@ MOUNTED_ROUTE_CONTRACT = {
     ("callbacks", "DELETE", "/v1/ella/emergency-contact/{contact_id}"): _contract(
         "delete_emergency_contact", "utils.ella.exact_firebase_auth:get_exact_firebase_uid"
     ),
+    ("callbacks", "GET", "/v1/ella/caregivers"): _contract(
+        "list_caregivers", "utils.ella.exact_firebase_auth:get_exact_firebase_uid"
+    ),
+    ("callbacks", "POST", "/v1/ella/caregivers/invite"): _contract(
+        "invite_caregiver", "utils.ella.exact_firebase_auth:get_exact_firebase_uid"
+    ),
+    ("callbacks", "GET", "/v1/ella/caregivers/emergency-contact"): _contract(
+        "get_emergency_caregiver", "utils.ella.exact_firebase_auth:get_exact_firebase_uid"
+    ),
+    ("callbacks", "PUT", "/v1/ella/caregivers/emergency-contact"): _contract(
+        "update_emergency_caregiver", "utils.ella.exact_firebase_auth:get_exact_firebase_uid"
+    ),
+    ("callbacks", "PUT", "/v1/ella/caregivers/{caregiver_id}/permissions"): _contract(
+        "update_caregiver_permissions", "utils.ella.exact_firebase_auth:get_exact_firebase_uid"
+    ),
+    ("callbacks", "POST", "/v1/ella/caregivers/{caregiver_id}/resend-invite"): _contract(
+        "resend_caregiver_invite", "utils.ella.exact_firebase_auth:get_exact_firebase_uid"
+    ),
+    ("callbacks", "DELETE", "/v1/ella/caregivers/{caregiver_id}"): _contract(
+        "remove_caregiver", "utils.ella.exact_firebase_auth:get_exact_firebase_uid"
+    ),
     ("callbacks", "GET", "/v1/ella/caregiver-dashboard-data"): _contract(
         "caregiver_dashboard_data", manual="validate_dashboard_token"
     ),
@@ -773,7 +806,7 @@ MOUNTED_ROUTE_CONTRACT = {
         "resolve_endpoint", "utils.ella.exact_firebase_auth:get_exact_firebase_uid"
     ),
     ("resolve", "GET", "/v1/ella/chat/history/{agent_id}"): _contract(
-        "proxy_chat_history", "utils.other.endpoints:get_current_user_uid"
+        "proxy_chat_history", "utils.ella.exact_firebase_auth:get_exact_firebase_uid"
     ),
     ("trace", "POST", "/v1/ella/debug/client-trace"): _contract(
         "ingest_client_trace", "utils.ella.exact_firebase_auth:get_exact_firebase_uid"
@@ -826,7 +859,7 @@ MOUNTED_ROUTE_CONTRACT = {
         "create_voice_session", "ella.services.ai_consent:require_current_ai_consent"
     ),
     ("voice", "GET", "/v1/voice/entitlement"): _contract(
-        "get_voice_entitlement", "utils.other.endpoints:get_current_user_uid"
+        "get_voice_entitlement", "utils.ella.exact_firebase_auth:get_exact_firebase_uid"
     ),
     ("voice", "POST", "/v1/voice/canary/accept"): _contract(
         "accept_voice_canary_session", manual="authenticate_voice_proxy_request"
@@ -851,7 +884,7 @@ MOUNTED_ROUTE_CONTRACT = {
     ),
     ("voice", "POST", "/v1/voice/search"): _contract("unified_search", manual="authenticate_voice_proxy_request"),
     ("voice", "GET", "/v1/entitlement"): _contract(
-        "get_voice_entitlement", "utils.other.endpoints:get_current_user_uid"
+        "get_voice_entitlement", "utils.ella.exact_firebase_auth:get_exact_firebase_uid"
     ),
 }
 
@@ -901,7 +934,7 @@ def test_real_mounted_route_manifest_has_exact_paths_authorities_and_no_duplicat
                 assert dependencies, f"unclassified authority: {key}"
 
     assert set(actual) == set(MOUNTED_ROUTE_CONTRACT)
-    assert len(actual) == len(MOUNTED_ROUTE_CONTRACT) == 42
+    assert len(actual) == len(MOUNTED_ROUTE_CONTRACT) == 49
     assert len(path_methods) == len(set(path_methods)), Counter(path_methods)
 
 

--- a/backend/tests/unit/test_ella_observer.py
+++ b/backend/tests/unit/test_ella_observer.py
@@ -341,7 +341,7 @@ def test_observer_router_runs_against_in_memory_test_ledger(monkeypatch):
 
     response = client.post(
         "/v1/ella/observer/run",
-        headers={"X-Ella-Observer-Token": "observer-token"},
+        headers={"X-Ella-Observer-Token": "observer-token", "X-Ella-Subject-Uid": "user-1"},
         json={"uid": "user-1", "dry_run": True, "channels": ["ios_chat"], "limit": 10},
     )
 
@@ -353,11 +353,77 @@ def test_observer_router_runs_against_in_memory_test_ledger(monkeypatch):
 
     run_id = body["run_id"]
     readback = client.get(
-        f"/v1/ella/observer/runs/{run_id}",
-        headers={"Authorization": "Bearer observer-token"},
+        f"/v1/ella/observer/runs/{run_id}?uid=user-1",
+        headers={"Authorization": "Bearer observer-token", "X-Ella-Subject-Uid": "user-1"},
     )
     assert readback.status_code == 200
     assert readback.json()["observer_run"]["run_id"] == run_id
+
+
+def test_observer_wrong_or_unbound_subject_fails_before_store_or_proposal_work(monkeypatch):
+    _install_proposal_stubs()
+    monkeypatch.setenv("ELLA_OBSERVER_ADMIN_TOKEN", "observer-token")
+    sys.modules.pop("ella.routers.observer", None)
+    sys.modules.pop("ella.services.observer_apply", None)
+    router_module = importlib.import_module("ella.routers.observer")
+
+    class NoEffects:
+        def __init__(self):
+            self.calls = []
+
+        async def timeline(self, **kwargs):
+            self.calls.append(("timeline", kwargs))
+            raise AssertionError("timeline must not run for denied authority")
+
+        async def write_batch(self, events):
+            self.calls.append(("write", events))
+            raise AssertionError("write must not run for denied authority")
+
+        async def get(self, run_id):
+            self.calls.append(("get", run_id))
+            raise AssertionError("log read must not run for denied authority")
+
+        async def save(self, log):
+            self.calls.append(("save", log))
+            raise AssertionError("log write must not run for denied authority")
+
+    effects = NoEffects()
+    app = FastAPI()
+    app.include_router(router_module.create_observer_router(event_store=effects, log_store=effects))
+    client = TestClient(app)
+    denied_headers = (
+        {},
+        {"X-Ella-Observer-Token": "wrong", "X-Ella-Subject-Uid": "user-1"},
+        {"X-Ella-Observer-Token": "observer-token"},
+        {"X-Ella-Observer-Token": "observer-token", "X-Ella-Subject-Uid": "user-2"},
+    )
+
+    for headers in denied_headers:
+        assert (
+            client.post(
+                "/v1/ella/observer/run",
+                headers=headers,
+                json={"uid": "user-1", "dry_run": False},
+            ).status_code
+            == 403
+        )
+        assert (
+            client.post(
+                "/v1/ella/observer/apply-pending",
+                headers=headers,
+                json={"uid": "user-1", "dry_run": False},
+            ).status_code
+            == 403
+        )
+        assert (
+            client.get(
+                "/v1/ella/observer/runs/run-a?uid=user-1",
+                headers=headers,
+            ).status_code
+            == 403
+        )
+
+    assert effects.calls == []
 
 
 def test_observer_router_can_use_extraction_result(monkeypatch):
@@ -411,7 +477,7 @@ def test_observer_router_can_use_extraction_result(monkeypatch):
 
     response = client.post(
         "/v1/ella/observer/run",
-        headers={"X-Ella-Observer-Token": "observer-token"},
+        headers={"X-Ella-Observer-Token": "observer-token", "X-Ella-Subject-Uid": "user-1"},
         json={"uid": "user-1", "dry_run": True, "extractor_mode": "heuristic", "limit": 10},
     )
 
@@ -600,7 +666,7 @@ def test_observer_apply_pending_writes_safe_memory_event(monkeypatch):
 
     response = client.post(
         "/v1/ella/observer/apply-pending",
-        headers={"X-Ella-Observer-Token": "observer-token"},
+        headers={"X-Ella-Observer-Token": "observer-token", "X-Ella-Subject-Uid": "user-1"},
         json={"uid": "user-1", "dry_run": False, "min_confidence": 0.9},
     )
 
@@ -655,7 +721,7 @@ def test_observer_apply_pending_accepts_trusted_mcp_memory_proposal(monkeypatch)
 
     response = client.post(
         "/v1/ella/observer/apply-pending",
-        headers={"X-Ella-Observer-Token": "observer-token"},
+        headers={"X-Ella-Observer-Token": "observer-token", "X-Ella-Subject-Uid": "user-1"},
         json={"uid": "user-1", "dry_run": False, "min_confidence": 0.9},
     )
 

--- a/backend/tests/unit/test_ella_plato_mcp.py
+++ b/backend/tests/unit/test_ella_plato_mcp.py
@@ -22,7 +22,7 @@ def _install_stubs():
     proposals.get_proposal_by_idempotency_key = MagicMock(return_value=None)
     proposals.save_proposal = MagicMock(side_effect=lambda proposal: proposal)
 
-    database = sys.modules.setdefault("database", types.ModuleType("database"))
+    database = importlib.import_module("database")
     setattr(database, "conversations", conversations)
     setattr(database, "memories", memories)
     setattr(database, "proposals", proposals)

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -1309,7 +1309,7 @@ elif mode in {"chat-xai", "chat-xai-whitespace"}:
     asyncio.run(consume())
     would_send_retained = captured.get("authorization") == f"Bearer {initial}"
 elif mode == "guardian-service":
-    module._verify_key(initial, None)
+    module._verify_key(initial, None, "synthetic-user")
     would_send_retained = True
 elif mode == "guardian-provision":
     async def no_timeline(*args, **kwargs):
@@ -1400,7 +1400,14 @@ elif mode == "guardian-tts":
     module._guardian_tts_candidates = lambda effective, requested: ["elevenlabs"]
     module.httpx.AsyncClient = SyntheticAsyncClient
     request = module.SynthesizeRequest(uid="synthetic-user", text="hello")
-    asyncio.run(module.synthesize_audio(request, "synthetic-distinct-guardian-service-key-000001", None))
+    asyncio.run(
+        module.synthesize_audio(
+            request,
+            "synthetic-distinct-guardian-service-key-000001",
+            None,
+            "synthetic-user",
+        )
+    )
     would_send_retained = captured.get("token") == retained
 elif mode in {"voice-xai", "voice-inworld", "voice-elevenlabs"}:
     class SyntheticResponse:
@@ -1659,7 +1666,10 @@ if module_name == "ella.routers.callbacks":
     fake_canonical_omi.write_omi_canonical_event = lambda *args, **kwargs: None
     sys.modules["utils.ella.canonical_omi"] = fake_canonical_omi
     fake_exact_auth = types.ModuleType("utils.ella.exact_firebase_auth")
+    fake_exact_auth.ELLA_SUBJECT_UID_HEADER = "X-Ella-Subject-Uid"
+    fake_exact_auth.EllaRequestAuthority = object
     fake_exact_auth.get_exact_firebase_uid = lambda *args, **kwargs: None
+    fake_exact_auth.get_exact_service_authority = lambda *args, **kwargs: None
     fake_exact_auth.require_matching_firebase_uid = lambda *args, **kwargs: None
     sys.modules["utils.ella.exact_firebase_auth"] = fake_exact_auth
     fake_storage = types.ModuleType("utils.other.storage")
@@ -1867,7 +1877,7 @@ def test_total_deadline_cancels_real_local_slow_drip_before_binding_writes(monke
     monkeypatch.setattr(
         provisioning_service,
         "provision_deadline",
-        lambda: ProvisionDeadline(provider_timeout_seconds=0.3, verification_grace_seconds=0.01, total_seconds=0.12),
+        lambda: ProvisionDeadline(provider_timeout_seconds=1.0, verification_grace_seconds=0.01, total_seconds=0.5),
     )
 
     async def scenario():
@@ -1889,7 +1899,7 @@ def test_total_deadline_cancels_real_local_slow_drip_before_binding_writes(monke
                 for byte in b'{"a":1}\n':
                     writer.write(bytes([byte]))
                     await writer.drain()
-                    await asyncio.sleep(0.025)
+                    await asyncio.sleep(0.1)
             except (asyncio.IncompleteReadError, BrokenPipeError, ConnectionResetError):
                 pass
             finally:
@@ -1910,8 +1920,8 @@ def test_total_deadline_cancels_real_local_slow_drip_before_binding_writes(monke
                 job=_job(state="provisioning", stage="profile_ready"),
                 identity=VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles"),
             )
-            await asyncio.wait_for(request_received.wait(), timeout=0.2)
-            await asyncio.wait_for(response_finished.wait(), timeout=0.2)
+            await asyncio.wait_for(request_received.wait(), timeout=2.0)
+            await asyncio.wait_for(response_finished.wait(), timeout=2.0)
 
         assert repository.staged is None
         assert repository.activation_calls == 0

--- a/backend/tests/unit/test_ella_scanner_batching.py
+++ b/backend/tests/unit/test_ella_scanner_batching.py
@@ -34,7 +34,10 @@ def test_guardian_trace_service_caller_uses_scoped_key(monkeypatch):
 
     assert len(posts) == 1
     assert posts[0][0] == scanner.GUARDIAN_TRACE_LOG_URL
-    assert posts[0][1]["headers"] == {"X-Guardian-Key": "configured-guardian-service-key"}
+    assert posts[0][1]["headers"] == {
+        "X-Guardian-Key": "configured-guardian-service-key",
+        "X-Ella-Subject-Uid": "uid-a",
+    }
 
 
 def test_guardian_trace_service_caller_fails_closed_without_configured_key(monkeypatch):

--- a/backend/tests/unit/test_hermes_cloud_enrichment_router.py
+++ b/backend/tests/unit/test_hermes_cloud_enrichment_router.py
@@ -51,13 +51,43 @@ def test_enrichment_router_requires_configured_service_token(monkeypatch):
 
 def test_enrichment_router_rejects_wrong_service_token(monkeypatch):
     monkeypatch.setenv("ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN", "x" * 32)
-    response = _client(FakeService()).post(
+    service = FakeService()
+    response = _client(service).post(
         "/v1/ella/internal/hermes-cloud/enrichment/run",
-        headers={"X-Ella-Hermes-Cloud-Enrichment-Token": "wrong"},
+        headers={
+            "X-Ella-Hermes-Cloud-Enrichment-Token": "wrong",
+            "X-Ella-Subject-Uid": "synthetic-user",
+        },
         json={"uid": "synthetic-user", "conversation_id": "conversation-a"},
     )
 
     assert response.status_code == 401
+    assert service.calls == []
+
+
+def test_enrichment_router_rejects_unbound_and_wrong_subject_before_service(monkeypatch):
+    token = "x" * 32
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_ENRICHMENT_TOKEN", token)
+    service = FakeService()
+    client = _client(service)
+
+    unbound = client.post(
+        "/v1/ella/internal/hermes-cloud/enrichment/run",
+        headers={"X-Ella-Hermes-Cloud-Enrichment-Token": token},
+        json={"uid": "synthetic-user", "conversation_id": "conversation-a"},
+    )
+    wrong_subject = client.post(
+        "/v1/ella/internal/hermes-cloud/enrichment/run",
+        headers={
+            "X-Ella-Hermes-Cloud-Enrichment-Token": token,
+            "X-Ella-Subject-Uid": "other-user",
+        },
+        json={"uid": "synthetic-user", "conversation_id": "conversation-a"},
+    )
+
+    assert unbound.status_code == 403
+    assert wrong_subject.status_code == 403
+    assert service.calls == []
 
 
 def test_enrichment_router_returns_content_free_receipt(monkeypatch):
@@ -66,7 +96,10 @@ def test_enrichment_router_returns_content_free_receipt(monkeypatch):
     service = FakeService()
     response = _client(service).post(
         "/v1/ella/internal/hermes-cloud/enrichment/run",
-        headers={"X-Ella-Hermes-Cloud-Enrichment-Token": token},
+        headers={
+            "X-Ella-Hermes-Cloud-Enrichment-Token": token,
+            "X-Ella-Subject-Uid": "synthetic-user",
+        },
         json={"uid": "synthetic-user", "conversation_id": "conversation-a"},
     )
 
@@ -93,7 +126,10 @@ def test_enrichment_router_binds_outbox_identity(monkeypatch):
     transcript_sha256 = "a" * 64
     response = _client(service).post(
         "/v1/ella/internal/hermes-cloud/enrichment/run",
-        headers={"X-Ella-Hermes-Cloud-Enrichment-Token": token},
+        headers={
+            "X-Ella-Hermes-Cloud-Enrichment-Token": token,
+            "X-Ella-Subject-Uid": "synthetic-user",
+        },
         json={
             "uid": "synthetic-user",
             "conversation_id": "conversation-a",

--- a/backend/tests/unit/test_hermes_cloud_photon.py
+++ b/backend/tests/unit/test_hermes_cloud_photon.py
@@ -1323,8 +1323,10 @@ def test_internal_router_requires_service_token_and_silently_ignores_unknown_sen
     monkeypatch,
 ):
     adapter, _, runtime_service = _adapter()
+    factory_calls = []
 
     async def factory():
+        factory_calls.append("adapter")
         return adapter
 
     app = FastAPI()
@@ -1343,22 +1345,44 @@ def test_internal_router_requires_service_token_and_silently_ignores_unknown_sen
         "synthetic": True,
     }
     monkeypatch.setenv("ELLA_HERMES_CLOUD_PHOTON_SIDECAR_TOKEN", "t" * 32)
+    monkeypatch.setenv("ELLA_HERMES_CLOUD_PHOTON_INTERNAL_OWNER_UID", "synthetic-owner")
 
     unauthorized = client.post(
         "/v1/ella/internal/hermes-cloud/photon/inbound",
         json=payload,
     )
-    ignored = client.post(
+    unbound = client.post(
         "/v1/ella/internal/hermes-cloud/photon/inbound",
         json=payload,
         headers={"X-Ella-Photon-Sidecar-Token": "t" * 32},
     )
-
+    wrong_subject = client.post(
+        "/v1/ella/internal/hermes-cloud/photon/inbound",
+        json=payload,
+        headers={
+            "X-Ella-Photon-Sidecar-Token": "t" * 32,
+            "X-Ella-Subject-Uid": "different-owner",
+        },
+    )
     assert unauthorized.status_code == 401
+    assert unbound.status_code == 403
+    assert wrong_subject.status_code == 403
+    assert factory_calls == []
+
+    ignored = client.post(
+        "/v1/ella/internal/hermes-cloud/photon/inbound",
+        json=payload,
+        headers={
+            "X-Ella-Photon-Sidecar-Token": "t" * 32,
+            "X-Ella-Subject-Uid": "synthetic-owner",
+        },
+    )
+
     assert ignored.status_code == 200
     assert ignored.json() == {
         "ok": True,
         "status": "ignored",
         "duplicate": False,
     }
+    assert factory_calls == ["adapter"]
     assert runtime_service.calls == []

--- a/backend/tests/unit/test_invitation_redemption.py
+++ b/backend/tests/unit/test_invitation_redemption.py
@@ -21,6 +21,7 @@ from ella.routers import invites
 from ella.routers import voice
 from ella.services import ai_consent
 from ella.services import invitation_authority
+from utils.ella.exact_firebase_auth import get_exact_firebase_uid
 from utils.other import endpoints as auth
 
 
@@ -220,7 +221,7 @@ def test_routes_require_auth_and_use_only_authenticated_uid(monkeypatch):
         "get_user",
         lambda _uid: SimpleNamespace(email="verified@example.test", email_verified=True),
     )
-    app.dependency_overrides[auth.get_current_user_uid] = lambda: "firebase-subject"
+    app.dependency_overrides[get_exact_firebase_uid] = lambda: "firebase-subject"
     response = client.post(
         "/v1/invite/redeem",
         json={"code": "ABCD-2345"},
@@ -236,7 +237,7 @@ def test_routes_require_auth_and_use_only_authenticated_uid(monkeypatch):
 def test_redeem_rejects_unverified_firebase_email_before_authority_or_database(monkeypatch):
     app = FastAPI()
     app.include_router(invites.router)
-    app.dependency_overrides[auth.get_current_user_uid] = lambda: "firebase-subject"
+    app.dependency_overrides[get_exact_firebase_uid] = lambda: "firebase-subject"
     monkeypatch.setattr(
         invites.auth,
         "get_user",
@@ -287,7 +288,7 @@ def test_authenticated_malformed_body_returns_safe_invalid_envelope(
 ):
     app = FastAPI()
     app.include_router(invites.router)
-    app.dependency_overrides[auth.get_current_user_uid] = lambda: "firebase-subject"
+    app.dependency_overrides[get_exact_firebase_uid] = lambda: "firebase-subject"
     redemption_called = False
 
     async def fake_redeem(**_kwargs):
@@ -336,7 +337,7 @@ def test_entitlement_read_requires_auth_and_is_uid_scoped(monkeypatch):
         return {"status": "none", "quota": {}}
 
     monkeypatch.setattr(voice.voice_canary_db, "get_entitlement_contract", fake_contract)
-    app.dependency_overrides[auth.get_current_user_uid] = lambda: "firebase-subject"
+    app.dependency_overrides[get_exact_firebase_uid] = lambda: "firebase-subject"
     response = client.get("/v1/entitlement")
     assert response.status_code == 200
     assert captured["uid"] == "firebase-subject"
@@ -347,7 +348,7 @@ def test_entitlement_read_requires_auth_and_is_uid_scoped(monkeypatch):
 def test_typed_failure_shape_is_compatible_with_ios(monkeypatch):
     app = FastAPI()
     app.include_router(invites.router)
-    app.dependency_overrides[auth.get_current_user_uid] = lambda: "firebase-subject"
+    app.dependency_overrides[get_exact_firebase_uid] = lambda: "firebase-subject"
 
     async def fake_redeem(**_kwargs):
         raise invitations.InviteRedemptionFailure(

--- a/backend/tests/unit/test_memory_reinterpretation_outbox.py
+++ b/backend/tests/unit/test_memory_reinterpretation_outbox.py
@@ -532,7 +532,10 @@ def test_reinterpretation_completion_requires_configured_ledger_bearer(monkeypat
     )
     accepted = client.post(
         f"/v1/ella/sessions/{session_id}/complete",
-        headers={"Authorization": "Bearer ledger-secret"},
+        headers={
+            "Authorization": "Bearer ledger-secret",
+            "X-Ella-Subject-Uid": UID,
+        },
         json=body,
     )
 
@@ -1224,7 +1227,7 @@ def test_authenticated_status_is_identifier_only_and_missing_nonowned_have_parit
     repository, job = asyncio.run(seed())
     app = FastAPI()
     app.include_router(reinterpretation_router.create_memory_reinterpretation_router(repository))
-    app.dependency_overrides[reinterpretation_router.auth.get_current_user_uid] = lambda: UID
+    app.dependency_overrides[reinterpretation_router.get_exact_firebase_uid] = lambda: UID
     monkeypatch.setattr(
         reinterpretation_router.conversations_db,
         "get_conversation",
@@ -1241,7 +1244,7 @@ def test_authenticated_status_is_identifier_only_and_missing_nonowned_have_parit
     assert "proposal_plan" not in body
 
     missing = client.get("/v1/ella/conversations/missing/reinterpretations/latest")
-    app.dependency_overrides[reinterpretation_router.auth.get_current_user_uid] = lambda: UID.lower()
+    app.dependency_overrides[reinterpretation_router.get_exact_firebase_uid] = lambda: UID.lower()
     nonowned = client.get(f"/v1/ella/conversations/{CONVERSATION_ID}/reinterpretations/latest")
     assert (missing.status_code, missing.json()) == (
         nonowned.status_code,
@@ -1496,7 +1499,7 @@ def test_worker_reinterpretation_receipt_and_authenticated_undo_restore_prior_su
 
     app = FastAPI()
     app.include_router(corrections.router)
-    app.dependency_overrides[corrections.auth.get_current_user_uid] = lambda: UID
+    app.dependency_overrides[corrections.get_exact_firebase_uid] = lambda: UID
     client = TestClient(app)
 
     receipt = client.get(f"/v1/ella/conversations/{CONVERSATION_ID}/corrections/{correction_id}")

--- a/backend/utils/ella/__init__.py
+++ b/backend/utils/ella/__init__.py
@@ -10,6 +10,8 @@
 #   - memory.py: Memory extraction
 #   - chat.py: Chat routing helpers
 
+from importlib import import_module
+
 __all__ = [
     'ELLA_CONFIG',
     'is_ella_enabled',
@@ -19,27 +21,22 @@ __all__ = [
     'is_ella_chat',
 ]
 
+_LAZY_EXPORTS = {
+    'ELLA_CONFIG': ('.config', 'ELLA_CONFIG'),
+    'is_ella_enabled': ('.config', 'is_ella_enabled'),
+    'send_to_scanner': ('.scanner', 'send_to_scanner'),
+    'call_summary_agent': ('.summary', 'call_summary_agent'),
+    'call_memory_agent': ('.memory', 'call_memory_agent'),
+    'is_ella_chat': ('.chat', 'is_ella_chat'),
+}
+
 
 def __getattr__(name: str):
     """Load legacy convenience exports without importing service clients eagerly."""
-    if name in {'ELLA_CONFIG', 'is_ella_enabled'}:
-        from .config import ELLA_CONFIG, is_ella_enabled
-
-        return {'ELLA_CONFIG': ELLA_CONFIG, 'is_ella_enabled': is_ella_enabled}[name]
-    if name == 'send_to_scanner':
-        from .scanner import send_to_scanner
-
-        return send_to_scanner
-    if name == 'call_summary_agent':
-        from .summary import call_summary_agent
-
-        return call_summary_agent
-    if name == 'call_memory_agent':
-        from .memory import call_memory_agent
-
-        return call_memory_agent
-    if name == 'is_ella_chat':
-        from .chat import is_ella_chat
-
-        return is_ella_chat
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    try:
+        module_name, attribute_name = _LAZY_EXPORTS[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+    value = getattr(import_module(module_name, __name__), attribute_name)
+    globals()[name] = value
+    return value

--- a/backend/utils/ella/__init__.py
+++ b/backend/utils/ella/__init__.py
@@ -10,12 +10,6 @@
 #   - memory.py: Memory extraction
 #   - chat.py: Chat routing helpers
 
-from .config import ELLA_CONFIG, is_ella_enabled
-from .scanner import send_to_scanner
-from .summary import call_summary_agent
-from .memory import call_memory_agent
-from .chat import is_ella_chat
-
 __all__ = [
     'ELLA_CONFIG',
     'is_ella_enabled',
@@ -24,3 +18,28 @@ __all__ = [
     'call_memory_agent',
     'is_ella_chat',
 ]
+
+
+def __getattr__(name: str):
+    """Load legacy convenience exports without importing service clients eagerly."""
+    if name in {'ELLA_CONFIG', 'is_ella_enabled'}:
+        from .config import ELLA_CONFIG, is_ella_enabled
+
+        return {'ELLA_CONFIG': ELLA_CONFIG, 'is_ella_enabled': is_ella_enabled}[name]
+    if name == 'send_to_scanner':
+        from .scanner import send_to_scanner
+
+        return send_to_scanner
+    if name == 'call_summary_agent':
+        from .summary import call_summary_agent
+
+        return call_summary_agent
+    if name == 'call_memory_agent':
+        from .memory import call_memory_agent
+
+        return call_memory_agent
+    if name == 'is_ella_chat':
+        from .chat import is_ella_chat
+
+        return is_ella_chat
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/backend/utils/ella/canonical_auth.py
+++ b/backend/utils/ella/canonical_auth.py
@@ -5,11 +5,18 @@ from __future__ import annotations
 import os
 
 CANONICAL_EVENT_SERVICE_HEADER = "X-Ella-Event-Ledger-Key"
+CANONICAL_EVENT_SUBJECT_HEADER = "X-Ella-Subject-Uid"
 
 
-def canonical_event_service_headers() -> dict[str, str]:
+def canonical_event_service_headers(subject_uid: str) -> dict[str, str]:
     """Return the configured internal ledger header without fallback credentials."""
     token = os.getenv("ELLA_EVENT_LEDGER_TOKEN", "").strip()
     if not token:
         raise RuntimeError("canonical_event_service_auth_not_configured")
-    return {CANONICAL_EVENT_SERVICE_HEADER: token}
+    normalized_subject = subject_uid.strip()
+    if not normalized_subject:
+        raise RuntimeError("canonical_event_service_subject_required")
+    return {
+        CANONICAL_EVENT_SERVICE_HEADER: token,
+        CANONICAL_EVENT_SUBJECT_HEADER: normalized_subject,
+    }

--- a/backend/utils/ella/canonical_context.py
+++ b/backend/utils/ella/canonical_context.py
@@ -100,7 +100,7 @@ async def fetch_canonical_timeline(
         response = await client.get(
             DEFAULT_TIMELINE_URL,
             params=params,
-            headers=canonical_event_service_headers(),
+            headers=canonical_event_service_headers(uid),
         )
     response.raise_for_status()
 

--- a/backend/utils/ella/canonical_omi.py
+++ b/backend/utils/ella/canonical_omi.py
@@ -201,7 +201,7 @@ def write_omi_canonical_event(
     response = requests.post(
         CANONICAL_EVENTS_URL,
         json={"events": [event]},
-        headers={"Content-Type": "application/json", **canonical_event_service_headers()},
+        headers={"Content-Type": "application/json", **canonical_event_service_headers(uid)},
         timeout=timeout if timeout is not None else CANONICAL_OMI_TIMEOUT,
     )
     elapsed_ms = int((time.time() - started) * 1000)

--- a/backend/utils/ella/exact_firebase_auth.py
+++ b/backend/utils/ella/exact_firebase_auth.py
@@ -12,6 +12,7 @@ from firebase_admin import auth as firebase_auth
 ELLA_SUBJECT_UID_HEADER = "X-Ella-Subject-Uid"
 MAX_FIREBASE_UID_LENGTH = 128
 CLIENT_VERSION_RE = re.compile(r"^\d+(?:\.\d+){0,3}$")
+APP_VERSION_WITH_BUILD_RE = re.compile(r"^(?P<version>\d+(?:\.\d+){0,3})(?:\+(?P<build>\d+))?$")
 
 
 def _normalize_subject_uid(subject_uid: Optional[str], *, feature: str) -> str:
@@ -51,6 +52,31 @@ def _version_tuple(value: str) -> tuple[int, ...]:
     return tuple(int(part) for part in value.split("."))
 
 
+def _client_gate_value(
+    minimum: str,
+    x_app_version: Optional[str],
+    x_ella_app_build: Optional[str],
+    x_ella_client_version: Optional[str],
+) -> str:
+    minimum_is_build = "." not in minimum
+    if minimum_is_build:
+        explicit_build = x_ella_app_build.strip() if isinstance(x_ella_app_build, str) else ""
+        if explicit_build:
+            return explicit_build
+    supplied_version = next(
+        (value.strip() for value in (x_app_version, x_ella_client_version) if isinstance(value, str) and value.strip()),
+        "",
+    )
+    match = APP_VERSION_WITH_BUILD_RE.fullmatch(supplied_version)
+    if match is None:
+        return supplied_version
+    if minimum_is_build:
+        if match.group("build"):
+            return match.group("build")
+        return match.group("version") if "." not in match.group("version") else ""
+    return match.group("version")
+
+
 def require_supported_ella_client(
     x_app_version: Optional[str] = Header(default=None, alias="X-App-Version"),
     x_ella_app_build: Optional[str] = Header(default=None, alias="X-Ella-App-Build"),
@@ -59,8 +85,7 @@ def require_supported_ella_client(
     minimum = os.getenv("ELLA_MIN_SUPPORTED_CLIENT_BUILD", "").strip()
     if not minimum:
         return
-    supplied_values = (x_ella_app_build, x_app_version, x_ella_client_version)
-    supplied = next((value.strip() for value in supplied_values if isinstance(value, str) and value.strip()), "")
+    supplied = _client_gate_value(minimum, x_app_version, x_ella_app_build, x_ella_client_version)
     try:
         minimum_parts = _version_tuple(minimum)
         supplied_parts = _version_tuple(supplied)

--- a/backend/utils/ella/exact_firebase_auth.py
+++ b/backend/utils/ella/exact_firebase_auth.py
@@ -1,11 +1,26 @@
 """Strict Firebase and narrowly scoped service authentication for Ella routes."""
 
+import os
+import re
 import secrets
 from dataclasses import dataclass
 from typing import Optional
 
 from fastapi import Header, HTTPException
 from firebase_admin import auth as firebase_auth
+
+ELLA_SUBJECT_UID_HEADER = "X-Ella-Subject-Uid"
+MAX_FIREBASE_UID_LENGTH = 128
+CLIENT_VERSION_RE = re.compile(r"^\d+(?:\.\d+){0,3}$")
+
+
+def _normalize_subject_uid(subject_uid: Optional[str], *, feature: str) -> str:
+    normalized = subject_uid.strip() if isinstance(subject_uid, str) else ""
+    if not normalized:
+        raise HTTPException(status_code=403, detail={"code": "service_subject_required", "feature": feature})
+    if len(normalized) > MAX_FIREBASE_UID_LENGTH or any(ord(character) < 32 for character in normalized):
+        raise HTTPException(status_code=403, detail={"code": "invalid_service_subject", "feature": feature})
+    return normalized
 
 
 @dataclass(frozen=True)
@@ -14,6 +29,7 @@ class EllaRequestAuthority:
 
     firebase_uid: Optional[str] = None
     service: Optional[str] = None
+    service_subject_uid: Optional[str] = None
 
     @property
     def is_service(self) -> bool:
@@ -23,12 +39,46 @@ class EllaRequestAuthority:
         normalized_claim = (claimed_uid or "").strip()
         if self.firebase_uid is not None:
             return require_matching_firebase_uid(self.firebase_uid, normalized_claim, feature=feature)
-        if not normalized_claim:
-            raise HTTPException(status_code=400, detail=f"{feature} UID is required")
-        return normalized_claim
+        bound_subject = _normalize_subject_uid(self.service_subject_uid, feature=feature)
+        if normalized_claim and not secrets.compare_digest(normalized_claim, bound_subject):
+            raise HTTPException(status_code=403, detail=f"{feature} UID does not match bound service subject")
+        return bound_subject
 
 
-def get_exact_firebase_uid(authorization: Optional[str] = Header(None)) -> str:
+def _version_tuple(value: str) -> tuple[int, ...]:
+    if not CLIENT_VERSION_RE.fullmatch(value):
+        raise ValueError
+    return tuple(int(part) for part in value.split("."))
+
+
+def require_supported_ella_client(
+    x_app_version: Optional[str] = Header(default=None, alias="X-App-Version"),
+    x_ella_app_build: Optional[str] = Header(default=None, alias="X-Ella-App-Build"),
+    x_ella_client_version: Optional[str] = Header(default=None, alias="X-Ella-Client-Version"),
+) -> None:
+    minimum = os.getenv("ELLA_MIN_SUPPORTED_CLIENT_BUILD", "").strip()
+    if not minimum:
+        return
+    supplied_values = (x_ella_app_build, x_app_version, x_ella_client_version)
+    supplied = next((value.strip() for value in supplied_values if isinstance(value, str) and value.strip()), "")
+    try:
+        minimum_parts = _version_tuple(minimum)
+        supplied_parts = _version_tuple(supplied)
+    except ValueError:
+        if not CLIENT_VERSION_RE.fullmatch(minimum):
+            raise HTTPException(status_code=503, detail={"code": "client_version_gate_not_configured"})
+        raise HTTPException(status_code=426, detail={"code": "update_required", "minimum_build": minimum})
+    width = max(len(minimum_parts), len(supplied_parts))
+    if supplied_parts + (0,) * (width - len(supplied_parts)) < minimum_parts + (0,) * (width - len(minimum_parts)):
+        raise HTTPException(status_code=426, detail={"code": "update_required", "minimum_build": minimum})
+
+
+def get_exact_firebase_uid(
+    authorization: Optional[str] = Header(None),
+    x_app_version: Optional[str] = Header(default=None, alias="X-App-Version"),
+    x_ella_app_build: Optional[str] = Header(default=None, alias="X-Ella-App-Build"),
+    x_ella_client_version: Optional[str] = Header(default=None, alias="X-Ella-Client-Version"),
+) -> str:
     """Return the Firebase subject without admin-key or local-dev fallbacks."""
     parts = authorization.split() if authorization else []
     if len(parts) != 2 or parts[0].lower() != "bearer" or not parts[1]:
@@ -40,13 +90,14 @@ def get_exact_firebase_uid(authorization: Optional[str] = Header(None)) -> str:
     uid = str(decoded.get("uid") or "").strip() if isinstance(decoded, dict) else ""
     if not uid:
         raise HTTPException(status_code=401, detail="Invalid Firebase bearer subject")
+    require_supported_ella_client(x_app_version, x_ella_app_build, x_ella_client_version)
     return uid
 
 
 def require_matching_firebase_uid(authenticated_uid: str, claimed_uid: Optional[str], *, feature: str) -> str:
     """Reject a caller-supplied subject that differs from the verified token."""
     normalized_claim = (claimed_uid or "").strip()
-    if normalized_claim and normalized_claim != authenticated_uid:
+    if normalized_claim and not secrets.compare_digest(normalized_claim, authenticated_uid):
         raise HTTPException(status_code=403, detail=f"{feature} UID does not match authenticated user")
     return authenticated_uid
 
@@ -57,11 +108,44 @@ def get_firebase_or_service_authority(
     provided_service_key: Optional[str],
     configured_service_key: Optional[str],
     service: str,
+    service_subject_uid: Optional[str] = None,
+    x_app_version: Optional[str] = None,
+    x_ella_app_build: Optional[str] = None,
+    x_ella_client_version: Optional[str] = None,
 ) -> EllaRequestAuthority:
     """Authenticate either an exact Firebase bearer or one named service."""
     if provided_service_key is not None:
         configured = configured_service_key or ""
         if not configured or not provided_service_key or not secrets.compare_digest(provided_service_key, configured):
             raise HTTPException(status_code=403, detail=f"Invalid {service} service credential")
-        return EllaRequestAuthority(service=service)
-    return EllaRequestAuthority(firebase_uid=get_exact_firebase_uid(authorization))
+        return EllaRequestAuthority(
+            service=service,
+            service_subject_uid=_normalize_subject_uid(service_subject_uid, feature=service),
+        )
+    return EllaRequestAuthority(
+        firebase_uid=get_exact_firebase_uid(
+            authorization,
+            x_app_version,
+            x_ella_app_build,
+            x_ella_client_version,
+        )
+    )
+
+
+def get_exact_service_authority(
+    *,
+    provided_service_key: Optional[str],
+    configured_service_key: Optional[str],
+    service_subject_uid: Optional[str],
+    service: str,
+) -> EllaRequestAuthority:
+    """Authenticate one service credential and bind it to exactly one subject."""
+    configured = configured_service_key or ""
+    if not configured:
+        raise HTTPException(status_code=503, detail={"code": f"{service}_service_auth_not_configured"})
+    if not provided_service_key or not secrets.compare_digest(provided_service_key, configured):
+        raise HTTPException(status_code=403, detail={"code": f"invalid_{service}_service_credential"})
+    return EllaRequestAuthority(
+        service=service,
+        service_subject_uid=_normalize_subject_uid(service_subject_uid, feature=service),
+    )

--- a/backend/utils/ella/scanner.py
+++ b/backend/utils/ella/scanner.py
@@ -635,7 +635,7 @@ def _log_trace_event(
                 "latency_ms": latency_ms,
                 "metadata": metadata or {},
             },
-            headers={"X-Guardian-Key": GUARDIAN_WEBHOOK_KEY},
+            headers={"X-Guardian-Key": GUARDIAN_WEBHOOK_KEY, "X-Ella-Subject-Uid": uid},
             timeout=0.25,
         )
     except Exception:
@@ -717,7 +717,7 @@ def _enqueue_wake_ack(uid: str, conversation_id: str, trace_id: str, scanner_seg
                 response = requests.post(
                     GUARDIAN_ENQUEUE_URL,
                     json=payload,
-                    headers={"X-Guardian-Key": GUARDIAN_WEBHOOK_KEY},
+                    headers={"X-Guardian-Key": GUARDIAN_WEBHOOK_KEY, "X-Ella-Subject-Uid": uid},
                     timeout=GUARDIAN_WAKE_ACK_TIMEOUT_S,
                 )
                 _log_trace_event(
@@ -759,7 +759,7 @@ def _insert_wake_ack_direct(uid: str, trace_id: str, payload: dict) -> dict:
         response = requests.post(
             GUARDIAN_ENQUEUE_URL,
             json=payload,
-            headers={"X-Guardian-Key": GUARDIAN_WEBHOOK_KEY},
+            headers={"X-Guardian-Key": GUARDIAN_WEBHOOK_KEY, "X-Ella-Subject-Uid": uid},
             timeout=max(GUARDIAN_WAKE_ACK_TIMEOUT_S, 12.0),
         )
         return {

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -1,11 +1,42 @@
 import json
+import logging
 import os
+import secrets
 import time
+from collections import Counter
 
 from fastapi import Header, HTTPException
 from fastapi import Request
 from firebase_admin import auth
 from firebase_admin.auth import InvalidIdTokenError
+
+logger = logging.getLogger(__name__)
+_ADMIN_BRANCH_COUNTS: Counter[str] = Counter()
+_ADMIN_BRANCH_COUNT_LIMIT = 1_000_000
+_ADMIN_CALLER_CLASSES = {"http", "websocket", "internal"}
+
+
+def _production_marker_enabled() -> bool:
+    return any(
+        os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on", "production", "prod"}
+        for name in ("ELLA_PRODUCTION", "PRODUCTION", "ENVIRONMENT", "DD_ENV")
+    )
+
+
+def _legacy_admin_subject_allowlist() -> set[str]:
+    return {item.strip() for item in os.getenv("ELLA_ADMIN_SUBJECT_ALLOWLIST", "").split(",") if item.strip()}
+
+
+def _observe_admin_subject_branch(caller_class: str) -> None:
+    normalized_class = caller_class if caller_class in _ADMIN_CALLER_CLASSES else "internal"
+    _ADMIN_BRANCH_COUNTS[normalized_class] = min(
+        _ADMIN_BRANCH_COUNTS[normalized_class] + 1,
+        _ADMIN_BRANCH_COUNT_LIMIT,
+    )
+    logger.info(
+        "Legacy ADMIN_KEY subject branch invoked",
+        extra={"caller_class": normalized_class, "invocation_count": _ADMIN_BRANCH_COUNTS[normalized_class]},
+    )
 
 
 def get_user(uid: str):
@@ -13,7 +44,7 @@ def get_user(uid: str):
     return user
 
 
-def verify_token(token: str) -> str:
+def verify_token(token: str, *, caller_class: str = "internal") -> str:
     """
     Verify a Firebase token or ADMIN_KEY and return the uid.
 
@@ -28,20 +59,26 @@ def verify_token(token: str) -> str:
     """
     # Check for ADMIN_KEY format
     admin_key = os.getenv('ADMIN_KEY')
-    if admin_key and admin_key in token:
-        return token.split(admin_key)[1]
+    if admin_key and token.startswith(admin_key):
+        _observe_admin_subject_branch(caller_class)
+        requested_subject = token[len(admin_key) :]
+        allowed_subjects = _legacy_admin_subject_allowlist()
+        for allowed_subject in allowed_subjects:
+            if requested_subject and secrets.compare_digest(requested_subject, allowed_subject):
+                return allowed_subject
+        raise InvalidIdTokenError("ADMIN_KEY subject is not allowlisted")
 
     # Verify Firebase token
     try:
         decoded_token = auth.verify_id_token(token)
         return decoded_token['uid']
     except InvalidIdTokenError:
-        if os.getenv('LOCAL_DEVELOPMENT') == 'true':
+        if os.getenv('LOCAL_DEVELOPMENT') == 'true' and not _production_marker_enabled():
             return '123'
         raise
     except Exception as e:
         print(f"Token verification error: {type(e).__name__}: {e}", flush=True)
-        if os.getenv('LOCAL_DEVELOPMENT') == 'true':
+        if os.getenv('LOCAL_DEVELOPMENT') == 'true' and not _production_marker_enabled():
             return '123'
         raise InvalidIdTokenError(str(e))
 
@@ -57,7 +94,7 @@ def get_current_user_uid(authorization: str = Header(None)):
         token = authorization.split(' ')[1]
         if not token:
             raise HTTPException(status_code=401, detail="Empty authorization token")
-        return verify_token(token)
+        return verify_token(token, caller_class="http")
     except InvalidIdTokenError as e:
         print(f"Error verifying Firebase ID token: {e}", flush=True)
         raise HTTPException(status_code=401, detail="Invalid authorization token")
@@ -95,7 +132,7 @@ def get_current_user_uid_from_ws_message(message: dict) -> str:
     if not token:
         raise ValueError("Missing token")
 
-    return verify_token(token)
+    return verify_token(token, caller_class="websocket")
 
 
 cached = {}


### PR DESCRIPTION
## Summary
- enforce the approved v4/v5 Firebase exact-owner and exact-bound service authority matrix across every mounted Ella route
- remove ADMIN_KEY subject minting, add first-party caregiver APIs, and fail closed on unsupported client builds
- add the all-router authority manifest, negative side-effect controls, cutover runbook, and deterministic hosted gates

## Exact stack
- base: `cc514ab2be8b8684390403bcaaf8916f08ac9e7b` (PR #368)
- head: `4d5cc878c4eec2a60eea8b690122bc4cc37b75a7`

## Verification
- full unit package in isolated pytest processes: 1,578 passed across 86 files, 0 skipped
- full PostgreSQL package: 107 passed, 0 skipped
- Invite Redemption collection: 160 passed, 0 skipped
- incident boundary: 53 passed, 0 skipped
- Hermes runtime collection: 514 passed, 0 skipped
- standard backend runner: 170 passed
- authority split: 443 passed; authority lock: 69 passed
- changed Python compile and Black checks, workflow YAML, OpenAPI, diff, and secret/debug scans passed

## Deployment boundary
No production, Caddy, environment, database, n8n, credential, vendor, iOS PR #362, deploy, or merge mutation was performed. Remaining rollout work is external: configure the accepted service credentials/subjects and minimum client build, deploy backend first, cut n8n over without dual acceptance, set `ELLA_PLATO_UID` only post-deploy/pre-binding, verify Guardian/TTS and six-part memory receipts, then apply the approved staged edge deny-lift criteria.