### PR TITLE
Guarantee account-scoped cache purge on logout

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:omi/backend/schema/app.dart';
@@ -1155,4 +1156,21 @@ class SharedPreferencesUtil {
     _invalidateAiConsentAuthority();
     return await _preferences?.clear() ?? false;
   }
+
+  /// Clears every persisted account value and verifies that no key survived.
+  /// Firebase identity must not change if this operation cannot be confirmed.
+  Future<void> clearAndVerifyForLogout() async {
+    _invalidateAiConsentAuthority();
+    final preferences = _preferences;
+    if (preferences == null) {
+      throw StateError('logout_cache_not_initialized');
+    }
+    final cleared = await preferences.clear();
+    if (!cleared || preferences.getKeys().isNotEmpty) {
+      throw StateError('logout_cache_purge_failed');
+    }
+  }
+
+  @visibleForTesting
+  Set<String> get keysForTesting => Set.unmodifiable(_preferences?.getKeys() ?? const <String>{});
 }

--- a/app/lib/desktop/pages/settings/desktop_settings_modal.dart
+++ b/app/lib/desktop/pages/settings/desktop_settings_modal.dart
@@ -40,11 +40,11 @@ import 'package:omi/pages/settings/widgets/developer_api_keys_section.dart';
 import 'package:omi/pages/speech_profile/page.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/providers/home_provider.dart';
-import 'package:omi/services/auth_service.dart';
 import 'package:omi/services/shortcut_service.dart';
 import 'package:omi/ui/atoms/omi_checkbox.dart';
 import 'package:omi/ui/atoms/omi_icon_button.dart';
 import 'package:omi/utils/analytics/mixpanel.dart';
+import 'package:omi/utils/auth_utils.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/other/temp.dart';
 import 'package:omi/utils/responsive/responsive_helper.dart';
