### PR TITLE
fix(iOS): preserve Ella history and bound silent chat

### DIFF
--- a/app/lib/ella/services/ella_chat_service.dart
+++ b/app/lib/ella/services/ella_chat_service.dart
@@ -32,6 +32,20 @@ typedef EllaChatHistoryTransport = Future<http.Response?> Function({
   required ExactAccountAuthorityVerifier exactAuthority,
 });
 
+const ellaChatInactivityTimeout = Duration(seconds: 75);
+
+Stream<T> withEllaChatInactivityTimeout<T>(
+  Stream<T> stream, {
+  Duration timeout = ellaChatInactivityTimeout,
+}) =>
+    stream.timeout(
+      timeout,
+      onTimeout: (sink) {
+        sink.addError(const ClientApiFailure(ClientApiFailureKind.unavailable, retryable: true));
+        sink.close();
+      },
+    );
+
 Future<http.Response?> _defaultHistoryTransport({
   required String url,
   required String expectedAuthenticatedUid,
@@ -83,11 +97,14 @@ Future<EllaServiceResult<List<ServerMessage>>> fetchEllaChatHistory({
     final rawMessages = data['messages'] as List<dynamic>? ?? [];
 
     final result = <ServerMessage>[];
+    var recognizedHistoryShape = rawMessages.isEmpty;
     for (final m in rawMessages) {
+      if (m is! Map<String, dynamic>) continue;
       final role = m['role'] as String? ?? '';
-      final content = m['content'] as String? ?? '';
-      final ts = m['timestamp'] as String?;
+      final content = (m['content'] ?? m['text']) as String? ?? '';
+      final ts = (m['timestamp'] ?? m['created_at']) as String?;
       final id = m['id'] as String? ?? const Uuid().v4();
+      recognizedHistoryShape = recognizedHistoryShape || m.containsKey('content') || m.containsKey('text');
       if (content.isEmpty) continue;
       if (content.startsWith('[SYSTEM:')) {
         continue; // Filter scanner notifications from chat UI
@@ -108,6 +125,11 @@ Future<EllaServiceResult<List<ServerMessage>>> fetchEllaChatHistory({
           askForNps: false,
         ),
       );
+    }
+
+    if (!recognizedHistoryShape) {
+      Logger.debug('[EllaChat] History response contained no supported message fields');
+      return const EllaServiceResult.failure(ClientApiFailure(ClientApiFailureKind.invalidResponse));
     }
 
     // API returns newest first; reverse for chronological UI order
@@ -147,12 +169,14 @@ Stream<ServerMessageChunk> sendEllaChatStream(
     return;
   }
 
-  yield* sendEllaMessageStream(
-    text,
-    headers: _ellaDebugHeaders(routeSource: 'proxy-canonical'),
-    clientMessageId: const Uuid().v4(),
-    clientSentAt: DateTime.now().toUtc(),
-    expectedAuthenticatedUid: expectedAuthenticatedUid,
-    exactAuthority: exactAuthority,
+  yield* withEllaChatInactivityTimeout(
+    sendEllaMessageStream(
+      text,
+      headers: _ellaDebugHeaders(routeSource: 'proxy-canonical'),
+      clientMessageId: const Uuid().v4(),
+      clientSentAt: DateTime.now().toUtc(),
+      expectedAuthenticatedUid: expectedAuthenticatedUid,
+      exactAuthority: exactAuthority,
+    ),
   );
 }

--- a/app/test/ella/services/ella_chat_route_contract_test.dart
+++ b/app/test/ella/services/ella_chat_route_contract_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -8,6 +9,7 @@ import 'package:omi/backend/http/api/messages.dart';
 import 'package:omi/backend/http/client_api_failure.dart';
 import 'package:omi/backend/http/http_pool_manager.dart';
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/message.dart';
 import 'package:omi/ella/services/ella_chat_service.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/services/wals/wal_owner_authority.dart';
@@ -126,5 +128,74 @@ void main() {
     expect(result.isFailure, isTrue);
     expect(result.value, isNull);
     expect(result.failure?.kind, ClientApiFailureKind.updateRequired);
+  });
+
+  test('history accepts canonical text and created_at fields', () async {
+    const authority = _CurrentAuthority('uid-a');
+    final result = await fetchEllaChatHistory(
+      expectedAuthenticatedUid: 'uid-a',
+      exactAuthority: authority,
+      transport: ({required url, required expectedAuthenticatedUid, required exactAuthority}) async {
+        return http.Response(
+          jsonEncode({
+            'messages': [
+              {
+                'id': 'canonical-1',
+                'role': 'assistant',
+                'text': 'Persisted answer',
+                'created_at': '2026-08-09T03:00:00Z',
+              },
+            ],
+          }),
+          200,
+        );
+      },
+    );
+
+    expect(result.isSuccess, isTrue);
+    expect(result.value, hasLength(1));
+    expect(result.value!.single.id, 'canonical-1');
+    expect(result.value!.single.text, 'Persisted answer');
+    expect(result.value!.single.createdAt.toUtc(), DateTime.parse('2026-08-09T03:00:00Z'));
+  });
+
+  test('history rejects a nonempty unsupported message shape so cache can be preserved', () async {
+    const authority = _CurrentAuthority('uid-a');
+    final result = await fetchEllaChatHistory(
+      expectedAuthenticatedUid: 'uid-a',
+      exactAuthority: authority,
+      transport: ({required url, required expectedAuthenticatedUid, required exactAuthority}) async {
+        return http.Response(
+          jsonEncode({
+            'messages': [
+              {'id': 'unknown-1', 'role': 'assistant', 'body': 'Not a supported contract'},
+            ],
+          }),
+          200,
+        );
+      },
+    );
+
+    expect(result.isFailure, isTrue);
+    expect(result.failure?.kind, ClientApiFailureKind.invalidResponse);
+  });
+
+  test('Ella chat inactivity timeout cancels an otherwise silent stream', () async {
+    final source = StreamController<ServerMessageChunk>();
+    final result = withEllaChatInactivityTimeout(
+      source.stream,
+      timeout: const Duration(milliseconds: 10),
+    ).toList();
+
+    await expectLater(
+      result,
+      throwsA(
+        isA<ClientApiFailure>()
+            .having((failure) => failure.kind, 'kind', ClientApiFailureKind.unavailable)
+            .having((failure) => failure.retryable, 'retryable', isTrue),
+      ),
+    );
+    expect(source.hasListener, isFalse);
+    await source.close();
   });
 }


### PR DESCRIPTION
Build >807 client follow-up. Accepts both canonical history fields and 807 aliases, treats unsupported nonempty history as an invalid response so the provider preserves its local cache, and applies a 75-second inactivity timeout to a silent Ella stream. Validation: full Flutter suite 399/399 passed; changed-file analyzer and Dart formatting are clean. The repository-wide analyzer remains red on the existing baseline (1639 issues). No TestFlight upload is included.