### PR TITLE
fix: recover repeated fresh consent safely

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -655,6 +655,7 @@ jobs:
             "tests/unit/test_ella_provisioning_service.py::test_post_provider_attestation_rejections_retry_and_reconcile_one_binding"
             "tests/unit/test_ella_provisioning_service.py::test_invitation_runtime_requires_persisted_profile_local_honcho_proof"
             "tests/unit/test_ella_provisioning_service.py::test_retained_owner_identity_is_exact_and_requires_server_configuration"
+            "tests/unit/test_ella_provisioning_service.py::test_fresh_uid_relax_activation_does_not_require_invitation_target"
             "tests/unit/test_voice_proxy_auth.py::test_self_hosted_voice_proxy_re_resolves_exact_voice_target"
             "tests/unit/test_voice_proxy_auth.py::test_self_hosted_voice_accept_drift_fails_before_session_or_provider_call[authority_digest-voice_runtime_authority_changed]"
             "tests/unit/test_voice_proxy_auth.py::test_self_hosted_voice_accept_drift_fails_before_session_or_provider_call[session-voice_session_claim_mismatch]"
@@ -682,7 +683,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 543
+          test "$collected" -eq 544
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \
@@ -785,7 +786,10 @@ jobs:
           grep -Fqx \
             "tests/postgres/test_authority_advisory_lock_postgres.py::test_seed_voice_entitlement_if_absent_creates_once_without_clobber" \
             <<<"$authority_lock_ids"
-          test "$(grep -c '::' <<<"$authority_lock_ids")" -eq 77
+          grep -Fqx \
+            "tests/postgres/test_authority_advisory_lock_postgres.py::test_fresh_regrant_is_idempotent_and_recovers_only_exact_quarantine" \
+            <<<"$authority_lock_ids"
+          test "$(grep -c '::' <<<"$authority_lock_ids")" -eq 78
           pytest \
             tests/unit/test_authority_advisory_lock.py \
             tests/unit/test_authority_writer_guard.py \

--- a/.github/workflows/invite-redemption-tests.yml
+++ b/.github/workflows/invite-redemption-tests.yml
@@ -170,7 +170,7 @@ jobs:
               tests/postgres/test_runtime_migration_atomicity_postgres.py |
               grep -c '::'
           )"
-          test "$collected" -eq 189
+          test "$collected" -eq 190
           collected_ids="$(
             pytest --collect-only -q \
               tests/unit/test_invitation_redemption.py \
@@ -212,6 +212,7 @@ jobs:
             "tests/unit/test_ella_provisioning_service.py::test_external_cancellation_after_provider_work_records_retryable_reconciliation"
             "tests/unit/test_ella_provisioning_service.py::test_post_provider_attestation_rejections_retry_and_reconcile_one_binding"
             "tests/unit/test_ella_provisioning_service.py::test_retained_owner_identity_is_exact_and_requires_server_configuration"
+            "tests/unit/test_ella_provisioning_service.py::test_fresh_uid_relax_activation_does_not_require_invitation_target"
             "tests/unit/test_ella_provisioning_service.py::test_resolve_self_hosted_active_direct_positive_healthy_active"
             "tests/unit/test_ella_provisioning_service.py::test_resolve_self_hosted_active_direct_negative_disabled_unhealthy"
             "tests/unit/test_ella_provisioning_service.py::test_resolve_self_hosted_active_direct_no_row_returns_none"

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -2979,7 +2979,7 @@ class EllaProvisioningRepository:
         return dict(row)
 
     async def seed_voice_entitlement_if_absent(self, *, uid: str) -> bool:
-        """Create-if-absent self-hosted grok voice entitlement.
+        """Create or safely recover a self-hosted grok voice entitlement.
 
         Fresh self-hosted hermes user provisioning should carry a working
         grok-voice entitlement so the first voice/chat session does not open
@@ -2988,9 +2988,11 @@ class EllaProvisioningRepository:
         plan=canary, provider_allowlist={grok-voice}, mode_allowlist={v4},
         explicit quota (daily 2700s / monthly 43200s / session 1200s).
 
-        No-clobber / row precedence: ``ON CONFLICT (uid) DO NOTHING`` — an
-        existing entitlement (e.g. a user with a prior voice row) is left
-        untouched. Returns True when a row was newly inserted.
+        No-clobber / row precedence: every existing entitlement is left
+        untouched except the exact invitationless auto-provision shape tied to
+        the content-free recovery receipt for a previous
+        ``managed_cloud_consent_grant_changed`` quarantine. Returns True when a
+        row was newly inserted or safely recovered.
         """
         async with self.pool.acquire() as connection:
             owner = await authority_advisory_lock.resolve_self_owner_unlocked(
@@ -3008,7 +3010,7 @@ class EllaProvisioningRepository:
                     owner=owner,
                     proof=owner_lock,
                 )
-                result = await connection.execute(
+                row = await connection.fetchrow(
                     """
                     INSERT INTO voice_entitlements (
                         uid, status, plan, daily_limit_s, monthly_limit_s,
@@ -3020,6 +3022,7 @@ class EllaProvisioningRepository:
                         $6::text[], $7::text[], $8::text[], $9::jsonb, $10
                     )
                     ON CONFLICT (uid) DO NOTHING
