### PR TITLE
feat(ella): add generated image contract foundation

### DIFF
--- a/app/lib/backend/schema/conversation.dart
+++ b/app/lib/backend/schema/conversation.dart
@@ -7,6 +7,7 @@ import 'package:collection/collection.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:omi/backend/schema/geolocation.dart';
+import 'package:omi/backend/schema/generated_image.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/backend/schema/transcript_segment.dart';
@@ -213,6 +214,7 @@ class ServerConversation {
   final List<TranscriptSegment> transcriptSegments;
   final Geolocation? geolocation;
   final List<ConversationPhoto> photos;
+  final GeneratedImageAsset? generatedImage;
   final List<AudioFile> audioFiles;
 
   final List<AppResponse> appResults;
@@ -280,6 +282,7 @@ class ServerConversation {
     this.suggestedSummarizationApps = const [],
     this.geolocation,
     this.photos = const [],
+    this.generatedImage,
     this.audioFiles = const [],
     this.discarded = false,
     this.deleted = false,
@@ -320,6 +323,7 @@ class ServerConversation {
       photos: json['photos'] != null
           ? ((json['photos'] ?? []) as List<dynamic>).map((photo) => ConversationPhoto.fromJson(photo)).toList()
           : [],
+      generatedImage: GeneratedImageAsset.tryFromJson(json['generated_image']),
       audioFiles: ((json['audio_files'] ?? []) as List<dynamic>).map((af) => AudioFile.fromJson(af)).toList(),
       discarded: json['discarded'] ?? false,
       source: json['source'] != null ? ConversationSource.values.asNameMap()[json['source']] : ConversationSource.omi,
@@ -363,6 +367,7 @@ class ServerConversation {
       'suggested_summarization_apps': suggestedSummarizationApps,
       'geolocation': geolocation?.toJson(),
       'photos': photos.map((photo) => photo.toJson()).toList(),
+      if (generatedImage != null) 'generated_image': generatedImage!.toJson(),
       'discarded': discarded,
       'deleted': deleted,
       'source': source?.toString(),

--- a/app/lib/backend/schema/generated_image.dart
+++ b/app/lib/backend/schema/generated_image.dart
@@ -1,0 +1,108 @@
+const String generatedImageAssetContractVersion = 'ella.generated_image.asset.v1';
+const String generatedImageDeliveryPrefix = '/v1/ella/generated-image-assets/';
+
+/// Canonical-confirmed reference to a privately delivered generated image.
+///
+/// Parsing is intentionally fail closed. Callers must preserve their source
+/// photo or static artwork fallback whenever this returns null.
+class GeneratedImageAsset {
+  const GeneratedImageAsset({
+    required this.assetId,
+    required this.jobId,
+    required this.receiptId,
+    required this.generation,
+    required this.mediaType,
+    required this.sha256,
+    required this.width,
+    required this.height,
+    required this.altText,
+    required this.deliveryPath,
+  });
+
+  static final RegExp _digestPattern = RegExp(r'^sha256:[0-9a-f]{64}$');
+  static const Set<String> _supportedMediaTypes = {'image/jpeg', 'image/png', 'image/webp'};
+
+  final String assetId;
+  final String jobId;
+  final String receiptId;
+  final int generation;
+  final String mediaType;
+  final String sha256;
+  final int width;
+  final int height;
+  final String altText;
+  final String deliveryPath;
+
+  static GeneratedImageAsset? tryFromJson(Object? value) {
+    if (value is! Map) return null;
+    final contractVersion = value['contract_version']?.toString().trim() ?? '';
+    final assetId = value['asset_id']?.toString().trim() ?? '';
+    final jobId = value['job_id']?.toString().trim() ?? '';
+    final receiptId = value['receipt_id']?.toString().trim() ?? '';
+    final generationValue = value['generation'];
+    final mediaType = value['media_type']?.toString().trim() ?? '';
+    final digest = value['sha256']?.toString().trim() ?? '';
+    final widthValue = value['width'];
+    final heightValue = value['height'];
+    final moderationStatus = value['moderation_status']?.toString().trim() ?? '';
+    final altText = value['alt_text']?.toString().trim() ?? '';
+    final deliveryPath = value['delivery_path']?.toString().trim() ?? '';
+    final pathIsSafe = deliveryPath == '$generatedImageDeliveryPrefix$assetId' &&
+        !deliveryPath.endsWith('/') &&
+        !deliveryPath.contains('?') &&
+        !deliveryPath.contains('#') &&
+        !deliveryPath.contains('..');
+
+    if (contractVersion != generatedImageAssetContractVersion ||
+        assetId.isEmpty ||
+        jobId.isEmpty ||
+        receiptId.isEmpty ||
+        generationValue is! num ||
+        generationValue != generationValue.toInt() ||
+        generationValue.toInt() < 1 ||
+        !_supportedMediaTypes.contains(mediaType) ||
+        !_digestPattern.hasMatch(digest) ||
+        widthValue is! num ||
+        widthValue != widthValue.toInt() ||
+        widthValue.toInt() < 1 ||
+        widthValue.toInt() > 16384 ||
+        heightValue is! num ||
+        heightValue != heightValue.toInt() ||
+        heightValue.toInt() < 1 ||
+        heightValue.toInt() > 16384 ||
+        moderationStatus != 'approved' ||
+        altText.isEmpty ||
+        altText.length > 500 ||
+        !pathIsSafe) {
+      return null;
+    }
+
+    return GeneratedImageAsset(
+      assetId: assetId,
+      jobId: jobId,
+      receiptId: receiptId,
+      generation: generationValue.toInt(),
+      mediaType: mediaType,
+      sha256: digest,
+      width: widthValue.toInt(),
+      height: heightValue.toInt(),
+      altText: altText,
+      deliveryPath: deliveryPath,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'contract_version': generatedImageAssetContractVersion,
+        'asset_id': assetId,
+        'job_id': jobId,
+        'receipt_id': receiptId,
+        'generation': generation,
+        'media_type': mediaType,
+        'sha256': sha256,
+        'width': width,
+        'height': height,
+        'moderation_status': 'approved',
+        'alt_text': altText,
+        'delivery_path': deliveryPath,
+      };
+}

--- a/app/lib/backend/schema/memory.dart
+++ b/app/lib/backend/schema/memory.dart
@@ -1,3 +1,5 @@
+import 'package:omi/backend/schema/generated_image.dart';
+
 enum MemoryCategory { system, interesting, manual }
 
 enum MemoryVisibility { private, public }
@@ -31,6 +33,7 @@ class Memory {
   bool deleted;
   MemoryVisibility visibility;
   bool isLocked;
+  final GeneratedImageAsset? generatedImage;
 
   Memory({
     required this.id,
@@ -47,6 +50,7 @@ class Memory {
     this.deleted = false,
     required this.visibility,
     this.isLocked = false,
+    this.generatedImage,
   });
 
   factory Memory.fromJson(Map<String, dynamic> json) {
@@ -67,6 +71,7 @@ class Memory {
           ? (MemoryVisibility.values.asNameMap()[json['visibility']] ?? MemoryVisibility.public)
           : MemoryVisibility.public,
       isLocked: json['is_locked'] ?? false,
+      generatedImage: GeneratedImageAsset.tryFromJson(json['generated_image']),
     );
   }
 
@@ -87,6 +92,7 @@ class Memory {
       'deleted': deleted,
       'visibility': visibility.name,
       'is_locked': isLocked,
+      if (generatedImage != null) 'generated_image': generatedImage!.toJson(),
     };
   }
 }

--- a/app/test/backend/schema/generated_image_test.dart
+++ b/app/test/backend/schema/generated_image_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/generated_image.dart';
+import 'package:omi/backend/schema/memory.dart';
+
+void main() {
+  const digest = 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+  Map<String, dynamic> assetJson() => {
+        'contract_version': generatedImageAssetContractVersion,
+        'asset_id': 'asset-fixture',
+        'job_id': 'job-fixture',
+        'receipt_id': 'receipt-fixture',
+        'generation': 3,
+        'media_type': 'image/webp',
+        'sha256': digest,
+        'width': 1024,
+        'height': 768,
+        'moderation_status': 'approved',
+        'alt_text': 'A gentle watercolor scene inspired by the memory.',
+        'delivery_path': '${generatedImageDeliveryPrefix}asset-fixture',
+      };
+
+  Map<String, dynamic> conversationJson(Object? generatedImage) => {
+        'id': 'conversation-fixture',
+        'created_at': '2026-08-10T12:00:00Z',
+        'structured': {
+          'title': 'A grounded memory',
+          'overview': 'A source-backed summary.',
+          'emoji': '',
+          'category': 'other',
+          'action_items': [],
+          'events': [],
+        },
+        'generated_image': generatedImage,
+      };
+
+  Map<String, dynamic> memoryJson(Object? generatedImage) => {
+        'id': 'memory-fixture',
+        'uid': 'owner-fixture',
+        'content': 'A source-backed memory.',
+        'category': 'interesting',
+        'created_at': '2026-08-10T12:00:00Z',
+        'updated_at': '2026-08-10T12:00:00Z',
+        'visibility': 'private',
+        'generated_image': generatedImage,
+      };
+
+  test('parses a canonical-confirmed first-party asset on both memory schemas', () {
+    final conversation = ServerConversation.fromJson(conversationJson(assetJson()));
+    final memory = Memory.fromJson(memoryJson(assetJson()));
+
+    expect(conversation.generatedImage?.assetId, 'asset-fixture');
+    expect(memory.generatedImage?.assetId, 'asset-fixture');
+    expect(conversation.toJson()['generated_image'], assetJson());
+    expect(memory.toJson()['generated_image'], assetJson());
+  });
+
+  test('falls back safely for absent, malformed, unmoderated, or externally delivered images', () {
+    final invalidAssets = <Object?>[
+      null,
+      'not-a-map',
+      {...assetJson(), 'moderation_status': 'pending'},
+      {...assetJson(), 'contract_version': 'ella.generated_image.asset.v2'},
+      {...assetJson(), 'delivery_path': 'https://provider.example/private-output.webp'},
+      {...assetJson(), 'delivery_path': '$generatedImageDeliveryPrefix../other-owner'},
+      {...assetJson(), 'delivery_path': '${generatedImageDeliveryPrefix}other-asset'},
+      {...assetJson(), 'sha256': 'sha256:short'},
+      {...assetJson(), 'generation': 1.5},
+      {...assetJson(), 'width': 1.5},
+    ];
+
+    for (final invalidAsset in invalidAssets) {
+      expect(ServerConversation.fromJson(conversationJson(invalidAsset)).generatedImage, isNull);
+      expect(Memory.fromJson(memoryJson(invalidAsset)).generatedImage, isNull);
+    }
+  });
+}

--- a/backend/ella/docs/GENERATED_MEMORY_IMAGES.md
+++ b/backend/ella/docs/GENERATED_MEMORY_IMAGES.md
@@ -1,0 +1,55 @@
+# Generated memory and Daily Note images
+
+Status: foundation only. No provider adapter, worker, upload, delivery route, or production consent policy is enabled.
+
+## Existing boundaries
+
+- Conversation enrichment runs in `ella/services/hermes_cloud_enrichment.py`. It reads the exact owner-bound conversation and authoritative transcript, creates a summary, and independently verifies that summary against transcript excerpts.
+- `ella/services/summary_writeback.py` binds the transcript hash, summary hash, owner hash, conversation hash, request identities, and new active summary version before the conversation becomes canonical. Stale transcript or summary-version writes fail closed.
+- `ella/services/today_card_postgres.py` admits only active, grounded summary versions into `ella.today_card.v1`. The materializer stores source refs, evidence hash, and source watermark; reads re-check that those refs are still current.
+- The mobile memory journal renders `ServerConversation` records. Its release-line media order is an existing source photo first and app-owned static watercolor artwork otherwise. Generated imagery must remain below source photos in that order.
+- Daily Note presentation is the `TodayCardPresentation` JSON object. The app already treats absent presentation details as normal, so `background_image` is additive.
+- Existing AI consent is processor-set, scope, profile-binding, and authority-generation bound. Its current processor inventory does not authorize an image processor. It must not be reused as implicit image-generation consent.
+- Canonical conversation writeback and Today Card persistence are the factual authorities. Provider responses, private storage objects, and UI caches are not canonical receipts.
+
+## Additive contract
+
+`models/generated_image.py` defines the only asset reference that app-facing memory or Today Card records may carry. It contains a first-party authenticated delivery path, never a provider URL or private storage key. It is valid only for an approved moderation result and a canonical-confirmed receipt.
+
+`ella/services/generated_images.py` defines:
+
+- an exact owner/profile/authority-generation snapshot;
+- a memory subject (conversation id plus optional fact-memory id) or Daily Note subject (Today Card id);
+- source version, source digest, grounding-receipt digest, and current generation;
+- prompt contract version and prompt digest without persisted prompt content;
+- named provider, named legal processor, and exact model;
+- image-specific consent policy, processor-set, scope, and immutable receipt reference;
+- provider generation request id, private asset id/digest, moderation result, and canonical event id;
+- job states and pure admission/start/output/canonical-confirmation transitions.
+
+Admission fails closed if consent is missing, declined, revoked, expired, future-dated, or differs in owner, binding, authority generation, provider, processor name/id, model, policy, processor set, or scope. The exact consent receipt is checked again immediately before provider egress, so a queued job cannot run after revocation or under a replacement grant. Admission and egress also fail when the grounded source snapshot or generation is no longer current. Codex image generation identifiers are explicitly rejected as production providers.
+
+The SQL ledger in migration 017 preserves those bindings independently of Firestore and Today Card JSON. A future worker must use compare-and-set updates for every state transition; the pure functions in the foundation repeat the source/generation checks immediately before provider egress, output binding, and attachment.
+
+## Intended sequence
+
+1. Enrichment or Today Card materialization produces a current grounded source receipt.
+2. The app presents a separate first-use image-sharing disclosure naming the actual image processor and offers a visible decline/not-now path.
+3. The server reads the immutable image-specific consent receipt and current owner authority. The client cannot supply authority, source text, prompt text, processor, or model.
+4. A server-side prompt builder derives a minimized creative brief from the grounded source. Only its contract version and digest are persisted.
+5. Admission and the pre-egress CAS both pass; only then may a server-side provider adapter receive the brief.
+6. Provider bytes are copied into private first-party storage, digested, discarded from memory, moderated, and assigned alt text. Provider URLs are not retained.
+7. A content-free receipt is written to the canonical ledger. A final CAS confirms the source version and generation, then attaches the approved asset reference.
+8. Memory UI continues source photo -> approved generated image -> static fallback. Daily Note continues approved background -> existing botanical/static surface. Any parse, auth, moderation, receipt, delivery, or digest failure falls back without hiding the text.
+
+## Deliberately unresolved
+
+- legal processor/provider and model;
+- the exact disclosure copy, image data categories, retention/deletion terms, and consent policy/scope versions;
+- whether generation runs in a first-party Worker or an authenticated n8n-mediated worker;
+- private object store/bucket, retention TTL, deletion propagation, and authenticated delivery route;
+- prompt-builder and moderation implementations;
+- quotas, retry policy, cost controls, and whether memory images are automatic or user-triggered;
+- release-line UI integration and visual treatment.
+
+Until those choices are approved and the image-specific consent policy is shipped, no job can obtain a valid production consent grant and no user content may leave Ella for image generation.

--- a/backend/ella/services/generated_images.py
+++ b/backend/ella/services/generated_images.py
@@ -1,0 +1,545 @@
+"""Authority-bound foundation for generated memory and Daily Note imagery.
+
+This module has no provider implementation and performs no network or storage
+I/O. It defines the admission, provider, asset, CAS, and receipt boundaries a
+future server-side worker must satisfy before any user content can leave Ella.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from models.generated_image import GENERATED_IMAGE_DELIVERY_PREFIX, GeneratedImageAssetRef
+
+GENERATED_IMAGE_JOB_CONTRACT_VERSION = "ella.generated_image.job.v1"
+GENERATED_IMAGE_RECEIPT_CONTRACT_VERSION = "ella.generated_image.receipt.v1"
+_DEVELOPMENT_ONLY_PROVIDER_IDS = {"codex", "codex-imagegen", "imagegen"}
+
+
+class GeneratedImageAdmissionError(ValueError):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+class GeneratedImageJobState(str, Enum):
+    pending_consent = "pending_consent"
+    queued = "queued"
+    generating = "generating"
+    moderating = "moderating"
+    awaiting_canonical = "awaiting_canonical"
+    ready = "ready"
+    rejected = "rejected"
+    stale = "stale"
+    failed = "failed"
+    cancelled = "cancelled"
+
+
+class GeneratedImageSubjectKind(str, Enum):
+    memory = "memory"
+    daily_note = "daily_note"
+
+
+class GeneratedImageAuthority(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    owner_uid: str = Field(min_length=1, max_length=256)
+    profile_binding_id: str = Field(min_length=1, max_length=256)
+    authority_generation: int = Field(ge=1)
+
+
+class GeneratedImageSourceSnapshot(BaseModel):
+    """Exact grounded source identity captured before prompt construction."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    authority: GeneratedImageAuthority
+    kind: GeneratedImageSubjectKind
+    subject_id: str = Field(min_length=1, max_length=256)
+    conversation_id: str | None = Field(default=None, max_length=256)
+    memory_id: str | None = Field(default=None, max_length=256)
+    today_card_id: str | None = Field(default=None, max_length=256)
+    source_version_id: str = Field(min_length=1, max_length=256)
+    source_digest: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    grounding_receipt_digest: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    generation: int = Field(ge=1)
+
+    def model_post_init(self, __context: object) -> None:
+        if self.kind == GeneratedImageSubjectKind.memory:
+            if (not self.conversation_id and not self.memory_id) or self.today_card_id:
+                raise ValueError("generated_image_memory_subject_invalid")
+        elif not self.today_card_id or self.conversation_id or self.memory_id:
+            raise ValueError("generated_image_daily_note_subject_invalid")
+
+
+class GeneratedImageConsentGrant(BaseModel):
+    """Server-read consent receipt projected into the exact egress scope."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    receipt_id: str = Field(min_length=1, max_length=128)
+    decision: Literal["granted", "declined", "revoked"]
+    subject_uid: str = Field(min_length=1, max_length=256)
+    profile_binding_id: str = Field(min_length=1, max_length=256)
+    authority_generation: int = Field(ge=1)
+    provider_id: str = Field(min_length=1, max_length=128)
+    processor_id: str = Field(min_length=1, max_length=128)
+    processor_name: str = Field(min_length=1, max_length=200)
+    model_id: str = Field(min_length=1, max_length=256)
+    policy_version: str = Field(min_length=1, max_length=128)
+    processor_set_hash: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    scope_version: str = Field(min_length=1, max_length=128)
+    scope_hash: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    decided_at: datetime
+    expires_at: datetime
+
+
+class GeneratedImageAdmissionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    source: GeneratedImageSourceSnapshot
+    prompt_contract_version: str = Field(min_length=1, max_length=128)
+    prompt_digest: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    provider_id: str = Field(min_length=1, max_length=128)
+    processor_id: str = Field(min_length=1, max_length=128)
+    processor_name: str = Field(min_length=1, max_length=200)
+    model_id: str = Field(min_length=1, max_length=256)
+    consent_policy_version: str = Field(min_length=1, max_length=128)
+    consent_processor_set_hash: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    consent_scope_version: str = Field(min_length=1, max_length=128)
+    consent_scope_hash: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+
+
+class GeneratedImageJob(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    contract_version: Literal["ella.generated_image.job.v1"] = GENERATED_IMAGE_JOB_CONTRACT_VERSION
+    job_id: str = Field(min_length=1, max_length=128)
+    source: GeneratedImageSourceSnapshot
+    prompt_contract_version: str
+    prompt_digest: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    provider_id: str
+    processor_id: str
+    processor_name: str
+    model_id: str
+    consent_receipt_ref: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    consent_policy_version: str
+    consent_processor_set_hash: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    consent_scope_version: str
+    consent_scope_hash: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    state: GeneratedImageJobState
+    provider_request_id: str | None = Field(default=None, max_length=256)
+    output_asset_id: str | None = Field(default=None, max_length=128)
+    output_asset_digest: str | None = Field(default=None, pattern=r"^sha256:[0-9a-f]{64}$")
+    moderation_status: Literal["pending", "approved", "rejected", "failed"] = "pending"
+    receipt_id: str | None = Field(default=None, max_length=128)
+    canonical_event_id: str | None = Field(default=None, max_length=256)
+    created_at: datetime
+    updated_at: datetime
+
+
+class GeneratedImageProviderRequest(BaseModel):
+    """In-memory provider request; prompt text must never be logged or stored."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    job_id: str
+    generation_request_id: str
+    provider_id: str
+    model_id: str
+    prompt: str = Field(min_length=1, max_length=8000, repr=False, exclude=True)
+
+
+class GeneratedImageProviderOutput(BaseModel):
+    """Provider output before private first-party storage and moderation."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    generation_request_id: str
+    media_type: Literal["image/jpeg", "image/png", "image/webp"]
+    content: bytes = Field(min_length=1, repr=False, exclude=True)
+    width: int = Field(ge=1, le=16384)
+    height: int = Field(ge=1, le=16384)
+
+
+class GeneratedImageProvider(Protocol):
+    """Implemented only by a future server-side, consent-gated adapter."""
+
+    provider_id: str
+    processor_id: str
+
+    async def generate(self, request: GeneratedImageProviderRequest) -> GeneratedImageProviderOutput: ...
+
+
+class GeneratedImageStoredOutput(BaseModel):
+    """Private storage result after the provider bytes have been discarded."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    asset_id: str = Field(min_length=1, max_length=128)
+    generation_request_id: str = Field(min_length=1, max_length=256)
+    storage_key: str = Field(min_length=1, max_length=1024)
+    media_type: Literal["image/jpeg", "image/png", "image/webp"]
+    sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    width: int = Field(ge=1, le=16384)
+    height: int = Field(ge=1, le=16384)
+    moderation_status: Literal["approved", "rejected", "failed"]
+    alt_text: str = Field(min_length=1, max_length=500)
+
+
+class GeneratedImageReceipt(BaseModel):
+    """Content-free receipt; attachability requires canonical confirmation."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    contract_version: Literal["ella.generated_image.receipt.v1"] = GENERATED_IMAGE_RECEIPT_CONTRACT_VERSION
+    receipt_id: str = Field(min_length=1, max_length=128)
+    job_id: str = Field(min_length=1, max_length=128)
+    source: GeneratedImageSourceSnapshot
+    prompt_contract_version: str
+    prompt_digest: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    provider_id: str
+    processor_id: str
+    processor_name: str
+    model_id: str
+    generation_request_id: str
+    output_asset_id: str
+    output_asset_digest: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    moderation_status: Literal["approved"] = "approved"
+    consent_receipt_ref: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    consent_policy_version: str
+    consent_processor_set_hash: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    consent_scope_version: str
+    consent_scope_hash: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    canonical_status: Literal["pending", "confirmed", "failed"]
+    canonical_event_id: str | None = None
+    created_at: datetime
+
+    @model_validator(mode="after")
+    def _canonical_shape(self) -> "GeneratedImageReceipt":
+        if self.canonical_status == "confirmed" and not self.canonical_event_id:
+            raise ValueError("generated_image_canonical_event_required")
+        if self.canonical_status != "confirmed" and self.canonical_event_id:
+            raise ValueError("generated_image_canonical_event_not_confirmed")
+        return self
+
+
+def sha256_digest(value: str | bytes) -> str:
+    payload = value.encode("utf-8") if isinstance(value, str) else value
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def consent_receipt_ref(owner_uid: str, receipt_id: str) -> str:
+    return sha256_digest(f"ella-generated-image-consent-v1\x1f{owner_uid}\x1f{receipt_id}")
+
+
+def _job_id(request: GeneratedImageAdmissionRequest) -> str:
+    source = request.source
+    material = "\x1f".join(
+        (
+            GENERATED_IMAGE_JOB_CONTRACT_VERSION,
+            source.authority.owner_uid,
+            source.authority.profile_binding_id,
+            str(source.authority.authority_generation),
+            source.kind.value,
+            source.subject_id,
+            source.conversation_id or "",
+            source.memory_id or "",
+            source.today_card_id or "",
+            source.source_version_id,
+            source.source_digest,
+            source.grounding_receipt_digest,
+            str(source.generation),
+            request.prompt_contract_version,
+            request.prompt_digest,
+            request.provider_id,
+            request.processor_id,
+            request.model_id,
+            request.consent_policy_version,
+            request.consent_processor_set_hash,
+            request.consent_scope_version,
+            request.consent_scope_hash,
+        )
+    )
+    return "igj_" + hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def _source_is_current(expected: GeneratedImageSourceSnapshot, current: GeneratedImageSourceSnapshot) -> bool:
+    return expected == current
+
+
+def _validate_consent(
+    *,
+    source: GeneratedImageSourceSnapshot,
+    consent: GeneratedImageConsentGrant | None,
+    provider_id: str,
+    processor_id: str,
+    processor_name: str,
+    model_id: str,
+    policy_version: str,
+    processor_set_hash: str,
+    scope_version: str,
+    scope_hash: str,
+    now: datetime,
+    expected_receipt_ref: str | None = None,
+) -> GeneratedImageConsentGrant:
+    if consent is None or consent.decision != "granted":
+        raise GeneratedImageAdmissionError("generated_image_consent_required")
+    if (
+        consent.decided_at.tzinfo is None
+        or consent.decided_at > now
+        or consent.expires_at.tzinfo is None
+        or consent.expires_at <= now
+    ):
+        raise GeneratedImageAdmissionError("generated_image_consent_expired")
+    authority = source.authority
+    if (
+        consent.subject_uid != authority.owner_uid
+        or consent.profile_binding_id != authority.profile_binding_id
+        or consent.authority_generation != authority.authority_generation
+    ):
+        raise GeneratedImageAdmissionError("generated_image_consent_authority_mismatch")
+    if (
+        consent.provider_id != provider_id
+        or consent.processor_id != processor_id
+        or consent.processor_name != processor_name
+        or consent.model_id != model_id
+        or consent.policy_version != policy_version
+        or consent.processor_set_hash != processor_set_hash
+        or consent.scope_version != scope_version
+        or consent.scope_hash != scope_hash
+    ):
+        raise GeneratedImageAdmissionError("generated_image_consent_processor_mismatch")
+    receipt_ref = consent_receipt_ref(authority.owner_uid, consent.receipt_id)
+    if expected_receipt_ref is not None and receipt_ref != expected_receipt_ref:
+        raise GeneratedImageAdmissionError("generated_image_consent_receipt_mismatch")
+    return consent
+
+
+def admit_generated_image_job(
+    request: GeneratedImageAdmissionRequest,
+    *,
+    consent: GeneratedImageConsentGrant | None,
+    current_source: GeneratedImageSourceSnapshot,
+    now: datetime | None = None,
+) -> GeneratedImageJob:
+    """Admit only an exact current source under an exact image-specific grant."""
+
+    admitted_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    if request.provider_id.casefold() in _DEVELOPMENT_ONLY_PROVIDER_IDS:
+        raise GeneratedImageAdmissionError("generated_image_development_provider_forbidden")
+    if not _source_is_current(request.source, current_source):
+        raise GeneratedImageAdmissionError("generated_image_source_stale")
+    consent = _validate_consent(
+        source=request.source,
+        consent=consent,
+        provider_id=request.provider_id,
+        processor_id=request.processor_id,
+        processor_name=request.processor_name,
+        model_id=request.model_id,
+        policy_version=request.consent_policy_version,
+        processor_set_hash=request.consent_processor_set_hash,
+        scope_version=request.consent_scope_version,
+        scope_hash=request.consent_scope_hash,
+        now=admitted_at,
+    )
+    authority = request.source.authority
+
+    return GeneratedImageJob(
+        job_id=_job_id(request),
+        source=request.source,
+        prompt_contract_version=request.prompt_contract_version,
+        prompt_digest=request.prompt_digest,
+        provider_id=request.provider_id,
+        processor_id=request.processor_id,
+        processor_name=request.processor_name,
+        model_id=request.model_id,
+        consent_receipt_ref=consent_receipt_ref(authority.owner_uid, consent.receipt_id),
+        consent_policy_version=request.consent_policy_version,
+        consent_processor_set_hash=request.consent_processor_set_hash,
+        consent_scope_version=request.consent_scope_version,
+        consent_scope_hash=request.consent_scope_hash,
+        state=GeneratedImageJobState.queued,
+        created_at=admitted_at,
+        updated_at=admitted_at,
+    )
+
+
+def start_generated_image_job(
+    job: GeneratedImageJob,
+    *,
+    consent: GeneratedImageConsentGrant | None,
+    prompt: str,
+    generation_request_id: str,
+    current_source: GeneratedImageSourceSnapshot,
+    expected_generation: int,
+    now: datetime | None = None,
+) -> tuple[GeneratedImageJob, GeneratedImageProviderRequest]:
+    if job.state != GeneratedImageJobState.queued:
+        raise GeneratedImageAdmissionError("generated_image_job_not_queued")
+    if expected_generation != job.source.generation or not _source_is_current(job.source, current_source):
+        raise GeneratedImageAdmissionError("generated_image_generation_stale")
+    updated_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    _validate_consent(
+        source=job.source,
+        consent=consent,
+        provider_id=job.provider_id,
+        processor_id=job.processor_id,
+        processor_name=job.processor_name,
+        model_id=job.model_id,
+        policy_version=job.consent_policy_version,
+        processor_set_hash=job.consent_processor_set_hash,
+        scope_version=job.consent_scope_version,
+        scope_hash=job.consent_scope_hash,
+        now=updated_at,
+        expected_receipt_ref=job.consent_receipt_ref,
+    )
+    if sha256_digest(prompt) != job.prompt_digest:
+        raise GeneratedImageAdmissionError("generated_image_prompt_digest_mismatch")
+    request_id = generation_request_id.strip()
+    if not request_id:
+        raise GeneratedImageAdmissionError("generated_image_request_id_required")
+    started = job.model_copy(
+        update={
+            "state": GeneratedImageJobState.generating,
+            "provider_request_id": request_id,
+            "updated_at": updated_at,
+        }
+    )
+    provider_request = GeneratedImageProviderRequest(
+        job_id=job.job_id,
+        generation_request_id=request_id,
+        provider_id=job.provider_id,
+        model_id=job.model_id,
+        prompt=prompt,
+    )
+    return started, provider_request
+
+
+def bind_generated_image_output(
+    job: GeneratedImageJob,
+    *,
+    output: GeneratedImageStoredOutput,
+    current_source: GeneratedImageSourceSnapshot,
+    expected_generation: int,
+    now: datetime | None = None,
+) -> tuple[GeneratedImageJob, GeneratedImageReceipt | None]:
+    if job.state not in {GeneratedImageJobState.generating, GeneratedImageJobState.moderating}:
+        raise GeneratedImageAdmissionError("generated_image_job_not_generating")
+    if expected_generation != job.source.generation or not _source_is_current(job.source, current_source):
+        raise GeneratedImageAdmissionError("generated_image_generation_stale")
+    if not job.provider_request_id or output.generation_request_id != job.provider_request_id:
+        raise GeneratedImageAdmissionError("generated_image_provider_request_mismatch")
+    updated_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    if output.moderation_status != "approved":
+        rejected = job.model_copy(
+            update={
+                "state": GeneratedImageJobState.rejected,
+                "moderation_status": output.moderation_status,
+                "updated_at": updated_at,
+            }
+        )
+        return rejected, None
+
+    receipt_id = (
+        "igir_" + hashlib.sha256(f"{job.job_id}\x1f{output.asset_id}\x1f{output.sha256}".encode("utf-8")).hexdigest()
+    )
+    pending = job.model_copy(
+        update={
+            "state": GeneratedImageJobState.awaiting_canonical,
+            "output_asset_id": output.asset_id,
+            "output_asset_digest": output.sha256,
+            "moderation_status": "approved",
+            "receipt_id": receipt_id,
+            "updated_at": updated_at,
+        }
+    )
+    receipt = GeneratedImageReceipt(
+        receipt_id=receipt_id,
+        job_id=job.job_id,
+        source=job.source,
+        prompt_contract_version=job.prompt_contract_version,
+        prompt_digest=job.prompt_digest,
+        provider_id=job.provider_id,
+        processor_id=job.processor_id,
+        processor_name=job.processor_name,
+        model_id=job.model_id,
+        generation_request_id=output.generation_request_id,
+        output_asset_id=output.asset_id,
+        output_asset_digest=output.sha256,
+        consent_receipt_ref=job.consent_receipt_ref,
+        consent_policy_version=job.consent_policy_version,
+        consent_processor_set_hash=job.consent_processor_set_hash,
+        consent_scope_version=job.consent_scope_version,
+        consent_scope_hash=job.consent_scope_hash,
+        canonical_status="pending",
+        created_at=updated_at,
+    )
+    return pending, receipt
+
+
+def confirm_generated_image_receipt(
+    job: GeneratedImageJob,
+    receipt: GeneratedImageReceipt,
+    output: GeneratedImageStoredOutput,
+    *,
+    canonical_event_id: str,
+    current_source: GeneratedImageSourceSnapshot,
+    expected_generation: int,
+    now: datetime | None = None,
+) -> tuple[GeneratedImageJob, GeneratedImageReceipt, GeneratedImageAssetRef]:
+    if job.state != GeneratedImageJobState.awaiting_canonical or receipt.canonical_status != "pending":
+        raise GeneratedImageAdmissionError("generated_image_receipt_not_pending")
+    if expected_generation != job.source.generation or not _source_is_current(job.source, current_source):
+        raise GeneratedImageAdmissionError("generated_image_generation_stale")
+    if (
+        receipt.job_id != job.job_id
+        or receipt.receipt_id != job.receipt_id
+        or receipt.source != job.source
+        or receipt.prompt_contract_version != job.prompt_contract_version
+        or receipt.prompt_digest != job.prompt_digest
+        or receipt.provider_id != job.provider_id
+        or receipt.processor_id != job.processor_id
+        or receipt.processor_name != job.processor_name
+        or receipt.model_id != job.model_id
+        or receipt.consent_receipt_ref != job.consent_receipt_ref
+        or receipt.consent_policy_version != job.consent_policy_version
+        or receipt.consent_processor_set_hash != job.consent_processor_set_hash
+        or receipt.consent_scope_version != job.consent_scope_version
+        or receipt.consent_scope_hash != job.consent_scope_hash
+        or receipt.output_asset_id != output.asset_id
+        or receipt.output_asset_digest != output.sha256
+        or receipt.generation_request_id != output.generation_request_id
+        or output.moderation_status != "approved"
+    ):
+        raise GeneratedImageAdmissionError("generated_image_receipt_binding_mismatch")
+    event_id = canonical_event_id.strip()
+    if not event_id:
+        raise GeneratedImageAdmissionError("generated_image_canonical_event_required")
+    updated_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    confirmed_receipt = receipt.model_copy(update={"canonical_status": "confirmed", "canonical_event_id": event_id})
+    ready_job = job.model_copy(
+        update={
+            "state": GeneratedImageJobState.ready,
+            "canonical_event_id": event_id,
+            "updated_at": updated_at,
+        }
+    )
+    asset = GeneratedImageAssetRef(
+        asset_id=output.asset_id,
+        job_id=job.job_id,
+        receipt_id=receipt.receipt_id,
+        generation=job.source.generation,
+        media_type=output.media_type,
+        sha256=output.sha256,
+        width=output.width,
+        height=output.height,
+        alt_text=output.alt_text,
+        delivery_path=GENERATED_IMAGE_DELIVERY_PREFIX + output.asset_id,
+    )
+    return ready_job, confirmed_receipt, asset

--- a/backend/ella/services/today_card.py
+++ b/backend/ella/services/today_card.py
@@ -14,6 +14,8 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from pydantic import BaseModel, Field, field_validator
 
+from models.generated_image import GeneratedImageAssetRef
+
 TODAY_CARD_CONTRACT_VERSION = "ella.today_card.v1"
 TODAY_CARD_RENDER_CONTRACT_VERSION = "ella.today_card.render.v1"
 TODAY_CARD_MATERIALIZATION_HOUR = 3
@@ -144,6 +146,7 @@ class TodayCardPresentation(BaseModel):
     style: str = "letter"
     artwork_ref: str | None = None
     alt_text: str | None = None
+    background_image: GeneratedImageAssetRef | None = None
 
 
 class TodayCardContent(BaseModel):

--- a/backend/migrations/017_create_generated_image_jobs.sql
+++ b/backend/migrations/017_create_generated_image_jobs.sql
@@ -1,0 +1,97 @@
+-- Authority-bound generated memory and Daily Note image jobs.
+--
+-- Assets remain private and provider URLs are never persisted. App-facing
+-- records receive only canonical-confirmed references from this ledger.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS ella_generated_image_jobs (
+    job_id TEXT COLLATE "C" PRIMARY KEY,
+    uid TEXT COLLATE "C" NOT NULL,
+    profile_binding_id TEXT COLLATE "C" NOT NULL,
+    authority_generation INTEGER NOT NULL CHECK (authority_generation >= 1),
+    subject_kind TEXT COLLATE "C" NOT NULL CHECK (subject_kind IN ('memory', 'daily_note')),
+    subject_id TEXT COLLATE "C" NOT NULL,
+    conversation_id TEXT COLLATE "C",
+    memory_id TEXT COLLATE "C",
+    today_card_id TEXT COLLATE "C",
+    source_version_id TEXT COLLATE "C" NOT NULL,
+    source_digest TEXT COLLATE "C" NOT NULL CHECK (source_digest ~ '^sha256:[0-9a-f]{64}$'),
+    grounding_receipt_digest TEXT COLLATE "C" NOT NULL
+        CHECK (grounding_receipt_digest ~ '^sha256:[0-9a-f]{64}$'),
+    generation INTEGER NOT NULL CHECK (generation >= 1),
+    prompt_contract_version TEXT COLLATE "C" NOT NULL,
+    prompt_digest TEXT COLLATE "C" NOT NULL CHECK (prompt_digest ~ '^sha256:[0-9a-f]{64}$'),
+    provider_id TEXT COLLATE "C" NOT NULL,
+    processor_id TEXT COLLATE "C" NOT NULL,
+    processor_name TEXT NOT NULL,
+    model_id TEXT COLLATE "C" NOT NULL,
+    consent_receipt_ref TEXT COLLATE "C" NOT NULL
+        CHECK (consent_receipt_ref ~ '^sha256:[0-9a-f]{64}$'),
+    consent_policy_version TEXT COLLATE "C" NOT NULL,
+    consent_processor_set_hash TEXT COLLATE "C" NOT NULL
+        CHECK (consent_processor_set_hash ~ '^sha256:[0-9a-f]{64}$'),
+    consent_scope_version TEXT COLLATE "C" NOT NULL,
+    consent_scope_hash TEXT COLLATE "C" NOT NULL CHECK (consent_scope_hash ~ '^sha256:[0-9a-f]{64}$'),
+    state TEXT COLLATE "C" NOT NULL CHECK (
+        state IN (
+            'pending_consent', 'queued', 'generating', 'moderating',
+            'awaiting_canonical', 'ready', 'rejected', 'stale', 'failed', 'cancelled'
+        )
+    ),
+    provider_request_id TEXT COLLATE "C",
+    output_asset_id UUID,
+    output_asset_digest TEXT COLLATE "C"
+        CHECK (output_asset_digest IS NULL OR output_asset_digest ~ '^sha256:[0-9a-f]{64}$'),
+    moderation_status TEXT COLLATE "C" NOT NULL DEFAULT 'pending'
+        CHECK (moderation_status IN ('pending', 'approved', 'rejected', 'failed')),
+    receipt_id TEXT COLLATE "C",
+    canonical_event_id TEXT COLLATE "C",
+    error_code TEXT COLLATE "C",
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT ella_generated_image_jobs_subject_shape CHECK (
+        (
+            subject_kind = 'memory'
+            AND (conversation_id IS NOT NULL OR memory_id IS NOT NULL)
+            AND today_card_id IS NULL
+        )
+        OR
+        (subject_kind = 'daily_note' AND today_card_id IS NOT NULL AND conversation_id IS NULL AND memory_id IS NULL)
+    ),
+    UNIQUE (uid, subject_kind, subject_id, source_version_id, prompt_contract_version, generation)
+);
+
+CREATE INDEX IF NOT EXISTS ella_generated_image_jobs_owner_state_idx
+    ON ella_generated_image_jobs (uid, state, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS ella_generated_image_assets (
+    asset_id UUID PRIMARY KEY,
+    job_id TEXT COLLATE "C" NOT NULL UNIQUE REFERENCES ella_generated_image_jobs(job_id) ON DELETE CASCADE,
+    uid TEXT COLLATE "C" NOT NULL,
+    storage_key TEXT COLLATE "C" NOT NULL UNIQUE,
+    media_type TEXT COLLATE "C" NOT NULL CHECK (media_type IN ('image/jpeg', 'image/png', 'image/webp')),
+    sha256 TEXT COLLATE "C" NOT NULL CHECK (sha256 ~ '^sha256:[0-9a-f]{64}$'),
+    width INTEGER NOT NULL CHECK (width BETWEEN 1 AND 16384),
+    height INTEGER NOT NULL CHECK (height BETWEEN 1 AND 16384),
+    moderation_status TEXT COLLATE "C" NOT NULL CHECK (moderation_status IN ('approved', 'rejected', 'failed')),
+    alt_text TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS ella_generated_image_receipts (
+    receipt_id TEXT COLLATE "C" PRIMARY KEY,
+    job_id TEXT COLLATE "C" NOT NULL UNIQUE REFERENCES ella_generated_image_jobs(job_id) ON DELETE CASCADE,
+    uid TEXT COLLATE "C" NOT NULL,
+    receipt JSONB NOT NULL CHECK (jsonb_typeof(receipt) = 'object'),
+    canonical_status TEXT COLLATE "C" NOT NULL CHECK (canonical_status IN ('pending', 'confirmed', 'failed')),
+    canonical_event_id TEXT COLLATE "C",
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT ella_generated_image_receipts_canonical_shape CHECK (
+        (canonical_status = 'confirmed' AND canonical_event_id IS NOT NULL)
+        OR (canonical_status <> 'confirmed' AND canonical_event_id IS NULL)
+    )
+);
+
+COMMIT;

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field, field_validator
 
 from models.chat import Message
+from models.generated_image import GeneratedImageAssetRef
 from models.other import Person
 from models.transcript_segment import TranscriptSegment
 
@@ -354,6 +355,7 @@ class Conversation(BaseModel):
     transcript_segments_compressed: Optional[bool] = False
     geolocation: Optional[Geolocation] = None
     photos: List[ConversationPhoto] = []
+    generated_image: Optional[GeneratedImageAssetRef] = None
     audio_files: List[AudioFile] = []
     private_cloud_sync_enabled: bool = False
 

--- a/backend/models/generated_image.py
+++ b/backend/models/generated_image.py
@@ -1,0 +1,51 @@
+"""Public, provider-neutral references to privately stored generated images."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+GENERATED_IMAGE_ASSET_CONTRACT_VERSION = "ella.generated_image.asset.v1"
+GENERATED_IMAGE_DELIVERY_PREFIX = "/v1/ella/generated-image-assets/"
+
+
+class GeneratedImageAssetRef(BaseModel):
+    """An attachable image reference safe to expose to authenticated clients.
+
+    Provider URLs and storage keys deliberately do not cross this boundary. A
+    reference is attachable only after moderation and canonical confirmation.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    contract_version: Literal["ella.generated_image.asset.v1"] = GENERATED_IMAGE_ASSET_CONTRACT_VERSION
+    asset_id: str = Field(min_length=1, max_length=128)
+    job_id: str = Field(min_length=1, max_length=128)
+    receipt_id: str = Field(min_length=1, max_length=128)
+    generation: int = Field(ge=1)
+    media_type: Literal["image/jpeg", "image/png", "image/webp"]
+    sha256: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    width: int = Field(ge=1, le=16384)
+    height: int = Field(ge=1, le=16384)
+    moderation_status: Literal["approved"] = "approved"
+    alt_text: str = Field(min_length=1, max_length=500)
+    delivery_path: str = Field(min_length=1, max_length=512)
+
+    @field_validator("delivery_path")
+    @classmethod
+    def _first_party_delivery_path_only(cls, value: str) -> str:
+        candidate = value.strip()
+        if (
+            not candidate.startswith(GENERATED_IMAGE_DELIVERY_PREFIX)
+            or "?" in candidate
+            or "#" in candidate
+            or ".." in candidate
+            or candidate.endswith("/")
+        ):
+            raise ValueError("generated_image_delivery_path_invalid")
+        return candidate
+
+    @model_validator(mode="after")
+    def _delivery_path_matches_asset(self) -> "GeneratedImageAssetRef":
+        if self.delivery_path != GENERATED_IMAGE_DELIVERY_PREFIX + self.asset_id:
+            raise ValueError("generated_image_delivery_asset_mismatch")
+        return self

--- a/backend/models/memories.py
+++ b/backend/models/memories.py
@@ -6,6 +6,7 @@ from typing import Optional, List
 from pydantic import BaseModel, Field, validator
 
 from database._client import document_id_from_seed
+from models.generated_image import GeneratedImageAssetRef
 
 
 class MemoryCategory(str, Enum):
@@ -123,6 +124,7 @@ class MemoryDB(Memory):
     data_protection_level: Optional[str] = None
     is_locked: bool = False
     kg_extracted: bool = False
+    generated_image: Optional[GeneratedImageAssetRef] = None
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/backend/tests/unit/test_generated_images.py
+++ b/backend/tests/unit/test_generated_images.py
@@ -1,0 +1,309 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from ella.services.generated_images import (
+    GeneratedImageAdmissionError,
+    GeneratedImageAdmissionRequest,
+    GeneratedImageAuthority,
+    GeneratedImageConsentGrant,
+    GeneratedImageJobState,
+    GeneratedImageSourceSnapshot,
+    GeneratedImageStoredOutput,
+    GeneratedImageSubjectKind,
+    admit_generated_image_job,
+    bind_generated_image_output,
+    confirm_generated_image_receipt,
+    sha256_digest,
+    start_generated_image_job,
+)
+from ella.services.today_card import TodayCardPresentation
+from models.generated_image import GeneratedImageAssetRef
+
+NOW = datetime(2026, 8, 10, 18, 0, tzinfo=timezone.utc)
+PROMPT = "A non-photoreal watercolor scene grounded in the selected memory."
+
+
+def _source(*, generation: int = 4, source_version_id: str = "summary-v4") -> GeneratedImageSourceSnapshot:
+    return GeneratedImageSourceSnapshot(
+        authority=GeneratedImageAuthority(
+            owner_uid="owner-fixture",
+            profile_binding_id="profile-binding-fixture",
+            authority_generation=7,
+        ),
+        kind=GeneratedImageSubjectKind.memory,
+        subject_id="memory-card-fixture",
+        conversation_id="conversation-fixture",
+        memory_id="memory-fixture",
+        source_version_id=source_version_id,
+        source_digest=sha256_digest("grounded-source-fixture"),
+        grounding_receipt_digest=sha256_digest("grounding-receipt-fixture"),
+        generation=generation,
+    )
+
+
+def _request(source: GeneratedImageSourceSnapshot | None = None, *, provider_id: str = "image-provider-fixture"):
+    return GeneratedImageAdmissionRequest(
+        source=source or _source(),
+        prompt_contract_version="ella.memory-image.prompt.v1",
+        prompt_digest=sha256_digest(PROMPT),
+        provider_id=provider_id,
+        processor_id="image-processor-fixture",
+        processor_name="Named Image Processor Fixture",
+        model_id="image-model-fixture-v1",
+        consent_policy_version="image-data-processors-v1",
+        consent_processor_set_hash=sha256_digest("processor-set-fixture"),
+        consent_scope_version="generated-memory-images-v1",
+        consent_scope_hash=sha256_digest("scope-fixture"),
+    )
+
+
+def _consent(request: GeneratedImageAdmissionRequest | None = None, **updates) -> GeneratedImageConsentGrant:
+    request = request or _request()
+    values = {
+        "receipt_id": "consent-receipt-fixture",
+        "decision": "granted",
+        "subject_uid": request.source.authority.owner_uid,
+        "profile_binding_id": request.source.authority.profile_binding_id,
+        "authority_generation": request.source.authority.authority_generation,
+        "provider_id": request.provider_id,
+        "processor_id": request.processor_id,
+        "processor_name": request.processor_name,
+        "model_id": request.model_id,
+        "policy_version": "image-data-processors-v1",
+        "processor_set_hash": sha256_digest("processor-set-fixture"),
+        "scope_version": "generated-memory-images-v1",
+        "scope_hash": sha256_digest("scope-fixture"),
+        "decided_at": NOW - timedelta(minutes=5),
+        "expires_at": NOW + timedelta(hours=1),
+    }
+    values.update(updates)
+    return GeneratedImageConsentGrant(**values)
+
+
+def _admit(request: GeneratedImageAdmissionRequest | None = None):
+    request = request or _request()
+    return admit_generated_image_job(
+        request,
+        consent=_consent(request),
+        current_source=request.source,
+        now=NOW,
+    )
+
+
+def _output(*, moderation_status="approved") -> GeneratedImageStoredOutput:
+    return GeneratedImageStoredOutput(
+        asset_id="00000000-0000-4000-8000-000000000001",
+        generation_request_id="provider-request-fixture",
+        storage_key="private/generated-images/fixture/output.webp",
+        media_type="image/webp",
+        sha256=sha256_digest(b"generated-image-fixture"),
+        width=1024,
+        height=768,
+        moderation_status=moderation_status,
+        alt_text="A gentle watercolor scene inspired by the selected memory.",
+    )
+
+
+@pytest.mark.parametrize("decision", [None, "declined", "revoked"])
+def test_admission_requires_an_exact_granted_image_consent_receipt(decision):
+    request = _request()
+    consent = None if decision is None else _consent(request, decision=decision)
+
+    with pytest.raises(GeneratedImageAdmissionError, match="generated_image_consent_required"):
+        admit_generated_image_job(request, consent=consent, current_source=request.source, now=NOW)
+
+
+@pytest.mark.parametrize(
+    ("updates", "code"),
+    [
+        ({"subject_uid": "different-owner"}, "generated_image_consent_authority_mismatch"),
+        ({"authority_generation": 8}, "generated_image_consent_authority_mismatch"),
+        ({"processor_name": "Different Processor"}, "generated_image_consent_processor_mismatch"),
+        ({"model_id": "different-model"}, "generated_image_consent_processor_mismatch"),
+        ({"scope_hash": sha256_digest("different-scope")}, "generated_image_consent_processor_mismatch"),
+        ({"expires_at": NOW}, "generated_image_consent_expired"),
+    ],
+)
+def test_admission_fails_closed_on_authority_processor_or_expiry_drift(updates, code):
+    request = _request()
+    with pytest.raises(GeneratedImageAdmissionError, match=code):
+        admit_generated_image_job(
+            request,
+            consent=_consent(request, **updates),
+            current_source=request.source,
+            now=NOW,
+        )
+
+
+def test_admission_rejects_stale_sources_and_codex_development_provider():
+    request = _request()
+    stale = _source(generation=5)
+    with pytest.raises(GeneratedImageAdmissionError, match="generated_image_source_stale"):
+        admit_generated_image_job(request, consent=_consent(request), current_source=stale, now=NOW)
+
+    development_request = _request(provider_id="codex-imagegen")
+    with pytest.raises(GeneratedImageAdmissionError, match="generated_image_development_provider_forbidden"):
+        admit_generated_image_job(
+            development_request,
+            consent=_consent(development_request),
+            current_source=development_request.source,
+            now=NOW,
+        )
+
+
+def test_job_binds_prompt_provider_request_output_and_canonical_receipt_before_attachment():
+    job = _admit()
+    assert job.state == GeneratedImageJobState.queued
+    assert job.consent_receipt_ref.startswith("sha256:")
+
+    started, provider_request = start_generated_image_job(
+        job,
+        consent=_consent(),
+        prompt=PROMPT,
+        generation_request_id="provider-request-fixture",
+        current_source=job.source,
+        expected_generation=4,
+        now=NOW,
+    )
+    assert started.state == GeneratedImageJobState.generating
+    assert provider_request.model_dump() == {
+        "job_id": job.job_id,
+        "generation_request_id": "provider-request-fixture",
+        "provider_id": "image-provider-fixture",
+        "model_id": "image-model-fixture-v1",
+    }
+
+    awaiting, pending_receipt = bind_generated_image_output(
+        started,
+        output=_output(),
+        current_source=job.source,
+        expected_generation=4,
+        now=NOW,
+    )
+    assert awaiting.state == GeneratedImageJobState.awaiting_canonical
+    assert pending_receipt is not None
+    assert pending_receipt.canonical_status == "pending"
+
+    mismatched_receipt = pending_receipt.model_copy(update={"source": _source(source_version_id="summary-v5")})
+    with pytest.raises(GeneratedImageAdmissionError, match="generated_image_receipt_binding_mismatch"):
+        confirm_generated_image_receipt(
+            awaiting,
+            mismatched_receipt,
+            _output(),
+            canonical_event_id="canonical-event-fixture",
+            current_source=job.source,
+            expected_generation=4,
+            now=NOW,
+        )
+
+    ready, confirmed_receipt, asset = confirm_generated_image_receipt(
+        awaiting,
+        pending_receipt,
+        _output(),
+        canonical_event_id="canonical-event-fixture",
+        current_source=job.source,
+        expected_generation=4,
+        now=NOW,
+    )
+    assert ready.state == GeneratedImageJobState.ready
+    assert confirmed_receipt.canonical_status == "confirmed"
+    assert asset.moderation_status == "approved"
+    assert asset.delivery_path.endswith(asset.asset_id)
+    assert "storage_key" not in asset.model_dump()
+    assert "provider" not in asset.delivery_path
+
+
+def test_generation_and_prompt_cas_rejects_stale_or_changed_work():
+    job = _admit()
+    with pytest.raises(GeneratedImageAdmissionError, match="generated_image_prompt_digest_mismatch"):
+        start_generated_image_job(
+            job,
+            consent=_consent(),
+            prompt="changed prompt",
+            generation_request_id="provider-request-fixture",
+            current_source=job.source,
+            expected_generation=4,
+            now=NOW,
+        )
+    with pytest.raises(GeneratedImageAdmissionError, match="generated_image_generation_stale"):
+        start_generated_image_job(
+            job,
+            consent=_consent(),
+            prompt=PROMPT,
+            generation_request_id="provider-request-fixture",
+            current_source=_source(generation=5),
+            expected_generation=4,
+            now=NOW,
+        )
+
+
+def test_rejected_moderation_never_creates_a_receipt():
+    job = _admit()
+    started, _ = start_generated_image_job(
+        job,
+        consent=_consent(),
+        prompt=PROMPT,
+        generation_request_id="provider-request-fixture",
+        current_source=job.source,
+        expected_generation=4,
+        now=NOW,
+    )
+    rejected, receipt = bind_generated_image_output(
+        started,
+        output=_output(moderation_status="rejected"),
+        current_source=job.source,
+        expected_generation=4,
+        now=NOW,
+    )
+    assert rejected.state == GeneratedImageJobState.rejected
+    assert receipt is None
+
+
+def test_pre_egress_check_rejects_revoked_or_different_consent_receipt():
+    job = _admit()
+    with pytest.raises(GeneratedImageAdmissionError, match="generated_image_consent_required"):
+        start_generated_image_job(
+            job,
+            consent=_consent(decision="revoked"),
+            prompt=PROMPT,
+            generation_request_id="provider-request-fixture",
+            current_source=job.source,
+            expected_generation=4,
+            now=NOW,
+        )
+    with pytest.raises(GeneratedImageAdmissionError, match="generated_image_consent_receipt_mismatch"):
+        start_generated_image_job(
+            job,
+            consent=_consent(receipt_id="different-consent-receipt"),
+            prompt=PROMPT,
+            generation_request_id="provider-request-fixture",
+            current_source=job.source,
+            expected_generation=4,
+            now=NOW,
+        )
+
+
+def test_memory_and_daily_note_fields_are_optional_and_accept_only_attachable_assets():
+    assert TodayCardPresentation().background_image is None
+    asset = GeneratedImageAssetRef(
+        asset_id="asset-fixture",
+        job_id="job-fixture",
+        receipt_id="receipt-fixture",
+        generation=1,
+        media_type="image/webp",
+        sha256=sha256_digest("asset-fixture"),
+        width=100,
+        height=100,
+        alt_text="Watercolor fallback fixture.",
+        delivery_path="/v1/ella/generated-image-assets/asset-fixture",
+    )
+    assert TodayCardPresentation(background_image=asset).background_image == asset
+
+    with pytest.raises(ValueError, match="generated_image_delivery_asset_mismatch"):
+        GeneratedImageAssetRef(
+            **{
+                **asset.model_dump(),
+                "delivery_path": "/v1/ella/generated-image-assets/different-asset",
+            }
+        )


### PR DESCRIPTION
## Summary

- add provider-neutral, authority-bound job/asset/receipt contracts for generated memory and Daily Note imagery
- bind owner/profile authority, conversation/memory/Today Card identity, grounded source version/digests, prompt contract/digest, named processor/provider/model, immutable consent receipt, provider request, moderation, output digest, and canonical confirmation
- fail closed at admission and immediately before provider egress when consent or current-source/generation CAS differs
- add optional backend memory/Today presentation fields plus strict Flutter parsing that preserves source-photo/static-art fallbacks
- document the existing enrichment, storage, consent, and canonical-receipt boundaries and the unresolved production decisions

This is intentionally a foundation-only stacked draft on #393. It contains no provider adapter, delivery route, worker, live storage write, production consent policy, or user-content egress. Codex/imagegen identifiers are explicitly forbidden as production providers.

## Safety properties

- provider prompt/content and output bytes are in-memory-only interface fields and excluded from model serialization/repr
- provider URLs and private storage keys cannot cross the app-facing asset boundary
- app-facing assets require approved moderation, exact first-party asset delivery paths, and a canonical-confirmed receipt
- existing source photos remain preferred; malformed, absent, unapproved, or non-first-party image records parse to `null`
- current AI consent cannot implicitly authorize image generation; an exact image-specific named-processor grant is required and rechecked pre-egress

## Validation

- `backend/test.sh`: 167 passed; 10 PostgreSQL tests skipped because no test database was configured
- affected backend enrichment/Today/generated-image suites: 210 passed
- `app/test.sh`: passed (21 tests)
- full `flutter test`: 106 passed
- focused generated-image/conversation schema tests: 9 passed; post-commit generated-image parser test: 2 passed
- focused `dart analyze`: exit 0, with 7 pre-existing enum naming infos in `conversation.dart`
- full `flutter analyze`: existing repository baseline remains nonzero (1,698 issues); no new-file analyzer findings in the focused run
- Python compile check, `git diff --check`, and staged gitleaks scan: passed

## Review notes / unresolved gates

- choose and legally name the production image processor/provider/model
- approve disclosure copy, data categories, retention/deletion, consent policy/scope versions, and visible decline/not-now UX
- choose first-party Worker versus authenticated n8n-mediated execution, private object store, TTL, authenticated delivery, moderation, quotas, and retry policy
- integrate release-line memory/Today UI only after the relevant iOS surface stack lands; preserve source photo -> approved generated image -> static fallback

Do not enable egress until the image-specific Apple 5.1.1(i)/5.1.2(i) consent flow and current-consent authority exist.
