### PR TITLE
fix(ios): restyle Delete Account page to Ella theme (ella-ai#1194)

### DIFF
--- a/app/lib/pages/settings/delete_account.dart
+++ b/app/lib/pages/settings/delete_account.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
 
-import 'package:gradient_borders/gradient_borders.dart';
-
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/core/app_shell.dart';
+import 'package:omi/ella/ella_theme.dart';
 import 'package:omi/services/auth_service.dart';
 import 'package:omi/utils/analytics/mixpanel.dart';
 import 'package:omi/utils/l10n_extensions.dart';
@@ -110,48 +109,34 @@ class _DeleteAccountState extends State<DeleteAccount> {
     return PopScope(
       canPop: !isDeleteing,
       child: Scaffold(
-        backgroundColor: Theme.of(context).colorScheme.primary,
-        appBar: AppBar(
-          backgroundColor: Theme.of(context).colorScheme.primary,
-          title: Text(context.l10n.deleteAccountTitle),
-        ),
+        backgroundColor: EllaColors.paper,
+        appBar: AppBar(title: Text(context.l10n.deleteAccountTitle)),
         body: SingleChildScrollView(
           padding: const EdgeInsets.symmetric(horizontal: 10),
           child: Column(
             children: [
-              const SizedBox(
-                height: 10,
-              ),
+              const SizedBox(height: 10),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 50),
                 child: Text(
                   context.l10n.deleteAccountConfirm,
-                  style: const TextStyle(
-                    fontSize: 24,
-                  ),
+                  style: Theme.of(context).textTheme.headlineMedium,
                   textAlign: TextAlign.center,
                 ),
               ),
-              const SizedBox(
-                height: 10,
-              ),
-              Text(
-                context.l10n.cannotBeUndone,
-                style: const TextStyle(fontSize: 18),
-              ),
-              const SizedBox(
-                height: 30,
-              ),
+              const SizedBox(height: 10),
+              Text(context.l10n.cannotBeUndone, style: EllaTextStyles.body),
+              const SizedBox(height: 30),
               ListTile(
-                leading: const Icon(Icons.message_rounded),
+                leading: const Icon(Icons.message_rounded, color: EllaColors.tealDeep),
                 title: Text(context.l10n.allDataErased),
               ),
               ListTile(
-                leading: const Icon(Icons.person_pin_outlined),
+                leading: const Icon(Icons.person_pin_outlined, color: EllaColors.tealDeep),
                 title: Text(context.l10n.appsDisconnected),
               ),
               ListTile(
-                leading: const Icon(Icons.upload_file_outlined),
+                leading: const Icon(Icons.upload_file_outlined, color: EllaColors.tealDeep),
                 title: Text(context.l10n.exportBeforeDelete),
               ),
               const SizedBox(height: 30),
@@ -165,79 +150,52 @@ class _DeleteAccountState extends State<DeleteAccount> {
                       }
                     },
                   ),
-                  Expanded(
-                    child: Text(context.l10n.deleteAccountCheckbox),
-                  ),
+                  Expanded(child: Text(context.l10n.deleteAccountCheckbox)),
                 ],
               ),
-              const SizedBox(
-                height: 30,
-              ),
+              const SizedBox(height: 30),
               isDeleteing
-                  ? const CircularProgressIndicator(
-                      color: Colors.white,
-                    )
-                  : Container(
-                      decoration: BoxDecoration(
-                        border: const GradientBoxBorder(
-                          gradient: LinearGradient(colors: [
-                            Color.fromARGB(127, 208, 208, 208),
-                            Color.fromARGB(127, 188, 99, 121),
-                            Color.fromARGB(127, 86, 101, 182),
-                            Color.fromARGB(127, 126, 190, 236)
-                          ]),
-                          width: 2,
-                        ),
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      child: ElevatedButton(
+                  ? const CircularProgressIndicator(color: EllaColors.tealDeep)
+                  : SizedBox(
+                      width: double.infinity,
+                      child: FilledButton(
                         onPressed: () {
                           if (checkboxValue) {
                             showDialog(
-                                context: context,
-                                builder: (c) {
-                                  return getDialog(context, () {
+                              context: context,
+                              builder: (c) {
+                                return getDialog(
+                                  context,
+                                  () {
                                     MixpanelManager().deleteAccountCancelled();
                                     Navigator.of(context).pop();
-                                  }, () {
+                                  },
+                                  () {
                                     deleteAccountNow();
                                     Navigator.of(context).pop();
-                                  }, context.l10n.areYouSure, context.l10n.deleteAccountFinal,
-                                      okButtonText: context.l10n.deleteNow, cancelButtonText: context.l10n.goBack);
-                                });
-                          } else {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(
-                                content: Text(context.l10n.checkBoxToConfirm),
-                              ),
+                                  },
+                                  context.l10n.areYouSure,
+                                  context.l10n.deleteAccountFinal,
+                                  okButtonText: context.l10n.deleteNow,
+                                  cancelButtonText: context.l10n.goBack,
+                                );
+                              },
                             );
+                          } else {
+                            ScaffoldMessenger.of(
+                              context,
+                            ).showSnackBar(SnackBar(content: Text(context.l10n.checkBoxToConfirm)));
                           }
                         },
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.transparent,
-                          shadowColor: const Color.fromARGB(255, 17, 17, 17),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12),
-                          ),
+                        style: FilledButton.styleFrom(
+                          backgroundColor: EllaColors.error,
+                          foregroundColor: EllaColors.paper,
+                          minimumSize: const Size.fromHeight(EllaSizes.minTouchTarget),
                         ),
-                        child: Container(
-                          width: double.infinity,
-                          height: 45,
-                          alignment: Alignment.center,
-                          child: Text(
-                            context.l10n.deleteAccount,
-                            style: const TextStyle(
-                              fontWeight: FontWeight.w400,
-                              fontSize: 18,
-                              color: Color.fromARGB(255, 255, 255, 255),
-                            ),
-                          ),
-                        ),
+                        child: Text(context.l10n.deleteAccount),
                       ),
                     ),
-              const SizedBox(
-                height: 70,
-              ),
+              const SizedBox(height: 70),
             ],
           ),
         ),