+                    RETURNING revision
                     """,
                     uid,
                     2700,
@@ -3032,7 +3035,70 @@ class EllaProvisioningRepository:
                     json.dumps({"enabled": False, "order": []}),
                     "auto-provision self-hosted grok voice",
                 )
-                return result == "INSERT 0 1"
+                if row is not None:
+                    return True
+
+                recovery_candidates = await connection.fetch(
+                    """
+                    SELECT job.id AS job_id, binding.id AS binding_id
+                    FROM users account
+                    JOIN ella_provisioning_jobs job
+                      ON job.user_id = account.id
+                    JOIN ella_runtime_bindings binding
+                      ON binding.user_id = account.id
+                     AND binding.provider = 'hermes'
+                     AND binding.role = 'user'
+                     AND binding.template_version = job.target_schema_version
+                    WHERE account.omi_uid = $1
+                      AND account.status = 'PENDING'
+                      AND job.state = 'provisioning'
+                      AND job.stage = 'smoke_passed'
+                      AND job.retryable = TRUE
+                      AND job.error_code IS NULL
+                      AND job.receipts @> '[{"type":"fresh_consent_regrant_rearmed","content_free":true}]'::jsonb
+                      AND binding.status = 'shadow'
+                      AND binding.active = FALSE
+                      AND binding.health_state = 'healthy'
+                      AND binding.runtime_target_mode = 'hermes-chat'
+                      AND binding.quarantine_reason IS NULL
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM ella_invitation_redemptions redemption
+                          WHERE redemption.user_id = account.id
+                      )
+                    FOR UPDATE OF job, binding
+                    """,
+                    uid,
+                )
+                if len(recovery_candidates) != 1:
+                    return False
+
+                row = await connection.fetchrow(
+                    """
+                    UPDATE voice_entitlements
+                    SET status = 'active',
+                        revision = revision + 1,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE uid = $1
+                      AND status = 'revoked'
+                      AND invitation_id IS NULL
+                      AND plan = 'canary'
+                      AND daily_limit_s = 2700
+                      AND monthly_limit_s = 43200
+                      AND max_session_s = 1200
+                      AND max_concurrent = 1
+                      AND provider_allowlist = ARRAY['grok-voice']::text[]
+                      AND model_allowlist = ARRAY[]::text[]
+                      AND mode_allowlist = ARRAY['v4']::text[]
+                      AND fallback_policy = '{"enabled":false,"order":[]}'::jsonb
+                      AND operator_note = 'auto-provision self-hosted grok voice'
+                      AND consent_authority_epoch IS NULL
+                      AND invitation_consent_pending = FALSE
+                    RETURNING revision
+                    """,
+                    uid,
+                )
+                return row is not None
 
     async def activate_runtime_binding(
         self,

--- a/backend/database/managed_cloud_consent.py
+++ b/backend/database/managed_cloud_consent.py
@@ -85,13 +85,9 @@ def invitation_consent_receipt_ref(uid: str, receipt_id: str) -> str:
     return hashlib.sha256(material.encode("utf-8")).hexdigest()
 
 
-def _grant_matches(row: asyncpg.Record, grant: ManagedCloudGrant) -> bool:
+def _grant_contract_matches(row: asyncpg.Record, grant: ManagedCloudGrant) -> bool:
     return bool(
         row["decision"] == "granted"
-        and hmac.compare_digest(
-            str(row["consent_receipt_ref"] or ""),
-            consent_receipt_ref(grant.account_uid, grant.consent_receipt_id),
-        )
         and hmac.compare_digest(
             str(row["profile_binding_id"] or ""),
             grant.profile_binding_id,
@@ -113,6 +109,142 @@ def _grant_matches(row: asyncpg.Record, grant: ManagedCloudGrant) -> bool:
             grant.scope_hash,
         )
     )
+
+
+def _grant_matches(row: asyncpg.Record, grant: ManagedCloudGrant) -> bool:
+    return bool(
+        _grant_contract_matches(row, grant)
+        and hmac.compare_digest(
+            str(row["consent_receipt_ref"] or ""),
+            consent_receipt_ref(grant.account_uid, grant.consent_receipt_id),
+        )
+    )
+
+
+async def _rearm_fresh_self_hosted_regrant_on_connection(
+    conn: asyncpg.Connection,
+    *,
+    uid: str,
+    user_id: uuid.UUID,
+    owner_lock: authority_advisory_lock.AuthorityLockProof,
+) -> bool:
+    """Rearm only the exact fresh-relax quarantine left by a prior regrant.
+
+    This does not reactivate a runtime. It moves one content-free, invitationless
+    provisioning attempt back to ``pending`` and its disabled binding back to a
+    non-authorizing ``shadow`` state. The normal provisioner must then obtain a
+    fresh Honcho attestation, restage a healthy binding, recover the exact
+    auto-provisioned voice row, and activate it.
+    """
+
+    await authority_advisory_lock.require_self_owner_lock(
+        conn,
+        owner_lock,
+        user_id=user_id,
+    )
+    candidates = await conn.fetch(
+        """
+        SELECT job.id AS job_id, binding.id AS binding_id
+        FROM users account
+        JOIN ella_provisioning_jobs job
+          ON job.user_id = account.id
+        JOIN ella_runtime_bindings binding
+          ON binding.user_id = account.id
+         AND binding.provider = 'hermes'
+         AND binding.role = 'user'
+         AND binding.template_version = job.target_schema_version
+        WHERE account.id = $1
+          AND account.omi_uid = $2
+          AND account.status = 'PENDING'
+          AND job.state = 'blocked'
+          AND job.stage = 'runtime_ready'
+          AND job.retryable = FALSE
+          AND job.error_code = 'invitation_authority_revoked'
+          AND job.error_detail ->> 'reason' = 'managed_cloud_consent_grant_changed'
+          AND binding.status = 'disabled'
+          AND binding.active = FALSE
+          AND binding.health_state = 'unhealthy'
+          AND binding.quarantine_reason = 'managed_cloud_consent_grant_changed'
+          AND binding.runtime_target_mode = 'hermes-chat'
+          AND NOT EXISTS (
+              SELECT 1
+              FROM ella_invitation_redemptions redemption
+              WHERE redemption.user_id = account.id
+          )
+          AND NOT EXISTS (
+              SELECT 1
+              FROM voice_entitlements entitlement
+              WHERE entitlement.uid = $2
+                AND NOT (
+                    entitlement.status = 'revoked'
+                    AND entitlement.invitation_id IS NULL
+                    AND entitlement.plan = 'canary'
+                    AND entitlement.daily_limit_s = 2700
+                    AND entitlement.monthly_limit_s = 43200
+                    AND entitlement.max_session_s = 1200
+                    AND entitlement.max_concurrent = 1
+                    AND entitlement.provider_allowlist = ARRAY['grok-voice']::text[]
+                    AND entitlement.model_allowlist = ARRAY[]::text[]
+                    AND entitlement.mode_allowlist = ARRAY['v4']::text[]
+                    AND entitlement.fallback_policy = '{"enabled":false,"order":[]}'::jsonb
+                    AND entitlement.operator_note = 'auto-provision self-hosted grok voice'
+                    AND entitlement.consent_authority_epoch IS NULL
+                    AND entitlement.invitation_consent_pending = FALSE
+                )
+          )
+        FOR UPDATE OF job, binding
+        """,
+        user_id,
+        uid,
+    )
+    if len(candidates) != 1:
+        return False
+
+    candidate = candidates[0]
+    job_result = await conn.execute(
+        """
+        UPDATE ella_provisioning_jobs
+        SET state = 'pending',
+            stage = 'identity_ready',
+            retryable = TRUE,
+            error_code = NULL,
+            error_detail = '{}'::jsonb,
+            receipts = receipts || jsonb_build_array(
+                jsonb_build_object(
+                    'type', 'fresh_consent_regrant_rearmed',
+                    'content_free', TRUE
+                )
+            ),
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = $1
+          AND state = 'blocked'
+          AND error_code = 'invitation_authority_revoked'
+        """,
+        candidate["job_id"],
+    )
+    binding_result = await conn.execute(
+        """
+        UPDATE ella_runtime_bindings
+        SET status = 'shadow',
+            active = FALSE,
+            health_state = 'pending',
+            health_receipt = '{"content_free":true,"reason":"managed_cloud_consent_regrant_recovery_pending"}'::jsonb,
+            disabled_at = NULL,
+            quarantined_at = NULL,
+            quarantine_reason = NULL,
+            revision = revision + 1,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = $1
+          AND status = 'disabled'
+          AND active = FALSE
+          AND health_state = 'unhealthy'
+          AND quarantine_reason = 'managed_cloud_consent_grant_changed'
+        """,
+        candidate["binding_id"],
+    )
+    if job_result != "UPDATE 1" or binding_result != "UPDATE 1":
+        raise ManagedCloudAuthorityUnavailable("fresh_consent_regrant_recovery_stale")
+    return True
 
 
 async def _quarantine_on_connection(
@@ -311,7 +443,25 @@ async def synchronize_grant(
                         grant.scope_version,
                         grant.scope_hash,
                     )
-                elif not _grant_matches(row, grant):
+                elif _grant_matches(row, grant):
+                    pass
+                elif _grant_contract_matches(row, grant):
+                    row = await conn.fetchrow(
+                        """
+                        UPDATE ella_managed_cloud_consent_authority
+                        SET consent_receipt_ref = $2,
+                            revision = revision + 1,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE user_id = $1
+                        RETURNING *
+                        """,
+                        user_id,
+                        consent_receipt_ref(
+                            grant.account_uid,
+                            grant.consent_receipt_id,
+                        ),
+                    )
+                else:
                     row = await conn.fetchrow(
                         """
                         UPDATE ella_managed_cloud_consent_authority
