### PR TITLE
fix(ios): prove capture start and enforce voice output

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -179,11 +179,14 @@ extension FlutterError: Error {}
         binaryMessenger: controller.binaryMessenger
     )
     audioRouteChannel?.setMethodCallHandler { [weak self] (call, result) in
-        guard call.method == "getCurrentRoute" else {
+        switch call.method {
+        case "getCurrentRoute":
+            result(self?.currentAudioRoutePayload() ?? [:])
+        case "ensureAudibleVoiceOutput":
+            result(self?.ensureAudibleVoiceOutput() ?? ["success": false])
+        default:
             result(FlutterMethodNotImplemented)
-            return
         }
-        result(self?.currentAudioRoutePayload() ?? [:])
     }
     print("AppDelegate: Audio Route MethodChannel registered")
 
@@ -298,7 +301,33 @@ extension FlutterError: Error {}
           "outputType": outputType.rawValue,
           "hasHeadset": hasHeadset,
           "usesPhoneSpeaker": outputType == .builtInSpeaker,
+          "usesReceiver": outputType == .builtInReceiver,
       ]
+  }
+
+  private func ensureAudibleVoiceOutput() -> [String: Any] {
+      let audioSession = AVAudioSession.sharedInstance()
+      do {
+          try audioSession.setCategory(
+              .playAndRecord,
+              mode: .voiceChat,
+              options: [.defaultToSpeaker, .allowBluetooth, .allowBluetoothA2DP, .allowAirPlay]
+          )
+          try audioSession.setActive(true, options: [])
+
+          let outputType = audioSession.currentRoute.outputs.first?.portType
+          if outputType == nil || outputType == .builtInReceiver {
+              try audioSession.overrideOutputAudioPort(.speaker)
+          }
+
+          var payload = currentAudioRoutePayload()
+          payload["success"] = payload["usesReceiver"] as? Bool != true
+          return payload
+      } catch {
+          var payload = currentAudioRoutePayload()
+          payload["success"] = false
+          return payload
+      }
   }
 
   @objc private func handleApplicationDidBecomeActive(notification: Notification) {

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -293,12 +293,13 @@ extension FlutterError: Error {}
           .bluetoothLE,
           .headphones,
       ]
-      let outputType = output?.portType ?? .builtInSpeaker
-      let hasHeadset = privateOutputTypes.contains(outputType)
+      let outputType = output?.portType
+      let hasHeadset = outputType.map(privateOutputTypes.contains) ?? false
 
       return [
-          "outputName": output?.portName ?? "iPhone speaker",
-          "outputType": outputType.rawValue,
+          "outputName": output?.portName ?? "",
+          "outputType": outputType?.rawValue ?? "",
+          "hasOutput": output != nil,
           "hasHeadset": hasHeadset,
           "usesPhoneSpeaker": outputType == .builtInSpeaker,
           "usesReceiver": outputType == .builtInReceiver,
@@ -321,7 +322,7 @@ extension FlutterError: Error {}
           }
 
           var payload = currentAudioRoutePayload()
