### PR TITLE
backend: interim fresh-UID admission relax behind env flag (ella-ai #1189)

### DIFF
--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -135,6 +135,19 @@ def self_hosted_provisioning_configured() -> bool:
     return os.getenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "false").strip().lower() in TRUE_VALUES
 
 
+def self_hosted_fresh_uid_relax_enabled() -> bool:
+    """INTERIM relax (Plato, 2026-08-07, elle-ai #1189).
+
+    Return True when the operator has asked us to admit brand-new self-hosted
+    UIDs that hold no matching invitation admission yet. This is explicitly
+    temporary: payload is to get a fully functional fresh user -> provision
+    hermes -> isolated account with chat/voice/memories -> delete-account
+    working end-to-end. Once E2E is proven, invitation gating is re-added by
+    unsetting/unsetting this flag (the strict path below is kept intact).
+    """
+    return os.getenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", "false").strip().lower() in TRUE_VALUES
+
+
 def current_self_hosted_runtime_lineage() -> RuntimeTargetLineage:
     """Return the exact invitation consent lineage required by local Hermes."""
     return RuntimeTargetLineage(
@@ -151,7 +164,15 @@ def self_hosted_provisioning_enabled(
     admission: Optional[dict[str, Any]] = None,
 ) -> bool:
     """Admit only the exact UID backed by current invitation authority."""
-    if not self_hosted_provisioning_configured() or not uid or not admission:
+    if not self_hosted_provisioning_configured() or not uid:
+        return False
+    if admission is None and self_hosted_fresh_uid_relax_enabled():
+        # INTERIM relax (Plato #1189): a brand-new self-hosted UID that has no
+        # admission record yet is admitted so the fresh-user flow (consent ->
+        # ensure -> provision -> isolated account) can run end-to-end. Invitation
+        # gating is re-added by unsetting ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID.
+        return True
+    if not admission:
         return False
     return hmac.compare_digest(str(admission.get("omi_uid") or ""), uid) and _self_hosted_invitation_matches(admission)
 
@@ -861,7 +882,16 @@ class ProvisioningCoordinator:
             raise ProvisioningError("invitation_authority_required", retryable=False)
         if self_hosted_configured and not self_hosted_required and not legacy_required:
             raise ProvisioningError("invitation_authority_required", retryable=False)
-        if self_hosted_required:
+        if self_hosted_required and invitation_admission is None:
+            # INTERIM relax (Plato #1189): a fresh self-hosted UID admitted
+            # without an admission record has no invitation chain to resolve.
+            # The attestation/context is derived from the job/user identity
+            # downstream (see _process_claimed_job_with_deadline fallbacks),
+            # so we do not hard-fail here. This branch only runs while
+            # ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID is set.
+            if not self_hosted_fresh_uid_relax_enabled():
+                assert invitation_admission is not None
+        elif self_hosted_required:
             # The current invitation, entitlement, consent epoch, and target
             # chain were resolved before identity, job, or provider side effects.
             assert invitation_admission is not None

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -54,6 +54,8 @@ from ella.services.provisioning import (
     retained_compatibility_receipt,
     resolve_gateway_credential,
     rollout_enabled,
+    self_hosted_fresh_uid_relax_enabled,
+    self_hosted_provisioning_enabled,
     stable_payload_hash,
     validate_internal_gateway_url,
     validated_provision_timeout_seconds,
@@ -2637,6 +2639,45 @@ def test_missing_attestation_key_fails_before_provisioner_or_binding_write(monke
         assert client.calls == []
         assert repository.staged is None
         assert repository.job["error_code"] == "honcho_attestation_key_unavailable"
+
+
+def test_fresh_uid_relax_admits_uninvited_self_hosted_when_flag_set(monkeypatch):
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "true")
+    identity = VerifiedIdentity("fresh-relax-user", "user@example.test", "User", "UTC")
+    repository = FakeRepository(self_hosted_admission=None, self_hosted_owned=False)
+
+    # Without the relax flag a fresh self-hosted UID is denied (strict gate).
+    assert self_hosted_provisioning_enabled(identity.uid, admission=None) is False
+
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", "true")
+    assert self_hosted_fresh_uid_relax_enabled() is True
+    assert self_hosted_provisioning_enabled(identity.uid, admission=None) is True
+
+    coordinator = ProvisioningCoordinator(repository, FakeProvisionClient(_runtime_receipt()))
+    job, binding, claimed = asyncio.run(
+        coordinator.ensure_job(
+            identity=identity,
+            target_schema_version="hermes-user-v1",
+            client_request_id="request-fresh-relax",
+            request_payload={"client": "ios"},
+        )
+    )
+    # Fresh user admitted: proceeds past the gate without invitation_authority_required.
+    assert job["state"] in {"provisioning", "queued"}
+    assert claimed is True
+    assert len(repository.identity_calls) == 1
+    assert len(repository.job_calls) == 1
+
+    # Strict matching still enforced when an admission record IS present.
+    monkeypatch.delenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", raising=False)
+    repository.self_hosted_admission = _self_hosted_admission(identity.uid)
+    assert self_hosted_provisioning_enabled(identity.uid, admission=repository.self_hosted_admission) is True
+    repository.self_hosted_admission.pop("consent_scope_hash", None)
+    repository.self_hosted_admission["consent_scope_hash"] = "sha256:deadbeef"
+    assert self_hosted_provisioning_enabled(identity.uid, admission=repository.self_hosted_admission) is False
+
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "false")
+    monkeypatch.delenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", raising=False)
 
 
 def test_runtime_resolver_enforces_owner_health_and_credential(monkeypatch):


### PR DESCRIPTION
## ella-ai#1189 — interim fresh-UID admission relax (flag-gated)

Fresh self-hosted accounts cannot onboard: consent "Agree" 503s and `/v1/ella/onboarding/ensure` returns 409 `invitation_authority_required`. This PR is the **backend relaxation** leg, implemented per owner authorization (relax the UID invitation check until end-to-end provisioning works, then re-add the gate).

### Change
- New env flag `ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID` (default **off**).
- When on, a self-hosted UID with **no** invitation-admission record is admitted into provisioning (`backend/ella/services/provisioning.py`), so a fresh identity can flow consent → /ensure → provision → isolated account.
- Strict invitation matching preserved **byte-for-byte** whenever an admission record exists or the flag is unset — the invitation re-gate path is intact for re-hardening later.
- Relaxed the `ensure_job` hard `assert invitation_admission is not None` for the fresh + flag-on path (attestation context already falls back to job/user ids), so relaxed fresh UIDs don't crash that job.
- Added `test_fresh_uid_relax_admits_uninvited_self_hosted_when_flag_set`.

### Verification
- Provisioning suite: **55/55** (54 baseline + 1 new)
- Consent + authority-guard suite: **46/46**
- black clean.

### Scope / non-goals
- **Not flipped in prod.** This is a revertible flag; the prod env-var flip is a separate authorized step once consent bootstrap + delete unlink land and live green-field E2E is validated.
- Does **not** fix the consent-time `users`-row 503 (separate ordering-fork work, owner-authorized, landing in a follow-up).
- Strict re-gate restored the moment the flag is unset.

Co-authored-by: Oleg <cd9186ef0af7b11781e5594ec89d3b58fbd5f1da65dba7e8a0b2b5a4b35984f4@ella.communities.buzz.xyz>
