### PR TITLE
feat(ios): typed consent grant failures with support code (ella-ai#1193)

### DIFF
--- a/app/lib/ella/pages/ella_provisioning_gate_page.dart
+++ b/app/lib/ella/pages/ella_provisioning_gate_page.dart
@@ -63,7 +63,7 @@ class _EllaProvisioningGatePageState extends State<EllaProvisioningGatePage> wit
       }
       final accepted = await AiConsentSheet.show(
         context,
-        onAccept: () async => (await consentService.grantCurrentConsent(uid: user.uid)) != null,
+        onAccept: () => consentService.grantCurrentConsentWithOutcome(uid: user.uid),
         onDecline: () => consentService.declineCurrentConsent(uid: user.uid),
       );
       if (!mounted) return;

--- a/app/lib/ella/pages/ella_settings_page.dart
+++ b/app/lib/ella/pages/ella_settings_page.dart
@@ -189,10 +189,12 @@ class _EllaSettingsPageState extends State<EllaSettingsPage> with RouteAware {
       context,
       reviewMode: true,
       onAccept: () async {
-        final receiptId = await consentService.grantCurrentConsent(uid: uid);
-        if (receiptId == null) return false;
-        if (mounted) context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
-        return true;
+        final outcome = await consentService.grantCurrentConsentWithOutcome(uid: uid);
+        final receiptId = outcome.receiptId;
+        if (receiptId != null && mounted) {
+          context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
+        }
+        return outcome;
       },
       onDecline: () async {
         revokeSynced = await consentService.revokeCurrentConsent(uid: uid);

--- a/app/lib/ella/services/ai_consent_coordinator.dart
+++ b/app/lib/ella/services/ai_consent_coordinator.dart
@@ -76,9 +76,9 @@ class AiConsentCoordinator {
     final accepted = await AiConsentSheet.show(
       context,
       onAccept: () async {
-        final receiptId = await service.grantCurrentConsent(uid: uid);
-        if (receiptId == null) return false;
-        if (context.mounted) {
+        final outcome = await service.grantCurrentConsentWithOutcome(uid: uid);
+        final receiptId = outcome.receiptId;
+        if (receiptId != null && context.mounted) {
           try {
             context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
           } catch (_) {
@@ -86,7 +86,7 @@ class AiConsentCoordinator {
             // action is rendered outside the provisioning provider tree.
           }
         }
-        return true;
+        return outcome;
       },
       onDecline: () => service.declineCurrentConsent(uid: uid),
     );

--- a/app/lib/ella/services/ella_ai_consent_service.dart
+++ b/app/lib/ella/services/ella_ai_consent_service.dart
@@ -135,12 +135,51 @@ class AiConsentSubmission {
       };
 }
 
+/// Transport-level result of a consent submission, preserving the failure
+/// cause instead of collapsing every non-200 response to null.
+class AiConsentSubmitResult {
+  const AiConsentSubmitResult({this.status, this.httpStatus, this.errorCode = ''});
+
+  final AiConsentStatus? status;
+
+  /// HTTP status of the response; null when the server was unreachable.
+  final int? httpStatus;
+
+  /// Backend `detail.code` for non-200 responses, when present.
+  final String errorCode;
+}
+
+enum AiConsentGrantFailureKind { authorityChanged, policyMismatch, serverUnavailable, network, rejected }
+
+/// Outcome of a grant attempt: an accepted receipt, or a typed failure the
+/// consent surface can present honestly. Failure never carries authority.
+class AiConsentGrantOutcome {
+  const AiConsentGrantOutcome.accepted(String this.receiptId)
+      : failureKind = null,
+        supportCode = '';
+
+  const AiConsentGrantOutcome.failed(this.failureKind, {this.supportCode = ''}) : receiptId = null;
+
+  final String? receiptId;
+  final AiConsentGrantFailureKind? failureKind;
+  final String supportCode;
+
+  bool get accepted => receiptId != null;
+}
+
 abstract class EllaAiConsentTransport {
   Future<AiConsentPolicy?> fetchPolicy();
 
   Future<AiConsentStatus?> fetchStatus();
 
   Future<AiConsentStatus?> submit(AiConsentSubmission submission);
+
+  /// Default detail wrapper so existing transports and fakes keep working:
+  /// a null status is reported as unreachable, anything else as HTTP 200.
+  Future<AiConsentSubmitResult> submitWithDetails(AiConsentSubmission submission) async {
+    final status = await submit(submission);
+    return AiConsentSubmitResult(status: status, httpStatus: status == null ? null : 200);
+  }
 }
 
 class EllaAiConsentHttpTransport implements EllaAiConsentTransport {
@@ -180,16 +219,30 @@ class EllaAiConsentHttpTransport implements EllaAiConsentTransport {
   }
 
   @override
-  Future<AiConsentStatus?> submit(AiConsentSubmission submission) async {
+  Future<AiConsentStatus?> submit(AiConsentSubmission submission) async => (await submitWithDetails(submission)).status;
+
+  @override
+  Future<AiConsentSubmitResult> submitWithDetails(AiConsentSubmission submission) async {
     final response = await makeApiCall(
       url: _endpoint,
       headers: const {},
       method: 'POST',
       body: jsonEncode(submission.toJson()),
     );
-    if (response?.statusCode != 200) return null;
-    final body = _decodeMap(response!.body);
-    return body == null ? null : AiConsentStatus.fromJson(body);
+    if (response == null) return const AiConsentSubmitResult();
+    if (response.statusCode != 200) {
+      return AiConsentSubmitResult(httpStatus: response.statusCode, errorCode: _errorCode(response.body));
+    }
+    final body = _decodeMap(response.body);
+    return AiConsentSubmitResult(status: body == null ? null : AiConsentStatus.fromJson(body), httpStatus: 200);
+  }
+
+  static String _errorCode(String body) {
+    final decoded = _decodeMap(body);
+    final detail = decoded?['detail'];
+    if (detail is Map<String, dynamic> && detail['code'] is String) return detail['code'] as String;
+    if (decoded?['code'] is String) return decoded!['code'] as String;
+    return '';
   }
 }
 
@@ -261,16 +314,60 @@ class EllaAiConsentService {
     }
   }
 
-  Future<String?> grantCurrentConsent({required String uid}) async {
+  Future<String?> grantCurrentConsent({required String uid}) async =>
+      (await grantCurrentConsentWithOutcome(uid: uid)).receiptId;
+
+  /// Grant with a typed outcome so the consent surface can say why an attempt
+  /// failed. Semantics are identical to [grantCurrentConsent]: fail closed,
+  /// never persist authority on any failure path.
+  Future<AiConsentGrantOutcome> grantCurrentConsentWithOutcome({required String uid}) async {
+    const authorityChanged = AiConsentGrantOutcome.failed(AiConsentGrantFailureKind.authorityChanged);
     final authority = _captureAuthority(uid);
     if (authority == null) {
       SharedPreferencesUtil.clearAiConsentServerVerification();
-      return null;
+      return authorityChanged;
     }
-    final status = await _submit(authority: authority, decision: AiConsentDecision.granted);
-    if (!_requireCurrentAuthority(authority) || status == null || !status.isCurrentGrantFor(uid)) return null;
-    if (!_persistVerifiedGrant(authority, status)) return null;
-    return _preferences.aiConsentAccepted ? status.receiptId : null;
+    SharedPreferencesUtil.clearAiConsentServerVerification();
+    if (!_requireCurrentAuthority(authority)) return authorityChanged;
+
+    final policy = await _transport.fetchPolicy();
+    if (!_requireCurrentAuthority(authority)) return authorityChanged;
+    if (policy == null) {
+      return const AiConsentGrantOutcome.failed(
+        AiConsentGrantFailureKind.serverUnavailable,
+        supportCode: 'consent_policy_unavailable',
+      );
+    }
+    if (!policy.isBundledCurrent) {
+      return const AiConsentGrantOutcome.failed(
+        AiConsentGrantFailureKind.policyMismatch,
+        supportCode: 'consent_policy_mismatch',
+      );
+    }
+
+    final result =
+        await _transport.submitWithDetails(_buildSubmission(policy: policy, decision: AiConsentDecision.granted));
+    if (!_requireCurrentAuthority(authority)) return authorityChanged;
+    if (result.httpStatus == null) {
+      return const AiConsentGrantOutcome.failed(AiConsentGrantFailureKind.network);
+    }
+    if (result.httpStatus != 200) {
+      return AiConsentGrantOutcome.failed(
+        result.errorCode == 'ai_consent_policy_mismatch'
+            ? AiConsentGrantFailureKind.policyMismatch
+            : AiConsentGrantFailureKind.serverUnavailable,
+        supportCode: result.errorCode.isEmpty ? 'http_${result.httpStatus}' : result.errorCode,
+      );
+    }
+    final status = result.status;
+    if (status == null || !status.isCurrentGrantFor(uid)) {
+      return const AiConsentGrantOutcome.failed(
+        AiConsentGrantFailureKind.rejected,
+        supportCode: 'consent_grant_not_current',
+      );
+    }
+    if (!_persistVerifiedGrant(authority, status)) return authorityChanged;
+    return _preferences.aiConsentAccepted ? AiConsentGrantOutcome.accepted(status.receiptId) : authorityChanged;
   }
 
   Future<bool> declineCurrentConsent({required String uid}) async {
@@ -303,26 +400,27 @@ class EllaAiConsentService {
     if (!_requireCurrentAuthority(authority)) return null;
     final policy = await _fetchAcceptedPolicy();
     if (!_requireCurrentAuthority(authority) || policy == null) return null;
+    final status = await _transport.submit(_buildSubmission(policy: policy, decision: decision));
+    return _requireCurrentAuthority(authority) ? status : null;
+  }
 
+  AiConsentSubmission _buildSubmission({required AiConsentPolicy policy, required AiConsentDecision decision}) {
     final fullVersion = _clientVersionFactory();
     final separator = fullVersion.lastIndexOf('+');
     final appVersion = separator > 0 ? fullVersion.substring(0, separator) : fullVersion;
     final buildNumber =
         separator > 0 && separator < fullVersion.length - 1 ? fullVersion.substring(separator + 1) : 'unknown';
-    final status = await _transport.submit(
-      AiConsentSubmission(
-        decision: decision,
-        policyVersion: policy.version,
-        processorSetHash: policy.processorSetHash,
-        requestId: _requestIdFactory(),
-        appVersion: appVersion,
-        buildNumber: buildNumber,
-        locale: _localeFactory(),
-        scopeVersion: policy.scopeVersion,
-        scopeHash: policy.scopeHash,
-      ),
+    return AiConsentSubmission(
+      decision: decision,
+      policyVersion: policy.version,
+      processorSetHash: policy.processorSetHash,
+      requestId: _requestIdFactory(),
+      appVersion: appVersion,
+      buildNumber: buildNumber,
+      locale: _localeFactory(),
+      scopeVersion: policy.scopeVersion,
+      scopeHash: policy.scopeHash,
     );
-    return _requireCurrentAuthority(authority) ? status : null;
   }
 
   Future<AiConsentPolicy?> _fetchAcceptedPolicy() async {

--- a/app/lib/ella/widgets/ai_consent_sheet.dart
+++ b/app/lib/ella/widgets/ai_consent_sheet.dart
@@ -4,6 +4,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/ella/services/ella_ai_consent_service.dart';
 import 'package:omi/ella/services/ella_legal_links.dart';
 import 'package:omi/utils/ella_pilot_locale_policy.dart';
 import 'package:omi/utils/l10n_extensions.dart';
@@ -13,14 +14,14 @@ class AiConsentSheet extends StatefulWidget {
 
   const AiConsentSheet({super.key, this.onAccept, this.onDecline, this.onRequestDeletion, this.reviewMode = false});
 
-  final Future<bool> Function()? onAccept;
+  final Future<AiConsentGrantOutcome> Function()? onAccept;
   final Future<bool> Function()? onDecline;
   final Future<void> Function()? onRequestDeletion;
   final bool reviewMode;
 
   static Future<bool?> show(
     BuildContext context, {
-    Future<bool> Function()? onAccept,
+    Future<AiConsentGrantOutcome> Function()? onAccept,
     Future<bool> Function()? onDecline,
     Future<void> Function()? onRequestDeletion,
     bool reviewMode = false,
@@ -54,34 +55,48 @@ class AiConsentSheet extends StatefulWidget {
 }
 
 class _AiConsentSheetState extends State<AiConsentSheet> {
+  static const _genericFailure = AiConsentGrantOutcome.failed(AiConsentGrantFailureKind.rejected);
+
   bool _isSubmitting = false;
-  bool _hasError = false;
+  AiConsentGrantFailureKind? _failureKind;
+  String _supportCode = '';
 
   Future<void> _accept() async {
     if (_isSubmitting) return;
     setState(() {
       _isSubmitting = true;
-      _hasError = false;
+      _failureKind = null;
+      _supportCode = '';
     });
 
+    var outcome = _genericFailure;
     try {
-      final accepted = await (widget.onAccept?.call() ?? Future<bool>.value(false));
+      outcome = await (widget.onAccept?.call() ?? Future<AiConsentGrantOutcome>.value(_genericFailure));
       if (!mounted) return;
-      if (accepted) {
+      if (outcome.accepted) {
         Navigator.of(context).pop(true);
         return;
       }
     } catch (_) {
       // Keep the consent surface open and capture disabled on acknowledgement failure.
+      outcome = _genericFailure;
     }
 
     if (mounted) {
       setState(() {
         _isSubmitting = false;
-        _hasError = true;
+        _failureKind = outcome.failureKind ?? AiConsentGrantFailureKind.rejected;
+        _supportCode = outcome.supportCode;
       });
     }
   }
+
+  String _failureMessage(BuildContext context) => switch (_failureKind) {
+        AiConsentGrantFailureKind.serverUnavailable => context.l10n.aiConsentGrantUnavailableBody,
+        AiConsentGrantFailureKind.policyMismatch => context.l10n.aiConsentGrantPolicyMismatchBody,
+        AiConsentGrantFailureKind.network => context.l10n.aiConsentGrantNetworkBody,
+        _ => context.l10n.somethingWentWrongTryAgain,
+      };
 
   Future<void> _decline() async {
     if (_isSubmitting) return;
@@ -213,17 +228,30 @@ class _AiConsentSheetState extends State<AiConsentSheet> {
                         recognizer: TapGestureRecognizer()..onTap = () => launchUrl(AiConsentSheet.privacyPolicyUri),
                       ),
                     ),
-                    if (_hasError) ...[
-                      const SizedBox(height: 12),
-                      Text(
-                        context.l10n.somethingWentWrongTryAgain,
-                        style: bodyStyle?.copyWith(color: EllaColors.error),
-                      ),
-                    ],
                   ],
                 ),
               ),
             ),
+            if (_failureKind != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 0, 24, 10),
+                child: Semantics(
+                  liveRegion: true,
+                  child: Column(
+                    children: [
+                      Text(
+                        _failureMessage(context),
+                        style: EllaTextStyles.secondary.copyWith(color: EllaColors.error),
+                        textAlign: TextAlign.center,
+                      ),
+                      if (_supportCode.isNotEmpty) ...[
+                        const SizedBox(height: 4),
+                        Text(_supportCode, style: EllaTextStyles.caption, textAlign: TextAlign.center),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 24),
               child: Column(

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10632,5 +10632,8 @@
   "ellaWorkspaceWhispersRoute": "Whispers",
   "ellaWorkspaceVerified": "Verified",
   "ellaWorkspaceNotVerified": "Not verified",
-  "ellaWorkspaceRouteExplanation": "Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet."
+  "ellaWorkspaceRouteExplanation": "Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.",
+  "aiConsentGrantUnavailableBody": "Ella couldn't confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.",
+  "aiConsentGrantPolicyMismatchBody": "This version of Ella no longer matches the current privacy policy. Please update the app, then try again.",
+  "aiConsentGrantNetworkBody": "Ella couldn't reach the server. Check your connection and try again."
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -17228,6 +17228,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.'**
   String get ellaWorkspaceRouteExplanation;
+
+  /// No description provided for @aiConsentGrantUnavailableBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.'**
+  String get aiConsentGrantUnavailableBody;
+
+  /// No description provided for @aiConsentGrantPolicyMismatchBody.
+  ///
+  /// In en, this message translates to:
+  /// **'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.'**
+  String get aiConsentGrantPolicyMismatchBody;
+
+  /// No description provided for @aiConsentGrantNetworkBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Ella couldn\'t reach the server. Check your connection and try again.'**
+  String get aiConsentGrantNetworkBody;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9194,4 +9194,15 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9282,4 +9282,15 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9298,4 +9298,15 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9245,4 +9245,15 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9234,4 +9234,15 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9316,4 +9316,15 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9307,4 +9307,15 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9247,4 +9247,15 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9264,4 +9264,15 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9249,4 +9249,15 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9248,4 +9248,15 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9323,4 +9323,15 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9230,4 +9230,15 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9287,4 +9287,15 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9262,4 +9262,15 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9299,4 +9299,15 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -9116,4 +9116,15 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9118,4 +9118,15 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9255,4 +9255,15 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9267,4 +9267,15 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9273,4 +9273,15 @@ class AppLocalizationsMs extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9275,4 +9275,15 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9245,4 +9245,15 @@ class AppLocalizationsNo extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9268,4 +9268,15 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9250,4 +9250,15 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9288,4 +9288,15 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9275,4 +9275,15 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9240,4 +9240,15 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9255,4 +9255,15 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9212,4 +9212,15 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9263,4 +9263,15 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9262,4 +9262,15 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9252,4 +9252,15 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -9106,4 +9106,15 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get ellaWorkspaceRouteExplanation =>
       'Not verified does not mean another account is in use. It means Ella has not received route-specific proof yet.';
+
+  @override
+  String get aiConsentGrantUnavailableBody =>
+      'Ella couldn\'t confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.';
+
+  @override
+  String get aiConsentGrantPolicyMismatchBody =>
+      'This version of Ella no longer matches the current privacy policy. Please update the app, then try again.';
+
+  @override
+  String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 }

--- a/app/lib/pages/onboarding/ella/ella_onboarding.dart
+++ b/app/lib/pages/onboarding/ella/ella_onboarding.dart
@@ -193,10 +193,12 @@ class _EllaOnboardingState extends State<EllaOnboarding> {
       await AiConsentSheet.show(
         context,
         onAccept: () async {
-          final receiptId = await consentService.grantCurrentConsent(uid: uid);
-          if (receiptId == null) return false;
-          if (mounted) context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
-          return true;
+          final outcome = await consentService.grantCurrentConsentWithOutcome(uid: uid);
+          final receiptId = outcome.receiptId;
+          if (receiptId != null && mounted) {
+            context.read<EllaProvisioningProvider>().setConsentReceiptId(receiptId);
+          }
+          return outcome;
         },
         onDecline: () => consentService.declineCurrentConsent(uid: uid),
       );

--- a/app/test/ella/services/ella_ai_consent_grant_outcome_test.dart
+++ b/app/test/ella/services/ella_ai_consent_grant_outcome_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ai_consent_policy.dart';
+import 'package:omi/ella/services/ella_ai_consent_service.dart';
+
+class _FakeTransport extends EllaAiConsentTransport {
+  _FakeTransport({this.policy, this.submitResult});
+
+  AiConsentPolicy? policy;
+  AiConsentSubmitResult? submitResult;
+  int submitCalls = 0;
+
+  @override
+  Future<AiConsentPolicy?> fetchPolicy() async => policy;
+
+  @override
+  Future<AiConsentStatus?> fetchStatus() async => null;
+
+  @override
+  Future<AiConsentStatus?> submit(AiConsentSubmission submission) async => (await submitWithDetails(submission)).status;
+
+  @override
+  Future<AiConsentSubmitResult> submitWithDetails(AiConsentSubmission submission) async {
+    submitCalls++;
+    return submitResult ?? const AiConsentSubmitResult();
+  }
+}
+
+AiConsentStatus _currentGrantStatus(String uid) => AiConsentStatus(
+      subjectUid: uid,
+      authorized: true,
+      policy: AiConsentPolicy.bundled,
+      decision: 'granted',
+      receiptId: '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-1',
+      policyVersion: SharedPreferencesUtil.currentAiConsentContractVersion,
+      processorSetHash: SharedPreferencesUtil.currentAiConsentProcessorSetHash,
+      appVersion: '1.0.0',
+      buildNumber: '1',
+      locale: 'en-US',
+      profileBindingId: 'binding-1',
+      scopeVersion: SharedPreferencesUtil.currentAiConsentScopeVersion,
+      scopeHash: SharedPreferencesUtil.currentAiConsentScopeHash,
+      serverDecidedAt: DateTime.utc(2026, 8, 7),
+    );
+
+EllaAiConsentService _service(_FakeTransport transport) => EllaAiConsentService(
+      transport: transport,
+      pilotLocaleRestricted: false,
+      requestIdFactory: () => 'request-1',
+      clientVersionFactory: () => '1.0.0+1',
+      localeFactory: () => 'en-US',
+      appLocaleFactory: () => 'en',
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const uid = 'uid-a';
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    SharedPreferencesUtil().uid = uid;
+  });
+
+  test('unreachable server maps to a network failure and never persists consent', () async {
+    final transport = _FakeTransport(policy: AiConsentPolicy.bundled, submitResult: const AiConsentSubmitResult());
+    final outcome = await _service(transport).grantCurrentConsentWithOutcome(uid: uid);
+
+    expect(outcome.accepted, isFalse);
+    expect(outcome.failureKind, AiConsentGrantFailureKind.network);
+    expect(SharedPreferencesUtil().aiConsentAccepted, isFalse);
+  });
+
+  test('503 grant rejection surfaces server-unavailable with the backend code', () async {
+    final transport = _FakeTransport(
+      policy: AiConsentPolicy.bundled,
+      submitResult:
+          const AiConsentSubmitResult(httpStatus: 503, errorCode: 'managed_cloud_consent_authority_unavailable'),
+    );
+    final outcome = await _service(transport).grantCurrentConsentWithOutcome(uid: uid);
+
+    expect(outcome.failureKind, AiConsentGrantFailureKind.serverUnavailable);
+    expect(outcome.supportCode, 'managed_cloud_consent_authority_unavailable');
+    expect(SharedPreferencesUtil().aiConsentAccepted, isFalse);
+  });
+
+  test('409 policy mismatch maps to the policy-mismatch failure kind', () async {
+    final transport = _FakeTransport(
+      policy: AiConsentPolicy.bundled,
+      submitResult: const AiConsentSubmitResult(httpStatus: 409, errorCode: 'ai_consent_policy_mismatch'),
+    );
+    final outcome = await _service(transport).grantCurrentConsentWithOutcome(uid: uid);
+
+    expect(outcome.failureKind, AiConsentGrantFailureKind.policyMismatch);
+    expect(outcome.supportCode, 'ai_consent_policy_mismatch');
+  });
+
+  test('non-200 without a body code falls back to an http support code', () async {
+    final transport = _FakeTransport(
+      policy: AiConsentPolicy.bundled,
+      submitResult: const AiConsentSubmitResult(httpStatus: 500),
+    );
+    final outcome = await _service(transport).grantCurrentConsentWithOutcome(uid: uid);
+
+    expect(outcome.failureKind, AiConsentGrantFailureKind.serverUnavailable);
+    expect(outcome.supportCode, 'http_500');
+  });
+
+  test('missing policy blocks the submit and reports server-unavailable', () async {
+    final transport = _FakeTransport(policy: null);
+    final outcome = await _service(transport).grantCurrentConsentWithOutcome(uid: uid);
+
+    expect(outcome.failureKind, AiConsentGrantFailureKind.serverUnavailable);
+    expect(outcome.supportCode, 'consent_policy_unavailable');
+    expect(transport.submitCalls, 0);
+  });
+
+  test('200 with a non-current grant is rejected without persisting authority', () async {
+    final transport = _FakeTransport(
+      policy: AiConsentPolicy.bundled,
+      submitResult: const AiConsentSubmitResult(httpStatus: 200),
+    );
+    final outcome = await _service(transport).grantCurrentConsentWithOutcome(uid: uid);
+
+    expect(outcome.failureKind, AiConsentGrantFailureKind.rejected);
+    expect(outcome.supportCode, 'consent_grant_not_current');
+    expect(SharedPreferencesUtil().aiConsentAccepted, isFalse);
+  });
+
+  test('current verified grant is accepted and persists the receipt', () async {
+    final transport = _FakeTransport(policy: AiConsentPolicy.bundled);
+    transport.submitResult = AiConsentSubmitResult(httpStatus: 200, status: _currentGrantStatus(uid));
+    final outcome = await _service(transport).grantCurrentConsentWithOutcome(uid: uid);
+
+    expect(outcome.accepted, isTrue);
+    expect(outcome.receiptId, '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-1');
+    expect(SharedPreferencesUtil().aiConsentAccepted, isTrue);
+    expect(SharedPreferencesUtil().aiConsentReceiptId, outcome.receiptId);
+  });
+
+  test('legacy grantCurrentConsent keeps returning only the receipt id', () async {
+    final transport = _FakeTransport(policy: AiConsentPolicy.bundled);
+    transport.submitResult = AiConsentSubmitResult(httpStatus: 200, status: _currentGrantStatus(uid));
+
+    expect(
+      await _service(transport).grantCurrentConsent(uid: uid),
+      '${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-1',
+    );
+  });
+}

--- a/app/test/ella/services/ella_provisioning_service_test.dart
+++ b/app/test/ella/services/ella_provisioning_service_test.dart
@@ -807,7 +807,7 @@ class _DeferredEnsureTransport implements EllaProvisioningTransport {
   Future<EllaProvisioningResponse> status() => throw StateError('status should not be called');
 }
 
-class _FakeConsentTransport implements EllaAiConsentTransport {
+class _FakeConsentTransport extends EllaAiConsentTransport {
   _FakeConsentTransport({required this.policy, this.statusResponse, this.submitResponse});
 
   final AiConsentPolicy? policy;
@@ -836,7 +836,7 @@ class _FakeConsentTransport implements EllaAiConsentTransport {
   }
 }
 
-class _DeferredConsentPolicyTransport implements EllaAiConsentTransport {
+class _DeferredConsentPolicyTransport extends EllaAiConsentTransport {
   _DeferredConsentPolicyTransport({this.statusResponse, this.submitResponse});
 
   final AiConsentStatus? statusResponse;
@@ -867,7 +867,7 @@ class _DeferredConsentPolicyTransport implements EllaAiConsentTransport {
   }
 }
 
-class _DeferredConsentStatusTransport implements EllaAiConsentTransport {
+class _DeferredConsentStatusTransport extends EllaAiConsentTransport {
   final Completer<AiConsentStatus?> _status = Completer<AiConsentStatus?>();
   final Completer<void> statusStarted = Completer<void>();
 
@@ -888,7 +888,7 @@ class _DeferredConsentStatusTransport implements EllaAiConsentTransport {
   }
 }
 
-class _DeferredConsentSubmitTransport implements EllaAiConsentTransport {
+class _DeferredConsentSubmitTransport extends EllaAiConsentTransport {
   final Completer<AiConsentStatus?> _status = Completer<AiConsentStatus?>();
   final Completer<void> submitStarted = Completer<void>();
   final List<AiConsentSubmission> submissions = [];

--- a/app/test/ella/widgets/ai_consent_sheet_test.dart
+++ b/app/test/ella/widgets/ai_consent_sheet_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/ella/services/ella_ai_consent_service.dart';
 import 'package:omi/ella/widgets/ai_consent_sheet.dart';
 import 'package:omi/l10n/app_localizations.dart';
 
@@ -37,10 +38,16 @@ void main() {
                 scopeVersion: SharedPreferencesUtil.currentAiConsentScopeVersion,
                 scopeHash: SharedPreferencesUtil.currentAiConsentScopeHash,
               );
-              return true;
+              return AiConsentGrantOutcome.accepted('${SharedPreferencesUtil.currentAiConsentReceiptPrefix}receipt-a');
             },
           ),
         ),
+      );
+
+  Widget buildFailingApp(AiConsentGrantOutcome outcome) => MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: AiConsentSheet(onAccept: () async => outcome)),
       );
 
   testWidgets('presents as a bounded sheet with Not now always visible', (tester) async {
@@ -165,6 +172,63 @@ void main() {
     expect(preferences.aiConsentContractVersion, SharedPreferencesUtil.currentAiConsentContractVersion);
     expect(preferences.aiConsentProcessorSetHash, SharedPreferencesUtil.currentAiConsentProcessorSetHash);
     expect(preferences.aiConsentDeferredVersion, isEmpty);
+  });
+
+  testWidgets('server-unavailable grant failure stays open with typed message and support code', (tester) async {
+    await tester.pumpWidget(buildFailingApp(const AiConsentGrantOutcome.failed(
+      AiConsentGrantFailureKind.serverUnavailable,
+      supportCode: 'managed_cloud_consent_authority_unavailable',
+    )));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(find.text('Allow and continue'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Allow and continue'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AiConsentSheet), findsOneWidget);
+    expect(
+      find.text("Ella couldn't confirm your choice with the server, so nothing has been shared yet. "
+          'Please try again in a few minutes.'),
+      findsOneWidget,
+    );
+    expect(find.text('managed_cloud_consent_authority_unavailable'), findsOneWidget);
+    expect(find.text('Allow and continue').hitTestable(), findsOneWidget);
+    expect(SharedPreferencesUtil().aiConsentAccepted, isFalse);
+  });
+
+  testWidgets('policy-mismatch grant failure asks for an app update', (tester) async {
+    await tester.pumpWidget(buildFailingApp(const AiConsentGrantOutcome.failed(
+      AiConsentGrantFailureKind.policyMismatch,
+      supportCode: 'consent_policy_mismatch',
+    )));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(find.text('Allow and continue'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Allow and continue'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('This version of Ella no longer matches the current privacy policy. '
+          'Please update the app, then try again.'),
+      findsOneWidget,
+    );
+    expect(find.text('consent_policy_mismatch'), findsOneWidget);
+    expect(SharedPreferencesUtil().aiConsentAccepted, isFalse);
+  });
+
+  testWidgets('network grant failure shows connection guidance without a support code', (tester) async {
+    await tester.pumpWidget(buildFailingApp(const AiConsentGrantOutcome.failed(AiConsentGrantFailureKind.network)));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(find.text('Allow and continue'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Allow and continue'));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Ella couldn't reach the server. Check your connection and try again."), findsOneWidget);
+    expect(SharedPreferencesUtil().aiConsentAccepted, isFalse);
   });
 
   testWidgets('Not now defers the current processor contract', (tester) async {

--- a/app/test/pages/onboarding/ella/ella_onboarding_pilot_locale_test.dart
+++ b/app/test/pages/onboarding/ella/ella_onboarding_pilot_locale_test.dart
@@ -188,7 +188,7 @@ void main() {
   });
 }
 
-class _GuardedConsentTransport implements EllaAiConsentTransport {
+class _GuardedConsentTransport extends EllaAiConsentTransport {
   bool allowRequests = false;
   int policyCalls = 0;
   int statusCalls = 0;


### PR DESCRIPTION
Fixes ellaaicare/ella-ai#1193 (consent gate silently re-renders on grant failure).

## Base

**Stacked on the reviewed #367 head `8dfb12bd` (`codex/1185-ios-client-fail-closed`), sibling to #371** — same rationale: `main` is not a valid iOS release base, and this rides the 806 → #362 → #367 line without touching either reviewed tree. Do not merge before #362/#367.

## Problem

Tapping "Allow and continue" gave no usable feedback when the server rejected the grant: the consent transport collapsed every non-200 `POST /v1/users/ai-consent` response to `null`, and the sheet's only error surface was a generic line inside the scrollable disclosure. Fresh accounts blocked by the backend admission wall (live-confirmed 503 `managed_cloud_consent_authority_unavailable`, see the #1189 thread) experienced an apparent refresh loop — the owner reproduced this on a brand-new account on 2026-08-07.

## Change

- `ella_ai_consent_service.dart`: transport gains `submitWithDetails` (HTTP status + backend `detail.code`; default implementation keeps existing transports/fakes source-compatible). New `grantCurrentConsentWithOutcome` maps failures to typed kinds — `serverUnavailable` (503/5xx + code), `policyMismatch` (bundled-policy drift or 409 `ai_consent_policy_mismatch`), `network` (unreachable), `authorityChanged`, `rejected`. **Fail-closed semantics unchanged**: no failure path persists consent or authority; the step order (clear verification → authority → policy → submit → verify current grant → persist) mirrors the previous implementation exactly; legacy `grantCurrentConsent` now delegates and still returns only the receipt id. Submission building is extracted into `_buildSubmission`, shared with the unchanged decline/revoke path.
- `ai_consent_sheet.dart`: `onAccept` returns the typed outcome; failures render a localized explanation plus the raw support code in an always-visible live region above the action buttons (previously the error could sit off-screen in the scroll). Accept/decline/revoke/deletion behavior unchanged.
- Call sites updated in the provisioning gate, settings page, consent coordinator, and onboarding (receipt propagation to the provisioning provider preserved).
- Three new English l10n keys (`aiConsentGrantUnavailableBody`, `aiConsentGrantPolicyMismatchBody`, `aiConsentGrantNetworkBody`); other locales use the generated English fallback, consistent with the internal pilot's English-only restriction. Generated localization files are included.
- Tests: new `ella_ai_consent_grant_outcome_test.dart` (8 cases: network / 503+code / 409 mismatch / http fallback code / policy-unavailable short-circuit / non-current-grant rejection without persist / accepted persist / legacy API compatibility); 3 new sheet widget tests (typed message + support code rendering, sheet stays open, nothing persisted); existing consent fakes switched from `implements` to `extends` to inherit the default detail wrapper.

## Verification (local, on base `8dfb12bd`)

- `flutter analyze` (post `build_runner` + `gen-l10n`): zero issues in changed files; only the 3 known base-environment errors remain (missing local `firebase_options_*`, upstream `const_eval_method_invocation`).
- Affected suites green: consent sheet, grant outcome, provisioning service, onboarding pilot locale, consent coordinator, provisioning gate page — 54/54.
- Full `flutter test`: **391 passed** (+11 new), 5 failed — the identical 5 `account_isolation_test.dart` production/real-HTTP tests that fail on the pristine base in this network-restricted environment (hosted CI on the base head: 385/385, run 30950501951). `app/test.sh` pass; `git diff --check` clean; `dart format` line length 120 applied.

## Explicitly out of scope

The underlying fresh-UID admission wall (backend/owner decision, #1189 thread) — this PR only makes the client honest about it. Consent copy in the disclosure body is untouched; the new strings avoid all banned words asserted by the disclosure test.

No secrets, credentials, user identifiers, or Apple/vendor mutations. No merge performed.
