### PR TITLE
feat(ella): refine Daily Note hero

### DIFF
--- a/app/lib/ella/widgets/today_card_surface.dart
+++ b/app/lib/ella/widgets/today_card_surface.dart
@@ -21,7 +21,7 @@ class TodayCardSurface extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final card = state.card;
-    final content = card == null ? _fallbackContent(context, state.status) : _TodayCardContent.fromCard(card);
+    final content = card == null ? _fallbackContent(context, state.status) : _TodayCardContent.fromCard(context, card);
 
     return EllaCardSurface(
       child: Semantics(
@@ -29,30 +29,66 @@ class TodayCardSurface extends StatelessWidget {
         container: true,
         explicitChildNodes: true,
         child: Padding(
-          padding: const EdgeInsets.all(EllaSizes.notePadding),
+          padding: const EdgeInsets.all(EllaSizes.spacingM),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Text(content.eyebrow, key: const Key('today-card-eyebrow'), style: EllaTextStyles.eyebrow),
-              const SizedBox(height: 12),
+              Text(
+                content.eyebrow,
+                key: const Key('today-card-eyebrow'),
+                style: EllaTextStyles.eyebrow,
+              ),
+              const SizedBox(height: 8),
               Semantics(
                 header: true,
                 child: Text(
                   content.headline,
                   key: const Key('today-card-headline'),
-                  style: Theme.of(context).textTheme.titleLarge,
+                  style: Theme.of(context).textTheme.titleLarge?.copyWith(fontSize: 20, height: 1.25),
                 ),
               ),
-              const SizedBox(height: 10),
-              Text(content.body, key: const Key('today-card-body'), style: EllaTextStyles.noteBody),
+              const SizedBox(height: 6),
+              Text(
+                content.body,
+                key: const Key('today-card-body'),
+                style: EllaTextStyles.noteBody.copyWith(fontSize: 18, height: 1.35),
+              ),
+              if (content.provenance != null) ...[
+                const SizedBox(height: 8),
+                Row(
+                  key: const Key('today-card-provenance'),
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Padding(
+                      padding: EdgeInsets.only(top: 2),
+                      child: Icon(
+                        Icons.history_rounded,
+                        size: 18,
+                        color: EllaColors.inkSoft,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        content.provenance!,
+                        style: EllaTextStyles.caption,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
               if (state.isCached) ...[
-                const SizedBox(height: 14),
+                const SizedBox(height: 10),
                 Row(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     const Padding(
-                      padding: EdgeInsets.only(top: 4),
-                      child: Icon(Icons.history_rounded, size: 18, color: EllaColors.inkSoft),
+                      padding: EdgeInsets.only(top: 2),
+                      child: Icon(
+                        Icons.cloud_off_outlined,
+                        size: 18,
+                        color: EllaColors.inkSoft,
+                      ),
                     ),
                     const SizedBox(width: 8),
                     Expanded(
@@ -72,38 +108,20 @@ class TodayCardSurface extends StatelessWidget {
                   child: SizedBox(
                     width: 20,
                     height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2, color: EllaColors.tealDeep),
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: EllaColors.tealDeep,
+                    ),
                   ),
                 ),
               ],
               if (card != null) ...[
-                const SizedBox(height: 22),
-                Semantics(
-                  button: true,
-                  label: context.l10n.memoryTalkAction,
-                  child: SizedBox(
-                    width: double.infinity,
-                    child: FilledButton.icon(
-                      key: const Key('today-card-talk'),
-                      onPressed: onTalk,
-                      icon: const Icon(Icons.graphic_eq_rounded),
-                      label: Text(context.l10n.memoryTalkAction),
-                    ),
-                  ),
+                const SizedBox(height: 12),
+                _TodayCardActions(
+                  isReading: isReading,
+                  onTalk: onTalk,
+                  onReadAloud: onReadAloud,
                 ),
-                if (onReadAloud != null) ...[
-                  const SizedBox(height: 6),
-                  TextButton.icon(
-                    key: const Key('today-card-read-aloud'),
-                    onPressed: onReadAloud,
-                    icon: Icon(isReading ? Icons.stop_circle_outlined : Icons.volume_up_outlined),
-                    label: Text(isReading ? context.l10n.stopReading : context.l10n.readAloud),
-                    style: TextButton.styleFrom(
-                      foregroundColor: EllaColors.tealDeep,
-                      minimumSize: const Size.fromHeight(EllaSizes.minTouchTarget),
-                    ),
-                  ),
-                ],
               ],
             ],
           ),
@@ -112,32 +130,119 @@ class TodayCardSurface extends StatelessWidget {
     );
   }
 
-  _TodayCardContent _fallbackContent(BuildContext context, TodayCardStatus status) => switch (status) {
-    TodayCardStatus.newUser => _TodayCardContent(
-      eyebrow: context.l10n.todayCardPreparingEyebrow,
-      headline: context.l10n.todayCardNewUserHeadline,
-      body: context.l10n.todayCardNewUserBody,
-    ),
-    TodayCardStatus.degraded => _TodayCardContent(
-      eyebrow: context.l10n.todayCardPreparingEyebrow,
-      headline: context.l10n.todayCardDegradedHeadline,
-      body: context.l10n.todayCardDegradedBody,
-    ),
-    TodayCardStatus.ready || TodayCardStatus.preparing => _TodayCardContent(
-      eyebrow: context.l10n.todayCardPreparingEyebrow,
-      headline: context.l10n.todayCardPreparingHeadline,
-      body: context.l10n.todayCardPreparingBody,
-    ),
-  };
+  _TodayCardContent _fallbackContent(
+    BuildContext context,
+    TodayCardStatus status,
+  ) =>
+      switch (status) {
+        TodayCardStatus.newUser => _TodayCardContent(
+            eyebrow: context.l10n.todayCardPreparingEyebrow,
+            headline: context.l10n.todayCardNewUserHeadline,
+            body: context.l10n.todayCardNewUserBody,
+          ),
+        TodayCardStatus.degraded => _TodayCardContent(
+            eyebrow: context.l10n.todayCardPreparingEyebrow,
+            headline: context.l10n.todayCardDegradedHeadline,
+            body: context.l10n.todayCardDegradedBody,
+          ),
+        TodayCardStatus.ready || TodayCardStatus.preparing => _TodayCardContent(
+            eyebrow: context.l10n.todayCardPreparingEyebrow,
+            headline: context.l10n.todayCardPreparingHeadline,
+            body: context.l10n.todayCardPreparingBody,
+          ),
+      };
+}
+
+class _TodayCardActions extends StatelessWidget {
+  const _TodayCardActions({
+    required this.isReading,
+    required this.onTalk,
+    required this.onReadAloud,
+  });
+
+  final bool isReading;
+  final VoidCallback? onTalk;
+  final VoidCallback? onReadAloud;
+
+  @override
+  Widget build(BuildContext context) {
+    final textScale = MediaQuery.textScalerOf(context).scale(16) / 16;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final shouldStack = textScale > 1.3 || constraints.maxWidth < 310;
+        final talk = Semantics(
+          button: true,
+          label: context.l10n.memoryTalkAction,
+          child: FilledButton.icon(
+            key: const Key('today-card-talk'),
+            onPressed: onTalk,
+            icon: const Icon(Icons.graphic_eq_rounded),
+            label: Text(context.l10n.memoryTalkAction),
+            style: FilledButton.styleFrom(
+              minimumSize: const Size(0, EllaSizes.minTouchTarget),
+            ),
+          ),
+        );
+        final readAloud = onReadAloud == null
+            ? null
+            : TextButton.icon(
+                key: const Key('today-card-read-aloud'),
+                onPressed: onReadAloud,
+                icon: Icon(
+                  isReading ? Icons.stop_circle_outlined : Icons.volume_up_outlined,
+                ),
+                label: Text(
+                  isReading ? context.l10n.stopReading : context.l10n.readAloud,
+                ),
+                style: TextButton.styleFrom(
+                  foregroundColor: EllaColors.tealDeep,
+                  minimumSize: const Size(0, EllaSizes.minTouchTarget),
+                ),
+              );
+
+        if (shouldStack) {
+          return Column(
+            key: const Key('today-card-actions-stacked'),
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              talk,
+              if (readAloud != null) ...[const SizedBox(height: 4), readAloud],
+            ],
+          );
+        }
+
+        return Row(
+          key: const Key('today-card-actions-row'),
+          children: [
+            Expanded(child: talk),
+            if (readAloud != null) ...[
+              const SizedBox(width: 8),
+              Flexible(child: readAloud),
+            ],
+          ],
+        );
+      },
+    );
+  }
 }
 
 class _TodayCardContent {
-  const _TodayCardContent({required this.eyebrow, required this.headline, required this.body});
+  const _TodayCardContent({
+    required this.eyebrow,
+    required this.headline,
+    required this.body,
+    this.provenance,
+  });
 
-  factory _TodayCardContent.fromCard(TodayCard card) =>
-      _TodayCardContent(eyebrow: card.eyebrow, headline: card.headline, body: card.body);
+  factory _TodayCardContent.fromCard(BuildContext context, TodayCard card) => _TodayCardContent(
+        eyebrow: context.l10n.todayCardPreparingEyebrow,
+        headline: card.headline,
+        body: card.body,
+        provenance: card.kind == TodayCardKind.welcome ? null : card.eyebrow,
+      );
 
   final String eyebrow;
   final String headline;
   final String body;
+  final String? provenance;
 }

--- a/app/lib/ella/widgets/today_card_surface.dart
+++ b/app/lib/ella/widgets/today_card_surface.dart
@@ -241,16 +241,13 @@ class _TodayCardContent {
   });
 
   factory _TodayCardContent.fromCard(BuildContext context, TodayCard card) {
-    final provenanceParts = <String>[
-      if (card.kind != TodayCardKind.welcome && card.sourceRefs.isNotEmpty)
-        context.l10n.todayCardProvenanceRecentMemory,
-      if (card.kind != TodayCardKind.welcome && card.localDate.isNotEmpty) context.l10n.todayCardProvenanceUpdatedToday,
-    ];
     return _TodayCardContent(
       eyebrow: context.l10n.todayCardPreparingEyebrow,
       headline: card.headline,
       body: card.body,
-      provenance: provenanceParts.isEmpty ? null : provenanceParts.join(' • '),
+      provenance: card.kind != TodayCardKind.welcome && card.sourceRefs.isNotEmpty
+          ? context.l10n.todayCardProvenanceRecentMemory
+          : null,
     );
   }
 

--- a/app/lib/ella/widgets/today_card_surface.dart
+++ b/app/lib/ella/widgets/today_card_surface.dart
@@ -21,7 +21,7 @@ class TodayCardSurface extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final card = state.card;
-    final content = card == null ? _fallbackContent(context, state.status) : _TodayCardContent.fromCard(context, card);
+    final content = card == null ? _fallbackContent(context, state) : _TodayCardContent.fromCard(context, card);
 
     return EllaCardSurface(
       child: Semantics(
@@ -132,19 +132,25 @@ class TodayCardSurface extends StatelessWidget {
 
   _TodayCardContent _fallbackContent(
     BuildContext context,
-    TodayCardStatus status,
+    TodayCardViewState state,
   ) =>
-      switch (status) {
+      switch (state.status) {
         TodayCardStatus.newUser => _TodayCardContent(
             eyebrow: context.l10n.todayCardPreparingEyebrow,
             headline: context.l10n.todayCardNewUserHeadline,
             body: context.l10n.todayCardNewUserBody,
           ),
-        TodayCardStatus.degraded => _TodayCardContent(
-            eyebrow: context.l10n.todayCardPreparingEyebrow,
-            headline: context.l10n.todayCardDegradedHeadline,
-            body: context.l10n.todayCardDegradedBody,
-          ),
+        TodayCardStatus.degraded => state.errorCode == 'no_safe_source'
+            ? _TodayCardContent(
+                eyebrow: context.l10n.todayCardPreparingEyebrow,
+                headline: context.l10n.todayCardNoSafeSourceHeadline,
+                body: context.l10n.todayCardNoSafeSourceBody,
+              )
+            : _TodayCardContent(
+                eyebrow: context.l10n.todayCardPreparingEyebrow,
+                headline: context.l10n.todayCardDegradedHeadline,
+                body: context.l10n.todayCardDegradedBody,
+              ),
         TodayCardStatus.ready || TodayCardStatus.preparing => _TodayCardContent(
             eyebrow: context.l10n.todayCardPreparingEyebrow,
             headline: context.l10n.todayCardPreparingHeadline,
@@ -234,12 +240,19 @@ class _TodayCardContent {
     this.provenance,
   });
 
-  factory _TodayCardContent.fromCard(BuildContext context, TodayCard card) => _TodayCardContent(
-        eyebrow: context.l10n.todayCardPreparingEyebrow,
-        headline: card.headline,
-        body: card.body,
-        provenance: card.kind == TodayCardKind.welcome ? null : card.eyebrow,
-      );
+  factory _TodayCardContent.fromCard(BuildContext context, TodayCard card) {
+    final provenanceParts = <String>[
+      if (card.kind != TodayCardKind.welcome && card.sourceRefs.isNotEmpty)
+        context.l10n.todayCardProvenanceRecentMemory,
+      if (card.kind != TodayCardKind.welcome && card.localDate.isNotEmpty) context.l10n.todayCardProvenanceUpdatedToday,
+    ];
+    return _TodayCardContent(
+      eyebrow: context.l10n.todayCardPreparingEyebrow,
+      headline: card.headline,
+      body: card.body,
+      provenance: provenanceParts.isEmpty ? null : provenanceParts.join(' • '),
+    );
+  }
 
   final String eyebrow;
   final String headline;

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10643,7 +10643,11 @@
   "todayCardPreparingBody": "Ella is finding one useful moment from your recent memories.",
   "todayCardNewUserHeadline": "What matters to you?",
   "todayCardNewUserBody": "Tell Ella about a person, place, or interest you would like to talk about.",
-  "todayCardDegradedHeadline": "No new note yet",
-  "todayCardDegradedBody": "Ella will add one when there is enough recent memory to be useful.",
-  "todayCardSavedStatus": "Showing the last note while Ella checks for an update."
+  "todayCardNoSafeSourceHeadline": "No new note yet",
+  "todayCardNoSafeSourceBody": "Ella will add one when there is enough recent memory to be useful.",
+  "todayCardDegradedHeadline": "Today's note isn't available right now",
+  "todayCardDegradedBody": "Pull down to try again. If this keeps happening, contact support.",
+  "todayCardSavedStatus": "Showing the last note while Ella checks for an update.",
+  "todayCardProvenanceRecentMemory": "From a recent memory",
+  "todayCardProvenanceUpdatedToday": "Updated today"
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10648,6 +10648,5 @@
   "todayCardDegradedHeadline": "Today's note isn't available right now",
   "todayCardDegradedBody": "Pull down to try again. If this keeps happening, contact support.",
   "todayCardSavedStatus": "Showing the last note while Ella checks for an update.",
-  "todayCardProvenanceRecentMemory": "From a recent memory",
-  "todayCardProvenanceUpdatedToday": "Updated today"
+  "todayCardProvenanceRecentMemory": "From a recent memory"
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10638,12 +10638,12 @@
   "aiConsentGrantUnavailableBody": "Ella couldn't confirm your choice with the server, so nothing has been shared yet. Please try again in a few minutes.",
   "aiConsentGrantPolicyMismatchBody": "This version of Ella no longer matches the current privacy policy. Please update the app, then try again.",
   "aiConsentGrantNetworkBody": "Ella couldn't reach the server. Check your connection and try again.",
-  "todayCardPreparingEyebrow": "FOR YOU TODAY",
-  "todayCardPreparingHeadline": "Ella is putting something together for you.",
-  "todayCardPreparingBody": "Pull down in a little while to check again.",
+  "todayCardPreparingEyebrow": "ELLA'S DAILY NOTE",
+  "todayCardPreparingHeadline": "Preparing today's note",
+  "todayCardPreparingBody": "Ella is finding one useful moment from your recent memories.",
   "todayCardNewUserHeadline": "What matters to you?",
   "todayCardNewUserBody": "Tell Ella about a person, place, or interest you would like to talk about.",
-  "todayCardDegradedHeadline": "Ella could not refresh this just now.",
-  "todayCardDegradedBody": "Pull down to try again.",
-  "todayCardSavedStatus": "Showing the last item Ella saved for you."
+  "todayCardDegradedHeadline": "No new note yet",
+  "todayCardDegradedBody": "Ella will add one when there is enough recent memory to be useful.",
+  "todayCardSavedStatus": "Showing the last note while Ella checks for an update."
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -17324,12 +17324,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'From a recent memory'**
   String get todayCardProvenanceRecentMemory;
-
-  /// No description provided for @todayCardProvenanceUpdatedToday.
-  ///
-  /// In en, this message translates to:
-  /// **'Updated today'**
-  String get todayCardProvenanceUpdatedToday;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -17262,19 +17262,19 @@ abstract class AppLocalizations {
   /// No description provided for @todayCardPreparingEyebrow.
   ///
   /// In en, this message translates to:
-  /// **'FOR YOU TODAY'**
+  /// **'ELLA\'S DAILY NOTE'**
   String get todayCardPreparingEyebrow;
 
   /// No description provided for @todayCardPreparingHeadline.
   ///
   /// In en, this message translates to:
-  /// **'Ella is putting something together for you.'**
+  /// **'Preparing today\'s note'**
   String get todayCardPreparingHeadline;
 
   /// No description provided for @todayCardPreparingBody.
   ///
   /// In en, this message translates to:
-  /// **'Pull down in a little while to check again.'**
+  /// **'Ella is finding one useful moment from your recent memories.'**
   String get todayCardPreparingBody;
 
   /// No description provided for @todayCardNewUserHeadline.
@@ -17292,19 +17292,19 @@ abstract class AppLocalizations {
   /// No description provided for @todayCardDegradedHeadline.
   ///
   /// In en, this message translates to:
-  /// **'Ella could not refresh this just now.'**
+  /// **'No new note yet'**
   String get todayCardDegradedHeadline;
 
   /// No description provided for @todayCardDegradedBody.
   ///
   /// In en, this message translates to:
-  /// **'Pull down to try again.'**
+  /// **'Ella will add one when there is enough recent memory to be useful.'**
   String get todayCardDegradedBody;
 
   /// No description provided for @todayCardSavedStatus.
   ///
   /// In en, this message translates to:
-  /// **'Showing the last item Ella saved for you.'**
+  /// **'Showing the last note while Ella checks for an update.'**
   String get todayCardSavedStatus;
 }
 

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -17289,16 +17289,28 @@ abstract class AppLocalizations {
   /// **'Tell Ella about a person, place, or interest you would like to talk about.'**
   String get todayCardNewUserBody;
 
-  /// No description provided for @todayCardDegradedHeadline.
+  /// No description provided for @todayCardNoSafeSourceHeadline.
   ///
   /// In en, this message translates to:
   /// **'No new note yet'**
+  String get todayCardNoSafeSourceHeadline;
+
+  /// No description provided for @todayCardNoSafeSourceBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Ella will add one when there is enough recent memory to be useful.'**
+  String get todayCardNoSafeSourceBody;
+
+  /// No description provided for @todayCardDegradedHeadline.
+  ///
+  /// In en, this message translates to:
+  /// **'Today\'s note isn\'t available right now'**
   String get todayCardDegradedHeadline;
 
   /// No description provided for @todayCardDegradedBody.
   ///
   /// In en, this message translates to:
-  /// **'Ella will add one when there is enough recent memory to be useful.'**
+  /// **'Pull down to try again. If this keeps happening, contact support.'**
   String get todayCardDegradedBody;
 
   /// No description provided for @todayCardSavedStatus.
@@ -17306,6 +17318,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Showing the last note while Ella checks for an update.'**
   String get todayCardSavedStatus;
+
+  /// No description provided for @todayCardProvenanceRecentMemory.
+  ///
+  /// In en, this message translates to:
+  /// **'From a recent memory'**
+  String get todayCardProvenanceRecentMemory;
+
+  /// No description provided for @todayCardProvenanceUpdatedToday.
+  ///
+  /// In en, this message translates to:
+  /// **'Updated today'**
+  String get todayCardProvenanceUpdatedToday;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9213,13 +9213,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9228,11 +9228,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9244,7 +9244,4 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9228,11 +9228,23 @@ class AppLocalizationsAr extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9332,7 +9332,4 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9301,13 +9301,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9316,11 +9316,11 @@ class AppLocalizationsBg extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9316,11 +9316,23 @@ class AppLocalizationsBg extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9332,11 +9332,23 @@ class AppLocalizationsCa extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9348,7 +9348,4 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9317,13 +9317,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9332,11 +9332,11 @@ class AppLocalizationsCa extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9279,11 +9279,23 @@ class AppLocalizationsCs extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9264,13 +9264,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9279,11 +9279,11 @@ class AppLocalizationsCs extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9295,7 +9295,4 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9253,13 +9253,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9268,11 +9268,11 @@ class AppLocalizationsDa extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9284,7 +9284,4 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9268,11 +9268,23 @@ class AppLocalizationsDa extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9350,11 +9350,23 @@ class AppLocalizationsDe extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9335,13 +9335,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9350,11 +9350,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9366,7 +9366,4 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9326,13 +9326,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9341,11 +9341,11 @@ class AppLocalizationsEl extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9357,7 +9357,4 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9341,11 +9341,23 @@ class AppLocalizationsEl extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9281,11 +9281,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9266,13 +9266,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9281,11 +9281,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9297,7 +9297,4 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9314,7 +9314,4 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9283,13 +9283,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9298,11 +9298,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9298,11 +9298,23 @@ class AppLocalizationsEs extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9283,11 +9283,23 @@ class AppLocalizationsEt extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9299,7 +9299,4 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9268,13 +9268,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9283,11 +9283,11 @@ class AppLocalizationsEt extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9282,11 +9282,23 @@ class AppLocalizationsFi extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9298,7 +9298,4 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9267,13 +9267,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9282,11 +9282,11 @@ class AppLocalizationsFi extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9342,13 +9342,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9357,11 +9357,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9357,11 +9357,23 @@ class AppLocalizationsFr extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9373,7 +9373,4 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9249,13 +9249,13 @@ class AppLocalizationsHi extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9264,11 +9264,11 @@ class AppLocalizationsHi extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9264,11 +9264,23 @@ class AppLocalizationsHi extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9280,7 +9280,4 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9337,7 +9337,4 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9306,13 +9306,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9321,11 +9321,11 @@ class AppLocalizationsHu extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9321,11 +9321,23 @@ class AppLocalizationsHu extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9281,13 +9281,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9296,11 +9296,11 @@ class AppLocalizationsId extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9312,7 +9312,4 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9296,11 +9296,23 @@ class AppLocalizationsId extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9349,7 +9349,4 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9318,13 +9318,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9333,11 +9333,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9333,11 +9333,23 @@ class AppLocalizationsIt extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -9150,11 +9150,23 @@ class AppLocalizationsJa extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -9135,13 +9135,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9150,11 +9150,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -9166,7 +9166,4 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9137,13 +9137,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9152,11 +9152,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9152,11 +9152,23 @@ class AppLocalizationsKo extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9168,7 +9168,4 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9305,7 +9305,4 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9274,13 +9274,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9289,11 +9289,11 @@ class AppLocalizationsLt extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9289,11 +9289,23 @@ class AppLocalizationsLt extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9286,13 +9286,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9301,11 +9301,11 @@ class AppLocalizationsLv extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9301,11 +9301,23 @@ class AppLocalizationsLv extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9317,7 +9317,4 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9292,13 +9292,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9307,11 +9307,11 @@ class AppLocalizationsMs extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9307,11 +9307,23 @@ class AppLocalizationsMs extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9323,7 +9323,4 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9325,7 +9325,4 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9294,13 +9294,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9309,11 +9309,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9309,11 +9309,23 @@ class AppLocalizationsNl extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9279,11 +9279,23 @@ class AppLocalizationsNo extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9264,13 +9264,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9279,11 +9279,11 @@ class AppLocalizationsNo extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9295,7 +9295,4 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9318,7 +9318,4 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9302,11 +9302,23 @@ class AppLocalizationsPl extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9287,13 +9287,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9302,11 +9302,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9284,11 +9284,23 @@ class AppLocalizationsPt extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9300,7 +9300,4 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9269,13 +9269,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9284,11 +9284,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9338,7 +9338,4 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9322,11 +9322,23 @@ class AppLocalizationsRo extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9307,13 +9307,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9322,11 +9322,11 @@ class AppLocalizationsRo extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9294,13 +9294,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9309,11 +9309,11 @@ class AppLocalizationsRu extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9325,7 +9325,4 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9309,11 +9309,23 @@ class AppLocalizationsRu extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9259,13 +9259,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9274,11 +9274,11 @@ class AppLocalizationsSk extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9290,7 +9290,4 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9274,11 +9274,23 @@ class AppLocalizationsSk extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9305,7 +9305,4 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9289,11 +9289,23 @@ class AppLocalizationsSv extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9274,13 +9274,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9289,11 +9289,11 @@ class AppLocalizationsSv extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9262,7 +9262,4 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9231,13 +9231,13 @@ class AppLocalizationsTh extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9246,11 +9246,11 @@ class AppLocalizationsTh extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9246,11 +9246,23 @@ class AppLocalizationsTh extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9282,13 +9282,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9297,11 +9297,11 @@ class AppLocalizationsTr extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9313,7 +9313,4 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9297,11 +9297,23 @@ class AppLocalizationsTr extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9281,13 +9281,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9296,11 +9296,11 @@ class AppLocalizationsUk extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9312,7 +9312,4 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9296,11 +9296,23 @@ class AppLocalizationsUk extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9302,7 +9302,4 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9286,11 +9286,23 @@ class AppLocalizationsVi extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9271,13 +9271,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9286,11 +9286,11 @@ class AppLocalizationsVi extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -9140,11 +9140,23 @@ class AppLocalizationsZh extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'No new note yet';
+  String get todayCardNoSafeSourceHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
+  String get todayCardNoSafeSourceBody => 'Ella will add one when there is enough recent memory to be useful.';
+
+  @override
+  String get todayCardDegradedHeadline => 'Today\'s note isn\'t available right now';
+
+  @override
+  String get todayCardDegradedBody => 'Pull down to try again. If this keeps happening, contact support.';
 
   @override
   String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
+
+  @override
+  String get todayCardProvenanceRecentMemory => 'From a recent memory';
+
+  @override
+  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -9125,13 +9125,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get aiConsentGrantNetworkBody => 'Ella couldn\'t reach the server. Check your connection and try again.';
 
   @override
-  String get todayCardPreparingEyebrow => 'FOR YOU TODAY';
+  String get todayCardPreparingEyebrow => 'ELLA\'S DAILY NOTE';
 
   @override
-  String get todayCardPreparingHeadline => 'Ella is putting something together for you.';
+  String get todayCardPreparingHeadline => 'Preparing today\'s note';
 
   @override
-  String get todayCardPreparingBody => 'Pull down in a little while to check again.';
+  String get todayCardPreparingBody => 'Ella is finding one useful moment from your recent memories.';
 
   @override
   String get todayCardNewUserHeadline => 'What matters to you?';
@@ -9140,11 +9140,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get todayCardNewUserBody => 'Tell Ella about a person, place, or interest you would like to talk about.';
 
   @override
-  String get todayCardDegradedHeadline => 'Ella could not refresh this just now.';
+  String get todayCardDegradedHeadline => 'No new note yet';
 
   @override
-  String get todayCardDegradedBody => 'Pull down to try again.';
+  String get todayCardDegradedBody => 'Ella will add one when there is enough recent memory to be useful.';
 
   @override
-  String get todayCardSavedStatus => 'Showing the last item Ella saved for you.';
+  String get todayCardSavedStatus => 'Showing the last note while Ella checks for an update.';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -9156,7 +9156,4 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get todayCardProvenanceRecentMemory => 'From a recent memory';
-
-  @override
-  String get todayCardProvenanceUpdatedToday => 'Updated today';
 }

--- a/app/lib/pages/home/today_page.dart
+++ b/app/lib/pages/home/today_page.dart
@@ -272,10 +272,8 @@ class TodayPageState extends State<TodayPage> with WidgetsBindingObserver {
 
   Future<void> _loadWhisperState() async {
     if (!_guardianAvailable) return;
-    final injectedInfo = widget.guardianModeLoader == null ? null : await widget.guardianModeLoader!.call();
-    final result = widget.guardianModeLoader == null ? await guardian_api.getGuardianMode() : null;
-    final info = result?.value ?? injectedInfo;
-    if (info == null || result?.isFailure == true) {
+    final info = await _readWhisperState();
+    if (info == null) {
       await (widget.guardianNativeStop?.call() ?? guardian_native.GuardianModeService().stop());
       if (!mounted) return;
       setState(() {
@@ -285,7 +283,7 @@ class TodayPageState extends State<TodayPage> with WidgetsBindingObserver {
       return;
     }
     if (!mounted) return;
-    var enabled = !(info.twoTierState?.isOff ?? info.currentMode == GuardianModeKey.off);
+    var enabled = _whispersEnabled(info);
     try {
       if (enabled) {
         await (widget.guardianNativeStart?.call() ?? guardian_native.GuardianModeService().start());
@@ -303,6 +301,24 @@ class TodayPageState extends State<TodayPage> with WidgetsBindingObserver {
       _whispersVerified = true;
     });
   }
+
+  Future<GuardianModeInfo?> _readWhisperState() async {
+    try {
+      final loader = widget.guardianModeLoader;
+      if (loader != null) return loader();
+      final result = await guardian_api.getGuardianMode();
+      return result.isSuccess ? result.value : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  bool _whispersEnabled(GuardianModeInfo info) =>
+      !(info.twoTierState?.isOff ?? info.currentMode == GuardianModeKey.off);
+
+  Future<void> _reconcileWhisperNative(bool enabled) => enabled
+      ? (widget.guardianNativeStart?.call() ?? guardian_native.GuardianModeService().start())
+      : (widget.guardianNativeStop?.call() ?? guardian_native.GuardianModeService().stop());
 
   void scrollToTop() {
     if (!_scrollController.hasClients) return;
@@ -337,6 +353,7 @@ class TodayPageState extends State<TodayPage> with WidgetsBindingObserver {
 
   Future<void> _setWhispers(bool enabled) async {
     if (_updatingWhispers || !_guardianAvailable) return;
+    final previousEnabled = _whispersOn;
     setState(() {
       _whispersOn = enabled;
       _updatingWhispers = true;
@@ -359,14 +376,40 @@ class TodayPageState extends State<TodayPage> with WidgetsBindingObserver {
       success = false;
     }
     if (!success && enabled) {
-      await (widget.guardianNativeStop?.call() ?? guardian_native.GuardianModeService().stop());
-      await (widget.guardianModeSetter?.call(const GuardianModeState()) ??
-          guardian_api.setGuardianModeTwoTier(const GuardianModeState()));
+      try {
+        await (widget.guardianNativeStop?.call() ?? guardian_native.GuardianModeService().stop());
+        await (widget.guardianModeSetter?.call(const GuardianModeState()) ??
+            guardian_api.setGuardianModeTwoTier(const GuardianModeState()));
+      } catch (_) {}
+    }
+    var resolvedEnabled = enabled;
+    var resolvedVerified = success;
+    if (!success) {
+      final authoritative = await _readWhisperState();
+      if (authoritative != null) {
+        resolvedEnabled = _whispersEnabled(authoritative);
+        try {
+          await _reconcileWhisperNative(resolvedEnabled);
+          resolvedVerified = true;
+        } catch (_) {
+          resolvedVerified = false;
+        }
+      } else {
+        // The write may have reached the server even though the response did
+        // not. Keep the last verified display value but mark it unavailable;
+        // never claim OFF (or ON) without an authoritative readback.
+        resolvedEnabled = previousEnabled;
+        resolvedVerified = false;
+        try {
+          await _reconcileWhisperNative(previousEnabled);
+        } catch (_) {}
+      }
     }
     if (!mounted) return;
     setState(() {
       _updatingWhispers = false;
-      if (!success) _whispersOn = false;
+      _whispersOn = resolvedEnabled;
+      _whispersVerified = resolvedVerified;
     });
     if (!success) {
       ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(context.l10n.anErrorOccurredTryAgain)));

--- a/app/lib/pages/home/today_page.dart
+++ b/app/lib/pages/home/today_page.dart
@@ -274,7 +274,9 @@ class TodayPageState extends State<TodayPage> with WidgetsBindingObserver {
     if (!_guardianAvailable) return;
     final info = await _readWhisperState();
     if (info == null) {
-      await (widget.guardianNativeStop?.call() ?? guardian_native.GuardianModeService().stop());
+      try {
+        await _reconcileWhisperNative(false);
+      } catch (_) {}
       if (!mounted) return;
       setState(() {
         _whispersOn = false;
@@ -283,22 +285,32 @@ class TodayPageState extends State<TodayPage> with WidgetsBindingObserver {
       return;
     }
     if (!mounted) return;
-    var enabled = _whispersEnabled(info);
+    final serverEnabled = _whispersEnabled(info);
+    var resolvedEnabled = serverEnabled;
+    var resolvedVerified = false;
     try {
-      if (enabled) {
-        await (widget.guardianNativeStart?.call() ?? guardian_native.GuardianModeService().start());
-      } else {
-        await (widget.guardianNativeStop?.call() ?? guardian_native.GuardianModeService().stop());
-      }
+      await _reconcileWhisperNative(serverEnabled);
+      resolvedVerified = true;
     } catch (_) {
-      enabled = false;
-      await (widget.guardianModeSetter?.call(const GuardianModeState()) ??
-          guardian_api.setGuardianModeTwoTier(const GuardianModeState()));
+      // If native capture cannot match an authoritative ON response, disable
+      // the server mode only when both the write and readback confirm OFF.
+      // Otherwise keep the last authoritative value behind an unavailable
+      // control and make no ON/OFF claim.
+      if (serverEnabled && await _writeWhisperState(const GuardianModeState())) {
+        final confirmed = await _readWhisperState();
+        if (confirmed != null && !_whispersEnabled(confirmed)) {
+          resolvedEnabled = false;
+          try {
+            await _reconcileWhisperNative(false);
+            resolvedVerified = true;
+          } catch (_) {}
+        }
+      }
     }
     if (!mounted) return;
     setState(() {
-      _whispersOn = enabled;
-      _whispersVerified = true;
+      _whispersOn = resolvedEnabled;
+      _whispersVerified = resolvedVerified;
     });
   }
 
@@ -319,6 +331,16 @@ class TodayPageState extends State<TodayPage> with WidgetsBindingObserver {
   Future<void> _reconcileWhisperNative(bool enabled) => enabled
       ? (widget.guardianNativeStart?.call() ?? guardian_native.GuardianModeService().start())
       : (widget.guardianNativeStop?.call() ?? guardian_native.GuardianModeService().stop());
+
+  Future<bool> _writeWhisperState(GuardianModeState state) async {
+    try {
+      final setter = widget.guardianModeSetter;
+      if (setter != null) return setter(state);
+      return (await guardian_api.setGuardianModeTwoTier(state)).isSuccess;
+    } catch (_) {
+      return false;
+    }
+  }
 
   void scrollToTop() {
     if (!_scrollController.hasClients) return;
@@ -364,11 +386,7 @@ class TodayPageState extends State<TodayPage> with WidgetsBindingObserver {
       if (!enabled) {
         await (widget.guardianNativeStop?.call() ?? guardian_native.GuardianModeService().stop());
       }
-      if (widget.guardianModeSetter != null) {
-        success = await widget.guardianModeSetter!(state);
-      } else {
-        success = (await guardian_api.setGuardianModeTwoTier(state)).isSuccess;
-      }
+      success = await _writeWhisperState(state);
       if (success && enabled) {
         await (widget.guardianNativeStart?.call() ?? guardian_native.GuardianModeService().start());
       }
@@ -378,8 +396,7 @@ class TodayPageState extends State<TodayPage> with WidgetsBindingObserver {
     if (!success && enabled) {
       try {
         await (widget.guardianNativeStop?.call() ?? guardian_native.GuardianModeService().stop());
-        await (widget.guardianModeSetter?.call(const GuardianModeState()) ??
-            guardian_api.setGuardianModeTwoTier(const GuardianModeState()));
+        await _writeWhisperState(const GuardianModeState());
       } catch (_) {}
     }
     var resolvedEnabled = enabled;

--- a/app/test/ella/public_build_call_paths_test.dart
+++ b/app/test/ella/public_build_call_paths_test.dart
@@ -382,6 +382,7 @@ void main() {
     var guardianServerEnabled = false;
     var guardianModeWriteSucceeds = true;
     var guardianReadbackSucceeds = true;
+    var guardianNativeStartSucceeds = true;
     guardian_model.GuardianModeState? writtenGuardianState;
     final runtimeNow = DateTime(2032, 5, 6, 9, 41);
     final previewNow = DateTime(2025, 7, 24, 9, 41);
@@ -432,75 +433,79 @@ void main() {
     await tester.binding.setSurfaceSize(const Size(1200, 2000));
     addTearDown(() => tester.binding.setSurfaceSize(null));
 
-    await tester.pumpWidget(
-      MultiProvider(
-        providers: [
-          ChangeNotifierProvider<HomeProvider>.value(value: homeProvider),
-          ChangeNotifierProvider<ActionItemsProvider>.value(value: actionItemsProvider),
-          ChangeNotifierProvider<AudioRouteProvider>.value(value: audioRouteProvider),
-          ChangeNotifierProvider<CaptureProvider>.value(value: captureProvider),
-          ChangeNotifierProvider<ConversationProvider>.value(value: conversationProvider),
-          ChangeNotifierProvider<DeviceProvider>.value(value: deviceProvider),
-          ChangeNotifierProvider<MessageProvider>.value(value: messageProvider),
-          ChangeNotifierProvider(create: (_) => AppProvider()),
-          ChangeNotifierProvider(create: (_) => ConnectivityProvider()),
-          ChangeNotifierProvider(create: (_) => VoiceRecorderProvider()),
-          ChangeNotifierProvider(create: (_) => IntegrationProvider()),
-        ],
-        child: MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: HomePage(
-            runtimeSideEffectsEnabled: false,
-            pagesOverride: [
-              TodayPage(
-                nowProvider: () => runtimeNow,
-                todayCardRepository: _FixedTodayCardRepository(
-                  TodayCardResponse(
-                    contractVersion: todayCardContractVersion,
-                    status: TodayCardStatus.ready,
-                    card: todayCard,
+    Widget buildHome({Key? todayKey}) => MultiProvider(
+          providers: [
+            ChangeNotifierProvider<HomeProvider>.value(value: homeProvider),
+            ChangeNotifierProvider<ActionItemsProvider>.value(value: actionItemsProvider),
+            ChangeNotifierProvider<AudioRouteProvider>.value(value: audioRouteProvider),
+            ChangeNotifierProvider<CaptureProvider>.value(value: captureProvider),
+            ChangeNotifierProvider<ConversationProvider>.value(value: conversationProvider),
+            ChangeNotifierProvider<DeviceProvider>.value(value: deviceProvider),
+            ChangeNotifierProvider<MessageProvider>.value(value: messageProvider),
+            ChangeNotifierProvider(create: (_) => AppProvider()),
+            ChangeNotifierProvider(create: (_) => ConnectivityProvider()),
+            ChangeNotifierProvider(create: (_) => VoiceRecorderProvider()),
+            ChangeNotifierProvider(create: (_) => IntegrationProvider()),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: HomePage(
+              runtimeSideEffectsEnabled: false,
+              pagesOverride: [
+                TodayPage(
+                  key: todayKey,
+                  nowProvider: () => runtimeNow,
+                  todayCardRepository: _FixedTodayCardRepository(
+                    TodayCardResponse(
+                      contractVersion: todayCardContractVersion,
+                      status: TodayCardStatus.ready,
+                      card: todayCard,
+                    ),
+                    onFetch: () => todayCardCalls++,
                   ),
-                  onFetch: () => todayCardCalls++,
+                  todayCardCache: _MemoryTodayCardCache(),
+                  todayCardAuthoritySnapshotProvider: () => authoritySnapshot,
+                  todayCardAuthorityChanges: authorityChanges,
+                  guardianAvailability: () =>
+                      (SharedPreferencesUtil.isPublicBuild || isEllaInternalPilotEnabled) && isEllaGuardianConfigured,
+                  guardianModeLoader: () async => guardianReadbackSucceeds
+                      ? guardian_model.GuardianModeInfo(
+                          currentMode: guardianServerEnabled
+                              ? guardian_model.GuardianModeKey.activeSupport
+                              : guardian_model.GuardianModeKey.off,
+                          twoTierState: guardianServerEnabled
+                              ? const guardian_model.GuardianModeState(features: ['ACTIVE_SUPPORT'])
+                              : const guardian_model.GuardianModeState(),
+                        )
+                      : null,
+                  guardianModeSetter: (state) async {
+                    guardianModeWrites++;
+                    writtenGuardianState = state;
+                    if (guardianModeWriteSucceeds) {
+                      guardianServerEnabled = !state.isOff;
+                    }
+                    return guardianModeWriteSucceeds;
+                  },
+                  guardianNativeStart: () async {
+                    guardianNativeStarts++;
+                    if (!guardianNativeStartSucceeds) {
+                      throw StateError('simulated native start failure');
+                    }
+                  },
+                  guardianNativeStop: () async {
+                    guardianNativeStops++;
+                  },
                 ),
-                todayCardCache: _MemoryTodayCardCache(),
-                todayCardAuthoritySnapshotProvider: () => authoritySnapshot,
-                todayCardAuthorityChanges: authorityChanges,
-                guardianAvailability: () =>
-                    (SharedPreferencesUtil.isPublicBuild || isEllaInternalPilotEnabled) && isEllaGuardianConfigured,
-                guardianModeLoader: () async => guardianReadbackSucceeds
-                    ? guardian_model.GuardianModeInfo(
-                        currentMode: guardianServerEnabled
-                            ? guardian_model.GuardianModeKey.activeSupport
-                            : guardian_model.GuardianModeKey.off,
-                        twoTierState: guardianServerEnabled
-                            ? const guardian_model.GuardianModeState(features: ['ACTIVE_SUPPORT'])
-                            : const guardian_model.GuardianModeState(),
-                      )
-                    : null,
-                guardianModeSetter: (state) async {
-                  guardianModeWrites++;
-                  writtenGuardianState = state;
-                  if (guardianModeWriteSucceeds) {
-                    guardianServerEnabled = !state.isOff;
-                  }
-                  return guardianModeWriteSucceeds;
-                },
-                guardianNativeStart: () async {
-                  guardianNativeStarts++;
-                },
-                guardianNativeStop: () async {
-                  guardianNativeStops++;
-                },
-              ),
-              const ChatPage(isPivotBottom: true),
-              const _Marker('voice'),
-              const _Marker('settings'),
-            ],
+                const ChatPage(isPivotBottom: true),
+                const _Marker('voice'),
+                const _Marker('settings'),
+              ],
+            ),
           ),
-        ),
-      ),
-    );
+        );
+
+    await tester.pumpWidget(buildHome());
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 350));
 
@@ -575,6 +580,31 @@ void main() {
       );
       expect(unavailableSwitch.value, isTrue);
       expect(unavailableSwitch.onChanged, isNull);
+      expect(find.textContaining('Whispers are off'), findsNothing);
+      expect(find.byKey(const Key('whispers-history-entry')), findsNothing);
+
+      // Initial reconciliation must also fail closed. If the server says ON,
+      // native start fails, and the compensating server disable is rejected,
+      // Home must not publish a verified OFF state.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      final writesBeforeInitialFailure = guardianModeWrites;
+      guardianServerEnabled = true;
+      guardianReadbackSucceeds = true;
+      guardianModeWriteSucceeds = false;
+      guardianNativeStartSucceeds = false;
+      await tester.pumpWidget(buildHome(todayKey: UniqueKey()));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      final initialFailureSwitch = tester.widget<Switch>(
+        find.descendant(of: find.byKey(const Key('guardian-whispers-control')), matching: find.byType(Switch)),
+      );
+      expect(guardianModeWrites, writesBeforeInitialFailure + 1);
+      expect(guardianServerEnabled, isTrue);
+      expect(initialFailureSwitch.value, isTrue);
+      expect(initialFailureSwitch.onChanged, isNull);
+      expect(find.textContaining('Whispers are on'), findsNothing);
       expect(find.textContaining('Whispers are off'), findsNothing);
       expect(find.byKey(const Key('whispers-history-entry')), findsNothing);
     } else if (!allowsGuardianSurface()) {

--- a/app/test/ella/public_build_call_paths_test.dart
+++ b/app/test/ella/public_build_call_paths_test.dart
@@ -378,6 +378,10 @@ void main() {
     var todayCardCalls = 0;
     var guardianModeWrites = 0;
     var guardianNativeStarts = 0;
+    var guardianNativeStops = 0;
+    var guardianServerEnabled = false;
+    var guardianModeWriteSucceeds = true;
+    var guardianReadbackSucceeds = true;
     guardian_model.GuardianModeState? writtenGuardianState;
     final runtimeNow = DateTime(2032, 5, 6, 9, 41);
     final previewNow = DateTime(2025, 7, 24, 9, 41);
@@ -464,19 +468,30 @@ void main() {
                 todayCardAuthorityChanges: authorityChanges,
                 guardianAvailability: () =>
                     (SharedPreferencesUtil.isPublicBuild || isEllaInternalPilotEnabled) && isEllaGuardianConfigured,
-                guardianModeLoader: () async => const guardian_model.GuardianModeInfo(
-                  currentMode: guardian_model.GuardianModeKey.off,
-                  twoTierState: guardian_model.GuardianModeState(),
-                ),
+                guardianModeLoader: () async => guardianReadbackSucceeds
+                    ? guardian_model.GuardianModeInfo(
+                        currentMode: guardianServerEnabled
+                            ? guardian_model.GuardianModeKey.activeSupport
+                            : guardian_model.GuardianModeKey.off,
+                        twoTierState: guardianServerEnabled
+                            ? const guardian_model.GuardianModeState(features: ['ACTIVE_SUPPORT'])
+                            : const guardian_model.GuardianModeState(),
+                      )
+                    : null,
                 guardianModeSetter: (state) async {
                   guardianModeWrites++;
                   writtenGuardianState = state;
-                  return true;
+                  if (guardianModeWriteSucceeds) {
+                    guardianServerEnabled = !state.isOff;
+                  }
+                  return guardianModeWriteSucceeds;
                 },
                 guardianNativeStart: () async {
                   guardianNativeStarts++;
                 },
-                guardianNativeStop: () async {},
+                guardianNativeStop: () async {
+                  guardianNativeStops++;
+                },
               ),
               const ChatPage(isPivotBottom: true),
               const _Marker('voice'),
@@ -519,6 +534,49 @@ void main() {
       expect(writtenGuardianState?.features, ['ACTIVE_SUPPORT']);
       expect(guardianNativeStarts, 1);
       expect(find.textContaining('Whispers are on'), findsOneWidget);
+
+      // A failed disable must read back server authority. The server remains
+      // ON here, so the control must return to ON and native capture must be
+      // reconciled instead of falsely claiming OFF.
+      guardianModeWriteSucceeds = false;
+      await tester.tap(
+        find.descendant(of: find.byKey(const Key('guardian-whispers-control')), matching: find.byType(Switch)),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(guardianModeWrites, 2);
+      expect(writtenGuardianState?.isOff, isTrue);
+      expect(guardianServerEnabled, isTrue);
+      expect(guardianNativeStops, greaterThanOrEqualTo(1));
+      expect(guardianNativeStarts, 2);
+      expect(find.textContaining('Whispers are on'), findsOneWidget);
+      expect(
+        tester
+            .widget<Switch>(
+              find.descendant(of: find.byKey(const Key('guardian-whispers-control')), matching: find.byType(Switch)),
+            )
+            .value,
+        isTrue,
+      );
+      expect(find.byType(SnackBar), findsOneWidget);
+
+      // If readback is also unavailable, keep the last verified switch value
+      // but disable the control and show no OFF claim until authority returns.
+      guardianReadbackSucceeds = false;
+      await tester.tap(
+        find.descendant(of: find.byKey(const Key('guardian-whispers-control')), matching: find.byType(Switch)),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      final unavailableSwitch = tester.widget<Switch>(
+        find.descendant(of: find.byKey(const Key('guardian-whispers-control')), matching: find.byType(Switch)),
+      );
+      expect(unavailableSwitch.value, isTrue);
+      expect(unavailableSwitch.onChanged, isNull);
+      expect(find.textContaining('Whispers are off'), findsNothing);
+      expect(find.byKey(const Key('whispers-history-entry')), findsNothing);
     } else if (!allowsGuardianSurface()) {
       expect(find.byKey(const Key('guardian-whispers-control')), findsNothing);
       expect(find.byKey(const Key('whispers-history-entry')), findsNothing);

--- a/app/test/ella/widgets/today_card_surface_test.dart
+++ b/app/test/ella/widgets/today_card_surface_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/ella/ella_theme.dart';
+import 'package:omi/ella/models/today_card.dart';
+import 'package:omi/ella/widgets/today_card_surface.dart';
+import 'package:omi/l10n/app_localizations.dart';
+
+void main() {
+  setUpAll(() async {
+    await (FontLoader('Manrope')
+          ..addFont(rootBundle.load('assets/fonts/Manrope-400.ttf'))
+          ..addFont(rootBundle.load('assets/fonts/Manrope-600.ttf'))
+          ..addFont(rootBundle.load('assets/fonts/Manrope-700.ttf')))
+        .load();
+    await (FontLoader('Fraunces')
+          ..addFont(rootBundle.load('assets/fonts/Fraunces-Latin-Regular.ttf'))
+          ..addFont(rootBundle.load('assets/fonts/Fraunces-Latin-Medium.ttf')))
+        .load();
+  });
+
+  void configureView(WidgetTester tester) {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(390, 844);
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+  }
+
+  Widget buildApp(TodayCardViewState state, {double textScale = 1}) => MaterialApp(
+        theme: ellaThemeData(),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        builder: (context, child) => MediaQuery(
+          data: MediaQuery.of(
+            context,
+          ).copyWith(textScaler: TextScaler.linear(textScale)),
+          child: child!,
+        ),
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: EllaSizes.screenPadding),
+              child: TodayCardSurface(
+                state: state,
+                isReading: false,
+                onTalk: () {},
+                onReadAloud: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+  TodayCard readyCard({TodayCardKind kind = TodayCardKind.memory}) => TodayCard(
+        id: 'daily-card-1',
+        version: 1,
+        kind: kind,
+        eyebrow: 'SERVER DISPLAY COPY',
+        headline: 'A calm moment worth repeating',
+        body:
+            'A little time outside stood out as a good moment yesterday. If it feels right, make space for that again today.',
+        generatedAt: DateTime.utc(2026, 8, 9, 12),
+        sourceRefs:
+            kind == TodayCardKind.welcome ? const [] : const [TodayCardSourceRef(kind: 'memory', id: 'memory-1')],
+      );
+
+  testWidgets(
+    'ready note uses stable hierarchy, derived provenance, and compact actions',
+    (tester) async {
+      configureView(tester);
+      await tester.pumpWidget(
+        buildApp(
+          TodayCardViewState(status: TodayCardStatus.ready, card: readyCard()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text("ELLA'S DAILY NOTE"), findsOneWidget);
+      expect(find.text('SERVER DISPLAY COPY'), findsOneWidget);
+      expect(find.byKey(const Key('today-card-actions-row')), findsOneWidget);
+      expect(find.byKey(const Key('today-card-talk')), findsOneWidget);
+      expect(find.byKey(const Key('today-card-read-aloud')), findsOneWidget);
+      expect(
+        tester.getSize(find.byKey(const Key('today-card-talk'))).height,
+        greaterThanOrEqualTo(48),
+      );
+      final surfaceSize = tester.getSize(find.byKey(const Key('today-card-semantics')));
+      final headlineSize = tester.getSize(find.byKey(const Key('today-card-headline')));
+      final bodySize = tester.getSize(find.byKey(const Key('today-card-body')));
+      final actionSize = tester.getSize(find.byKey(const Key('today-card-actions-row')));
+      final effectiveScale =
+          MediaQuery.textScalerOf(tester.element(find.byKey(const Key('today-card-body')))).scale(16) / 16;
+      expect(
+        surfaceSize.height,
+        lessThanOrEqualTo(300),
+        reason: 'surface=$surfaceSize headline=$headlineSize body=$bodySize actions=$actionSize scale=$effectiveScale',
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('large text stacks actions without clipping or overflow', (
+    tester,
+  ) async {
+    configureView(tester);
+    await tester.pumpWidget(
+      buildApp(
+        TodayCardViewState(status: TodayCardStatus.ready, card: readyCard()),
+        textScale: 2,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('today-card-actions-stacked')), findsOneWidget);
+    expect(find.text('A calm moment worth repeating'), findsOneWidget);
+    expect(find.textContaining('A little time outside'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+    'generic unavailable state exposes no personal content or actions',
+    (tester) async {
+      configureView(tester);
+      await tester.pumpWidget(
+        buildApp(const TodayCardViewState(status: TodayCardStatus.degraded)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('No new note yet'), findsOneWidget);
+      expect(find.byKey(const Key('today-card-provenance')), findsNothing);
+      expect(find.byKey(const Key('today-card-talk')), findsNothing);
+      expect(find.byKey(const Key('today-card-read-aloud')), findsNothing);
+      expect(tester.takeException(), isNull);
+    },
+  );
+}

--- a/app/test/ella/widgets/today_card_surface_test.dart
+++ b/app/test/ella/widgets/today_card_surface_test.dart
@@ -54,7 +54,7 @@ void main() {
         ),
       );
 
-  TodayCard readyCard({TodayCardKind kind = TodayCardKind.memory}) => TodayCard(
+  TodayCard readyCard({TodayCardKind kind = TodayCardKind.memory, String localDate = '2026-08-09'}) => TodayCard(
         id: 'daily-card-1',
         version: 1,
         kind: kind,
@@ -64,7 +64,7 @@ void main() {
             'A little time outside stood out as a good moment yesterday. If it feels right, make space for that again today.',
         generatedAt: DateTime.utc(2026, 8, 9, 12),
         sourceDate: '2026-08-08',
-        localDate: '2026-08-09',
+        localDate: localDate,
         sourceRefs:
             kind == TodayCardKind.welcome ? const [] : const [TodayCardSourceRef(kind: 'memory', id: 'memory-1')],
       );
@@ -81,7 +81,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text("ELLA'S DAILY NOTE"), findsOneWidget);
-      expect(find.text('From a recent memory • Updated today'), findsOneWidget);
+      expect(find.text('From a recent memory'), findsOneWidget);
+      expect(find.textContaining('Updated today'), findsNothing);
       expect(find.text('SERVER DISPLAY COPY'), findsNothing);
       expect(find.byKey(const Key('today-card-actions-row')), findsOneWidget);
       expect(find.byKey(const Key('today-card-talk')), findsOneWidget);
@@ -119,7 +120,8 @@ void main() {
         find.byKey(Key(width == 320 ? 'today-card-actions-stacked' : 'today-card-actions-row')),
         findsOneWidget,
       );
-      expect(find.text('From a recent memory • Updated today'), findsOneWidget);
+      expect(find.text('From a recent memory'), findsOneWidget);
+      expect(find.textContaining('Updated today'), findsNothing);
       expect(tester.takeException(), isNull);
     });
   }
@@ -150,7 +152,7 @@ void main() {
         buildApp(
           TodayCardViewState(
             status: TodayCardStatus.preparing,
-            card: readyCard(),
+            card: readyCard(localDate: '2026-08-08'),
             isLoading: true,
             isCached: true,
           ),
@@ -159,6 +161,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Showing the last note while Ella checks for an update.'), findsOneWidget);
+      expect(find.text('From a recent memory'), findsOneWidget);
+      expect(find.textContaining('Updated today'), findsNothing);
       expect(find.byKey(const Key('today-card-talk')), findsOneWidget);
       expect(tester.takeException(), isNull);
     },

--- a/app/test/ella/widgets/today_card_surface_test.dart
+++ b/app/test/ella/widgets/today_card_surface_test.dart
@@ -20,9 +20,9 @@ void main() {
         .load();
   });
 
-  void configureView(WidgetTester tester) {
+  void configureView(WidgetTester tester, {double width = 390, double height = 844}) {
     tester.view.devicePixelRatio = 1;
-    tester.view.physicalSize = const Size(390, 844);
+    tester.view.physicalSize = Size(width, height);
     addTearDown(() {
       tester.view.resetPhysicalSize();
       tester.view.resetDevicePixelRatio();
@@ -63,6 +63,8 @@ void main() {
         body:
             'A little time outside stood out as a good moment yesterday. If it feels right, make space for that again today.',
         generatedAt: DateTime.utc(2026, 8, 9, 12),
+        sourceDate: '2026-08-08',
+        localDate: '2026-08-09',
         sourceRefs:
             kind == TodayCardKind.welcome ? const [] : const [TodayCardSourceRef(kind: 'memory', id: 'memory-1')],
       );
@@ -79,7 +81,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text("ELLA'S DAILY NOTE"), findsOneWidget);
-      expect(find.text('SERVER DISPLAY COPY'), findsOneWidget);
+      expect(find.text('From a recent memory • Updated today'), findsOneWidget);
+      expect(find.text('SERVER DISPLAY COPY'), findsNothing);
       expect(find.byKey(const Key('today-card-actions-row')), findsOneWidget);
       expect(find.byKey(const Key('today-card-talk')), findsOneWidget);
       expect(find.byKey(const Key('today-card-read-aloud')), findsOneWidget);
@@ -102,6 +105,25 @@ void main() {
     },
   );
 
+  for (final width in [320.0, 430.0]) {
+    testWidgets('ready note is responsive at ${width.toInt()} points', (tester) async {
+      configureView(tester, width: width);
+      await tester.pumpWidget(
+        buildApp(
+          TodayCardViewState(status: TodayCardStatus.ready, card: readyCard()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(Key(width == 320 ? 'today-card-actions-stacked' : 'today-card-actions-row')),
+        findsOneWidget,
+      );
+      expect(find.text('From a recent memory • Updated today'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  }
+
   testWidgets('large text stacks actions without clipping or overflow', (
     tester,
   ) async {
@@ -121,19 +143,83 @@ void main() {
   });
 
   testWidgets(
-    'generic unavailable state exposes no personal content or actions',
+    'cached refresh keeps the safe card and marks it as saved',
     (tester) async {
       configureView(tester);
       await tester.pumpWidget(
-        buildApp(const TodayCardViewState(status: TodayCardStatus.degraded)),
+        buildApp(
+          TodayCardViewState(
+            status: TodayCardStatus.preparing,
+            card: readyCard(),
+            isLoading: true,
+            isCached: true,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Showing the last note while Ella checks for an update.'), findsOneWidget);
+      expect(find.byKey(const Key('today-card-talk')), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('preparing state exposes no actions or invented personal content', (tester) async {
+    configureView(tester);
+    await tester.pumpWidget(
+      buildApp(const TodayCardViewState(status: TodayCardStatus.preparing, isLoading: true)),
+    );
+    await tester.pump();
+
+    expect(find.text("Preparing today's note"), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byKey(const Key('today-card-talk')), findsNothing);
+    expect(find.byKey(const Key('today-card-read-aloud')), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+    'no-safe-source degraded state uses the evidence-absence explanation',
+    (tester) async {
+      configureView(tester);
+      await tester.pumpWidget(
+        buildApp(
+          const TodayCardViewState(
+            status: TodayCardStatus.degraded,
+            errorCode: 'no_safe_source',
+          ),
+        ),
       );
       await tester.pumpAndSettle();
 
       expect(find.text('No new note yet'), findsOneWidget);
+      expect(find.textContaining('enough recent memory'), findsOneWidget);
       expect(find.byKey(const Key('today-card-provenance')), findsNothing);
       expect(find.byKey(const Key('today-card-talk')), findsNothing);
       expect(find.byKey(const Key('today-card-read-aloud')), findsNothing);
       expect(tester.takeException(), isNull);
     },
   );
+
+  for (final errorCode in ['generation_failed', 'generation_output_invalid', 'today_card_unavailable']) {
+    testWidgets('operational degraded state stays truthful for $errorCode', (tester) async {
+      configureView(tester);
+      await tester.pumpWidget(
+        buildApp(
+          TodayCardViewState(
+            status: TodayCardStatus.degraded,
+            errorCode: errorCode,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text("Today's note isn't available right now"), findsOneWidget);
+      expect(find.textContaining('Pull down to try again'), findsOneWidget);
+      expect(find.textContaining('enough recent memory'), findsNothing);
+      expect(find.byKey(const Key('today-card-talk')), findsNothing);
+      expect(find.byKey(const Key('today-card-read-aloud')), findsNothing);
+      expect(tester.takeException(), isNull);
+    });
+  }
 }


### PR DESCRIPTION
## Summary

- refine the authenticated `ella.today_card.v1` Home hero into the quiet editorial Ella Daily Note direction
- keep the existing exact-authority, bounded-cache, tombstone, Talk, and read-aloud contracts from #387
- add responsive action layout, typed source provenance, reason-specific privacy-safe fallback copy, and real-font widget/semantics coverage
- reconcile failed Whisper writes and initial native startup against authoritative server state; when readback or rollback is unavailable, retain the last authoritative value without claiming ON or OFF

## Verification

- focused corrected Daily Note / public Home / Whisper contract: 19/19
- full Flutter package: 425/425
- public / internal / invitation configurations: 27/27
- current-tree executable native Guardian production boundary: passed
- changed-file analyzer: no errors or warnings; four pre-existing infos in `public_build_call_paths_test.dart`
- `git diff --check`: clean

## Release gates

- stacked on #387 exact `190d45eef046eccec94b31a327733744b9cb39c9`
- supersedes the review-blocked PR heads `d98190f171845c98e62a4dcf9074a6c6a09114a5` and `893910782b149b9a3ee10bcc3718cc6bdb5569fe`
- no version bump, build, upload, merge, App Store metadata, or production state change in this PR
- build 808 remains gated on independent review, PR #360 exact-head approval/deploy canary, current-tree Guardian verification, and final release validation

## Test plan

- verify 320/390/430 widths and 200% text scale
- verify ready, cached-refresh, preparing, no-safe-source, operational-error, authority replacement, and tombstone states
- verify Home Whisper control plus Whisper history/settings
- verify failed Whisper disable restores the server-authoritative ON state, and unavailable readback makes the switch unavailable without an OFF claim
- verify initial server-ON/native-start failure cannot claim OFF when the compensating server disable is rejected
- verify a prior-day cached card uses neutral typed-source provenance rather than claiming it was updated today
- verify Talk and read-aloud stay exact-authority fenced