--- a/app/test/pages/settings/delete_account_receipt_test.dart
+++ b/app/test/pages/settings/delete_account_receipt_test.dart
@@ -151,7 +151,7 @@ Future<void> _pumpDeleteAccount(
 Future<void> _confirmDeletion(WidgetTester tester) async {
   await tester.tap(find.byType(Checkbox));
   await tester.pump();
-  await tester.tap(find.byType(ElevatedButton));
+  await tester.tap(find.byType(FilledButton));
   await tester.pumpAndSettle();
   await tester.tap(find.text('Delete Now'));
   await tester.pumpAndSettle();


### PR DESCRIPTION
Fixes ellaaicare/ella-ai#1194 (owner-reported white-on-white Delete Account page).

## Base

**Stacked on the reviewed #367 head `8dfb12bd` (`codex/1185-ios-client-fail-closed`), not `main`** — `main` is not a valid iOS release base (it declares 1.0.522+785), and this lets the fix ride the authorized 806 → #362 → #367 release line without modifying either reviewed tree. Do not merge before #362/#367; the diff here is only this change.

## Problem

`delete_account.dart` is an inherited upstream OMI page designed for a dark theme. The Ella theme deliberately maps `colorScheme.primary` to the light paper color for legacy page backgrounds (`ella_theme.dart:181-183`), so the page's hardcoded white foregrounds — the delete-button label (`Color.fromARGB(255,255,255,255)`) on a transparent button and the white `CircularProgressIndicator` — rendered white-on-white.

## Change (2 files)

- `app/lib/pages/settings/delete_account.dart`: paper scaffold + theme app bar (drops the `colorScheme.primary` background overrides), `headlineMedium` confirm header, `EllaTextStyles.body` secondary line, `tealDeep` list icons and spinner, and a standard destructive `FilledButton` (`EllaColors.error` on paper, `minTouchTarget` height) replacing the transparent gradient-border `ElevatedButton`. The unused `gradient_borders` import is removed. Deletion behavior, checkbox confirm, dialog flow, and receipt handling are untouched.
- `app/test/pages/settings/delete_account_receipt_test.dart`: the tap target finder follows the widget change (`ElevatedButton` → `FilledButton`). Assertions unchanged.

## Verification (local, exact head `fc0a9b956` on base `8dfb12bd`)

- `dart format --line-length 120` clean; `git diff --check` clean.
- `flutter analyze` after `build_runner` + `gen-l10n`: zero issues in the changed files. 3 pre-existing base errors remain (missing local `firebase_options_*` in a fresh checkout, and an upstream `const_eval_method_invocation` in `message_action_menu.dart`) — present with the change stashed as well.
- `app/test.sh`: pass.
- Focused: `delete_account_receipt_test.dart` 4/4.
- Full `flutter test`: 380 passed, 5 failed — the same 5 `account_isolation_test.dart` production/real-HTTP tests fail identically on the **pristine base** in this environment (network-restricted); hosted CI on this base head was green 385/385 (run 30950501951). No new failures introduced.

No secrets, credentials, user identifiers, or Apple/vendor mutations. No merge performed.
