### PR TITLE
fix(voice): keep direct binding authority domains separate

### DIFF
--- a/backend/ella/routers/voice.py
+++ b/backend/ella/routers/voice.py
@@ -1161,10 +1161,14 @@ async def create_voice_session(
             current_identity = runtime_authority_identity(current_runtime)
         except ProvisioningError as exc:
             raise HTTPException(status_code=503 if exc.retryable else 409, detail={"code": exc.code}) from exc
-        if (
-            not hmac.compare_digest(current_identity.digest, runtime_authority_digest)
-            or int(current_runtime.target_entitlement_revision) != entitlement_revision
-        ):
+        runtime_authority_changed = not hmac.compare_digest(
+            current_identity.digest,
+            runtime_authority_digest,
+        )
+        invitation_entitlement_changed = self_hosted_required and (
+            int(current_runtime.target_entitlement_revision) != entitlement_revision
+        )
+        if runtime_authority_changed or invitation_entitlement_changed:
             raise HTTPException(status_code=409, detail={"code": "voice_runtime_authority_changed"})
         runtime = current_runtime
 

--- a/backend/tests/unit/test_ella_runtime_route_isolation.py
+++ b/backend/tests/unit/test_ella_runtime_route_isolation.py
@@ -681,6 +681,7 @@ def test_voice_session_issues_isolated_token_for_enabled_uid_canary(monkeypatch)
 def test_active_direct_hermes_binding_forces_isolated_grok_voice_without_rollout_flags(monkeypatch):
     runtime = _invitation_chat_runtime(uid="fresh-user")
     direct_resolutions = []
+    policy_calls = []
 
     async def direct_runtime(uid):
         direct_resolutions.append(uid)
@@ -688,6 +689,15 @@ def test_active_direct_hermes_binding_forces_isolated_grok_voice_without_rollout
 
     async def forbidden_rollout_runtime(*_args, **_kwargs):
         raise AssertionError("row-intrinsic binding must not enter rollout-classified resolution")
+
+    async def evaluate_issuance(**kwargs):
+        policy_calls.append(kwargs)
+        return SimpleNamespace(
+            allowed=True,
+            code="ok",
+            entitlement={"revision": 3},
+            quota={},
+        )
 
     class Pool:
         async def fetchrow(self, *_args):
@@ -697,11 +707,13 @@ def test_active_direct_hermes_binding_forces_isolated_grok_voice_without_rollout
         return Pool()
 
     monkeypatch.setattr(voice, "ELLA_SESSION_SECRET", "test-session-secret-at-least-32-bytes")
+    monkeypatch.setattr(voice, "VOICE_CANARY_ENFORCEMENT_ENABLED", True)
     monkeypatch.setattr(voice, "runtime_bindings_enabled", lambda uid=None: False)
     monkeypatch.setattr(voice, "cloud_provisioning_enabled", lambda uid=None: False)
     monkeypatch.setattr(voice, "isolated_voice_routing_enabled", lambda uid=None: False)
     monkeypatch.setattr(voice, "resolve_direct_self_hosted_runtime", direct_runtime)
     monkeypatch.setattr(voice, "resolve_isolated_runtime", forbidden_rollout_runtime)
+    monkeypatch.setattr(voice.voice_canary_db, "evaluate_issuance", evaluate_issuance)
     monkeypatch.setattr(voice, "_get_pool", pool)
 
     result = asyncio.run(
@@ -722,6 +734,8 @@ def test_active_direct_hermes_binding_forces_isolated_grok_voice_without_rollout
     assert result.voice_mode == "v4"
     assert claims["isolated_runtime"] is True
     assert claims["runtime_authority_digest"] == RUNTIME_AUTHORITY_DIGEST
+    assert claims["entitlement_revision"] == 3
+    assert len(policy_calls) == 1
     principal = voice.VoiceProxyPrincipal(
         uid="fresh-user",
         session_id=claims["jti"],


### PR DESCRIPTION
## Summary

- keep the direct persisted Hermes binding digest independent from the Grok voice entitlement revision during session-token issuance
- retain exact target-entitlement revision checks for invitation-owned self-hosted runtimes
- extend the direct-binding regression to exercise positive, unequal runtime and voice entitlement revisions

## Incident

Build 807 received `409 voice_runtime_authority_changed` before token issuance after the direct active/healthy Hermes route became isolated. The persisted direct binding has no invitation-owned `target_entitlement_revision`, while the independent Grok voice entitlement has a positive revision. Comparing those separate authority domains rejected an unchanged runtime.

## Verification

- regression fails on deployed base `45ffcff3582525cf708cd9b98ed6d1ed851d37eb` and passes on this head
- focused voice boundary: 104 passed
- Black 24.8 changed ranges: clean
- `py_compile` and whitespace: clean

## Release boundary

Stacked directly on deployed PR #385 head. Do not merge to `main` or deploy until the exact head passes hosted gates and independent release review. Retain `45ffcff35-prod` as rollback for any immutable deployment.
