### PR TITLE
relax: fresh-UID entitlement gate under relax flag (ella-ai#1199/#1189)

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -544,6 +544,9 @@ jobs:
             "tests/unit/test_ella_provisioning_service.py::test_attestation_window_covers_max_slow_response_and_rejects_invalid_config"
             "tests/unit/test_ella_provisioning_service.py::test_total_deadline_cancels_real_local_slow_drip_before_binding_writes"
             "tests/unit/test_ella_provisioning_service.py::test_oversized_provision_receipt_is_rejected_before_parse_or_binding_write"
+            "tests/unit/test_ella_provisioning_service.py::test_provision_conflict_contract_matches_reviewed_shim_codes"
+            "tests/unit/test_ella_provisioning_service.py::test_recursive_provision_conflict_is_content_free_and_nonretryable"
+            "tests/unit/test_ella_provisioning_service.py::test_provision_conflict_rechecks_authority_after_inflight_body_drift"
             "tests/unit/test_ella_provisioning_service.py::test_total_deadline_rejects_delayed_json_parse_before_binding_write"
             "tests/unit/test_ella_provisioning_service.py::test_total_deadline_stops_delayed_verification_and_local_publication[verification]"
             "tests/unit/test_ella_provisioning_service.py::test_total_deadline_stops_delayed_verification_and_local_publication[staging]"
@@ -669,7 +672,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 514
+          test "$collected" -eq 528
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -170,7 +170,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 174
+          test "$collected" -eq 180
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
@@ -212,6 +212,11 @@ jobs:
             "tests/unit/test_ella_provisioning_service.py::test_external_cancellation_after_provider_work_records_retryable_reconciliation"
             "tests/unit/test_ella_provisioning_service.py::test_post_provider_attestation_rejections_retry_and_reconcile_one_binding"
             "tests/unit/test_ella_provisioning_service.py::test_retained_owner_identity_is_exact_and_requires_server_configuration"
+            "tests/unit/test_ella_provisioning_service.py::test_resolve_self_hosted_active_direct_positive_healthy_active"
+            "tests/unit/test_ella_provisioning_service.py::test_resolve_self_hosted_active_direct_negative_disabled_unhealthy"
+            "tests/unit/test_ella_provisioning_service.py::test_resolve_self_hosted_active_direct_no_row_returns_none"
+            "tests/unit/test_ella_provisioning_service.py::test_resolve_self_hosted_active_direct_requires_hermes_provider"
+            "tests/unit/test_ella_provisioning_service.py::test_public_receipt_flattened_voice_mode_parse_contract"
             "tests/postgres/test_invitation_redemption_postgres.py::test_self_hosted_redemption_binds_verified_email_identity_and_target_atomically"
             "tests/postgres/test_invitation_redemption_postgres.py::test_self_hosted_email_mismatch_and_concurrent_open_redeem_fail_closed"
             "tests/postgres/test_invitation_redemption_postgres.py::test_pilot_operator_rotation_is_atomic_idempotent_and_preserves_email_scope"

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -170,7 +170,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 160
+          test "$collected" -eq 174
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
@@ -202,6 +202,9 @@ jobs:
             "tests/unit/test_ella_provisioning_service.py::test_attestation_window_covers_max_slow_response_and_rejects_invalid_config"
             "tests/unit/test_ella_provisioning_service.py::test_total_deadline_cancels_real_local_slow_drip_before_binding_writes"
             "tests/unit/test_ella_provisioning_service.py::test_oversized_provision_receipt_is_rejected_before_parse_or_binding_write"
+            "tests/unit/test_ella_provisioning_service.py::test_provision_conflict_contract_matches_reviewed_shim_codes"
+            "tests/unit/test_ella_provisioning_service.py::test_recursive_provision_conflict_is_content_free_and_nonretryable"
+            "tests/unit/test_ella_provisioning_service.py::test_provision_conflict_rechecks_authority_after_inflight_body_drift"
             "tests/unit/test_ella_provisioning_service.py::test_total_deadline_rejects_delayed_json_parse_before_binding_write"
             "tests/unit/test_ella_provisioning_service.py::test_total_deadline_stops_delayed_verification_and_local_publication[verification]"
             "tests/unit/test_ella_provisioning_service.py::test_total_deadline_stops_delayed_verification_and_local_publication[staging]"

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -3583,9 +3583,7 @@ class EllaProvisioningRepository:
                         # (possibly stale) job-target schema here, and requiring a
                         # match would reproduce the "incomplete on status" bug the
                         # fallback exists to fix. `POST /ensure` passes None (inert).
-                        fallback = await self._resolve_self_hosted_active_direct(
-                            uid=uid, role=role
-                        )
+                        fallback = await self._resolve_self_hosted_active_direct(uid=uid, role=role)
                         return fallback
                     decision = await voice_canary_db.revalidate_runtime_resolution_on_connection(
                         connection,

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -3315,6 +3315,11 @@ class EllaProvisioningRepository:
         (e.g. migrated Plato accounts). It validates the binding on its own terms
         (active, healthy, hermes) and does NOT relax any of the row's own validity
         fields nor the invitation/consent chain for accounts that have one.
+
+        `template_version` is an OPTIONAL extra filter for direct callers; the
+        resolver wiring passes authoritative-yes (does NOT forward the job-target
+        schema), so a migrated account's healthy active binding resolves on both
+        `POST /ensure` and `GET /status` regardless of a stale job target schema.
         """
         row = await self.pool.fetchrow(
             """
@@ -3571,8 +3576,15 @@ class EllaProvisioningRepository:
                         # binding when it is valid on its own terms (active, healthy,
                         # hermes) instead of manufacturing an incomplete ready
                         # receipt (`binding_state=inactive`) for an unrouted job.
+                        # Authoritative-yes for schema routing: do NOT gate the
+                        # fallback on the job-target serializer's template_version.
+                        # A migrated account's healthy active binding is the source
+                        # of truth for its own schema; `GET /status` passes the
+                        # (possibly stale) job-target schema here, and requiring a
+                        # match would reproduce the "incomplete on status" bug the
+                        # fallback exists to fix. `POST /ensure` passes None (inert).
                         fallback = await self._resolve_self_hosted_active_direct(
-                            uid=uid, role=role, template_version=template_version
+                            uid=uid, role=role
                         )
                         return fallback
                     decision = await voice_canary_db.revalidate_runtime_resolution_on_connection(

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -3302,6 +3302,39 @@ class EllaProvisioningRepository:
         )
         return bool(row and row["eligible"])
 
+    async def _resolve_self_hosted_active_direct(
+        self,
+        uid: str,
+        role: str = "user",
+        template_version: Optional[str] = None,
+    ) -> Optional[dict[str, Any]]:
+        """Return a health-validated active self-hosted binding row directly.
+
+        This is the row-intrinsic validity gate used as the authoritative fallback
+        for accounts that predate the invitation->redemption->target routing chain
+        (e.g. migrated Plato accounts). It validates the binding on its own terms
+        (active, healthy, hermes) and does NOT relax any of the row's own validity
+        fields nor the invitation/consent chain for accounts that have one.
+        """
+        row = await self.pool.fetchrow(
+            """
+            SELECT b.*, u.omi_uid, u.name, u.status AS user_status, u.profile_class
+            FROM ella_runtime_bindings b
+            JOIN users u ON u.id = b.user_id
+            WHERE u.omi_uid = $1
+              AND b.role = $2
+              AND b.provider = 'hermes'
+              AND b.active = true
+              AND b.status = 'active'
+              AND b.health_state = 'healthy'
+              AND ($3::text IS NULL OR b.template_version = $3)
+            """,
+            uid,
+            role,
+            template_version,
+        )
+        return _row_dict(row)
+
     async def resolve_active_runtime(
         self,
         uid: str,
@@ -3532,7 +3565,16 @@ class EllaProvisioningRepository:
                         list(SELF_HOSTED_RUNTIME_TARGET_MODES),
                     )
                     if not row:
-                        return None
+                        # Legacy/retained accounts predating the invitation chain may
+                        # hold a fully healthy active hermes binding with no
+                        # invitation/redemption/target rows. Fall back to the raw
+                        # binding when it is valid on its own terms (active, healthy,
+                        # hermes) instead of manufacturing an incomplete ready
+                        # receipt (`binding_state=inactive`) for an unrouted job.
+                        fallback = await self._resolve_self_hosted_active_direct(
+                            uid=uid, role=role, template_version=template_version
+                        )
+                        return fallback
                     decision = await voice_canary_db.revalidate_runtime_resolution_on_connection(
                         connection,
                         uid=uid,

--- a/backend/database/voice_canary.py
+++ b/backend/database/voice_canary.py
@@ -28,6 +28,20 @@ TOKEN_ISSUANCE_LIMIT_PER_MINUTE = int(os.getenv("ELLA_VOICE_TOKEN_ISSUANCE_LIMIT
 SOCKET_ACCEPT_LIMIT_PER_MINUTE = int(os.getenv("ELLA_VOICE_SOCKET_ACCEPT_LIMIT_PER_MINUTE", "8"))
 AUTH_FAILURE_ALERT_THRESHOLD = int(os.getenv("ELLA_VOICE_AUTH_FAILURE_ALERT_THRESHOLD", "10"))
 
+
+def _self_hosted_fresh_uid_relax_enabled() -> bool:
+    """INTERIM relax (Plato, #1189): admit brand-new self-hosted UIDs that hold
+    no invitation admission yet, mirroring provisioning.self_hosted_fresh_uid_relax_enabled.
+    Invitation gating returns when ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID is unset.
+    """
+    return os.getenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 _pool: Optional[asyncpg.Pool] = None
 
 
@@ -748,19 +762,34 @@ async def get_entitlement_contract_for_connection(
         await _expire_stale_sessions(conn, current, uid=uid)
     row = await conn.fetchrow("SELECT * FROM voice_entitlements WHERE uid = $1", uid)
     if not row:
+        quota = {
+            "daily_used_s": 0,
+            "daily_limit_s": 0,
+            "monthly_used_s": 0,
+            "monthly_limit_s": 0,
+            "max_session_s": 0,
+            "max_concurrent": 0,
+            "soft_limit_ratio": DEFAULT_SOFT_LIMIT_RATIO,
+            "resets_at": (_day_start(current) + timedelta(days=1)).isoformat(),
+            "monthly_resets_at": _next_month(current).isoformat(),
+        }
+        if _self_hosted_fresh_uid_relax_enabled():
+            # INTERIM relax (Plato, #1189 fresh-user E2E): a brand-new
+            # self-hosted UID admitted without an invitation chain has no
+            # voice_entitlements row yet. Front the client entitlement gate with
+            # a provisionable status so it proceeds to /onboarding/ensure (also
+            # relaxed under this flag) instead of the invite-code entry wall.
+            # Only active while ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID
+            # is set; strict invitation gating returns when the flag is unset.
+            return {
+                "status": "invited",
+                "plan": "canary",
+                "revision": 0,
+                "quota": quota,
+            }
         return {
             "status": "none",
-            "quota": {
-                "daily_used_s": 0,
-                "daily_limit_s": 0,
-                "monthly_used_s": 0,
-                "monthly_limit_s": 0,
-                "max_session_s": 0,
-                "max_concurrent": 0,
-                "soft_limit_ratio": DEFAULT_SOFT_LIMIT_RATIO,
-                "resets_at": (_day_start(current) + timedelta(days=1)).isoformat(),
-                "monthly_resets_at": _next_month(current).isoformat(),
-            },
+            "quota": quota,
         }
     entitlement = _record_dict(row)
     rollup = await _usage_rollup(conn, uid, current)

--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -459,6 +459,14 @@ def _register_routers(app) -> None:
     except ImportError as e:
         print(f"  ⚠️ Invitation redemption not available: {e}", flush=True)
 
+    # Legacy iOS app onboarding compatibility endpoint
+    try:
+        from ella.routers.legacy_onboarding import router as legacy_onboarding_router
+        app.include_router(legacy_onboarding_router, tags=["Legacy Onboarding"])
+        print("  /api/onboarding - Legacy iOS onboarding compatibility", flush=True)
+    except ImportError as e:
+        print(f"  Legacy onboarding not available: {e}", flush=True)
+
     # Voice session management (token issuance for Ella Voice)
     if ELLA_VOICE_V2_ENABLED:
         try:

--- a/backend/ella/routers/legacy_onboarding.py
+++ b/backend/ella/routers/legacy_onboarding.py
@@ -1,0 +1,43 @@
+"""Compatibility endpoint for the old iOS app onboarding flow."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+from database.ella_provisioning import EllaProvisioningRepository
+
+logger = logging.getLogger('ella.legacy_onboarding')
+
+router = APIRouter(prefix='/api', tags=['legacy-onboarding'])
+
+
+class LegacyOnboardingRequest(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    firebaseUid: str
+    email: str = ''
+    name: str = ''
+    timezone: str = 'America/Los_Angeles'
+
+
+@router.post('/onboarding')
+async def legacy_onboarding(
+    payload: LegacyOnboardingRequest,
+) -> dict[str, Any]:
+    """Compatibility shim: accept old iOS app format, return expected response."""
+    uid = payload.firebaseUid.strip()
+    if not uid:
+        raise HTTPException(status_code=400, detail={'error': 'firebaseUid is required'})
+
+    # Return a simple response that lets the app proceed
+    # The app expects: {userId, ellaKey, agents, provisioned}
+    # If provisioned: false + agents != null -> pre-provisioned, skip onboarding
+    return {
+        'userId': uid,
+        'ellaKey': '',
+        'provisioned': True,
+        'agents': None,
+    }

--- a/backend/ella/routers/onboarding.py
+++ b/backend/ella/routers/onboarding.py
@@ -15,12 +15,14 @@ from database.ella_provisioning import (
     IdentityConflictError,
     ProvisioningSchemaNotReadyError,
 )
+from database import app_settings as app_settings_db
 from database.runtime_targets import CLOUD_RUNTIME_MODEL, CLOUD_RUNTIME_PROVIDER, SELF_HOSTED_RUNTIME_MODEL
 from ella.services.ai_consent import (
     MANAGED_CLOUD_MEMORY_PROVIDER,
     MANAGED_CLOUD_PHOTON_SCOPE,
     require_current_ai_consent,
 )
+from ella.services.app_settings import normalize_voice_mode
 from ella.services.hermes_cloud_policy import current_cloud_authority
 from ella.services.provisioning import (
     DEFAULT_TARGET_SCHEMA_VERSION,
@@ -96,6 +98,28 @@ def _verified_identity(uid: str, payload: OnboardingEnsureRequest) -> VerifiedId
 
 async def _coordinator() -> ProvisioningCoordinator:
     return ProvisioningCoordinator(await EllaProvisioningRepository.create(firestore_db=_firestore_db))
+
+
+def _resolved_voice_mode(uid: str) -> str:
+    """Resolve the provisioned voice mode from the per-user settings control plane.
+
+    Reads the server-backed Firestore voice settings (the same store backed by
+    GET/PATCH /v1/ella/settings). An empty result leaves the receipt's
+    ``effective_voice_mode`` empty so the client falls through to its local
+    pick (ElevenLabs default) — preserving today's behavior for every user
+    without a provisioned value.
+    """
+    if not uid:
+        return ""
+    try:
+        voice = app_settings_db.get_voice_settings(uid) or {}
+        raw = str(voice.get("voice_mode") or "").strip()
+        if not raw:
+            return ""
+        return normalize_voice_mode(raw)
+    except Exception:  # noqa: BLE001 - never let settings lookup break onboarding
+        logger.warning("voice-settings lookup failed for uid=%s; defaulting to empty", uid)
+        return ""
 
 
 async def _retained_receipt(uid: str, target_schema_version: str) -> Optional[dict[str, Any]]:
@@ -204,7 +228,7 @@ async def ensure_onboarding(
             detail={"code": exc.code},
         ) from exc
 
-    receipt = public_receipt(job, binding)
+    receipt = public_receipt(job, binding, effective_voice_mode=_resolved_voice_mode(uid))
     if claimed:
         try:
             if authority_snapshot is not None:
@@ -306,4 +330,4 @@ async def onboarding_status(
         )
     if not binding and cloud_required:
         binding = await repository.resolve_cloud_binding_state(uid)
-    return public_receipt(job, binding)
+    return public_receipt(job, binding, effective_voice_mode=_resolved_voice_mode(uid))

--- a/backend/ella/routers/onboarding.py
+++ b/backend/ella/routers/onboarding.py
@@ -15,7 +15,6 @@ from database.ella_provisioning import (
     IdentityConflictError,
     ProvisioningSchemaNotReadyError,
 )
-from database import app_settings as app_settings_db
 from database.runtime_targets import CLOUD_RUNTIME_MODEL, CLOUD_RUNTIME_PROVIDER, SELF_HOSTED_RUNTIME_MODEL
 from ella.services.ai_consent import (
     MANAGED_CLOUD_MEMORY_PROVIDER,
@@ -112,6 +111,13 @@ def _resolved_voice_mode(uid: str) -> str:
     if not uid:
         return ""
     try:
+        # Import lazily inside the function: the module-level import in this
+        # router runs `database._client.db = firestore.Client()` transitively at
+        # import time, which breaks test collection / jobs that lack a
+        # FIRESTORE_EMULATOR_HOST (DefaultCredentialsError on import). Runtime
+        # degradation is already graceful under the try/except below.
+        from database import app_settings as app_settings_db
+
         voice = app_settings_db.get_voice_settings(uid) or {}
         raw = str(voice.get("voice_mode") or "").strip()
         if not raw:

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -389,7 +389,11 @@ def stable_payload_hash(payload: dict[str, Any]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def public_receipt(job: dict[str, Any], binding: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+def public_receipt(
+    job: dict[str, Any],
+    binding: Optional[dict[str, Any]] = None,
+    effective_voice_mode: str = "",
+) -> dict[str, Any]:
     state = str(job.get("state") or "pending")
     stage = str(job.get("stage") or "identity_ready")
     public_state = {
@@ -425,6 +429,7 @@ def public_receipt(job: dict[str, Any], binding: Optional[dict[str, Any]] = None
         ),
         "runtime_provider": str(binding.get("provider") or "") if binding else None,
         "runtime_status": str(binding.get("status") or "") if binding else None,
+        "effective_voice_mode": str(effective_voice_mode or ""),
     }
     if job.get("error_code"):
         result["error_code"] = job["error_code"]

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -84,6 +84,32 @@ DEFAULT_ATTESTATION_VERIFICATION_GRACE_SECONDS = 30.0
 ATTESTATION_VERIFICATION_GRACE_ENV = "ELLA_HERMES_PROVISION_ATTESTATION_VERIFICATION_GRACE_SECONDS"
 ATTESTATION_CLOCK_SKEW_MARGIN_SECONDS = 1.0
 MAX_PROVISION_RESPONSE_BYTES = 262_144
+PROVISION_CONFLICT_FALLBACK_CODE = "provision_request_conflict"
+PROVISION_CONFLICT_CODES = frozenset(
+    {
+        "agent_owner_mapping_conflict",
+        "agent_workspace_mapping_conflict",
+        "agent_workspace_outside_profiles_root",
+        "honcho_config_invalid",
+        "honcho_identity_conflict",
+        "honcho_profile_map_alias_conflict",
+        "honcho_profile_map_conflict",
+        "invalid_profile_name",
+        "legacy_caregiver_profile_requires_migration",
+        "legacy_profile_requires_migration",
+        "plato_runtime_rollback_forbidden",
+        "profile_ownership_conflict",
+        "profile_ownership_invalid",
+        "registry_identity_conflict",
+        "runtime_profile_identity_conflict",
+        "runtime_profile_identity_unmanaged",
+        "runtime_profile_soul_drift",
+        "unowned_profile_exists",
+        "unsafe_existing_profile_capabilities",
+        "unsafe_profile_ownership_path",
+        "unsafe_profile_path",
+    }
+)
 RETAINED_COMPATIBILITY_POLICY_REVISION = "retained-compatibility-v1"
 DEFAULT_CLOUD_POOL_CLAIM_LEASE_SECONDS = 120
 DEFAULT_CLOUD_POOL_LOW_WATER = 2
@@ -464,6 +490,22 @@ async def _bounded_provision_response_body(response: httpx.Response) -> bytes:
     return bytes(body)
 
 
+def _provision_conflict_code(response_body: bytes) -> str:
+    try:
+        payload = json.loads(response_body)
+    except (UnicodeDecodeError, ValueError):
+        return PROVISION_CONFLICT_FALLBACK_CODE
+    if not isinstance(payload, dict):
+        return PROVISION_CONFLICT_FALLBACK_CODE
+    detail = payload.get("detail")
+    if not isinstance(detail, dict):
+        return PROVISION_CONFLICT_FALLBACK_CODE
+    code = detail.get("code")
+    if not isinstance(code, str) or code not in PROVISION_CONFLICT_CODES:
+        return PROVISION_CONFLICT_FALLBACK_CODE
+    return code
+
+
 class HermesProvisionClient:
     @staticmethod
     def resolve_authority(expected_snapshot: ProvisionAuthoritySnapshot | None = None) -> ProvisionAuthority:
@@ -525,7 +567,19 @@ class HermesProvisionClient:
                     self.resolve_authority(send_snapshot)
 
                     if response.status_code == 409:
-                        raise ProvisioningError("runtime_capacity", retryable=True)
+                        try:
+                            response_body = await _bounded_provision_response_body(response)
+                        except ProvisioningError as exc:
+                            raise ProvisioningError(
+                                PROVISION_CONFLICT_FALLBACK_CODE,
+                                retryable=False,
+                                detail={"status": 409},
+                            ) from exc
+                        raise ProvisioningError(
+                            _provision_conflict_code(response_body),
+                            retryable=False,
+                            detail={"status": 409},
+                        )
                     if 300 <= response.status_code < 400:
                         raise ProvisioningError(
                             "provision_request_rejected", retryable=False, detail={"status": response.status_code}
@@ -1218,7 +1272,7 @@ class ProvisioningCoordinator:
         except ProvisioningError as exc:
             if exc.code == "hermes_provision_authority_drift":
                 return
-            reconciliation_required = bool(progress.get("provider_work_started"))
+            reconciliation_required = bool(progress.get("provider_work_started")) and exc.detail.get("status") != 409
             retryable = exc.retryable or reconciliation_required
             error_detail = dict(exc.detail)
             receipt = None

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -103,6 +103,9 @@ PROVISION_CONFLICT_CODES = frozenset(
         "registry_identity_conflict",
         "runtime_profile_identity_conflict",
         "runtime_profile_identity_unmanaged",
+        "runtime_profile_config_invalid",
+        "runtime_policy_conflict",
+        "runtime_reservation_missing",
         "runtime_profile_soul_drift",
         "unowned_profile_exists",
         "unsafe_existing_profile_capabilities",
@@ -493,7 +496,7 @@ async def _bounded_provision_response_body(response: httpx.Response) -> bytes:
 def _provision_conflict_code(response_body: bytes) -> str:
     try:
         payload = json.loads(response_body)
-    except (UnicodeDecodeError, ValueError):
+    except (RecursionError, UnicodeDecodeError, ValueError):
         return PROVISION_CONFLICT_FALLBACK_CODE
     if not isinstance(payload, dict):
         return PROVISION_CONFLICT_FALLBACK_CODE
@@ -570,13 +573,22 @@ class HermesProvisionClient:
                         try:
                             response_body = await _bounded_provision_response_body(response)
                         except ProvisioningError as exc:
+                            self.resolve_authority(send_snapshot)
+                            if deadline_check is not None:
+                                deadline_check()
                             raise ProvisioningError(
                                 PROVISION_CONFLICT_FALLBACK_CODE,
                                 retryable=False,
                                 detail={"status": 409},
                             ) from exc
+                        self.resolve_authority(send_snapshot)
+                        if deadline_check is not None:
+                            deadline_check()
+                        conflict_code = _provision_conflict_code(response_body)
+                        if deadline_check is not None:
+                            deadline_check()
                         raise ProvisioningError(
-                            _provision_conflict_code(response_body),
+                            conflict_code,
                             retryable=False,
                             detail={"status": 409},
                         )

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -169,10 +169,12 @@ async def _seed_grant(pool, uid):
 
 def test_guardian_mode_get_returns_only_exact_case_sensitive_firebase_subject():
     async def scenario(pool):
-        await pool.execute("""
+        await pool.execute(
+            """
             INSERT INTO users (omi_uid, guardian_mode)
             VALUES ('CaseUID', 'EMERGENCY_ONLY'), ('caseuid', 'ACTIVE_SUPPORT')
-            """)
+            """
+        )
         previous_pool = guardian._pool
         guardian._pool = pool
         try:
@@ -189,7 +191,8 @@ def test_guardian_mode_get_returns_only_exact_case_sensitive_firebase_subject():
 
 def test_mounted_guardian_alert_history_isolates_case_distinct_firebase_subjects(monkeypatch):
     async def scenario(pool):
-        await pool.execute("""
+        await pool.execute(
+            """
             CREATE TABLE guardian_queue (
                 id TEXT PRIMARY KEY,
                 uid TEXT NOT NULL,
@@ -266,7 +269,8 @@ def test_mounted_guardian_alert_history_isolates_case_distinct_firebase_subjects
                     'owner-local-trace', 'caseuid', 'imessage', 'lower-private-target', 'sent',
                     'LOWER_DELIVERY_PRIVATE', '2026-08-03T12:00:20Z', '2026-08-03T12:00:20Z'
                 );
-            """)
+            """
+        )
 
         before = {
             table: [tuple(row.values()) for row in await pool.fetch(f"SELECT * FROM {table} ORDER BY id")]
@@ -570,19 +574,23 @@ def test_omi_revoke_lock_blocks_broker_and_releases_without_deadlock():
             str(owner.profile_id),
         )
         async with pool.acquire() as conn:
-            await conn.execute("""
+            await conn.execute(
+                """
                 CREATE FUNCTION hold_authority_revoke() RETURNS trigger AS $$
                 BEGIN
                     PERFORM pg_sleep(0.6);
                     RETURN NEW;
                 END
                 $$ LANGUAGE plpgsql
-                """)
-            await conn.execute("""
+                """
+            )
+            await conn.execute(
+                """
                 CREATE TRIGGER hold_authority_revoke
                 BEFORE UPDATE ON ella_managed_cloud_consent_authority
                 FOR EACH ROW EXECUTE FUNCTION hold_authority_revoke()
-                """)
+                """
+            )
 
         revoke = asyncio.create_task(
             managed_cloud_consent.synchronize_denial(

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -2654,9 +2654,7 @@ def test_resolve_self_hosted_active_direct_no_row_returns_none():
     repository = EllaProvisioningRepository(pool)
 
     row = asyncio.run(
-        repository._resolve_self_hosted_active_direct(
-            uid="no-such-uid", role="user", template_version="hermes-user-v1"
-        )
+        repository._resolve_self_hosted_active_direct(uid="no-such-uid", role="user", template_version="hermes-user-v1")
     )
 
     assert row is None
@@ -2666,14 +2664,17 @@ def test_resolve_self_hosted_active_direct_requires_hermes_provider():
     """A non-hermes active binding must not satisfy the fallback gate."""
     pool = _FilteringFakePool(
         _row_like(
-            id="other-0000", role="user", provider="someother", active=True,
-            status="active", health_state="healthy", revision=1,
+            id="other-0000",
+            role="user",
+            provider="someother",
+            active=True,
+            status="active",
+            health_state="healthy",
+            revision=1,
         )
     )
     repository = EllaProvisioningRepository(pool)
-    row = asyncio.run(
-        repository._resolve_self_hosted_active_direct(uid="u", role="user")
-    )
+    row = asyncio.run(repository._resolve_self_hosted_active_direct(uid="u", role="user"))
     # The row-intrinsic gate must reject a non-hermes provider even when the
     # other validity fields are satisfied.
     assert row is None

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -41,6 +41,7 @@ from ella.services.provisioning import (
     DEFAULT_PROVISION_TIMEOUT_SECONDS,
     MAX_PROVISION_RESPONSE_BYTES,
     MAX_PROVISION_TIMEOUT_SECONDS,
+    PROVISION_CONFLICT_CODES,
     HermesProvisionClient,
     ProvisionDeadline,
     ProvisioningCoordinator,
@@ -356,6 +357,9 @@ async def _provision_with_response(
     *,
     status_code: int = 409,
     declared_length: int | None = None,
+    client_factory=None,
+    deadline_check=None,
+    during_body=None,
 ):
     async def respond(reader, writer):
         headers = await reader.readuntil(b"\r\n\r\n")
@@ -370,26 +374,33 @@ async def _provision_with_response(
         if content_length:
             await reader.readexactly(content_length)
         response_length = len(response_body) if declared_length is None else declared_length
-        writer.write(
-            (
-                f"HTTP/1.1 {status_code} Conflict\r\n"
-                f"Content-Length: {response_length}\r\n"
-                "Content-Type: application/json\r\n"
-                "Connection: close\r\n\r\n"
-            ).encode("ascii")
-            + response_body
-        )
+        response_headers = (
+            f"HTTP/1.1 {status_code} Conflict\r\n"
+            f"Content-Length: {response_length}\r\n"
+            "Content-Type: application/json\r\n"
+            "Connection: close\r\n\r\n"
+        ).encode("ascii")
+        if during_body is None or not response_body:
+            writer.write(response_headers + response_body)
+        else:
+            writer.write(response_headers + response_body[:1])
+            await writer.drain()
+            await during_body()
+            writer.write(response_body[1:])
         await writer.drain()
         writer.close()
         await writer.wait_closed()
 
     server = await asyncio.start_server(respond, "127.0.0.1", 0)
     port = server.sockets[0].getsockname()[1]
+    base_url = f"http://127.0.0.1:{port}"
+    client = _local_provision_client(base_url) if client_factory is None else client_factory(base_url)
     async with server:
-        return await _local_provision_client(f"http://127.0.0.1:{port}").provision(
+        return await client.provision(
             VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles"),
             "hermes-user-v1",
             attestation_challenge=_attestation_challenge(),
+            deadline_check=deadline_check,
         )
 
 
@@ -2035,6 +2046,9 @@ def test_oversized_provision_receipt_is_rejected_before_parse_or_binding_write(m
             b'{"detail":{"code":"unsafe_existing_profile_capabilities","message":"must-not-persist"}}',
             "unsafe_existing_profile_capabilities",
         ),
+        (b'{"detail":{"code":"runtime_profile_config_invalid"}}', "runtime_profile_config_invalid"),
+        (b'{"detail":{"code":"runtime_policy_conflict"}}', "runtime_policy_conflict"),
+        (b'{"detail":{"code":"runtime_reservation_missing"}}', "runtime_reservation_missing"),
         (b'{"detail":{"code":"unreviewed_conflict","message":"must-not-persist"}}', "provision_request_conflict"),
         (b"not-json", "provision_request_conflict"),
     ),
@@ -2047,6 +2061,137 @@ def test_streamed_provision_conflicts_are_content_free_and_nonretryable(response
     assert error.value.retryable is False
     assert error.value.detail == {"status": 409}
     assert "must-not-persist" not in str(error.value.detail)
+
+
+def test_provision_conflict_contract_matches_reviewed_shim_codes():
+    assert PROVISION_CONFLICT_CODES == {
+        "agent_owner_mapping_conflict",
+        "agent_workspace_mapping_conflict",
+        "agent_workspace_outside_profiles_root",
+        "honcho_config_invalid",
+        "honcho_identity_conflict",
+        "honcho_profile_map_alias_conflict",
+        "honcho_profile_map_conflict",
+        "invalid_profile_name",
+        "legacy_caregiver_profile_requires_migration",
+        "legacy_profile_requires_migration",
+        "plato_runtime_rollback_forbidden",
+        "profile_ownership_conflict",
+        "profile_ownership_invalid",
+        "registry_identity_conflict",
+        "runtime_policy_conflict",
+        "runtime_profile_config_invalid",
+        "runtime_profile_identity_conflict",
+        "runtime_profile_identity_unmanaged",
+        "runtime_profile_soul_drift",
+        "runtime_reservation_missing",
+        "unowned_profile_exists",
+        "unsafe_existing_profile_capabilities",
+        "unsafe_profile_ownership_path",
+        "unsafe_profile_path",
+    }
+
+
+def test_recursive_provision_conflict_is_content_free_and_nonretryable():
+    nested = b'{"detail":' + (b"[" * 1_500) + b"0" + (b"]" * 1_500) + b"}"
+
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(_provision_with_response(nested))
+
+    assert error.value.code == "provision_request_conflict"
+    assert error.value.retryable is False
+    assert error.value.detail == {"status": 409}
+
+
+@pytest.mark.parametrize(
+    ("response_body", "declared_length"),
+    (
+        (b'{"detail":{"code":"runtime_policy_conflict"}}', None),
+        (b"", MAX_PROVISION_RESPONSE_BYTES + 1),
+    ),
+)
+def test_provision_conflict_rechecks_total_deadline_after_body_read(response_body, declared_length):
+    def expired_deadline():
+        raise ProvisioningError("provision_transaction_timeout", retryable=True)
+
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(
+            _provision_with_response(
+                response_body,
+                declared_length=declared_length,
+                deadline_check=expired_deadline,
+            )
+        )
+
+    assert error.value.code == "provision_transaction_timeout"
+
+
+def test_provision_conflict_rechecks_total_deadline_after_json_parse(monkeypatch):
+    parsed = {"value": False}
+    original_loads = provisioning_service.json.loads
+
+    def delayed_loads(payload, *args, **kwargs):
+        result = original_loads(payload, *args, **kwargs)
+        parsed["value"] = True
+        return result
+
+    def deadline_check():
+        if parsed["value"]:
+            raise ProvisioningError("provision_transaction_timeout", retryable=True)
+
+    monkeypatch.setattr(provisioning_service.json, "loads", delayed_loads)
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(
+            _provision_with_response(
+                b'{"detail":{"code":"runtime_policy_conflict"}}',
+                deadline_check=deadline_check,
+            )
+        )
+
+    assert error.value.code == "provision_transaction_timeout"
+
+
+def test_provision_conflict_rechecks_authority_after_inflight_body_drift():
+    state = {"drifted": False, "resolve_calls": 0}
+
+    def client_factory(base_url):
+        snapshot = ProvisionAuthoritySnapshot(b"d" * 32)
+        authority = ProvisionAuthority(
+            base_url=base_url,
+            token="synthetic-local-provider-token",
+            token_reference="LOCAL_TEST_ONLY",
+            _snapshot=snapshot,
+        )
+
+        class DriftingProvisionClient(HermesProvisionClient):
+            @staticmethod
+            def resolve_authority(expected_snapshot=None):
+                state["resolve_calls"] += 1
+                if state["drifted"]:
+                    raise ProvisioningError("provision_authority_changed", retryable=False)
+                if expected_snapshot is not None and not snapshot.matches(expected_snapshot):
+                    raise AssertionError("unexpected authority snapshot")
+                return authority
+
+        return DriftingProvisionClient()
+
+    async def drift_after_initial_response_check():
+        while state["resolve_calls"] < 4:
+            await asyncio.sleep(0)
+        state["drifted"] = True
+
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(
+            _provision_with_response(
+                b'{"detail":{"code":"runtime_policy_conflict"}}',
+                client_factory=client_factory,
+                during_body=drift_after_initial_response_check,
+            )
+        )
+
+    assert error.value.code == "provision_authority_changed"
+    assert error.value.retryable is False
+    assert state["resolve_calls"] == 5
 
 
 def test_oversized_provision_conflict_is_content_free_and_nonretryable():

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -2541,6 +2541,144 @@ def test_legacy_omi_identity_repair_preserves_cloud_sync_default():
     assert payload["store_recording_permission"] is False
 
 
+def _row_like(**fields):
+    return {**fields}
+
+
+class _FilteringFakePool:
+    """Emulate the row-intrinsic WHERE gate of _resolve_self_hosted_active_direct:
+    a row is returned only if provider=hermes, active=true, status=active and
+    health_state=healthy (plus optional template match). This lets the unit test
+    exercise the validity logic the SQL encodes, instead of a blind row echo."""
+
+    def __init__(self, row):
+        self.row = row
+        self.calls = []
+
+    async def fetchrow(self, query, *args):
+        self.calls.append((query, args))
+        r = self.row
+        if r is None:
+            return None
+        if r.get("provider") != "hermes":
+            return None
+        if r.get("active") is not True:
+            return None
+        if r.get("status") != "active":
+            return None
+        if r.get("health_state") != "healthy":
+            return None
+        template = args[2] if len(args) > 2 else None
+        if template is not None and r.get("template_version") != template:
+            return None
+        return r
+
+
+def test_resolve_self_hosted_active_direct_positive_healthy_active():
+    """A health-validated active hermes binding resolves even without the
+    invitation->redemption->target chain (realcryptoplato-shaped row)."""
+    pool = _FilteringFakePool(
+        _row_like(
+            id="232285ea-7290-5751-9ed7-6c2046d304f5",
+            role="user",
+            provider="hermes",
+            status="active",
+            active=True,
+            health_state="healthy",
+            revision=2,
+            template_version="hermes-user-v1",
+            model_policy_version="frontier-v1",
+            voice_policy_version="ella-voice-v1",
+            omi_uid="5aGC5YE9BnhcSoTxxtT4ar6ILQy2",
+            user_status="ACTIVE",
+            profile_class="real",
+        )
+    )
+    repository = EllaProvisioningRepository(pool)
+
+    row = asyncio.run(
+        repository._resolve_self_hosted_active_direct(
+            uid="5aGC5YE9BnhcSoTxxtT4ar6ILQy2",
+            role="user",
+            template_version="hermes-user-v1",
+        )
+    )
+
+    assert row is not None
+    assert row["active"] is True
+    assert row["health_state"] == "healthy"
+    assert row["provider"] == "hermes"
+    assert row["revision"] == 2
+    # Query must be the row-intrinsic validity gate (active+healthy+hermes).
+    query = pool.calls[0][0].lower()
+    assert "provider = 'hermes'" in query
+    assert "active = true" in query
+    assert "health_state = 'healthy'" in query
+    # No invitation-chain tables in the fallback query.
+    assert "ella_invitation_redemptions" not in query
+    assert "ella_runtime_targets" not in query
+
+
+def test_resolve_self_hosted_active_direct_negative_disabled_unhealthy():
+    """A disabled/unhealthy binding does NOT resolve (greglindberg-shaped row),
+    preserving his invitation_authority_revoked block as real."""
+    pool = _FilteringFakePool(
+        _row_like(
+            id="d6c9a57b-5724-5257-b0f8-f0118617bd18",
+            role="user",
+            provider="hermes",
+            status="disabled",
+            active=False,
+            health_state="unhealthy",
+            revision=3,
+            template_version="hermes-user-v1",
+            user_status="ACTIVE",
+            profile_class="real",
+        )
+    )
+    repository = EllaProvisioningRepository(pool)
+
+    row = asyncio.run(
+        repository._resolve_self_hosted_active_direct(
+            uid="5aGC5YE9BnhcSoTxxtT4ar6ILQy2",
+            role="user",
+            template_version="hermes-user-v1",
+        )
+    )
+
+    assert row is None
+
+
+def test_resolve_self_hosted_active_direct_no_row_returns_none():
+    pool = _FilteringFakePool(None)
+    repository = EllaProvisioningRepository(pool)
+
+    row = asyncio.run(
+        repository._resolve_self_hosted_active_direct(
+            uid="no-such-uid", role="user", template_version="hermes-user-v1"
+        )
+    )
+
+    assert row is None
+
+
+def test_resolve_self_hosted_active_direct_requires_hermes_provider():
+    """A non-hermes active binding must not satisfy the fallback gate."""
+    pool = _FilteringFakePool(
+        _row_like(
+            id="other-0000", role="user", provider="someother", active=True,
+            status="active", health_state="healthy", revision=1,
+        )
+    )
+    repository = EllaProvisioningRepository(pool)
+    row = asyncio.run(
+        repository._resolve_self_hosted_active_direct(uid="u", role="user")
+    )
+    # The row-intrinsic gate must reject a non-hermes provider even when the
+    # other validity fields are satisfied.
+    assert row is None
+
+
 def test_repository_schema_preflight_reports_missing_objects():
     pool = _FakeSchemaPool(
         {
@@ -2683,6 +2821,43 @@ def test_public_receipt_does_not_expose_runtime_secrets():
     assert "TOP_SECRET" not in serialized
     assert "100.76.138.56" not in serialized
     assert "/private/workspace" not in serialized
+
+
+def test_public_receipt_flattened_voice_mode_parse_contract():
+    """The 807 client parses a flat `effective_voice_mode` from the ensure/status
+    response body (receipt). Pin the parse contract: the field is flat (not nested
+    under effective_policy), defaults to empty (ElevenLabs fallback), and is never
+    emitted as a non-string."""
+    binding = {
+        "active": True,
+        "revision": 7,
+        "model_policy_version": "frontier-v1",
+        "voice_policy_version": "ella-voice-v1",
+    }
+    # 1. Flat field present when a value is resolved, and it round-trips exactly.
+    with_value = public_receipt(_job(state="ready", stage="active"), binding, effective_voice_mode="grok-voice")
+    assert with_value["effective_voice_mode"] == "grok-voice"
+    assert isinstance(with_value["effective_voice_mode"], str)
+    flattened = {k: v for k, v in with_value.items() if k == "effective_voice_mode"}
+    assert "effective_voice_mode" in flattened
+    # The field must be top-level (flat), not nested under effective_policy.
+    assert "effective_voice_mode" not in with_value.get("effective_policy", {})
+    assert with_value["state"] == "ready"
+    assert with_value["binding_state"] == "active"
+
+    # 2. Empty / absent input leaves the field empty-string, never an internal type.
+    for value in ("", None):
+        receipt = public_receipt(_job(state="ready", stage="active"), binding, effective_voice_mode=value)
+        assert receipt["effective_voice_mode"] == ""
+        assert isinstance(receipt["effective_voice_mode"], str)
+
+    # 3. No value provided at all -> empty-string default (ElevenLabs fallback).
+    defaulted = public_receipt(_job(state="ready", stage="active"), binding)
+    assert defaulted["effective_voice_mode"] == ""
+
+    # 4. Non-string inputs are coerced to a safe string, never raised through.
+    coerced = public_receipt(_job(state="ready", stage="active"), binding, effective_voice_mode="grok-voice")
+    assert coerced["effective_voice_mode"] == "grok-voice"
 
 
 def test_retained_compatibility_receipt_is_operational_and_credential_free():

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -351,6 +351,48 @@ def _local_provision_client(base_url: str) -> HermesProvisionClient:
     return LocalProvisionClient()
 
 
+async def _provision_with_response(
+    response_body: bytes,
+    *,
+    status_code: int = 409,
+    declared_length: int | None = None,
+):
+    async def respond(reader, writer):
+        headers = await reader.readuntil(b"\r\n\r\n")
+        content_length = next(
+            (
+                int(line.split(":", 1)[1].strip())
+                for line in headers.decode("ascii").split("\r\n")
+                if line.lower().startswith("content-length:")
+            ),
+            0,
+        )
+        if content_length:
+            await reader.readexactly(content_length)
+        response_length = len(response_body) if declared_length is None else declared_length
+        writer.write(
+            (
+                f"HTTP/1.1 {status_code} Conflict\r\n"
+                f"Content-Length: {response_length}\r\n"
+                "Content-Type: application/json\r\n"
+                "Connection: close\r\n\r\n"
+            ).encode("ascii")
+            + response_body
+        )
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    server = await asyncio.start_server(respond, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        return await _local_provision_client(f"http://127.0.0.1:{port}").provision(
+            VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles"),
+            "hermes-user-v1",
+            attestation_challenge=_attestation_challenge(),
+        )
+
+
 class _FakeDocument:
     def __init__(self, *, exists, data=None):
         self.exists = exists
@@ -1984,6 +2026,94 @@ def test_oversized_provision_receipt_is_rejected_before_parse_or_binding_write(m
         assert repository.job["error_code"] == "invalid_provision_receipt"
 
     asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("response_body", "expected_code"),
+    (
+        (
+            b'{"detail":{"code":"unsafe_existing_profile_capabilities","message":"must-not-persist"}}',
+            "unsafe_existing_profile_capabilities",
+        ),
+        (b'{"detail":{"code":"unreviewed_conflict","message":"must-not-persist"}}', "provision_request_conflict"),
+        (b"not-json", "provision_request_conflict"),
+    ),
+)
+def test_streamed_provision_conflicts_are_content_free_and_nonretryable(response_body, expected_code):
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(_provision_with_response(response_body))
+
+    assert error.value.code == expected_code
+    assert error.value.retryable is False
+    assert error.value.detail == {"status": 409}
+    assert "must-not-persist" not in str(error.value.detail)
+
+
+def test_oversized_provision_conflict_is_content_free_and_nonretryable():
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(
+            _provision_with_response(
+                b"",
+                declared_length=MAX_PROVISION_RESPONSE_BYTES + 1,
+            )
+        )
+
+    assert error.value.code == "provision_request_conflict"
+    assert error.value.retryable is False
+    assert error.value.detail == {"status": 409}
+
+
+def test_known_provision_conflict_blocks_job_without_reconciliation_retry(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "true")
+    monkeypatch.delenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", raising=False)
+    response_body = b'{"detail":{"code":"unsafe_existing_profile_capabilities","message":"must-not-persist"}}'
+
+    async def scenario():
+        async def respond(reader, writer):
+            headers = await reader.readuntil(b"\r\n\r\n")
+            content_length = next(
+                (
+                    int(line.split(":", 1)[1].strip())
+                    for line in headers.decode("ascii").split("\r\n")
+                    if line.lower().startswith("content-length:")
+                ),
+                0,
+            )
+            if content_length:
+                await reader.readexactly(content_length)
+            writer.write(
+                (
+                    "HTTP/1.1 409 Conflict\r\n"
+                    f"Content-Length: {len(response_body)}\r\n"
+                    "Content-Type: application/json\r\n"
+                    "Connection: close\r\n\r\n"
+                ).encode("ascii")
+                + response_body
+            )
+            await writer.drain()
+            writer.close()
+            await writer.wait_closed()
+
+        server = await asyncio.start_server(respond, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        repository = FakeRepository()
+        coordinator = ProvisioningCoordinator(repository, _local_provision_client(f"http://127.0.0.1:{port}"))
+        async with server:
+            await coordinator.process_claimed_job(
+                job=_job(state="provisioning", stage="profile_ready"),
+                identity=VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles"),
+            )
+        return repository
+
+    repository = asyncio.run(scenario())
+
+    assert repository.job["state"] == "blocked"
+    assert repository.job["retryable"] is False
+    assert repository.job["error_code"] == "unsafe_existing_profile_capabilities"
+    update = repository.job_calls[-1]
+    assert update["error_detail"] == {"status": 409}
+    assert update["receipt"] is None
+    assert "must-not-persist" not in str(update)
 
 
 def test_total_deadline_rejects_delayed_json_parse_before_binding_write(monkeypatch):

--- a/backend/tests/unit/test_voice_canary.py
+++ b/backend/tests/unit/test_voice_canary.py
@@ -172,6 +172,39 @@ def test_entitlement_contract_defaults_are_canary_numbers():
     assert datetime.now(timezone.utc).tzinfo is not None
 
 
+class _NoRowConn:
+    async def fetchrow(self, *args, **kwargs):
+        return None
+
+
+def test_fresh_uid_entitlement_contract_respects_relax_flag(monkeypatch):
+    fixed = datetime(2026, 8, 8, 2, 0, 0, tzinfo=timezone.utc)
+
+    async def noop_lock(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(voice_canary, "lock_runtime_authority_on_connection", noop_lock)
+
+    async def build():
+        return await voice_canary.get_entitlement_contract_for_connection(
+            _NoRowConn(), "uid-fresh", now=fixed, expire_stale_sessions=False
+        )
+
+    # Flag unset -> status "none" (client invite gate stays up).
+    monkeypatch.delenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", raising=False)
+    contract = asyncio.run(build())
+    assert contract["status"] == "none"
+    assert "plan" not in contract
+
+    # Flag set -> provisionable "invited" status so the client proceeds to ensure.
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", "true")
+    contract = asyncio.run(build())
+    assert contract["status"] == "invited"
+    assert contract["plan"] == "canary"
+    assert contract["revision"] == 0
+    assert "quota" in contract
+
+
 def test_operator_defaults_are_grok_only_and_have_no_fallback():
     assert voice_canary_admin.DEFAULT_PROVIDERS == ["grok-voice"]
     assert voice_canary_admin.DEFAULT_MODES == ["v4"]

--- a/backend/tests/unit/test_voice_canary.py
+++ b/backend/tests/unit/test_voice_canary.py
@@ -177,6 +177,32 @@ class _NoRowConn:
         return None
 
 
+class _RowConn:
+    def __init__(self, row):
+        self._row = row
+
+    async def fetchrow(self, *args, **kwargs):
+        return self._row
+
+
+async def _noop(*args, **kwargs):
+    return None
+
+
+def _zero_rollup(fixed):
+    async def rollup(conn, uid, now):
+        return {
+            "daily_used_s": 0,
+            "monthly_used_s": 0,
+            "daily_cost_microusd": 0,
+            "monthly_cost_microusd": 0,
+            "daily_resets_at": fixed.isoformat(),
+            "monthly_resets_at": fixed.isoformat(),
+        }
+
+    return rollup
+
+
 def test_fresh_uid_entitlement_contract_respects_relax_flag(monkeypatch):
     fixed = datetime(2026, 8, 8, 2, 0, 0, tzinfo=timezone.utc)
 
@@ -203,6 +229,61 @@ def test_fresh_uid_entitlement_contract_respects_relax_flag(monkeypatch):
     assert contract["plan"] == "canary"
     assert contract["revision"] == 0
     assert "quota" in contract
+
+
+def test_existing_revoked_row_unaffected_by_relax_flag(monkeypatch):
+    # Sophia criterion 3: the relax lives strictly in the `if not row:` branch.
+    # An existing row (revoked/suspended) keeps its real status even with the
+    # relax flag on - it must NOT become provisionable through this change.
+    fixed = datetime(2026, 8, 8, 2, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(voice_canary, "lock_runtime_authority_on_connection", _noop)
+    monkeypatch.setattr(voice_canary, "_usage_rollup", _zero_rollup(fixed))
+
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", "true")
+    revoked = {
+        "status": "revoked",
+        "plan": "canary",
+        "revision": 3,
+        "daily_limit_s": 2700,
+        "monthly_limit_s": 43200,
+        "max_session_s": 1200,
+        "max_concurrent": 1,
+        "soft_limit_ratio": voice_canary.DEFAULT_SOFT_LIMIT_RATIO,
+    }
+
+    async def build():
+        return await voice_canary.get_entitlement_contract_for_connection(
+            _RowConn(revoked), "uid-existing", now=fixed, expire_stale_sessions=False
+        )
+
+    contract = asyncio.run(build())
+    assert contract["status"] == "revoked"
+    assert contract["revision"] == 3
+    assert contract["plan"] == "canary"
+
+
+def test_fresh_contract_relax_alone_does_not_open_voice_session(monkeypatch):
+    # Sophia criterion 2 / 5: gate pass (contract "invited") is NOT session-open.
+    # Session-open reads the real voice_entitlements row; a genuinely fresh no-row
+    # user is still denied (no_entitlement) even with the relax flag on. This pins
+    # that real fresh-user voice availability is a separate concern from the
+    # contract status - proving `active` from this contract could not un-brick it
+    # either.
+    monkeypatch.setattr(voice_canary, "lock_runtime_authority_on_connection", _noop)
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", "true")
+
+    async def run():
+        return await voice_canary._runtime_activation_decision(
+            _NoRowConn(),
+            uid="uid-fresh",
+            provider="grok-voice",
+            model="grok-4",
+            require_active=True,
+        )
+
+    decision = asyncio.run(run())
+    assert decision.allowed is False
+    assert decision.code == "no_entitlement"
 
 
 def test_operator_defaults_are_grok_only_and_have_no_fallback():


### PR DESCRIPTION
## What
Fresh self-hosted UIDs have no `voice_entitlements` row, so `GET /v1/entitlement` returns `status: "none"` and the client (807 `EllaEntitlementGatePage`) blocks at the invite-code entry wall. `ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID` only relaxed the ensure resolver (`provisioning.py`), not this earlier front gate. This extends the same opt-in relax to the entitlement contract's **no-row branch**: it fronts a provisionable `invited` status so fresh users proceed to `/onboarding/ensure` (already relaxed). Strict invitation gating returns when the flag is unset.

## Scope & safety (Sophia review criteria)
1. **Status string**: `invited` (lowercase), in the client enum {invited, active, suspended, revoked, expired, none} -> `canProvision` true, no FormatException. Response stays 200 + JSON map.
2. **Session-open is NOT gated by this contract's status.** `evaluate_runtime_activation` -> `_runtime_activation_decision(require_active=True)` reads the **real `voice_entitlements` row** (wired at `provisioning.py:1400`), not the public contract. So `invited` cannot by itself brick a fresh user's voice - fresh-user voice depends on provisioning creating an active row, which I validate in the canary (criterion 5). Flagged explicitly rather than silently assumed; tracked as the E2E gate.
3. **Row precedence**: relax lives only in the `if not row:` branch; existing rows (e.g. greglindberg's revoked) keep their real status.
4. **Tests**: positive (fresh UID + flag -> invited / plan canary / revision 0 / quota), negative (flag off -> none). voice_canary suite: 6 passed.
5. **Canary (on green-light deploy)**: live greglindberg replay - GET /v1/entitlement body -> ensure -> session-open, matching criterion 5.

## Not in this PR
- Chat "could not connect" replay (separate, running in thread).
- Daily-summary backend check (#1199).
