### PR TITLE
fix: recover fresh chat history, latency, and isolated voice

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -635,6 +635,7 @@ jobs:
             "tests/unit/test_ella_runtime_route_isolation.py::test_isolated_hermes_chat_has_a_bounded_provider_timeout"
             "tests/unit/test_ella_runtime_route_isolation.py::test_legacy_history_unexpected_failure_logs_fixed_content_free_classification"
             "tests/unit/test_ella_runtime_route_isolation.py::test_self_hosted_voice_session_uses_exact_invitation_authority_without_legacy_registry"
+            "tests/unit/test_ella_runtime_route_isolation.py::test_active_direct_hermes_binding_forces_isolated_grok_voice_without_rollout_flags"
             "tests/unit/test_ella_runtime_route_isolation.py::test_self_hosted_voice_session_activation_race_drift_fails_before_token_or_provider"
             "tests/unit/test_ella_runtime_route_isolation.py::test_self_hosted_voice_session_authority_denials_precede_provider_setup[invitation_runtime_fallback_enabled]"
             "tests/unit/test_ella_provisioning_service.py::test_runtime_receipt_requires_owned_workspace_port_and_honcho"

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -632,6 +632,7 @@ jobs:
             "tests/unit/test_hermes_product_fit_canary.py::test_fixture_cleanup_recovers_from_partial_cleanup_idempotently"
             "tests/unit/test_hermes_product_fit_canary.py::test_fixture_show_and_cleanup_accept_expected_post_enrichment_state_only"
             "tests/unit/test_ella_runtime_route_isolation.py::test_cloud_chat_failure_still_emits_one_terminal_marker"
+            "tests/unit/test_ella_runtime_route_isolation.py::test_isolated_hermes_chat_has_a_bounded_provider_timeout"
             "tests/unit/test_ella_runtime_route_isolation.py::test_legacy_history_unexpected_failure_logs_fixed_content_free_classification"
             "tests/unit/test_ella_runtime_route_isolation.py::test_self_hosted_voice_session_uses_exact_invitation_authority_without_legacy_registry"
             "tests/unit/test_ella_runtime_route_isolation.py::test_self_hosted_voice_session_activation_race_drift_fails_before_token_or_provider"
@@ -683,7 +684,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 544
+          test "$collected" -eq 545
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -685,7 +685,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 545
+          test "$collected" -eq 546
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \

--- a/backend/database/ella_provisioning.py
+++ b/backend/database/ella_provisioning.py
@@ -3437,7 +3437,7 @@ class EllaProvisioningRepository:
         )
         return bool(row and row["eligible"])
 