@@ -2562,10 +2562,9 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
           ),
           TextButton(
             onPressed: () async {
-              await SharedPreferencesUtil().clear();
               Navigator.of(dialogContext).pop();
               Navigator.of(context).pop(); // Close settings modal
-              await AuthService.instance.signOut();
+              await signOutAndClearUserData(context);
               if (mounted) {
                 routeToPage(context, const DesktopOnboardingWrapper(), replace: true);
               }

--- a/app/lib/ella/services/ella_logout_cache_purge.dart
+++ b/app/lib/ella/services/ella_logout_cache_purge.dart
@@ -1,0 +1,19 @@
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/utils/wal_file_manager.dart';
+
+/// Removes persisted account state before Firebase can change identity.
+///
+/// Account-owned WAL files remain isolated on disk for recovery by the same
+/// owner, but the process must release their authority before another account
+/// can become current.
+class EllaLogoutCachePurge {
+  const EllaLogoutCachePurge({this.clearPreferences, this.releaseWalOwner});
+
+  final Future<void> Function()? clearPreferences;
+  final Future<void> Function()? releaseWalOwner;
+
+  Future<void> purge() async {
+    await (clearPreferences ?? SharedPreferencesUtil().clearAndVerifyForLogout).call();
+    await (releaseWalOwner ?? WalFileManager.releaseActiveOwnerForLogout).call();
+  }
+}

--- a/app/lib/pages/onboarding/ella/ella_welcome.dart
+++ b/app/lib/pages/onboarding/ella/ella_welcome.dart
@@ -4,7 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/ella_theme.dart';
-import 'package:omi/services/auth_service.dart';
+import 'package:omi/utils/auth_utils.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class EllaWelcome extends StatefulWidget {
@@ -177,7 +177,7 @@ class _EllaWelcomeState extends State<EllaWelcome> {
                           if (widget.onSignOut != null)
                             GestureDetector(
                               onTap: () async {
-                                await AuthService.instance.signOut();
+                                await signOutAndClearUserData(context);
                                 widget.onSignOut?.call();
                               },
                               child: Text(

--- a/app/lib/pages/settings/delete_account.dart
+++ b/app/lib/pages/settings/delete_account.dart
@@ -67,12 +67,23 @@ class _DeleteAccountState extends State<DeleteAccount> {
 
     try {
       (widget.onDeleteSucceeded ?? MixpanelManager().deleteUser).call();
-      await (widget.signOut ?? AuthService.instance.signOut).call();
-      await (widget.clearWal ?? WalFileManager.clearAll).call();
-      if (widget.clearPreferences != null) {
-        widget.clearPreferences!.call();
+      if (widget.signOut != null) {
+        // Test/integration overrides own their complete local cleanup contract.
+        await widget.signOut!.call();
+        await (widget.clearWal ?? WalFileManager.clearAll).call();
+        if (widget.clearPreferences != null) {
+          widget.clearPreferences!.call();
+        } else {
+          await SharedPreferencesUtil().clear();
+        }
       } else {
-        await SharedPreferencesUtil().clear();
+        // Delete the confirmed account's WAL while its owner is still active.
+        // The structural sign-out purge then clears preferences and releases
+        // that owner before Firebase can change identity.
+        await AuthService.instance.signOutWithQuiescedCleanup(() async {
+          await (widget.clearWal ?? WalFileManager.clearAll).call();
+          widget.clearPreferences?.call();
+        });
       }
       if (!mounted) return;
       setState(() {

--- a/app/lib/services/auth_service.dart
+++ b/app/lib/services/auth_service.dart
@@ -18,6 +18,7 @@ import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/ella/services/ella_account_isolation_service.dart';
+import 'package:omi/ella/services/ella_logout_cache_purge.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 
@@ -43,6 +44,7 @@ class AuthService {
   }
 
   Future<UserCredential> replaceIdentityWithCredential(AuthCredential credential) => runIdentityTransition(() async {
+        await const EllaLogoutCachePurge().purge();
         await FirebaseAuth.instance.signOut();
         return FirebaseAuth.instance.signInWithCredential(credential);
       });
@@ -164,9 +166,10 @@ class AuthService {
   /// caches cannot survive into the next account, while callers that already
   /// need cleanup do not invoke the full shutdown sequence a second time.
   Future<void> signOutWithQuiescedCleanup(Future<void> Function() cleanup) => runIdentityTransition(() async {
-    await cleanup();
-    await FirebaseAuth.instance.signOut();
-  });
+        await cleanup();
+        await const EllaLogoutCachePurge().purge();
+        await FirebaseAuth.instance.signOut();
+      });
 
   Future<void> signOut() => signOutWithQuiescedCleanup(() async {});
 

--- a/app/lib/utils/auth_utils.dart
+++ b/app/lib/utils/auth_utils.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import 'package:omi/backend/preferences.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/providers/ella_entitlement_provider.dart';
@@ -10,9 +9,8 @@ import 'package:omi/providers/message_provider.dart';
 import 'package:omi/providers/people_provider.dart';
 import 'package:omi/services/auth_service.dart';
 
-/// Clears all user-specific data from local cache and in-memory providers,
-/// then signs out of Firebase. Call this on every sign-out path to prevent
-/// data leaking between accounts (see issue #300).
+/// Resets mounted account providers before the structural AuthService logout.
+/// AuthService owns the verified persisted-cache purge for every sign-out path.
 Future<void> signOutAndClearUserData(BuildContext context) async {
   CaptureProvider? captureProvider;
   ConversationProvider? conversationProvider;
@@ -41,29 +39,11 @@ Future<void> signOutAndClearUserData(BuildContext context) async {
   await AuthService.instance.signOutWithQuiescedCleanup(() async {
     // Clear in-memory provider state only after every account producer has
     // quiesced. Firebase sign-out follows this callback in the same transition.
-    try {
-      conversationProvider?.reset();
-    } catch (_) {}
-    try {
-      messageProvider?.reset();
-    } catch (_) {}
-    try {
-      captureProvider?.reset();
-    } catch (_) {}
-    try {
-      peopleProvider?.reset();
-    } catch (_) {}
-    try {
-      memoriesProvider?.reset();
-    } catch (_) {}
-    try {
-      entitlementProvider?.reset();
-    } catch (_) {}
-
-    // Explicitly clear conversation/message caches first (prevents cross-account data leak)
-    SharedPreferencesUtil().clearUserCaches();
-
-    // Clear all persisted local data before Firebase changes identity.
-    await SharedPreferencesUtil().clear();
+    conversationProvider?.reset();
+    messageProvider?.reset();
+    captureProvider?.reset();
+    peopleProvider?.reset();
+    memoriesProvider?.reset();
+    entitlementProvider?.reset();
   });
 }

--- a/app/lib/utils/wal_file_manager.dart
+++ b/app/lib/utils/wal_file_manager.dart
@@ -66,6 +66,18 @@ class WalFileManager {
     _initialization = null;
   }
 
+  /// Releases process authority for account-owned WAL state without deleting
+  /// it. A later account must explicitly establish its own owner before use.
+  static Future<void> releaseActiveOwnerForLogout() async {
+    while (_initialization != null) {
+      await _initialization;
+    }
+    _activeOwner = null;
+  }
+
+  @visibleForTesting
+  static WalOwner? get activeOwnerForTesting => _activeOwner;
+
   static Future<List<Wal>> loadWals({WalOwner? activeOwner}) async {
     await init(activeOwner: activeOwner);
     final active = await _readWals(_activeWalFile);

--- a/app/test/ella/account_isolation_test.dart
+++ b/app/test/ella/account_isolation_test.dart
@@ -22,6 +22,7 @@ import 'package:omi/backend/schema/person.dart';
 import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/ella/services/ai_consent_active_session_lease.dart';
 import 'package:omi/ella/services/ella_account_isolation_service.dart';
+import 'package:omi/ella/services/ella_logout_cache_purge.dart';
 import 'package:omi/ella/services/elevenlabs_tts.dart';
 import 'package:omi/ella/services/standard_voice_turn.dart';
 import 'package:omi/ella/services/ella_workspace_status.dart';
@@ -36,6 +37,7 @@ import 'package:omi/services/services.dart';
 import 'package:omi/services/wals/wal.dart';
 import 'package:omi/services/wals/wal_owner_authority.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
+import 'package:omi/utils/wal_file_manager.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -45,6 +47,81 @@ void main() {
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
     await SharedPreferencesUtil.init();
+    WalFileManager.resetForTesting();
+  });
+
+  test('logout purge removes account caches and releases WAL ownership before the next login', () async {
+    final prefs = SharedPreferencesUtil()..uid = 'uid-a';
+    await prefs.saveString('email', 'account-a@example.com');
+    await prefs.saveStringList('cachedConversations', ['conversation-a']);
+    await prefs.saveString('cachedConversationsUid', 'uid-a');
+    await prefs.saveStringList('cachedMessages', ['message-a']);
+    await prefs.saveString('cachedMessagesUid', 'uid-a');
+    await prefs.saveStringList('cachedMemories', ['memory-a']);
+    await prefs.saveStringList('pendingMemories:uid-a', ['pending-a']);
+    await prefs.saveStringList('cachedPeople:uid-a', ['person-a']);
+    await prefs.saveString('modifiedConversationDetails:uid-a', 'conversation-detail-a');
+    await prefs.saveString('emergencyContactName:uid-a', 'Account A contact');
+    await prefs.saveString('emergencyContactPhone:uid-a', '+15555550100');
+    await prefs.saveString('pendingEmergency:uid-a', 'pending-a');
+    await prefs.saveString('ellaProvisioningReceipt:uid-a', '{"state":"ready"}');
+    await prefs.saveString('ellaProvisioningVerifiedAt:uid-a', '2026-08-08T00:00:00Z');
+    await _grantAuthority(prefs, 'uid-a');
+
+    const owner = WalOwner(
+      uid: 'uid-a',
+      profileBindingId: 'profile-uid-a',
+      bindingRevision: 3,
+      consentReceiptId: 'aicr_uid-a',
+      authorityGenerationAtCapture: 7,
+    );
+    final walRoot = await Directory.systemTemp.createTemp('ella_logout_wal_');
+    addTearDown(() async {
+      WalFileManager.resetForTesting();
+      if (walRoot.existsSync()) await walRoot.delete(recursive: true);
+    });
+    await WalFileManager.init(baseDirectory: walRoot, activeOwner: owner);
+    final ownerDirectory = Directory('${walRoot.path}/ella_wal_accounts/${owner.storageNamespace}');
+    final retainedAudio = File('${ownerDirectory.path}/audio_account_a.bin');
+    await retainedAudio.writeAsBytes([1, 2, 3]);
+
+    expect(prefs.keysForTesting, isNotEmpty);
+    expect(WalFileManager.activeOwnerForTesting?.uid, 'uid-a');
+
+    await const EllaLogoutCachePurge().purge();
+    await SharedPreferencesUtil.init(); // Simulate the next launch on the same device.
+
+    expect(prefs.keysForTesting, isEmpty);
+    expect(prefs.hasCurrentAiConsentAuthority(), isFalse);
+    expect(WalFileManager.activeOwnerForTesting, isNull);
+    expect(retainedAudio.existsSync(), isTrue, reason: 'logout must not silently delete recoverable owner data');
+
+    prefs.uid = 'uid-b';
+    await prefs.saveString('email', 'account-b@example.com');
+    expect(prefs.cachedMessages, isEmpty);
+    expect(prefs.pendingMemories, isEmpty);
+    expect(prefs.cachedPeople, isEmpty);
+    expect(prefs.modifiedConversationDetails, isNull);
+    expect(prefs.emergencyContactName, isEmpty);
+    expect(prefs.emergencyContactPhone, isEmpty);
+    expect(prefs.pendingEmergency, isEmpty);
+    final workspace = EllaWorkspaceStatus.current(preferences: prefs, uid: 'uid-b', email: 'account-b@example.com');
+    expect(workspace.workspaceVerified, isFalse);
+    expect(workspace.workspaceFingerprint, isEmpty);
+  });
+
+  test('logout purge does not release WAL authority when persisted cache clearing fails', () async {
+    var releasedWalOwner = false;
+    final purge = EllaLogoutCachePurge(
+      clearPreferences: () async => throw StateError('storage unavailable'),
+      releaseWalOwner: () async {
+        releasedWalOwner = true;
+      },
+    );
+
+    await expectLater(purge.purge(), throwsStateError);
+
+    expect(releasedWalOwner, isFalse);
   });
 
   test('account-scoped caches never appear under the next account', () async {

--- a/app/test/ella/services/p1_hygiene_test.dart
+++ b/app/test/ella/services/p1_hygiene_test.dart
@@ -216,11 +216,44 @@ void main() {
     expect(auth, contains('Future<void> signOutWithQuiescedCleanup'));
     expect(auth, contains('Future<void> signOut() => signOutWithQuiescedCleanup(() async {})'));
     expect(auth, contains('replaceIdentityWithCredential'));
+    expect(auth, contains('await const EllaLogoutCachePurge().purge()'));
+    final replaceTransition = auth.substring(
+      auth.indexOf('Future<UserCredential> replaceIdentityWithCredential'),
+      auth.indexOf('bool isSignedIn()'),
+    );
+    expect(
+      replaceTransition.indexOf('await const EllaLogoutCachePurge().purge()'),
+      lessThan(replaceTransition.indexOf('await FirebaseAuth.instance.signOut()')),
+    );
+    final signOutTransition = auth.substring(auth.indexOf('Future<void> signOutWithQuiescedCleanup'));
+    expect(
+      signOutTransition.indexOf('await cleanup();'),
+      lessThan(signOutTransition.indexOf('await const EllaLogoutCachePurge().purge()')),
+    );
+    expect(
+      signOutTransition.indexOf('await const EllaLogoutCachePurge().purge()'),
+      lessThan(signOutTransition.indexOf('await FirebaseAuth.instance.signOut()')),
+    );
 
     final authUtils = File('${lib.path}/utils/auth_utils.dart').readAsStringSync();
     expect(authUtils, contains('signOutWithQuiescedCleanup(() async {'));
     expect(authUtils, isNot(contains('stopForAccountTransition()')));
     expect(authUtils, isNot(contains('AuthService.instance.signOut()')));
+    expect(authUtils, isNot(contains('clearUserCaches()')));
+
+    for (final relativePath in [
+      'pages/onboarding/ella/ella_welcome.dart',
+      'desktop/pages/settings/desktop_settings_modal.dart',
+    ]) {
+      final source = File('${lib.path}/$relativePath').readAsStringSync();
+      expect(source, contains('signOutAndClearUserData(context)'), reason: relativePath);
+      expect(source, isNot(contains('AuthService.instance.signOut()')), reason: relativePath);
+    }
+
+    final deletion = File('${lib.path}/pages/settings/delete_account.dart').readAsStringSync();
+    expect(deletion, contains('AuthService.instance.signOutWithQuiescedCleanup(() async {'));
+    final deleteTransition = deletion.substring(deletion.indexOf('signOutWithQuiescedCleanup(() async {'));
+    expect(deleteTransition, contains('WalFileManager.clearAll'));
 
     final provider = File('${lib.path}/providers/auth_provider.dart').readAsStringSync();
     expect(provider, contains('runIdentityTransition(_auth.signInAnonymously)'));


### PR DESCRIPTION
## Summary
- centralize an awaited, verified SharedPreferences purge before every Firebase sign-out or credential replacement
- release active WAL ownership without deleting account-owned recovery data; preserve confirmed account-deletion ordering
- reset mounted providers without swallowing failures and route remaining reachable sign-out UI through the structural path
- add same-device logout/relaunch/account-B residue and fail-closed WAL regressions

## Lineage
- stacked on ellaaicare/omi#381 exact head `97b2dbd65d8b7c9890407334631d5dfe84474a06`
- implements ellaaicare/ella-ai#1197
- does not modify ellaaicare/omi#381

## Validation
- exact app tree validated at `3871512a8670fe538e934d26b42e263d45487053`
- focused logout/isolation/deletion: 54/54
- full Flutter: 398/398
- `app/test.sh`: 21/21
- changed-source analyzer: no warnings/errors; only pre-existing info-level desktop lints
- `git diff --check`: clean
- Gitleaks exact commit: clean

## Hosted CI note
The parent release tree already has 40 scoped and 62 total Flutter test files, while `.github/workflows/ella-ios-source-ci.yml` still asserts 39/61. I attempted the narrow inventory correction, but the installed GitHub OAuth credential lacks `workflow` scope and GitHub rejected that push. The source/test change is published without workflow mutation; hosted exact-stack dispatch is blocked until an authorized workflow owner corrects those two stale counters.

No build, TestFlight, ASC, backend, production, flag, credential, or user-data mutation.

AgentStatus: ready-for-review