@@ -348,6 +498,13 @@ async def synchronize_grant(
                     )
                 if row is None or not _grant_matches(row, grant):
                     raise ManagedCloudAuthorityUnavailable("managed_cloud_authority_grant_failed")
+                if allow_fresh_uid_bootstrap:
+                    await _rearm_fresh_self_hosted_regrant_on_connection(
+                        conn,
+                        uid=grant.account_uid,
+                        user_id=user_id,
+                        owner_lock=owner_lock,
+                    )
                 pending_count = int(
                     await conn.fetchval(
                         """

--- a/backend/ella/services/provisioning.py
+++ b/backend/ella/services/provisioning.py
@@ -1350,20 +1350,21 @@ class ProvisioningCoordinator:
                 uid=identity.uid,
             )
             # Firestore voice_mode only when a fresh DB entitlement row was
-            # actually inserted -- keeps a returning/operator-seeded user's own
-            # voice state untouched and the receipt consistent with the row.
+            # inserted or the exact auto-provisioned quarantine row was safely
+            # recovered -- keeps operator-seeded voice state untouched.
             _ensure_self_hosted_grok_voice_mode(
                 identity.uid,
                 fresh_entitlement_created=bool(voice_entitlement_created),
             )
             deadline_check()
+            invitation_target_required = invitation_admission is not None
             activated = await self._repository_call(
                 authority_snapshot,
                 self.repository.activate_runtime_binding,
                 uid=identity.uid,
                 provider="hermes",
-                require_invitation_target=self_hosted_required,
-                authority_lineage=(current_self_hosted_runtime_lineage() if self_hosted_required else None),
+                require_invitation_target=invitation_target_required,
+                authority_lineage=(current_self_hosted_runtime_lineage() if invitation_target_required else None),
                 model=SELF_HOSTED_RUNTIME_MODEL,
             )
             deadline_check()

--- a/backend/tests/postgres/test_authority_advisory_lock_postgres.py
+++ b/backend/tests/postgres/test_authority_advisory_lock_postgres.py
@@ -372,6 +372,23 @@ def _managed_cloud_grant(uid: str, *, revision: str = "one") -> managed_cloud_co
     )
 
 
+def _reissued_managed_cloud_grant(
+    grant: managed_cloud_consent.ManagedCloudGrant,
+    *,
+    receipt_id: str,
+) -> managed_cloud_consent.ManagedCloudGrant:
+    return managed_cloud_consent.ManagedCloudGrant(
+        account_uid=grant.account_uid,
+        profile_uid=grant.profile_uid,
+        consent_receipt_id=receipt_id,
+        profile_binding_id=grant.profile_binding_id,
+        policy_version=grant.policy_version,
+        processor_set_hash=grant.processor_set_hash,
+        scope_version=grant.scope_version,
+        scope_hash=grant.scope_hash,
+    )
+
+
 async def _wait_for_advisory_waiter(
     pool: asyncpg.Pool,
     owner: authority_advisory_lock.AuthorityOwner,
@@ -2165,6 +2182,277 @@ def test_fresh_managed_terminal_decision_reconciles_email_owner_before_quarantin
     asyncio.run(_run_with_database(scenario))
 
 
+def test_fresh_regrant_is_idempotent_and_recovers_only_exact_quarantine():
+    async def scenario(pool):
+        uid = "synthetic-fresh-regrant-recovery"
+        initial_grant = _managed_cloud_grant(uid)
+        initial = await managed_cloud_consent.synchronize_grant(
+            grant=initial_grant,
+            allow_fresh_uid_bootstrap=True,
+            bootstrap_email="fresh-regrant@example.invalid",
+        )
+        user_id = initial["user_id"]
+        job_id = uuid.uuid4()
+        binding_id = uuid.uuid4()
+        repository = EllaProvisioningRepository(pool)
+        assert await repository.seed_voice_entitlement_if_absent(uid=uid) is True
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO ella_provisioning_jobs (
+                    id, user_id, target_schema_version, request_payload_hash,
+                    state, stage, retryable
+                ) VALUES (
+                    $1, $2, 'hermes-user-v1', 'synthetic',
+                    'provisioning', 'smoke_passed', TRUE
+                )
+                """,
+                job_id,
+                user_id,
+            )
+            await conn.execute(
+                """
+                INSERT INTO ella_runtime_bindings (
+                    id, user_id, account_user_id, profile_user_id,
+                    role, provider, profile_name, agent_id,
+                    template_version, model_policy_version, voice_policy_version,
+                    health_state, health_receipt, runtime_target_mode,
+                    status, active
+                ) VALUES (
+                    $1, $2, $2, $2,
+                    'user', 'hermes', 'fresh-regrant-profile', 'fresh-regrant-agent',
+                    'hermes-user-v1', 'model-policy-v1', 'voice-policy-v1',
+                    'healthy', '{}'::jsonb, 'hermes-chat',
+                    'shadow', FALSE
+                )
+                """,
+                binding_id,
+                user_id,
+            )
+            initial_epoch = await conn.fetchval(
+                """
+                SELECT authority_epoch
+                FROM ella_managed_cloud_consent_authority
+                WHERE user_id = $1
+                """,
+                user_id,
+            )
+            initial_revision = await conn.fetchval(
+                """
+                SELECT revision
+                FROM ella_managed_cloud_consent_authority
+                WHERE user_id = $1
+                """,
+                user_id,
+            )
+
+        exact_repeat = await managed_cloud_consent.synchronize_grant(
+            grant=initial_grant,
+            allow_fresh_uid_bootstrap=True,
+            bootstrap_email="fresh-regrant@example.invalid",
+        )
+        assert exact_repeat["authority_epoch"] == initial_epoch
+        assert exact_repeat["revision"] == initial_revision
+
+        repeated_grant = _reissued_managed_cloud_grant(
+            initial_grant,
+            receipt_id="synthetic-receipt-reaffirmed",
+        )
+        repeated = await managed_cloud_consent.synchronize_grant(
+            grant=repeated_grant,
+            allow_fresh_uid_bootstrap=True,
+            bootstrap_email="fresh-regrant@example.invalid",
+        )
+        assert repeated["authority_epoch"] == initial_epoch
+
+        async with pool.acquire() as observer:
+            unchanged = await observer.fetchrow(
+                """
+                SELECT job.state, job.stage, binding.status,
+                       binding.health_state, binding.active,
+                       entitlement.status AS entitlement_status
+                FROM ella_provisioning_jobs job
+                JOIN ella_runtime_bindings binding
+                  ON binding.user_id = job.user_id
+                JOIN voice_entitlements entitlement
+                  ON entitlement.uid = $2
+                WHERE job.id = $1
+                """,
+                job_id,
+                uid,
+            )
+        assert tuple(unchanged.values()) == (
+            "provisioning",
+            "smoke_passed",
+            "shadow",
+            "healthy",
+            False,
+            "active",
+        )
+
+        # Reproduce the exact production state left by the old receipt-change
+        # path. The next valid same-contract grant may rearm this state, but it
+        # must not activate either the binding or voice row by itself.
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE ella_provisioning_jobs
+                SET state = 'blocked',
+                    stage = 'runtime_ready',
+                    retryable = FALSE,
+                    error_code = 'invitation_authority_revoked',
+                    error_detail = '{"content_free":true,"reason":"managed_cloud_consent_grant_changed"}'::jsonb
+                WHERE id = $1
+                """,
+                job_id,
+            )
+            await conn.execute(
+                """
+                UPDATE ella_runtime_bindings
+                SET status = 'disabled',
+                    active = FALSE,
+                    health_state = 'unhealthy',
+                    quarantine_reason = 'managed_cloud_consent_grant_changed',
+                    disabled_at = CURRENT_TIMESTAMP,
+                    runtime_target_mode = NULL
+                WHERE id = $1
+                """,
+                binding_id,
+            )
+            await conn.execute(
+                """
+                UPDATE voice_entitlements
+                SET status = 'revoked', revision = revision + 1
+                WHERE uid = $1
+                """,
+                uid,
+            )
+
+        nonmatching_grant = _reissued_managed_cloud_grant(
+            initial_grant,
+            receipt_id="synthetic-receipt-nonmatching-quarantine",
+        )
+        nonmatching = await managed_cloud_consent.synchronize_grant(
+            grant=nonmatching_grant,
+            allow_fresh_uid_bootstrap=True,
+            bootstrap_email="fresh-regrant@example.invalid",
+        )
+        assert nonmatching["authority_epoch"] == initial_epoch
+        async with pool.acquire() as observer:
+            still_blocked = await observer.fetchrow(
+                """
+                SELECT job.state, job.error_code, binding.status,
+                       binding.runtime_target_mode,
+                       entitlement.status AS entitlement_status
+                FROM ella_provisioning_jobs job
+                JOIN ella_runtime_bindings binding
+                  ON binding.user_id = job.user_id
+                JOIN voice_entitlements entitlement
+                  ON entitlement.uid = $2
+                WHERE job.id = $1
+                """,
+                job_id,
+                uid,
+            )
+        assert tuple(still_blocked.values()) == (
+            "blocked",
+            "invitation_authority_revoked",
+            "disabled",
+            None,
+            "revoked",
+        )
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE ella_runtime_bindings
+                SET runtime_target_mode = 'hermes-chat'
+                WHERE id = $1
+                """,
+                binding_id,
+            )
+
+        recovery_grant = _reissued_managed_cloud_grant(
+            initial_grant,
+            receipt_id="synthetic-receipt-recovery",
+        )
+        recovered = await managed_cloud_consent.synchronize_grant(
+            grant=recovery_grant,
+            allow_fresh_uid_bootstrap=True,
+            bootstrap_email="fresh-regrant@example.invalid",
+        )
+        assert recovered["authority_epoch"] == initial_epoch
+
+        async with pool.acquire() as observer:
+            pending = await observer.fetchrow(
+                """
+                SELECT job.state, job.stage, job.retryable, job.error_code,
+                       binding.status, binding.health_state, binding.active,
+                       binding.quarantine_reason,
+                       entitlement.status AS entitlement_status
+                FROM ella_provisioning_jobs job
+                JOIN ella_runtime_bindings binding
+                  ON binding.user_id = job.user_id
+                JOIN voice_entitlements entitlement
+                  ON entitlement.uid = $2
+                WHERE job.id = $1
+                """,
+                job_id,
+                uid,
+            )
+        assert tuple(pending.values()) == (
+            "pending",
+            "identity_ready",
+            True,
+            None,
+            "shadow",
+            "pending",
+            False,
+            None,
+            "revoked",
+        )
+
+        staged = await repository.stage_runtime_binding(
+            uid=uid,
+            binding={
+                "binding_id": str(binding_id),
+                "provider": "hermes",
+                "profile_name": "fresh-regrant-profile",
+                "agent_id": "fresh-regrant-agent",
+                "template_version": "hermes-user-v1",
+                "model_policy_version": "model-policy-v1",
+                "voice_policy_version": "voice-policy-v1",
+                "health_state": "healthy",
+                "health_receipt": {"content_free": True},
+                "runtime_target_mode": "hermes-chat",
+            },
+        )
+        assert staged["status"] == "shadow"
+        smoke_passed = await repository.update_job(
+            job_id=str(job_id),
+            state="provisioning",
+            stage="smoke_passed",
+            retryable=True,
+            receipt={"type": "runtime_smoke_passed", "content_free": True},
+        )
+        assert smoke_passed["stage"] == "smoke_passed"
+        assert await repository.seed_voice_entitlement_if_absent(uid=uid) is True
+        activated = await repository.activate_runtime_binding(
+            uid=uid,
+            provider="hermes",
+            require_invitation_target=False,
+        )
+        assert activated["id"] == binding_id
+        assert activated["status"] == "active"
+        assert activated["active"] is True
+        async with pool.acquire() as observer:
+            assert await observer.fetchval("SELECT status FROM users WHERE id = $1", user_id) == "ACTIVE"
+            assert await observer.fetchval("SELECT status FROM voice_entitlements WHERE uid = $1", uid) == "active"
+
+    asyncio.run(_run_with_database(scenario))
+
+
 def test_seed_voice_entitlement_if_absent_creates_once_without_clobber():
     async def scenario(pool):
         uid = "synthetic-fresh-voice-seed"