-    async def _resolve_self_hosted_active_direct(
+    async def resolve_self_hosted_active_direct(
         self,
         uid: str,
         role: str = "user",
@@ -3474,6 +3474,19 @@ class EllaProvisioningRepository:
             template_version,
         )
         return _row_dict(row)
+
+    async def _resolve_self_hosted_active_direct(
+        self,
+        uid: str,
+        role: str = "user",
+        template_version: Optional[str] = None,
+    ) -> Optional[dict[str, Any]]:
+        """Compatibility wrapper for existing internal callers."""
+        return await self.resolve_self_hosted_active_direct(
+            uid=uid,
+            role=role,
+            template_version=template_version,
+        )
 
     async def resolve_active_runtime(
         self,
@@ -3718,7 +3731,7 @@ class EllaProvisioningRepository:
                         # (possibly stale) job-target schema here, and requiring a
                         # match would reproduce the "incomplete on status" bug the
                         # fallback exists to fix. `POST /ensure` passes None (inert).
-                        fallback = await self._resolve_self_hosted_active_direct(uid=uid, role=role)
+                        fallback = await self.resolve_self_hosted_active_direct(uid=uid, role=role)
                         return fallback
                     decision = await voice_canary_db.revalidate_runtime_resolution_on_connection(
                         connection,

--- a/backend/ella/routers/chat.py
+++ b/backend/ella/routers/chat.py
@@ -80,6 +80,7 @@ HERMES_AGENT_ID = os.getenv("HERMES_AGENT_ID", "hermes")
 HERMES_MODEL = os.getenv("HERMES_MODEL", "").strip()
 HERMES_CHAT_SESSION_EPOCH = os.getenv("ELLA_CHAT_HERMES_SESSION_EPOCH", "").strip()
 HERMES_CHAT_SESSION_SCOPE = os.getenv("ELLA_CHAT_HERMES_SESSION_SCOPE", "canonical").strip().lower()
+HERMES_CHAT_REQUEST_TIMEOUT_SECONDS = float(os.getenv("ELLA_CHAT_HERMES_REQUEST_TIMEOUT_SECONDS", "60"))
 CHAT_CONTEXT_LIMIT = int(os.getenv("ELLA_CHAT_CANONICAL_CONTEXT_LIMIT", "25"))
 CHAT_CONTEXT_MAX_CHARS = int(os.getenv("ELLA_CHAT_CANONICAL_CONTEXT_MAX_CHARS", "6000"))
 CHAT_TEMPORAL_CONTEXT_LIMIT = int(os.getenv("ELLA_CHAT_TEMPORAL_CONTEXT_LIMIT", "250"))
@@ -809,7 +810,7 @@ async def _stream_hermes_chat(
         agent_id = send_runtime.agent_id if send_runtime else HERMES_MODEL
         if not gateway_token:
             raise ProvisioningError("hermes_runtime_credential_missing", retryable=False)
-        async with httpx.AsyncClient(timeout=None) as client:
+        async with httpx.AsyncClient(timeout=HERMES_CHAT_REQUEST_TIMEOUT_SECONDS) as client:
             async with client.stream(
                 "POST",
                 f"{gateway_url}/v1/chat/completions",

--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -55,6 +55,7 @@ from ella.services.provisioning import (
     self_hosted_runtime_authority_required,
 )
 from ella.services.runtime_resolver import (
+    resolve_direct_self_hosted_runtime,
     resolve_isolated_runtime,
     runtime_authority_identity,
     runtime_bindings_enabled,
@@ -316,10 +317,17 @@ def authenticate_voice_proxy_request(request: Request, requested_uid: str) -> Vo
 async def _resolve_voice_runtime(principal: VoiceProxyPrincipal):
     """Resolve an isolated session to the exact active Hermes receipt."""
     self_hosted_required = await _self_hosted_voice_required(principal.uid)
+    cloud_required = cloud_provisioning_enabled(principal.uid)
+    direct_runtime = None
+    if not self_hosted_required and not cloud_required:
+        try:
+            direct_runtime = await resolve_direct_self_hosted_runtime(principal.uid)
+        except ProvisioningError as exc:
+            raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
     authority_enabled = (
-        runtime_bindings_enabled(principal.uid) or cloud_provisioning_enabled(principal.uid) or self_hosted_required
+        runtime_bindings_enabled(principal.uid) or cloud_required or self_hosted_required or direct_runtime is not None
     )
-    voice_enabled = isolated_voice_routing_enabled(principal.uid)
+    voice_enabled = isolated_voice_routing_enabled(principal.uid) or direct_runtime is not None
     if voice_enabled and not authority_enabled:
         raise HTTPException(status_code=409, detail={"code": "voice_runtime_claim_stale"})
     if authority_enabled and not voice_enabled:
@@ -333,16 +341,18 @@ async def _resolve_voice_runtime(principal: VoiceProxyPrincipal):
         principal.provider != SELF_HOSTED_RUNTIME_PROVIDER or principal.voice_mode != "hermes-voice"
     ):
         raise HTTPException(status_code=409, detail={"code": "self_hosted_voice_claim_stale"})
-    try:
-        runtime = await resolve_isolated_runtime(
-            principal.uid,
-            target_mode="hermes-voice" if self_hosted_required else "hermes-cloud-voice",
-        )
-    except ProvisioningError as exc:
-        raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
+    runtime = direct_runtime
+    if runtime is None:
+        try:
+            runtime = await resolve_isolated_runtime(
+                principal.uid,
+                target_mode="hermes-voice" if self_hosted_required else "hermes-cloud-voice",
+            )
+        except ProvisioningError as exc:
+            raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
     if not runtime:
         raise HTTPException(status_code=503, detail={"code": "isolated_voice_runtime_required"})
-    if self_hosted_required:
+    if self_hosted_required or direct_runtime is not None:
         try:
             current_identity = runtime_authority_identity(runtime)
         except ProvisioningError as exc:
@@ -1031,28 +1041,37 @@ async def create_voice_session(
 
     cloud_required = cloud_provisioning_enabled(uid)
     self_hosted_required = await _self_hosted_voice_required(uid)
-    runtime_bound = runtime_bindings_enabled(uid) or cloud_required or self_hosted_required
-    voice_rollout_enabled = isolated_voice_routing_enabled(uid)
+    direct_runtime = None
+    if not cloud_required and not self_hosted_required:
+        try:
+            direct_runtime = await resolve_direct_self_hosted_runtime(uid)
+        except ProvisioningError as exc:
+            raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
+    runtime_bound = (
+        runtime_bindings_enabled(uid) or cloud_required or self_hosted_required or direct_runtime is not None
+    )
+    voice_rollout_enabled = isolated_voice_routing_enabled(uid) or direct_runtime is not None
     if voice_rollout_enabled and not runtime_bound:
         raise HTTPException(status_code=503, detail={"code": "isolated_voice_runtime_required"})
     isolated_runtime = runtime_bound and voice_rollout_enabled
-    runtime = None
+    runtime = direct_runtime
     runtime_authority_digest = ""
     if runtime_bound:
         if not isolated_runtime:
             # Invitation-owned users remain authority-bound even while voice is
             # disabled; they cannot enter the legacy provider registry.
             raise HTTPException(status_code=503, detail={"code": "isolated_voice_not_ready"})
-        try:
-            runtime = await resolve_isolated_runtime(
-                uid,
-                target_mode="hermes-voice" if self_hosted_required else "hermes-cloud-voice",
-            )
-        except ProvisioningError as exc:
-            raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
+        if runtime is None:
+            try:
+                runtime = await resolve_isolated_runtime(
+                    uid,
+                    target_mode="hermes-voice" if self_hosted_required else "hermes-cloud-voice",
+                )
+            except ProvisioningError as exc:
+                raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
         if not runtime:
             raise HTTPException(status_code=503, detail={"code": "isolated_voice_runtime_required"})
-        if self_hosted_required:
+        if self_hosted_required or direct_runtime is not None:
             try:
                 runtime_authority_digest = runtime_authority_identity(runtime).digest
             except ProvisioningError as exc:
@@ -1130,11 +1149,12 @@ async def create_voice_session(
     except Exception as e:
         logger.warning(f"[FLOW:VOICE-SESSION] name lookup failed for {uid}: {e}")
 
-    if self_hosted_required and runtime is not None:
+    if (self_hosted_required or direct_runtime is not None) and runtime is not None:
         try:
-            current_runtime = await resolve_isolated_runtime(
-                uid,
-                target_mode="hermes-voice",
+            current_runtime = (
+                await resolve_direct_self_hosted_runtime(uid)
+                if direct_runtime is not None
+                else await resolve_isolated_runtime(uid, target_mode="hermes-voice")
             )
             if current_runtime is None:
                 raise ProvisioningError("isolated_voice_runtime_required", retryable=False)

--- a/backend/ella/services/runtime_resolver.py
+++ b/backend/ella/services/runtime_resolver.py
@@ -14,6 +14,7 @@ from uuid import UUID
 
 from database.ella_provisioning import (
     EllaProvisioningRepository,
+    ProvisioningSchemaNotReadyError,
     RuntimePoolClaimError,
 )
 from database.honcho_attestation import (
@@ -482,6 +483,30 @@ def runtime_from_binding(binding: dict, uid: str, *, allow_shadow: bool = False)
         account_user_id=account_user_id,
         profile_user_id=profile_user_id,
     )
+
+
+async def resolve_direct_self_hosted_runtime(
+    uid: str,
+    repository: Optional[EllaProvisioningRepository] = None,
+) -> Optional[IsolatedRuntime]:
+    """Resolve a row-intrinsically active Hermes binding for voice isolation.
+
+    Fresh-relax and migrated accounts can hold a healthy binding without an
+    invitation admission or exact-UID rollout flag. The binding must still pass
+    the same runtime receipt validation before it can leave legacy voice routing.
+    """
+    if not uid:
+        return None
+    try:
+        repository = repository or await EllaProvisioningRepository.create()
+        binding = await repository.resolve_self_hosted_active_direct(uid=uid)
+    except ProvisioningSchemaNotReadyError as exc:
+        raise ProvisioningError("provisioning_schema_not_ready", retryable=True) from exc
+    except ProvisioningError:
+        raise
+    except Exception as exc:
+        raise ProvisioningError("self_hosted_runtime_authority_unavailable", retryable=True) from exc
+    return runtime_from_binding(binding, uid) if binding else None
 
 
 async def resolve_isolated_runtime(

--- a/backend/tests/fixtures/ella_chat_history_canonical_response_v1.json
+++ b/backend/tests/fixtures/ella_chat_history_canonical_response_v1.json
@@ -3,7 +3,9 @@
     {
       "id": "canonical-assistant-turn",
       "created_at": "2026-08-03T12:01:00+00:00",
+      "timestamp": "2026-08-03T12:01:00+00:00",
       "text": "Exact assistant history response.",
+      "content": "Exact assistant history response.",
       "sender": "ai",
       "type": "text",
       "plugin_id": null,
@@ -21,7 +23,9 @@
     {
       "id": "canonical-user-turn",
       "created_at": "2026-08-03T12:00:00+00:00",
+      "timestamp": "2026-08-03T12:00:00+00:00",
       "text": "Exact user history request.",
+      "content": "Exact user history request.",
       "sender": "human",
       "type": "text",
       "plugin_id": null,

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -2681,7 +2681,7 @@ def test_resolve_self_hosted_active_direct_positive_healthy_active():
     repository = EllaProvisioningRepository(pool)
 
     row = asyncio.run(
-        repository._resolve_self_hosted_active_direct(
+        repository.resolve_self_hosted_active_direct(
             uid="5aGC5YE9BnhcSoTxxtT4ar6ILQy2",
             role="user",
             template_version="hermes-user-v1",

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -209,6 +209,67 @@ def test_chat_history_rejects_query_uid_that_differs_from_firebase_subject():
     assert error.value.status_code == 403
 
 
+def test_isolated_hermes_chat_has_a_bounded_provider_timeout(monkeypatch):
+    captured = {}
+
+    async def no_events(*_args, **_kwargs):
+        return []
+
+    async def no_temporal(*_args, **_kwargs):
+        return "recent context", []
+
+    async def canonical_write(*_args, **_kwargs):
+        return None
+
+    async def stable_runtime(_identity):
+        return _invitation_chat_runtime()
+
+    class TimedOutStreamResponse:
+        status_code = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def aiter_lines(self):
+            raise chat.httpx.ReadTimeout("content-free provider timeout")
+            yield
+
+    class TimedClient:
+        def __init__(self, *_args, **kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        def stream(self, *_args, **_kwargs):
+            return TimedOutStreamResponse()
+
+    monkeypatch.setattr(chat, "_fetch_chat_canonical_events", no_events)
+    monkeypatch.setattr(chat, "_fetch_temporal_chat_context", no_temporal)
+    monkeypatch.setattr(chat, "_write_ios_chat_canonical_event", canonical_write)
+    monkeypatch.setattr(chat, "revalidate_runtime_authority", stable_runtime)
+    monkeypatch.setattr(chat.httpx, "AsyncClient", TimedClient)
+
+    chunks = asyncio.run(
+        _collect_stream(
+            chat._stream_hermes_chat(
+                "content-free timeout test",
+                "invited-user",
+                runtime=_invitation_chat_runtime(),
+            )
+        )
+    )
+
+    assert captured["timeout"] == chat.HERMES_CHAT_REQUEST_TIMEOUT_SECONDS == 60.0
+    assert chunks == ["data: Error: Hermes request timed out\n\n"]
+
+
 def test_mounted_chat_history_authenticates_before_runtime_or_history_work(monkeypatch):
     downstream_calls = []
 

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.testclient import TestClient
 
 sys.modules.setdefault("websockets", ModuleType("websockets"))
+sys.modules.setdefault("database.proposals", ModuleType("database.proposals"))
 conversations_module = ModuleType("database.conversations")
 conversations_module._decrypt_conversation_data = lambda value: value
 sys.modules.setdefault("database.conversations", conversations_module)
@@ -27,8 +28,12 @@ def voice_authority_defaults(monkeypatch):
     async def self_hosted_disabled(_uid):
         return False
 
+    async def no_direct_runtime(_uid):
+        return None
+
     monkeypatch.setattr(voice, "VOICE_CANARY_ENFORCEMENT_ENABLED", False)
     monkeypatch.setattr(voice, "_self_hosted_voice_required", self_hosted_disabled)
+    monkeypatch.setattr(voice, "resolve_direct_self_hosted_runtime", no_direct_runtime)
     monkeypatch.setattr(
         voice,
         "runtime_authority_identity",
@@ -671,6 +676,64 @@ def test_voice_session_issues_isolated_token_for_enabled_uid_canary(monkeypatch)
     assert claims["voice_mode"] == "v4"
     assert claims["provider"] == "grok-voice"
     assert claims["isolated_runtime"] is True
+
+
+def test_active_direct_hermes_binding_forces_isolated_grok_voice_without_rollout_flags(monkeypatch):
+    runtime = _invitation_chat_runtime(uid="fresh-user")
+    direct_resolutions = []
+
+    async def direct_runtime(uid):
+        direct_resolutions.append(uid)
+        return runtime
+
+    async def forbidden_rollout_runtime(*_args, **_kwargs):
+        raise AssertionError("row-intrinsic binding must not enter rollout-classified resolution")
+
+    class Pool:
+        async def fetchrow(self, *_args):
+            return None
+
+    async def pool():
+        return Pool()
+
+    monkeypatch.setattr(voice, "ELLA_SESSION_SECRET", "test-session-secret-at-least-32-bytes")
+    monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "cloud_provisioning_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
+    monkeypatch.setattr(voice, "resolve_direct_self_hosted_runtime", direct_runtime)
+    monkeypatch.setattr(voice, "resolve_isolated_runtime", forbidden_rollout_runtime)
+    monkeypatch.setattr(voice, "_get_pool", pool)
+
+    result = asyncio.run(
+        voice.create_voice_session(
+            body=voice.VoiceSessionRequest(uid="fresh-user", provider="grok-voice"),
+            authenticated_uid="fresh-user",
+        )
+    )
+    claims = voice.jwt.decode(
+        result.session_token,
+        voice.ELLA_SESSION_SECRET,
+        algorithms=["HS256"],
+        issuer="omi-backend",
+        audience=voice.VOICE_SESSION_AUDIENCE,
+    )
+
+    assert result.provider == "grok-voice"
+    assert result.voice_mode == "v4"
+    assert claims["isolated_runtime"] is True
+    assert claims["runtime_authority_digest"] == RUNTIME_AUTHORITY_DIGEST
+    principal = voice.VoiceProxyPrincipal(
+        uid="fresh-user",
+        session_id=claims["jti"],
+        provider=claims["provider"],
+        voice_mode=claims["voice_mode"],
+        isolated_runtime=claims["isolated_runtime"],
+        entitlement_revision=claims["entitlement_revision"],
+        correlation_id=claims["correlation_id"],
+        runtime_authority_digest=claims["runtime_authority_digest"],
+    )
+    assert asyncio.run(voice._resolve_voice_runtime(principal)) is runtime
+    assert direct_resolutions == ["fresh-user", "fresh-user", "fresh-user"]
 
 
 def test_self_hosted_voice_session_uses_exact_invitation_authority_without_legacy_registry(monkeypatch):

--- a/backend/tests/unit/test_voice_canary.py
+++ b/backend/tests/unit/test_voice_canary.py
@@ -23,7 +23,11 @@ def retained_runtime_not_invitation_owned(monkeypatch):
     async def authority_disabled(_uid):
         return False
 
+    async def no_direct_runtime(_uid):
+        return None
+
     monkeypatch.setattr(voice, "self_hosted_runtime_authority_required", authority_disabled)
+    monkeypatch.setattr(voice, "resolve_direct_self_hosted_runtime", no_direct_runtime)
 
 
 def _entitlement(**overrides):

--- a/backend/tests/unit/test_voice_proxy_auth.py
+++ b/backend/tests/unit/test_voice_proxy_auth.py
@@ -113,11 +113,15 @@ def voice_auth(monkeypatch):
     async def retained_runtime_not_invitation_owned(_uid):
         return False
 
+    async def no_direct_runtime(_uid):
+        return None
+
     monkeypatch.setattr(
         voice,
         "self_hosted_runtime_authority_required",
         retained_runtime_not_invitation_owned,
     )
+    monkeypatch.setattr(voice, "resolve_direct_self_hosted_runtime", no_direct_runtime)
 
 
 def test_voice_session_token_has_firebase_subject_and_proxy_audience():

--- a/backend/utils/ella/canonical_context.py
+++ b/backend/utils/ella/canonical_context.py
@@ -168,11 +168,17 @@ def canonical_events_to_chat_turns(events: list[dict[str, Any]], *, limit: int =
 def canonical_events_to_server_messages(events: list[dict[str, Any]], *, limit: int = 50) -> list[dict[str, Any]]:
     messages: list[dict[str, Any]] = []
     for event in reversed(list(events)[-limit:]):
+        timestamp = _event_time(event)
+        text = _event_text(event, max_chars=2000)
         messages.append(
             {
                 "id": str(event.get("event_id") or event.get("id") or ""),
-                "created_at": _event_time(event),
-                "text": _event_text(event, max_chars=2000),
+                # Keep the normal ServerMessage keys and the legacy Ella iOS
+                # aliases together. TestFlight 807 reads only content/timestamp.
+                "created_at": timestamp,
+                "timestamp": timestamp,
+                "text": text,
+                "content": text,
                 "sender": "ai" if _role_for_event(event) == "assistant" else "human",
                 "type": "text",
                 "plugin_id": None,


### PR DESCRIPTION
Production acceptance repair stacked directly on deployed 89c7fa26e. Adds build-807 history aliases while retaining canonical fields; bounds silent Hermes reads at 60 seconds; resolves active healthy direct Hermes bindings row-intrinsically so fresh-user Grok V4 tokens and proxy revalidation are isolated even when rollout flags are false. Workflow collection is pinned at 546 with both new boundary IDs. Exact local workflow run: 490 passed, 56 PostgreSQL tests skipped because no DSN; collection/required IDs, Black 24.8 modified ranges, py_compile, and whitespace are clean. Independent real-PostgreSQL review and all hosted gates are required before immutable deploy. No direct account mutation and no main merge.