### PR TITLE
feat(ella): auto-provision grok voice entitlement on fresh self-hosted hermes user

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -544,6 +544,9 @@ jobs:
             "tests/unit/test_ella_provisioning_service.py::test_attestation_window_covers_max_slow_response_and_rejects_invalid_config"
             "tests/unit/test_ella_provisioning_service.py::test_total_deadline_cancels_real_local_slow_drip_before_binding_writes"
             "tests/unit/test_ella_provisioning_service.py::test_oversized_provision_receipt_is_rejected_before_parse_or_binding_write"
+            "tests/unit/test_ella_provisioning_service.py::test_provision_conflict_contract_matches_reviewed_shim_codes"
+            "tests/unit/test_ella_provisioning_service.py::test_recursive_provision_conflict_is_content_free_and_nonretryable"
+            "tests/unit/test_ella_provisioning_service.py::test_provision_conflict_rechecks_authority_after_inflight_body_drift"
             "tests/unit/test_ella_provisioning_service.py::test_total_deadline_rejects_delayed_json_parse_before_binding_write"
             "tests/unit/test_ella_provisioning_service.py::test_total_deadline_stops_delayed_verification_and_local_publication[verification]"
             "tests/unit/test_ella_provisioning_service.py::test_total_deadline_stops_delayed_verification_and_local_publication[staging]"
@@ -669,7 +672,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 514
+          test "$collected" -eq 528
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -170,7 +170,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 174
+          test "$collected" -eq 180
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
@@ -212,6 +212,11 @@ jobs:
             "tests/unit/test_ella_provisioning_service.py::test_external_cancellation_after_provider_work_records_retryable_reconciliation"
             "tests/unit/test_ella_provisioning_service.py::test_post_provider_attestation_rejections_retry_and_reconcile_one_binding"
             "tests/unit/test_ella_provisioning_service.py::test_retained_owner_identity_is_exact_and_requires_server_configuration"
+            "tests/unit/test_ella_provisioning_service.py::test_resolve_self_hosted_active_direct_positive_healthy_active"
+            "tests/unit/test_ella_provisioning_service.py::test_resolve_self_hosted_active_direct_negative_disabled_unhealthy"
+            "tests/unit/test_ella_provisioning_service.py::test_resolve_self_hosted_active_direct_no_row_returns_none"
+            "tests/unit/test_ella_provisioning_service.py::test_resolve_self_hosted_active_direct_requires_hermes_provider"
+            "tests/unit/test_ella_provisioning_service.py::test_public_receipt_flattened_voice_mode_parse_contract"
             "tests/postgres/test_invitation_redemption_postgres.py::test_self_hosted_redemption_binds_verified_email_identity_and_target_atomically"
             "tests/postgres/test_invitation_redemption_postgres.py::test_self_hosted_email_mismatch_and_concurrent_open_redeem_fail_closed"
             "tests/postgres/test_invitation_redemption_postgres.py::test_pilot_operator_rotation_is_atomic_idempotent_and_preserves_email_scope"

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -170,7 +170,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 160
+          test "$collected" -eq 174
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
@@ -202,6 +202,9 @@ jobs:
             "tests/unit/test_ella_provisioning_service.py::test_attestation_window_covers_max_slow_response_and_rejects_invalid_config"
             "tests/unit/test_ella_provisioning_service.py::test_total_deadline_cancels_real_local_slow_drip_before_binding_writes"
             "tests/unit/test_ella_provisioning_service.py::test_oversized_provision_receipt_is_rejected_before_parse_or_binding_write"
+            "tests/unit/test_ella_provisioning_service.py::test_provision_conflict_contract_matches_reviewed_shim_codes"
+            "tests/unit/test_ella_provisioning_service.py::test_recursive_provision_conflict_is_content_free_and_nonretryable"
+            "tests/unit/test_ella_provisioning_service.py::test_provision_conflict_rechecks_authority_after_inflight_body_drift"
             "tests/unit/test_ella_provisioning_service.py::test_total_deadline_rejects_delayed_json_parse_before_binding_write"
             "tests/unit/test_ella_provisioning_service.py::test_total_deadline_stops_delayed_verification_and_local_publication[verification]"
             "tests/unit/test_ella_provisioning_service.py::test_total_deadline_stops_delayed_verification_and_local_publication[staging]"

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -3583,9 +3583,7 @@ class EllaProvisioningRepository:
                         # (possibly stale) job-target schema here, and requiring a
                         # match would reproduce the "incomplete on status" bug the
                         # fallback exists to fix. `POST /ensure` passes None (inert).
-                        fallback = await self._resolve_self_hosted_active_direct(
-                            uid=uid, role=role
-                        )
+                        fallback = await self._resolve_self_hosted_active_direct(uid=uid, role=role)
                         return fallback
                     decision = await voice_canary_db.revalidate_runtime_resolution_on_connection(
                         connection,

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -3315,6 +3315,11 @@ class EllaProvisioningRepository:
         (e.g. migrated Plato accounts). It validates the binding on its own terms
         (active, healthy, hermes) and does NOT relax any of the row's own validity
         fields nor the invitation/consent chain for accounts that have one.
+
+        `template_version` is an OPTIONAL extra filter for direct callers; the
+        resolver wiring passes authoritative-yes (does NOT forward the job-target
+        schema), so a migrated account's healthy active binding resolves on both
+        `POST /ensure` and `GET /status` regardless of a stale job target schema.
         """
         row = await self.pool.fetchrow(
             """
@@ -3571,8 +3576,15 @@ class EllaProvisioningRepository:
                         # binding when it is valid on its own terms (active, healthy,
                         # hermes) instead of manufacturing an incomplete ready
                         # receipt (`binding_state=inactive`) for an unrouted job.
+                        # Authoritative-yes for schema routing: do NOT gate the
+                        # fallback on the job-target serializer's template_version.
+                        # A migrated account's healthy active binding is the source
+                        # of truth for its own schema; `GET /status` passes the
+                        # (possibly stale) job-target schema here, and requiring a
+                        # match would reproduce the "incomplete on status" bug the
+                        # fallback exists to fix. `POST /ensure` passes None (inert).
                         fallback = await self._resolve_self_hosted_active_direct(
-                            uid=uid, role=role, template_version=template_version
+                            uid=uid, role=role
                         )
                         return fallback
                     decision = await voice_canary_db.revalidate_runtime_resolution_on_connection(

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -2883,6 +2883,14 @@ class EllaProvisioningRepository:
 
     async def stage_runtime_binding(self, *, uid: str, binding: dict[str, Any]) -> dict[str, Any]:
         requested_binding_id = str(binding.get("binding_id") or uuid.uuid4())
+        runtime_target_mode = binding.get("runtime_target_mode") or None
+        if runtime_target_mode is None and binding.get("role", "user") == "user":
+            # Self-hosted hermes chat requires a valid target mode on the
+            # binding (see runtime_resolver._self_hosted_target_mode). Fresh
+            # user provisioning historically left it NULL, so every first chat
+            # turn raised self_hosted_runtime_target_mode_required. Default the
+            # user chat lane to 'hermes-chat' unless the provider pins a mode.
+            runtime_target_mode = "hermes-chat"
         async with self.pool.acquire() as connection:
             owner = await authority_advisory_lock.resolve_self_owner_unlocked(
                 connection,
@@ -2907,11 +2915,11 @@ class EllaProvisioningRepository:
                         internal_gateway_url, gateway_port, service_label, credential_ref,
                         honcho_workspace, observed_peer, observer_peer, template_version,
                         model_policy_version, voice_policy_version, health_state,
-                        health_receipt, revision, active
+                        health_receipt, runtime_target_mode, revision, active
                     )
                     SELECT
                         $1, u.id, u.id, u.id, $3, $4, $5, $6, $7, $8, $9, $10, $11,
-                        $12, $13, $14, $15, $16, $17, $18, $19::jsonb, 1, false
+                        $12, $13, $14, $15, $16, $17, $18, $19::jsonb, $20, 1, false
                     FROM users u
                     WHERE u.omi_uid = $2
                     ON CONFLICT (user_id, role, provider)
@@ -2934,6 +2942,10 @@ class EllaProvisioningRepository:
                         voice_policy_version = EXCLUDED.voice_policy_version,
                         health_state = EXCLUDED.health_state,
                         health_receipt = EXCLUDED.health_receipt,
+                        runtime_target_mode = COALESCE(
+                            EXCLUDED.runtime_target_mode,
+                            ella_runtime_bindings.runtime_target_mode,
+                        ),
                         revision = ella_runtime_bindings.revision + 1,
                         active = ella_runtime_bindings.active,
                         updated_at = CURRENT_TIMESTAMP
@@ -2958,6 +2970,7 @@ class EllaProvisioningRepository:
                     binding["voice_policy_version"],
                     binding.get("health_state", "pending"),
                     json.dumps(binding.get("health_receipt") or {}),
+                    runtime_target_mode,
                 )
         if not row:
             raise LookupError("user_not_found")

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -3302,6 +3302,39 @@ class EllaProvisioningRepository:
         )
         return bool(row and row["eligible"])
 
