### PR TITLE
fix(ios): refresh phone capture authority

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -233,6 +233,28 @@ class SharedPreferencesUtil {
 
   bool get aiConsentAccepted => hasCurrentAiConsentAuthority();
 
+  /// Returns the durable receipt for the current account and bundled contract
+  /// without treating it as live data authority. Callers must still perform a
+  /// fresh server verification before any protected capture or egress.
+  String get persistedAiConsentReceiptIdForCurrentAccount {
+    if (isEllaInternalPilotEnabled &&
+        !isEllaInternalPilotLocaleSupported(getString('app_locale'))) {
+      return '';
+    }
+    final receiptId = aiConsentReceiptId;
+    final persistedGrant = getBool('aiConsentAccepted', defaultValue: false) &&
+        aiConsentContractVersion == currentAiConsentContractVersion &&
+        aiConsentProcessorSetHash == currentAiConsentProcessorSetHash &&
+        uid.isNotEmpty &&
+        receiptId.startsWith(currentAiConsentReceiptPrefix) &&
+        aiConsentReceiptUid == uid &&
+        aiConsentProfileBindingId.isNotEmpty &&
+        aiConsentScopeVersion == currentAiConsentScopeVersion &&
+        aiConsentScopeHash == currentAiConsentScopeHash &&
+        DateTime.tryParse(aiConsentServerDecidedAt) != null;
+    return persistedGrant ? receiptId : '';
+  }
+
   bool hasCurrentAiConsentAuthority({bool enforceEnglishPilotLocale = isEllaInternalPilotEnabled}) {
     if (enforceEnglishPilotLocale && !isEllaInternalPilotLocaleSupported(getString('app_locale'))) {
       return false;

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -24,6 +24,7 @@ import 'package:omi/backend/schema/transcript_segment.dart';
 import 'package:omi/ella/services/ai_consent_active_session_lease.dart';
 import 'package:omi/ella/services/ai_consent_coordinator.dart';
 import 'package:omi/ella/services/ella_account_isolation_service.dart';
+import 'package:omi/ella/services/ella_ai_consent_service.dart';
 import 'package:omi/models/custom_stt_config.dart';
 import 'package:omi/providers/calendar_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
@@ -80,6 +81,18 @@ class PhoneCaptureStartProof {
 
   Future<void> waitForAudio({Duration timeout = const Duration(seconds: 5)}) =>
       _firstAudioFrame.future.timeout(timeout);
+}
+
+@visibleForTesting
+Future<bool> ensurePhoneCaptureConsentAuthority({
+  required bool Function() hasCurrentConsent,
+  required String Function() authenticatedUid,
+  required Future<bool> Function(String uid) refreshAuthority,
+}) async {
+  if (hasCurrentConsent()) return true;
+  final uid = authenticatedUid().trim();
+  if (uid.isEmpty || !await refreshAuthority(uid)) return false;
+  return hasCurrentConsent();
 }
 
 class CaptureProvider extends ChangeNotifier
@@ -1069,8 +1082,13 @@ class CaptureProvider extends ChangeNotifier
   }
 
   Future<PhoneCaptureStartResult> _streamRecording() async {
-    if (!SharedPreferencesUtil().aiConsentAccepted) return PhoneCaptureStartResult.consentUnavailable;
     final generation = _captureGeneration;
+    final consentCurrent = await ensurePhoneCaptureConsentAuthority(
+      hasCurrentConsent: () => SharedPreferencesUtil().aiConsentAccepted,
+      authenticatedUid: () => WalOwnerAuthority.authenticatedUid,
+      refreshAuthority: (uid) => EllaAiConsentService().refreshServerAuthority(uid: uid),
+    );
+    if (!consentCurrent || generation != _captureGeneration) return PhoneCaptureStartResult.consentUnavailable;
     final captureAuthority = WalOwnerAuthority.active();
     if (captureAuthority == null || !_isCaptureCurrent(generation, captureAuthority)) {
       return PhoneCaptureStartResult.cancelled;

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -87,12 +87,14 @@ class PhoneCaptureStartProof {
 Future<bool> ensurePhoneCaptureConsentAuthority({
   required bool Function() hasCurrentConsent,
   required String Function() authenticatedUid,
+  required String Function() persistedConsentReceiptId,
   required Future<bool> Function(String uid) refreshAuthority,
 }) async {
   if (hasCurrentConsent()) return true;
   final uid = authenticatedUid().trim();
-  if (uid.isEmpty || !await refreshAuthority(uid)) return false;
-  return hasCurrentConsent();
+  final priorReceiptId = persistedConsentReceiptId().trim();
+  if (uid.isEmpty || priorReceiptId.isEmpty || !await refreshAuthority(uid)) return false;
+  return hasCurrentConsent() && persistedConsentReceiptId().trim() == priorReceiptId;
 }
 
 class CaptureProvider extends ChangeNotifier
@@ -1086,6 +1088,8 @@ class CaptureProvider extends ChangeNotifier
     final consentCurrent = await ensurePhoneCaptureConsentAuthority(
       hasCurrentConsent: () => SharedPreferencesUtil().aiConsentAccepted,
       authenticatedUid: () => WalOwnerAuthority.authenticatedUid,
+      persistedConsentReceiptId: () =>
+          SharedPreferencesUtil().persistedAiConsentReceiptIdForCurrentAccount,
       refreshAuthority: (uid) => EllaAiConsentService().refreshServerAuthority(uid: uid),
     );
     if (!consentCurrent || generation != _captureGeneration) return PhoneCaptureStartResult.consentUnavailable;

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.533+811
+version: 1.0.534+812
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/test/backend/preferences_public_mode_test.dart
+++ b/app/test/backend/preferences_public_mode_test.dart
@@ -161,6 +161,7 @@ void main() {
     preferences.uid = 'uid-b';
 
     expect(preferences.aiConsentAccepted, isFalse);
+    expect(preferences.persistedAiConsentReceiptIdForCurrentAccount, isEmpty);
     expect(preferences.hasAccountBoundAiConsent('uid-b'), isFalse);
   });
 
@@ -180,6 +181,7 @@ void main() {
     await SharedPreferencesUtil.init();
 
     expect(SharedPreferencesUtil().aiConsentAccepted, isFalse);
+    expect(SharedPreferencesUtil().persistedAiConsentReceiptIdForCurrentAccount, isEmpty);
   });
 
   test('expired server verification fails closed without deleting the cached receipt', () {
@@ -200,6 +202,7 @@ void main() {
 
     expect(preferences.aiConsentAccepted, isFalse);
     expect(preferences.aiConsentReceiptId, 'aicr_receipt-a');
+    expect(preferences.persistedAiConsentReceiptIdForCurrentAccount, 'aicr_receipt-a');
   });
 
   test('provider, profile, or Photon scope drift fails closed without deleting the cached receipt', () async {

--- a/app/test/providers/phone_capture_start_proof_test.dart
+++ b/app/test/providers/phone_capture_start_proof_test.dart
@@ -21,4 +21,65 @@ void main() {
     expect(proof.acceptFrame(const [1, 2, 3]), isTrue);
     await proof.waitForAudio(timeout: const Duration(milliseconds: 50));
   });
+
+  test('current consent starts without a server refresh', () async {
+    var refreshCalls = 0;
+
+    final accepted = await ensurePhoneCaptureConsentAuthority(
+      hasCurrentConsent: () => true,
+      authenticatedUid: () => 'owner',
+      refreshAuthority: (_) async {
+        refreshCalls++;
+        return true;
+      },
+    );
+
+    expect(accepted, isTrue);
+    expect(refreshCalls, 0);
+  });
+
+  test('expired consent refreshes before phone capture', () async {
+    var consentCurrent = false;
+    var refreshCalls = 0;
+
+    final accepted = await ensurePhoneCaptureConsentAuthority(
+      hasCurrentConsent: () => consentCurrent,
+      authenticatedUid: () => ' owner ',
+      refreshAuthority: (uid) async {
+        refreshCalls++;
+        expect(uid, 'owner');
+        consentCurrent = true;
+        return true;
+      },
+    );
+
+    expect(accepted, isTrue);
+    expect(refreshCalls, 1);
+  });
+
+  test('phone capture stays closed without an authenticated owner', () async {
+    var refreshCalls = 0;
+
+    final accepted = await ensurePhoneCaptureConsentAuthority(
+      hasCurrentConsent: () => false,
+      authenticatedUid: () => '   ',
+      refreshAuthority: (_) async {
+        refreshCalls++;
+        return true;
+      },
+    );
+
+    expect(accepted, isFalse);
+    expect(refreshCalls, 0);
+  });
+
+  test('refresh receipt must make local consent authority current', () async {
+    final accepted = await ensurePhoneCaptureConsentAuthority(
+      hasCurrentConsent: () => false,
+      authenticatedUid: () => 'owner',
+      refreshAuthority: (_) async => true,
+    );
+
+    expect(accepted, isFalse);
+  });
 }

--- a/app/test/providers/phone_capture_start_proof_test.dart
+++ b/app/test/providers/phone_capture_start_proof_test.dart
@@ -28,6 +28,7 @@ void main() {
     final accepted = await ensurePhoneCaptureConsentAuthority(
       hasCurrentConsent: () => true,
       authenticatedUid: () => 'owner',
+      persistedConsentReceiptId: () => '',
       refreshAuthority: (_) async {
         refreshCalls++;
         return true;
@@ -45,6 +46,7 @@ void main() {
     final accepted = await ensurePhoneCaptureConsentAuthority(
       hasCurrentConsent: () => consentCurrent,
       authenticatedUid: () => ' owner ',
+      persistedConsentReceiptId: () => 'aicr-local-receipt',
       refreshAuthority: (uid) async {
         refreshCalls++;
         expect(uid, 'owner');
@@ -63,6 +65,24 @@ void main() {
     final accepted = await ensurePhoneCaptureConsentAuthority(
       hasCurrentConsent: () => false,
       authenticatedUid: () => '   ',
+      persistedConsentReceiptId: () => 'aicr-local-receipt',
+      refreshAuthority: (_) async {
+        refreshCalls++;
+        return true;
+      },
+    );
+
+    expect(accepted, isFalse);
+    expect(refreshCalls, 0);
+  });
+
+  test('phone capture cannot reconstruct consent without a local receipt', () async {
+    var refreshCalls = 0;
+
+    final accepted = await ensurePhoneCaptureConsentAuthority(
+      hasCurrentConsent: () => false,
+      authenticatedUid: () => 'owner',
+      persistedConsentReceiptId: () => '',
       refreshAuthority: (_) async {
         refreshCalls++;
         return true;
@@ -77,7 +97,26 @@ void main() {
     final accepted = await ensurePhoneCaptureConsentAuthority(
       hasCurrentConsent: () => false,
       authenticatedUid: () => 'owner',
+      persistedConsentReceiptId: () => 'aicr-local-receipt',
       refreshAuthority: (_) async => true,
+    );
+
+    expect(accepted, isFalse);
+  });
+
+  test('server refresh cannot replace the local capture receipt', () async {
+    var consentCurrent = false;
+    var receiptId = 'aicr-local-receipt';
+
+    final accepted = await ensurePhoneCaptureConsentAuthority(
+      hasCurrentConsent: () => consentCurrent,
+      authenticatedUid: () => 'owner',
+      persistedConsentReceiptId: () => receiptId,
+      refreshAuthority: (_) async {
+        consentCurrent = true;
+        receiptId = 'aicr-different-receipt';
+        return true;
+      },
     );
 
     expect(accepted, isFalse);


### PR DESCRIPTION
## Summary

- refresh server authority before starting phone capture when the five-minute verification lease has expired
- permit that refresh only when the same account already holds a durable, current-contract local consent receipt
- reject missing identity, missing prior receipt, failed refresh, account transition, receipt replacement, and stale local authority
- advance the independently reviewable TestFlight candidate to `1.0.534+812`

## Device root cause

Build 811 reached the device with the native recorder/first-frame changes, but Home checked volatile consent authority before reaching that code. The server verification lease expires after five minutes while Home remains rendered. A later tap therefore returned the generic `Recording isn't available right now.` result before permission, websocket, WAL, or native recorder startup.

The successor snapshots the durable account-bound receipt, refreshes the server verification, and accepts the result only when current live authority and the same receipt remain present. It cannot use the general refresh service to reconstruct consent for an account without an existing local grant.

## Review correction

Independent review of the first head correctly found that the general refresh service can restore local consent from a server grant. Corrected head `890c8e1b1bb20006dc702792037254237ae69d69` adds the missing capture-specific durable-receipt precondition and exact receipt recheck.

## Verification at corrected head

- focused phone-capture + preferences authority suites: 20/20
- full Flutter package: 461/461
- changed-file analyzer: 0 issues
- `git diff --check`: clean
- gitleaks exact base-to-head diff: no leaks
- unsigned production iOS compile: success; `com.ellaaicare.ella`, `1.0.534`, build `812`

Physical-iPhone acceptance remains required. Do not merge, sign, upload, or change Apple state until independent exact-head review is green.
