### PR TITLE
fix(ella): consent-time users-row bootstrap + delete-account unlink (ella-ai #1189)

### DIFF
--- a/backend/database/authority_advisory_lock.py
+++ b/backend/database/authority_advisory_lock.py
@@ -390,3 +390,79 @@ async def verify_self_owner_after_lock(
     if current != owner.account_id or current != owner.profile_id:
         raise AuthorityLockError("authority_lock_owner_drift")
     return current
+
+
+async def resolve_self_owner_unlocked_or_bootstrap(
+    connection: asyncpg.Connection,
+    *,
+    uid: str,
+    allow_bootstrap: bool,
+) -> AuthorityOwner:
+    """Resolve an existing self-owner, or return the deterministic not-yet-created
+    owner when ``allow_bootstrap`` (the reversible fresh-UID consent relax).
+
+    Mirrors :func:`resolve_self_owner_unlocked` but instead of raising
+    ``authority_lock_owner_missing`` for a UID with no ``users`` row, it returns
+    the deterministic provisional owner so the caller can bootstrap the row
+    inside the advisory-lock transaction. Without ``allow_bootstrap`` the strict
+    ``authority_lock_owner_missing`` behavior is preserved byte-for-byte.
+    """
+    row = await connection.fetchrow(
+        "SELECT id FROM users WHERE omi_uid = $1",
+        uid,
+    )
+    if row:
+        return AuthorityOwner.from_values(row["id"], row["id"])
+    if not allow_bootstrap:
+        raise AuthorityLockError("authority_lock_owner_missing")
+    return provisional_identity_owner(uid)
+
+
+async def verify_self_owner_after_lock_or_bootstrap(
+    connection: asyncpg.Connection,
+    *,
+    uid: str,
+    owner: AuthorityOwner,
+    proof: AuthorityLockProof,
+    allow_bootstrap: bool,
+) -> uuid.UUID:
+    """Re-read and lock ownership inside the advisory-lock transaction, creating
+    the deterministic ``users`` row for a fresh UID when ``allow_bootstrap``.
+
+    The INSERT only runs while the per-UID advisory lock is held (matching the
+    codebase's write discipline), uses the deterministic provisional owner id so
+    a later redemption/ensure reconciles onto the same row, and is idempotent via
+    ``ON CONFLICT (omi_uid) DO NOTHING``.
+    """
+    owner_lock = proof
+    await require_self_owner_lock(
+        connection,
+        owner_lock,
+        user_id=owner.account_id,
+    )
+    row = await connection.fetchrow(
+        "SELECT id FROM users WHERE omi_uid = $1 FOR UPDATE",
+        uid,
+    )
+    if row is None and allow_bootstrap:
+        row = await connection.fetchrow(
+            """
+            INSERT INTO users (id, omi_uid, name, timezone, status)
+            VALUES ($1, $2, 'Synthetic User', 'UTC', 'PENDING')
+            ON CONFLICT (omi_uid) DO NOTHING
+            RETURNING id
+            """,
+            owner.account_id,
+            uid,
+        )
+        if row is None:
+            row = await connection.fetchrow(
+                "SELECT id FROM users WHERE omi_uid = $1",
+                uid,
+            )
+    if not row:
+        raise AuthorityLockError("authority_lock_owner_missing")
+    current = _validated_database_uuid(row["id"], field="user_id")
+    if current != owner.account_id or current != owner.profile_id:
+        raise AuthorityLockError("authority_lock_owner_drift")
+    return current

--- a/backend/database/managed_cloud_consent.py
+++ b/backend/database/managed_cloud_consent.py
@@ -244,15 +244,23 @@ async def lock_or_bootstrap_grant_on_connection(
 async def synchronize_grant(
     *,
     grant: ManagedCloudGrant,
+    allow_fresh_uid_bootstrap: bool = False,
 ) -> dict[str, Any]:
-    """Publish a Firestore grant into the PostgreSQL ordering authority."""
+    """Publish a Firestore grant into the PostgreSQL ordering authority.
+
+    When ``allow_fresh_uid_bootstrap`` is set, a UID with no ``users`` row gets a
+    deterministic ``users`` row created inside the advisory-lock transaction so a
+    fresh self-hosted account can complete consent (the reversible relax flag).
+    Without it, the strict ``authority_lock_owner_missing`` behavior is preserved.
+    """
     grant.validate()
     try:
         pool = await voice_canary.get_pool()
         async with pool.acquire() as conn:
-            owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked_or_bootstrap(
                 conn,
                 uid=grant.account_uid,
+                allow_bootstrap=allow_fresh_uid_bootstrap,
             )
             async with conn.transaction():
                 owner_lock = await authority_advisory_lock.acquire_authority_lock(
@@ -263,11 +271,12 @@ async def synchronize_grant(
                     conn,
                     uid=grant.account_uid,
                 )
-                user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+                user_id = await authority_advisory_lock.verify_self_owner_after_lock_or_bootstrap(
                     conn,
                     uid=grant.account_uid,
                     owner=owner,
                     proof=owner_lock,
+                    allow_bootstrap=allow_fresh_uid_bootstrap,
                 )
                 row = await conn.fetchrow(
                     """

--- a/backend/database/managed_cloud_consent.py
+++ b/backend/database/managed_cloud_consent.py
@@ -430,6 +430,74 @@ async def synchronize_grant(
         raise ManagedCloudAuthorityUnavailable("managed_cloud_authority_unavailable") from exc
 
 
+async def unlink_self_owner_account_on_deletion(*, uid: str) -> None:
+    """Unlink a confirmed account from its data and free the UID for re-admission.
+
+    Runs under the same per-UID authority advisory lock that gates every other
+    writer. Clears the FK dependents (consent authority, entitlement/runtime
+    links) then deletes the ``users`` row so the same Firebase UID's next login
+    bootstraps a *fresh* account (Plato's "fresh account on relogin" semantic),
+    rather than resuming the old one. Idempotent and a no-op when no ``users``
+    row exists — so the deletion receipt is only issued when the server state
+    was actually unlinked.
+    """
+    try:
+        pool = await voice_canary.get_pool()
+        async with pool.acquire() as conn:
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+                conn,
+                uid=uid,
+            )
+            async with conn.transaction():
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(
+                    conn,
+                    owner=owner,
+                )
+                await voice_canary.lock_runtime_authority_on_connection(
+                    conn,
+                    uid=uid,
+                )
+                user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+                    conn,
+                    uid=uid,
+                    owner=owner,
+                    proof=owner_lock,
+                )
+                # Clear the FK dependents under the lock before freeing omi_uid.
+                await _quarantine_on_connection(
+                    conn,
+                    uid=uid,
+                    user_id=user_id,
+                    reason="account_deletion_confirmed",
+                    owner_lock=owner_lock,
+                )
+                # ella_invitation_redemptions.user_id is ON DELETE RESTRICT; detach it.
+                await conn.execute(
+                    """
+                    UPDATE ella_invitation_redemptions
+                    SET user_id = NULL
+                    WHERE user_id = $1
+                    """,
+                    user_id,
+                )
+                await conn.execute(
+                    """
+                    DELETE FROM users
+                    WHERE id = $1
+                    """,
+                    user_id,
+                )
+    except authority_advisory_lock.AuthorityLockError as exc:
+        if exc.code == "authority_lock_owner_missing":
+            # Nothing server-side to unlink; the receipt stays accurate.
+            return
+        raise ManagedCloudAuthorityUnavailable("managed_cloud_authority_unavailable") from exc
+    except ManagedCloudAuthorityUnavailable:
+        raise
+    except Exception as exc:
+        raise ManagedCloudAuthorityUnavailable("managed_cloud_authority_unavailable") from exc
+
+
 async def synchronize_denial(
     *,
     uid: str,

--- a/backend/ella/services/consent_authority.py
+++ b/backend/ella/services/consent_authority.py
@@ -11,6 +11,7 @@ from ella.services.ai_consent import (
     ConsentSubmission,
     managed_cloud_real_data_enabled,
 )
+from ella.services.provisioning import self_hosted_fresh_uid_relax_enabled
 
 
 def _managed_authority_required(uid: str) -> bool:
@@ -59,6 +60,7 @@ async def submit_with_managed_cloud_authority(
             grant=managed_cloud_consent.ManagedCloudGrant.from_mapping(
                 uid,
                 payload.get("receipt"),
-            )
+            ),
+            allow_fresh_uid_bootstrap=self_hosted_fresh_uid_relax_enabled(),
         )
     return payload

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -135,6 +135,19 @@ def self_hosted_provisioning_configured() -> bool:
     return os.getenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "false").strip().lower() in TRUE_VALUES
 
 
+def self_hosted_fresh_uid_relax_enabled() -> bool:
+    """INTERIM relax (Plato, 2026-08-07, elle-ai #1189).
+
+    Return True when the operator has asked us to admit brand-new self-hosted
+    UIDs that hold no matching invitation admission yet. This is explicitly
+    temporary: payload is to get a fully functional fresh user -> provision
+    hermes -> isolated account with chat/voice/memories -> delete-account
+    working end-to-end. Once E2E is proven, invitation gating is re-added by
+    unsetting/unsetting this flag (the strict path below is kept intact).
+    """
+    return os.getenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", "false").strip().lower() in TRUE_VALUES
+
+
 def current_self_hosted_runtime_lineage() -> RuntimeTargetLineage:
     """Return the exact invitation consent lineage required by local Hermes."""
     return RuntimeTargetLineage(
@@ -151,7 +164,15 @@ def self_hosted_provisioning_enabled(
     admission: Optional[dict[str, Any]] = None,
 ) -> bool:
     """Admit only the exact UID backed by current invitation authority."""
-    if not self_hosted_provisioning_configured() or not uid or not admission:
+    if not self_hosted_provisioning_configured() or not uid:
+        return False
+    if admission is None and self_hosted_fresh_uid_relax_enabled():
+        # INTERIM relax (Plato #1189): a brand-new self-hosted UID that has no
+        # admission record yet is admitted so the fresh-user flow (consent ->
+        # ensure -> provision -> isolated account) can run end-to-end. Invitation
+        # gating is re-added by unsetting ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID.
+        return True
+    if not admission:
         return False
     return hmac.compare_digest(str(admission.get("omi_uid") or ""), uid) and _self_hosted_invitation_matches(admission)
 
@@ -861,7 +882,16 @@ class ProvisioningCoordinator:
             raise ProvisioningError("invitation_authority_required", retryable=False)
         if self_hosted_configured and not self_hosted_required and not legacy_required:
             raise ProvisioningError("invitation_authority_required", retryable=False)
-        if self_hosted_required:
+        if self_hosted_required and invitation_admission is None:
+            # INTERIM relax (Plato #1189): a fresh self-hosted UID admitted
+            # without an admission record has no invitation chain to resolve.
+            # The attestation/context is derived from the job/user identity
+            # downstream (see _process_claimed_job_with_deadline fallbacks),
+            # so we do not hard-fail here. This branch only runs while
+            # ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID is set.
+            if not self_hosted_fresh_uid_relax_enabled():
+                assert invitation_admission is not None
+        elif self_hosted_required:
             # The current invitation, entitlement, consent epoch, and target
             # chain were resolved before identity, job, or provider side effects.
             assert invitation_admission is not None

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -57,6 +57,7 @@ from utils.notifications import send_notification, send_training_data_submitted_
 from utils.llm.external_integrations import generate_comprehensive_daily_summary
 from models.notification_message import NotificationMessage
 from utils.other import endpoints as auth
+from ella.services.ai_consent import build_account_deletion_receipt
 from utils.other.storage import (
     delete_all_conversation_recordings,
     get_speech_sample_signed_urls,
@@ -93,13 +94,27 @@ def get_user_profile_endpoint(uid: str = Depends(auth.get_current_user_uid)):
 
 @router.delete('/v1/users/delete-account', tags=['v1'])
 def delete_account(uid: str = Depends(auth.get_current_user_uid)):
-    raise HTTPException(
-        status_code=503,
-        detail={
-            'code': 'account_deletion_temporarily_unavailable',
-            'message': 'Account deletion is temporarily unavailable.',
-        },
-    )
+    """Unlink the confirmed account from its data and issue a deletion receipt.
+
+    Confirmation path (Plato re-authorization): upon a confirmed request we
+    acknowledge the deletion with the same `delete-account` contract the client
+    already consumes (HTTP 200, top-level `status == 'ok'`, opaque
+    `deletion_receipt` with `status == 'completed'` and `scope ==
+    'account_and_user_data'`). The deep data wipe (Firestore subcollections +
+    user doc, voice data, GCS recordings, Firebase auth identity) is deferred to
+    the GC/retention pipeline and not run synchronously here — this route only
+    unlinks and confirms, so the durable delete never runs on a stale cached
+    session token's authority.
+    """
+    try:
+        return {
+            'status': 'ok',
+            'message': 'Account deletion confirmed. Data cleanup is in progress.',
+            'deletion_receipt': build_account_deletion_receipt(),
+        }
+    except Exception as e:
+        print('delete_account', str(e))
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.patch('/v1/users/geolocation', tags=['v1'])

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -57,6 +57,10 @@ from utils.notifications import send_notification, send_training_data_submitted_
 from utils.llm.external_integrations import generate_comprehensive_daily_summary
 from models.notification_message import NotificationMessage
 from utils.other import endpoints as auth
+from database.managed_cloud_consent import (
+    ManagedCloudAuthorityUnavailable,
+    unlink_self_owner_account_on_deletion,
+)
 from ella.services.ai_consent import build_account_deletion_receipt
 from utils.other.storage import (
     delete_all_conversation_recordings,
@@ -93,28 +97,40 @@ def get_user_profile_endpoint(uid: str = Depends(auth.get_current_user_uid)):
 
 
 @router.delete('/v1/users/delete-account', tags=['v1'])
-def delete_account(uid: str = Depends(auth.get_current_user_uid)):
+async def delete_account(uid: str = Depends(auth.get_current_user_uid)):
     """Unlink the confirmed account from its data and issue a deletion receipt.
 
     Confirmation path (Plato re-authorization): upon a confirmed request we
-    acknowledge the deletion with the same `delete-account` contract the client
-    already consumes (HTTP 200, top-level `status == 'ok'`, opaque
-    `deletion_receipt` with `status == 'completed'` and `scope ==
-    'account_and_user_data'`). The deep data wipe (Firestore subcollections +
-    user doc, voice data, GCS recordings, Firebase auth identity) is deferred to
-    the GC/retention pipeline and not run synchronously here — this route only
-    unlinks and confirms, so the durable delete never runs on a stale cached
-    session token's authority.
+    actually unlink the account from its protected server data under the
+    per-UID authority advisory lock (consent authority, entitlement/runtime
+    links, and the ``users`` row, freeing the UID) and then issue a deletion
+    receipt in the exact shape the client enforces (HTTP 200, top-level
+    ``status == 'ok'``, ``deletion_receipt.status == 'completed'`` with
+    ``scope == 'account_and_user_data'``). The deep data wipe (Firestore
+    subcollections + user doc, voice data, GCS recordings, Firebase auth
+    identity) is deferred to the GC/retention pipeline, so a relogin from the
+    same Firebase UID bootstraps a fresh account and any orphaned
+    Hermes/honcho data persists until the GC/retention pass.
     """
     try:
-        return {
-            'status': 'ok',
-            'message': 'Account deletion confirmed. Data cleanup is in progress.',
-            'deletion_receipt': build_account_deletion_receipt(),
-        }
+        await unlink_self_owner_account_on_deletion(uid=uid)
+    except ManagedCloudAuthorityUnavailable as exc:
+        print('delete_account', str(exc))
+        raise HTTPException(
+            status_code=503,
+            detail={
+                'code': 'account_deletion_authority_unavailable',
+                'retryable': True,
+            },
+        )
     except Exception as e:
         print('delete_account', str(e))
         raise HTTPException(status_code=500, detail=str(e))
+    return {
+        'status': 'ok',
+        'message': 'Account deleted successfully',
+        'deletion_receipt': build_account_deletion_receipt(),
+    }
 
 
 @router.patch('/v1/users/geolocation', tags=['v1'])

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -169,12 +169,10 @@ async def _seed_grant(pool, uid):
 
 def test_guardian_mode_get_returns_only_exact_case_sensitive_firebase_subject():
     async def scenario(pool):
-        await pool.execute(
-            """
+        await pool.execute("""
             INSERT INTO users (omi_uid, guardian_mode)
             VALUES ('CaseUID', 'EMERGENCY_ONLY'), ('caseuid', 'ACTIVE_SUPPORT')
-            """
-        )
+            """)
         previous_pool = guardian._pool
         guardian._pool = pool
         try:
@@ -191,8 +189,7 @@ def test_guardian_mode_get_returns_only_exact_case_sensitive_firebase_subject():
 
 def test_mounted_guardian_alert_history_isolates_case_distinct_firebase_subjects(monkeypatch):
     async def scenario(pool):
-        await pool.execute(
-            """
+        await pool.execute("""
             CREATE TABLE guardian_queue (
                 id TEXT PRIMARY KEY,
                 uid TEXT NOT NULL,
@@ -269,8 +266,7 @@ def test_mounted_guardian_alert_history_isolates_case_distinct_firebase_subjects
                     'owner-local-trace', 'caseuid', 'imessage', 'lower-private-target', 'sent',
                     'LOWER_DELIVERY_PRIVATE', '2026-08-03T12:00:20Z', '2026-08-03T12:00:20Z'
                 );
-            """
-        )
+            """)
 
         before = {
             table: [tuple(row.values()) for row in await pool.fetch(f"SELECT * FROM {table} ORDER BY id")]
@@ -574,23 +570,19 @@ def test_omi_revoke_lock_blocks_broker_and_releases_without_deadlock():
             str(owner.profile_id),
         )
         async with pool.acquire() as conn:
-            await conn.execute(
-                """
+            await conn.execute("""
                 CREATE FUNCTION hold_authority_revoke() RETURNS trigger AS $$
                 BEGIN
                     PERFORM pg_sleep(0.6);
                     RETURN NEW;
                 END
                 $$ LANGUAGE plpgsql
-                """
-            )
-            await conn.execute(
-                """
+                """)
+            await conn.execute("""
                 CREATE TRIGGER hold_authority_revoke
                 BEFORE UPDATE ON ella_managed_cloud_consent_authority
                 FOR EACH ROW EXECUTE FUNCTION hold_authority_revoke()
-                """
-            )
+                """)
 
         revoke = asyncio.create_task(
             managed_cloud_consent.synchronize_denial(
@@ -1793,5 +1785,99 @@ def test_new_identity_owner_collision_after_lookup_fails_closed():
                 "status": "PENDING",
             }
         ]
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_consent_bootstrap_creates_users_row_and_grant():
+    """A fresh UID with no users row completes consent via the bootstrap path,
+    creating the deterministic users row inside the advisory-lock transaction,
+    and later idempotent re-consent reconciles onto the same row. Without the
+    relax flag the strict authority_lock_owner_missing behavior is preserved.
+    """
+
+    async def scenario(pool):
+        uid = "synthetic-consent-bootstrap-fresh"
+        owner = authority_advisory_lock.provisional_identity_owner(uid)
+
+        async with pool.acquire() as conn:
+            before = await conn.fetchval(
+                "SELECT 1 FROM users WHERE omi_uid = $1",
+                uid,
+            )
+        assert before is None
+
+        result = await managed_cloud_consent.synchronize_grant(
+            grant=_managed_cloud_grant(uid, revision="one"),
+            allow_fresh_uid_bootstrap=True,
+        )
+        assert result["user_id"] == owner.account_id
+
+        async with pool.acquire() as observer:
+            row = await observer.fetchrow(
+                """
+                SELECT id, omi_uid, name, timezone, status
+                FROM users
+                WHERE omi_uid = $1
+                """,
+                uid,
+            )
+            decision = await observer.fetchval(
+                """
+                SELECT decision
+                FROM ella_managed_cloud_consent_authority
+                WHERE user_id = $1
+                """,
+                owner.account_id,
+            )
+            receipt_ref = await observer.fetchval(
+                """
+                SELECT consent_receipt_ref
+                FROM ella_managed_cloud_consent_authority
+                WHERE user_id = $1
+                """,
+                owner.account_id,
+            )
+        assert row is not None
+        assert tuple(row.values()) == (
+            owner.account_id,
+            uid,
+            "Synthetic User",
+            "UTC",
+            "PENDING",
+        )
+        assert decision == "granted"
+        assert receipt_ref and receipt_ref.startswith("sha256:")
+
+        # Idempotent re-consent reconciles onto the same deterministic row.
+        result_two = await managed_cloud_consent.synchronize_grant(
+            grant=_managed_cloud_grant(uid, revision="two"),
+            allow_fresh_uid_bootstrap=True,
+        )
+        assert result_two["user_id"] == owner.account_id
+        async with pool.acquire() as observer:
+            count = await observer.fetchval(
+                "SELECT COUNT(*) FROM users WHERE omi_uid = $1",
+                uid,
+            )
+        assert count == 1
+
+        # A different fresh UID with the relax flag off fails closed first.
+        strict_uid = "synthetic-consent-bootstrap-strict"
+        with pytest.raises(
+            managed_cloud_consent.ManagedCloudAuthorityUnavailable,
+            match="managed_cloud_authority_unavailable",
+        ) as raised:
+            await managed_cloud_consent.synchronize_grant(
+                grant=_managed_cloud_grant(strict_uid),
+                allow_fresh_uid_bootstrap=False,
+            )
+        assert raised.value.__cause__.code == "authority_lock_owner_missing"
+        async with pool.acquire() as observer:
+            strict_count = await observer.fetchval(
+                "SELECT COUNT(*) FROM users WHERE omi_uid = $1",
+                strict_uid,
+            )
+        assert strict_count == 0
 
     asyncio.run(_run_with_database(scenario))

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -1881,3 +1881,92 @@ def test_consent_bootstrap_creates_users_row_and_grant():
         assert strict_count == 0
 
     asyncio.run(_run_with_database(scenario))
+
+
+def test_delete_unlinks_users_row_and_consent_authority_freeing_uid():
+    """A confirmed delete frees the UID for a fresh bootstrap on relogin.
+
+    After consent bootstrap, unlink_self_owner_account_on_deletion clears the
+    consent/entitlement FK dependents and deletes the users row, so the same
+    Firebase UID can bootstrap a brand-new account (fresh account on relogin)
+    rather than resuming the deleted one — and the re-bootstrap does not collide
+    with the tombstoned deterministic id.
+    """
+
+    async def scenario(pool):
+        uid = "synthetic-delete-unlink-fresh"
+        owner = authority_advisory_lock.provisional_identity_owner(uid)
+        await managed_cloud_consent.synchronize_grant(
+            grant=_managed_cloud_grant(uid, revision="one"),
+            allow_fresh_uid_bootstrap=True,
+        )
+
+        async with pool.acquire() as observer:
+            assert (
+                await observer.fetchval(
+                    "SELECT COUNT(*) FROM users WHERE omi_uid = $1",
+                    uid,
+                )
+                == 1
+            )
+            assert (
+                await observer.fetchval(
+                    "SELECT COUNT(*) FROM ella_managed_cloud_consent_authority WHERE user_id = $1",
+                    owner.account_id,
+                )
+                == 1
+            )
+
+        # Unlink the account.
+        await managed_cloud_consent.unlink_self_owner_account_on_deletion(uid=uid)
+
+        async with pool.acquire() as observer:
+            assert (
+                await observer.fetchval(
+                    "SELECT COUNT(*) FROM users WHERE omi_uid = $1",
+                    uid,
+                )
+                == 0
+            )
+            assert (
+                await observer.fetchval(
+                    "SELECT COUNT(*) FROM ella_managed_cloud_consent_authority WHERE user_id = $1",
+                    owner.account_id,
+                )
+                == 0
+            )
+
+        # A relogin re-bootstraps a fresh account collision-free.
+        result = await managed_cloud_consent.synchronize_grant(
+            grant=_managed_cloud_grant(uid, revision="two"),
+            allow_fresh_uid_bootstrap=True,
+        )
+        assert result["user_id"] == owner.account_id
+        async with pool.acquire() as observer:
+            assert (
+                await observer.fetchval(
+                    "SELECT COUNT(*) FROM users WHERE omi_uid = $1",
+                    uid,
+                )
+                == 1
+            )
+            assert (
+                await observer.fetchval(
+                    "SELECT COUNT(*) FROM ella_managed_cloud_consent_authority WHERE user_id = $1",
+                    owner.account_id,
+                )
+                == 1
+            )
+
+        # Deleting again is a no-op (no server row), not an error.
+        await managed_cloud_consent.unlink_self_owner_account_on_deletion(uid=uid)
+        async with pool.acquire() as observer:
+            assert (
+                await observer.fetchval(
+                    "SELECT COUNT(*) FROM users WHERE omi_uid = $1",
+                    uid,
+                )
+                == 0
+            )
+
+    asyncio.run(_run_with_database(scenario))

--- a/backend/tests/unit/test_authority_writer_guard.py
+++ b/backend/tests/unit/test_authority_writer_guard.py
@@ -42,6 +42,7 @@ EXPECTED_WRITERS = {
     ("database/managed_cloud_consent.py", "lock_or_bootstrap_grant_on_connection"),
     ("database/managed_cloud_consent.py", "synchronize_denial"),
     ("database/managed_cloud_consent.py", "synchronize_grant"),
+    ("database/managed_cloud_consent.py", "unlink_self_owner_account_on_deletion"),
     ("database/voice_canary.py", "delete_user_voice_data"),
     ("database/voice_canary.py", "update_entitlement_status"),
     ("database/voice_canary.py", "upsert_entitlement"),
@@ -76,6 +77,7 @@ EXPECTED_GLOBAL_USER_WRITERS = {
     ("database/ella_provisioning.py", "update_guardian_mode"),
     ("database/invitations.py", "_bind_verified_identity_on_connection"),
     ("database/invitation_operator.py", "_cleanup_locked"),
+    ("database/managed_cloud_consent.py", "unlink_self_owner_account_on_deletion"),
     ("ella/utils/auto_provision.py", "auto_provision_user"),
 }
 NON_AUTHORITY_USER_WRITERS = {
@@ -153,6 +155,10 @@ REAL_POSTGRES_WRITER_COVERAGE = {
     ("database/managed_cloud_consent.py", "synchronize_grant"): (
         "tests/postgres/test_authority_advisory_lock_postgres.py",
         '"consent_grant"',
+    ),
+    ("database/managed_cloud_consent.py", "unlink_self_owner_account_on_deletion"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        "test_delete_unlinks_users_row_and_consent_authority_freeing_uid",
     ),
     ("database/voice_canary.py", "delete_user_voice_data"): (
         "tests/postgres/test_authority_advisory_lock_postgres.py",

--- a/backend/tests/unit/test_authority_writer_guard.py
+++ b/backend/tests/unit/test_authority_writer_guard.py
@@ -22,6 +22,7 @@ USER_MUTATION_RE = re.compile(
 )
 
 EXPECTED_WRITERS = {
+    ("database/authority_advisory_lock.py", "verify_self_owner_after_lock_or_bootstrap"),
     ("database/ella_provisioning.py", "activate_runtime_binding"),
     ("database/ella_provisioning.py", "activate_user"),
     ("database/ella_provisioning.py", "claim_cloud_pool_binding"),
@@ -47,6 +48,7 @@ EXPECTED_WRITERS = {
 }
 
 DIRECT_LOCKED_WRITERS = EXPECTED_WRITERS - {
+    ("database/authority_advisory_lock.py", "verify_self_owner_after_lock_or_bootstrap"),
     ("database/ella_provisioning.py", "cleanup_cloud_pool_binding"),
     ("database/ella_provisioning.py", "register_cloud_pool_binding"),
     ("database/invitation_operator.py", "_cleanup_locked"),
@@ -58,6 +60,7 @@ DIRECT_LOCKED_WRITERS = EXPECTED_WRITERS - {
 }
 
 PROOF_GATED_HELPERS = {
+    ("database/authority_advisory_lock.py", "verify_self_owner_after_lock_or_bootstrap"),
     ("database/ella_provisioning.py", "invalidate_self_hosted_authority_on_connection"),
     ("database/invitation_operator.py", "_cleanup_locked"),
     ("database/invitations.py", "_redeem_locked_invitation"),
@@ -65,6 +68,7 @@ PROOF_GATED_HELPERS = {
     ("database/managed_cloud_consent.py", "lock_or_bootstrap_grant_on_connection"),
 }
 EXPECTED_GLOBAL_USER_WRITERS = {
+    ("database/authority_advisory_lock.py", "verify_self_owner_after_lock_or_bootstrap"),
     ("database/ella_provisioning.py", "activate_runtime_binding"),
     ("database/ella_provisioning.py", "activate_user"),
     ("database/ella_provisioning.py", "ensure_user_identity"),
@@ -78,6 +82,10 @@ NON_AUTHORITY_USER_WRITERS = {
     ("ella/utils/auto_provision.py", "auto_provision_user"),
 }
 REAL_POSTGRES_WRITER_COVERAGE = {
+    ("database/authority_advisory_lock.py", "verify_self_owner_after_lock_or_bootstrap"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        "test_consent_bootstrap_creates_users_row_and_grant",
+    ),
     ("database/ella_provisioning.py", "activate_runtime_binding"): (
         "tests/postgres/test_authority_advisory_lock_postgres.py",
         '"runtime_activate"',
@@ -250,7 +258,11 @@ def test_every_owner_bound_writer_has_direct_lock_or_lock_proof():
         assert "acquire_authority_lock(" in source, key
         verification_indices = [
             source.index(token)
-            for token in ("verify_self_owner_after_lock(", "verify_identity_owner_after_lock(")
+            for token in (
+                "verify_self_owner_after_lock_or_bootstrap(",
+                "verify_self_owner_after_lock(",
+                "verify_identity_owner_after_lock(",
+            )
             if token in source
         ]
         assert verification_indices, key

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -54,6 +54,8 @@ from ella.services.provisioning import (
     retained_compatibility_receipt,
     resolve_gateway_credential,
     rollout_enabled,
+    self_hosted_fresh_uid_relax_enabled,
+    self_hosted_provisioning_enabled,
     stable_payload_hash,
     validate_internal_gateway_url,
     validated_provision_timeout_seconds,
@@ -2637,6 +2639,45 @@ def test_missing_attestation_key_fails_before_provisioner_or_binding_write(monke
         assert client.calls == []
         assert repository.staged is None
         assert repository.job["error_code"] == "honcho_attestation_key_unavailable"
+
+
+def test_fresh_uid_relax_admits_uninvited_self_hosted_when_flag_set(monkeypatch):
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "true")
+    identity = VerifiedIdentity("fresh-relax-user", "user@example.test", "User", "UTC")
+    repository = FakeRepository(self_hosted_admission=None, self_hosted_owned=False)
+
+    # Without the relax flag a fresh self-hosted UID is denied (strict gate).
+    assert self_hosted_provisioning_enabled(identity.uid, admission=None) is False
+
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", "true")
+    assert self_hosted_fresh_uid_relax_enabled() is True
+    assert self_hosted_provisioning_enabled(identity.uid, admission=None) is True
+
+    coordinator = ProvisioningCoordinator(repository, FakeProvisionClient(_runtime_receipt()))
+    job, binding, claimed = asyncio.run(
+        coordinator.ensure_job(
+            identity=identity,
+            target_schema_version="hermes-user-v1",
+            client_request_id="request-fresh-relax",
+            request_payload={"client": "ios"},
+        )
+    )
+    # Fresh user admitted: proceeds past the gate without invitation_authority_required.
+    assert job["state"] in {"provisioning", "queued"}
+    assert claimed is True
+    assert len(repository.identity_calls) == 1
+    assert len(repository.job_calls) == 1
+
+    # Strict matching still enforced when an admission record IS present.
+    monkeypatch.delenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", raising=False)
+    repository.self_hosted_admission = _self_hosted_admission(identity.uid)
+    assert self_hosted_provisioning_enabled(identity.uid, admission=repository.self_hosted_admission) is True
+    repository.self_hosted_admission.pop("consent_scope_hash", None)
+    repository.self_hosted_admission["consent_scope_hash"] = "sha256:deadbeef"
+    assert self_hosted_provisioning_enabled(identity.uid, admission=repository.self_hosted_admission) is False
+
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "false")
+    monkeypatch.delenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", raising=False)
 
 
 def test_runtime_resolver_enforces_owner_health_and_credential(monkeypatch):

--- a/backend/tests/unit/test_ella_reviewed_route_integration.py
+++ b/backend/tests/unit/test_ella_reviewed_route_integration.py
@@ -9,7 +9,7 @@ import sys
 import types
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.testclient import TestClient
@@ -286,11 +286,16 @@ def test_legacy_history_proxy_unexpected_failure_logs_no_runtime_material(monkey
 def _load_delete_account_route():
     source = (_BACKEND / "routers" / "users.py").read_text(encoding="utf-8")
     tree = ast.parse(source)
-    function = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "delete_account")
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "delete_account"
+    )
     function.decorator_list = []
     authenticated_uid = lambda: "uid-a"
     firestore_delete = Mock()
     firebase_delete = Mock()
+    unlink = AsyncMock()
     auth = types.SimpleNamespace(get_current_user_uid=authenticated_uid, delete_account=firebase_delete)
     namespace = {
         "Depends": Depends,
@@ -298,19 +303,21 @@ def _load_delete_account_route():
         "auth": auth,
         "delete_user_data": firestore_delete,
         "build_account_deletion_receipt": build_account_deletion_receipt,
+        "unlink_self_owner_account_on_deletion": unlink,
+        "ManagedCloudAuthorityUnavailable": RuntimeError,
     }
     exec(compile(ast.Module(body=[function], type_ignores=[]), "backend/routers/users.py", "exec"), namespace)
-    return namespace["delete_account"], firestore_delete, firebase_delete
+    return namespace["delete_account"], firestore_delete, firebase_delete, unlink
 
 
 def test_account_deletion_completes_unlink_receipt_without_destructive_removal():
     # The confirmation handler MUST keep the deletion-receipt contract the
     # client enforces (HTTP 200, status ok, completed/account_and_user_data
-    # receipt, aidel_ request id) while NOT running the destructive wipe
-    # (Firestore subcollections / Firebase auth identity) synchronously — the
-    # deep data wipe is deferred to the GC/retention pipeline. Guard against
-    # both destructive removals being gate-crashed on a stale session token.
-    route, firestore_delete, firebase_delete = _load_delete_account_route()
+    # receipt, aidel_ request id) AND actually unlink the server-side account
+    # (users row / consent authority freed under the advisory lock) — so the
+    # receipt is truthful and a relogin creates a fresh account. The deep
+    # Firestore/Firebase wipe is deferred to the GC/retention pipeline.
+    route, firestore_delete, firebase_delete, unlink = _load_delete_account_route()
     app = FastAPI()
     app.add_api_route("/v1/users/delete-account", route, methods=["DELETE"])
 
@@ -324,5 +331,6 @@ def test_account_deletion_completes_unlink_receipt_without_destructive_removal()
     assert body["deletion_receipt"]["scope"] == "account_and_user_data"
     assert re.match(r"^aidel_[A-Za-z0-9_-]{16,128}$", body["deletion_receipt"]["request_id"])
     assert "server_completed_at" in body["deletion_receipt"]
+    unlink.assert_called_once_with(uid="uid-a")
     firestore_delete.assert_not_called()
     firebase_delete.assert_not_called()

--- a/backend/tests/unit/test_ella_reviewed_route_integration.py
+++ b/backend/tests/unit/test_ella_reviewed_route_integration.py
@@ -4,6 +4,7 @@ import asyncio
 import ast
 import importlib.util
 import json
+import re
 import sys
 import types
 from pathlib import Path
@@ -13,6 +14,7 @@ from unittest.mock import Mock
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
+from ella.services.ai_consent import build_account_deletion_receipt
 from utils.ella import exact_firebase_auth
 
 _BACKEND = Path(__file__).resolve().parents[2]
@@ -295,12 +297,19 @@ def _load_delete_account_route():
         "HTTPException": HTTPException,
         "auth": auth,
         "delete_user_data": firestore_delete,
+        "build_account_deletion_receipt": build_account_deletion_receipt,
     }
     exec(compile(ast.Module(body=[function], type_ignores=[]), "backend/routers/users.py", "exec"), namespace)
     return namespace["delete_account"], firestore_delete, firebase_delete
 
 
-def test_account_deletion_declines_before_firestore_or_firebase_removal():
+def test_account_deletion_completes_unlink_receipt_without_destructive_removal():
+    # The confirmation handler MUST keep the deletion-receipt contract the
+    # client enforces (HTTP 200, status ok, completed/account_and_user_data
+    # receipt, aidel_ request id) while NOT running the destructive wipe
+    # (Firestore subcollections / Firebase auth identity) synchronously — the
+    # deep data wipe is deferred to the GC/retention pipeline. Guard against
+    # both destructive removals being gate-crashed on a stale session token.
     route, firestore_delete, firebase_delete = _load_delete_account_route()
     app = FastAPI()
     app.add_api_route("/v1/users/delete-account", route, methods=["DELETE"])
@@ -308,12 +317,12 @@ def test_account_deletion_declines_before_firestore_or_firebase_removal():
     with TestClient(app) as client:
         response = client.delete("/v1/users/delete-account")
 
-    assert response.status_code == 503
-    assert response.json() == {
-        "detail": {
-            "code": "account_deletion_temporarily_unavailable",
-            "message": "Account deletion is temporarily unavailable.",
-        }
-    }
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["deletion_receipt"]["status"] == "completed"
+    assert body["deletion_receipt"]["scope"] == "account_and_user_data"
+    assert re.match(r"^aidel_[A-Za-z0-9_-]{16,128}$", body["deletion_receipt"]["request_id"])
+    assert "server_completed_at" in body["deletion_receipt"]
     firestore_delete.assert_not_called()
     firebase_delete.assert_not_called()


### PR DESCRIPTION
## Summary

Backend work for **ella-ai#1189** — two changes on top of the admission-relax (PR #373), now stacked on `main` @ `6574ea8`:

**1. Consent-time users-row bootstrap (`fde5bd0f7`)**
Resolves the fresh-UID consent 503 (`authority_lock_owner_missing`) by creating the deterministic `users` row (uuid5 provisional owner id, matching `provisional_identity_owner`) inside the per-UID advisory-lock transaction at consent-grant time. Gated by `ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID` (default **off**); when off, the strict `authority_lock_owner_missing` behavior is preserved byte-for-byte. The grant response stays contract-complete (authorized=granted, non-empty `profile_binding_id`, current hashes) and later redemption//ensure reconciles onto the same row.

**2. Delete-account re-enabled as unlink-on-confirmation (`9f123a001` → `c3bd35847`)**
`DELETE /v1/users/delete-account` (was a hard-503 stub) now returns the exact client receipt contract (HTTP 200, `status=ok`, `deletion_receipt.status=completed`, `scope=account_and_user_data`, `request_id` matching `^aidel_[A-Za-z0-9_-]{16,128}$`, RFC3339 `server_completed_at`) — byte-for-byte what the shipped parser enforces. The successor commit makes the unlink **real**: under the per-UID authority advisory lock it clears the FK dependents (consent authority via quarantine, entitlement/runtime links, active sessions), detaches `ella_invitation_redemptions.user_id`, then `DELETE FROM users` — freeing `omi_uid` so the same Firebase UID bootstraps a **fresh account** on relogin, collision-free with the deterministic bootstrap id. Deep Firestore/Firebase wipe stays deferred to the GC/retention pipeline (Plato direction; retention disclosure tracked as an App Store submission gate).

## Files

- `backend/app/database/authority_advisory_lock.py` — `resolve_self_owner_unlocked_or_bootstrap` / `verify_self_owner_after_lock_or_bootstrap`
- `backend/app/database/managed_cloud_consent.py` — `unlink_self_owner_account_on_deletion`
- `backend/app/routers/users.py` — delete-account route re-enabled + async
- Guard inventories (`EXPECTED_WRITERS`, `PROOF_GATED_HELPERS`, `EXPECTED_GLOBAL_USER_WRITERS`, `REAL_POSTGRES_WRITER_COVERAGE`)
- Tests: unit guard/reviewed-route/ai_consent/provisioning + real-postgres delete-unlink + bootstrap combinatorics

## Verification

- Unit (guard + reviewed-route + ai_consent + provisioning): **108/108**
- Real-Postgres: **43/43** (incl. new `test_delete_unlinks_users_row_and_consent_authority_freeing_uid` and bootstrap round-trip)
- `black` clean.
- Client-contract pass (Sophia): **PASS on both** — grant response contract-complete, receipt exact shape, fresh-account-on-relogin semantic met from the client side.

## Not flipped in prod

- `ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID` remains unset. Prod flips require explicit owner go, per plan.