@@ -2219,6 +2507,59 @@ def test_seed_voice_entitlement_if_absent_creates_once_without_clobber():
             "provider_allowlist": ["grok-voice"],
             "mode_allowlist": ["v4"],
             "revision": 1,
+        }
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE voice_entitlements
+                SET status = 'revoked', revision = revision + 1
+                WHERE uid = $1
+                """,
+                uid,
+            )
+        assert await repository.seed_voice_entitlement_if_absent(uid=uid) is False
+        async with pool.acquire() as observer:
+            unrearmed = await observer.fetchrow(
+                """
+                SELECT status, provider_allowlist, mode_allowlist, revision
+                FROM voice_entitlements
+                WHERE uid = $1
+                """,
+                uid,
+            )
+        assert dict(unrearmed) == {
+            "status": "revoked",
+            "provider_allowlist": ["grok-voice"],
+            "mode_allowlist": ["v4"],
+            "revision": 2,
+        }
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE voice_entitlements
+                SET status = 'revoked',
+                    operator_note = 'operator-controlled',
+                    revision = revision + 1
+                WHERE uid = $1
+                """,
+                uid,
+            )
+        assert await repository.seed_voice_entitlement_if_absent(uid=uid) is False
+        async with pool.acquire() as observer:
+            operator_row = await observer.fetchrow(
+                """
+                SELECT status, operator_note, revision
+                FROM voice_entitlements
+                WHERE uid = $1
+                """,
+                uid,
+            )
+        assert dict(operator_row) == {
+            "status": "revoked",
+            "operator_note": "operator-controlled",
+            "revision": 3,
         }
 
     asyncio.run(_run_with_database(scenario))

