### PR TITLE
fix(today-card): admit grounded retained summaries

### DIFF
--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -14,6 +14,7 @@ on:
       - "backend/contracts/authority_advisory_lock_v1.json"
       - "backend/contracts/README.md"
       - "backend/database/authority_advisory_lock.py"
+      - "backend/database/conversations.py"
       - "backend/database/ella_provisioning.py"
       - "backend/database/ella_postgres.py"
       - "backend/database/honcho_attestation.py"
@@ -118,6 +119,7 @@ on:
       - "backend/tests/unit/test_ella_postprocess_cloud_routing.py"
       - "backend/tests/unit/test_voice_proxy_auth.py"
       - "backend/tests/unit/test_ella_callbacks_summary_update.py"
+      - "backend/tests/unit/test_conversation_summary_cas.py"
       - "backend/tests/unit/test_ella_conversation_corrections.py"
       - "backend/tests/unit/test_ella_guardian_delivery.py"
       - "backend/tests/unit/test_ella_canonical_context.py"
@@ -157,6 +159,7 @@ on:
       - "backend/contracts/authority_advisory_lock_v1.json"
       - "backend/contracts/README.md"
       - "backend/database/authority_advisory_lock.py"
+      - "backend/database/conversations.py"
       - "backend/database/ella_provisioning.py"
       - "backend/database/ella_postgres.py"
       - "backend/database/honcho_attestation.py"
@@ -261,6 +264,7 @@ on:
       - "backend/tests/unit/test_ella_postprocess_cloud_routing.py"
       - "backend/tests/unit/test_voice_proxy_auth.py"
       - "backend/tests/unit/test_ella_callbacks_summary_update.py"
+      - "backend/tests/unit/test_conversation_summary_cas.py"
       - "backend/tests/unit/test_ella_conversation_corrections.py"
       - "backend/tests/unit/test_ella_guardian_delivery.py"
       - "backend/tests/unit/test_ella_canonical_context.py"
@@ -430,6 +434,7 @@ jobs:
         run: >-
           black --check --line-length 120 --skip-string-normalization
           database/authority_advisory_lock.py
+          database/conversations.py
           database/ella_caregivers.py
           database/ella_provisioning.py database/honcho_attestation.py database/invitations.py
           database/ella_postgres.py
@@ -471,6 +476,7 @@ jobs:
           scripts/ella_observer_cron.py
           scripts/hermes_product_fit_canary.py
           tests/unit/test_ella_callbacks_summary_update.py
+          tests/unit/test_conversation_summary_cas.py
           tests/unit/test_authority_advisory_lock.py
           tests/unit/test_authority_writer_guard.py
           tests/unit/test_ella_ai_consent.py
@@ -746,7 +752,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 558
+          test "$collected" -eq 557
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \
@@ -912,8 +918,10 @@ jobs:
             tests/unit/test_authority_writer_guard.py \
             tests/postgres/test_authority_advisory_lock_postgres.py \
             -v
-          test "$(pytest --collect-only -q tests/unit/test_ella_callbacks_summary_update.py | grep -c '::')" -eq 21
+          test "$(pytest --collect-only -q tests/unit/test_ella_callbacks_summary_update.py | grep -c '::')" -eq 24
           pytest tests/unit/test_ella_callbacks_summary_update.py -v
+          test "$(pytest --collect-only -q tests/unit/test_conversation_summary_cas.py | grep -c '::')" -eq 6
+          pytest tests/unit/test_conversation_summary_cas.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_conversation_corrections.py | grep -c '::')" -eq 73
           pytest tests/unit/test_ella_conversation_corrections.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_guardian_delivery.py | grep -c '::')" -eq 44

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -920,7 +920,7 @@ jobs:
             -v
           test "$(pytest --collect-only -q tests/unit/test_ella_callbacks_summary_update.py | grep -c '::')" -eq 24
           pytest tests/unit/test_ella_callbacks_summary_update.py -v
-          test "$(pytest --collect-only -q tests/unit/test_conversation_summary_cas.py | grep -c '::')" -eq 9
+          test "$(pytest --collect-only -q tests/unit/test_conversation_summary_cas.py | grep -c '::')" -eq 10
           pytest tests/unit/test_conversation_summary_cas.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_conversation_corrections.py | grep -c '::')" -eq 73
           pytest tests/unit/test_ella_conversation_corrections.py -v

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -920,7 +920,7 @@ jobs:
             -v
           test "$(pytest --collect-only -q tests/unit/test_ella_callbacks_summary_update.py | grep -c '::')" -eq 24
           pytest tests/unit/test_ella_callbacks_summary_update.py -v
-          test "$(pytest --collect-only -q tests/unit/test_conversation_summary_cas.py | grep -c '::')" -eq 6
+          test "$(pytest --collect-only -q tests/unit/test_conversation_summary_cas.py | grep -c '::')" -eq 9
           pytest tests/unit/test_conversation_summary_cas.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_conversation_corrections.py | grep -c '::')" -eq 73
           pytest tests/unit/test_ella_conversation_corrections.py -v

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -796,7 +796,11 @@ jobs:
             "tests/unit/test_today_card_postgres.py::test_materialized_save_fails_closed_when_selected_source_is_tombstoned"
             "tests/unit/test_today_card_postgres.py::test_today_card_router_registration_has_no_function_local_imports"
             "tests/unit/test_ella_canonical_omi.py::test_build_omi_canonical_event_emits_bound_semantic_grounding_provenance"
+            "tests/unit/test_ella_canonical_omi.py::test_build_omi_canonical_event_preserves_parallel_verifier_receipt"
+            "tests/unit/test_ella_canonical_omi.py::test_build_omi_canonical_event_rejects_any_cross_call_identity_reuse"
             "tests/unit/test_ella_conversation_corrections.py::test_semantic_attestation_is_atomically_bound_to_new_version_and_canonical_event"
+            "tests/unit/test_today_card_postgres.py::test_parallel_verifier_receipt_is_eligible_today_card_evidence"
+            "tests/unit/test_today_card_postgres.py::test_parallel_receipt_with_reused_verifier_identity_fails_closed"
             "tests/unit/test_today_card_postgres.py::test_semantic_receipt_is_bound_and_cannot_be_copied_or_coerced[summary]"
             "tests/unit/test_today_card_postgres.py::test_semantic_receipt_is_bound_and_cannot_be_copied_or_coerced[owner]"
             "tests/unit/test_today_card_api.py::test_internal_uid_mutations_require_exact_service_subject"
@@ -908,7 +912,7 @@ jobs:
             tests/unit/test_authority_writer_guard.py \
             tests/postgres/test_authority_advisory_lock_postgres.py \
             -v
-          test "$(pytest --collect-only -q tests/unit/test_ella_callbacks_summary_update.py | grep -c '::')" -eq 15
+          test "$(pytest --collect-only -q tests/unit/test_ella_callbacks_summary_update.py | grep -c '::')" -eq 21
           pytest tests/unit/test_ella_callbacks_summary_update.py -v
           test "$(pytest --collect-only -q tests/unit/test_ella_conversation_corrections.py | grep -c '::')" -eq 73
           pytest tests/unit/test_ella_conversation_corrections.py -v

--- a/.github/workflows/hermes-cloud-runtime-tests.yml
+++ b/.github/workflows/hermes-cloud-runtime-tests.yml
@@ -752,7 +752,7 @@ jobs:
             pytest --collect-only -q tests/unit/test_hermes_product_fit_canary.py |
               grep -c '::'
           )" -eq 19
