### PR TITLE
fix(ella): bootstrap fresh consent with verified email

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -529,6 +529,10 @@ jobs:
             "tests/unit/test_ella_auth_authority_contract.py::test_admin_key_suffix_cannot_mint_arbitrary_subject"
             "tests/unit/test_ella_auth_authority_contract.py::test_admin_branch_observation_is_bounded_and_content_free"
             "tests/unit/test_ella_auth_authority_contract.py::test_exact_firebase_boundary_never_accepts_admin_key"
+            "tests/unit/test_ella_auth_authority_contract.py::test_firebase_token_identity_exposes_only_verified_email"
+            "tests/unit/test_ella_auth_authority_contract.py::test_exact_firebase_uid_delegates_to_single_token_identity_boundary"
+            "tests/unit/test_ella_auth_authority_contract.py::test_firebase_boundaries_share_malformed_token_and_client_gate[get_firebase_token_identity]"
+            "tests/unit/test_ella_auth_authority_contract.py::test_firebase_boundaries_share_malformed_token_and_client_gate[get_exact_firebase_uid]"
             "tests/unit/test_ella_auth_authority_contract.py::test_ella_lazy_exports_keep_imports_at_module_scope"
             "tests/unit/test_ella_auth_authority_contract.py::test_minimum_client_build_is_fail_closed_and_version_aware"
             "tests/unit/test_ella_auth_authority_contract.py::test_service_authority_is_constant_time_bound_to_one_subject"
@@ -557,7 +561,7 @@ jobs:
           for required_id in "${required_incident_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$incident_ids"
           done
-          test "$(grep -c '::' <<<"$incident_ids")" -eq 54
+          test "$(grep -c '::' <<<"$incident_ids")" -eq 58
           pytest \
             tests/unit/test_ella_incident_1182_route_isolation.py \
             tests/unit/test_ella_incident_1182_callback_auth.py \
@@ -756,7 +760,25 @@ jobs:
           grep -Fqx \
             "tests/postgres/test_authority_advisory_lock_postgres.py::test_mounted_guardian_alert_history_isolates_case_distinct_firebase_subjects" \
             <<<"$authority_lock_ids"
-          test "$(grep -c '::' <<<"$authority_lock_ids")" -eq 69
+          grep -Fqx \
+            "tests/postgres/test_authority_advisory_lock_postgres.py::test_consent_bootstrap_reconciles_email_owner_and_rejects_conflicting_owners" \
+            <<<"$authority_lock_ids"
+          grep -Fqx \
+            "tests/postgres/test_authority_advisory_lock_postgres.py::test_consent_bootstrap_serializes_concurrent_email_owner_claims" \
+            <<<"$authority_lock_ids"
+          grep -Fqx \
+            "tests/postgres/test_authority_advisory_lock_postgres.py::test_fresh_managed_terminal_decisions_without_email_leave_zero_usable_authority" \
+            <<<"$authority_lock_ids"
+          grep -Fqx \
+            "tests/postgres/test_authority_advisory_lock_postgres.py::test_fresh_managed_terminal_decision_reconciles_email_owner_before_quarantine[declined]" \
+            <<<"$authority_lock_ids"
+          grep -Fqx \
+            "tests/postgres/test_authority_advisory_lock_postgres.py::test_fresh_managed_terminal_decision_reconciles_email_owner_before_quarantine[revoked]" \
+            <<<"$authority_lock_ids"
+          grep -Fqx \
+            "tests/postgres/test_authority_advisory_lock_postgres.py::test_seed_voice_entitlement_if_absent_creates_once_without_clobber" \
+            <<<"$authority_lock_ids"
+          test "$(grep -c '::' <<<"$authority_lock_ids")" -eq 77
           pytest \
             tests/unit/test_authority_advisory_lock.py \
             tests/unit/test_authority_writer_guard.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -720,7 +720,7 @@ jobs:
               tests/unit/test_ella_plato_mcp.py |
               sed '/^$/d'
           )"
-          test "$(grep -c '::' <<<"$authority_split_ids")" -eq 443
+          test "$(grep -c '::' <<<"$authority_split_ids")" -eq 448
           required_authority_split_ids=(
             "tests/unit/test_ella_provision_authority_split.py::test_new_user_auto_provision_posts_only_to_hermes_authority"
             "tests/unit/test_ella_provision_authority_split.py::test_real_provision_client_and_coordinator_reject_before_http_or_repository_side_effect[two_way_url_swap]"
@@ -732,7 +732,8 @@ jobs:
             "tests/unit/test_ella_provision_authority_split.py::test_identity_sync_entrypoints_reject_before_http_database_state_or_thread[metadata_destination-reconcile]"
             "tests/unit/test_ella_provision_authority_split.py::test_real_provision_client_revalidates_after_client_entry_before_send[url]"
             "tests/unit/test_ella_provision_authority_split.py::test_real_claimed_worker_stops_after_inflight_http_authority_drift[token]"
-            "tests/unit/test_ella_provision_authority_split.py::test_claimed_worker_rechecks_before_every_post_http_mutation[activate_runtime_binding-1-forbidden2-binding_reference]"
+            "tests/unit/test_ella_provision_authority_split.py::test_claimed_worker_rechecks_before_every_post_http_mutation[seed_voice_entitlement_if_absent-1-forbidden2-binding_reference]"
+            "tests/unit/test_ella_provision_authority_split.py::test_claimed_worker_rechecks_before_every_post_http_mutation[activate_runtime_binding-1-forbidden3-binding_reference]"
             "tests/unit/test_ella_provision_authority_split.py::test_auto_provision_stops_database_write_after_inflight_http_drift[destination_policy]"
             "tests/unit/test_ella_provision_authority_split.py::test_identity_sync_detects_inflight_http_drift_before_later_effects[binding_secret-async]"
             "tests/unit/test_ella_provision_authority_split.py::test_identity_sync_entrypoints_revalidate_after_request_construction_before_transport[url-sync]"

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -494,6 +494,9 @@ jobs:
               tests/unit/test_ella_provisioning_service.py::test_attestation_window_covers_max_slow_response_and_rejects_invalid_config \
               tests/unit/test_ella_provisioning_service.py::test_total_deadline_cancels_real_local_slow_drip_before_binding_writes \
               tests/unit/test_ella_provisioning_service.py::test_oversized_provision_receipt_is_rejected_before_parse_or_binding_write \
+              tests/unit/test_ella_provisioning_service.py::test_provision_conflict_contract_matches_reviewed_shim_codes \
+              tests/unit/test_ella_provisioning_service.py::test_recursive_provision_conflict_is_content_free_and_nonretryable \
+              tests/unit/test_ella_provisioning_service.py::test_provision_conflict_rechecks_authority_after_inflight_body_drift \
               tests/unit/test_ella_provisioning_service.py::test_total_deadline_rejects_delayed_json_parse_before_binding_write \
               tests/unit/test_ella_provisioning_service.py::test_total_deadline_stops_delayed_verification_and_local_publication \
               tests/unit/test_ella_provisioning_service.py::test_external_cancellation_after_provider_work_records_retryable_reconciliation \
@@ -561,7 +564,7 @@ jobs:
           for required_id in "${required_incident_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$incident_ids"
           done
-          test "$(grep -c '::' <<<"$incident_ids")" -eq 58
+          test "$(grep -c '::' <<<"$incident_ids")" -eq 61
           pytest \
             tests/unit/test_ella_incident_1182_route_isolation.py \
             tests/unit/test_ella_incident_1182_callback_auth.py \
@@ -576,6 +579,9 @@ jobs:
             tests/unit/test_ella_provisioning_service.py::test_attestation_window_covers_max_slow_response_and_rejects_invalid_config \
             tests/unit/test_ella_provisioning_service.py::test_total_deadline_cancels_real_local_slow_drip_before_binding_writes \
             tests/unit/test_ella_provisioning_service.py::test_oversized_provision_receipt_is_rejected_before_parse_or_binding_write \
+            tests/unit/test_ella_provisioning_service.py::test_provision_conflict_contract_matches_reviewed_shim_codes \
+            tests/unit/test_ella_provisioning_service.py::test_recursive_provision_conflict_is_content_free_and_nonretryable \
+            tests/unit/test_ella_provisioning_service.py::test_provision_conflict_rechecks_authority_after_inflight_body_drift \
             tests/unit/test_ella_provisioning_service.py::test_total_deadline_rejects_delayed_json_parse_before_binding_write \
             tests/unit/test_ella_provisioning_service.py::test_total_deadline_stops_delayed_verification_and_local_publication \
             tests/unit/test_ella_provisioning_service.py::test_external_cancellation_after_provider_work_records_retryable_reconciliation \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -682,7 +682,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 528
+          test "$collected" -eq 543
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -824,7 +824,7 @@ jobs:
             "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_unexpected_runtime_failure_logs_fixed_content_free_classification"
             "tests/unit/test_ella_reviewed_route_integration.py::test_resolve_expected_provisioning_failure_logs_fixed_content_free_classification"
             "tests/unit/test_ella_reviewed_route_integration.py::test_legacy_history_proxy_unexpected_failure_logs_no_runtime_material"
-            "tests/unit/test_ella_reviewed_route_integration.py::test_account_deletion_declines_before_firestore_or_firebase_removal"
+            "tests/unit/test_ella_reviewed_route_integration.py::test_account_deletion_completes_unlink_receipt_without_destructive_removal"
           )
           for required_id in "${required_reviewed_route_ids[@]}"; do
             grep -Fqx "$required_id" <<<"$reviewed_route_ids"

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -170,7 +170,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 180
+          test "$collected" -eq 189
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \

--- a/backend/database/authority_advisory_lock.py
+++ b/backend/database/authority_advisory_lock.py
@@ -500,10 +500,13 @@ async def verify_self_owner_after_lock_or_bootstrap(
     else:
         row = await connection.fetchrow(
             """
-            INSERT INTO users (id, email, omi_uid, name, timezone, status, identities)
+            INSERT INTO users (
+                id, email, omi_uid, name, timezone, status, identities, updated_at
+            )
             VALUES (
                 $1, $2, $3, 'Synthetic User', 'UTC', 'PENDING',
-                jsonb_build_object('omi_uid', $3::text, 'email', $2::text)
+                jsonb_build_object('omi_uid', $3::text, 'email', $2::text),
+                CURRENT_TIMESTAMP
             )
             RETURNING id
             """,

--- a/backend/database/authority_advisory_lock.py
+++ b/backend/database/authority_advisory_lock.py
@@ -425,6 +425,7 @@ async def verify_self_owner_after_lock_or_bootstrap(
     owner: AuthorityOwner,
     proof: AuthorityLockProof,
     allow_bootstrap: bool,
+    bootstrap_email: str = "",
 ) -> uuid.UUID:
     """Re-read and lock ownership inside the advisory-lock transaction, creating
     the deterministic ``users`` row for a fresh UID when ``allow_bootstrap``.
@@ -445,14 +446,21 @@ async def verify_self_owner_after_lock_or_bootstrap(
         uid,
     )
     if row is None and allow_bootstrap:
+        email = bootstrap_email.strip().lower()
+        if not email:
+            raise AuthorityLockError("authority_lock_bootstrap_email_missing")
         row = await connection.fetchrow(
             """
-            INSERT INTO users (id, omi_uid, name, timezone, status)
-            VALUES ($1, $2, 'Synthetic User', 'UTC', 'PENDING')
+            INSERT INTO users (id, email, omi_uid, name, timezone, status, identities)
+            VALUES (
+                $1, $2, $3, 'Synthetic User', 'UTC', 'PENDING',
+                jsonb_build_object('omi_uid', $3::text, 'email', $2::text)
+            )
             ON CONFLICT (omi_uid) DO NOTHING
             RETURNING id
             """,
             owner.account_id,
+            email,
             uid,
         )
         if row is None:

--- a/backend/database/authority_advisory_lock.py
+++ b/backend/database/authority_advisory_lock.py
@@ -346,17 +346,30 @@ async def verify_identity_owner_after_lock(
         proof,
         owner=resolution.owner,
     )
-    rows = await connection.fetch(
-        """
-        SELECT id, omi_uid, email, name, timezone, status
-        FROM users
-        WHERE omi_uid = $1 OR lower(email) = lower($2)
-        ORDER BY id
-        FOR UPDATE
-        """,
-        uid,
-        email,
-    )
+    normalized_email = email.strip().lower()
+    if normalized_email:
+        rows = await connection.fetch(
+            """
+            SELECT id, omi_uid, email, name, timezone, status
+            FROM users
+            WHERE omi_uid = $1 OR lower(email) = $2
+            ORDER BY id
+            FOR UPDATE
+            """,
+            uid,
+            normalized_email,
+        )
+    else:
+        rows = await connection.fetch(
+            """
+            SELECT id, omi_uid, email, name, timezone, status
+            FROM users
+            WHERE omi_uid = $1
+            ORDER BY id
+            FOR UPDATE
+            """,
+            uid,
+        )
     owner_ids = {_validated_database_uuid(row["id"], field="user_id") for row in rows}
     if len(owner_ids) > 1 or (owner_ids and owner_ids != {resolution.owner.account_id}):
         raise AuthorityLockError("authority_lock_owner_drift")
@@ -397,58 +410,94 @@ async def resolve_self_owner_unlocked_or_bootstrap(
     *,
     uid: str,
     allow_bootstrap: bool,
-) -> AuthorityOwner:
-    """Resolve an existing self-owner, or return the deterministic not-yet-created
-    owner when ``allow_bootstrap`` (the reversible fresh-UID consent relax).
+    bootstrap_email: str = "",
+) -> IdentityOwnerResolution:
+    """Resolve the exact UID/email owner for a fresh consent bootstrap.
 
-    Mirrors :func:`resolve_self_owner_unlocked` but instead of raising
-    ``authority_lock_owner_missing`` for a UID with no ``users`` row, it returns
-    the deterministic provisional owner so the caller can bootstrap the row
-    inside the advisory-lock transaction. Without ``allow_bootstrap`` the strict
-    ``authority_lock_owner_missing`` behavior is preserved byte-for-byte.
+    Strict callers retain UID-only resolution. The reversible fresh-UID path
+    additionally resolves the Firebase-verified email so a legacy email-owned
+    row is reconciled instead of colliding with its independent unique key.
     """
+    if not allow_bootstrap:
+        owner = await resolve_self_owner_unlocked(connection, uid=uid)
+        return IdentityOwnerResolution(owner=owner, allow_create=False)
+
+    email = bootstrap_email.strip().lower()
+    if email:
+        return await resolve_identity_owner_unlocked(
+            connection,
+            uid=uid,
+            email=email,
+        )
+
     row = await connection.fetchrow(
         "SELECT id FROM users WHERE omi_uid = $1",
         uid,
     )
     if row:
-        return AuthorityOwner.from_values(row["id"], row["id"])
-    if not allow_bootstrap:
-        raise AuthorityLockError("authority_lock_owner_missing")
-    return provisional_identity_owner(uid)
+        owner = AuthorityOwner.from_values(row["id"], row["id"])
+        return IdentityOwnerResolution(owner=owner, allow_create=False)
+    raise AuthorityLockError("authority_lock_bootstrap_email_missing")
 
 
 async def verify_self_owner_after_lock_or_bootstrap(
     connection: asyncpg.Connection,
     *,
     uid: str,
-    owner: AuthorityOwner,
+    resolution: IdentityOwnerResolution,
     proof: AuthorityLockProof,
     allow_bootstrap: bool,
     bootstrap_email: str = "",
 ) -> uuid.UUID:
-    """Re-read and lock ownership inside the advisory-lock transaction, creating
-    the deterministic ``users`` row for a fresh UID when ``allow_bootstrap``.
-
-    The INSERT only runs while the per-UID advisory lock is held (matching the
-    codebase's write discipline), uses the deterministic provisional owner id so
-    a later redemption/ensure reconciles onto the same row, and is idempotent via
-    ``ON CONFLICT (omi_uid) DO NOTHING``.
-    """
+    """Re-read exact identity ownership and bind or create the fresh UID row."""
+    email = bootstrap_email.strip().lower()
     owner_lock = proof
-    await require_self_owner_lock(
+    rows = await verify_identity_owner_after_lock(
         connection,
-        owner_lock,
-        user_id=owner.account_id,
+        uid=uid,
+        email=email,
+        resolution=resolution,
+        proof=owner_lock,
     )
-    row = await connection.fetchrow(
-        "SELECT id FROM users WHERE omi_uid = $1 FOR UPDATE",
-        uid,
+
+    by_uid = next((row for row in rows if row["omi_uid"] == uid), None)
+    if by_uid is not None:
+        stored_email = str(by_uid["email"] or "").strip().lower()
+        if email and stored_email != email:
+            raise AuthorityLockError("authority_lock_uid_email_mismatch")
+        return _validated_database_uuid(by_uid["id"], field="user_id")
+
+    if not allow_bootstrap:
+        raise AuthorityLockError("authority_lock_owner_missing")
+    if not email:
+        raise AuthorityLockError("authority_lock_bootstrap_email_missing")
+
+    by_email = next(
+        (row for row in rows if str(row["email"] or "").strip().lower() == email),
+        None,
     )
-    if row is None and allow_bootstrap:
-        email = bootstrap_email.strip().lower()
-        if not email:
-            raise AuthorityLockError("authority_lock_bootstrap_email_missing")
+    if by_email is not None:
+        existing_uid = str(by_email["omi_uid"] or "").strip()
+        if existing_uid and existing_uid != uid:
+            raise AuthorityLockError("authority_lock_identity_conflict")
+        row = await connection.fetchrow(
+            """
+            UPDATE users
+            SET omi_uid = $1,
+                identities = COALESCE(identities, '{}'::jsonb)
+                    || jsonb_build_object('omi_uid', $1::text, 'email', $2::text),
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = $3
+              AND (omi_uid IS NULL OR omi_uid = '' OR omi_uid = $1)
+            RETURNING id
+            """,
+            uid,
+            email,
+            resolution.owner.account_id,
+        )
+        if row is None:
+            raise AuthorityLockError("authority_lock_owner_drift")
+    else:
         row = await connection.fetchrow(
             """
             INSERT INTO users (id, email, omi_uid, name, timezone, status, identities)
@@ -456,21 +505,14 @@ async def verify_self_owner_after_lock_or_bootstrap(
                 $1, $2, $3, 'Synthetic User', 'UTC', 'PENDING',
                 jsonb_build_object('omi_uid', $3::text, 'email', $2::text)
             )
-            ON CONFLICT (omi_uid) DO NOTHING
             RETURNING id
             """,
-            owner.account_id,
+            resolution.owner.account_id,
             email,
             uid,
         )
-        if row is None:
-            row = await connection.fetchrow(
-                "SELECT id FROM users WHERE omi_uid = $1",
-                uid,
-            )
-    if not row:
-        raise AuthorityLockError("authority_lock_owner_missing")
+
     current = _validated_database_uuid(row["id"], field="user_id")
-    if current != owner.account_id or current != owner.profile_id:
+    if current != resolution.owner.account_id or current != resolution.owner.profile_id:
         raise AuthorityLockError("authority_lock_owner_drift")
     return current

--- a/backend/database/managed_cloud_consent.py
+++ b/backend/database/managed_cloud_consent.py
@@ -258,15 +258,16 @@ async def synchronize_grant(
     try:
         pool = await voice_canary.get_pool()
         async with pool.acquire() as conn:
-            owner = await authority_advisory_lock.resolve_self_owner_unlocked_or_bootstrap(
+            resolution = await authority_advisory_lock.resolve_self_owner_unlocked_or_bootstrap(
                 conn,
                 uid=grant.account_uid,
                 allow_bootstrap=allow_fresh_uid_bootstrap,
+                bootstrap_email=bootstrap_email,
             )
             async with conn.transaction():
                 owner_lock = await authority_advisory_lock.acquire_authority_lock(
                     conn,
-                    owner=owner,
+                    owner=resolution.owner,
                 )
                 await voice_canary.lock_runtime_authority_on_connection(
                     conn,
@@ -275,7 +276,7 @@ async def synchronize_grant(
                 user_id = await authority_advisory_lock.verify_self_owner_after_lock_or_bootstrap(
                     conn,
                     uid=grant.account_uid,
-                    owner=owner,
+                    resolution=resolution,
                     proof=owner_lock,
                     allow_bootstrap=allow_fresh_uid_bootstrap,
                     bootstrap_email=bootstrap_email,
@@ -504,30 +505,106 @@ async def synchronize_denial(
     *,
     uid: str,
     decision: Literal["declined", "revoked"],
+    verified_email: str = "",
 ) -> dict[str, Any]:
     """Order denial before Firestore and quarantine all durable Cloud authority."""
     try:
         pool = await voice_canary.get_pool()
         async with pool.acquire() as conn:
-            owner = await authority_advisory_lock.resolve_self_owner_unlocked(
-                conn,
-                uid=uid,
-            )
+            email = verified_email.strip().lower()
+            if email:
+                resolution = await authority_advisory_lock.resolve_identity_owner_unlocked(
+                    conn,
+                    uid=uid,
+                    email=email,
+                )
+            else:
+                try:
+                    owner = await authority_advisory_lock.resolve_self_owner_unlocked(
+                        conn,
+                        uid=uid,
+                    )
+                    resolution = authority_advisory_lock.IdentityOwnerResolution(
+                        owner=owner,
+                        allow_create=False,
+                    )
+                except authority_advisory_lock.AuthorityLockError as exc:
+                    if exc.code != "authority_lock_owner_missing":
+                        raise
+                    resolution = authority_advisory_lock.IdentityOwnerResolution(
+                        owner=authority_advisory_lock.provisional_identity_owner(uid),
+                        allow_create=True,
+                    )
             async with conn.transaction():
                 owner_lock = await authority_advisory_lock.acquire_authority_lock(
                     conn,
-                    owner=owner,
+                    owner=resolution.owner,
                 )
                 await voice_canary.lock_runtime_authority_on_connection(
                     conn,
                     uid=uid,
                 )
-                user_id = await authority_advisory_lock.verify_self_owner_after_lock(
+                identity_rows = await authority_advisory_lock.verify_identity_owner_after_lock(
                     conn,
                     uid=uid,
-                    owner=owner,
+                    email=email,
+                    resolution=resolution,
                     proof=owner_lock,
                 )
+                by_uid = next((row for row in identity_rows if row["omi_uid"] == uid), None)
+                by_email = next(
+                    (row for row in identity_rows if email and str(row["email"] or "").strip().lower() == email),
+                    None,
+                )
+                identity_row = by_uid or by_email
+                if identity_row is None:
+                    await conn.execute(
+                        """
+                        UPDATE voice_entitlements
+                        SET status = 'revoked',
+                            revision = revision + 1,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE uid = $1
+                          AND status <> 'revoked'
+                        """,
+                        uid,
+                    )
+                    await conn.execute(
+                        "DELETE FROM voice_active_sessions WHERE uid = $1",
+                        uid,
+                    )
+                    return {
+                        "decision": decision,
+                        "authority_absent": True,
+                    }
+
+                if by_uid is None and by_email is not None:
+                    identity_row = await conn.fetchrow(
+                        """
+                        UPDATE users
+                        SET omi_uid = $1,
+                            identities = COALESCE(identities, '{}'::jsonb)
+                                || jsonb_build_object('omi_uid', $1::text, 'email', $2::text),
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE id = $3
+                          AND (omi_uid IS NULL OR omi_uid = '' OR omi_uid = $1)
+                        RETURNING id, omi_uid, email, name, timezone, status
+                        """,
+                        uid,
+                        email,
+                        resolution.owner.account_id,
+                    )
+                    if identity_row is None:
+                        raise authority_advisory_lock.AuthorityLockError("authority_lock_owner_drift")
+
+                existing_uid = str(identity_row["omi_uid"] or "").strip()
+                if existing_uid and existing_uid != uid:
+                    raise authority_advisory_lock.AuthorityLockError("authority_lock_identity_conflict")
+                if by_uid is not None and email:
+                    stored_email = str(by_uid["email"] or "").strip().lower()
+                    if stored_email != email:
+                        raise authority_advisory_lock.AuthorityLockError("authority_lock_uid_email_mismatch")
+                user_id = uuid.UUID(str(identity_row["id"]))
                 row = await conn.fetchrow(
                     """
                     SELECT *

--- a/backend/database/managed_cloud_consent.py
+++ b/backend/database/managed_cloud_consent.py
@@ -245,6 +245,7 @@ async def synchronize_grant(
     *,
     grant: ManagedCloudGrant,
     allow_fresh_uid_bootstrap: bool = False,
+    bootstrap_email: str = "",
 ) -> dict[str, Any]:
     """Publish a Firestore grant into the PostgreSQL ordering authority.
 
@@ -277,6 +278,7 @@ async def synchronize_grant(
                     owner=owner,
                     proof=owner_lock,
                     allow_bootstrap=allow_fresh_uid_bootstrap,
+                    bootstrap_email=bootstrap_email,
                 )
                 row = await conn.fetchrow(
                     """

--- a/backend/ella/routers/ai_consent.py
+++ b/backend/ella/routers/ai_consent.py
@@ -14,7 +14,11 @@ from ella.services.ai_consent import (
 )
 from ella.services.consent_authority import submit_with_managed_cloud_authority
 from database.managed_cloud_consent import ManagedCloudAuthorityUnavailable
-from utils.ella.exact_firebase_auth import get_exact_firebase_uid
+from utils.ella.exact_firebase_auth import (
+    FirebaseTokenIdentity,
+    get_exact_firebase_uid,
+    get_firebase_token_identity,
+)
 
 router = APIRouter(tags=["AI Consent"])
 
@@ -55,11 +59,12 @@ def get_ai_consent_receipt(receipt_id: str, uid: str = Depends(get_exact_firebas
 @router.post("/v1/users/ai-consent")
 async def submit_ai_consent(
     request: AiConsentSubmissionRequest,
-    uid: str = Depends(get_exact_firebase_uid),
+    identity: FirebaseTokenIdentity = Depends(get_firebase_token_identity),
 ):
     try:
         return await submit_with_managed_cloud_authority(
-            uid=uid,
+            uid=identity.uid,
+            verified_email=identity.verified_email,
             service=get_ai_consent_service(),
             submission=ConsentSubmission(
                 decision=request.decision,

--- a/backend/ella/services/consent_authority.py
+++ b/backend/ella/services/consent_authority.py
@@ -53,6 +53,7 @@ async def submit_with_managed_cloud_authority(
         await managed_cloud_consent.synchronize_denial(
             uid=uid,
             decision=submission.decision,
+            verified_email=verified_email,
         )
 
     payload = service.submit(uid, submission)

--- a/backend/ella/services/consent_authority.py
+++ b/backend/ella/services/consent_authority.py
@@ -39,6 +39,7 @@ async def submit_with_managed_cloud_authority(
     uid: str,
     submission: ConsentSubmission,
     service: AiConsentService,
+    verified_email: str = "",
 ) -> dict[str, Any]:
     """Record consent with asymmetric ordering that fails closed on partial work.
 
@@ -62,5 +63,6 @@ async def submit_with_managed_cloud_authority(
                 payload.get("receipt"),
             ),
             allow_fresh_uid_bootstrap=self_hosted_fresh_uid_relax_enabled(),
+            bootstrap_email=verified_email,
         )
     return payload

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -1809,6 +1809,9 @@ def test_consent_bootstrap_creates_users_row_and_grant():
         owner = authority_advisory_lock.provisional_identity_owner(uid)
 
         async with pool.acquire() as conn:
+            # Match production: a fresh authority bootstrap must provide the
+            # Firebase-verified email, not rely on a nullable test fixture.
+            await conn.execute("ALTER TABLE users ALTER COLUMN email SET NOT NULL")
             before = await conn.fetchval(
                 "SELECT 1 FROM users WHERE omi_uid = $1",
                 uid,
@@ -1818,13 +1821,14 @@ def test_consent_bootstrap_creates_users_row_and_grant():
         result = await managed_cloud_consent.synchronize_grant(
             grant=_managed_cloud_grant(uid, revision="one"),
             allow_fresh_uid_bootstrap=True,
+            bootstrap_email="fresh-consent@example.invalid",
         )
         assert result["user_id"] == owner.account_id
 
         async with pool.acquire() as observer:
             row = await observer.fetchrow(
                 """
-                SELECT id, omi_uid, name, timezone, status
+                SELECT id, omi_uid, email, name, timezone, status, identities
                 FROM users
                 WHERE omi_uid = $1
                 """,
@@ -1850,17 +1854,32 @@ def test_consent_bootstrap_creates_users_row_and_grant():
         assert tuple(row.values()) == (
             owner.account_id,
             uid,
+            "fresh-consent@example.invalid",
             "Synthetic User",
             "UTC",
             "PENDING",
+            {"omi_uid": uid, "email": "fresh-consent@example.invalid"},
         )
         assert decision == "granted"
         assert receipt_ref and receipt_ref.startswith("sha256:")
+
+        # Normal provisioning must reconcile the bootstrap row without changing
+        # its deterministic owner or rejecting the same verified identity.
+        identity = await EllaProvisioningRepository(pool).ensure_user_identity(
+            uid=uid,
+            email="fresh-consent@example.invalid",
+            name="Fresh Consent User",
+            timezone_name="America/Los_Angeles",
+        )
+        assert identity["id"] == owner.account_id
+        assert identity["email"] == "fresh-consent@example.invalid"
+        assert identity["name"] == "Fresh Consent User"
 
         # Idempotent re-consent reconciles onto the same deterministic row.
         result_two = await managed_cloud_consent.synchronize_grant(
             grant=_managed_cloud_grant(uid, revision="two"),
             allow_fresh_uid_bootstrap=True,
+            bootstrap_email="fresh-consent@example.invalid",
         )
         assert result_two["user_id"] == owner.account_id
         async with pool.acquire() as observer:
@@ -1869,6 +1888,27 @@ def test_consent_bootstrap_creates_users_row_and_grant():
                 uid,
             )
         assert count == 1
+
+        blank_email_uid = "synthetic-consent-bootstrap-blank-email"
+        blank_email_owner = authority_advisory_lock.provisional_identity_owner(blank_email_uid)
+        with pytest.raises(
+            managed_cloud_consent.ManagedCloudAuthorityUnavailable,
+            match="managed_cloud_authority_unavailable",
+        ) as blank_email_error:
+            await managed_cloud_consent.synchronize_grant(
+                grant=_managed_cloud_grant(blank_email_uid),
+                allow_fresh_uid_bootstrap=True,
+            )
+        assert blank_email_error.value.__cause__.code == "authority_lock_bootstrap_email_missing"
+        async with pool.acquire() as observer:
+            assert await observer.fetchval("SELECT 1 FROM users WHERE omi_uid = $1", blank_email_uid) is None
+            assert (
+                await observer.fetchval(
+                    "SELECT 1 FROM ella_managed_cloud_consent_authority WHERE user_id = $1",
+                    blank_email_owner.account_id,
+                )
+                is None
+            )
 
         # A different fresh UID with the relax flag off fails closed first.
         strict_uid = "synthetic-consent-bootstrap-strict"
@@ -1907,6 +1947,7 @@ def test_delete_unlinks_users_row_and_consent_authority_freeing_uid():
         await managed_cloud_consent.synchronize_grant(
             grant=_managed_cloud_grant(uid, revision="one"),
             allow_fresh_uid_bootstrap=True,
+            bootstrap_email="fresh-delete@example.invalid",
         )
 
         async with pool.acquire() as observer:
@@ -1948,6 +1989,7 @@ def test_delete_unlinks_users_row_and_consent_authority_freeing_uid():
         result = await managed_cloud_consent.synchronize_grant(
             grant=_managed_cloud_grant(uid, revision="two"),
             allow_fresh_uid_bootstrap=True,
+            bootstrap_email="fresh-delete@example.invalid",
         )
         assert result["user_id"] == owner.account_id
         async with pool.acquire() as observer:

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -1811,8 +1811,10 @@ def test_consent_bootstrap_creates_users_row_and_grant():
 
         async with pool.acquire() as conn:
             # Match production: a fresh authority bootstrap must provide the
-            # Firebase-verified email, not rely on a nullable test fixture.
+            # Firebase-verified email and explicitly persist updated_at; neither
+            # production column has a default that can mask an incomplete INSERT.
             await conn.execute("ALTER TABLE users ALTER COLUMN email SET NOT NULL")
+            await conn.execute("ALTER TABLE users ALTER COLUMN updated_at DROP DEFAULT")
             before = await conn.fetchval(
                 "SELECT 1 FROM users WHERE omi_uid = $1",
                 uid,
@@ -1829,7 +1831,8 @@ def test_consent_bootstrap_creates_users_row_and_grant():
         async with pool.acquire() as observer:
             row = await observer.fetchrow(
                 """
-                SELECT id, omi_uid, email, name, timezone, status, identities
+                SELECT id, omi_uid, email, name, timezone, status, identities,
+                       updated_at
                 FROM users
                 WHERE omi_uid = $1
                 """,
@@ -1853,7 +1856,7 @@ def test_consent_bootstrap_creates_users_row_and_grant():
             )
         assert row is not None
         identities = json.loads(row["identities"]) if isinstance(row["identities"], str) else row["identities"]
-        assert tuple(row.values())[:-1] == (
+        assert tuple(row.values())[:-2] == (
             owner.account_id,
             uid,
             "fresh-consent@example.invalid",
@@ -1862,6 +1865,7 @@ def test_consent_bootstrap_creates_users_row_and_grant():
             "PENDING",
         )
         assert identities == {"omi_uid": uid, "email": "fresh-consent@example.invalid"}
+        assert row["updated_at"] is not None
         assert decision == "granted"
         assert receipt_ref and receipt_ref.startswith("sha256:")
 

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -170,10 +170,12 @@ async def _seed_grant(pool, uid):
 
 def test_guardian_mode_get_returns_only_exact_case_sensitive_firebase_subject():
     async def scenario(pool):
-        await pool.execute("""
+        await pool.execute(
+            """
             INSERT INTO users (omi_uid, guardian_mode)
             VALUES ('CaseUID', 'EMERGENCY_ONLY'), ('caseuid', 'ACTIVE_SUPPORT')
-            """)
+            """
+        )
         previous_pool = guardian._pool
         guardian._pool = pool
         try:
@@ -190,7 +192,8 @@ def test_guardian_mode_get_returns_only_exact_case_sensitive_firebase_subject():
 
 def test_mounted_guardian_alert_history_isolates_case_distinct_firebase_subjects(monkeypatch):
     async def scenario(pool):
-        await pool.execute("""
+        await pool.execute(
+            """
             CREATE TABLE guardian_queue (
                 id TEXT PRIMARY KEY,
                 uid TEXT NOT NULL,
@@ -267,7 +270,8 @@ def test_mounted_guardian_alert_history_isolates_case_distinct_firebase_subjects
                     'owner-local-trace', 'caseuid', 'imessage', 'lower-private-target', 'sent',
                     'LOWER_DELIVERY_PRIVATE', '2026-08-03T12:00:20Z', '2026-08-03T12:00:20Z'
                 );
-            """)
+            """
+        )
 
         before = {
             table: [tuple(row.values()) for row in await pool.fetch(f"SELECT * FROM {table} ORDER BY id")]
@@ -571,19 +575,23 @@ def test_omi_revoke_lock_blocks_broker_and_releases_without_deadlock():
             str(owner.profile_id),
         )
         async with pool.acquire() as conn:
-            await conn.execute("""
+            await conn.execute(
+                """
                 CREATE FUNCTION hold_authority_revoke() RETURNS trigger AS $$
                 BEGIN
                     PERFORM pg_sleep(0.6);
                     RETURN NEW;
                 END
                 $$ LANGUAGE plpgsql
-                """)
-            await conn.execute("""
+                """
+            )
+            await conn.execute(
+                """
                 CREATE TRIGGER hold_authority_revoke
                 BEFORE UPDATE ON ella_managed_cloud_consent_authority
                 FOR EACH ROW EXECUTE FUNCTION hold_authority_revoke()
-                """)
+                """
+            )
 
         revoke = asyncio.create_task(
             managed_cloud_consent.synchronize_denial(

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import uuid
 from dataclasses import dataclass
@@ -169,12 +170,10 @@ async def _seed_grant(pool, uid):
 
 def test_guardian_mode_get_returns_only_exact_case_sensitive_firebase_subject():
     async def scenario(pool):
-        await pool.execute(
-            """
+        await pool.execute("""
             INSERT INTO users (omi_uid, guardian_mode)
             VALUES ('CaseUID', 'EMERGENCY_ONLY'), ('caseuid', 'ACTIVE_SUPPORT')
-            """
-        )
+            """)
         previous_pool = guardian._pool
         guardian._pool = pool
         try:
@@ -191,8 +190,7 @@ def test_guardian_mode_get_returns_only_exact_case_sensitive_firebase_subject():
 
 def test_mounted_guardian_alert_history_isolates_case_distinct_firebase_subjects(monkeypatch):
     async def scenario(pool):
-        await pool.execute(
-            """
+        await pool.execute("""
             CREATE TABLE guardian_queue (
                 id TEXT PRIMARY KEY,
                 uid TEXT NOT NULL,
@@ -269,8 +267,7 @@ def test_mounted_guardian_alert_history_isolates_case_distinct_firebase_subjects
                     'owner-local-trace', 'caseuid', 'imessage', 'lower-private-target', 'sent',
                     'LOWER_DELIVERY_PRIVATE', '2026-08-03T12:00:20Z', '2026-08-03T12:00:20Z'
                 );
-            """
-        )
+            """)
 
         before = {
             table: [tuple(row.values()) for row in await pool.fetch(f"SELECT * FROM {table} ORDER BY id")]
@@ -574,23 +571,19 @@ def test_omi_revoke_lock_blocks_broker_and_releases_without_deadlock():
             str(owner.profile_id),
         )
         async with pool.acquire() as conn:
-            await conn.execute(
-                """
+            await conn.execute("""
                 CREATE FUNCTION hold_authority_revoke() RETURNS trigger AS $$
                 BEGIN
                     PERFORM pg_sleep(0.6);
                     RETURN NEW;
                 END
                 $$ LANGUAGE plpgsql
-                """
-            )
-            await conn.execute(
-                """
+                """)
+            await conn.execute("""
                 CREATE TRIGGER hold_authority_revoke
                 BEFORE UPDATE ON ella_managed_cloud_consent_authority
                 FOR EACH ROW EXECUTE FUNCTION hold_authority_revoke()
-                """
-            )
+                """)
 
         revoke = asyncio.create_task(
             managed_cloud_consent.synchronize_denial(
@@ -1851,15 +1844,16 @@ def test_consent_bootstrap_creates_users_row_and_grant():
                 owner.account_id,
             )
         assert row is not None
-        assert tuple(row.values()) == (
+        identities = json.loads(row["identities"]) if isinstance(row["identities"], str) else row["identities"]
+        assert tuple(row.values())[:-1] == (
             owner.account_id,
             uid,
             "fresh-consent@example.invalid",
             "Synthetic User",
             "UTC",
             "PENDING",
-            {"omi_uid": uid, "email": "fresh-consent@example.invalid"},
         )
+        assert identities == {"omi_uid": uid, "email": "fresh-consent@example.invalid"}
         assert decision == "granted"
         assert receipt_ref and receipt_ref.startswith("sha256:")
 
@@ -1927,6 +1921,293 @@ def test_consent_bootstrap_creates_users_row_and_grant():
                 strict_uid,
             )
         assert strict_count == 0
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_consent_bootstrap_reconciles_email_owner_and_rejects_conflicting_owners():
+    async def scenario(pool):
+        uid = "synthetic-consent-email-owner"
+        email = "consent-email-owner@example.invalid"
+        async with pool.acquire() as conn:
+            await conn.execute("ALTER TABLE users ALTER COLUMN email SET NOT NULL")
+            email_owner_id = await conn.fetchval(
+                """
+                INSERT INTO users (email, name, status, profile_class)
+                VALUES ($1, 'Legacy Email Owner', 'PENDING', 'real')
+                RETURNING id
+                """,
+                email,
+            )
+
+        result = await managed_cloud_consent.synchronize_grant(
+            grant=_managed_cloud_grant(uid),
+            allow_fresh_uid_bootstrap=True,
+            bootstrap_email=email,
+        )
+        assert result["user_id"] == email_owner_id
+
+        async with pool.acquire() as observer:
+            reconciled = await observer.fetchrow(
+                """
+                SELECT id, omi_uid, email, identities ->> 'omi_uid' AS identity_uid
+                FROM users
+                WHERE id = $1
+                """,
+                email_owner_id,
+            )
+            assert tuple(reconciled.values()) == (email_owner_id, uid, email, uid)
+            assert (
+                await observer.fetchval(
+                    "SELECT COUNT(*) FROM ella_managed_cloud_consent_authority WHERE user_id = $1",
+                    email_owner_id,
+                )
+                == 1
+            )
+
+            conflicting_uid = "synthetic-consent-conflicting-uid"
+            conflicting_email = "synthetic-consent-conflicting-email@example.invalid"
+            uid_owner_id = await observer.fetchval(
+                """
+                INSERT INTO users (omi_uid, email, name, status, profile_class)
+                VALUES ($1, $2, 'UID Owner', 'PENDING', 'real')
+                RETURNING id
+                """,
+                conflicting_uid,
+                "uid-owner@example.invalid",
+            )
+            email_conflict_owner_id = await observer.fetchval(
+                """
+                INSERT INTO users (email, name, status, profile_class)
+                VALUES ($1, 'Email Conflict Owner', 'PENDING', 'real')
+                RETURNING id
+                """,
+                conflicting_email,
+            )
+
+        with pytest.raises(
+            managed_cloud_consent.ManagedCloudAuthorityUnavailable,
+            match="managed_cloud_authority_unavailable",
+        ) as conflict:
+            await managed_cloud_consent.synchronize_grant(
+                grant=_managed_cloud_grant(conflicting_uid),
+                allow_fresh_uid_bootstrap=True,
+                bootstrap_email=conflicting_email,
+            )
+        assert conflict.value.__cause__.code == "authority_lock_identity_conflict"
+
+        async with pool.acquire() as observer:
+            owners = await observer.fetch(
+                """
+                SELECT id, omi_uid, email
+                FROM users
+                WHERE id = ANY($1::uuid[])
+                ORDER BY id
+                """,
+                [uid_owner_id, email_conflict_owner_id],
+            )
+            assert {row["id"] for row in owners} == {uid_owner_id, email_conflict_owner_id}
+            assert next(row for row in owners if row["id"] == uid_owner_id)["omi_uid"] == conflicting_uid
+            assert next(row for row in owners if row["id"] == email_conflict_owner_id)["omi_uid"] is None
+            assert (
+                await observer.fetchval(
+                    """
+                    SELECT COUNT(*)
+                    FROM ella_managed_cloud_consent_authority
+                    WHERE user_id = ANY($1::uuid[])
+                    """,
+                    [uid_owner_id, email_conflict_owner_id],
+                )
+                == 0
+            )
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_consent_bootstrap_serializes_concurrent_email_owner_claims():
+    async def scenario(pool):
+        uid = "synthetic-consent-email-owner-concurrent"
+        email = "consent-email-owner-concurrent@example.invalid"
+        async with pool.acquire() as conn:
+            await conn.execute("ALTER TABLE users ALTER COLUMN email SET NOT NULL")
+            email_owner_id = await conn.fetchval(
+                """
+                INSERT INTO users (email, name, status, profile_class)
+                VALUES ($1, 'Concurrent Email Owner', 'PENDING', 'real')
+                RETURNING id
+                """,
+                email,
+            )
+
+        grant = _managed_cloud_grant(uid)
+        results = await asyncio.gather(
+            managed_cloud_consent.synchronize_grant(
+                grant=grant,
+                allow_fresh_uid_bootstrap=True,
+                bootstrap_email=email,
+            ),
+            managed_cloud_consent.synchronize_grant(
+                grant=grant,
+                allow_fresh_uid_bootstrap=True,
+                bootstrap_email=email,
+            ),
+        )
+        assert [result["user_id"] for result in results] == [email_owner_id, email_owner_id]
+
+        async with pool.acquire() as observer:
+            assert await observer.fetchval("SELECT COUNT(*) FROM users WHERE omi_uid = $1", uid) == 1
+            assert (
+                await observer.fetchval(
+                    "SELECT COUNT(*) FROM ella_managed_cloud_consent_authority WHERE user_id = $1",
+                    email_owner_id,
+                )
+                == 1
+            )
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_fresh_managed_terminal_decisions_without_email_leave_zero_usable_authority():
+    async def scenario(pool):
+        async with pool.acquire() as conn:
+            await conn.execute("ALTER TABLE users ALTER COLUMN email SET NOT NULL")
+
+        for decision in ("declined", "revoked"):
+            uid = f"synthetic-consent-terminal-{decision}"
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    "INSERT INTO voice_entitlements (uid, status) VALUES ($1, 'active')",
+                    uid,
+                )
+
+            result = await managed_cloud_consent.synchronize_denial(
+                uid=uid,
+                decision=decision,
+            )
+            assert result == {"decision": decision, "authority_absent": True}
+
+            async with pool.acquire() as observer:
+                assert await observer.fetchval("SELECT 1 FROM users WHERE omi_uid = $1", uid) is None
+                assert (
+                    await observer.fetchval(
+                        """
+                        SELECT COUNT(*)
+                        FROM ella_managed_cloud_consent_authority authority
+                        JOIN users app_user ON app_user.id = authority.user_id
+                        WHERE app_user.omi_uid = $1
+                        """,
+                        uid,
+                    )
+                    == 0
+                )
+                assert await observer.fetchval("SELECT status FROM voice_entitlements WHERE uid = $1", uid) == "revoked"
+                assert await observer.fetchval("SELECT COUNT(*) FROM voice_active_sessions WHERE uid = $1", uid) == 0
+
+    asyncio.run(_run_with_database(scenario))
+
+
+@pytest.mark.parametrize("decision", ("declined", "revoked"))
+def test_fresh_managed_terminal_decision_reconciles_email_owner_before_quarantine(decision):
+    async def scenario(pool):
+        uid = f"synthetic-email-owner-terminal-{decision}"
+        email = f"email-owner-terminal-{decision}@example.invalid"
+        async with pool.acquire() as conn:
+            await conn.execute("ALTER TABLE users ALTER COLUMN email SET NOT NULL")
+            user_id = await conn.fetchval(
+                """
+                INSERT INTO users (email, name, status, profile_class)
+                VALUES ($1, 'Legacy Email Owner', 'PENDING', 'real')
+                RETURNING id
+                """,
+                email,
+            )
+            await conn.execute(
+                "INSERT INTO voice_entitlements (uid, status) VALUES ($1, 'active')",
+                uid,
+            )
+
+        result = await managed_cloud_consent.synchronize_denial(
+            uid=uid,
+            decision=decision,
+            verified_email=email,
+        )
+        assert result["user_id"] == user_id
+        assert result["decision"] == decision
+
+        async with pool.acquire() as observer:
+            identity = await observer.fetchrow(
+                "SELECT omi_uid, email FROM users WHERE id = $1",
+                user_id,
+            )
+            assert tuple(identity.values()) == (uid, email)
+            assert (
+                await observer.fetchval(
+                    "SELECT decision FROM ella_managed_cloud_consent_authority WHERE user_id = $1",
+                    user_id,
+                )
+                == decision
+            )
+            assert await observer.fetchval("SELECT status FROM voice_entitlements WHERE uid = $1", uid) == "revoked"
+            assert await observer.fetchval("SELECT COUNT(*) FROM voice_active_sessions WHERE uid = $1", uid) == 0
+
+    asyncio.run(_run_with_database(scenario))
+
+
+def test_seed_voice_entitlement_if_absent_creates_once_without_clobber():
+    async def scenario(pool):
+        uid = "synthetic-fresh-voice-seed"
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO users (omi_uid, email, profile_class)
+                VALUES ($1, $2, 'real')
+                """,
+                uid,
+                "fresh-voice-seed@example.invalid",
+            )
+
+        repository = EllaProvisioningRepository(pool)
+        assert await repository.seed_voice_entitlement_if_absent(uid=uid) is True
+
+        async with pool.acquire() as observer:
+            seeded = await observer.fetchrow(
+                """
+                SELECT status, plan, daily_limit_s, monthly_limit_s,
+                       max_session_s, max_concurrent,
+                       provider_allowlist, mode_allowlist, revision
+                FROM voice_entitlements
+                WHERE uid = $1
+                """,
+                uid,
+            )
+        assert dict(seeded) == {
+            "status": "active",
+            "plan": "canary",
+            "daily_limit_s": 2700,
+            "monthly_limit_s": 43200,
+            "max_session_s": 1200,
+            "max_concurrent": 1,
+            "provider_allowlist": ["grok-voice"],
+            "mode_allowlist": ["v4"],
+            "revision": 1,
+        }
+
+        assert await repository.seed_voice_entitlement_if_absent(uid=uid) is False
+        async with pool.acquire() as observer:
+            unchanged = await observer.fetchrow(
+                """
+                SELECT status, provider_allowlist, mode_allowlist, revision
+                FROM voice_entitlements
+                WHERE uid = $1
+                """,
+                uid,
+            )
+        assert dict(unchanged) == {
+            "status": "active",
+            "provider_allowlist": ["grok-voice"],
+            "mode_allowlist": ["v4"],
+            "revision": 1,
+        }
 
     asyncio.run(_run_with_database(scenario))
 

--- a/backend/tests/unit/test_authority_writer_guard.py
+++ b/backend/tests/unit/test_authority_writer_guard.py
@@ -33,6 +33,7 @@ EXPECTED_WRITERS = {
     ("database/ella_provisioning.py", "promote_cloud_binding"),
     ("database/ella_provisioning.py", "quarantine_cloud_pool_claim"),
     ("database/ella_provisioning.py", "register_cloud_pool_binding"),
+    ("database/ella_provisioning.py", "seed_voice_entitlement_if_absent"),
     ("database/ella_provisioning.py", "stage_runtime_binding"),
     ("database/ella_provisioning.py", "update_guardian_mode"),
     ("database/invitation_operator.py", "_cleanup_locked"),
@@ -77,6 +78,7 @@ EXPECTED_GLOBAL_USER_WRITERS = {
     ("database/ella_provisioning.py", "update_guardian_mode"),
     ("database/invitations.py", "_bind_verified_identity_on_connection"),
     ("database/invitation_operator.py", "_cleanup_locked"),
+    ("database/managed_cloud_consent.py", "synchronize_denial"),
     ("database/managed_cloud_consent.py", "unlink_self_owner_account_on_deletion"),
     ("ella/utils/auto_provision.py", "auto_provision_user"),
 }
@@ -123,6 +125,10 @@ REAL_POSTGRES_WRITER_COVERAGE = {
     ("database/ella_provisioning.py", "quarantine_cloud_pool_claim"): (
         "tests/postgres/test_authority_advisory_lock_postgres.py",
         '"cloud_quarantine"',
+    ),
+    ("database/ella_provisioning.py", "seed_voice_entitlement_if_absent"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        "test_seed_voice_entitlement_if_absent_creates_once_without_clobber",
     ),
     ("database/ella_provisioning.py", "stage_runtime_binding"): (
         "tests/postgres/test_authority_advisory_lock_postgres.py",

--- a/backend/tests/unit/test_ella_ai_consent.py
+++ b/backend/tests/unit/test_ella_ai_consent.py
@@ -10,7 +10,11 @@ from pydantic import ValidationError
 from ella.routers import ai_consent
 from ella.services import ai_consent as consent, consent_authority
 from database import managed_cloud_consent
-from utils.ella.exact_firebase_auth import get_exact_firebase_uid
+from utils.ella.exact_firebase_auth import (
+    FirebaseTokenIdentity,
+    get_exact_firebase_uid,
+    get_firebase_token_identity,
+)
 
 
 def _submission(
@@ -840,7 +844,15 @@ def test_router_returns_conflict_for_stale_grant(monkeypatch):
     )
 
     with pytest.raises(HTTPException) as error:
-        asyncio.run(ai_consent.submit_ai_consent(request, uid="user-a"))
+        asyncio.run(
+            ai_consent.submit_ai_consent(
+                request,
+                identity=FirebaseTokenIdentity(
+                    uid="user-a",
+                    verified_email="user-a@example.invalid",
+                ),
+            )
+        )
 
     assert error.value.status_code == 409
     assert error.value.detail["code"] == "ai_consent_policy_mismatch"
@@ -904,6 +916,36 @@ def test_managed_cloud_consent_orders_denial_before_firestore_and_grant_after(
         "postgres:revoked",
         "firestore:revoked",
     ]
+
+
+def test_self_hosted_grant_passes_only_verified_email_to_authority(monkeypatch):
+    uid = "user-a"
+    service = _service()
+    captured = {}
+
+    async def grant(**kwargs):
+        captured.update(kwargs)
+        return {"decision": "granted"}
+
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "true")
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", "true")
+    monkeypatch.setattr(
+        consent_authority.managed_cloud_consent,
+        "synchronize_grant",
+        grant,
+    )
+
+    asyncio.run(
+        consent_authority.submit_with_managed_cloud_authority(
+            uid=uid,
+            verified_email="User-A@Example.invalid",
+            submission=_submission(request_id="request-verified-email-propagation"),
+            service=service,
+        )
+    )
+
+    assert captured["allow_fresh_uid_bootstrap"] is True
+    assert captured["bootstrap_email"] == "User-A@Example.invalid"
 
 
 def test_managed_cloud_denial_authority_error_prevents_firestore_mutation(
@@ -1017,7 +1059,10 @@ def test_authenticated_api_records_exact_v7_profile_bound_receipt(monkeypatch):
     monkeypatch.setattr(ai_consent, "get_ai_consent_service", lambda: service)
     app = FastAPI()
     app.include_router(ai_consent.router)
-    app.dependency_overrides[get_exact_firebase_uid] = lambda: "user-a"
+    app.dependency_overrides[get_firebase_token_identity] = lambda: FirebaseTokenIdentity(
+        uid="user-a",
+        verified_email="user-a@example.invalid",
+    )
     client = TestClient(app)
 
     response = client.post(
@@ -1048,3 +1093,34 @@ def test_authenticated_api_records_exact_v7_profile_bound_receipt(monkeypatch):
     assert body["receipt"]["scope_version"] == consent.CURRENT_SCOPE_VERSION
     assert body["receipt"]["scope_hash"] == consent.CURRENT_SCOPE_HASH
     assert body["receipt"]["server_decided_at"] == "2026-07-26T23:45:00+00:00"
+
+
+@pytest.mark.parametrize("decision", ("declined", "revoked"))
+def test_authenticated_api_allows_terminal_decisions_without_verified_email(monkeypatch, decision):
+    service = _service()
+    monkeypatch.setattr(ai_consent, "get_ai_consent_service", lambda: service)
+    monkeypatch.delenv("ELLA_HERMES_CLOUD_PROVISIONING_ENABLED", raising=False)
+    monkeypatch.delenv("ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS", raising=False)
+    monkeypatch.delenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", raising=False)
+    app = FastAPI()
+    app.include_router(ai_consent.router)
+    app.dependency_overrides[get_firebase_token_identity] = lambda: FirebaseTokenIdentity(uid="user-a")
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/users/ai-consent",
+        json={
+            "decision": decision,
+            "policy_version": consent.CURRENT_POLICY_VERSION,
+            "processor_set_hash": consent.CURRENT_PROCESSOR_SET_HASH,
+            "scope_version": consent.CURRENT_SCOPE_VERSION,
+            "scope_hash": consent.CURRENT_SCOPE_HASH,
+            "request_id": f"request-api-{decision}",
+            "app_version": "1.0.0",
+            "build_number": "804",
+            "locale": "en-US",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["receipt"]["decision"] == decision

--- a/backend/tests/unit/test_ella_ai_consent.py
+++ b/backend/tests/unit/test_ella_ai_consent.py
@@ -1098,10 +1098,21 @@ def test_authenticated_api_records_exact_v7_profile_bound_receipt(monkeypatch):
 @pytest.mark.parametrize("decision", ("declined", "revoked"))
 def test_authenticated_api_allows_terminal_decisions_without_verified_email(monkeypatch, decision):
     service = _service()
+    denials = []
+
+    async def deny(**kwargs):
+        denials.append(kwargs)
+        return {"decision": kwargs["decision"], "authority_absent": True}
+
     monkeypatch.setattr(ai_consent, "get_ai_consent_service", lambda: service)
     monkeypatch.delenv("ELLA_HERMES_CLOUD_PROVISIONING_ENABLED", raising=False)
     monkeypatch.delenv("ELLA_HERMES_CLOUD_PROVISIONING_ENABLED_UIDS", raising=False)
-    monkeypatch.delenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", raising=False)
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "true")
+    monkeypatch.setattr(
+        consent_authority.managed_cloud_consent,
+        "synchronize_denial",
+        deny,
+    )
     app = FastAPI()
     app.include_router(ai_consent.router)
     app.dependency_overrides[get_firebase_token_identity] = lambda: FirebaseTokenIdentity(uid="user-a")
@@ -1124,3 +1135,10 @@ def test_authenticated_api_allows_terminal_decisions_without_verified_email(monk
 
     assert response.status_code == 200
     assert response.json()["receipt"]["decision"] == decision
+    assert denials == [
+        {
+            "uid": "user-a",
+            "decision": decision,
+            "verified_email": "",
+        }
+    ]

--- a/backend/tests/unit/test_ella_all_router_authority_manifest.py
+++ b/backend/tests/unit/test_ella_all_router_authority_manifest.py
@@ -299,6 +299,12 @@ ROUTE_GROUPS = (
         ("GET", "/v1/ella/onboarding/status", "onboarding_status"),
     ),
     _group(
+        "legacy_onboarding",
+        "unauthenticated_caller_claimed_subject",
+        "deprecated_legacy_public",
+        ("POST", "/api/onboarding", "legacy_onboarding"),
+    ),
+    _group(
         "photon",
         "photon_service_exact_subject",
         "internal_only",

--- a/backend/tests/unit/test_ella_auth_authority_contract.py
+++ b/backend/tests/unit/test_ella_auth_authority_contract.py
@@ -80,6 +80,34 @@ def test_exact_firebase_boundary_never_accepts_admin_key(monkeypatch):
     assert error.value.status_code == 401
 
 
+def test_firebase_token_identity_exposes_only_verified_email(monkeypatch):
+    monkeypatch.setattr(
+        exact_firebase_auth.firebase_auth,
+        "verify_id_token",
+        lambda _token: {
+            "uid": "user-a",
+            "email": "User-A@Example.invalid",
+            "email_verified": True,
+        },
+    )
+
+    identity = exact_firebase_auth.get_firebase_token_identity("Bearer firebase")
+
+    assert identity == exact_firebase_auth.FirebaseTokenIdentity(
+        uid="user-a",
+        verified_email="user-a@example.invalid",
+    )
+
+    monkeypatch.setattr(
+        exact_firebase_auth.firebase_auth,
+        "verify_id_token",
+        lambda _token: {"uid": "user-a", "email": "user-a@example.invalid", "email_verified": False},
+    )
+    assert exact_firebase_auth.get_firebase_token_identity(
+        "Bearer firebase"
+    ) == exact_firebase_auth.FirebaseTokenIdentity(uid="user-a")
+
+
 def test_ella_lazy_exports_keep_imports_at_module_scope():
     source = (BACKEND / "utils" / "ella" / "__init__.py").read_text()
     tree = ast.parse(source)

--- a/backend/tests/unit/test_ella_auth_authority_contract.py
+++ b/backend/tests/unit/test_ella_auth_authority_contract.py
@@ -108,6 +108,62 @@ def test_firebase_token_identity_exposes_only_verified_email(monkeypatch):
     ) == exact_firebase_auth.FirebaseTokenIdentity(uid="user-a")
 
 
+def test_exact_firebase_uid_delegates_to_single_token_identity_boundary(monkeypatch):
+    calls = []
+
+    def identity(*args):
+        calls.append(args)
+        return exact_firebase_auth.FirebaseTokenIdentity(
+            uid="user-a",
+            verified_email="user-a@example.invalid",
+        )
+
+    monkeypatch.setattr(exact_firebase_auth, "get_firebase_token_identity", identity)
+
+    assert (
+        exact_firebase_auth.get_exact_firebase_uid(
+            "Bearer firebase",
+            "1.0.529+807",
+            "807",
+            "1.0.529",
+        )
+        == "user-a"
+    )
+    assert calls == [
+        (
+            "Bearer firebase",
+            "1.0.529+807",
+            "807",
+            "1.0.529",
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "resolver",
+    (
+        exact_firebase_auth.get_firebase_token_identity,
+        exact_firebase_auth.get_exact_firebase_uid,
+    ),
+)
+def test_firebase_boundaries_share_malformed_token_and_client_gate(monkeypatch, resolver):
+    with pytest.raises(HTTPException) as missing:
+        resolver(None, None, None, None)
+    assert missing.value.status_code == 401
+
+    monkeypatch.setattr(
+        exact_firebase_auth.firebase_auth,
+        "verify_id_token",
+        lambda _token: {"uid": "user-a", "email": "user-a@example.invalid", "email_verified": True},
+    )
+    monkeypatch.setenv("ELLA_MIN_SUPPORTED_CLIENT_BUILD", "807")
+
+    with pytest.raises(HTTPException) as old:
+        resolver("Bearer firebase", None, "806", None)
+    assert old.value.status_code == 426
+    assert resolver("Bearer firebase", None, "807", None)
+
+
 def test_ella_lazy_exports_keep_imports_at_module_scope():
     source = (BACKEND / "utils" / "ella" / "__init__.py").read_text()
     tree = ast.parse(source)

--- a/backend/tests/unit/test_ella_provision_authority_split.py
+++ b/backend/tests/unit/test_ella_provision_authority_split.py
@@ -856,6 +856,11 @@ class _RecordingRepository:
         self.job.update(kwargs)
         return dict(self.job)
 
+    async def seed_voice_entitlement_if_absent(self, *, uid):
+        del uid
+        self._record("seed_voice_entitlement_if_absent")
+        return False
+
     async def activate_runtime_binding(self, **_kwargs):
         self._record("activate_runtime_binding")
         return {**self.staged, "revision": 2, "active": True}
@@ -963,6 +968,11 @@ def test_real_claimed_worker_stops_after_inflight_http_authority_drift(monkeypat
     [
         ("stage_runtime_binding", 1, {"stage_runtime_binding", "update_job", "activate_runtime_binding"}),
         ("update_job", 1, {"update_job", "activate_runtime_binding"}),
+        (
+            "seed_voice_entitlement_if_absent",
+            1,
+            {"seed_voice_entitlement_if_absent", "activate_runtime_binding"},
+        ),
         ("activate_runtime_binding", 1, {"activate_runtime_binding"}),
         ("update_job", 2, set()),
     ],

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -237,7 +237,7 @@ class FakeRepository:
         )
         self.job_calls = []
         self.voice_seed_calls = []
-        self.voice_seed_result = True
+        self.voice_seed_result = False
 
     async def assert_schema_ready(self):
         self.schema_checks += 1
@@ -1944,6 +1944,7 @@ def test_fresh_self_hosted_provision_seeds_grok_voice(monkeypatch):
     )
 
     repository = FakeRepository()
+    repository.voice_seed_result = True
     client = FakeProvisionClient(_runtime_receipt())
     asyncio.run(
         ProvisioningCoordinator(repository, client).process_claimed_job(

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import httpx
 import pytest
 
+import database
 from database.runtime_targets import (
     SELF_HOSTED_RUNTIME_MODEL,
     SELF_HOSTED_RUNTIME_PROVIDER,
@@ -1979,6 +1980,7 @@ def test_grok_voice_firestore_seed_gated_on_fresh_entitlement_row(monkeypatch):
 
     fake = _FakeAppSettings()
     monkeypatch.setitem(sys.modules, "database.app_settings", fake)
+    monkeypatch.setattr(database, "app_settings", fake, raising=False)
 
     # No fresh row -> firestore is never even read.
     provisioning_service._ensure_self_hosted_grok_voice_mode("u1", fresh_entitlement_created=False)

--- a/backend/utils/ella/exact_firebase_auth.py
+++ b/backend/utils/ella/exact_firebase_auth.py
@@ -134,18 +134,12 @@ def get_exact_firebase_uid(
     x_ella_client_version: Optional[str] = Header(default=None, alias="X-Ella-Client-Version"),
 ) -> str:
     """Return the Firebase subject without admin-key or local-dev fallbacks."""
-    parts = authorization.split() if authorization else []
-    if len(parts) != 2 or parts[0].lower() != "bearer" or not parts[1]:
-        raise HTTPException(status_code=401, detail="Missing or invalid Firebase bearer")
-    try:
-        decoded = firebase_auth.verify_id_token(parts[1])
-    except Exception:
-        raise HTTPException(status_code=401, detail="Invalid or expired Firebase bearer")
-    uid = str(decoded.get("uid") or "").strip() if isinstance(decoded, dict) else ""
-    if not uid:
-        raise HTTPException(status_code=401, detail="Invalid Firebase bearer subject")
-    require_supported_ella_client(x_app_version, x_ella_app_build, x_ella_client_version)
-    return uid
+    return get_firebase_token_identity(
+        authorization,
+        x_app_version,
+        x_ella_app_build,
+        x_ella_client_version,
+    ).uid
 
 
 def require_matching_firebase_uid(authenticated_uid: str, claimed_uid: Optional[str], *, feature: str) -> str:

--- a/backend/utils/ella/exact_firebase_auth.py
+++ b/backend/utils/ella/exact_firebase_auth.py
@@ -46,6 +46,12 @@ class EllaRequestAuthority:
         return bound_subject
 
 
+@dataclass(frozen=True)
+class FirebaseTokenIdentity:
+    uid: str
+    verified_email: str = ""
+
+
 def _version_tuple(value: str) -> tuple[int, ...]:
     if not CLIENT_VERSION_RE.fullmatch(value):
         raise ValueError
@@ -96,6 +102,29 @@ def require_supported_ella_client(
     width = max(len(minimum_parts), len(supplied_parts))
     if supplied_parts + (0,) * (width - len(supplied_parts)) < minimum_parts + (0,) * (width - len(minimum_parts)):
         raise HTTPException(status_code=426, detail={"code": "update_required", "minimum_build": minimum})
+
+
+def get_firebase_token_identity(
+    authorization: Optional[str] = Header(None),
+    x_app_version: Optional[str] = Header(default=None, alias="X-App-Version"),
+    x_ella_app_build: Optional[str] = Header(default=None, alias="X-Ella-App-Build"),
+    x_ella_client_version: Optional[str] = Header(default=None, alias="X-Ella-Client-Version"),
+) -> FirebaseTokenIdentity:
+    """Return the exact Firebase subject and optional verified email."""
+    parts = authorization.split() if authorization else []
+    if len(parts) != 2 or parts[0].lower() != "bearer" or not parts[1]:
+        raise HTTPException(status_code=401, detail="Missing or invalid Firebase bearer")
+    try:
+        decoded = firebase_auth.verify_id_token(parts[1])
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid or expired Firebase bearer")
+    uid = str(decoded.get("uid") or "").strip() if isinstance(decoded, dict) else ""
+    if not uid:
+        raise HTTPException(status_code=401, detail="Invalid Firebase bearer subject")
+    email = str(decoded.get("email") or "").strip().lower() if isinstance(decoded, dict) else ""
+    verified_email = email if decoded.get("email_verified") is True else ""
+    require_supported_ella_client(x_app_version, x_ella_app_build, x_ella_client_version)
+    return FirebaseTokenIdentity(uid=uid, verified_email=verified_email)
 
 
 def get_exact_firebase_uid(


### PR DESCRIPTION
## Incident
Fresh self-hosted consent returned managed_cloud_consent_authority_unavailable because the deterministic bootstrap inserted users without the live schema required email.

## Fix
- Carry the verified Firebase token email to the serialized authority grant.
- Write that exact normalized email and identity metadata in the locked fresh-user bootstrap.
- Preserve deterministic owner ID, UID uniqueness, rollback, and no-clobber behavior.
- Keep decline and revoke available for valid Firebase identities without a verified email.

## Validation
- 58 passed: tests/unit/test_ella_ai_consent.py and tests/unit/test_ella_auth_authority_contract.py.
- Black check passes for every touched file.
- The Postgres regression test now applies email NOT NULL, checks same UID/email reconciliation with real ensure_user_identity, and checks blank-email rollback. It could not run here because ELLA_TEST_POSTGRES_DSN and Firebase application credentials are unavailable; production was not used as a test target.

## Baseline Constraints
- Full tests/unit collection has pre-existing branch/module import conflicts.
- Authority inventory and router manifest checks have pre-existing failures on the deployed base.

Release-line only: this PR targets codex/auto-provision-grok-voice, not main.