--- a/backend/tests/postgres/test_invitation_redemption_postgres.py
+++ b/backend/tests/postgres/test_invitation_redemption_postgres.py
@@ -1815,7 +1815,7 @@ def test_self_hosted_consent_authority_change_invalidates_runtime(
                     profile_uid=changed.profile_uid,
                     consent_receipt_id=f"{changed.consent_receipt_id}-changed",
                     profile_binding_id=changed.profile_binding_id,
-                    policy_version=changed.policy_version,
+                    policy_version=f"{changed.policy_version}-changed",
                     processor_set_hash=changed.processor_set_hash,
                     scope_version=changed.scope_version,
                     scope_hash=changed.scope_hash,

--- a/backend/tests/unit/test_authority_writer_guard.py
+++ b/backend/tests/unit/test_authority_writer_guard.py
@@ -40,6 +40,7 @@ EXPECTED_WRITERS = {
     ("database/invitations.py", "_bind_verified_identity_on_connection"),
     ("database/invitations.py", "_redeem_locked_invitation"),
     ("database/managed_cloud_consent.py", "_quarantine_on_connection"),
+    ("database/managed_cloud_consent.py", "_rearm_fresh_self_hosted_regrant_on_connection"),
     ("database/managed_cloud_consent.py", "lock_or_bootstrap_grant_on_connection"),
     ("database/managed_cloud_consent.py", "synchronize_denial"),
     ("database/managed_cloud_consent.py", "synchronize_grant"),
@@ -58,6 +59,7 @@ DIRECT_LOCKED_WRITERS = EXPECTED_WRITERS - {
     ("database/invitations.py", "_bind_verified_identity_on_connection"),
     ("database/invitations.py", "_redeem_locked_invitation"),
     ("database/managed_cloud_consent.py", "_quarantine_on_connection"),
+    ("database/managed_cloud_consent.py", "_rearm_fresh_self_hosted_regrant_on_connection"),
     ("database/managed_cloud_consent.py", "lock_or_bootstrap_grant_on_connection"),
 }
 
@@ -67,6 +69,7 @@ PROOF_GATED_HELPERS = {
     ("database/invitation_operator.py", "_cleanup_locked"),
     ("database/invitations.py", "_redeem_locked_invitation"),
     ("database/managed_cloud_consent.py", "_quarantine_on_connection"),
+    ("database/managed_cloud_consent.py", "_rearm_fresh_self_hosted_regrant_on_connection"),
     ("database/managed_cloud_consent.py", "lock_or_bootstrap_grant_on_connection"),
 }
 EXPECTED_GLOBAL_USER_WRITERS = {
@@ -149,6 +152,10 @@ REAL_POSTGRES_WRITER_COVERAGE = {
     ("database/managed_cloud_consent.py", "_quarantine_on_connection"): (
         "tests/postgres/test_authority_advisory_lock_postgres.py",
         '"consent_regrant"',
+    ),
+    ("database/managed_cloud_consent.py", "_rearm_fresh_self_hosted_regrant_on_connection"): (
+        "tests/postgres/test_authority_advisory_lock_postgres.py",
+        "test_fresh_regrant_is_idempotent_and_recovers_only_exact_quarantine",
     ),
     ("database/managed_cloud_consent.py", "lock_or_bootstrap_grant_on_connection"): (
         "tests/postgres/test_invitation_redemption_postgres.py",

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -49,6 +49,7 @@ from ella.services.provisioning import (
     ProvisioningError,
     VerifiedIdentity,
     extract_runtime_binding,
+    current_self_hosted_runtime_lineage,
     provision_idempotency_key,
     provision_timeout_seconds,
     public_receipt,
@@ -238,6 +239,7 @@ class FakeRepository:
         self.job_calls = []
         self.voice_seed_calls = []
         self.voice_seed_result = False
+        self.last_activation_arguments = None
 
     async def assert_schema_ready(self):
         self.schema_checks += 1
@@ -322,7 +324,11 @@ class FakeRepository:
         authority_lineage=None,
         model=SELF_HOSTED_RUNTIME_MODEL,
     ):
-        del require_invitation_target, authority_lineage, model
+        self.last_activation_arguments = {
+            "require_invitation_target": require_invitation_target,
+            "authority_lineage": authority_lineage,
+            "model": model,
+        }
         self.activation_calls += 1
         self.binding = dict(self.staged, active=True, revision=2)
         self.user_active = True
@@ -3172,7 +3178,7 @@ def test_missing_attestation_key_fails_before_provisioner_or_binding_write(monke
 
 def test_fresh_uid_relax_admits_uninvited_self_hosted_when_flag_set(monkeypatch):
     monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "true")
-    identity = VerifiedIdentity("fresh-relax-user", "user@example.test", "User", "UTC")
+    identity = VerifiedIdentity("user-a", "user@example.test", "User", "UTC")
     repository = FakeRepository(self_hosted_admission=None, self_hosted_owned=False)
 
     # Without the relax flag a fresh self-hosted UID is denied (strict gate).
@@ -3207,6 +3213,51 @@ def test_fresh_uid_relax_admits_uninvited_self_hosted_when_flag_set(monkeypatch)
 
     monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "false")
     monkeypatch.delenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", raising=False)
+
+
+def test_fresh_uid_relax_activation_does_not_require_invitation_target(monkeypatch):
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_ENABLED", "true")
+    monkeypatch.setenv("ELLA_SELF_HOSTED_PROVISIONING_RELAX_FRESH_UID", "true")
+    monkeypatch.setenv(
+        "ELLA_HERMES_PROVISION_ATTESTATION_KEY",
+        "unit-test-attestation-key-32-bytes-minimum",
+    )
+    identity = VerifiedIdentity("fresh-relax-user", "user@example.test", "User", "UTC")
+
+    relaxed_repository = FakeRepository(self_hosted_admission=None, self_hosted_owned=False)
+    asyncio.run(
+        ProvisioningCoordinator(
+            relaxed_repository,
+            FakeProvisionClient(_runtime_receipt()),
+        ).process_claimed_job(
+            job=_job(state="provisioning", stage="profile_ready"),
+            identity=identity,
+        )
+    )
+    assert relaxed_repository.job["state"] == "ready"
+    assert relaxed_repository.last_activation_arguments == {
+        "require_invitation_target": False,
+        "authority_lineage": None,
+        "model": SELF_HOSTED_RUNTIME_MODEL,
+    }
+
+    admission = _self_hosted_admission(identity.uid)
+    invitation_repository = FakeRepository(
+        self_hosted_admission=admission,
+        self_hosted_owned=True,
+    )
+    asyncio.run(
+        ProvisioningCoordinator(
+            invitation_repository,
+            FakeProvisionClient(_runtime_receipt()),
+        ).process_claimed_job(
+            job=_job(state="provisioning", stage="profile_ready"),
+            identity=identity,
+        )
+    )
+    assert invitation_repository.job["state"] == "ready"
+    assert invitation_repository.last_activation_arguments["require_invitation_target"] is True
+    assert invitation_repository.last_activation_arguments["authority_lineage"] == current_self_hosted_runtime_lineage()
 
 
 def test_runtime_resolver_enforces_owner_health_and_credential(monkeypatch):


### PR DESCRIPTION
## What changed

- Treat a reissued consent receipt as idempotent when the profile binding, policy, processor set, and scope are unchanged. The receipt reference and revision advance, but the authority epoch is preserved and no runtime quarantine is triggered.
- Rearm only the exact fresh-relax quarantine produced by the previous repeat-grant behavior. Recovery requires the matching pending user, blocked job, disabled Hermes binding, no invitation redemption, and an absent or exact auto-provisioned revoked voice row. It returns the job and binding to non-authorizing states; normal provisioning must restage, attest, seed voice, and activate.
- Keep invitation-backed activation strict while allowing the explicit fresh-UID relax path to activate without a nonexistent invitation target.
- Recover a revoked auto-provisioned Grok entitlement only when the provisioning job carries the content-free recovery receipt. Ordinary revoked or operator-controlled rows remain untouched.
- Pin the new unit and real-PostgreSQL tests in the hosted workflow counts and required-ID guards.

## Root cause

Build 807 sends a second valid consent receipt during onboarding. The server treated the receipt identifier itself as authority-lineage identity, rotated the authority epoch, and quarantined the in-progress binding. Fresh-relax provisioning then also required an invitation runtime target even though that path intentionally has no invitation admission, leaving the job terminally blocked with `invitation_authority_revoked`.

## Validation

- affected provisioning, consent, authority split, repository, voice, and writer-guard suites: **565 passed**
- broader Hermes runtime unit boundary available in this host: **486 passed**
- authority-writer inventory: **5 passed**
- Black 24.8, `py_compile`, and `git diff --check`: clean
- workflow collection deltas verified from the exact previously green base: runtime **543 -> 544**; authority/PostgreSQL **77 -> 78**
- independent configured real-PostgreSQL authority suite: **78 passed** at exact final head
- hosted `hermes-cloud-runtime`, `guardian-app-contracts`, and `invite-redemption`: **passed** at exact final head

Immutable production deployment and the preserved blocked-account recovery canary passed at exact final head. The same-contract grant preserved the authority epoch; the job and binding rearmed through normal APIs; final user/job/binding/Grok entitlement state is active and healthy. No direct production-row cleanup or repair was used.