-          test "$collected" -eq 557
+          test "$collected" -eq 559
           pytest \
             tests/unit/test_ella_ai_consent.py \
             tests/unit/test_ella_ai_consent_route_gates.py \

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -631,7 +631,8 @@ def _update_conversation_if_transcript_hash_transaction(
     if not snapshot.exists:
         return False
     conversation = snapshot.to_dict() or {}
-    if transcript_grounding_hash(conversation.get('transcript_segments') or []) != expected_transcript_hash:
+    readable_conversation = _prepare_conversation_for_read(conversation, uid) or {}
+    if transcript_grounding_hash(readable_conversation.get('transcript_segments') or []) != expected_transcript_hash:
         return False
     if expected_active_summary_version_id is not None and str(
         conversation.get('active_summary_version_id') or ''

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -616,6 +616,74 @@ def update_conversation_if_active_summary_version(
     )
 
 
+def _update_conversation_if_transcript_hash_transaction(
+    transaction,
+    conversation_ref,
+    uid: str,
+    expected_transcript_hash: str,
+    update_data: dict,
+    *,
+    expected_active_summary_version_id: Optional[str] = None,
+) -> bool:
+    from utils.ella.canonical_omi import transcript_grounding_hash
+
+    snapshot = conversation_ref.get(transaction=transaction)
+    if not snapshot.exists:
+        return False
+    conversation = snapshot.to_dict() or {}
+    if transcript_grounding_hash(conversation.get('transcript_segments') or []) != expected_transcript_hash:
+        return False
+    if expected_active_summary_version_id is not None and str(
+        conversation.get('active_summary_version_id') or ''
+    ) != str(expected_active_summary_version_id or ''):
+        return False
+    doc_level = conversation.get('data_protection_level', 'standard')
+    prepared_data = _prepare_conversation_for_write(update_data, uid, doc_level)
+    transaction.update(conversation_ref, prepared_data)
+    return True
+
+
+@transactional
+def _update_conversation_if_transcript_hash(
+    transaction,
+    conversation_ref,
+    uid: str,
+    expected_transcript_hash: str,
+    update_data: dict,
+    *,
+    expected_active_summary_version_id: Optional[str] = None,
+) -> bool:
+    return _update_conversation_if_transcript_hash_transaction(
+        transaction,
+        conversation_ref,
+        uid,
+        expected_transcript_hash,
+        update_data,
+        expected_active_summary_version_id=expected_active_summary_version_id,
+    )
+
+
+def update_conversation_if_transcript_hash(
+    uid: str,
+    conversation_id: str,
+    expected_transcript_hash: str,
+    update_data: dict,
+    *,
+    expected_active_summary_version_id: Optional[str] = None,
+) -> bool:
+    conversation_ref = (
+        db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
+    )
+    return _update_conversation_if_transcript_hash(
+        db.transaction(),
+        conversation_ref,
+        uid,
+        expected_transcript_hash,
+        update_data,
+        expected_active_summary_version_id=expected_active_summary_version_id,
+    )
+
+
 def _ensure_voice_memory_summary_version_transaction(
     transaction,
     conversation_ref,

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -407,6 +407,37 @@ def _prepare_conversation_for_read(conversation_data: Optional[Dict[str, Any]], 
     return data
 
 
+def _prepare_conversation_for_transcript_hash(
+    conversation_data: Optional[Dict[str, Any]], uid: str
+) -> Optional[Dict[str, Any]]:
+    """Return a silent, fail-closed transcript projection for protected CAS admission."""
+    if not conversation_data:
+        return None
+
+    data = copy.deepcopy(conversation_data)
+    segments = data.get('transcript_segments')
+
+    try:
+        if data.get('data_protection_level') == 'enhanced' and isinstance(segments, str):
+            segments = encryption.decrypt_strict(segments, uid)
+
+        if data.get('transcript_segments_compressed'):
+            if isinstance(segments, str):
+                segments = bytes.fromhex(segments)
+            if not isinstance(segments, bytes):
+                return None
+            segments = json.loads(zlib.decompress(segments).decode('utf-8'))
+        elif isinstance(segments, str):
+            segments = json.loads(segments)
+    except Exception:
+        return None
+
+    if not isinstance(segments, list):
+        return None
+    data['transcript_segments'] = segments
+    return data
+
+
 def _prepare_photo_for_write(data: Dict[str, Any], uid: str, level: str) -> Dict[str, Any]:
     data = copy.deepcopy(data)
     data['data_protection_level'] = level
@@ -631,7 +662,9 @@ def _update_conversation_if_transcript_hash_transaction(
     if not snapshot.exists:
         return False
     conversation = snapshot.to_dict() or {}
-    readable_conversation = _prepare_conversation_for_read(conversation, uid) or {}
+    readable_conversation = _prepare_conversation_for_transcript_hash(conversation, uid)
+    if readable_conversation is None:
+        return False
     if transcript_grounding_hash(readable_conversation.get('transcript_segments') or []) != expected_transcript_hash:
         return False
     if expected_active_summary_version_id is not None and str(

--- a/backend/ella/docs/hermes-cloud-runtime-targets.openapi.yaml
+++ b/backend/ella/docs/hermes-cloud-runtime-targets.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Ella Hermes Cloud Runtime Targets
-  version: 0.2.0
+  version: 0.3.0
   description: >
     Backend-owned contract for account/profile Cloud runtime target resolution
     and AI processor consent. This fragment documents the Ella-specific surfaces;
@@ -309,12 +309,53 @@ paths:
   /v1/ella/conversation/{conversation_id}/summary:
     patch:
       tags: [Callbacks and Summary]
-      security: []
-      summary: Internal summary callback with no Cloud-to-Mini assessment fallback.
+      security:
+        - callbackServiceKey: []
+          callbackSubjectUid: []
+      summary: Internal summary callback with exact authority and bound grounding provenance.
       x-internal-only: true
       x-ella-runtime-target:
-        mode: hermes-cloud-transcript
         fallback: none
+        profiles:
+          hermes_cloud:
+            mode: hermes-cloud-transcript
+            summary-source: hermes_cloud
+            attester: hermes_cloud_grounding_verifier
+            policy-version: hermes-cloud-grounding-verifier-v1
+          hermes_parallel:
+            mode: retained-hermes-enrichment
+            summary-source: hermes_parallel
+            attester: hermes_parallel_grounding_verifier
+            policy-version: hermes-parallel-grounding-verifier-v1
+      parameters:
+        - $ref: "#/components/parameters/ConversationId"
+        - name: uid
+          in: query
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConversationSummaryUpdate"
+      responses:
+        "200":
+          description: Summary writeback receipt.
+        "400":
+          description: UID or summary payload is invalid.
+        "422":
+          description: Summary content failed sanitization.
+  /v1/ella/conversation/{conversation_id}/data:
+    get:
+      tags: [Callbacks and Summary]
+      security:
+        - callbackServiceKey: []
+          callbackSubjectUid: []
+      summary: Return authoritative transcript segments for a first-party reprocessing worker.
+      x-internal-only: true
+      x-ella-authoritative-grounding-input: true
       parameters:
         - $ref: "#/components/parameters/ConversationId"
         - name: uid
@@ -324,11 +365,15 @@ paths:
             type: string
       responses:
         "200":
-          description: Summary writeback receipt.
+          description: Exact conversation transcript and structured summary.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConversationData"
         "400":
-          description: UID or summary payload is invalid.
-        "422":
-          description: Summary content failed sanitization.
+          description: UID or callback subject is invalid.
+        "404":
+          description: Conversation is not owned by the exact subject.
   /v1/conversations/{conversation_id}/processing-retries:
     post:
       tags: [Callbacks and Summary]
@@ -395,6 +440,14 @@ components:
       type: apiKey
       in: header
       name: X-Ella-Observer-Token
+    callbackServiceKey:
+      type: apiKey
+      in: header
+      name: X-Ella-Callback-Service-Key
+    callbackSubjectUid:
+      type: apiKey
+      in: header
+      name: X-Ella-Subject-Uid
   parameters:
     ConversationId:
       name: conversation_id
@@ -403,6 +456,111 @@ components:
       schema:
         type: string
   schemas:
+    ParallelTodayCardGroundingEvidence:
+      type: object
+      additionalProperties: false
+      required:
+        - attester
+        - semantic_outcome
+        - supporting_quotes
+        - policy_version
+        - summary_request_id
+        - summary_response_id
+        - verifier_request_id
+        - verifier_response_id
+      properties:
+        attester:
+          type: string
+          const: hermes_parallel_grounding_verifier
+        semantic_outcome:
+          type: string
+          const: supported
+        supporting_quotes:
+          type: array
+          minItems: 1
+          maxItems: 3
+          items:
+            type: string
+            minLength: 1
+        policy_version:
+          type: string
+          const: hermes-parallel-grounding-verifier-v1
+        summary_request_id:
+          type: string
+          minLength: 1
+          maxLength: 512
+        summary_response_id:
+          type: string
+          minLength: 1
+          maxLength: 512
+        verifier_request_id:
+          type: string
+          minLength: 1
+          maxLength: 512
+        verifier_response_id:
+          type: string
+          minLength: 1
+          maxLength: 512
+    ConversationSummaryUpdate:
+      type: object
+      additionalProperties: false
+      properties:
+        title:
+          type: string
+        overview:
+          type: string
+        emoji:
+          type: string
+        category:
+          type: string
+        summary_source:
+          type: string
+        summary_kind:
+          type: string
+        trace_id:
+          type: string
+        set_active:
+          type: boolean
+        require_canonical:
+          type: boolean
+        ella_tags:
+          type: array
+          items:
+            type: string
+        ella_signal:
+          type: object
+        today_card_grounding_evidence:
+          $ref: "#/components/schemas/ParallelTodayCardGroundingEvidence"
+    ConversationData:
+      type: object
+      required: [conversation_id, uid, transcript, transcript_segments, segment_count, structured]
+      properties:
+        conversation_id:
+          type: string
+        uid:
+          type: string
+        transcript:
+          type: string
+        transcript_segments:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            required: [id, text, speaker, is_user]
+            properties:
+              id:
+                type: [string, "null"]
+              text:
+                type: string
+              speaker:
+                type: string
+              is_user:
+                type: boolean
+        segment_count:
+          type: integer
+          minimum: 0
+        structured:
+          type: object
     AiConsentPolicy:
       type: object
       required:

--- a/backend/ella/docs/hermes-cloud-runtime-targets.openapi.yaml
+++ b/backend/ella/docs/hermes-cloud-runtime-targets.openapi.yaml
@@ -464,6 +464,7 @@ components:
         - semantic_outcome
         - supporting_quotes
         - policy_version
+        - transcript_hash
         - summary_request_id
         - summary_response_id
         - verifier_request_id
@@ -485,6 +486,9 @@ components:
         policy_version:
           type: string
           const: hermes-parallel-grounding-verifier-v1
+        transcript_hash:
+          type: string
+          pattern: '^sha256:[0-9a-f]{64}$'
         summary_request_id:
           type: string
           minLength: 1
@@ -533,7 +537,7 @@ components:
           $ref: "#/components/schemas/ParallelTodayCardGroundingEvidence"
     ConversationData:
       type: object
-      required: [conversation_id, uid, transcript, transcript_segments, segment_count, structured]
+      required: [conversation_id, uid, transcript, transcript_segments, transcript_hash, segment_count, structured]
       properties:
         conversation_id:
           type: string
@@ -546,16 +550,29 @@ components:
           items:
             type: object
             additionalProperties: false
-            required: [id, text, speaker, is_user]
+            required: [id, text, speaker, speaker_id, is_user, person_id, start, end, timestamp]
             properties:
               id:
                 type: [string, "null"]
               text:
                 type: string
               speaker:
-                type: string
+                type: [string, "null"]
+              speaker_id:
+                type: [integer, "null"]
               is_user:
                 type: boolean
+              person_id:
+                type: [string, "null"]
+              start:
+                type: [number, "null"]
+              end:
+                type: [number, "null"]
+              timestamp:
+                type: [string, "null"]
+        transcript_hash:
+          type: string
+          pattern: '^sha256:[0-9a-f]{64}$'
         segment_count:
           type: integer
           minimum: 0

--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -31,7 +31,7 @@ import string
 import asyncio
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 import asyncpg
 import httpx
@@ -207,6 +207,19 @@ def _upload_audio_to_gcs(audio_bytes: bytes, uid: str) -> Optional[str]:
 # ============================================================================
 
 
+class ParallelTodayCardGroundingEvidence(BaseModel):
+    attester: Literal["hermes_parallel_grounding_verifier"]
+    semantic_outcome: Literal["supported"]
+    supporting_quotes: List[str] = Field(min_length=1, max_length=3)
+    policy_version: Literal["hermes-parallel-grounding-verifier-v1"]
+    summary_request_id: str = Field(min_length=1, max_length=512)
+    summary_response_id: str = Field(min_length=1, max_length=512)
+    verifier_request_id: str = Field(min_length=1, max_length=512)
+    verifier_response_id: str = Field(min_length=1, max_length=512)
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class ConversationSummaryUpdate(BaseModel):
     """Schema for updating conversation structured summary fields."""
 
@@ -223,6 +236,9 @@ class ConversationSummaryUpdate(BaseModel):
     require_canonical: bool = False
     ella_tags: List[str] = Field(default_factory=list)
     ella_signal: Optional[Dict[str, Any]] = None
+    today_card_grounding_evidence: Optional[ParallelTodayCardGroundingEvidence] = None
+
+    model_config = ConfigDict(extra="forbid")
 
 
 def _active_summary_version(conversation: dict) -> Optional[dict]:
@@ -409,6 +425,11 @@ async def update_conversation_summary(
             correction_audit_updater=_update_correction_audit,
             canonical_writer=write_omi_canonical_event,
             require_canonical=update.require_canonical,
+            today_card_grounding_evidence=(
+                update.today_card_grounding_evidence.model_dump()
+                if update.today_card_grounding_evidence is not None
+                else None
+            ),
         )
     except SummarySanitizationError as e:
         raise HTTPException(
@@ -530,14 +551,27 @@ async def get_conversation_data(
 
     segments = _conversation_field(conversation, "transcript_segments", []) or []
     transcript_parts = []
+    transcript_segments = []
     for segment in segments:
         if isinstance(segment, dict):
-            speaker = "User" if segment.get("is_user") else (segment.get("speaker") or "Other")
-            text = segment.get("text", "")
+            is_user = bool(segment.get("is_user"))
+            speaker = "User" if is_user else str(segment.get("speaker") or "Other")
+            text = str(segment.get("text") or "")
+            segment_id = segment.get("id")
         else:
-            speaker = "User" if getattr(segment, "is_user", False) else (getattr(segment, "speaker", None) or "Other")
-            text = getattr(segment, "text", "")
+            is_user = bool(getattr(segment, "is_user", False))
+            speaker = "User" if is_user else str(getattr(segment, "speaker", None) or "Other")
+            text = str(getattr(segment, "text", None) or "")
+            segment_id = getattr(segment, "id", None)
         transcript_parts.append(f"{speaker}: {text}")
+        transcript_segments.append(
+            {
+                "id": str(segment_id) if segment_id is not None else None,
+                "text": text,
+                "speaker": speaker,
+                "is_user": is_user,
+            }
+        )
 
     structured_src = _conversation_field(conversation, "structured", {}) or {}
     structured = {}
@@ -555,6 +589,7 @@ async def get_conversation_data(
         "conversation_id": conversation_id,
         "uid": uid,
         "transcript": "\n\n".join(transcript_parts),
+        "transcript_segments": transcript_segments,
         "segment_count": len(segments),
         "structured": structured,
         "started_at": str(_conversation_field(conversation, "started_at", "")),

--- a/backend/ella/routers/callbacks.py
+++ b/backend/ella/routers/callbacks.py
@@ -62,12 +62,17 @@ from ella.services.runtime_resolver import (
 )
 from ella.services.summary_sanitizer import SummarySanitizationError
 from ella.services.summary_writeback import (
+    ConcurrentConversationSummaryChangeError,
     ConversationSummaryNotFoundError,
     InvalidConversationSummaryCategoryError,
     write_conversation_summary,
 )
 from utils.notifications import send_notification
-from utils.ella.canonical_omi import write_omi_canonical_event
+from utils.ella.canonical_omi import (
+    canonical_transcript_segments,
+    transcript_grounding_hash,
+    write_omi_canonical_event,
+)
 from utils.ella.exact_firebase_auth import (
     ELLA_SUBJECT_UID_HEADER,
     EllaRequestAuthority,
@@ -212,6 +217,7 @@ class ParallelTodayCardGroundingEvidence(BaseModel):
     semantic_outcome: Literal["supported"]
     supporting_quotes: List[str] = Field(min_length=1, max_length=3)
     policy_version: Literal["hermes-parallel-grounding-verifier-v1"]
+    transcript_hash: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
     summary_request_id: str = Field(min_length=1, max_length=512)
     summary_response_id: str = Field(min_length=1, max_length=512)
     verifier_request_id: str = Field(min_length=1, max_length=512)
@@ -440,6 +446,8 @@ async def update_conversation_summary(
         raise HTTPException(status_code=404, detail="Conversation not found")
     except InvalidConversationSummaryCategoryError as e:
         raise HTTPException(status_code=400, detail=f"Invalid category: '{e.args[0]}'")
+    except ConcurrentConversationSummaryChangeError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
@@ -550,28 +558,13 @@ async def get_conversation_data(
         raise HTTPException(status_code=404, detail="Conversation not found")
 
     segments = _conversation_field(conversation, "transcript_segments", []) or []
+    transcript_segments = canonical_transcript_segments(list(segments))
     transcript_parts = []
-    transcript_segments = []
-    for segment in segments:
-        if isinstance(segment, dict):
-            is_user = bool(segment.get("is_user"))
-            speaker = "User" if is_user else str(segment.get("speaker") or "Other")
-            text = str(segment.get("text") or "")
-            segment_id = segment.get("id")
-        else:
-            is_user = bool(getattr(segment, "is_user", False))
-            speaker = "User" if is_user else str(getattr(segment, "speaker", None) or "Other")
-            text = str(getattr(segment, "text", None) or "")
-            segment_id = getattr(segment, "id", None)
+    for segment in transcript_segments:
+        is_user = bool(segment.get("is_user"))
+        speaker = "User" if is_user else str(segment.get("speaker") or "Other")
+        text = str(segment.get("text") or "")
         transcript_parts.append(f"{speaker}: {text}")
-        transcript_segments.append(
-            {
-                "id": str(segment_id) if segment_id is not None else None,
-                "text": text,
-                "speaker": speaker,
-                "is_user": is_user,
-            }
-        )
 
     structured_src = _conversation_field(conversation, "structured", {}) or {}
     structured = {}
@@ -590,6 +583,7 @@ async def get_conversation_data(
         "uid": uid,
         "transcript": "\n\n".join(transcript_parts),
         "transcript_segments": transcript_segments,
+        "transcript_hash": transcript_grounding_hash(transcript_segments),
         "segment_count": len(segments),
         "structured": structured,
         "started_at": str(_conversation_field(conversation, "started_at", "")),

--- a/backend/ella/services/summary_writeback.py
+++ b/backend/ella/services/summary_writeback.py
@@ -12,7 +12,9 @@ from models.conversation import CategoryEnum
 from utils.ella.canonical_omi import (
     TODAY_CARD_GROUNDING_ATTESTER,
     TODAY_CARD_GROUNDING_CONTRACT_VERSION,
+    TODAY_CARD_PARALLEL_GROUNDING_ATTESTER,
     summary_grounding_hash,
+    today_card_grounding_identity_is_valid,
     transcript_grounding_hash,
     write_omi_canonical_event,
 )
@@ -34,6 +36,68 @@ class CanonicalSummaryWriteUnconfirmedError(RuntimeError):
 
 class ConcurrentConversationSummaryChangeError(RuntimeError):
     pass
+
+
+def _normalized_grounding_text(value: Any) -> str:
+    return ' '.join(str(value or '').split()).strip()
+
+
+def _parallel_grounding_attestation(
+    evidence: dict[str, Any],
+    *,
+    uid: str,
+    conversation_id: str,
+    structured: dict[str, Any],
+    transcript_segments: list[dict[str, Any]],
+) -> dict[str, Any]:
+    allowed_keys = {
+        'attester',
+        'semantic_outcome',
+        'supporting_quotes',
+        'policy_version',
+        'summary_request_id',
+        'summary_response_id',
+        'verifier_request_id',
+        'verifier_response_id',
+    }
+    if (
+        set(evidence) != allowed_keys
+        or evidence.get('attester') != TODAY_CARD_PARALLEL_GROUNDING_ATTESTER
+        or evidence.get('semantic_outcome') != 'supported'
+        or evidence.get('policy_version') != 'hermes-parallel-grounding-verifier-v1'
+    ):
+        raise ValueError('today_card_grounding_evidence_invalid')
+    transcript = _normalized_grounding_text(
+        ' '.join(str(segment.get('text') or '') for segment in transcript_segments if isinstance(segment, dict))
+    ).casefold()
+    raw_quotes = evidence.get('supporting_quotes')
+    if not isinstance(raw_quotes, list):
+        raise ValueError('today_card_grounding_evidence_invalid')
+    quotes = [_normalized_grounding_text(value) for value in raw_quotes]
+    if not 1 <= len(quotes) <= 3 or any(not quote for quote in quotes):
+        raise ValueError('today_card_grounding_evidence_invalid')
+    if any(quote.casefold() not in transcript for quote in quotes):
+        raise ValueError('today_card_grounding_quote_not_in_transcript')
+    if any(sum(character.isalnum() for character in quote) < 8 for quote in quotes):
+        raise ValueError('today_card_grounding_quote_too_short')
+    receipt = {
+        'contract_version': TODAY_CARD_GROUNDING_CONTRACT_VERSION,
+        'attester': TODAY_CARD_PARALLEL_GROUNDING_ATTESTER,
+        'semantic_outcome': 'supported',
+        'transcript_hash': transcript_grounding_hash(transcript_segments),
+        'summary_hash': summary_grounding_hash(structured),
+        'supporting_quote_hashes': ['sha256:' + hashlib.sha256(quote.encode('utf-8')).hexdigest() for quote in quotes],
+        'policy_version': 'hermes-parallel-grounding-verifier-v1',
+        'owner_hash': 'sha256:' + hashlib.sha256(uid.encode('utf-8')).hexdigest(),
+        'conversation_id_hash': 'sha256:' + hashlib.sha256(conversation_id.encode('utf-8')).hexdigest(),
+        'summary_request_id': str(evidence.get('summary_request_id') or '').strip(),
+        'summary_response_id': str(evidence.get('summary_response_id') or '').strip(),
+        'verifier_request_id': str(evidence.get('verifier_request_id') or '').strip(),
+        'verifier_response_id': str(evidence.get('verifier_response_id') or '').strip(),
+    }
+    if not today_card_grounding_identity_is_valid(receipt, 'hermes_parallel'):
+        raise ValueError('today_card_grounding_identity_invalid')
+    return receipt
 
 
 async def write_conversation_summary(
@@ -59,6 +123,7 @@ async def write_conversation_summary(
     require_based_on_match: bool = False,
     preserve_generated_results: bool = False,
     today_card_grounding: Optional[dict[str, Any]] = None,
+    today_card_grounding_evidence: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     conversation = conversations_db.get_conversation(uid, conversation_id)
     if conversation is None:
@@ -164,17 +229,31 @@ async def write_conversation_summary(
         based_on_version_id=based_on_version_id,
         activate=set_active,
     )
+    if today_card_grounding is not None and today_card_grounding_evidence is not None:
+        raise ValueError('today_card_grounding_inputs_conflict')
+    grounding_bound_from_evidence = False
     bound_today_card_grounding: Optional[dict[str, Any]] = None
+    raw_segments = conversation.get('transcript_segments') or []
+    transcript_segments: list[dict[str, Any]] = []
+    for segment in raw_segments:
+        if isinstance(segment, dict):
+            transcript_segments.append(dict(segment))
+        elif hasattr(segment, 'model_dump'):
+            transcript_segments.append(segment.model_dump(mode='json'))
+        elif hasattr(segment, 'dict'):
+            transcript_segments.append(segment.dict())
+    if today_card_grounding_evidence is not None:
+        if summary_source != 'hermes_parallel' or summary_kind != 'hermes_enriched' or not require_canonical:
+            raise ValueError('today_card_grounding_evidence_scope_invalid')
+        today_card_grounding = _parallel_grounding_attestation(
+            today_card_grounding_evidence,
+            uid=uid,
+            conversation_id=conversation_id,
+            structured=structured,
+            transcript_segments=transcript_segments,
+        )
+        grounding_bound_from_evidence = True
     if today_card_grounding is not None:
-        raw_segments = conversation.get('transcript_segments') or []
-        transcript_segments: list[dict[str, Any]] = []
-        for segment in raw_segments:
-            if isinstance(segment, dict):
-                transcript_segments.append(dict(segment))
-            elif hasattr(segment, 'model_dump'):
-                transcript_segments.append(segment.model_dump(mode='json'))
-            elif hasattr(segment, 'dict'):
-                transcript_segments.append(segment.dict())
         quote_hashes = today_card_grounding.get('supporting_quote_hashes')
         quote_hashes_are_valid = (
             isinstance(quote_hashes, list)
@@ -188,21 +267,29 @@ async def write_conversation_summary(
             )
         )
         if not (
-            summary_source == 'hermes_cloud'
+            summary_source in {'hermes_cloud', 'hermes_parallel'}
+            and (summary_source != 'hermes_parallel' or grounding_bound_from_evidence)
             and summary_kind == 'hermes_enriched'
             and today_card_grounding.get('contract_version') == TODAY_CARD_GROUNDING_CONTRACT_VERSION
-            and today_card_grounding.get('attester') == TODAY_CARD_GROUNDING_ATTESTER
+            and today_card_grounding.get('attester')
+            == (
+                TODAY_CARD_GROUNDING_ATTESTER
+                if summary_source == 'hermes_cloud'
+                else TODAY_CARD_PARALLEL_GROUNDING_ATTESTER
+            )
             and today_card_grounding.get('semantic_outcome') == 'supported'
             and today_card_grounding.get('transcript_hash') == transcript_grounding_hash(transcript_segments)
             and today_card_grounding.get('summary_hash') == summary_grounding_hash(structured)
             and today_card_grounding.get('owner_hash') == 'sha256:' + hashlib.sha256(uid.encode('utf-8')).hexdigest()
             and today_card_grounding.get('conversation_id_hash')
             == 'sha256:' + hashlib.sha256(conversation_id.encode('utf-8')).hexdigest()
-            and bool(str(today_card_grounding.get('runtime_interaction_id') or '').strip())
-            and bool(str(today_card_grounding.get('canonical_assistant_event_id') or '').strip())
-            and bool(str(today_card_grounding.get('verifier_runtime_interaction_id') or '').strip())
-            and bool(str(today_card_grounding.get('verifier_canonical_assistant_event_id') or '').strip())
-            and today_card_grounding.get('policy_version') == 'hermes-cloud-grounding-verifier-v1'
+            and today_card_grounding_identity_is_valid(today_card_grounding, summary_source)
+            and today_card_grounding.get('policy_version')
+            == (
+                'hermes-cloud-grounding-verifier-v1'
+                if summary_source == 'hermes_cloud'
+                else 'hermes-parallel-grounding-verifier-v1'
+            )
             and quote_hashes_are_valid
         ):
             raise ValueError('today_card_grounding_attestation_invalid')

--- a/backend/ella/services/summary_writeback.py
+++ b/backend/ella/services/summary_writeback.py
@@ -42,6 +42,18 @@ def _normalized_grounding_text(value: Any) -> str:
     return ' '.join(str(value or '').split()).strip()
 
 
+def _conversation_transcript_segments(conversation: dict[str, Any]) -> list[dict[str, Any]]:
+    transcript_segments: list[dict[str, Any]] = []
+    for segment in conversation.get('transcript_segments') or []:
+        if isinstance(segment, dict):
+            transcript_segments.append(dict(segment))
+        elif hasattr(segment, 'model_dump'):
+            transcript_segments.append(segment.model_dump(mode='json'))
+        elif hasattr(segment, 'dict'):
+            transcript_segments.append(segment.dict())
+    return transcript_segments
+
+
 def _parallel_grounding_attestation(
     evidence: dict[str, Any],
     *,
@@ -55,6 +67,7 @@ def _parallel_grounding_attestation(
         'semantic_outcome',
         'supporting_quotes',
         'policy_version',
+        'transcript_hash',
         'summary_request_id',
         'summary_response_id',
         'verifier_request_id',
@@ -80,11 +93,14 @@ def _parallel_grounding_attestation(
         raise ValueError('today_card_grounding_quote_not_in_transcript')
     if any(sum(character.isalnum() for character in quote) < 8 for quote in quotes):
         raise ValueError('today_card_grounding_quote_too_short')
+    observed_transcript_hash = str(evidence.get('transcript_hash') or '').strip()
+    if observed_transcript_hash != transcript_grounding_hash(transcript_segments):
+        raise ValueError('today_card_grounding_transcript_changed')
     receipt = {
         'contract_version': TODAY_CARD_GROUNDING_CONTRACT_VERSION,
         'attester': TODAY_CARD_PARALLEL_GROUNDING_ATTESTER,
         'semantic_outcome': 'supported',
-        'transcript_hash': transcript_grounding_hash(transcript_segments),
+        'transcript_hash': observed_transcript_hash,
         'summary_hash': summary_grounding_hash(structured),
         'supporting_quote_hashes': ['sha256:' + hashlib.sha256(quote.encode('utf-8')).hexdigest() for quote in quotes],
         'policy_version': 'hermes-parallel-grounding-verifier-v1',
@@ -133,6 +149,15 @@ async def write_conversation_summary(
 
     enrichment_state = conversation.get('enrichment_state') or {}
     same_trace = bool(trace_id and enrichment_state.get('trace_id') == trace_id)
+    existing_grounding = enrichment_state.get('today_card_grounding')
+    if (
+        same_trace
+        and summary_source == 'hermes_parallel'
+        and isinstance(existing_grounding, dict)
+        and existing_grounding.get('transcript_hash')
+        != transcript_grounding_hash(_conversation_transcript_segments(conversation))
+    ):
+        raise ConcurrentConversationSummaryChangeError('transcript_changed')
     if (
         same_trace
         and enrichment_state.get('status') == 'writeback_applied'
@@ -233,15 +258,7 @@ async def write_conversation_summary(
         raise ValueError('today_card_grounding_inputs_conflict')
     grounding_bound_from_evidence = False
     bound_today_card_grounding: Optional[dict[str, Any]] = None
-    raw_segments = conversation.get('transcript_segments') or []
-    transcript_segments: list[dict[str, Any]] = []
-    for segment in raw_segments:
-        if isinstance(segment, dict):
-            transcript_segments.append(dict(segment))
-        elif hasattr(segment, 'model_dump'):
-            transcript_segments.append(segment.model_dump(mode='json'))
-        elif hasattr(segment, 'dict'):
-            transcript_segments.append(segment.dict())
+    transcript_segments = _conversation_transcript_segments(conversation)
     if today_card_grounding_evidence is not None:
         if summary_source != 'hermes_parallel' or summary_kind != 'hermes_enriched' or not require_canonical:
             raise ValueError('today_card_grounding_evidence_scope_invalid')
@@ -338,7 +355,17 @@ async def write_conversation_summary(
             'active_summary_version_id': version_update['active_summary_version_id'],
         }
 
-    if require_based_on_match:
+    if grounding_bound_from_evidence:
+        updated = conversations_db.update_conversation_if_transcript_hash(
+            uid,
+            conversation_id,
+            bound_today_card_grounding['transcript_hash'],
+            update_data,
+            expected_active_summary_version_id=(based_on_version_id if require_based_on_match else None),
+        )
+        if not updated:
+            raise ConcurrentConversationSummaryChangeError('transcript_changed')
+    elif require_based_on_match:
         updated = conversations_db.update_conversation_if_active_summary_version(
             uid,
             conversation_id,

--- a/backend/ella/services/today_card_postgres.py
+++ b/backend/ella/services/today_card_postgres.py
@@ -34,9 +34,10 @@ from ella.services.today_card import (
     today_card_source_pack,
 )
 from utils.ella.canonical_omi import (
-    TODAY_CARD_GROUNDING_ATTESTER,
     TODAY_CARD_GROUNDING_CONTRACT_VERSION,
     summary_grounding_hash,
+    today_card_grounding_identity_is_valid,
+    today_card_grounding_profile,
     transcript_grounding_hash,
 )
 
@@ -198,11 +199,12 @@ def _has_grounded_content_provenance(
     if len(matching_versions) != 1:
         return False
     active_version = matching_versions[0]
+    grounding_profile = today_card_grounding_profile(active_version.get("source"))
     if (
         str(active_version.get("title") or "").strip() != str(structured.get("title") or "").strip()
         or str(active_version.get("overview") or "").strip() != str(structured.get("overview") or "").strip()
-        or active_version.get("source") != "hermes_cloud"
         or active_version.get("kind") != "hermes_enriched"
+        or grounding_profile is None
     ):
         return False
     quote_hashes = grounding.get("supporting_quote_hashes")
@@ -220,7 +222,7 @@ def _has_grounded_content_provenance(
     )
     return (
         grounding.get("contract_version") == TODAY_CARD_GROUNDING_CONTRACT_VERSION
-        and grounding.get("attester") == TODAY_CARD_GROUNDING_ATTESTER
+        and grounding.get("attester") == grounding_profile["attester"]
         and grounding.get("semantic_outcome") == "supported"
         and grounding.get("source_version_id") == source_version_id
         and grounding.get("transcript_hash") == transcript_grounding_hash(normalized_segments)
@@ -230,11 +232,8 @@ def _has_grounded_content_provenance(
         == "sha256:" + hashlib.sha256(conversation_id.encode("utf-8")).hexdigest()
         and expected_owner_hash is not None
         and grounding.get("owner_hash") == expected_owner_hash
-        and bool(str(grounding.get("runtime_interaction_id") or "").strip())
-        and bool(str(grounding.get("canonical_assistant_event_id") or "").strip())
-        and bool(str(grounding.get("verifier_runtime_interaction_id") or "").strip())
-        and bool(str(grounding.get("verifier_canonical_assistant_event_id") or "").strip())
-        and grounding.get("policy_version") == "hermes-cloud-grounding-verifier-v1"
+        and today_card_grounding_identity_is_valid(grounding, active_version.get("source"))
+        and grounding.get("policy_version") == grounding_profile["policy_version"]
         and valid_quote_hashes
     )
 

--- a/backend/tests/unit/test_conversation_summary_cas.py
+++ b/backend/tests/unit/test_conversation_summary_cas.py
@@ -4,6 +4,9 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+from utils.ella.canonical_omi import transcript_grounding_hash
+
 
 def _load_conversations_module(monkeypatch):
     import utils
@@ -74,3 +77,99 @@ def test_active_summary_version_compare_and_set_is_atomic_and_fail_closed(monkey
         is False
     )
     assert stale_transaction.updates == []
+
+
+@pytest.mark.parametrize(
+    "current_segments",
+    [
+        [
+            {"id": "one", "text": "The original supported statement.", "start": 0.0, "end": 2.0},
+            {"id": "two", "text": "A later contradictory segment.", "start": 2.0, "end": 4.0},
+        ],
+        [{"id": "one", "text": "The original statement was edited.", "start": 0.0, "end": 2.0}],
+        [
+            {"id": "two", "text": "A second original segment.", "start": 2.0, "end": 4.0},
+            {"id": "one", "text": "The original supported statement.", "start": 0.0, "end": 2.0},
+        ],
+        [{"id": "replacement", "text": "An unrelated replacement transcript.", "start": 8.0, "end": 10.0}],
+    ],
+    ids=["append", "edit", "reorder", "replacement"],
+)
+def test_transcript_hash_compare_and_set_rejects_every_source_race(monkeypatch, current_segments):
+    conversations = _load_conversations_module(monkeypatch)
+    observed_segments = [
+        {"id": "one", "text": "The original supported statement.", "start": 0.0, "end": 2.0},
+        {"id": "two", "text": "A second original segment.", "start": 2.0, "end": 4.0},
+    ]
+
+    class ConversationRef:
+        def get(self, transaction=None):
+            return SimpleNamespace(
+                exists=True,
+                to_dict=lambda: {
+                    "active_summary_version_id": "source-v1",
+                    "data_protection_level": "standard",
+                    "transcript_segments": current_segments,
+                },
+            )
+
+    class Transaction:
+        def __init__(self):
+            self.updates = []
+
+        def update(self, ref, payload):
+            self.updates.append((ref, payload))
+
+    transaction = Transaction()
+    assert (
+        conversations._update_conversation_if_transcript_hash_transaction(
+            transaction,
+            ConversationRef(),
+            "uid-1",
+            transcript_grounding_hash(observed_segments),
+            {"active_summary_version_id": "summary-v2"},
+        )
+        is False
+    )
+    assert transaction.updates == []
+
+
+def test_transcript_hash_compare_and_set_publishes_once_for_exact_source(monkeypatch):
+    conversations = _load_conversations_module(monkeypatch)
+    observed_segments = [
+        {"id": "one", "text": "The original supported statement.", "start": 0.0, "end": 2.0},
+        {"id": "two", "text": "A second original segment.", "start": 2.0, "end": 4.0},
+    ]
+
+    class ConversationRef:
+        def get(self, transaction=None):
+            return SimpleNamespace(
+                exists=True,
+                to_dict=lambda: {
+                    "active_summary_version_id": "source-v1",
+                    "data_protection_level": "standard",
+                    "transcript_segments": observed_segments,
+                },
+            )
+
+    class Transaction:
+        def __init__(self):
+            self.updates = []
+
+        def update(self, ref, payload):
+            self.updates.append((ref, payload))
+
+    conversation_ref = ConversationRef()
+    transaction = Transaction()
+    assert (
+        conversations._update_conversation_if_transcript_hash_transaction(
+            transaction,
+            conversation_ref,
+            "uid-1",
+            transcript_grounding_hash(observed_segments),
+            {"active_summary_version_id": "summary-v2"},
+            expected_active_summary_version_id="source-v1",
+        )
+        is True
+    )
+    assert transaction.updates == [(conversation_ref, {"active_summary_version_id": "summary-v2"})]

--- a/backend/tests/unit/test_conversation_summary_cas.py
+++ b/backend/tests/unit/test_conversation_summary_cas.py
@@ -1,5 +1,7 @@
 import importlib.util
+import json
 import sys
+import zlib
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -173,3 +175,88 @@ def test_transcript_hash_compare_and_set_publishes_once_for_exact_source(monkeyp
         is True
     )
     assert transaction.updates == [(conversation_ref, {"active_summary_version_id": "summary-v2"})]
+
+
+@pytest.mark.parametrize("protection_level", ["standard", "enhanced"])
+def test_transcript_hash_compare_and_set_uses_decrypted_transaction_snapshot(monkeypatch, protection_level):
+    conversations = _load_conversations_module(monkeypatch)
+    observed_segments = [
+        {"id": "one", "text": "The exact protected source statement.", "start": 0.0, "end": 2.0},
+        {"id": "two", "text": "A second protected source segment.", "start": 2.0, "end": 4.0},
+    ]
+    compressed = zlib.compress(json.dumps(observed_segments).encode("utf-8"))
+    stored_segments = compressed
+    if protection_level == "enhanced":
+        stored_segments = "encrypted-transcript"
+        conversations.encryption.decrypt.return_value = compressed.hex()
+
+    class ConversationRef:
+        def get(self, transaction=None):
+            return SimpleNamespace(
+                exists=True,
+                to_dict=lambda: {
+                    "active_summary_version_id": "source-v1",
+                    "data_protection_level": protection_level,
+                    "transcript_segments": stored_segments,
+                    "transcript_segments_compressed": True,
+                },
+            )
+
+    class Transaction:
+        def __init__(self):
+            self.updates = []
+
+        def update(self, ref, payload):
+            self.updates.append((ref, payload))
+
+    conversation_ref = ConversationRef()
+    transaction = Transaction()
+    assert (
+        conversations._update_conversation_if_transcript_hash_transaction(
+            transaction,
+            conversation_ref,
+            "uid-1",
+            transcript_grounding_hash(observed_segments),
+            {"active_summary_version_id": "summary-v2"},
+            expected_active_summary_version_id="source-v1",
+        )
+        is True
+    )
+    assert transaction.updates == [(conversation_ref, {"active_summary_version_id": "summary-v2"})]
+
+
+def test_transcript_hash_compare_and_set_fails_closed_when_protected_source_cannot_decrypt(monkeypatch):
+    conversations = _load_conversations_module(monkeypatch)
+    conversations.encryption.decrypt.side_effect = ValueError("invalid ciphertext")
+
+    class ConversationRef:
+        def get(self, transaction=None):
+            return SimpleNamespace(
+                exists=True,
+                to_dict=lambda: {
+                    "active_summary_version_id": "source-v1",
+                    "data_protection_level": "enhanced",
+                    "transcript_segments": "invalid-ciphertext",
+                    "transcript_segments_compressed": True,
+                },
+            )
+
+    class Transaction:
+        def __init__(self):
+            self.updates = []
+
+        def update(self, ref, payload):
+            self.updates.append((ref, payload))
+
+    transaction = Transaction()
+    assert (
+        conversations._update_conversation_if_transcript_hash_transaction(
+            transaction,
+            ConversationRef(),
+            "uid-1",
+            transcript_grounding_hash([{"text": "Expected protected source."}]),
+            {"active_summary_version_id": "summary-v2"},
+        )
+        is False
+    )
+    assert transaction.updates == []

--- a/backend/tests/unit/test_conversation_summary_cas.py
+++ b/backend/tests/unit/test_conversation_summary_cas.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import logging
 import sys
 import zlib
 from pathlib import Path
@@ -188,7 +189,7 @@ def test_transcript_hash_compare_and_set_uses_decrypted_transaction_snapshot(mon
     stored_segments = compressed
     if protection_level == "enhanced":
         stored_segments = "encrypted-transcript"
-        conversations.encryption.decrypt.return_value = compressed.hex()
+        conversations.encryption.decrypt_strict.return_value = compressed.hex()
 
     class ConversationRef:
         def get(self, transaction=None):
@@ -225,9 +226,14 @@ def test_transcript_hash_compare_and_set_uses_decrypted_transaction_snapshot(mon
     assert transaction.updates == [(conversation_ref, {"active_summary_version_id": "summary-v2"})]
 
 
-def test_transcript_hash_compare_and_set_fails_closed_when_protected_source_cannot_decrypt(monkeypatch):
+def test_transcript_hash_compare_and_set_fails_closed_silently_when_protected_source_cannot_decrypt(
+    monkeypatch, caplog, capsys
+):
     conversations = _load_conversations_module(monkeypatch)
-    conversations.encryption.decrypt.side_effect = ValueError("invalid ciphertext")
+    subject = "private-subject-uid"
+    ciphertext = "private-ciphertext"
+    exception_detail = "private-decryption-exception"
+    conversations.encryption.decrypt_strict.side_effect = ValueError(exception_detail)
 
     class ConversationRef:
         def get(self, transaction=None):
@@ -236,7 +242,7 @@ def test_transcript_hash_compare_and_set_fails_closed_when_protected_source_cann
                 to_dict=lambda: {
                     "active_summary_version_id": "source-v1",
                     "data_protection_level": "enhanced",
-                    "transcript_segments": "invalid-ciphertext",
+                    "transcript_segments": ciphertext,
                     "transcript_segments_compressed": True,
                 },
             )
@@ -249,14 +255,40 @@ def test_transcript_hash_compare_and_set_fails_closed_when_protected_source_cann
             self.updates.append((ref, payload))
 
     transaction = Transaction()
-    assert (
-        conversations._update_conversation_if_transcript_hash_transaction(
-            transaction,
-            ConversationRef(),
-            "uid-1",
-            transcript_grounding_hash([{"text": "Expected protected source."}]),
-            {"active_summary_version_id": "summary-v2"},
+    with caplog.at_level(logging.DEBUG):
+        assert (
+            conversations._update_conversation_if_transcript_hash_transaction(
+                transaction,
+                ConversationRef(),
+                subject,
+                transcript_grounding_hash([{"text": "Expected protected source."}]),
+                {"active_summary_version_id": "summary-v2"},
+            )
+            is False
         )
-        is False
-    )
     assert transaction.updates == []
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+    assert caplog.records == []
+
+
+def test_strict_decrypt_round_trip_and_failure_emit_no_protected_context(monkeypatch, caplog, capsys):
+    monkeypatch.setenv("ENCRYPTION_SECRET", "test-encryption-secret-exactly-32-bytes")
+    path = Path(__file__).resolve().parents[2] / "utils" / "encryption.py"
+    spec = importlib.util.spec_from_file_location("utils.encryption_strict_cas_test", path)
+    encryption = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(encryption)
+
+    subject = "private-subject-uid"
+    ciphertext = "private-ciphertext"
+    plaintext = "private-transcript-payload"
+    assert encryption.decrypt_strict(encryption.encrypt(plaintext, subject), subject) == plaintext
+    with caplog.at_level(logging.DEBUG), pytest.raises(Exception):
+        encryption.decrypt_strict(ciphertext, subject)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+    assert caplog.records == []

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 sys.modules.setdefault("database._client", MagicMock())
 sys.modules.setdefault("database.conversations", MagicMock())
@@ -205,7 +206,7 @@ def test_get_conversation_data_returns_transcript_payload(monkeypatch):
         "get_conversation",
         lambda uid, conversation_id: {
             "transcript_segments": [
-                {"is_user": True, "text": "Can you reprocess this?"},
+                {"id": 7, "is_user": True, "text": "Can you reprocess this?"},
                 {"speaker": "Other", "text": "Yes, with the full transcript."},
             ],
             "structured": {
@@ -231,6 +232,10 @@ def test_get_conversation_data_returns_transcript_payload(monkeypatch):
     assert result["uid"] == "user-123"
     assert result["segment_count"] == 2
     assert result["transcript"] == "User: Can you reprocess this?\n\nOther: Yes, with the full transcript."
+    assert result["transcript_segments"] == [
+        {"id": "7", "text": "Can you reprocess this?", "speaker": "User", "is_user": True},
+        {"id": None, "text": "Yes, with the full transcript.", "speaker": "Other", "is_user": False},
+    ]
     assert result["structured"]["title"] == "Original title"
     assert result["structured"]["overview"] == "Original overview"
     assert result["structured"]["emoji"] == "🧠"
@@ -545,6 +550,178 @@ def test_update_conversation_summary_writes_enriched_omi_to_canonical(monkeypatc
         "summary_kind": "observer_enriched",
         "trace_id": "trace-cafe",
     }
+
+
+def _parallel_grounding_evidence():
+    return {
+        "attester": "hermes_parallel_grounding_verifier",
+        "semantic_outcome": "supported",
+        "supporting_quotes": ["I ordered a waffle with oat milk after our morning walk."],
+        "policy_version": "hermes-parallel-grounding-verifier-v1",
+        "summary_request_id": "summary-request-1",
+        "summary_response_id": "summary-response-1",
+        "verifier_request_id": "verifier-request-1",
+        "verifier_response_id": "verifier-response-1",
+    }
+
+
+def _configure_parallel_grounding_write(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: {
+            "id": conversation_id,
+            "structured": {
+                "title": "Original cafe title",
+                "overview": "[Ella] Original cafe overview with enough detail.",
+                "emoji": "☕",
+                "category": callbacks.CategoryEnum.other,
+            },
+            "transcript_segments": [
+                {"is_user": True, "text": "I ordered a waffle with oat milk after our morning walk."}
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "build_summary_version_update",
+        lambda conversation, **kwargs: {
+            "summary_versions": [
+                {
+                    "id": "parallel-v2",
+                    "title": kwargs["next_structured"]["title"],
+                    "overview": kwargs["next_structured"]["overview"],
+                    "source": kwargs["source"],
+                    "kind": kwargs["kind"],
+                }
+            ],
+            "active_summary_version_id": "parallel-v2",
+            "new_summary_version_id": "parallel-v2",
+        },
+    )
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "update_conversation",
+        lambda uid, conversation_id, update_data: captured.setdefault("update_data", update_data),
+    )
+
+    def write_canonical(uid, conversation, **kwargs):
+        captured["canonical_conversation"] = conversation
+        return {"ok": True}
+
+    monkeypatch.setattr(callbacks, "write_omi_canonical_event", write_canonical)
+    return captured
+
+
+def test_parallel_enrichment_binds_independent_grounding_to_canonical_version(monkeypatch):
+    captured = _configure_parallel_grounding_write(monkeypatch)
+
+    result = asyncio.run(
+        callbacks.update_conversation_summary(
+            "cafe-123",
+            callbacks.ConversationSummaryUpdate(
+                title="Cafe Coffee and Waffle Stop",
+                overview="[Ella] You ordered a waffle with oat milk after your morning walk.",
+                summary_source="hermes_parallel",
+                summary_kind="hermes_enriched",
+                trace_id="parallel-grounding:cafe-123",
+                require_canonical=True,
+                today_card_grounding_evidence=_parallel_grounding_evidence(),
+            ),
+            uid="user-123",
+            service=_service_authority("user-123"),
+        )
+    )
+
+    receipt = captured["update_data"]["enrichment_state"]["today_card_grounding"]
+    assert result["canonical_confirmed"] is True
+    assert receipt["source_version_id"] == "parallel-v2"
+    assert receipt["attester"] == "hermes_parallel_grounding_verifier"
+    assert receipt["summary_request_id"] == "summary-request-1"
+    assert receipt["verifier_request_id"] == "verifier-request-1"
+    assert receipt["supporting_quote_hashes"][0].startswith("sha256:")
+    assert "supporting_quotes" not in receipt
+    canonical_receipt = captured["canonical_conversation"]["enrichment_state"]["today_card_grounding"]
+    assert canonical_receipt == receipt
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected"),
+    [
+        ("quote", "today_card_grounding_quote_not_in_transcript"),
+        ("identity", "today_card_grounding_identity_invalid"),
+        ("scope", "today_card_grounding_evidence_scope_invalid"),
+    ],
+)
+def test_parallel_grounding_evidence_fails_closed(monkeypatch, mutation, expected):
+    captured = _configure_parallel_grounding_write(monkeypatch)
+    evidence = _parallel_grounding_evidence()
+    summary_source = "hermes_parallel"
+    if mutation == "quote":
+        evidence["supporting_quotes"] = ["This statement never appeared in the transcript."]
+    elif mutation == "identity":
+        evidence["verifier_request_id"] = evidence["summary_request_id"]
+        evidence["verifier_response_id"] = evidence["summary_response_id"]
+    elif mutation == "scope":
+        summary_source = "observer"
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(
+            callbacks.update_conversation_summary(
+                "cafe-123",
+                callbacks.ConversationSummaryUpdate(
+                    title="Cafe Coffee and Waffle Stop",
+                    overview="[Ella] You ordered a waffle with oat milk after your morning walk.",
+                    summary_source=summary_source,
+                    summary_kind="hermes_enriched",
+                    trace_id="parallel-grounding:cafe-123",
+                    require_canonical=True,
+                    today_card_grounding_evidence=evidence,
+                ),
+                uid="user-123",
+                service=_service_authority("user-123"),
+            )
+        )
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail == expected
+    assert "update_data" not in captured
+
+
+def test_parallel_grounding_evidence_rejects_unknown_fields_at_schema_boundary():
+    evidence = _parallel_grounding_evidence()
+    evidence["untrusted"] = True
+
+    with pytest.raises(ValidationError):
+        callbacks.ConversationSummaryUpdate(
+            title="Cafe",
+            overview="[Ella] A grounded cafe memory with enough detail.",
+            summary_source="hermes_parallel",
+            summary_kind="hermes_enriched",
+            require_canonical=True,
+            today_card_grounding_evidence=evidence,
+        )
+
+
+def test_parallel_prebuilt_grounding_receipt_cannot_bypass_quote_binding(monkeypatch):
+    captured = _configure_parallel_grounding_write(monkeypatch)
+
+    with pytest.raises(ValueError, match="today_card_grounding_attestation_invalid"):
+        asyncio.run(
+            callbacks.write_conversation_summary(
+                uid="user-123",
+                conversation_id="cafe-123",
+                title="Cafe Coffee and Waffle Stop",
+                overview="[Ella] You ordered a waffle with oat milk after your morning walk.",
+                summary_source="hermes_parallel",
+                summary_kind="hermes_enriched",
+                require_canonical=True,
+                today_card_grounding={"attester": "hermes_parallel_grounding_verifier"},
+            )
+        )
+
+    assert "update_data" not in captured
 
 
 def test_update_conversation_summary_same_trace_is_idempotent(monkeypatch):

--- a/backend/tests/unit/test_ella_callbacks_summary_update.py
+++ b/backend/tests/unit/test_ella_callbacks_summary_update.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from fastapi import HTTPException
 from pydantic import ValidationError
+from utils.ella.canonical_omi import transcript_grounding_hash
 
 sys.modules.setdefault("database._client", MagicMock())
 sys.modules.setdefault("database.conversations", MagicMock())
@@ -233,9 +234,30 @@ def test_get_conversation_data_returns_transcript_payload(monkeypatch):
     assert result["segment_count"] == 2
     assert result["transcript"] == "User: Can you reprocess this?\n\nOther: Yes, with the full transcript."
     assert result["transcript_segments"] == [
-        {"id": "7", "text": "Can you reprocess this?", "speaker": "User", "is_user": True},
-        {"id": None, "text": "Yes, with the full transcript.", "speaker": "Other", "is_user": False},
+        {
+            "id": "7",
+            "text": "Can you reprocess this?",
+            "speaker": None,
+            "speaker_id": None,
+            "is_user": True,
+            "person_id": None,
+            "start": None,
+            "end": None,
+            "timestamp": None,
+        },
+        {
+            "id": None,
+            "text": "Yes, with the full transcript.",
+            "speaker": "Other",
+            "speaker_id": None,
+            "is_user": False,
+            "person_id": None,
+            "start": None,
+            "end": None,
+            "timestamp": None,
+        },
     ]
+    assert result["transcript_hash"] == transcript_grounding_hash(result["transcript_segments"])
     assert result["structured"]["title"] == "Original title"
     assert result["structured"]["overview"] == "Original overview"
     assert result["structured"]["emoji"] == "🧠"
@@ -553,11 +575,13 @@ def test_update_conversation_summary_writes_enriched_omi_to_canonical(monkeypatc
 
 
 def _parallel_grounding_evidence():
+    transcript_segments = [{"is_user": True, "text": "I ordered a waffle with oat milk after our morning walk."}]
     return {
         "attester": "hermes_parallel_grounding_verifier",
         "semantic_outcome": "supported",
         "supporting_quotes": ["I ordered a waffle with oat milk after our morning walk."],
         "policy_version": "hermes-parallel-grounding-verifier-v1",
+        "transcript_hash": transcript_grounding_hash(transcript_segments),
         "summary_request_id": "summary-request-1",
         "summary_response_id": "summary-response-1",
         "verifier_request_id": "verifier-request-1",
@@ -599,6 +623,15 @@ def _configure_parallel_grounding_write(monkeypatch):
             "active_summary_version_id": "parallel-v2",
             "new_summary_version_id": "parallel-v2",
         },
+    )
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "update_conversation_if_transcript_hash",
+        lambda uid, conversation_id, expected_hash, update_data, **kwargs: (
+            captured.setdefault("cas_expected_hash", expected_hash),
+            captured.setdefault("update_data", update_data),
+            True,
+        )[-1],
     )
     monkeypatch.setattr(
         callbacks.conversations_db,
@@ -651,6 +684,7 @@ def test_parallel_enrichment_binds_independent_grounding_to_canonical_version(mo
     [
         ("quote", "today_card_grounding_quote_not_in_transcript"),
         ("identity", "today_card_grounding_identity_invalid"),
+        ("transcript", "today_card_grounding_transcript_changed"),
         ("scope", "today_card_grounding_evidence_scope_invalid"),
     ],
 )
@@ -663,6 +697,8 @@ def test_parallel_grounding_evidence_fails_closed(monkeypatch, mutation, expecte
     elif mutation == "identity":
         evidence["verifier_request_id"] = evidence["summary_request_id"]
         evidence["verifier_response_id"] = evidence["summary_response_id"]
+    elif mutation == "transcript":
+        evidence["transcript_hash"] = "sha256:" + ("f" * 64)
     elif mutation == "scope":
         summary_source = "observer"
 
@@ -687,6 +723,86 @@ def test_parallel_grounding_evidence_fails_closed(monkeypatch, mutation, expecte
     assert excinfo.value.status_code == 400
     assert excinfo.value.detail == expected
     assert "update_data" not in captured
+
+
+def test_parallel_grounding_transcript_compare_and_set_loses_race_without_publication(monkeypatch):
+    captured = _configure_parallel_grounding_write(monkeypatch)
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "update_conversation_if_transcript_hash",
+        lambda *args, **kwargs: False,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(
+            callbacks.update_conversation_summary(
+                "cafe-123",
+                callbacks.ConversationSummaryUpdate(
+                    title="Cafe Coffee and Waffle Stop",
+                    overview="[Ella] You ordered a waffle with oat milk after your morning walk.",
+                    summary_source="hermes_parallel",
+                    summary_kind="hermes_enriched",
+                    trace_id="parallel-grounding:cafe-123",
+                    require_canonical=True,
+                    today_card_grounding_evidence=_parallel_grounding_evidence(),
+                ),
+                uid="user-123",
+                service=_service_authority("user-123"),
+            )
+        )
+
+    assert excinfo.value.status_code == 409
+    assert excinfo.value.detail == "transcript_changed"
+    assert "canonical_conversation" not in captured
+
+
+def test_parallel_pending_canonical_replay_rejects_transcript_drift_without_publication(monkeypatch):
+    captured = _configure_parallel_grounding_write(monkeypatch)
+    original_hash = _parallel_grounding_evidence()["transcript_hash"]
+    monkeypatch.setattr(
+        callbacks.conversations_db,
+        "get_conversation",
+        lambda uid, conversation_id: {
+            "id": conversation_id,
+            "structured": {
+                "title": "Cafe Coffee and Waffle Stop",
+                "overview": "[Ella] You ordered a waffle with oat milk after your morning walk.",
+                "emoji": "☕",
+                "category": callbacks.CategoryEnum.other,
+            },
+            "transcript_segments": [
+                {"is_user": True, "text": "The transcript was replaced after summary publication."}
+            ],
+            "enrichment_state": {
+                "status": "writeback_pending_canonical",
+                "canonical_status": "pending",
+                "trace_id": "parallel-grounding:cafe-123",
+                "today_card_grounding": {"transcript_hash": original_hash},
+            },
+        },
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(
+            callbacks.update_conversation_summary(
+                "cafe-123",
+                callbacks.ConversationSummaryUpdate(
+                    title="Cafe Coffee and Waffle Stop",
+                    overview="[Ella] You ordered a waffle with oat milk after your morning walk.",
+                    summary_source="hermes_parallel",
+                    summary_kind="hermes_enriched",
+                    trace_id="parallel-grounding:cafe-123",
+                    require_canonical=True,
+                    today_card_grounding_evidence=_parallel_grounding_evidence(),
+                ),
+                uid="user-123",
+                service=_service_authority("user-123"),
+            )
+        )
+
+    assert excinfo.value.status_code == 409
+    assert excinfo.value.detail == "transcript_changed"
+    assert "canonical_conversation" not in captured
 
 
 def test_parallel_grounding_evidence_rejects_unknown_fields_at_schema_boundary():

--- a/backend/tests/unit/test_ella_canonical_omi.py
+++ b/backend/tests/unit/test_ella_canonical_omi.py
@@ -30,6 +30,28 @@ def _semantic_receipt(conversation, source_version_id, uid="uid-123"):
     }
 
 
+def _parallel_semantic_receipt(conversation, source_version_id, uid="uid-123"):
+    receipt = _semantic_receipt(conversation, source_version_id, uid)
+    for key in (
+        "runtime_interaction_id",
+        "canonical_assistant_event_id",
+        "verifier_runtime_interaction_id",
+        "verifier_canonical_assistant_event_id",
+    ):
+        receipt.pop(key)
+    receipt.update(
+        {
+            "attester": "hermes_parallel_grounding_verifier",
+            "policy_version": "hermes-parallel-grounding-verifier-v1",
+            "summary_request_id": "summary-request-a",
+            "summary_response_id": "summary-response-a",
+            "verifier_request_id": "verifier-request-a",
+            "verifier_response_id": "verifier-response-a",
+        }
+    )
+    return receipt
+
+
 def test_build_omi_canonical_event_preserves_enriched_summary_and_transcript():
     conversation = {
         "id": "cafe-123",
@@ -122,6 +144,84 @@ def test_build_omi_canonical_event_emits_bound_semantic_grounding_provenance():
     assert english_grounding["transcript_hash"] == transcript_grounding_hash(
         english_event["metadata"]["transcript_segments"]
     )
+
+
+def test_build_omi_canonical_event_preserves_parallel_verifier_receipt():
+    conversation = {
+        "id": "grounded-parallel",
+        "started_at": datetime(2026, 5, 7, 18, 56, 59, tzinfo=timezone.utc),
+        "structured": {"title": "A grounded visit", "overview": "A meaningful visit in the garden."},
+        "active_summary_version_id": "parallel-v1",
+        "summary_versions": [
+            {
+                "id": "parallel-v1",
+                "title": "A grounded visit",
+                "overview": "A meaningful visit in the garden.",
+                "source": "hermes_parallel",
+                "kind": "hermes_enriched",
+            }
+        ],
+        "transcript_segments": [{"text": "We planted tomatoes together in the garden after lunch."}],
+    }
+    conversation["enrichment_state"] = {"today_card_grounding": _parallel_semantic_receipt(conversation, "parallel-v1")}
+
+    event = build_omi_canonical_event("uid-123", conversation)
+
+    grounding = event["metadata"]["today_card"]["grounding"]
+    assert grounding["attester"] == "hermes_parallel_grounding_verifier"
+    assert grounding["source_version_id"] == "parallel-v1"
+    assert grounding["verifier_request_id"] == "verifier-request-a"
+
+
+def test_build_omi_canonical_event_rejects_reused_parallel_verifier_identity():
+    conversation = {
+        "id": "grounded-parallel-reused",
+        "structured": {"title": "Garden visit", "overview": "We planted tomatoes in the garden."},
+        "active_summary_version_id": "parallel-v1",
+        "summary_versions": [
+            {
+                "id": "parallel-v1",
+                "title": "Garden visit",
+                "overview": "We planted tomatoes in the garden.",
+                "source": "hermes_parallel",
+                "kind": "hermes_enriched",
+            }
+        ],
+        "transcript_segments": [{"text": "We planted tomatoes in the garden after lunch."}],
+    }
+    receipt = _parallel_semantic_receipt(conversation, "parallel-v1")
+    receipt["verifier_request_id"] = receipt["summary_request_id"]
+    receipt["verifier_response_id"] = receipt["summary_response_id"]
+    conversation["enrichment_state"] = {"today_card_grounding": receipt}
+
+    event = build_omi_canonical_event("uid-123", conversation)
+
+    assert event["metadata"]["today_card"]["grounding"] == {}
+
+
+def test_build_omi_canonical_event_rejects_any_cross_call_identity_reuse():
+    conversation = {
+        "id": "grounded-parallel-cross-reuse",
+        "structured": {"title": "Garden visit", "overview": "We planted tomatoes in the garden."},
+        "active_summary_version_id": "parallel-v1",
+        "summary_versions": [
+            {
+                "id": "parallel-v1",
+                "title": "Garden visit",
+                "overview": "We planted tomatoes in the garden.",
+                "source": "hermes_parallel",
+                "kind": "hermes_enriched",
+            }
+        ],
+        "transcript_segments": [{"text": "We planted tomatoes in the garden after lunch."}],
+    }
+    receipt = _parallel_semantic_receipt(conversation, "parallel-v1")
+    receipt["verifier_request_id"] = receipt["summary_response_id"]
+    conversation["enrichment_state"] = {"today_card_grounding": receipt}
+
+    event = build_omi_canonical_event("uid-123", conversation)
+
+    assert event["metadata"]["today_card"]["grounding"] == {}
 
 
 def test_build_omi_canonical_event_rejects_forged_or_stale_semantic_grounding():

--- a/backend/tests/unit/test_ella_canonical_omi.py
+++ b/backend/tests/unit/test_ella_canonical_omi.py
@@ -52,6 +52,13 @@ def _parallel_semantic_receipt(conversation, source_version_id, uid="uid-123"):
     return receipt
 
 
+def test_transcript_grounding_hash_matches_parallel_runtime_contract():
+    assert (
+        transcript_grounding_hash([{"text": "I ordered a waffle with oat milk after our morning walk."}])
+        == "sha256:504ea992fe2ddf25098ea54cc133e1bcaccd2e3cf65af79d3b9fab879b916c96"
+    )
+
+
 def test_build_omi_canonical_event_preserves_enriched_summary_and_transcript():
     conversation = {
         "id": "cafe-123",

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -1721,6 +1721,9 @@ if module_name == "ella.routers.callbacks":
     fake_sanitizer.SummarySanitizationError = type("SummarySanitizationError", (Exception,), {})
     sys.modules["ella.services.summary_sanitizer"] = fake_sanitizer
     fake_writeback = types.ModuleType("ella.services.summary_writeback")
+    fake_writeback.ConcurrentConversationSummaryChangeError = type(
+        "ConcurrentConversationSummaryChangeError", (Exception,), {}
+    )
     fake_writeback.ConversationSummaryNotFoundError = type("ConversationSummaryNotFoundError", (Exception,), {})
     fake_writeback.InvalidConversationSummaryCategoryError = type(
         "InvalidConversationSummaryCategoryError", (Exception,), {}
@@ -1739,6 +1742,7 @@ if module_name == "ella.routers.callbacks":
         "attester": "hermes_cloud_grounding_verifier",
         "policy_version": "hermes-cloud-grounding-verifier-v1",
     }
+    fake_canonical_omi.canonical_transcript_segments = lambda value: value
     fake_canonical_omi.transcript_grounding_hash = lambda _value: "sha256:" + ("0" * 64)
     fake_canonical_omi.write_omi_canonical_event = lambda *args, **kwargs: None
     sys.modules["utils.ella.canonical_omi"] = fake_canonical_omi

--- a/backend/tests/unit/test_ella_provisioning_service.py
+++ b/backend/tests/unit/test_ella_provisioning_service.py
@@ -1734,6 +1734,11 @@ if module_name == "ella.routers.callbacks":
     fake_canonical_omi.TODAY_CARD_GROUNDING_ATTESTER = "hermes_cloud_grounding_verifier"
     fake_canonical_omi.TODAY_CARD_GROUNDING_CONTRACT_VERSION = "ella.today_card.semantic-grounding.v1"
     fake_canonical_omi.summary_grounding_hash = lambda _value: "sha256:" + ("0" * 64)
+    fake_canonical_omi.today_card_grounding_identity_is_valid = lambda *_args, **_kwargs: True
+    fake_canonical_omi.today_card_grounding_profile = lambda _source: {
+        "attester": "hermes_cloud_grounding_verifier",
+        "policy_version": "hermes-cloud-grounding-verifier-v1",
+    }
     fake_canonical_omi.transcript_grounding_hash = lambda _value: "sha256:" + ("0" * 64)
     fake_canonical_omi.write_omi_canonical_event = lambda *args, **kwargs: None
     sys.modules["utils.ella.canonical_omi"] = fake_canonical_omi

--- a/backend/tests/unit/test_hermes_cloud_openapi.py
+++ b/backend/tests/unit/test_hermes_cloud_openapi.py
@@ -83,6 +83,7 @@ def test_openapi_documents_exact_parallel_grounding_callback_contract():
         "semantic_outcome",
         "supporting_quotes",
         "policy_version",
+        "transcript_hash",
         "summary_request_id",
         "summary_response_id",
         "verifier_request_id",
@@ -90,6 +91,11 @@ def test_openapi_documents_exact_parallel_grounding_callback_contract():
     }
     assert evidence["properties"]["attester"]["const"] == "hermes_parallel_grounding_verifier"
     assert evidence["properties"]["supporting_quotes"]["maxItems"] == 3
+    assert evidence["properties"]["transcript_hash"]["pattern"] == "^sha256:[0-9a-f]{64}$"
+
+    conversation_data = contract["components"]["schemas"]["ConversationData"]
+    assert "transcript_hash" in conversation_data["required"]
+    assert conversation_data["properties"]["transcript_hash"]["pattern"] == "^sha256:[0-9a-f]{64}$"
 
 
 def test_openapi_processor_disclosure_uses_only_exact_v8_processor_ids():

--- a/backend/tests/unit/test_hermes_cloud_openapi.py
+++ b/backend/tests/unit/test_hermes_cloud_openapi.py
@@ -26,7 +26,6 @@ def test_openapi_covers_every_reviewed_runtime_boundary_with_exact_targets():
         "/v1/voice/search": "hermes-cloud-voice",
         "/v4/listen": "hermes-cloud-transcript",
         "/v4/web/listen": "hermes-cloud-transcript",
-        "/v1/ella/conversation/{conversation_id}/summary": "hermes-cloud-transcript",
         "/v1/conversations/{conversation_id}/processing-retries": "hermes-cloud-transcript",
         "/v1/ella/observer/run": "hermes-cloud-guardian",
         "/v1/ella/guardian/next-audio": "hermes-cloud-guardian",
@@ -39,6 +38,58 @@ def test_openapi_covers_every_reviewed_runtime_boundary_with_exact_targets():
     invitation = paths["/v1/invite/redeem"]["post"]["x-ella-runtime-target"]
     assert tuple(invitation["publishes-modes"]) == CLOUD_RUNTIME_TARGET_MODES
     assert invitation["fallback"] == "none"
+
+
+def test_openapi_documents_exact_parallel_grounding_callback_contract():
+    contract = yaml.safe_load(
+        (Path(__file__).resolve().parents[2] / "ella" / "docs" / "hermes-cloud-runtime-targets.openapi.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    paths = contract["paths"]
+    summary = paths["/v1/ella/conversation/{conversation_id}/summary"]["patch"]
+    data = paths["/v1/ella/conversation/{conversation_id}/data"]["get"]
+
+    required_authority = [{"callbackServiceKey": [], "callbackSubjectUid": []}]
+    assert summary["security"] == required_authority
+    assert data["security"] == required_authority
+    assert data["x-ella-authoritative-grounding-input"] is True
+    assert (
+        data["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
+        == "#/components/schemas/ConversationData"
+    )
+
+    profiles = summary["x-ella-runtime-target"]
+    assert profiles["fallback"] == "none"
+    assert profiles["profiles"] == {
+        "hermes_cloud": {
+            "mode": "hermes-cloud-transcript",
+            "summary-source": "hermes_cloud",
+            "attester": "hermes_cloud_grounding_verifier",
+            "policy-version": "hermes-cloud-grounding-verifier-v1",
+        },
+        "hermes_parallel": {
+            "mode": "retained-hermes-enrichment",
+            "summary-source": "hermes_parallel",
+            "attester": "hermes_parallel_grounding_verifier",
+            "policy-version": "hermes-parallel-grounding-verifier-v1",
+        },
+    }
+
+    evidence = contract["components"]["schemas"]["ParallelTodayCardGroundingEvidence"]
+    assert evidence["additionalProperties"] is False
+    assert set(evidence["required"]) == {
+        "attester",
+        "semantic_outcome",
+        "supporting_quotes",
+        "policy_version",
+        "summary_request_id",
+        "summary_response_id",
+        "verifier_request_id",
+        "verifier_response_id",
+    }
+    assert evidence["properties"]["attester"]["const"] == "hermes_parallel_grounding_verifier"
+    assert evidence["properties"]["supporting_quotes"]["maxItems"] == 3
 
 
 def test_openapi_processor_disclosure_uses_only_exact_v8_processor_ids():

--- a/backend/tests/unit/test_today_card_postgres.py
+++ b/backend/tests/unit/test_today_card_postgres.py
@@ -72,6 +72,33 @@ def _attest_row(row):
     return row
 
 
+def _attest_parallel_row(row):
+    _attest_row(row)
+    source_version_id = row["source_ref"]["active_summary_version_id"]
+    active_version = row["metadata"]["summary_versions"][0]
+    active_version["source"] = "hermes_parallel"
+    grounding = row["metadata"]["today_card"]["grounding"]
+    for key in (
+        "runtime_interaction_id",
+        "canonical_assistant_event_id",
+        "verifier_runtime_interaction_id",
+        "verifier_canonical_assistant_event_id",
+    ):
+        grounding.pop(key)
+    grounding.update(
+        {
+            "attester": "hermes_parallel_grounding_verifier",
+            "policy_version": "hermes-parallel-grounding-verifier-v1",
+            "source_version_id": source_version_id,
+            "summary_request_id": "summary-request-a",
+            "summary_response_id": "summary-response-a",
+            "verifier_request_id": "verifier-request-a",
+            "verifier_response_id": "verifier-response-a",
+        }
+    )
+    return row
+
+
 def _summary_row(version="summary-v2", *, privacy_scope="user_private", scan_policy="none", grounded=True):
     row = {
         "uid": "uid-a",
@@ -94,6 +121,37 @@ def _summary_row(version="summary-v2", *, privacy_scope="user_private", scan_pol
         },
     }
     return _attest_row(row) if grounded else row
+
+
+def test_parallel_verifier_receipt_is_eligible_today_card_evidence():
+    row = _attest_parallel_row(_summary_row(grounded=False))
+
+    evidence = today_card_postgres._evidence_from_row(
+        row,
+        previous_day_start=datetime(2026, 7, 31, tzinfo=timezone.utc),
+        previous_day_end=datetime(2026, 8, 1, tzinfo=timezone.utc),
+    )
+
+    assert evidence is not None
+    assert evidence.meaningful is True
+    assert today_card_postgres.evidence_is_safe(evidence) is True
+
+
+def test_parallel_receipt_with_reused_verifier_identity_fails_closed():
+    row = _attest_parallel_row(_summary_row(grounded=False))
+    grounding = row["metadata"]["today_card"]["grounding"]
+    grounding["verifier_request_id"] = grounding["summary_request_id"]
+    grounding["verifier_response_id"] = grounding["summary_response_id"]
+
+    evidence = today_card_postgres._evidence_from_row(
+        row,
+        previous_day_start=datetime(2026, 7, 31, tzinfo=timezone.utc),
+        previous_day_end=datetime(2026, 8, 1, tzinfo=timezone.utc),
+    )
+
+    assert evidence is not None
+    assert evidence.meaningful is False
+    assert today_card_postgres.evidence_is_safe(evidence) is False
 
 
 def _card(version="summary-v2"):

--- a/backend/utils/ella/canonical_omi.py
+++ b/backend/utils/ella/canonical_omi.py
@@ -123,12 +123,13 @@ def _segment_dict(segment: Any) -> dict[str, Any]:
     data = _model_to_dict(segment)
     if not data and isinstance(segment, dict):
         data = dict(segment)
+    segment_id = data.get("id")
     return {
-        "id": data.get("id"),
+        "id": str(segment_id) if segment_id is not None else None,
         "text": data.get("text") or "",
         "speaker": data.get("speaker"),
         "speaker_id": data.get("speaker_id"),
-        "is_user": data.get("is_user"),
+        "is_user": bool(data.get("is_user")),
         "person_id": data.get("person_id"),
         "start": data.get("start"),
         "end": data.get("end"),
@@ -138,11 +139,15 @@ def _segment_dict(segment: Any) -> dict[str, Any]:
 
 def _transcript_segments(conversation: Any) -> list[dict[str, Any]]:
     segments = _object_get(conversation, "transcript_segments") or []
-    return [_segment_dict(segment) for segment in segments]
+    return canonical_transcript_segments(segments)
+
+
+def canonical_transcript_segments(transcript_segments: list[Any]) -> list[dict[str, Any]]:
+    return [_json_safe(_segment_dict(segment)) for segment in transcript_segments]
 
 
 def transcript_grounding_hash(transcript_segments: list[dict[str, Any]]) -> str:
-    normalized_segments = [_json_safe(_segment_dict(segment)) for segment in transcript_segments]
+    normalized_segments = canonical_transcript_segments(transcript_segments)
     source = json.dumps(
         normalized_segments,
         ensure_ascii=False,

--- a/backend/utils/ella/canonical_omi.py
+++ b/backend/utils/ella/canonical_omi.py
@@ -17,6 +17,45 @@ CANONICAL_OMI_WRITE_ENABLED = os.getenv("ELLA_CANONICAL_OMI_WRITE_ENABLED", "tru
 CANONICAL_OMI_TIMEOUT = float(os.getenv("ELLA_CANONICAL_OMI_TIMEOUT", "5"))
 TODAY_CARD_GROUNDING_CONTRACT_VERSION = "ella.today_card.semantic-grounding.v1"
 TODAY_CARD_GROUNDING_ATTESTER = "hermes_cloud_grounding_verifier"
+TODAY_CARD_PARALLEL_GROUNDING_ATTESTER = "hermes_parallel_grounding_verifier"
+TODAY_CARD_GROUNDING_PROFILES = {
+    "hermes_cloud": {
+        "attester": TODAY_CARD_GROUNDING_ATTESTER,
+        "policy_version": "hermes-cloud-grounding-verifier-v1",
+        "identity_fields": (
+            "runtime_interaction_id",
+            "canonical_assistant_event_id",
+            "verifier_runtime_interaction_id",
+            "verifier_canonical_assistant_event_id",
+        ),
+    },
+    "hermes_parallel": {
+        "attester": TODAY_CARD_PARALLEL_GROUNDING_ATTESTER,
+        "policy_version": "hermes-parallel-grounding-verifier-v1",
+        "identity_fields": (
+            "summary_request_id",
+            "summary_response_id",
+            "verifier_request_id",
+            "verifier_response_id",
+        ),
+    },
+}
+
+
+def today_card_grounding_profile(summary_source: Any) -> Optional[dict[str, Any]]:
+    profile = TODAY_CARD_GROUNDING_PROFILES.get(str(summary_source or ""))
+    return dict(profile) if profile else None
+
+
+def today_card_grounding_identity_is_valid(receipt: dict[str, Any], summary_source: Any) -> bool:
+    profile = today_card_grounding_profile(summary_source)
+    if profile is None:
+        return False
+    fields = profile["identity_fields"]
+    values = [str(receipt.get(field) or "").strip() for field in fields]
+    if any(not value for value in values):
+        return False
+    return len(set(values)) == len(values)
 
 
 def _enum_value(value: Any) -> Any:
@@ -147,11 +186,12 @@ def _today_card_grounding(
     if len(matching_versions) != 1:
         return {}
     active_version = matching_versions[0]
+    grounding_profile = today_card_grounding_profile(active_version.get("source"))
     if (
         str(active_version.get("title") or "").strip() != str(structured.get("title") or "").strip()
         or str(active_version.get("overview") or "").strip() != str(structured.get("overview") or "").strip()
-        or active_version.get("source") != "hermes_cloud"
         or active_version.get("kind") != "hermes_enriched"
+        or grounding_profile is None
     ):
         return {}
     expected_transcript_hash = transcript_grounding_hash(transcript_segments)
@@ -170,7 +210,7 @@ def _today_card_grounding(
         return {}
     if not (
         receipt.get("contract_version") == TODAY_CARD_GROUNDING_CONTRACT_VERSION
-        and receipt.get("attester") == TODAY_CARD_GROUNDING_ATTESTER
+        and receipt.get("attester") == grounding_profile["attester"]
         and receipt.get("semantic_outcome") == "supported"
         and receipt.get("source_version_id") == source_version_id
         and receipt.get("transcript_hash") == expected_transcript_hash
@@ -178,11 +218,8 @@ def _today_card_grounding(
         and receipt.get("owner_hash") == "sha256:" + hashlib.sha256(uid.encode("utf-8")).hexdigest()
         and receipt.get("conversation_id_hash")
         == "sha256:" + hashlib.sha256(str(_object_get(conversation, "id") or "").encode("utf-8")).hexdigest()
-        and bool(str(receipt.get("runtime_interaction_id") or "").strip())
-        and bool(str(receipt.get("canonical_assistant_event_id") or "").strip())
-        and bool(str(receipt.get("verifier_runtime_interaction_id") or "").strip())
-        and bool(str(receipt.get("verifier_canonical_assistant_event_id") or "").strip())
-        and receipt.get("policy_version") == "hermes-cloud-grounding-verifier-v1"
+        and today_card_grounding_identity_is_valid(receipt, active_version.get("source"))
+        and receipt.get("policy_version") == grounding_profile["policy_version"]
     ):
         return {}
     return dict(receipt)

--- a/backend/utils/encryption.py
+++ b/backend/utils/encryption.py
@@ -49,6 +49,30 @@ def encrypt(data: str, uid: str) -> str:
     return base64.b64encode(encrypted_payload).decode('utf-8')
 
 
+def decrypt_strict(encrypted_data: str, uid: str) -> str:
+    """
+    Decrypts a base64 encoded string using a user-specific key.
+
+    Unlike ``decrypt``, this helper does not log identifiers or suppress failures. Callers
+    handling protected-data admission can therefore fail closed without leaking context.
+    """
+    if not encrypted_data or not isinstance(encrypted_data, str):
+        raise ValueError('Encrypted data must be a non-empty string')
+
+    key = derive_key(uid)
+    aesgcm = AESGCM(key)
+
+    encrypted_payload = base64.b64decode(encrypted_data.encode('utf-8'), validate=True)
+
+    # Extract nonce and ciphertext
+    nonce = encrypted_payload[:12]
+    ciphertext = encrypted_payload[12:]
+
+    decrypted_bytes = aesgcm.decrypt(nonce, ciphertext, None)
+
+    return decrypted_bytes.decode('utf-8')
+
+
 def decrypt(encrypted_data: str, uid: str) -> str:
     """
     Decrypts a base64 encoded string using a user-specific key.
@@ -57,18 +81,7 @@ def decrypt(encrypted_data: str, uid: str) -> str:
         return encrypted_data
 
     try:
-        key = derive_key(uid)
-        aesgcm = AESGCM(key)
-
-        encrypted_payload = base64.b64decode(encrypted_data.encode('utf-8'))
-
-        # Extract nonce and ciphertext
-        nonce = encrypted_payload[:12]
-        ciphertext = encrypted_payload[12:]
-
-        decrypted_bytes = aesgcm.decrypt(nonce, ciphertext, None)
-
-        return decrypted_bytes.decode('utf-8')
+        return decrypt_strict(encrypted_data, uid)
     except Exception as e:
         # If decryption fails (e.g., wrong key, corrupted data), return the original encrypted data
         # to avoid data loss and to make debugging easier. In a production system, you might want


### PR DESCRIPTION
## Outcome

Admit Today Card evidence from the retained `hermes_parallel` summary path only when a separate verifier call supplies exact transcript support and the backend independently binds that evidence to the owner, conversation, active summary version, authoritative transcript, and normalized summary.

This is stacked on the exact deployed backend head from PR #390 (`1e0e9b51a133dd6a0ae40b30065461f8e3ec93f0`). It must deploy before the companion `ellaaicare/ella-ai` retained-runtime change.

## Security boundary

- requires the existing dual callback authority and exact subject UID;
- accepts one to three exact support excerpts, verifies them against the stored transcript, persists only hashes, and discards raw excerpts;
- requires four non-empty, mutually distinct summary/verifier request and response identities;
- binds transcript, summary, owner, conversation, and new summary-version hashes before canonical confirmation;
- rejects prebuilt `hermes_parallel` receipts, unknown payload fields, cross-call identity reuse, stale hashes, and non-canonical writes;
- preserves the existing `hermes_cloud` grounding contract.

## Verification at exact head `69c1de943e0ebcec49c5259c19805665b29defa1`

- repository `backend/test.sh`: green; 10 PostgreSQL cases remain environment-skipped by that harness;
- callback summary suite: 21/21;
- canonical adapter: 7/7;
- Today Card PostgreSQL unit suite: 112/112;
- internal OpenAPI contract: 3/3;
- Black with repository flags, YAML parsing, diff check, clean worktree;
- Gitleaks: one commit / 30.10 KB, no leaks.

The monolithic `backend/tests/unit` collection is not a valid repository harness: it fails with 18 import-stub/dependency collection errors on both this head and untouched base `1e0e9b51`.

No deployment, protected-store, production-data, TestFlight, or App Store state is changed by this PR.