-          payload["success"] = payload["usesReceiver"] as? Bool != true
+          payload["success"] = payload["hasOutput"] as? Bool == true && payload["usesReceiver"] as? Bool != true
           return payload
       } catch {
           var payload = currentAudioRoutePayload()

--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -79,6 +79,10 @@ class EllaVoiceChatPage extends StatefulWidget {
   static bool shouldInjectVoiceTurns(V2VSessionScope? sessionScope) => sessionScope == null;
 
   @visibleForTesting
+  static bool shouldResumeAfterStandardTurn(StandardVoiceTurnResult result) =>
+      result.reply.isEmpty || result.usedOnDeviceTts;
+
+  @visibleForTesting
   static bool shouldInitializeSpeech(EllaVoiceDemoState? demoState) => demoState == null;
 
   @visibleForTesting
@@ -1207,7 +1211,9 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
             playFile: (audioPath) async {
               if (!mounted || !operation.isCurrent) return;
               debugPrint('[VoiceChat] Playing authority-bound audio: $audioPath');
-              if (!await _prepareTtsPlaybackSession(isCurrent: () => mounted && operation.isCurrent)) return;
+              if (!await _prepareTtsPlaybackSession(isCurrent: () => mounted && operation.isCurrent)) {
+                throw const StandardVoicePlaybackUnavailable();
+              }
               if (!mounted || !operation.isCurrent) return;
               await _audioPlayer.setVolume(1.0);
               if (!mounted || !operation.isCurrent) return;
@@ -1218,7 +1224,7 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
           );
 
           if (!mounted || !operation.isCurrent || result.discarded) return;
-          if (result.reply.isEmpty || result.usedOnDeviceTts) {
+          if (EllaVoiceChatPage.shouldResumeAfterStandardTurn(result)) {
             if (_voiceModeActive) {
               _startListening();
             } else {

--- a/app/lib/ella/pages/ella_voice_chat_page.dart
+++ b/app/lib/ella/pages/ella_voice_chat_page.dart
@@ -24,6 +24,7 @@ import 'package:omi/ella/services/ai_consent_coordinator.dart';
 import 'package:omi/ella/services/ella_entitlement_service.dart';
 import 'package:omi/ella/services/elevenlabs_tts.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
+import 'package:omi/ella/services/ella_voice_audio_route.dart';
 import 'package:omi/ella/services/memory_reinterpretation_receipt_service.dart';
 import 'package:omi/ella/services/standard_voice_turn.dart';
 import 'package:omi/ella/services/today_card_repository.dart';
@@ -1278,6 +1279,8 @@ class _EllaVoiceChatPageState extends State<EllaVoiceChatPage> with AutomaticKee
     );
     if (isCurrent?.call() == false) return false;
     await session.setActive(true);
+    if (isCurrent?.call() == false) return false;
+    if (!await EllaVoiceAudioRoute.ensureAudibleOutput()) return false;
     if (isCurrent?.call() == false) return false;
     debugPrint('[VoiceChat] Audio session prepared for TTS playback');
     return true;

--- a/app/lib/ella/services/ella_voice_audio_route.dart
+++ b/app/lib/ella/services/ella_voice_audio_route.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Keeps Ella voice playback on a private route when one is connected and on
+/// the iPhone loudspeaker otherwise. `playAndRecord` sessions can fall back to
+/// the receiver after microphone or route transitions, so `defaultToSpeaker`
+/// alone is not a sufficient runtime guarantee.
+class EllaVoiceAudioRoute {
+  const EllaVoiceAudioRoute._();
+
+  static const MethodChannel _channel = MethodChannel(
+    'com.ellaaicare.ella/audio_route',
+  );
+
+  static Future<bool> ensureAudibleOutput({
+    @visibleForTesting MethodChannel channel = _channel,
+    @visibleForTesting bool? isIos,
+  }) async {
+    if (!(isIos ?? Platform.isIOS)) return true;
+    try {
+      final result = await channel.invokeMapMethod<String, dynamic>(
+        'ensureAudibleVoiceOutput',
+      );
+      return result?['success'] == true && result?['usesReceiver'] != true;
+    } on PlatformException {
+      return false;
+    } on MissingPluginException {
+      return false;
+    }
+  }
+}

--- a/app/lib/ella/services/standard_voice_turn.dart
+++ b/app/lib/ella/services/standard_voice_turn.dart
@@ -18,6 +18,10 @@ typedef StandardVoiceSynthesizer = Future<String?> Function(
   ExactAccountAuthorityVerifier? exactAuthority,
 });
 
+class StandardVoicePlaybackUnavailable implements Exception {
+  const StandardVoicePlaybackUnavailable();
+}
+
 class StandardVoiceTurnResult {
   const StandardVoiceTurnResult({
     required this.reply,
@@ -105,6 +109,7 @@ class StandardVoiceTurnCoordinator {
       } on ExactAccountAuthorityChangedException {
         rethrow;
       } catch (_) {
+        await ElevenLabsTts.discardSynthesizedFile(audioPath);
         if (!authority.isExactCurrent()) return const StandardVoiceTurnResult(reply: '', discarded: true);
         await speakOnDevice(ttsText);
         if (!authority.isExactCurrent()) return const StandardVoiceTurnResult(reply: '', discarded: true);

--- a/app/lib/ella/services/v2v_client.dart
+++ b/app/lib/ella/services/v2v_client.dart
@@ -13,6 +13,7 @@ import 'package:omi/backend/http/shared.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/ella/services/ai_consent_active_session_lease.dart';
 import 'package:omi/ella/services/ella_provisioning_service.dart';
+import 'package:omi/ella/services/ella_voice_audio_route.dart';
 import 'package:omi/ella/services/ella_entitlement_service.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/utils/debug_log_manager.dart';
@@ -308,6 +309,7 @@ class V2VClient {
   final Future<void> Function(V2VProtectedEgressBoundary boundary)? _beforeProtectedEgress;
   final void Function(V2VProtectedEgressBoundary boundary)? _onProtectedEgress;
   final Future<bool> Function()? _microphoneStarter;
+  final Future<bool> Function() _audibleOutputEnforcer;
 
   V2VClient({
     this.onEvent,
@@ -315,9 +317,11 @@ class V2VClient {
     @visibleForTesting Future<void> Function(V2VProtectedEgressBoundary boundary)? beforeProtectedEgress,
     @visibleForTesting void Function(V2VProtectedEgressBoundary boundary)? onProtectedEgress,
     @visibleForTesting Future<bool> Function()? microphoneStarter,
+    @visibleForTesting Future<bool> Function()? audibleOutputEnforcer,
   })  : _beforeProtectedEgress = beforeProtectedEgress,
         _onProtectedEgress = onProtectedEgress,
-        _microphoneStarter = microphoneStarter;
+        _microphoneStarter = microphoneStarter,
+        _audibleOutputEnforcer = audibleOutputEnforcer ?? EllaVoiceAudioRoute.ensureAudibleOutput;
 
   bool get isConnected => _isConnected;
 
@@ -885,6 +889,9 @@ class V2VClient {
       ),
     );
     await session.setActive(true);
+    if (!await _audibleOutputEnforcer()) {
+      throw StateError('Ella voice output route could not be made audible');
+    }
     Logger.debug('[V2V] Audio session: playAndRecord + defaultToSpeaker + BT + AirPlay');
   }
 
@@ -1344,14 +1351,19 @@ class V2VClient {
 
     if (_streamPlaybackStarted) return;
 
-    _isPlaying = true;
-    _streamPlaybackStarted = true;
+    if (!await _audibleOutputEnforcer()) {
+      throw StateError('Ella voice output route could not be made audible');
+    }
+
+    await _streamPlayer.setVolume(1.0);
     await _streamPlayer.startPlayerFromStream(
       codec: Codec.pcm16,
       sampleRate: _pcmSampleRate,
       numChannels: _pcmChannels,
       bufferSize: 4096,
     );
+    _isPlaying = true;
+    _streamPlaybackStarted = true;
     _streamPlaybackStartedAt = DateTime.now();
     Logger.debug('[V2V] PCM stream player started');
   }

--- a/app/lib/ella/services/v2v_client.dart
+++ b/app/lib/ella/services/v2v_client.dart
@@ -259,7 +259,6 @@ class V2VClient {
   static const int _pcmSampleRate = 24000;
   static const int _pcmBytesPerSample = 2;
   static const int _pcmChannels = 1;
-  static const Duration _postPlaybackMicCooldown = Duration(seconds: 2);
   static const Duration _playbackFinishQuietPeriod = Duration(milliseconds: 900);
 
   static V2VClient? _activeClient;
@@ -310,6 +309,9 @@ class V2VClient {
   final void Function(V2VProtectedEgressBoundary boundary)? _onProtectedEgress;
   final Future<bool> Function()? _microphoneStarter;
   final Future<bool> Function() _audibleOutputEnforcer;
+  final Future<void> Function()? _streamPlaybackStarter;
+  final bool Function()? _liveChannelForTesting;
+  final Duration _playbackMicCooldown;
 
   V2VClient({
     this.onEvent,
@@ -318,10 +320,16 @@ class V2VClient {
     @visibleForTesting void Function(V2VProtectedEgressBoundary boundary)? onProtectedEgress,
     @visibleForTesting Future<bool> Function()? microphoneStarter,
     @visibleForTesting Future<bool> Function()? audibleOutputEnforcer,
+    @visibleForTesting Future<void> Function()? streamPlaybackStarter,
+    @visibleForTesting bool Function()? liveChannelForTesting,
+    @visibleForTesting Duration playbackMicCooldown = const Duration(seconds: 2),
   })  : _beforeProtectedEgress = beforeProtectedEgress,
         _onProtectedEgress = onProtectedEgress,
         _microphoneStarter = microphoneStarter,
-        _audibleOutputEnforcer = audibleOutputEnforcer ?? EllaVoiceAudioRoute.ensureAudibleOutput;
+        _audibleOutputEnforcer = audibleOutputEnforcer ?? EllaVoiceAudioRoute.ensureAudibleOutput,
+        _streamPlaybackStarter = streamPlaybackStarter,
+        _liveChannelForTesting = liveChannelForTesting,
+        _playbackMicCooldown = playbackMicCooldown;
 
   bool get isConnected => _isConnected;
 
@@ -330,6 +338,21 @@ class V2VClient {
 
   @visibleForTesting
   bool get hasActiveConsentLeaseForTesting => _aiConsentLease?.isActive == true;
+
+  @visibleForTesting
+  bool get micMutedForTesting => _micMuted;
+
+  @visibleForTesting
+  bool get micSuspendedForPlaybackForTesting => _micSuspendedForPlayback;
+
+  @visibleForTesting
+  void markConnectedForTesting() => _isConnected = true;
+
+  @visibleForTesting
+  void streamAudioChunkForTesting(Uint8List pcmData) => _streamAudioChunk(pcmData);
+
+  @visibleForTesting
+  Future<void> waitForStreamFeedForTesting() => _streamFeedFuture;
 
   V2VConnectionReceipt? get lastConnectionReceipt => _lastConnectionReceipt;
 
@@ -1180,6 +1203,8 @@ class V2VClient {
       _aiConsentLease = null;
       return false;
     }
+    _micMuted = false;
+    _micSuspendedForPlayback = false;
     return true;
   }
 
@@ -1281,12 +1306,12 @@ class V2VClient {
       return;
     }
 
-    Logger.debug('[V2V] Mic gate cooldown: ${_postPlaybackMicCooldown.inMilliseconds}ms');
+    Logger.debug('[V2V] Mic gate cooldown: ${_playbackMicCooldown.inMilliseconds}ms');
     onEvent?.call(const V2VEvent(type: 'v2v_debug', text: 'Mic gate cooldown'));
-    await Future.delayed(_postPlaybackMicCooldown);
+    await Future.delayed(_playbackMicCooldown);
     await _micGateFuture;
 
-    if (!_isConnected || _channel == null) {
+    if (!_hasLiveSessionTransport) {
       Logger.debug('[V2V] Mic gate remains closed: session disconnected');
       _micSuspendedForPlayback = false;
       _micMuted = false;
@@ -1309,8 +1334,11 @@ class V2VClient {
       await _handleRuntimeAuthorityLoss();
       return;
     }
-    await _startAuthorizedMicrophone(authority: authority, shouldContinue: shouldContinue);
+    final resumed = await _startAuthorizedMicrophone(authority: authority, shouldContinue: shouldContinue);
+    if (!resumed) await disconnect();
   }
+
+  bool get _hasLiveSessionTransport => _isConnected && (_channel != null || _liveChannelForTesting?.call() == true);
 
   // --- Low-latency PCM streaming playback ---
 
@@ -1325,13 +1353,10 @@ class V2VClient {
     _chunkCount++;
     _pcmBuffer.add(pcmData);
 
-    _streamFeedFuture = _streamFeedFuture.then((_) async {
+    _streamFeedFuture = _streamFeedFuture.then<void>((_) async {
       await _ensureStreamingPlaybackStarted();
       _streamPlayer.uint8ListSink?.add(pcmData);
-    }).catchError((error) {
-      Logger.error('[V2V] Stream playback feed error: $error');
-      onEvent?.call(V2VEvent(type: 'error', text: 'Audio stream error: $error'));
-    });
+    }).catchError(_recoverFromStreamFeedFailure);
 
     if (_chunkCount == 1) {
       onEvent?.call(const V2VEvent(type: 'v2v_debug', text: 'Streaming response audio'));
@@ -1344,6 +1369,12 @@ class V2VClient {
   }
 
   Future<void> _ensureStreamingPlaybackStarted() async {
+    final injectedStarter = _streamPlaybackStarter;
+    if (injectedStarter != null) {
+      await injectedStarter();
+      return;
+    }
+
     if (!_streamPlayerOpen) {
       await _streamPlayer.openPlayer();
       _streamPlayerOpen = true;
@@ -1366,6 +1397,43 @@ class V2VClient {
     _streamPlaybackStarted = true;
     _streamPlaybackStartedAt = DateTime.now();
     Logger.debug('[V2V] PCM stream player started');
+  }
+
+  Future<void> _recoverFromStreamFeedFailure(Object error, StackTrace stackTrace) async {
+    Logger.error('[V2V] Stream playback feed error: $error');
+    onEvent?.call(V2VEvent(type: 'error', text: 'Audio stream error: $error'));
+    _finishPlaybackTimer?.cancel();
+    _finishPlaybackTimer = null;
+    try {
+      await _stopStreamingPlayback();
+    } catch (_) {}
+    _isPlaying = false;
+    _streamPlaybackStarted = false;
+    _streamPlaybackStartedAt = null;
+    _pcmBuffer.clear();
+    _chunkCount = 0;
+
+    try {
+      if (_hasLiveSessionTransport && _hasCurrentSessionAuthority() && _aiConsentLease?.isActive == true) {
+        await _resumeMicAfterPlayback();
+      } else if (_isConnected) {
+        await disconnect();
+      } else {
+        _micSuspendedForPlayback = false;
+        _micMuted = false;
+      }
+    } catch (recoveryError) {
+      Logger.error('[V2V] Stream playback recovery failed: ${recoveryError.runtimeType}');
+      try {
+        await disconnect();
+      } catch (_) {}
+    } finally {
+      if (!_isConnected) {
+        _micSuspendedForPlayback = false;
+        _micMuted = false;
+      }
+      onEvent?.call(const V2VEvent(type: 'playback_complete'));
+    }
   }
 
   Future<void> _stopStreamingPlayback() async {

--- a/app/lib/ella/services/v2v_client.dart
+++ b/app/lib/ella/services/v2v_client.dart
@@ -296,6 +296,8 @@ class V2VClient {
   bool _streamPlaybackStarted = false;
   DateTime? _streamPlaybackStartedAt;
   Future<void> _streamFeedFuture = Future.value();
+  int _streamFeedGeneration = 0;
+  bool _streamFeedRecoveryActive = false;
   Timer? _finishPlaybackTimer;
   bool _finishingPlayback = false;
 
@@ -850,6 +852,7 @@ class V2VClient {
 
   /// Interrupt current playback (e.g., user started speaking).
   Future<void> interruptPlayback() async {
+    _streamFeedGeneration++;
     if (_isPlaying) {
       try {
         await _stopStreamingPlayback();
@@ -879,6 +882,8 @@ class V2VClient {
   }
 
   void _resetTurnState() {
+    _streamFeedGeneration++;
+    _streamFeedRecoveryActive = false;
     _isPlaying = false;
     _micMuted = false;
     _micSuspendedForPlayback = false;
@@ -1340,11 +1345,15 @@ class V2VClient {
 
   bool get _hasLiveSessionTransport => _isConnected && (_channel != null || _liveChannelForTesting?.call() == true);
 
+  bool _isCurrentStreamFeed(int generation) =>
+      generation == _streamFeedGeneration && !_streamFeedRecoveryActive && _hasLiveSessionTransport;
+
   // --- Low-latency PCM streaming playback ---
 
   /// Stream incoming PCM16 audio chunk to the platform player.
   void _streamAudioChunk(Uint8List pcmData) {
-    if (pcmData.isEmpty) return;
+    if (pcmData.isEmpty || _streamFeedRecoveryActive || !_hasLiveSessionTransport) return;
+    final generation = _streamFeedGeneration;
 
     // Gate the microphone before enqueueing playback so provider VAD cannot
     // hear Ella's own response audio and interrupt the active turn.
@@ -1354,9 +1363,22 @@ class V2VClient {
     _pcmBuffer.add(pcmData);
 
     _streamFeedFuture = _streamFeedFuture.then<void>((_) async {
+      if (!_isCurrentStreamFeed(generation)) return;
+      // A prior feed may have completed failure recovery and reopened the
+      // microphone while this operation was queued. Re-establish and await the
+      // gate immediately before every surviving playback start.
+      _suspendMicForPlayback('queued_audio_chunk');
+      await _micGateFuture;
+      if (!_isCurrentStreamFeed(generation)) return;
       await _ensureStreamingPlaybackStarted();
+      if (!_isCurrentStreamFeed(generation)) {
+        await _stopStreamingPlayback();
+        return;
+      }
       _streamPlayer.uint8ListSink?.add(pcmData);
-    }).catchError(_recoverFromStreamFeedFailure);
+    }).catchError(
+      (Object error, StackTrace stackTrace) => _recoverFromStreamFeedFailure(error, stackTrace, generation),
+    );
 
     if (_chunkCount == 1) {
       onEvent?.call(const V2VEvent(type: 'v2v_debug', text: 'Streaming response audio'));
@@ -1399,7 +1421,10 @@ class V2VClient {
     Logger.debug('[V2V] PCM stream player started');
   }
 
-  Future<void> _recoverFromStreamFeedFailure(Object error, StackTrace stackTrace) async {
+  Future<void> _recoverFromStreamFeedFailure(Object error, StackTrace stackTrace, int generation) async {
+    if (generation != _streamFeedGeneration || _streamFeedRecoveryActive) return;
+    _streamFeedRecoveryActive = true;
+    _streamFeedGeneration++;
     Logger.error('[V2V] Stream playback feed error: $error');
     onEvent?.call(V2VEvent(type: 'error', text: 'Audio stream error: $error'));
     _finishPlaybackTimer?.cancel();
@@ -1432,6 +1457,7 @@ class V2VClient {
         _micSuspendedForPlayback = false;
         _micMuted = false;
       }
+      _streamFeedRecoveryActive = false;
       onEvent?.call(const V2VEvent(type: 'playback_complete'));
     }
   }

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -68,6 +68,20 @@ enum PhoneCaptureStartResult {
   cancelled,
 }
 
+@visibleForTesting
+class PhoneCaptureStartProof {
+  final Completer<void> _firstAudioFrame = Completer<void>();
+
+  bool acceptFrame(List<int> bytes) {
+    if (bytes.isEmpty) return false;
+    if (!_firstAudioFrame.isCompleted) _firstAudioFrame.complete();
+    return true;
+  }
+
+  Future<void> waitForAudio({Duration timeout = const Duration(seconds: 5)}) =>
+      _firstAudioFrame.future.timeout(timeout);
+}
+
 class CaptureProvider extends ChangeNotifier
     with MessageNotifierMixin, WidgetsBindingObserver
     implements ITransctiptSegmentSocketServiceListener {
@@ -1101,23 +1115,35 @@ class CaptureProvider extends ChangeNotifier
       return PhoneCaptureStartResult.transcriptionUnavailable;
     }
 
-    // record
+    // A native start receipt proves the recorder is physically running. The
+    // first non-empty frame additionally proves that audio reached this
+    // account-scoped transcription boundary before Home reports success.
+    final startProof = PhoneCaptureStartProof();
     try {
       await ServiceManager.instance().mic.start(onByteReceived: (bytes) {
-        if (_isCaptureCurrent(generation, captureAuthority) && _socket?.state == SocketServiceState.connected) {
+        if (_isCaptureCurrent(generation, captureAuthority) &&
+            _socket?.state == SocketServiceState.connected &&
+            startProof.acceptFrame(bytes)) {
           _socket?.send(bytes);
         }
       }, onRecording: () {
-        if (_isCaptureCurrent(generation, captureAuthority)) updateRecordingState(RecordingState.record);
+        // The isolate receipt is authoritative for physical start. Keep the UI
+        // initialising until the first frame also reaches transcription.
       }, onStop: () {
         if (_isCaptureCurrent(generation, captureAuthority)) updateRecordingState(RecordingState.stop);
       }, onInitializing: () {
         if (_isCaptureCurrent(generation, captureAuthority)) updateRecordingState(RecordingState.initialising);
       });
+      await startProof.waitForAudio();
     } catch (error) {
-      Logger.error('Phone microphone could not start: $error');
+      Logger.error('Phone microphone did not produce an acknowledged audio frame: $error');
       updateRecordingState(RecordingState.stop);
-      await _socket?.stop(reason: 'phone recorder unavailable');
+      try {
+        await ServiceManager.instance().mic.stop();
+      } catch (stopError) {
+        Logger.error('Phone microphone cleanup failed after start failure: $stopError');
+      }
+      await _socket?.stop(reason: 'phone recorder did not produce audio');
       return PhoneCaptureStartResult.recorderUnavailable;
     }
     if (!_isCaptureCurrent(generation, captureAuthority)) {
@@ -1133,12 +1159,7 @@ class CaptureProvider extends ChangeNotifier
       await _socket?.stop(reason: 'phone capture transcript disconnected');
       return PhoneCaptureStartResult.transcriptionUnavailable;
     }
-    if (recordingState != RecordingState.record) {
-      await ServiceManager.instance().mic.stop();
-      updateRecordingState(RecordingState.stop);
-      await _socket?.stop(reason: 'phone recorder did not start');
-      return PhoneCaptureStartResult.recorderUnavailable;
-    }
+    updateRecordingState(RecordingState.record);
     // Capture has actually started; do not send location for failed attempts.
     _sendCurrentGeolocation();
     return PhoneCaptureStartResult.started;

--- a/app/lib/services/services.dart
+++ b/app/lib/services/services.dart
@@ -151,9 +151,17 @@ class BackgroundRecorderIsolateBridge {
 
   void start() {
     _service.on('recorder.start').listen((event) {
+      final requestId = event?['request_id']?.toString() ?? '';
       final generation = event?['generation'] as int? ?? 0;
-      if (generation <= _quiescedThroughGeneration) return;
-      unawaited(_operations.run(() => _startRecorder(generation)).catchError(_logBridgeError));
+      if (generation <= _quiescedThroughGeneration) {
+        _service.invoke("recorder.ui.startResult", {
+          "request_id": requestId,
+          "status": 'error',
+          "error": 'Recorder start was superseded by an account transition',
+        });
+        return;
+      }
+      unawaited(_operations.run(() => _startRecorder(requestId, generation)).catchError(_logBridgeError));
     });
 
     _service.on('recorder.stop').listen((event) {
@@ -177,19 +185,39 @@ class BackgroundRecorderIsolateBridge {
     _watchdog = Timer.periodic(watchdogInterval, _watchdogTick);
   }
 
-  Future<void> _startRecorder(int generation) async {
-    if (generation <= _quiescedThroughGeneration) return;
-    final recorder = _recorder ??= MicRecorderService(isInBG: Platform.isAndroid);
-    recorder.resumeAfterAccountTransition();
-    await recorder.start(
-      onByteReceived: (bytes) {
-        if (generation <= _quiescedThroughGeneration) return;
-        _service.invoke("recorder.ui.audioBytes", {"data": bytes.toList()});
-      },
-      onStop: () => _service.invoke("recorder.ui.stateUpdate", {"state": 'stopped'}),
-      onRecording: () => _service.invoke("recorder.ui.stateUpdate", {"state": 'recording'}),
-    );
-    if (generation <= _quiescedThroughGeneration) await recorder.stopForAccountTransition();
+  Future<void> _startRecorder(String requestId, int generation) async {
+    if (generation <= _quiescedThroughGeneration) {
+      _service.invoke("recorder.ui.startResult", {
+        "request_id": requestId,
+        "status": 'error',
+        "error": 'Recorder start was superseded by an account transition',
+      });
+      return;
+    }
+    try {
+      final recorder = _recorder ??= MicRecorderService(isInBG: Platform.isAndroid);
+      recorder.resumeAfterAccountTransition();
+      await recorder.start(
+        onByteReceived: (bytes) {
+          if (generation <= _quiescedThroughGeneration) return;
+          _service.invoke("recorder.ui.audioBytes", {"data": bytes.toList()});
+        },
+        onStop: () => _service.invoke("recorder.ui.stateUpdate", {"state": 'stopped'}),
+        onRecording: () => _service.invoke("recorder.ui.stateUpdate", {"state": 'recording'}),
+        onInitializing: () => _service.invoke("recorder.ui.stateUpdate", {"state": 'initializing'}),
+      );
+      if (generation <= _quiescedThroughGeneration) {
+        await recorder.stopForAccountTransition();
+        throw BackgroundRecorderStartException('Recorder start was superseded by an account transition');
+      }
+      _service.invoke("recorder.ui.startResult", {"request_id": requestId, "status": 'recording'});
+    } catch (error) {
+      _service.invoke("recorder.ui.startResult", {
+        "request_id": requestId,
+        "status": 'error',
+        "error": error.toString(),
+      });
+    }
   }
 
   Future<void> _stopRecorder(String requestId, {required bool quiesce}) async {
@@ -252,6 +280,10 @@ class BackgroundRecorderStopException extends StateError {
   BackgroundRecorderStopException(super.message);
 }
 
+class BackgroundRecorderStartException extends StateError {
+  BackgroundRecorderStartException(super.message);
+}
+
 class _SerializedCaptureOperations {
   Future<void> _tail = Future<void>.value();
 
@@ -271,16 +303,22 @@ class _SerializedCaptureOperations {
 }
 
 class BackgroundService implements IBackgroundRecorderRunner {
-  BackgroundService({this.recorderStopTimeout = const Duration(seconds: 3)});
+  BackgroundService({
+    this.recorderStartTimeout = const Duration(seconds: 5),
+    this.recorderStopTimeout = const Duration(seconds: 3),
+  });
 
   late FlutterBackgroundService _service;
   BackgroundServiceStatus? _status;
   StreamSubscription? _recordAudioByteStream;
   StreamSubscription? _recordStateStream;
+  final Map<String, Completer<void>> _pendingStarts = {};
   final Map<String, Completer<void>> _pendingStops = {};
   bool _initialized = false;
   int _recorderGeneration = 0;
+  int _startRequestSequence = 0;
   int _stopRequestSequence = 0;
+  final Duration recorderStartTimeout;
   final Duration recorderStopTimeout;
 
   BackgroundServiceStatus? get status => _status;
@@ -315,6 +353,19 @@ class BackgroundService implements IBackgroundRecorderRunner {
       } else {
         completer.completeError(
           BackgroundRecorderStopException(event?['error']?.toString() ?? 'Native recorder stop failed'),
+        );
+      }
+    });
+
+    _service.on('recorder.ui.startResult').listen((event) {
+      final requestId = event?['request_id']?.toString() ?? '';
+      final completer = _pendingStarts.remove(requestId);
+      if (completer == null || completer.isCompleted) return;
+      if (event?['status'] == 'recording') {
+        completer.complete();
+      } else {
+        completer.completeError(
+          BackgroundRecorderStartException(event?['error']?.toString() ?? 'Native recorder start failed'),
         );
       }
     });
@@ -381,8 +432,15 @@ class BackgroundService implements IBackgroundRecorderRunner {
       }
     });
 
-    // tell service > start record
-    _service.invoke("recorder.start", {"generation": generation});
+    final requestId = '${generation}_${++_startRequestSequence}';
+    final started = Completer<void>();
+    _pendingStarts[requestId] = started;
+    _service.invoke("recorder.start", {"request_id": requestId, "generation": generation});
+    try {
+      await started.future.timeout(recorderStartTimeout);
+    } finally {
+      _pendingStarts.remove(requestId);
+    }
   }
 
   @override
@@ -551,9 +609,7 @@ class MicRecorderService implements IMicRecorderService {
     _onByteReceived = onByteReceived;
     _onStop = onStop;
     _onRecording = onRecording;
-    if (_onRecording != null) {
-      _onRecording!();
-    }
+    onInitializing?.call();
 
     // new record
     await _recorder.openRecorder(isBGService: _isInBG);
@@ -582,6 +638,7 @@ class MicRecorderService implements IMicRecorderService {
     });
 
     _status = RecorderServiceStatus.recording;
+    _onRecording?.call();
     return;
   }
 

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.532+810
+version: 1.0.533+811
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/test/ella/account_isolation_test.dart
+++ b/app/test/ella/account_isolation_test.dart
@@ -618,6 +618,49 @@ void main() {
     expect(fixture.native.startCalls, 1);
   });
 
+  test('production isolate bridge does not acknowledge start before the native recorder starts', () async {
+    final fixture = _ProductionRecorderFixture(
+      startTimeout: const Duration(seconds: 1),
+      stopTimeout: const Duration(seconds: 1),
+      holdNativeStart: true,
+    );
+    addTearDown(fixture.dispose);
+    var recordingCallbacks = 0;
+    var startCompleted = false;
+
+    final start = fixture.mic
+        .start(onByteReceived: (_) {}, onRecording: () => recordingCallbacks++)
+        .then((_) => startCompleted = true);
+    await fixture.native.startEntered.future;
+    await Future<void>.delayed(Duration.zero);
+
+    expect(startCompleted, isFalse);
+    expect(recordingCallbacks, 0);
+    expect(fixture.background.startResults, isEmpty);
+
+    fixture.native.releaseStart();
+    await start;
+
+    expect(startCompleted, isTrue);
+    expect(recordingCallbacks, 1);
+    expect(fixture.background.startResults.single['status'], 'recording');
+  });
+
+  test('production isolate bridge propagates native start failure', () async {
+    final fixture = _ProductionRecorderFixture(
+      startTimeout: const Duration(seconds: 1),
+      stopTimeout: const Duration(seconds: 1),
+      nativeStartError: StateError('physical recorder start failed'),
+    );
+    addTearDown(fixture.dispose);
+
+    await expectLater(
+      fixture.mic.start(onByteReceived: (_) {}),
+      throwsA(isA<BackgroundRecorderStartException>()),
+    );
+    expect(fixture.background.startResults.single['status'], 'error');
+  });
+
   test('production isolate bridge propagates native stop error and blocks transition mutation', () async {
     final fixture = _ProductionRecorderFixture(
       stopTimeout: const Duration(seconds: 1),
@@ -1159,13 +1202,26 @@ EllaAccountIsolationService _accountBarrier() => EllaAccountIsolationService(
     );
 
 class _ProductionRecorderFixture {
-  _ProductionRecorderFixture({required Duration stopTimeout, bool holdNativeStop = false, Object? nativeStopError})
-      : native = _ControlledFlutterSoundRecorderPlatform(holdStop: holdNativeStop, stopError: nativeStopError),
+  _ProductionRecorderFixture({
+    Duration startTimeout = const Duration(seconds: 5),
+    required Duration stopTimeout,
+    bool holdNativeStart = false,
+    bool holdNativeStop = false,
+    Object? nativeStartError,
+    Object? nativeStopError,
+  })  : native = _ControlledFlutterSoundRecorderPlatform(
+          holdStart: holdNativeStart,
+          holdStop: holdNativeStop,
+          startError: nativeStartError,
+          stopError: nativeStopError,
+        ),
         background = _FakeBackgroundServicePlatform() {
     _originalRecorderPlatform = FlutterSoundRecorderPlatform.instance;
     FlutterSoundRecorderPlatform.instance = native;
     FlutterBackgroundServicePlatform.instance = background;
-    mic = MicRecorderBackgroundService(runner: BackgroundService(recorderStopTimeout: stopTimeout));
+    mic = MicRecorderBackgroundService(
+      runner: BackgroundService(recorderStartTimeout: startTimeout, recorderStopTimeout: stopTimeout),
+    );
   }
 
   final _ControlledFlutterSoundRecorderPlatform native;
@@ -1174,6 +1230,7 @@ class _ProductionRecorderFixture {
   late final MicRecorderBackgroundService mic;
 
   Future<void> dispose() async {
+    native.releaseStart();
     native.releaseStop();
     background.shutdown();
     await Future<void>.delayed(Duration.zero);
@@ -1184,6 +1241,7 @@ class _ProductionRecorderFixture {
 class _FakeBackgroundServicePlatform extends FlutterBackgroundServicePlatform {
   final Map<String, StreamController<Map<String, dynamic>?>> _isolateStreams = {};
   final Map<String, StreamController<Map<String, dynamic>?>> _uiStreams = {};
+  final List<Map<String, dynamic>> startResults = [];
   final List<Map<String, dynamic>> stopResults = [];
   final Completer<void> _stopResultReceived = Completer<void>();
   late final _FakeServiceInstance _serviceInstance = _FakeServiceInstance(this);
@@ -1224,6 +1282,9 @@ class _FakeBackgroundServicePlatform extends FlutterBackgroundServicePlatform {
   Stream<Map<String, dynamic>?> on(String method) => _controller(_uiStreams, method).stream;
 
   void emitToUi(String method, Map<String, dynamic>? args) {
+    if (method == 'recorder.ui.startResult' && args != null) {
+      startResults.add(args);
+    }
     if (method == 'recorder.ui.stopResult' && args != null) {
       stopResults.add(args);
       if (!_stopResultReceived.isCompleted) _stopResultReceived.complete();
@@ -1256,10 +1317,17 @@ class _FakeServiceInstance implements ServiceInstance {
 }
 
 class _ControlledFlutterSoundRecorderPlatform extends FlutterSoundRecorderPlatform {
-  _ControlledFlutterSoundRecorderPlatform({required bool holdStop, this.stopError})
-      : _stopRelease = holdStop ? Completer<void>() : null;
+  _ControlledFlutterSoundRecorderPlatform({
+    required bool holdStart,
+    required bool holdStop,
+    this.startError,
+    this.stopError,
+  })  : _startRelease = holdStart ? Completer<void>() : null,
+        _stopRelease = holdStop ? Completer<void>() : null;
 
+  final Completer<void>? _startRelease;
   final Completer<void>? _stopRelease;
+  final Object? startError;
   final Object? stopError;
   final Completer<void> startEntered = Completer<void>();
   final Completer<void> stopEntered = Completer<void>();
@@ -1300,6 +1368,8 @@ class _ControlledFlutterSoundRecorderPlatform extends FlutterSoundRecorderPlatfo
     _callback = callback;
     startCalls++;
     if (!startEntered.isCompleted) startEntered.complete();
+    await _startRelease?.future;
+    if (startError != null) throw startError!;
     callback.startRecorderCompleted(RecorderState.isRecording.index, true);
   }
 
@@ -1317,6 +1387,11 @@ class _ControlledFlutterSoundRecorderPlatform extends FlutterSoundRecorderPlatfo
   }
 
   void emit(Uint8List bytes) => _callback?.interleavedRecording(data: bytes);
+
+  void releaseStart() {
+    final startRelease = _startRelease;
+    if (startRelease != null && !startRelease.isCompleted) startRelease.complete();
+  }
 
   void releaseStop() {
     final stopRelease = _stopRelease;

--- a/app/test/ella/account_isolation_test.dart
+++ b/app/test/ella/account_isolation_test.dart
@@ -20,6 +20,7 @@ import 'package:omi/backend/schema/memory.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/backend/schema/person.dart';
 import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/ella/pages/ella_voice_chat_page.dart';
 import 'package:omi/ella/services/ai_consent_active_session_lease.dart';
 import 'package:omi/ella/services/ella_account_isolation_service.dart';
 import 'package:omi/ella/services/elevenlabs_tts.dart';
@@ -646,6 +647,33 @@ void main() {
     expect(fixture.background.startResults.single['status'], 'recording');
   });
 
+  test('production start timeout queues cleanup behind a late native start', () async {
+    final fixture = _ProductionRecorderFixture(
+      startTimeout: const Duration(milliseconds: 20),
+      stopTimeout: const Duration(seconds: 1),
+      holdNativeStart: true,
+    );
+    addTearDown(fixture.dispose);
+
+    final start = fixture.mic.start(onByteReceived: (_) {});
+    await fixture.native.startEntered.future;
+    await expectLater(start, throwsA(isA<TimeoutException>()));
+
+    var stopCompleted = false;
+    final stop = fixture.mic.stop().then((_) => stopCompleted = true);
+    await Future<void>.delayed(Duration.zero);
+    expect(stopCompleted, isFalse);
+
+    fixture.native.releaseStart();
+    await stop;
+
+    expect(stopCompleted, isTrue);
+    // FlutterSound performs one stopped-state preflight before start; the
+    // second native stop is the cleanup queued after the timed-out start.
+    expect(fixture.native.stopCalls, 2);
+    expect(fixture.background.stopResults.single['status'], 'stopped');
+  });
+
   test('production isolate bridge propagates native start failure', () async {
     final fixture = _ProductionRecorderFixture(
       startTimeout: const Duration(seconds: 1),
@@ -953,6 +981,28 @@ void main() {
     expect(provider.messages.map((message) => message.text), ['Current question', 'Current reply']);
     expect(prefs.cachedMessages.map((message) => message.text), ['Current question', 'Current reply']);
     expect(playbacks, 1);
+  });
+
+  test('standard voice route failure falls back and returns from speaking state', () async {
+    var onDeviceFallbacks = 0;
+    final coordinator = StandardVoiceTurnCoordinator(
+      streamSender: (text, {expectedAuthenticatedUid, exactAuthority}) => _completedVoiceStream('Audible reply'),
+      synthesizer: (text, {expectedAuthenticatedUid, exactAuthority}) async => '/tmp/route-failure.mp3',
+    );
+
+    final result = await coordinator.run(
+      transcript: 'Current question',
+      authority: _activeAuthority('uid-a', () => true),
+      commitMessages: (_, __) => true,
+      onReplyReady: (_) {},
+      playFile: (_) async => throw const StandardVoicePlaybackUnavailable(),
+      speakOnDevice: (_) async => onDeviceFallbacks++,
+    );
+
+    expect(result.usedOnDeviceTts, isTrue);
+    expect(result.reply, 'Audible reply');
+    expect(onDeviceFallbacks, 1);
+    expect(EllaVoiceChatPage.shouldResumeAfterStandardTurn(result), isTrue);
   });
 
   test('typed backend failure is never committed or spoken by standard voice', () async {

--- a/app/test/ella/services/ella_voice_audio_route_test.dart
+++ b/app/test/ella/services/ella_voice_audio_route_test.dart
@@ -9,23 +9,21 @@ void main() {
   const channel = MethodChannel('com.ellaaicare.ella/audio_route.test');
 
   tearDown(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(channel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
   });
 
   test(
     'iOS voice route requires an acknowledged non-receiver output',
     () async {
       MethodCall? received;
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, (call) async {
-            received = call;
-            return <String, dynamic>{
-              'success': true,
-              'usesReceiver': false,
-              'usesPhoneSpeaker': true,
-            };
-          });
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (call) async {
+        received = call;
+        return <String, dynamic>{
+          'success': true,
+          'usesReceiver': false,
+          'usesPhoneSpeaker': true,
+        };
+      });
 
       expect(
         await EllaVoiceAudioRoute.ensureAudibleOutput(
@@ -41,15 +39,14 @@ void main() {
   test(
     'iOS voice route fails closed when output remains on the receiver',
     () async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            channel,
-            (_) async => <String, dynamic>{
-              'success': true,
-              'usesReceiver': true,
-              'usesPhoneSpeaker': false,
-            },
-          );
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        channel,
+        (_) async => <String, dynamic>{
+          'success': true,
+          'usesReceiver': true,
+          'usesPhoneSpeaker': false,
+        },
+      );
 
       expect(
         await EllaVoiceAudioRoute.ensureAudibleOutput(
@@ -61,13 +58,29 @@ void main() {
     },
   );
 
+  test('iOS voice route fails closed when native output is absent', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      channel,
+      (_) async => <String, dynamic>{
+        'success': false,
+        'hasOutput': false,
+        'usesReceiver': false,
+        'usesPhoneSpeaker': false,
+      },
+    );
+
+    expect(
+      await EllaVoiceAudioRoute.ensureAudibleOutput(channel: channel, isIos: true),
+      isFalse,
+    );
+  });
+
   test('non-iOS voice route does not invoke the iOS channel', () async {
     var calls = 0;
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(channel, (_) async {
-          calls++;
-          return <String, dynamic>{'success': true, 'usesReceiver': false};
-        });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (_) async {
+      calls++;
+      return <String, dynamic>{'success': true, 'usesReceiver': false};
+    });
 
     expect(
       await EllaVoiceAudioRoute.ensureAudibleOutput(

--- a/app/test/ella/services/ella_voice_audio_route_test.dart
+++ b/app/test/ella/services/ella_voice_audio_route_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/ella/services/ella_voice_audio_route.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.ellaaicare.ella/audio_route.test');
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test(
+    'iOS voice route requires an acknowledged non-receiver output',
+    () async {
+      MethodCall? received;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            received = call;
+            return <String, dynamic>{
+              'success': true,
+              'usesReceiver': false,
+              'usesPhoneSpeaker': true,
+            };
+          });
+
+      expect(
+        await EllaVoiceAudioRoute.ensureAudibleOutput(
+          channel: channel,
+          isIos: true,
+        ),
+        isTrue,
+      );
+      expect(received?.method, 'ensureAudibleVoiceOutput');
+    },
+  );
+
+  test(
+    'iOS voice route fails closed when output remains on the receiver',
+    () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            channel,
+            (_) async => <String, dynamic>{
+              'success': true,
+              'usesReceiver': true,
+              'usesPhoneSpeaker': false,
+            },
+          );
+
+      expect(
+        await EllaVoiceAudioRoute.ensureAudibleOutput(
+          channel: channel,
+          isIos: true,
+        ),
+        isFalse,
+      );
+    },
+  );
+
+  test('non-iOS voice route does not invoke the iOS channel', () async {
+    var calls = 0;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (_) async {
+          calls++;
+          return <String, dynamic>{'success': true, 'usesReceiver': false};
+        });
+
+    expect(
+      await EllaVoiceAudioRoute.ensureAudibleOutput(
+        channel: channel,
+        isIos: false,
+      ),
+      isTrue,
+    );
+    expect(calls, 0);
+  });
+}

--- a/app/test/ella/services/v2v_client_test.dart
+++ b/app/test/ella/services/v2v_client_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -220,7 +221,8 @@ void main() {
           'conversation_id': 'another-conversation',
           'active_summary_version_id': 'summary-v2',
           'can_reinterpret': true,
-        })!.matches(requested),
+        })!
+            .matches(requested),
         isFalse,
       );
     });
@@ -242,7 +244,8 @@ void main() {
           'card_id': 'today-card-42',
           'card_version': 4,
           'can_reinterpret': false,
-        })!.matches(requested),
+        })!
+            .matches(requested),
         isFalse,
       );
     });
@@ -553,6 +556,47 @@ void main() {
         isTrue,
       );
       expect(microphoneStarts, 1);
+      await client.disconnect();
+    });
+
+    test('stream playback startup failure reopens the authorized microphone gate', () async {
+      grantCurrentConsent();
+      final authority = AiConsentAuthoritySnapshot.capture(
+        preferences: SharedPreferencesUtil(),
+        expectedUid: 'uid-a',
+      );
+      expect(authority, isNotNull);
+
+      final events = <V2VEvent>[];
+      var microphoneStarts = 0;
+      final client = V2VClient(
+        onEvent: events.add,
+        onConnectionChanged: (_) {},
+        microphoneStarter: () async {
+          microphoneStarts++;
+          return true;
+        },
+        streamPlaybackStarter: () async => throw StateError('route unavailable'),
+        liveChannelForTesting: () => true,
+        playbackMicCooldown: Duration.zero,
+      );
+
+      expect(
+        await client.startAuthorizedMicrophoneForTesting(
+          authority: authority!,
+          shouldContinue: () => true,
+        ),
+        isTrue,
+      );
+      client.markConnectedForTesting();
+      client.streamAudioChunkForTesting(Uint8List.fromList([1, 2, 3]));
+      await client.waitForStreamFeedForTesting();
+
+      expect(microphoneStarts, 2);
+      expect(client.micMutedForTesting, isFalse);
+      expect(client.micSuspendedForPlaybackForTesting, isFalse);
+      expect(events.where((event) => event.type == 'error'), hasLength(1));
+      expect(events.where((event) => event.type == 'playback_complete'), hasLength(1));
       await client.disconnect();
     });
   });

--- a/app/test/ella/services/v2v_client_test.dart
+++ b/app/test/ella/services/v2v_client_test.dart
@@ -599,6 +599,125 @@ void main() {
       expect(events.where((event) => event.type == 'playback_complete'), hasLength(1));
       await client.disconnect();
     });
+
+    test('failed stream generation drops queued PCM and re-gates the next generation', () async {
+      grantCurrentConsent();
+      final authority = AiConsentAuthoritySnapshot.capture(
+        preferences: SharedPreferencesUtil(),
+        expectedUid: 'uid-a',
+      );
+      expect(authority, isNotNull);
+
+      final firstStartEntered = Completer<void>();
+      final releaseFirstStart = Completer<void>();
+      final nextStartEntered = Completer<void>();
+      final releaseNextStart = Completer<void>();
+      var playbackStarts = 0;
+      var microphoneStarts = 0;
+      final client = V2VClient(
+        onEvent: (_) {},
+        onConnectionChanged: (_) {},
+        microphoneStarter: () async {
+          microphoneStarts++;
+          return true;
+        },
+        streamPlaybackStarter: () async {
+          playbackStarts++;
+          if (playbackStarts == 1) {
+            firstStartEntered.complete();
+            await releaseFirstStart.future;
+            throw StateError('route unavailable');
+          }
+          nextStartEntered.complete();
+          await releaseNextStart.future;
+        },
+        liveChannelForTesting: () => true,
+        playbackMicCooldown: Duration.zero,
+      );
+
+      expect(
+        await client.startAuthorizedMicrophoneForTesting(
+          authority: authority!,
+          shouldContinue: () => true,
+        ),
+        isTrue,
+      );
+      client.markConnectedForTesting();
+      client.streamAudioChunkForTesting(Uint8List.fromList([1]));
+      await firstStartEntered.future;
+      client.streamAudioChunkForTesting(Uint8List.fromList([2]));
+      final failedGeneration = client.waitForStreamFeedForTesting();
+
+      expect(client.micMutedForTesting, isTrue);
+      expect(client.micSuspendedForPlaybackForTesting, isTrue);
+      releaseFirstStart.complete();
+      await failedGeneration;
+
+      expect(playbackStarts, 1, reason: 'the second stale chunk must be dropped');
+      expect(microphoneStarts, 2, reason: 'failure recovery should reopen the authorized microphone');
+      expect(client.micMutedForTesting, isFalse);
+      expect(client.micSuspendedForPlaybackForTesting, isFalse);
+
+      client.streamAudioChunkForTesting(Uint8List.fromList([3]));
+      await nextStartEntered.future;
+      expect(playbackStarts, 2);
+      expect(client.micMutedForTesting, isTrue);
+      expect(client.micSuspendedForPlaybackForTesting, isTrue);
+      releaseNextStart.complete();
+      await client.waitForStreamFeedForTesting();
+      await client.disconnect();
+    });
+
+    test('disconnect invalidates held and queued stream feeds', () async {
+      grantCurrentConsent();
+      final authority = AiConsentAuthoritySnapshot.capture(
+        preferences: SharedPreferencesUtil(),
+        expectedUid: 'uid-a',
+      );
+      expect(authority, isNotNull);
+
+      final firstStartEntered = Completer<void>();
+      final releaseFirstStart = Completer<void>();
+      var playbackStarts = 0;
+      final client = V2VClient(
+        onEvent: (_) {},
+        onConnectionChanged: (_) {},
+        microphoneStarter: () async => true,
+        streamPlaybackStarter: () async {
+          playbackStarts++;
+          if (playbackStarts > 1) fail('stale queued PCM restarted playback after disconnect');
+          firstStartEntered.complete();
+          await releaseFirstStart.future;
+          throw StateError('late route failure');
+        },
+        liveChannelForTesting: () => true,
+        playbackMicCooldown: Duration.zero,
+      );
+
+      expect(
+        await client.startAuthorizedMicrophoneForTesting(
+          authority: authority!,
+          shouldContinue: () => true,
+        ),
+        isTrue,
+      );
+      client.markConnectedForTesting();
+      client.streamAudioChunkForTesting(Uint8List.fromList([1]));
+      await firstStartEntered.future;
+      client.streamAudioChunkForTesting(Uint8List.fromList([2]));
+      final queuedFeeds = client.waitForStreamFeedForTesting();
+
+      await client.disconnect();
+      releaseFirstStart.complete();
+      await queuedFeeds;
+      client.streamAudioChunkForTesting(Uint8List.fromList([3]));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(playbackStarts, 1);
+      expect(client.isConnected, isFalse);
+      expect(client.micMutedForTesting, isFalse);
+      expect(client.micSuspendedForPlaybackForTesting, isFalse);
+    });
   });
 
   group('V2VClient proxy event mapping', () {

--- a/app/test/providers/phone_capture_start_proof_test.dart
+++ b/app/test/providers/phone_capture_start_proof_test.dart
@@ -1,0 +1,24 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/providers/capture_provider.dart';
+
+void main() {
+  test('empty frames cannot prove phone capture started', () async {
+    final proof = PhoneCaptureStartProof();
+
+    expect(proof.acceptFrame(const []), isFalse);
+    await expectLater(
+      proof.waitForAudio(timeout: const Duration(milliseconds: 1)),
+      throwsA(isA<TimeoutException>()),
+    );
+  });
+
+  test('first non-empty frame proves phone capture started', () async {
+    final proof = PhoneCaptureStartProof();
+
+    expect(proof.acceptFrame(const [1, 2, 3]), isTrue);
+    await proof.waitForAudio(timeout: const Duration(milliseconds: 50));
+  });
+}


### PR DESCRIPTION
## Summary

- make phone-only capture wait for an isolate/native start receipt and the first non-empty account-scoped audio frame before reporting success
- propagate native start failures and preserve transition quiescence instead of treating an early UI callback as physical recorder proof
- force Ella voice playback away from the iPhone receiver while preserving private headset/Bluetooth routes, and set streamed PCM playback to full app volume
- advance the successor version to `1.0.533+811`

## Device evidence addressed

- build 810 `Record a moment` returned “Recording isn’t available right now”
- voice playback was barely audible and behaved like receiver output

The authenticated Whisper canary, Daily Note generation, and content-specific memory imagery are server receipt gates and are not simulated in this client patch.

## Validation

- full Flutter package: 449/449
- focused recorder/voice/account/Home set: 84/84
- repository capture/transcript harness: 18/18 + 3/3
- changed-file analyzer: 0 errors, 0 warnings; 6 unchanged speech-plugin deprecation infos
- unsigned production iOS release compile: green, `Ella Care.app` 126.9 MB
- diff check and exact-commit SHA bracketing: green

No archive, signing, TestFlight upload, App Store Connect mutation, backend, workflow, or production change was performed.