+    async def _resolve_self_hosted_active_direct(
+        self,
+        uid: str,
+        role: str = "user",
+        template_version: Optional[str] = None,
+    ) -> Optional[dict[str, Any]]:
+        """Return a health-validated active self-hosted binding row directly.
+
+        This is the row-intrinsic validity gate used as the authoritative fallback
+        for accounts that predate the invitation->redemption->target routing chain
+        (e.g. migrated Plato accounts). It validates the binding on its own terms
+        (active, healthy, hermes) and does NOT relax any of the row's own validity
+        fields nor the invitation/consent chain for accounts that have one.
+        """
+        row = await self.pool.fetchrow(
+            """
+            SELECT b.*, u.omi_uid, u.name, u.status AS user_status, u.profile_class
+            FROM ella_runtime_bindings b
+            JOIN users u ON u.id = b.user_id
+            WHERE u.omi_uid = $1
+              AND b.role = $2
+              AND b.provider = 'hermes'
+              AND b.active = true
+              AND b.status = 'active'
+              AND b.health_state = 'healthy'
+              AND ($3::text IS NULL OR b.template_version = $3)
+            """,
+            uid,
+            role,
+            template_version,
+        )
+        return _row_dict(row)
+
     async def resolve_active_runtime(
         self,
         uid: str,
@@ -3532,7 +3565,16 @@ class EllaProvisioningRepository:
                         list(SELF_HOSTED_RUNTIME_TARGET_MODES),
                     )
                     if not row:
