### PR TITLE
fix(ios): complete logout in one identity transition

### DIFF
--- a/app/lib/services/auth_service.dart
+++ b/app/lib/services/auth_service.dart
@@ -159,7 +159,16 @@ class AuthService {
     }
   }
 
-  Future<void> signOut() => runIdentityTransition(FirebaseAuth.instance.signOut);
+  /// Quiesce account-scoped producers once, run the caller's local cleanup,
+  /// then mutate Firebase identity. Cleanup remains inside the transition so
+  /// caches cannot survive into the next account, while callers that already
+  /// need cleanup do not invoke the full shutdown sequence a second time.
+  Future<void> signOutWithQuiescedCleanup(Future<void> Function() cleanup) => runIdentityTransition(() async {
+    await cleanup();
+    await FirebaseAuth.instance.signOut();
+  });
+
+  Future<void> signOut() => signOutWithQuiescedCleanup(() async {});
 
   Future<String?> getIdToken() async {
     try {

--- a/app/lib/utils/auth_utils.dart
+++ b/app/lib/utils/auth_utils.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:omi/backend/preferences.dart';
-import 'package:omi/ella/services/ella_account_isolation_service.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/providers/ella_entitlement_provider.dart';
@@ -39,39 +38,32 @@ Future<void> signOutAndClearUserData(BuildContext context) async {
   try {
     entitlementProvider = context.read<EllaEntitlementProvider>();
   } catch (_) {}
-  await EllaAccountIsolationService(
-    stopCapture: () async {
-      await captureProvider?.stopStreamDeviceRecording(cleanDevice: true);
-      await captureProvider?.stopStreamRecording();
-    },
-  ).stopForAccountTransition();
+  await AuthService.instance.signOutWithQuiescedCleanup(() async {
+    // Clear in-memory provider state only after every account producer has
+    // quiesced. Firebase sign-out follows this callback in the same transition.
+    try {
+      conversationProvider?.reset();
+    } catch (_) {}
+    try {
+      messageProvider?.reset();
+    } catch (_) {}
+    try {
+      captureProvider?.reset();
+    } catch (_) {}
+    try {
+      peopleProvider?.reset();
+    } catch (_) {}
+    try {
+      memoriesProvider?.reset();
+    } catch (_) {}
+    try {
+      entitlementProvider?.reset();
+    } catch (_) {}
 
-  // Clear in-memory provider state
-  try {
-    conversationProvider?.reset();
-  } catch (_) {}
-  try {
-    messageProvider?.reset();
-  } catch (_) {}
-  try {
-    captureProvider?.reset();
-  } catch (_) {}
-  try {
-    peopleProvider?.reset();
-  } catch (_) {}
-  try {
-    memoriesProvider?.reset();
-  } catch (_) {}
-  try {
-    entitlementProvider?.reset();
-  } catch (_) {}
+    // Explicitly clear conversation/message caches first (prevents cross-account data leak)
+    SharedPreferencesUtil().clearUserCaches();
 
-  // Explicitly clear conversation/message caches first (prevents cross-account data leak)
-  SharedPreferencesUtil().clearUserCaches();
-
-  // Clear all persisted local data
-  await SharedPreferencesUtil().clear();
-
-  // Sign out of Firebase
-  await AuthService.instance.signOut();
+    // Clear all persisted local data before Firebase changes identity.
+    await SharedPreferencesUtil().clear();
+  });
 }

--- a/app/test/ella/services/p1_hygiene_test.dart
+++ b/app/test/ella/services/p1_hygiene_test.dart
@@ -213,8 +213,14 @@ void main() {
     final auth = File('${lib.path}/services/auth_service.dart').readAsStringSync();
     expect(auth, contains('Future<T> runIdentityTransition<T>'));
     expect(auth.indexOf('stopForAccountTransition()'), lessThan(auth.indexOf('return mutation();')));
-    expect(auth, contains('Future<void> signOut() => runIdentityTransition(FirebaseAuth.instance.signOut)'));
+    expect(auth, contains('Future<void> signOutWithQuiescedCleanup'));
+    expect(auth, contains('Future<void> signOut() => signOutWithQuiescedCleanup(() async {})'));
     expect(auth, contains('replaceIdentityWithCredential'));
+
+    final authUtils = File('${lib.path}/utils/auth_utils.dart').readAsStringSync();
+    expect(authUtils, contains('signOutWithQuiescedCleanup(() async {'));
+    expect(authUtils, isNot(contains('stopForAccountTransition()')));
+    expect(authUtils, isNot(contains('AuthService.instance.signOut()')));
 
     final provider = File('${lib.path}/providers/auth_provider.dart').readAsStringSync();
     expect(provider, contains('runIdentityTransition(_auth.signInAnonymously)'));


### PR DESCRIPTION
## What changed

- routes full logout through one account identity transition
- quiesces account-scoped producers before clearing provider and preference state
- performs Firebase sign-out inside that same transition instead of starting a second shutdown pass
- strengthens the P1 source contract so the full logout path cannot reintroduce nested account transitions

## Root cause

Build 807 called `stopForAccountTransition()` directly from `signOutAndClearUserData`, reset entitlement and other provider state, then called `AuthService.signOut()`, which invoked the complete account transition a second time. If that second pass stalled, Firebase remained signed in while the entitlement provider was already reset, leaving the UI indefinitely on “Checking your Ella access.”

## User impact

Sign out now has one fail-closed ordering: stop all account producers, clear account-local state, then change Firebase identity. This addresses the observed stuck sign-out without weakening the account-isolation boundary.

## Validation

- exact base: `testflight/phase-a-807` / `sophia/release-1.0.529+807` at `9d1419c682fc91ba939e7debe5c0d996c3195dd1`
- focused P1 hygiene test: 11/11 passed
- full Flutter package: 396/396 passed
- targeted Dart analysis of all three changed files: no issues
- repository-wide analyzer still reports its pre-existing backlog; no finding points to these files

## Scope

This fixes the separate build-807 client logout stall. Fresh signup remains blocked on backend activation and quarantine/recovery defects and must not be declared complete from this PR.