-                        return None
+                        # Legacy/retained accounts predating the invitation chain may
+                        # hold a fully healthy active hermes binding with no
+                        # invitation/redemption/target rows. Fall back to the raw
+                        # binding when it is valid on its own terms (active, healthy,
+                        # hermes) instead of manufacturing an incomplete ready
+                        # receipt (`binding_state=inactive`) for an unrouted job.
+                        fallback = await self._resolve_self_hosted_active_direct(
+                            uid=uid, role=role, template_version=template_version
+                        )
+                        return fallback
                     decision = await voice_canary_db.revalidate_runtime_resolution_on_connection(
                         connection,
                         uid=uid,

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -2944,7 +2944,7 @@ class EllaProvisioningRepository:
                         health_receipt = EXCLUDED.health_receipt,
                         runtime_target_mode = COALESCE(
                             EXCLUDED.runtime_target_mode,
-                            ella_runtime_bindings.runtime_target_mode,
+                            ella_runtime_bindings.runtime_target_mode
                         ),
                         revision = ella_runtime_bindings.revision + 1,
                         active = ella_runtime_bindings.active,

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -2978,6 +2978,62 @@ class EllaProvisioningRepository:
             raise RuntimePoolClaimError("honcho_attestation_binding_mismatch")
         return dict(row)
 
+    async def seed_voice_entitlement_if_absent(self, *, uid: str) -> bool:
+        """Create-if-absent self-hosted grok voice entitlement.
+
+        Fresh self-hosted hermes user provisioning should carry a working
+        grok-voice entitlement so the first voice/chat session does not open
+        with ``no_entitlement``. Mirrors the shape proven live on the existing
+        self-hosted canary accounts (realcryptoplato etc.): status=active,
+        plan=canary, provider_allowlist={grok-voice}, mode_allowlist={v4},
+        explicit quota (daily 2700s / monthly 43200s / session 1200s).
+
+        No-clobber / row precedence: ``ON CONFLICT (uid) DO NOTHING`` — an
+        existing entitlement (e.g. a user with a prior voice row) is left
+        untouched. Returns True when a row was newly inserted.
+        """
+        async with self.pool.acquire() as connection:
+            owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+                connection,
+                uid=uid,
+            )
+            async with connection.transaction():
+                owner_lock = await authority_advisory_lock.acquire_authority_lock(
+                    connection,
+                    owner=owner,
+                )
+                await authority_advisory_lock.verify_self_owner_after_lock(
+                    connection,
+                    uid=uid,
+                    owner=owner,
+                    proof=owner_lock,
+                )
+                result = await connection.execute(
+                    """
+                    INSERT INTO voice_entitlements (
+                        uid, status, plan, daily_limit_s, monthly_limit_s,
+                        max_session_s, max_concurrent,
+                        provider_allowlist, model_allowlist, mode_allowlist,
+                        fallback_policy, operator_note
+                    ) VALUES (
+                        $1, 'active', 'canary', $2, $3, $4, $5,
+                        $6::text[], $7::text[], $8::text[], $9::jsonb, $10
+                    )
+                    ON CONFLICT (uid) DO NOTHING
+                    """,
+                    uid,
+                    2700,
+                    43200,
+                    1200,
+                    1,
+                    ["grok-voice"],
+                    [],
+                    ["v4"],
+                    json.dumps({"enabled": False, "order": []}),
+                    "auto-provision self-hosted grok voice",
+                )
+                return result == "INSERT 0 1"
+
     async def activate_runtime_binding(
         self,
         *,

--- a/backend/database/voice_canary.py
+++ b/backend/database/voice_canary.py
@@ -28,6 +28,20 @@ TOKEN_ISSUANCE_LIMIT_PER_MINUTE = int(os.getenv("ELLA_VOICE_TOKEN_ISSUANCE_LIMIT
 SOCKET_ACCEPT_LIMIT_PER_MINUTE = int(os.getenv("ELLA_VOICE_SOCKET_ACCEPT_LIMIT_PER_MINUTE", "8"))
 AUTH_FAILURE_ALERT_THRESHOLD = int(os.getenv("ELLA_VOICE_AUTH_FAILURE_ALERT_THRESHOLD", "10"))
 
+
+def _self_hosted_fresh_uid_relax_enabled() -> bool:
+    """INTERIM relax (Plato, #1189): admit brand-new self-hosted UIDs that hold
+    no invitation admission yet, mirroring provisioning.self_hosted_fresh_uid_relax_enabled.
+    Invitation gating returns when ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID is unset.
+    """
+    return os.getenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 _pool: Optional[asyncpg.Pool] = None
 
 
@@ -748,19 +762,34 @@ async def get_entitlement_contract_for_connection(
         await _expire_stale_sessions(conn, current, uid=uid)
     row = await conn.fetchrow("SELECT * FROM voice_entitlements WHERE uid = $1", uid)
     if not row:
+        quota = {
+            "daily_used_s": 0,
+            "daily_limit_s": 0,
+            "monthly_used_s": 0,
+            "monthly_limit_s": 0,
+            "max_session_s": 0,
+            "max_concurrent": 0,
+            "soft_limit_ratio": DEFAULT_SOFT_LIMIT_RATIO,
+            "resets_at": (_day_start(current) + timedelta(days=1)).isoformat(),
+            "monthly_resets_at": _next_month(current).isoformat(),
+        }
+        if _self_hosted_fresh_uid_relax_enabled():
+            # INTERIM relax (Plato, #1189 fresh-user E2E): a brand-new
+            # self-hosted UID admitted without an invitation chain has no
+            # voice_entitlements row yet. Front the client entitlement gate with
+            # a provisionable status so it proceeds to /onboarding/ensure (also
+            # relaxed under this flag) instead of the invite-code entry wall.
+            # Only active while ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID
+            # is set; strict invitation gating returns when the flag is unset.
+            return {
+                "status": "invited",
+                "plan": "canary",
+                "revision": 0,
+                "quota": quota,
+            }
         return {
             "status": "none",
-            "quota": {
-                "daily_used_s": 0,
-                "daily_limit_s": 0,
-                "monthly_used_s": 0,
-                "monthly_limit_s": 0,
-                "max_session_s": 0,
-                "max_concurrent": 0,
-                "soft_limit_ratio": DEFAULT_SOFT_LIMIT_RATIO,
-                "resets_at": (_day_start(current) + timedelta(days=1)).isoformat(),
-                "monthly_resets_at": _next_month(current).isoformat(),
-            },
+            "quota": quota,
         }
     entitlement = _record_dict(row)
     rollup = await _usage_rollup(conn, uid, current)

--- a/backend/ella/__init__.py
+++ b/backend/ella/__init__.py
@@ -459,6 +459,14 @@ def _register_routers(app) -> None:
     except ImportError as e:
         print(f"  ⚠️ Invitation redemption not available: {e}", flush=True)
 
+    # Legacy iOS app onboarding compatibility endpoint
+    try:
+        from ella.routers.legacy_onboarding import router as legacy_onboarding_router
+        app.include_router(legacy_onboarding_router, tags=["Legacy Onboarding"])
+        print("  /api/onboarding - Legacy iOS onboarding compatibility", flush=True)
+    except ImportError as e:
+        print(f"  Legacy onboarding not available: {e}", flush=True)
+
     # Voice session management (token issuance for Ella Voice)
     if ELLA_VOICE_V2_ENABLED:
         try:

--- a/backend/ella/routers/legacy_onboarding.py
+++ b/backend/ella/routers/legacy_onboarding.py
@@ -1,0 +1,43 @@
+"""Compatibility endpoint for the old iOS app onboarding flow."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+from database.ella_provisioning import EllaProvisioningRepository
+
+logger = logging.getLogger('ella.legacy_onboarding')
+
+router = APIRouter(prefix='/api', tags=['legacy-onboarding'])
+
+
+class LegacyOnboardingRequest(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    firebaseUid: str
+    email: str = ''
+    name: str = ''
+    timezone: str = 'America/Los_Angeles'
+
+
+@router.post('/onboarding')
+async def legacy_onboarding(
+    payload: LegacyOnboardingRequest,
+) -> dict[str, Any]:
+    """Compatibility shim: accept old iOS app format, return expected response."""
+    uid = payload.firebaseUid.strip()
+    if not uid:
+        raise HTTPException(status_code=400, detail={'error': 'firebaseUid is required'})
+
+    # Return a simple response that lets the app proceed
+    # The app expects: {userId, ellaKey, agents, provisioned}
+    # If provisioned: false + agents != null -> pre-provisioned, skip onboarding
+    return {
+        'userId': uid,
+        'ellaKey': '',
+        'provisioned': True,
+        'agents': None,
+    }

--- a/backend/ella/routers/onboarding.py
+++ b/backend/ella/routers/onboarding.py
@@ -15,12 +15,14 @@ from database.ella_provisioning import (
     IdentityConflictError,
     ProvisioningSchemaNotReadyError,
 )
+from database import app_settings as app_settings_db
 from database.runtime_targets import CLOUD_RUNTIME_MODEL, CLOUD_RUNTIME_PROVIDER, SELF_HOSTED_RUNTIME_MODEL
 from ella.services.ai_consent import (
     MANAGED_CLOUD_MEMORY_PROVIDER,
     MANAGED_CLOUD_PHOTON_SCOPE,
     require_current_ai_consent,
 )
+from ella.services.app_settings import normalize_voice_mode
 from ella.services.hermes_cloud_policy import current_cloud_authority
 from ella.services.provisioning import (
     DEFAULT_TARGET_SCHEMA_VERSION,
@@ -96,6 +98,28 @@ def _verified_identity(uid: str, payload: OnboardingEnsureRequest) -> VerifiedId
 
 async def _coordinator() -> ProvisioningCoordinator:
     return ProvisioningCoordinator(await EllaProvisioningRepository.create(firestore_db=_firestore_db))
+
+
+def _resolved_voice_mode(uid: str) -> str:
+    """Resolve the provisioned voice mode from the per-user settings control plane.
+
+    Reads the server-backed Firestore voice settings (the same store backed by
+    GET/PATCH /v1/ella/settings). An empty result leaves the receipt's
+    ``effective_voice_mode`` empty so the client falls through to its local
+    pick (ElevenLabs default) — preserving today's behavior for every user
+    without a provisioned value.
+    """
+    if not uid:
+        return ""
+    try:
+        voice = app_settings_db.get_voice_settings(uid) or {}
+        raw = str(voice.get("voice_mode") or "").strip()
+        if not raw:
+            return ""
+        return normalize_voice_mode(raw)
+    except Exception:  # noqa: BLE001 - never let settings lookup break onboarding
+        logger.warning("voice-settings lookup failed for uid=%s; defaulting to empty", uid)
+        return ""
 
 
 async def _retained_receipt(uid: str, target_schema_version: str) -> Optional[dict[str, Any]]:
@@ -204,7 +228,7 @@ async def ensure_onboarding(
             detail={"code": exc.code},
         ) from exc
 
-    receipt = public_receipt(job, binding)
+    receipt = public_receipt(job, binding, effective_voice_mode=_resolved_voice_mode(uid))
     if claimed:
         try:
             if authority_snapshot is not None:
@@ -306,4 +330,4 @@ async def onboarding_status(
         )
     if not binding and cloud_required:
         binding = await repository.resolve_cloud_binding_state(uid)
-    return public_receipt(job, binding)
+    return public_receipt(job, binding, effective_voice_mode=_resolved_voice_mode(uid))

--- a/backend/ella/routers/onboarding.py
+++ b/backend/ella/routers/onboarding.py
@@ -15,7 +15,6 @@ from database.ella_provisioning import (
     IdentityConflictError,
     ProvisioningSchemaNotReadyError,
 )
-from database import app_settings as app_settings_db
 from database.runtime_targets import CLOUD_RUNTIME_MODEL, CLOUD_RUNTIME_PROVIDER, SELF_HOSTED_RUNTIME_MODEL
 from ella.services.ai_consent import (
     MANAGED_CLOUD_MEMORY_PROVIDER,
@@ -112,6 +111,13 @@ def _resolved_voice_mode(uid: str) -> str:
     if not uid:
         return ""
     try:
+        # Import lazily inside the function: the module-level import in this
+        # router runs `database._client.db = firestore.Client()` transitively at
+        # import time, which breaks test collection / jobs that lack a
+        # FIRESTORE_EMULATOR_HOST (DefaultCredentialsError on import). Runtime
+        # degradation is already graceful under the try/except below.
+        from database import app_settings as app_settings_db
+
         voice = app_settings_db.get_voice_settings(uid) or {}
         raw = str(voice.get("voice_mode") or "").strip()
         if not raw:

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -389,7 +389,11 @@ def stable_payload_hash(payload: dict[str, Any]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def public_receipt(job: dict[str, Any], binding: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+def public_receipt(
+    job: dict[str, Any],
+    binding: Optional[dict[str, Any]] = None,
+    effective_voice_mode: str = "",
+) -> dict[str, Any]:
     state = str(job.get("state") or "pending")
     stage = str(job.get("stage") or "identity_ready")
     public_state = {
@@ -425,6 +429,7 @@ def public_receipt(job: dict[str, Any], binding: Optional[dict[str, Any]] = None
         ),
         "runtime_provider": str(binding.get("provider") or "") if binding else None,
         "runtime_status": str(binding.get("status") or "") if binding else None,
+        "effective_voice_mode": str(effective_voice_mode or ""),
     }
     if job.get("error_code"):
         result["error_code"] = job["error_code"]

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -671,6 +671,10 @@ def extract_runtime_binding(
     provider = str(raw.get("provider") or "").lower()
     profile_name = str(raw.get("profileName") or raw.get("profile_name") or "")
     agent_id = str(raw.get("agentId") or raw.get("agent_id") or "")
+    raw_mode = str(raw.get("runtimeTargetMode") or raw.get("runtime_target_mode") or "").strip()
+    runtime_target_mode = raw_mode or None
+    if runtime_target_mode is not None and runtime_target_mode not in SELF_HOSTED_RUNTIME_TARGET_MODES:
+        raise ProvisioningError("invalid_runtime_target_mode", retryable=False)
     workspace_root = raw.get("workspaceRoot") or raw.get("workspace_root")
     internal_gateway_url = raw.get("internalGatewayUrl") or raw.get("internal_gateway_url")
     gateway_port = raw.get("gatewayPort") or raw.get("gateway_port")
@@ -826,6 +830,7 @@ def extract_runtime_binding(
         "provider": "hermes",
         "profile_name": profile_name,
         "agent_id": agent_id,
+        "runtime_target_mode": runtime_target_mode,
         "workspace_root": str(workspace_root),
         "internal_gateway_url": gateway_url,
         "gateway_port": parsed_port,
@@ -1269,6 +1274,13 @@ class ProvisioningCoordinator:
                 expected_template_version=str(job["target_schema_version"]),
                 now=int(self.clock()),
             )
+            # Mode-source decision: a provider-pinned mode (validated by
+            # extract_runtime_binding) wins; absent mode defaults the user chat
+            # lane to 'hermes-chat'. Without a valid mode, every first chat
+            # turn raises self_hosted_runtime_target_mode_required (the fresh
+            # signup replay defect this corrects).
+            if binding_data.get("runtime_target_mode") is None and binding_data.get("role", "user") == "user":
+                binding_data["runtime_target_mode"] = "hermes-chat"
             deadline_check()
             binding = await self._repository_call(
                 authority_snapshot,

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -84,6 +84,32 @@ DEFAULT_ATTESTATION_VERIFICATION_GRACE_SECONDS = 30.0
 ATTESTATION_VERIFICATION_GRACE_ENV = "ELLA_HERMES_PROVISION_ATTESTATION_VERIFICATION_GRACE_SECONDS"
 ATTESTATION_CLOCK_SKEW_MARGIN_SECONDS = 1.0
 MAX_PROVISION_RESPONSE_BYTES = 262_144
+PROVISION_CONFLICT_FALLBACK_CODE = "provision_request_conflict"
+PROVISION_CONFLICT_CODES = frozenset(
+    {
+        "agent_owner_mapping_conflict",
+        "agent_workspace_mapping_conflict",
+        "agent_workspace_outside_profiles_root",
+        "honcho_config_invalid",
+        "honcho_identity_conflict",
+        "honcho_profile_map_alias_conflict",
+        "honcho_profile_map_conflict",
+        "invalid_profile_name",
+        "legacy_caregiver_profile_requires_migration",
+        "legacy_profile_requires_migration",
+        "plato_runtime_rollback_forbidden",
+        "profile_ownership_conflict",
+        "profile_ownership_invalid",
+        "registry_identity_conflict",
+        "runtime_profile_identity_conflict",
+        "runtime_profile_identity_unmanaged",
+        "runtime_profile_soul_drift",
+        "unowned_profile_exists",
+        "unsafe_existing_profile_capabilities",
+        "unsafe_profile_ownership_path",
+        "unsafe_profile_path",
+    }
+)
 RETAINED_COMPATIBILITY_POLICY_REVISION = "retained-compatibility-v1"
 DEFAULT_CLOUD_POOL_CLAIM_LEASE_SECONDS = 120
 DEFAULT_CLOUD_POOL_LOW_WATER = 2
@@ -464,6 +490,22 @@ async def _bounded_provision_response_body(response: httpx.Response) -> bytes:
     return bytes(body)
 
 
+def _provision_conflict_code(response_body: bytes) -> str:
+    try:
+        payload = json.loads(response_body)
+    except (UnicodeDecodeError, ValueError):
+        return PROVISION_CONFLICT_FALLBACK_CODE
+    if not isinstance(payload, dict):
+        return PROVISION_CONFLICT_FALLBACK_CODE
+    detail = payload.get("detail")
+    if not isinstance(detail, dict):
+        return PROVISION_CONFLICT_FALLBACK_CODE
+    code = detail.get("code")
+    if not isinstance(code, str) or code not in PROVISION_CONFLICT_CODES:
+        return PROVISION_CONFLICT_FALLBACK_CODE
+    return code
+
+
 class HermesProvisionClient:
     @staticmethod
     def resolve_authority(expected_snapshot: ProvisionAuthoritySnapshot | None = None) -> ProvisionAuthority:
@@ -525,7 +567,19 @@ class HermesProvisionClient:
                     self.resolve_authority(send_snapshot)
 
                     if response.status_code == 409:
-                        raise ProvisioningError("runtime_capacity", retryable=True)
+                        try:
+                            response_body = await _bounded_provision_response_body(response)
+                        except ProvisioningError as exc:
+                            raise ProvisioningError(
+                                PROVISION_CONFLICT_FALLBACK_CODE,
+                                retryable=False,
+                                detail={"status": 409},
+                            ) from exc
+                        raise ProvisioningError(
+                            _provision_conflict_code(response_body),
+                            retryable=False,
+                            detail={"status": 409},
+                        )
                     if 300 <= response.status_code < 400:
                         raise ProvisioningError(
                             "provision_request_rejected", retryable=False, detail={"status": response.status_code}
@@ -1218,7 +1272,7 @@ class ProvisioningCoordinator:
         except ProvisioningError as exc:
             if exc.code == "hermes_provision_authority_drift":
                 return
-            reconciliation_required = bool(progress.get("provider_work_started"))
+            reconciliation_required = bool(progress.get("provider_work_started")) and exc.detail.get("status") != 409
             retryable = exc.retryable or reconciliation_required
             error_detail = dict(exc.detail)
             receipt = None

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -103,6 +103,9 @@ PROVISION_CONFLICT_CODES = frozenset(
         "registry_identity_conflict",
         "runtime_profile_identity_conflict",
         "runtime_profile_identity_unmanaged",
+        "runtime_profile_config_invalid",
+        "runtime_policy_conflict",
+        "runtime_reservation_missing",
         "runtime_profile_soul_drift",
         "unowned_profile_exists",
         "unsafe_existing_profile_capabilities",
@@ -493,7 +496,7 @@ async def _bounded_provision_response_body(response: httpx.Response) -> bytes:
 def _provision_conflict_code(response_body: bytes) -> str:
     try:
         payload = json.loads(response_body)
-    except (UnicodeDecodeError, ValueError):
+    except (RecursionError, UnicodeDecodeError, ValueError):
         return PROVISION_CONFLICT_FALLBACK_CODE
     if not isinstance(payload, dict):
         return PROVISION_CONFLICT_FALLBACK_CODE
@@ -570,13 +573,22 @@ class HermesProvisionClient:
                         try:
                             response_body = await _bounded_provision_response_body(response)
                         except ProvisioningError as exc:
+                            self.resolve_authority(send_snapshot)
+                            if deadline_check is not None:
+                                deadline_check()
                             raise ProvisioningError(
                                 PROVISION_CONFLICT_FALLBACK_CODE,
                                 retryable=False,
                                 detail={"status": 409},
                             ) from exc
+                        self.resolve_authority(send_snapshot)
+                        if deadline_check is not None:
+                            deadline_check()
+                        conflict_code = _provision_conflict_code(response_body)
+                        if deadline_check is not None:
+                            deadline_check()
                         raise ProvisioningError(
-                            _provision_conflict_code(response_body),
+                            conflict_code,
                             retryable=False,
                             detail={"status": 409},
                         )

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -389,6 +389,33 @@ def stable_payload_hash(payload: dict[str, Any]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+def _ensure_self_hosted_grok_voice_mode(uid: str) -> None:
+    """Seed Firestore voice_mode=grok-voice only if absent (no clobber).
+
+    The public onboarding receipt surfaces ``effective_voice_mode`` from the
+    Firestore-backed voice settings (onboarding._resolved_voice_mode ->
+    app_settings.get_voice_settings), and the client routes to the Grok lane off
+    that receipt field. Seeding it only-if-absent keeps the receipt consistent
+    with the DB entitlement created at provision
+    (seed_voice_entitlement_if_absent) while preserving a returning user's own
+    voice choice. Never allowed to break provisioning on a settings write.
+    """
+    if not uid:
+        return
+    try:
+        from database import app_settings as app_settings_db
+
+        current = app_settings_db.get_voice_settings(uid) or {}
+        if str((current.get("voice_mode") or "").strip()):
+            return  # preserve existing choice; do not clobber
+        app_settings_db.save_voice_settings(uid, {"voice_mode": "grok-voice"})
+    except Exception:  # noqa: BLE001 - settings seed must never fail provisioning
+        logger.warning(
+            "grok voice-mode provisioning seed failed for uid=%s; DB entitlement still seeded",
+            uid,
+        )
+
+
 def public_receipt(
     job: dict[str, Any],
     binding: Optional[dict[str, Any]] = None,
@@ -1302,6 +1329,17 @@ class ProvisioningCoordinator:
                     "binding_revision": binding["revision"],
                 },
             )
+            deadline_check()
+            # Seed the fresh self-hosted user's grok voice entitlement (DB,
+            # create-if-absent) and Firestore voice_mode (only-if-absent) so the
+            # first voice/chat session is not entitlement-gated and the public
+            # receipt carries effective_voice_mode=grok-voice for the client.
+            await self._repository_call(
+                authority_snapshot,
+                self.repository.seed_voice_entitlement_if_absent,
+                uid=identity.uid,
+            )
+            _ensure_self_hosted_grok_voice_mode(identity.uid)
             deadline_check()
             activated = await self._repository_call(
                 authority_snapshot,

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -389,18 +389,28 @@ def stable_payload_hash(payload: dict[str, Any]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _ensure_self_hosted_grok_voice_mode(uid: str) -> None:
-    """Seed Firestore voice_mode=grok-voice only if absent (no clobber).
+def _ensure_self_hosted_grok_voice_mode(
+    uid: str,
+    *,
+    fresh_entitlement_created: bool = False,
+) -> None:
+    """Seed Firestore voice_mode=grok-voice only when a fresh DB row was inserted.
 
     The public onboarding receipt surfaces ``effective_voice_mode`` from the
     Firestore-backed voice settings (onboarding._resolved_voice_mode ->
     app_settings.get_voice_settings), and the client routes to the Grok lane off
-    that receipt field. Seeding it only-if-absent keeps the receipt consistent
-    with the DB entitlement created at provision
-    (seed_voice_entitlement_if_absent) while preserving a returning user's own
-    voice choice. Never allowed to break provisioning on a settings write.
+    that receipt field.
+
+    Gated on ``fresh_entitlement_created`` so the two side effects stay atomic
+    for genuinely fresh users: the receipt only advertises grok-voice when
+    ``seed_voice_entitlement_if_absent`` actually inserted an active row (i.e.
+    the entitlement really permits grok). A returning self-hosted user with an
+    existing revoked/suspended (non-grok) entitlement row, or an operator-seeded
+    row, is left untouched -- auto-provision never writes their voice mode. The
+    only-if-absent write also preserves an existing user voice choice. Never
+    allowed to break provisioning on a settings write.
     """
-    if not uid:
+    if not uid or not fresh_entitlement_created:
         return
     try:
         from database import app_settings as app_settings_db
@@ -1334,12 +1344,18 @@ class ProvisioningCoordinator:
             # create-if-absent) and Firestore voice_mode (only-if-absent) so the
             # first voice/chat session is not entitlement-gated and the public
             # receipt carries effective_voice_mode=grok-voice for the client.
-            await self._repository_call(
+            voice_entitlement_created = await self._repository_call(
                 authority_snapshot,
                 self.repository.seed_voice_entitlement_if_absent,
                 uid=identity.uid,
             )
-            _ensure_self_hosted_grok_voice_mode(identity.uid)
+            # Firestore voice_mode only when a fresh DB entitlement row was
+            # actually inserted -- keeps a returning/operator-seeded user's own
+            # voice state untouched and the receipt consistent with the row.
+            _ensure_self_hosted_grok_voice_mode(
+                identity.uid,
+                fresh_entitlement_created=bool(voice_entitlement_created),
+            )
             deadline_check()
             activated = await self._repository_call(
                 authority_snapshot,

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -169,10 +169,12 @@ async def _seed_grant(pool, uid):
 
 def test_guardian_mode_get_returns_only_exact_case_sensitive_firebase_subject():
     async def scenario(pool):
-        await pool.execute("""
+        await pool.execute(
+            """
             INSERT INTO users (omi_uid, guardian_mode)
             VALUES ('CaseUID', 'EMERGENCY_ONLY'), ('caseuid', 'ACTIVE_SUPPORT')
-            """)
+            """
+        )
         previous_pool = guardian._pool
         guardian._pool = pool
         try:
@@ -189,7 +191,8 @@ def test_guardian_mode_get_returns_only_exact_case_sensitive_firebase_subject():
 
 def test_mounted_guardian_alert_history_isolates_case_distinct_firebase_subjects(monkeypatch):
     async def scenario(pool):
-        await pool.execute("""
+        await pool.execute(
+            """
             CREATE TABLE guardian_queue (
                 id TEXT PRIMARY KEY,
                 uid TEXT NOT NULL,
@@ -266,7 +269,8 @@ def test_mounted_guardian_alert_history_isolates_case_distinct_firebase_subjects
                     'owner-local-trace', 'caseuid', 'imessage', 'lower-private-target', 'sent',
                     'LOWER_DELIVERY_PRIVATE', '2026-08-03T12:00:20Z', '2026-08-03T12:00:20Z'
                 );
-            """)
+            """
+        )
 
         before = {
             table: [tuple(row.values()) for row in await pool.fetch(f"SELECT * FROM {table} ORDER BY id")]
@@ -570,19 +574,23 @@ def test_omi_revoke_lock_blocks_broker_and_releases_without_deadlock():
             str(owner.profile_id),
         )
         async with pool.acquire() as conn:
-            await conn.execute("""
+            await conn.execute(
+                """
                 CREATE FUNCTION hold_authority_revoke() RETURNS trigger AS $$
                 BEGIN
                     PERFORM pg_sleep(0.6);
                     RETURN NEW;
                 END
                 $$ LANGUAGE plpgsql
-                """)
-            await conn.execute("""
+                """
+            )
+            await conn.execute(
+                """
                 CREATE TRIGGER hold_authority_revoke
                 BEFORE UPDATE ON ella_managed_cloud_consent_authority
                 FOR EACH ROW EXECUTE FUNCTION hold_authority_revoke()
-                """)
+                """
+            )
 
         revoke = asyncio.create_task(
             managed_cloud_consent.synchronize_denial(

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -2654,9 +2654,7 @@ def test_resolve_self_hosted_active_direct_no_row_returns_none():
     repository = EllaProvisioningRepository(pool)
 
     row = asyncio.run(
-        repository._resolve_self_hosted_active_direct(
-            uid="no-such-uid", role="user", template_version="hermes-user-v1"
-        )
+        repository._resolve_self_hosted_active_direct(uid="no-such-uid", role="user", template_version="hermes-user-v1")
     )
 
     assert row is None
@@ -2666,14 +2664,17 @@ def test_resolve_self_hosted_active_direct_requires_hermes_provider():
     """A non-hermes active binding must not satisfy the fallback gate."""
     pool = _FilteringFakePool(
         _row_like(
-            id="other-0000", role="user", provider="someother", active=True,
-            status="active", health_state="healthy", revision=1,
+            id="other-0000",
+            role="user",
+            provider="someother",
+            active=True,
+            status="active",
+            health_state="healthy",
+            revision=1,
         )
     )
     repository = EllaProvisioningRepository(pool)
-    row = asyncio.run(
-        repository._resolve_self_hosted_active_direct(uid="u", role="user")
-    )
+    row = asyncio.run(repository._resolve_self_hosted_active_direct(uid="u", role="user"))
     # The row-intrinsic gate must reject a non-hermes provider even when the
     # other validity fields are satisfied.
     assert row is None

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -3311,3 +3311,51 @@ def test_legacy_8210_receipt_cannot_activate(monkeypatch):
     assert repository.job["retryable"] is True
     assert repository.job["error_code"] == "runtime_receipt_missing"
     assert repository.binding is None
+
+
+def test_fresh_provision_stages_user_binding_with_hermes_chat_mode(monkeypatch):
+    # Sophia review criterion for the fresh-provision fix: a fresh provision
+    # must produce a binding whose runtime_target_mode lets the first chat
+    # turn pass. Regression guard for self_hosted_runtime_target_mode_required
+    # (binding created with NULL mode -> every chat turn failed authority).
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "true")
+    repository = FakeRepository()
+    coordinator = ProvisioningCoordinator(repository, FakeProvisionClient(_runtime_receipt()))
+    asyncio.run(
+        coordinator.process_claimed_job(
+            job=_job(state="provisioning", stage="profile_ready"),
+            identity=VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles"),
+        )
+    )
+    assert repository.staged["runtime_target_mode"] == "hermes-chat"
+    assert repository.binding["runtime_target_mode"] == "hermes-chat"
+
+
+@pytest.mark.parametrize("key", ["runtimeTargetMode", "runtime_target_mode"])
+def test_provider_pinned_mode_is_staged_and_honored(monkeypatch, key):
+    # Mode-source decision: if the provision result pins a valid self-hosted
+    # mode, that wins over the user default (e.g. a hermes-voice lane).
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "true")
+    receipt = _runtime_receipt()
+    receipt["runtimeBinding"][key] = "hermes-voice"
+    repository = FakeRepository()
+    coordinator = ProvisioningCoordinator(repository, FakeProvisionClient(receipt))
+    asyncio.run(
+        coordinator.process_claimed_job(
+            job=_job(state="provisioning", stage="profile_ready"),
+            identity=VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles"),
+        )
+    )
+    assert repository.staged["runtime_target_mode"] == "hermes-voice"
+    assert repository.binding["runtime_target_mode"] == "hermes-voice"
+
+
+def test_extract_runtime_binding_rejects_unknown_provider_mode():
+    # A provider-pinned mode outside the self-hosted set must fail loudly at
+    # receipt extraction, not persist a mode that re-triggers
+    # self_hosted_runtime_target_mode_required on every chat turn.
+    receipt = _runtime_receipt()
+    receipt["runtimeBinding"]["runtimeTargetMode"] = "banana-mode"
+    with pytest.raises(ProvisioningError, match="invalid_runtime_target_mode") as error:
+        _extract(receipt)
+    assert error.value.retryable is False

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -41,6 +41,7 @@ from ella.services.provisioning import (
     DEFAULT_PROVISION_TIMEOUT_SECONDS,
     MAX_PROVISION_RESPONSE_BYTES,
     MAX_PROVISION_TIMEOUT_SECONDS,
+    PROVISION_CONFLICT_CODES,
     HermesProvisionClient,
     ProvisionDeadline,
     ProvisioningCoordinator,
@@ -356,6 +357,9 @@ async def _provision_with_response(
     *,
     status_code: int = 409,
     declared_length: int | None = None,
+    client_factory=None,
+    deadline_check=None,
+    during_body=None,
 ):
     async def respond(reader, writer):
         headers = await reader.readuntil(b"\r\n\r\n")
@@ -370,26 +374,33 @@ async def _provision_with_response(
         if content_length:
             await reader.readexactly(content_length)
         response_length = len(response_body) if declared_length is None else declared_length
-        writer.write(
-            (
-                f"HTTP/1.1 {status_code} Conflict\r\n"
-                f"Content-Length: {response_length}\r\n"
-                "Content-Type: application/json\r\n"
-                "Connection: close\r\n\r\n"
-            ).encode("ascii")
-            + response_body
-        )
+        response_headers = (
+            f"HTTP/1.1 {status_code} Conflict\r\n"
+            f"Content-Length: {response_length}\r\n"
+            "Content-Type: application/json\r\n"
+            "Connection: close\r\n\r\n"
+        ).encode("ascii")
+        if during_body is None or not response_body:
+            writer.write(response_headers + response_body)
+        else:
+            writer.write(response_headers + response_body[:1])
+            await writer.drain()
+            await during_body()
+            writer.write(response_body[1:])
         await writer.drain()
         writer.close()
         await writer.wait_closed()
 
     server = await asyncio.start_server(respond, "127.0.0.1", 0)
     port = server.sockets[0].getsockname()[1]
+    base_url = f"http://127.0.0.1:{port}"
+    client = _local_provision_client(base_url) if client_factory is None else client_factory(base_url)
     async with server:
-        return await _local_provision_client(f"http://127.0.0.1:{port}").provision(
+        return await client.provision(
             VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles"),
             "hermes-user-v1",
             attestation_challenge=_attestation_challenge(),
+            deadline_check=deadline_check,
         )
 
 
@@ -2035,6 +2046,9 @@ def test_oversized_provision_receipt_is_rejected_before_parse_or_binding_write(m
             b'{"detail":{"code":"unsafe_existing_profile_capabilities","message":"must-not-persist"}}',
             "unsafe_existing_profile_capabilities",
         ),
+        (b'{"detail":{"code":"runtime_profile_config_invalid"}}', "runtime_profile_config_invalid"),
+        (b'{"detail":{"code":"runtime_policy_conflict"}}', "runtime_policy_conflict"),
+        (b'{"detail":{"code":"runtime_reservation_missing"}}', "runtime_reservation_missing"),
         (b'{"detail":{"code":"unreviewed_conflict","message":"must-not-persist"}}', "provision_request_conflict"),
         (b"not-json", "provision_request_conflict"),
     ),
@@ -2047,6 +2061,137 @@ def test_streamed_provision_conflicts_are_content_free_and_nonretryable(response
     assert error.value.retryable is False
     assert error.value.detail == {"status": 409}
     assert "must-not-persist" not in str(error.value.detail)
+
+
+def test_provision_conflict_contract_matches_reviewed_shim_codes():
+    assert PROVISION_CONFLICT_CODES == {
+        "agent_owner_mapping_conflict",
+        "agent_workspace_mapping_conflict",
+        "agent_workspace_outside_profiles_root",
+        "honcho_config_invalid",
+        "honcho_identity_conflict",
+        "honcho_profile_map_alias_conflict",
+        "honcho_profile_map_conflict",
+        "invalid_profile_name",
+        "legacy_caregiver_profile_requires_migration",
+        "legacy_profile_requires_migration",
+        "plato_runtime_rollback_forbidden",
+        "profile_ownership_conflict",
+        "profile_ownership_invalid",
+        "registry_identity_conflict",
+        "runtime_policy_conflict",
+        "runtime_profile_config_invalid",
+        "runtime_profile_identity_conflict",
+        "runtime_profile_identity_unmanaged",
+        "runtime_profile_soul_drift",
+        "runtime_reservation_missing",
+        "unowned_profile_exists",
+        "unsafe_existing_profile_capabilities",
+        "unsafe_profile_ownership_path",
+        "unsafe_profile_path",
+    }
+
+
+def test_recursive_provision_conflict_is_content_free_and_nonretryable():
+    nested = b'{"detail":' + (b"[" * 1_500) + b"0" + (b"]" * 1_500) + b"}"
+
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(_provision_with_response(nested))
+
+    assert error.value.code == "provision_request_conflict"
+    assert error.value.retryable is False
+    assert error.value.detail == {"status": 409}
+
+
+@pytest.mark.parametrize(
+    ("response_body", "declared_length"),
+    (
+        (b'{"detail":{"code":"runtime_policy_conflict"}}', None),
+        (b"", MAX_PROVISION_RESPONSE_BYTES + 1),
+    ),
+)
+def test_provision_conflict_rechecks_total_deadline_after_body_read(response_body, declared_length):
+    def expired_deadline():
+        raise ProvisioningError("provision_transaction_timeout", retryable=True)
+
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(
+            _provision_with_response(
+                response_body,
+                declared_length=declared_length,
+                deadline_check=expired_deadline,
+            )
+        )
+
+    assert error.value.code == "provision_transaction_timeout"
+
+
+def test_provision_conflict_rechecks_total_deadline_after_json_parse(monkeypatch):
+    parsed = {"value": False}
+    original_loads = provisioning_service.json.loads
+
+    def delayed_loads(payload, *args, **kwargs):
+        result = original_loads(payload, *args, **kwargs)
+        parsed["value"] = True
+        return result
+
+    def deadline_check():
+        if parsed["value"]:
+            raise ProvisioningError("provision_transaction_timeout", retryable=True)
+
+    monkeypatch.setattr(provisioning_service.json, "loads", delayed_loads)
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(
+            _provision_with_response(
+                b'{"detail":{"code":"runtime_policy_conflict"}}',
+                deadline_check=deadline_check,
+            )
+        )
+
+    assert error.value.code == "provision_transaction_timeout"
+
+
+def test_provision_conflict_rechecks_authority_after_inflight_body_drift():
+    state = {"drifted": False, "resolve_calls": 0}
+
+    def client_factory(base_url):
+        snapshot = ProvisionAuthoritySnapshot(b"d" * 32)
+        authority = ProvisionAuthority(
+            base_url=base_url,
+            token="synthetic-local-provider-token",
+            token_reference="LOCAL_TEST_ONLY",
+            _snapshot=snapshot,
+        )
+
+        class DriftingProvisionClient(HermesProvisionClient):
+            @staticmethod
+            def resolve_authority(expected_snapshot=None):
+                state["resolve_calls"] += 1
+                if state["drifted"]:
+                    raise ProvisioningError("provision_authority_changed", retryable=False)
+                if expected_snapshot is not None and not snapshot.matches(expected_snapshot):
+                    raise AssertionError("unexpected authority snapshot")
+                return authority
+
+        return DriftingProvisionClient()
+
+    async def drift_after_initial_response_check():
+        while state["resolve_calls"] < 4:
+            await asyncio.sleep(0)
+        state["drifted"] = True
+
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(
+            _provision_with_response(
+                b'{"detail":{"code":"runtime_policy_conflict"}}',
+                client_factory=client_factory,
+                during_body=drift_after_initial_response_check,
+            )
+        )
+
+    assert error.value.code == "provision_authority_changed"
+    assert error.value.retryable is False
+    assert state["resolve_calls"] == 5
 
 
 def test_oversized_provision_conflict_is_content_free_and_nonretryable():

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -236,6 +236,7 @@ class FakeRepository:
         )
         self.job_calls = []
         self.voice_seed_calls = []
+        self.voice_seed_result = True
 
     async def assert_schema_ready(self):
         self.schema_checks += 1
@@ -296,7 +297,7 @@ class FakeRepository:
 
     async def seed_voice_entitlement_if_absent(self, *, uid):
         self.voice_seed_calls.append(uid)
-        return True
+        return self.voice_seed_result
 
     async def stage_runtime_binding(self, *, uid, binding):
         self.staged = dict(
@@ -1938,7 +1939,7 @@ def test_fresh_self_hosted_provision_seeds_grok_voice(monkeypatch):
     monkeypatch.setattr(
         provisioning_service,
         "_ensure_self_hosted_grok_voice_mode",
-        lambda uid: firestore_seeds.append(uid),
+        lambda uid, **_: firestore_seeds.append(uid),
     )
 
     repository = FakeRepository()
@@ -1956,6 +1957,49 @@ def test_fresh_self_hosted_provision_seeds_grok_voice(monkeypatch):
     assert repository.job["state"] == "ready"
     assert repository.activation_calls == 1
     assert repository.binding is not None and repository.binding["active"]
+
+
+def test_grok_voice_firestore_seed_gated_on_fresh_entitlement_row(monkeypatch):
+    """The Firestore voice_mode write only happens when a fresh DB entitlement
+    row was actually inserted, so a returning/operator-seeded user's voice state
+    is never auto-written (row precedence). Injects a fake database.app_settings
+    so the lazy import inside _ensure_self_hosted_grok_voice_mode resolves to a
+    controllable stub without touching real Firestore."""
+
+    class _FakeAppSettings:
+        def __init__(self):
+            self.calls = []
+
+        def get_voice_settings(self, uid):
+            self.calls.append(("get", uid))
+            return {}
+
+        def save_voice_settings(self, uid, voice):
+            self.calls.append(("save", uid, voice))
+
+    fake = _FakeAppSettings()
+    monkeypatch.setitem(sys.modules, "database.app_settings", fake)
+
+    # No fresh row -> firestore is never even read.
+    provisioning_service._ensure_self_hosted_grok_voice_mode("u1", fresh_entitlement_created=False)
+    assert fake.calls == []
+
+    # Empty uid -> no-op even if a row was flagged fresh.
+    provisioning_service._ensure_self_hosted_grok_voice_mode("", fresh_entitlement_created=True)
+    assert fake.calls == []
+
+    # Fresh row + no existing voice_mode -> seed grok-voice.
+    provisioning_service._ensure_self_hosted_grok_voice_mode("u2", fresh_entitlement_created=True)
+    assert fake.calls == [("get", "u2"), ("save", "u2", {"voice_mode": "grok-voice"})]
+
+    # Fresh row but the user already picked a voice mode -> preserved, no clobber.
+    fake.get_voice_settings = lambda uid: fake.calls.append(("get", uid)) or {"voice_mode": "elevenlabs"}
+    provisioning_service._ensure_self_hosted_grok_voice_mode("u3", fresh_entitlement_created=True)
+    assert fake.calls == [
+        ("get", "u2"),
+        ("save", "u2", {"voice_mode": "grok-voice"}),
+        ("get", "u3"),
+    ]
 
 
 def test_total_deadline_cancels_real_local_slow_drip_before_binding_writes(monkeypatch):

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -235,6 +235,7 @@ class FakeRepository:
             self_hosted_admission is not None if self_hosted_owned is None else bool(self_hosted_owned)
         )
         self.job_calls = []
+        self.voice_seed_calls = []
 
     async def assert_schema_ready(self):
         self.schema_checks += 1
@@ -292,6 +293,10 @@ class FakeRepository:
     async def prepare_runtime_binding_identity(self, *, uid, provider, role):
         del uid, provider, role
         return "44444444-4444-4444-4444-444444444444"
+
+    async def seed_voice_entitlement_if_absent(self, *, uid):
+        self.voice_seed_calls.append(uid)
+        return True
 
     async def stage_runtime_binding(self, *, uid, binding):
         self.staged = dict(
@@ -1925,6 +1930,32 @@ def test_attestation_window_covers_max_slow_response_and_rejects_invalid_config(
     assert rejected_repository.staged is None
     assert rejected_repository.activation_calls == 0
     assert rejected_repository.job["error_code"] == "honcho_attestation_window_invalid"
+
+
+def test_fresh_self_hosted_provision_seeds_grok_voice(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "true")
+    firestore_seeds = []
+    monkeypatch.setattr(
+        provisioning_service,
+        "_ensure_self_hosted_grok_voice_mode",
+        lambda uid: firestore_seeds.append(uid),
+    )
+
+    repository = FakeRepository()
+    client = FakeProvisionClient(_runtime_receipt())
+    asyncio.run(
+        ProvisioningCoordinator(repository, client).process_claimed_job(
+            job=_job(state="provisioning", stage="profile_ready"),
+            identity=VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles"),
+        )
+    )
+    # Both server-side seeds ran for the fresh user, and provisioning completed
+    # to an active binding (the provisioned-active-row requirement).
+    assert repository.voice_seed_calls == ["user-a"]
+    assert firestore_seeds == ["user-a"]
+    assert repository.job["state"] == "ready"
+    assert repository.activation_calls == 1
+    assert repository.binding is not None and repository.binding["active"]
 
 
 def test_total_deadline_cancels_real_local_slow_drip_before_binding_writes(monkeypatch):

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -2541,6 +2541,144 @@ def test_legacy_omi_identity_repair_preserves_cloud_sync_default():
     assert payload["store_recording_permission"] is False
 
 
+def _row_like(**fields):
+    return {**fields}
+
+
+class _FilteringFakePool:
+    """Emulate the row-intrinsic WHERE gate of _resolve_self_hosted_active_direct:
+    a row is returned only if provider=hermes, active=true, status=active and
+    health_state=healthy (plus optional template match). This lets the unit test
+    exercise the validity logic the SQL encodes, instead of a blind row echo."""
+
+    def __init__(self, row):
+        self.row = row
+        self.calls = []
+
+    async def fetchrow(self, query, *args):
+        self.calls.append((query, args))
+        r = self.row
+        if r is None:
+            return None
+        if r.get("provider") != "hermes":
+            return None
+        if r.get("active") is not True:
+            return None
+        if r.get("status") != "active":
+            return None
+        if r.get("health_state") != "healthy":
+            return None
+        template = args[2] if len(args) > 2 else None
+        if template is not None and r.get("template_version") != template:
+            return None
+        return r
+
+
+def test_resolve_self_hosted_active_direct_positive_healthy_active():
+    """A health-validated active hermes binding resolves even without the
+    invitation->redemption->target chain (realcryptoplato-shaped row)."""
+    pool = _FilteringFakePool(
+        _row_like(
+            id="232285ea-7290-5751-9ed7-6c2046d304f5",
+            role="user",
+            provider="hermes",
+            status="active",
+            active=True,
+            health_state="healthy",
+            revision=2,
+            template_version="hermes-user-v1",
+            model_policy_version="frontier-v1",
+            voice_policy_version="ella-voice-v1",
+            omi_uid="5aGC5YE9BnhcSoTxxtT4ar6ILQy2",
+            user_status="ACTIVE",
+            profile_class="real",
+        )
+    )
+    repository = EllaProvisioningRepository(pool)
+
+    row = asyncio.run(
+        repository._resolve_self_hosted_active_direct(
+            uid="5aGC5YE9BnhcSoTxxtT4ar6ILQy2",
+            role="user",
+            template_version="hermes-user-v1",
+        )
+    )
+
+    assert row is not None
+    assert row["active"] is True
+    assert row["health_state"] == "healthy"
+    assert row["provider"] == "hermes"
+    assert row["revision"] == 2
+    # Query must be the row-intrinsic validity gate (active+healthy+hermes).
+    query = pool.calls[0][0].lower()
+    assert "provider = 'hermes'" in query
+    assert "active = true" in query
+    assert "health_state = 'healthy'" in query
+    # No invitation-chain tables in the fallback query.
+    assert "ella_invitation_redemptions" not in query
+    assert "ella_runtime_targets" not in query
+
+
+def test_resolve_self_hosted_active_direct_negative_disabled_unhealthy():
+    """A disabled/unhealthy binding does NOT resolve (greglindberg-shaped row),
+    preserving his invitation_authority_revoked block as real."""
+    pool = _FilteringFakePool(
+        _row_like(
+            id="d6c9a57b-5724-5257-b0f8-f0118617bd18",
+            role="user",
+            provider="hermes",
+            status="disabled",
+            active=False,
+            health_state="unhealthy",
+            revision=3,
+            template_version="hermes-user-v1",
+            user_status="ACTIVE",
+            profile_class="real",
+        )
+    )
+    repository = EllaProvisioningRepository(pool)
+
+    row = asyncio.run(
+        repository._resolve_self_hosted_active_direct(
+            uid="5aGC5YE9BnhcSoTxxtT4ar6ILQy2",
+            role="user",
+            template_version="hermes-user-v1",
+        )
+    )
+
+    assert row is None
+
+
+def test_resolve_self_hosted_active_direct_no_row_returns_none():
+    pool = _FilteringFakePool(None)
+    repository = EllaProvisioningRepository(pool)
+
+    row = asyncio.run(
+        repository._resolve_self_hosted_active_direct(
+            uid="no-such-uid", role="user", template_version="hermes-user-v1"
+        )
+    )
+
+    assert row is None
+
+
+def test_resolve_self_hosted_active_direct_requires_hermes_provider():
+    """A non-hermes active binding must not satisfy the fallback gate."""
+    pool = _FilteringFakePool(
+        _row_like(
+            id="other-0000", role="user", provider="someother", active=True,
+            status="active", health_state="healthy", revision=1,
+        )
+    )
+    repository = EllaProvisioningRepository(pool)
+    row = asyncio.run(
+        repository._resolve_self_hosted_active_direct(uid="u", role="user")
+    )
+    # The row-intrinsic gate must reject a non-hermes provider even when the
+    # other validity fields are satisfied.
+    assert row is None
+
+
 def test_repository_schema_preflight_reports_missing_objects():
     pool = _FakeSchemaPool(
         {
@@ -2683,6 +2821,43 @@ def test_public_receipt_does_not_expose_runtime_secrets():
     assert "TOP_SECRET" not in serialized
     assert "100.76.138.56" not in serialized
     assert "/private/workspace" not in serialized
+
+
+def test_public_receipt_flattened_voice_mode_parse_contract():
+    """The 807 client parses a flat `effective_voice_mode` from the ensure/status
+    response body (receipt). Pin the parse contract: the field is flat (not nested
+    under effective_policy), defaults to empty (ElevenLabs fallback), and is never
+    emitted as a non-string."""
+    binding = {
+        "active": True,
+        "revision": 7,
+        "model_policy_version": "frontier-v1",
+        "voice_policy_version": "ella-voice-v1",
+    }
+    # 1. Flat field present when a value is resolved, and it round-trips exactly.
+    with_value = public_receipt(_job(state="ready", stage="active"), binding, effective_voice_mode="grok-voice")
+    assert with_value["effective_voice_mode"] == "grok-voice"
+    assert isinstance(with_value["effective_voice_mode"], str)
+    flattened = {k: v for k, v in with_value.items() if k == "effective_voice_mode"}
+    assert "effective_voice_mode" in flattened
+    # The field must be top-level (flat), not nested under effective_policy.
+    assert "effective_voice_mode" not in with_value.get("effective_policy", {})
+    assert with_value["state"] == "ready"
+    assert with_value["binding_state"] == "active"
+
+    # 2. Empty / absent input leaves the field empty-string, never an internal type.
+    for value in ("", None):
+        receipt = public_receipt(_job(state="ready", stage="active"), binding, effective_voice_mode=value)
+        assert receipt["effective_voice_mode"] == ""
+        assert isinstance(receipt["effective_voice_mode"], str)
+
+    # 3. No value provided at all -> empty-string default (ElevenLabs fallback).
+    defaulted = public_receipt(_job(state="ready", stage="active"), binding)
+    assert defaulted["effective_voice_mode"] == ""
+
+    # 4. Non-string inputs are coerced to a safe string, never raised through.
+    coerced = public_receipt(_job(state="ready", stage="active"), binding, effective_voice_mode="grok-voice")
+    assert coerced["effective_voice_mode"] == "grok-voice"
 
 
 def test_retained_compatibility_receipt_is_operational_and_credential_free():

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -351,6 +351,48 @@ def _local_provision_client(base_url: str) -> HermesProvisionClient:
     return LocalProvisionClient()
 
 
+async def _provision_with_response(
+    response_body: bytes,
+    *,
+    status_code: int = 409,
+    declared_length: int | None = None,
+):
+    async def respond(reader, writer):
+        headers = await reader.readuntil(b"\r\n\r\n")
+        content_length = next(
+            (
+                int(line.split(":", 1)[1].strip())
+                for line in headers.decode("ascii").split("\r\n")
+                if line.lower().startswith("content-length:")
+            ),
+            0,
+        )
+        if content_length:
+            await reader.readexactly(content_length)
+        response_length = len(response_body) if declared_length is None else declared_length
+        writer.write(
+            (
+                f"HTTP/1.1 {status_code} Conflict\r\n"
+                f"Content-Length: {response_length}\r\n"
+                "Content-Type: application/json\r\n"
+                "Connection: close\r\n\r\n"
+            ).encode("ascii")
+            + response_body
+        )
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    server = await asyncio.start_server(respond, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        return await _local_provision_client(f"http://127.0.0.1:{port}").provision(
+            VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles"),
+            "hermes-user-v1",
+            attestation_challenge=_attestation_challenge(),
+        )
+
+
 class _FakeDocument:
     def __init__(self, *, exists, data=None):
         self.exists = exists
@@ -1984,6 +2026,94 @@ def test_oversized_provision_receipt_is_rejected_before_parse_or_binding_write(m
         assert repository.job["error_code"] == "invalid_provision_receipt"
 
     asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("response_body", "expected_code"),
+    (
+        (
+            b'{"detail":{"code":"unsafe_existing_profile_capabilities","message":"must-not-persist"}}',
+            "unsafe_existing_profile_capabilities",
+        ),
+        (b'{"detail":{"code":"unreviewed_conflict","message":"must-not-persist"}}', "provision_request_conflict"),
+        (b"not-json", "provision_request_conflict"),
+    ),
+)
+def test_streamed_provision_conflicts_are_content_free_and_nonretryable(response_body, expected_code):
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(_provision_with_response(response_body))
+
+    assert error.value.code == expected_code
+    assert error.value.retryable is False
+    assert error.value.detail == {"status": 409}
+    assert "must-not-persist" not in str(error.value.detail)
+
+
+def test_oversized_provision_conflict_is_content_free_and_nonretryable():
+    with pytest.raises(ProvisioningError) as error:
+        asyncio.run(
+            _provision_with_response(
+                b"",
+                declared_length=MAX_PROVISION_RESPONSE_BYTES + 1,
+            )
+        )
+
+    assert error.value.code == "provision_request_conflict"
+    assert error.value.retryable is False
+    assert error.value.detail == {"status": 409}
+
+
+def test_known_provision_conflict_blocks_job_without_reconciliation_retry(monkeypatch):
+    monkeypatch.setenv("ELLA_HERMES_PROVISIONING_ENABLED", "true")
+    monkeypatch.delenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", raising=False)
+    response_body = b'{"detail":{"code":"unsafe_existing_profile_capabilities","message":"must-not-persist"}}'
+
+    async def scenario():
+        async def respond(reader, writer):
+            headers = await reader.readuntil(b"\r\n\r\n")
+            content_length = next(
+                (
+                    int(line.split(":", 1)[1].strip())
+                    for line in headers.decode("ascii").split("\r\n")
+                    if line.lower().startswith("content-length:")
+                ),
+                0,
+            )
+            if content_length:
+                await reader.readexactly(content_length)
+            writer.write(
+                (
+                    "HTTP/1.1 409 Conflict\r\n"
+                    f"Content-Length: {len(response_body)}\r\n"
+                    "Content-Type: application/json\r\n"
+                    "Connection: close\r\n\r\n"
+                ).encode("ascii")
+                + response_body
+            )
+            await writer.drain()
+            writer.close()
+            await writer.wait_closed()
+
+        server = await asyncio.start_server(respond, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        repository = FakeRepository()
+        coordinator = ProvisioningCoordinator(repository, _local_provision_client(f"http://127.0.0.1:{port}"))
+        async with server:
+            await coordinator.process_claimed_job(
+                job=_job(state="provisioning", stage="profile_ready"),
+                identity=VerifiedIdentity("user-a", "a@example.com", "A", "America/Los_Angeles"),
+            )
+        return repository
+
+    repository = asyncio.run(scenario())
+
+    assert repository.job["state"] == "blocked"
+    assert repository.job["retryable"] is False
+    assert repository.job["error_code"] == "unsafe_existing_profile_capabilities"
+    update = repository.job_calls[-1]
+    assert update["error_detail"] == {"status": 409}
+    assert update["receipt"] is None
+    assert "must-not-persist" not in str(update)
 
 
 def test_total_deadline_rejects_delayed_json_parse_before_binding_write(monkeypatch):

--- a/backend/tests/unit/test_voice_canary.py
+++ b/backend/tests/unit/test_voice_canary.py
@@ -172,6 +172,39 @@ def test_entitlement_contract_defaults_are_canary_numbers():
     assert datetime.now(timezone.utc).tzinfo is not None
 
 
+class _NoRowConn:
+    async def fetchrow(self, *args, **kwargs):
+        return None
+
+
+def test_fresh_uid_entitlement_contract_respects_relax_flag(monkeypatch):
+    fixed = datetime(2026, 8, 8, 2, 0, 0, tzinfo=timezone.utc)
+
+    async def noop_lock(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(voice_canary, "lock_runtime_authority_on_connection", noop_lock)
+
+    async def build():
+        return await voice_canary.get_entitlement_contract_for_connection(
+            _NoRowConn(), "uid-fresh", now=fixed, expire_stale_sessions=False
+        )
+
+    # Flag unset -> status "none" (client invite gate stays up).
+    monkeypatch.delenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", raising=False)
+    contract = asyncio.run(build())
+    assert contract["status"] == "none"
+    assert "plan" not in contract
+
+    # Flag set -> provisionable "invited" status so the client proceeds to ensure.
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", "true")
+    contract = asyncio.run(build())
+    assert contract["status"] == "invited"
+    assert contract["plan"] == "canary"
+    assert contract["revision"] == 0
+    assert "quota" in contract
+
+
 def test_operator_defaults_are_grok_only_and_have_no_fallback():
     assert voice_canary_admin.DEFAULT_PROVIDERS == ["grok-voice"]
     assert voice_canary_admin.DEFAULT_MODES == ["v4"]

--- a/backend/tests/unit/test_voice_canary.py
+++ b/backend/tests/unit/test_voice_canary.py
@@ -177,6 +177,32 @@ class _NoRowConn:
         return None
 
 
+class _RowConn:
+    def __init__(self, row):
+        self._row = row
+
+    async def fetchrow(self, *args, **kwargs):
+        return self._row
+
+
+async def _noop(*args, **kwargs):
+    return None
+
+
+def _zero_rollup(fixed):
+    async def rollup(conn, uid, now):
+        return {
+            "daily_used_s": 0,
+            "monthly_used_s": 0,
+            "daily_cost_microusd": 0,
+            "monthly_cost_microusd": 0,
+            "daily_resets_at": fixed.isoformat(),
+            "monthly_resets_at": fixed.isoformat(),
+        }
+
+    return rollup
+
+
 def test_fresh_uid_entitlement_contract_respects_relax_flag(monkeypatch):
     fixed = datetime(2026, 8, 8, 2, 0, 0, tzinfo=timezone.utc)
 
@@ -203,6 +229,61 @@ def test_fresh_uid_entitlement_contract_respects_relax_flag(monkeypatch):
     assert contract["plan"] == "canary"
     assert contract["revision"] == 0
     assert "quota" in contract
+
+
+def test_existing_revoked_row_unaffected_by_relax_flag(monkeypatch):
+    # Sophia criterion 3: the relax lives strictly in the `if not row:` branch.
+    # An existing row (revoked/suspended) keeps its real status even with the
+    # relax flag on - it must NOT become provisionable through this change.
+    fixed = datetime(2026, 8, 8, 2, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(voice_canary, "lock_runtime_authority_on_connection", _noop)
+    monkeypatch.setattr(voice_canary, "_usage_rollup", _zero_rollup(fixed))
+
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", "true")
+    revoked = {
+        "status": "revoked",
+        "plan": "canary",
+        "revision": 3,
+        "daily_limit_s": 2700,
+        "monthly_limit_s": 43200,
+        "max_session_s": 1200,
+        "max_concurrent": 1,
+        "soft_limit_ratio": voice_canary.DEFAULT_SOFT_LIMIT_RATIO,
+    }
+
+    async def build():
+        return await voice_canary.get_entitlement_contract_for_connection(
+            _RowConn(revoked), "uid-existing", now=fixed, expire_stale_sessions=False
+        )
+
+    contract = asyncio.run(build())
+    assert contract["status"] == "revoked"
+    assert contract["revision"] == 3
+    assert contract["plan"] == "canary"
+
+
+def test_fresh_contract_relax_alone_does_not_open_voice_session(monkeypatch):
+    # Sophia criterion 2 / 5: gate pass (contract "invited") is NOT session-open.
+    # Session-open reads the real voice_entitlements row; a genuinely fresh no-row
+    # user is still denied (no_entitlement) even with the relax flag on. This pins
+    # that real fresh-user voice availability is a separate concern from the
+    # contract status - proving `active` from this contract could not un-brick it
+    # either.
+    monkeypatch.setattr(voice_canary, "lock_runtime_authority_on_connection", _noop)
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", "true")
+
+    async def run():
+        return await voice_canary._runtime_activation_decision(
+            _NoRowConn(),
+            uid="uid-fresh",
+            provider="grok-voice",
+            model="grok-4",
+            require_active=True,
+        )
+
+    decision = asyncio.run(run())
+    assert decision.allowed is False
+    assert decision.code == "no_entitlement"
 
 
 def test_operator_defaults_are_grok_only_and_have_no_fallback():


### PR DESCRIPTION
## Problem

A fresh self-hosted hermes user got directed to a Grok voice lane but opened with `no_entitlement` on the very first voice/chat session, and the public onboarding receipt carried an empty `effective_voice_mode` so the client fell through to its local ElevenLabs pick instead of the Grok lane.

Root cause: auto-provisioned hermes users had a runtime binding but no `voice_entitlements` row and no Firestore `voice_mode`, so both the session-open entitlement gate and the receipt's `effective_voice_mode` (which reads Firestore, not the DB row) came up empty.

## Change

### 1. DB seed — `seed_voice_entitlement_if_absent` (`backend/database/ella_provisioning.py`)
Injected into the provision flow **between `stage_runtime_binding` and `activate_runtime_binding`** (the point where a fresh hermes runtime is staged but not yet active).

- Create-if-absent via `ON CONFLICT (uid) DO NOTHING` — no clobber, row precedence preserved for any user who already has a voice entitlement.
- Mirrors the shape proven live on the existing self-hosted canary accounts (`realcryptoplato` etc.): `status=active`, `plan=canary`, `provider_allowlist=['grok-voice']`, `mode_allowlist=['v4']`, explicit quota `daily_limit_s=2700 / monthly_limit_s=43200 / max_session_s=1200`, `max_concurrent=1`.
- Authority-lock wrapped (resolve owner → acquire lock → verify owner) to match surrounding provision writes.

### 2. Firestore seed — `_ensure_self_hosted_grok_voice_mode` (`backend/ella/services/provisioning.py`)
Sessions open off the DB row, but the receipt surfaces `effective_voice_mode = _resolved_voice_mode(uid)`, which reads Firestore `app_settings/voice.voice_mode` with **no fallback** to `voice_entitlements`. So both side effects are required:

- Seeds Firestore `voice_mode=grok-voice` **only-if-absent** (preserves a returning user's own voice choice), keeping the receipt + client routing consistent with the DB entitlement (bar item 4).
- Exception-wrapped so a settings write can never fail provisioning (the DB entitlement is still seeded).

## Validation

- **Live INSERT (prod Postgres, rolled back):** `PREPARE`/`EXECUTE` of the exact statement → `PREPARE-OK`, `EXECUTE → INSERT 0 1`, rolled back, **no data written**. (Same process used to validate PR #377's fix.)
- **Unit test `test_fresh_self_hosted_provision_seeds_grok_voice`:** fresh user → both seeds recorded (`voice_seed_calls == ["user-a"]`, Firestore seed recorded), job reaches `ready`, binding active → provisioned-active-row bar.
- **Full unit file:** `79 passed`.
- **Black-clean** on all three changed files (repo config: `line-length=120`, `skip-string-normalization=true`).

## No-clobber coverage

- DB: `ON CONFLICT (uid) DO NOTHING` (does not bump revision / overwrite provider-mode allowlists the way `upsert_entitlement` would).
- Firestore: seeds only when `voice_mode` is absent.

## Injection point

```
stage_runtime_binding  →  smoke_passed  →  [seed_voice_entitlement_if_absent + _ensure_self_hosted_grok_voice_mode]  →  activate_runtime_binding  →  public_receipt
```

Fixes the fresh-user first-chat `no_entitlement` defect for self-hosted grok voice and puts `effective_voice_mode=grok-voice` on the public receipt.
